### PR TITLE
Experimental lazy properties

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Pylons environment configuration"""
 import os
 import logging
@@ -194,6 +195,42 @@ def load_environment(global_conf, app_conf):
     #                                                               #
     #################################################################
 
+
+
+    '''
+    This code is based on Genshi code
+
+    Copyright © 2006-2012 Edgewall Software
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, are permitted provided that the following
+    conditions are met:
+
+        Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+
+        Redistributions in binary form must reproduce the above
+        copyright notice, this list of conditions and the following
+        disclaimer in the documentation and/or other materials provided
+        with the distribution.
+
+        The name of the author may not be used to endorse or promote
+        products derived from this software without specific prior
+        written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS" AND ANY EXPRESS OR
+    IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+    GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+    IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+    OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+    IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    '''
     from genshi.template.eval import LookupBase
 
     @classmethod


### PR DESCRIPTION
This is a proposed patch that would allow us to start the process of moving some stuff that is currently done in controllers out into helper functions.  The best example I am aware of is the the ckan index page currently renders an activity stream that is not used on the datahub.

by changing from

```
c.var = do_lots_of_work()
```

to

```
@property 
def wrapper_function():
    return do_lots_of_work()

c.var = wrapper_function
```

we make the function only get called if needed.  Following this it is also easy to replace the call with that to a helper function and eventually deprecate the wrapper function / template variable

This does need us to patch genshi but as we are using a pyenv and needing a specific version it should hopefully be safe.  I cannot see how else we can easily move away from work done in controllers to work done in helpers which feels the better approach for stability etc.

If we are happy with this then I'd like to see it or one similar in ckan 1.8
