### PR TITLE
[WIP] [#2815] Fix tracking info and isopen being stripped by validate

### DIFF
--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -206,7 +206,8 @@ def package_dictize(pkg, context):
     result_dict["extras"] = extras_list_dictize(result, context)
     #tracking
     tracking = model.TrackingSummary.get_for_package(pkg.id)
-    result_dict['tracking_summary'] = tracking
+    result_dict['tracking_summary_total'] = tracking['total']
+    result_dict['tracking_summary_recent'] = tracking['recent']
     #groups
     member_rev = model.member_revision_table
     group = model.group_table

--- a/ckan/lib/plugins.py
+++ b/ckan/lib/plugins.py
@@ -262,6 +262,13 @@ class DefaultDatasetForm(object):
                                'extras_validation', 'save', 'return_to',
                                'resources', 'type']
 
+        # Tracking summary might not exist if tracking not enabled.
+        surplus_keys_schema.extend(['tracking_summary_total',
+            'tracking_summary_recent'])
+
+        # isopen might not exist.
+        surplus_keys_schema.extend(['isopen'])
+
         if not schema:
             schema = self.form_to_db_schema()
         schema_keys = schema.keys()

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -133,7 +133,10 @@ def default_package_schema():
             'name': [ignore_missing, unicode],
             'title': [ignore_missing, unicode],
             '__extras': [ignore],
-        }
+        },
+        'tracking_summary_total': [ignore_missing],
+        'tracking_summary_recent': [ignore_missing],
+        'isopen': [ignore_missing],
     }
     return schema
 

--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -218,7 +218,8 @@ class Package(vdm.sqlalchemy.RevisionedObjectMixin,
         #tracking
         import ckan.model as model
         tracking = model.TrackingSummary.get_for_package(self.id)
-        _dict['tracking_summary'] = tracking
+        _dict['tracking_summary_total'] = tracking['total']
+        _dict['tracking_summary_recent'] = tracking['recent']
         return _dict
 
     def add_relationship(self, type_, related_package, comment=u''):

--- a/ckan/tests/lib/test_dictization.py
+++ b/ckan/tests/lib/test_dictization.py
@@ -113,9 +113,12 @@ class TestBasicDictize:
                      {'name': u'tolstoy', 'display_name': u'tolstoy',
                          'state': u'active'}],
             'title': u'A Novel By Tolstoy',
-            'tracking_summary': {'total': 0, 'recent': 0},
+            'tracking_summary_total': 0,
+            'tracking_summary_recent': 0,
             'url': u'http://www.annakarenina.com',
-            'version': u'0.7a'}
+            'version': u'0.7a',
+            'isopen': True,
+            }
 
 
     @classmethod

--- a/ckan/tests/lib/test_dictization_schema.py
+++ b/ckan/tests/lib/test_dictization_schema.py
@@ -99,7 +99,11 @@ class TestBasicDictize:
                                           {'name': u'tolstoy'}],
                                  'title': u'A Novel By Tolstoy',
                                  'url': u'http://www.annakarenina.com',
-                                 'version': u'0.7a'}, pformat(converted_data)
+                                 'version': u'0.7a',
+                                 'isopen': True,
+                                 'tracking_summary_total': 0,
+                                 'tracking_summary_recent': 0,
+                                 }, pformat(converted_data)
 
 
 


### PR DESCRIPTION
See the ticket: http://trac.ckan.org/ticket/2815

The 'tracking_summary' and 'isopen' fields were being stripped from
package dicts by validation. Only happened when there was a schema in use
that packages dict were being validated against, e.g. when there was an
IDatasetForm plugin with a db_to_form_schema() method.

When dictizing packages, 'tracking_summary' was being added to package
dicts as a sub-dict with two keys 'total' and 'recent', but
ckan/lib/navl/dictization_functions.py:validate() does not allow package
dicts to contain sub-dicts ("Only lists of dicts can be placed against
subschema"), they can contain only single values (e.g. strings, numbers,
bools) or lists of dicts (e.g. list of tag dicts) but not single dicts.
So change the dictization of packages to add two keys
'tracking_summary_total' and 'tracking_summary_recent' instead.

Add 'tracking_summary_total', 'tracking_summary_recent' and 'isopen' to
default_package_schema() so that they do not get stripped from package
dicts during validation.

Update a few tests now that package dicts have these three new keys.
