### PR TITLE
Remove duplicate debug setting from deployment.ini_tmpl

### DIFF
--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -8,6 +8,10 @@
 # Change debug to true when doing CKAN development, it enables Pylons'
 # interactive debugging tool, makes Fanstatic serve unminified JS and CSS
 # files, and enables CKAN templates' debugging features.
+#   
+# WARNING: *THIS SETTING MUST BE SET TO FALSE ON A PRODUCTION ENVIRONMENT*
+# Debug mode will enable the interactive debugging tool, allowing ANYONE to
+# execute malicious code after an exception is raised.
 debug = false
 
 email_to = you@yourdomain.com


### PR DESCRIPTION
deployement.ini_tmpl had debug = true at the top and then set debug =
false further down was overriding it. Set debug only once. Also since
this is deployment.ini_tmpl make the default debug = false and tell
people to set it true for development, not vice-versa.
