### PR TITLE
[2383] Properly convert microseconds in date_str_to_datetime helper.

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -616,7 +616,8 @@ def date_str_to_datetime(date_str):
         m = re.match('(?P<seconds>\d{2})(\.(?P<microseconds>\d{6}))?$',
                      time_tuple[5])
         if not m:
-            raise ValueError
+            raise ValueError('Unable to parse %s as seconds.microseconds' %
+                             time_tuple[5])
         seconds = int(m.groupdict().get('seconds'))
         microseconds = int(m.groupdict(0).get('microseconds'))
         time_tuple = time_tuple[:5] + [seconds, microseconds]

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -56,6 +56,11 @@ class TestHelpers(TestController):
                       h.date_str_to_datetime,
                       '2008-04-13T20:40:20-01:30')
 
+    def test_date_str_to_datetime_with_timezone_without_colon(self):
+        assert_raises(ValueError,
+                      h.date_str_to_datetime,
+                      '2008-04-13T20:40:20-0130')
+
     def test_date_str_to_datetime_with_garbage_on_end(self):
         assert_raises(ValueError,
                       h.date_str_to_datetime,


### PR DESCRIPTION
Stop this helper function from incorrectly parsing a UTC offset "+0100" as
100 microseconds.

Now, if passed UTC offset as "+0100", this function will not parse the
timestamp.  The same behaviour as when it's passed "+01:00" as a UTC
offset.

http://trac.ckan.org/ticket/2383
