### PR TITLE
[#2497] when we have a 401 and not logged in keep locale (for 1.7.1)

### DIFF
--- a/ckan/lib/repoze_patch.py
+++ b/ckan/lib/repoze_patch.py
@@ -56,7 +56,8 @@ def identify(self, environ):
 
         # we don't do anything with the openid we found ourselves but we put it in here
         # to tell the challenge plugin to initiate the challenge
-        identity['repoze.whoplugins.openid.openid'] = environ['repoze.whoplugins.openid.openid'] = open_id
+        identity['repoze.whoplugins.openid.openid'] = open_id
+        environ['repoze.whoplugins.openid.openid'] = open_id
 
         # this part now is for the case when the openid provider redirects
         # the user back. We should find some openid specific fields in the request.


### PR DESCRIPTION
This stops a bug.

The bug is triggered when the language is non-default we are not logged in and we go to a url that is not allowed (triggers a http 401 error)  eg /fr/dataset/new  The unpatched code reverts to the default language - this fixes it.

This would be nice to add to 1.7.1 as 1.7 has this bug
