### PR TITLE
[For 1.8] 2867 Fixes a problem with passing unicode to url_for

### DIFF
--- a/ckan/controllers/storage.py
+++ b/ckan/controllers/storage.py
@@ -187,7 +187,7 @@ class StorageController(BaseController):
             fapp = FileApp(filepath, headers=None, **headers)
             return fapp(request.environ, self.start_response)
         else:
-            h.redirect_to(file_url)
+            h.redirect_to(file_url.encode('ascii','ignore'))
 
 
 class StorageAPIController(BaseController):


### PR DESCRIPTION
Forces the file_url to be ascii as it appears that for some reason, and only
occassionally OFS returns unicode instead of str.  We don't want to fix OFS
as it is scheduled for removal and we can't fix routes.

Toby has promised a better fix elsewhere as he has encountered this as well.
