### PR TITLE
2515 related tab issue

### DIFF
--- a/ckan/controllers/related.py
+++ b/ckan/controllers/related.py
@@ -34,5 +34,5 @@ class RelatedController(base.BaseController):
             base.abort(401, base._('Unauthorized to read package %s') % id)
 
         c.related_count = len(c.pkg.related)
-
+        c.action = 'related'
         return base.render("package/related_list.html")


### PR DESCRIPTION
Fixes 'selection' status of the related tab when viewing related items within a dataset.
