### PR TITLE
Bugfix urls to EU-S3 buckets.

### DIFF
--- a/ckan/controllers/storage.py
+++ b/ckan/controllers/storage.py
@@ -262,8 +262,9 @@ class StorageAPIController(BaseController):
         if storage_backend in ['google', 's3']:
             if not label.startswith("/"):
                 label = "/" + label
-            url = "https://%s/%s%s" % (self.ofs.conn.server_name(),
-                                       bucket, label)
+            url = "https://%s%s" % (
+                self.ofs.conn.calling_format.build_host(
+                    self.ofs.conn.server_name(), bucket), label)
         else:
             url = h.url_for('storage_file',
                             label=label,


### PR DESCRIPTION
If you try to address EU-buckets with http://s3.amazonaws.com/bucket/
you get:
    The bucket you are attempting to access must be addressed using
    the specified endpoint. Please send all future requests to this
    endpoint.

Thats why we should let underlying infrastructure form the url as it
might know this kind if things.
