### PR TITLE
[#2811] Show dataset author and maintainer names even if they have no emails

### DIFF
--- a/ckan/lib/package_saver.py
+++ b/ckan/lib/package_saver.py
@@ -33,31 +33,12 @@ class PackageSaver(object):
         c.pkg_url_link = h.link_to(url, url, rel='foaf:homepage', target='_blank') \
                 if url else _("No web page given")
 
-        if pkg.get('author') and pkg.get('author_email'):
-            c.pkg_author_link = cls._person_email_link(
-                    name=pkg['author'], email=pkg['author_email'],
-                    reference="Author")
-        elif pkg.get('author'):
-            c.pkg_author_link = pkg['author']
-        elif pkg.get('author_email'):
-            c.pkg_author_link = cls._person_email_link(
-                    name=pkg['author_email'], email=pkg['author_email'],
-                    reference="Author")
-        else:
-            c.pkg_author_link = _("Author not given")
-
-        if pkg.get('maintainer') and pkg.get('maintainer_email'):
-            c.pkg_maintainer_link = cls._person_email_link(
-                    name=pkg['maintainer'], email=pkg['maintainer_email'],
-                    reference="Maintainer")
-        elif pkg.get('maintainer'):
-            c.pkg_maintainer_link = pkg['maintainer']
-        elif pkg.get('maintainer_email'):
-            c.pkg_maintainer_link = cls._person_email_link(
-                    name=pkg['maintainer_email'],
-                    email=pkg['maintainer_email'], reference="Maintainer")
-        else:
-            c.pkg_maintainer_link = _("Maintainer not given")
+        c.pkg_author_link = cls._person_email_link(
+                name=pkg.get('author'), email=pkg.get('author_email'),
+                fallback=_("Author not given"))
+        c.pkg_maintainer_link = cls._person_email_link(
+                name=pkg.get('maintainer'), email=pkg.get('maintainer_email'),
+                fallback=_("Maintainer not given"))
 
         c.package_relationships = context['package'].get_relationships_printable()
         c.pkg_extras = []
@@ -119,9 +100,12 @@ class PackageSaver(object):
         return errors
 
     @classmethod
-    def _person_email_link(cls, name, email, reference):
-        assert email
-        return h.mail_to(email_address=email, name=name or email, encode='hex')
+    def _person_email_link(cls, name, email, fallback):
+        if email:
+            return h.mail_to(email_address=email, name=name or email,
+                    encode='hex')
+        else:
+            return name or fallback
 
 class WritePackageFromBoundFieldset(object):
 


### PR DESCRIPTION
Dataset author and maintainer names were not being shown on the dataset
read page unless the dataset's author_email and maintainer_email fields
were also filled out (in CKAN 2.0 author and maintainer are simply not
shown, in 1.8 and 1.7 it actually says incorrectly 'No author given' or
'No maintainer given').

Change this behaviour so that:
1. Author/maintainer is not shown if neither author/maintainer nor
   author_email/maintainer_email is filled out
2. If only author/maintainer is filled out (no email) just show the name
3. If only email is filled then use the email as both link text and
   mailto: href
4. If both name and email are given then use name as link text and email
   as mailto: href
