### PR TITLE
2866 Missing key results in strip() being called on None

### DIFF
--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -95,6 +95,8 @@ def send_reset_link(user):
     mail_user(user, _('Reset your password'), body)
 
 def verify_reset_link(user, key):
+    if not key:
+        return False
     if not user.reset_key or len(user.reset_key) < 5:
         return False
     return key.strip() == user.reset_key

--- a/ckan/tests/functional/test_user.py
+++ b/ckan/tests/functional/test_user.py
@@ -965,6 +965,15 @@ class TestUserController(FunctionalTestCase, HtmlCheckMethods, PylonsTestCase, S
                          key='randomness') # i.e. incorrect
         res = self.app.get(offset, status=403) # error
 
+    def test_perform_reset_user_password_link_key_missing(self):
+        CreateTestData.create_user(name='jack', password='test1')
+        user = model.User.by_name(u'jack')
+        offset = url_for(controller='user',
+                         action='perform_reset',
+                         id=user.id)  # not, no key specified
+        res = self.app.get(offset, status=403) # error
+
+
     def test_perform_reset_user_password_link_user_incorrect(self):
         # Make up a key - i.e. trying to hack this
         user = model.User.by_name(u'jack')


### PR DESCRIPTION
When no reset key is present then None is used to verify the key
and it is strip()ed first, resulting in an error.

This pull request contains a test + fix.
