### PR TITLE
[#2755] Don't call user_show twice - for 1.8

### DIFF
--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -107,10 +107,6 @@ class UserController(BaseController):
             abort(401, _('Not authorized to see this page'))
 
         context['with_related'] = True
-        try:
-            user_dict = get_action('user_show')(context,data_dict)
-        except NotFound:
-            h.redirect_to(controller='user', action='login', id=None)
 
         self._setup_template_variables(context, data_dict)
 


### PR DESCRIPTION
self._setup_template_variables(context, data_dict)

calls get_action('user_show') so we don't need to do it in the read action
