### PR TITLE
[#2872] Fix for non-open licenses appearing open

### DIFF
--- a/ckan/model/license.py
+++ b/ckan/model/license.py
@@ -153,7 +153,11 @@ class DefaultLicense(dict):
     def __getitem__(self, key):
         ''' behave like a dict but get from attributes '''
         if key in self.keys:
-            return unicode(getattr(self, key))
+            value = getattr(self, key)
+            if isinstance(value, str):
+                return unicode(value)
+            else:
+                return value
         else:
             raise KeyError()
 


### PR DESCRIPTION
**Merge into master, then ask Adria to cherry-pick into 1.8**

The 'This dataset is openly licensed' icon was appearing next to
non-open datasets as well. The problem was that DefaultLicense was
returning u"False" (a string) for boolean attributes such as
is_okd_compliant. Change the class so it no longer turns non-string
attributes into unicode strings when you access them.
