### PR TITLE
Add FileStore configuration settings to deployment.ini_tmpl

### DIFF
--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -201,6 +201,8 @@ ckan.feeds.author_link =
 # CKAN allows users to upload files directly to file storage either on the local
 # file system or to online ‘cloud’ storage like Amazon S3 or Google Storage.
 #
+# If you are using local file storage, remember to set ckan.site_url.
+#
 # To enable cloud storage (Google or S3), first run: pip install boto
 #
 # @see http://docs.ckan.org/en/latest/filestore.html

--- a/doc/filestore.rst
+++ b/doc/filestore.rst
@@ -36,6 +36,9 @@ after the ``[app:main]`` line::
    # directory on disk for data storage (should be empty)
    ofs.storage_dir = /my/path/to/storage/root/directory
 
+You must also set ``ckan.site_url`` to your CKAN instance's base URL, e.g.
+``http://scotdata.ckan.net``.
+
 Cloud Storage
 -------------
 


### PR DESCRIPTION
Right now, you need to know to hunt down the docs in http://docs.ckan.org/en/latest/filestore.html. Make it easier on users by adding the configuration settings to the deployment.ini file.
