### PR TITLE
[#2844] fix simple search for db clean [for 1.8]

### DIFF
--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -233,7 +233,7 @@ def clear(package_reference=None):
         log.debug("Clearing search index for dataset %s..." %
                   package_reference)
         package_index.delete_package({'id': package_reference})
-    else:
+    elif not SIMPLE_SEARCH:
         log.debug("Clearing search index...")
         package_index.clear()
 


### PR DESCRIPTION
Fixes `paster db clean` when simple search enabled
