### PR TITLE
Wrap up script elements at the bottom of main template

### DIFF
--- a/ckan/templates/layout_base.html
+++ b/ckan/templates/layout_base.html
@@ -215,7 +215,8 @@
       </div>
     </footer>
   </div> <!-- eo #container -->
-
+  
+  <div style="display:none;" id="scripts">
   <script src="${h.url_for_static('/scripts/vendor/jquery/1.7.1/jquery.js')}"></script>
   <script type="text/javascript" src="${h.url_for_static('/scripts/vendor/json2.js')}"></script>
   <script type="text/javascript" src="${h.url_for_static('/scripts/vendor/jquery.tmpl/beta1/jquery.tmpl.js')}"></script>
@@ -288,6 +289,7 @@
                  });
   </script>
   </py:if>
+  </div> <!-- #scripts -->
 
   <py:if test="defined('optional_footer')">
     ${optional_footer()}


### PR DESCRIPTION
The script elements at the bottom of the main template (layout_base.html) should be wrapped up by an element to facilitate their replacement or appending by other templates, e.g.:

```
<py:match="//div[@id='scripts']">
  ${select('*')}
  <script type="text/javascript" src="mynewscript.js"></script>
</py:match>
```
