### PR TITLE
Internal tracking fix backport for 1.8

### DIFF
--- a/ckan/templates/snippets/internal-tracking.html
+++ b/ckan/templates/snippets/internal-tracking.html
@@ -3,6 +3,7 @@
       xmlns:i18n="http://genshi.edgewall.org/i18n"
       xmlns:py="http://genshi.edgewall.org/"
       xmlns:xi="http://www.w3.org/2001/XInclude"
+      py:strip="True"
       >
   <script type="text/javascript">
     $(function (){


### PR DESCRIPTION
stops the html being broken
