### PR TITLE
[#2816] Re-add some items to model.__init__  [for 1.8]

### DIFF
--- a/ckan/model/__init__.py
+++ b/ckan/model/__init__.py
@@ -81,13 +81,13 @@ from group import (
     member_revision_table,
     group_table,
     GroupRevision,
-    #MemberRevision,
-    #member_table,
+    MemberRevision,
+    member_table,
 )
 from group_extra import (
     GroupExtra,
-    #group_extra_table,
-    #GroupExtraRevision,
+    group_extra_table,
+    GroupExtraRevision,
 )
 from package_extra import (
     PackageExtra,
@@ -99,12 +99,12 @@ from resource import (
     Resource,
     ResourceGroup,
     ResourceRevision,
-    #DictProxy,
+    DictProxy,
     resource_group_table,
     resource_table,
     resource_revision_table,
-    #ResourceGroupRevision,
-    #resource_group_revision_table,
+    ResourceGroupRevision,
+    resource_group_revision_table,
 )
 from tracking import (
     tracking_summary_table,
@@ -126,7 +126,7 @@ from package_relationship import (
 )
 from task_status import (
     TaskStatus,
-    #task_status_table,
+    task_status_table,
 )
 from vocabulary import (
     Vocabulary,
@@ -136,8 +136,8 @@ from vocabulary import (
 from activity import (
     Activity,
     ActivityDetail,
-    #activity_table,
-    #activity_detail_table,
+    activity_table,
+    activity_detail_table,
 )
 from term_translation import (
     term_translation_table,
@@ -146,7 +146,10 @@ from follower import (
     UserFollowingUser,
     UserFollowingDataset,
 )
-
+from domain_object import (
+    DomainObjectOperation,
+    DomainObject,
+)
 import ckan.migration
 
 log = logging.getLogger(__name__)

--- a/ckan/model/domain_object.py
+++ b/ckan/model/domain_object.py
@@ -7,7 +7,7 @@ from sqlalchemy.util import OrderedDict
 import meta
 import core
 
-__all__ = ['DomainObject']
+__all__ = ['DomainObject', 'DomainObjectOperation']
 
 class Enum(set):
     '''Simple enumeration


### PR DESCRIPTION
These items were removed as not needed for tests etc. when cleaning up.  At least one is used by an extension so re-adding all to be safe
