### PR TITLE
Fix e2073a37 which caused double slashes to occur

### DIFF
--- a/ckan/controllers/storage.py
+++ b/ckan/controllers/storage.py
@@ -270,7 +270,7 @@ class StorageAPIController(BaseController):
                             qualified=False
                             )
             if url.startswith('/'):
-                url = config.get('ckan.site_url','').rstrip('/') + '/' + url
+                url = config.get('ckan.site_url','').rstrip('/') + url
 
         if not self.ofs.exists(bucket, label):
             abort(404)


### PR DESCRIPTION
``` python
if url.startswith('/'):
    url = config.get('ckan.site_url','').rstrip('/') + '/' + url
```

Think about it. url starts with "/". You add a slash before url. What do you get? Double slash! (Which causes URLs to 404 unless your web server automatically reduces multiple consecutive slashes to single slashes).
