### PR TITLE
Fixed missing markdown on the resource read page.

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -772,6 +772,11 @@ class PackageController(BaseController):
         c.datastore_api = h.url_for('datastore_read', id=c.resource.get('id'),
                                     qualified=True)
 
+        c.resource_desc_formatted = ckan.misc.MarkdownFormat().to_html(
+            c.resource.get('description',''))
+        c.pkg_notes_formatted = ckan.misc.MarkdownFormat().to_html(
+            c.package.get('notes',''))
+
         c.related_count = len(c.pkg.related)
         return render('package/resource_read.html')
 

--- a/ckan/templates/package/resource_read.html
+++ b/ckan/templates/package/resource_read.html
@@ -126,19 +126,21 @@
       </dl>
     </div>
 
-    <div class="notes" property="rdfs:label">
+    <div class="notes" property="rdfs:label" py:if="c.resource_desc_formatted">
       <div id="notes-extract">
-        ${c.resource.get('description') or '(No description)'}
+          ${ Markup(c.resource_desc_formatted) }
       </div>
     </div>
 
-    <div py:if="not c.resource.get('description') and c.package.get('notes')" id="dataset-description">
+    <div py:if="not c.resource_desc_formatted and c.pkg_notes_formatted">
       <div>
         <strong i18n:msg="">
           From the <a href="${h.url_for(controller='package', action='read', id=c.package['name'])}">Dataset</a>:
         </strong>
       </div>
-      <div>${h.markdown_extract(c.package.get('notes'), 300)}</div>
+      <div class="notes">
+          <div  id="notes-extract">${ Markup(c.pkg_notes_formatted)}</div>
+      </div>
     </div>
 
     <div class="resource-preview">


### PR DESCRIPTION
Resource creation asks for markdown, but then it never renders as markdown.

Changed the read_resource method in package controller to generate the
notes from the dictionary and use the dataset notes if no resource
description is available.  
