### PR TITLE
#2954 - Fixes for data-viewer flickering

### DIFF
--- a/ckan/public/base/javascript/modules/data-viewer.js
+++ b/ckan/public/base/javascript/modules/data-viewer.js
@@ -31,10 +31,7 @@ this.ckan.module('data-viewer', function (jQuery) {
     _recalibrate: function() {
       var height = this.el.contents().find('body').outerHeight(true);
       height = Math.max(height, this.options.minHeight);
-      var deltaHeight = height - (this.el.height() - this.options.padding);
-      if (deltaHeight > 1 || deltaHeight < -10) {
-        this.el.css('height', height + this.options.padding);
-      }
+      this.el.css('height', height + this.options.padding);
     },
 
     // firefox caches iframes so force it to get fresh content


### PR DESCRIPTION
Essentially the flickering was caused by the `jQuery.animate` function making rendering a little weird. Therefore I removed them and replaced them with `jQuery.css` mentions. This is slightly better behaviour as well.

I also made sure we were using `.outerHeight()` instead of `.height()` as `.outerHeight()` includes padding within it and therefore is a more accurate representation of the `body` height.
