### PR TITLE
[#2672] Pass in passive=True to Session.is_modified()

### DIFF
--- a/ckan/lib/dictization/__init__.py
+++ b/ckan/lib/dictization/__init__.py
@@ -133,7 +133,7 @@ def table_dict_save(table_dict, ModelClass, context):
         setattr(obj, key, value)
 
     if context.get('pending'):
-        if session.is_modified(obj, include_collections=False):
+        if session.is_modified(obj, include_collections=False, passive=True):
             if table_dict.get('state', '') == 'deleted':
                 obj.state = 'pending-deleted'
             else:

--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -46,7 +46,7 @@ def resource_dict_save(res_dict, context):
         del obj.extras[delete_me]
 
     if context.get('pending'):
-        if session.is_modified(obj, include_collections=False):
+        if session.is_modified(obj, include_collections=False, passive=True):
             obj.state = u'pending'
     else:
         obj.state = u'active'

--- a/ckan/model/meta.py
+++ b/ckan/model/meta.py
@@ -60,7 +60,7 @@ class CkanSessionExtension(SessionExtension):
                                     'changed': set()}
 
         changed = [obj for obj in session.dirty if 
-            session.is_modified(obj, include_collections=False)]
+            session.is_modified(obj, include_collections=False, passive=True)]
 
         session._object_cache['new'].update(session.new)
         session._object_cache['deleted'].update(session.deleted)


### PR DESCRIPTION
@kindly  Can I run this past you please?

Spotted that we're not calling Session.is_modified() properly [1].

This fixes a problem I've had with running tests against code that creates a one-one back reference from a new table to the User table, where the new table is being created in a ckan extension (ie outside of the usual migration scripts).  I'd really like to get this in to 1.8 as a bug fix as it's a dependency for http://trac.ckan.org/ticket/2550 . // cc @rossjones

[1] http://docs.sqlalchemy.org/en/rel_0_7/orm/session.html?highlight=is_modified#sqlalchemy.orm.session.Session.is_modified
