### PR TITLE
Another fix for IE 6/7/8 compatibility.

### DIFF
--- a/ckan/templates/_util.html
+++ b/ckan/templates/_util.html
@@ -480,4 +480,23 @@
     </span>
   </div>
 
+  <!--! jsConditionalForIe(ieVersion, tagContent, matchOperator): takes a
+        IE version number, a tag or other HTML code that will be wrapped inside
+        a IE conditional comment, and the comparison operator (lt, lte, etc..
+        see http://msdn.microsoft.com/en-us/library/ms537512%28v=vs.85%29.aspx)
+        returning Genshi stream ready to be shown in a template.
+        
+        NOTE:
+        Internet Explorer Conditional Import are confused as Genshi comments 
+        and python variables and method calls are not executed if inside them.
+        This function helps to output tags with Python code inside conditional
+        comments, eg ${h.url_for_static()} -->
+  <?python
+    from genshi import HTML
+    def jsConditionalForIe(ieVersion, tagContent, matchOperator = 'lt'):
+      html = HTML('<!--[if ' + matchOperator +  ' IE ' + str(ieVersion) + ''']>
+                     ''' + tagContent + '''
+                   <![endif]-->''')
+      return html
+  ?>
 </html>

--- a/ckan/templates/layout_base.html
+++ b/ckan/templates/layout_base.html
@@ -34,13 +34,9 @@
   <link rel="stylesheet" href="${h.url_for_static('/css/chosen.css')}" type="text/css" />
   <link rel="stylesheet" href="${h.url_for_static('/css/blueprint/screen.css')}" type="text/css" media="screen, projection" />
   <link rel="stylesheet" href="${h.url_for_static('/css/blueprint/print.css')}" type="text/css" media="print" />
-  <!--[if lt IE 8]>
-    <link rel="stylesheet" href="${h.url_for_static('/css/blueprint/ie.css')}" type="text/css" media="screen, projection">
-  <![endif]-->
-  <!--[if lt IE 9]>
-    <script type="text/javascript" src="${h.url_for_static('/scripts/vendor/html5shiv/html5.js')}"></script>
-  <![endif]-->
+  ${jsConditionalForIe(8, '&lt;link rel="stylesheet" href="' + h.url_for_static('/css/blueprint/ie.css') + '" type="text/css" media="screen, projection"&gt;')}
   <link rel="stylesheet" href="${h.url_for_static('/css/style.css?v=2')}" />
+  ${jsConditionalForIe(9, '&lt;script type="text/javascript" src=" + h.url_for_static('/scripts/vendor/html5shiv/html5.js') + "&gt;&lt;/script&gt;')}
 
   <py:if test="defined('optional_head')">
     ${optional_head()}


### PR DESCRIPTION
IE < 9 visualization was still completely messed up after my previous contribution (already merged okfn/ckan@27f4fc7 ).

The problem were calls to ${h.url_for_static()} inside IE Conditional Comments which were not being executed, and sent to the browser "as is".

So, I wrote a new pure Python function inside  _util.html to be able to workaround the problem and still h.url_for_static().
