### PR TITLE
[#2843] Remove 'Add Existing Datasets' option from organization edit

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -52,6 +52,9 @@ class GroupController(BaseController):
     def _history_template(self, group_type):
         return lookup_group_plugin(group_type).history_template()
 
+    def _edit_template(self, group_type):
+        return lookup_group_plugin(group_type).edit_template()
+
     ## end hooks
 
     def _guess_group_type(self, expecting_name=False):
@@ -291,7 +294,7 @@ class GroupController(BaseController):
 
         self._setup_template_variables(context, data, group_type=group_type)
         c.form = render(self._group_form(group_type), extra_vars=vars)
-        return render('group/edit.html')
+        return render(self._edit_template(c.group.type))
 
     def _get_group_type(self, id):
         """

--- a/ckan/lib/plugins.py
+++ b/ckan/lib/plugins.py
@@ -341,9 +341,16 @@ class DefaultGroupForm(object):
     def history_template(self):
         """
         Returns a string representing the location of the template to be
-        rendered for the read page
+        rendered for the history page
         """
         return 'group/history.html'
+
+    def edit_template(self):
+        """
+        Returns a string representing the location of the template to be
+        rendered for the edit page
+        """
+        return 'group/edit.html'
 
 
     def group_form(self):

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -638,6 +638,12 @@ class IGroupForm(Interface):
         rendered for the history page
         """
 
+    def edit_template(self):
+        """
+        Returns a string representing the location of the template to be
+        rendered for the edit page
+        """
+
     def package_form(self):
         """
         Returns a string representing the location of the template to be

--- a/ckanext/organizations/forms.py
+++ b/ckanext/organizations/forms.py
@@ -102,6 +102,13 @@ class OrganizationForm(SingletonPlugin):
         """
         return 'organization_history.html'
 
+    def edit_template(self):
+        """
+        Returns a string representing the location of the template to be
+        rendered for the edit page
+        """
+        return 'organization_edit.html'
+
     def group_form(self):
         """
         Returns a string representing the location of the template to be

--- a/ckanext/organizations/templates/organization_edit.html
+++ b/ckanext/organizations/templates/organization_edit.html
@@ -1,0 +1,16 @@
+<html xmlns:py="http://genshi.edgewall.org/"
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  py:strip="">
+
+  <py:def function="page_title">Edit: ${c.group.display_name}</py:def>
+  <py:def function="page_heading">Edit: ${c.group.display_name}</py:def>
+  <py:def function="body_class">${h.literal('no-sidebar')}</py:def>
+
+
+  <div py:match="content" class="group-edit-form">
+    ${Markup(c.form)}
+  </div>
+
+  <xi:include href="organization_layout.html" />
+</html>
+


### PR DESCRIPTION
**The branch is based off release-v1.8, it should be merged into release-v1.8 and the commit should be cherry-picked into master**

The link wasn't working, and this option doesn't make any sense when
organizations is enabled, because every dataset must belong to one and
only one organization anyway.

This commit simply removes the link from the organization edit page,
making it consistent with the other organization pages (read etc.)

It was necessary to add the ability to override the group/edit.html
template to the IGroupForm plugin to do this.
