### PR TITLE
Api user delete

### DIFF
--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -361,9 +361,5 @@ def user_delete(context, data_dict):
 
     _check_access('user_update',context, data_dict)
 
-    #rev = model.repo.new_revision()
-    #rev.author = user
-    #rev.message = _(u'REST API: Delete Package: %s') % entity.name
-
     user_obj.delete()
     model.repo.commit()


### PR DESCRIPTION
Added the possibility to delete a user in the action API.

Call with a POST to `/api/action/user_delete` with a dict `{"id":"username"}`

Authorization is checked against the `user_update` right.
