### PR TITLE
[#2591] fix postgresql 9.1.4 unicode issue

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -273,7 +273,15 @@ def load_environment(global_conf, app_conf):
 
     if ckan_db:
         config['sqlalchemy.url'] = ckan_db
-    engine = sqlalchemy.engine_from_config(config, 'sqlalchemy.', client_encoding='utf8')
+
+    # for postgresql we want to enforce utf-8
+    sqlalchemy_url = config.get('sqlalchemy.url', '')
+    if sqlalchemy_url.startswith('postgresql://'):
+        extras = {'client_encoding': 'utf8'}
+    else:
+        extras = {}
+
+    engine = sqlalchemy.engine_from_config(config, 'sqlalchemy.', **extras)
 
     if not model.meta.engine:
         model.init_model(engine)


### PR DESCRIPTION
sqlalchemy gets confused over unicode encoding in postgresql v9.1.4
we get utf-8 data but we can think that we are getting SQL_ASCII
this patch forces sqlalchemy to use utf-8 which will make things easier
as all ckan data should be treated as utf-8

This was causing me a problem on arch and this fixes it.  I am using datahub data and this is a problem which seems to be a postgresql upgrade - can someone check this does not cause problems on ubuntu
it should not affect anything if you can do a `paster search-index rebuild -c dev.ini` with unicode data in ckan then all should be good.

I need this fix  
