### PR TITLE
Stop the package controller from crashing when used at the root URL

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -93,6 +93,13 @@ class PackageController(BaseController):
             Guess the type of package from the URL handling the case
             where there is a prefix on the URL (such as /data/package)
         """
+
+        # Special case: if the rot URL '/' has been redirected to the package
+        # controller (e.g. by an IRoutes extension) then there's nothing to do
+        # here.
+        if request.path == '/':
+            return 'dataset'
+
         parts = [x for x in request.path.split('/') if x]
 
         idx = -1


### PR DESCRIPTION
If the root URL '/' was connected to the package controller (e.g. by an
IRoutes plugin) _guess_package_type() would crash. Add a special case to
avoid the crash.
