### PR TITLE
[#3003] New pg databases should be created with UTF8 encoding rather than system...

### DIFF
--- a/ckan_deb/usr/lib/ckan/common.sh
+++ b/ckan_deb/usr/lib/ckan/common.sh
@@ -155,7 +155,7 @@ ckan_ensure_db_exists () {
         COMMAND_OUTPUT=`sudo -u postgres psql -c "select datname from pg_database where datname='$INSTANCE'"`
         if ! [[ "$COMMAND_OUTPUT" =~ ${INSTANCE} ]] ; then
             echo "Creating the database ..."
-            sudo -u postgres createdb -O ${INSTANCE} ${INSTANCE}
+            sudo -u postgres createdb -O ${INSTANCE} ${INSTANCE} -E utf-8 -l en_US.utf8 -T template0
             paster --plugin=ckan db init --config=/etc/ckan/${INSTANCE}/${INSTANCE}.ini
         fi
     fi


### PR DESCRIPTION
... default, which might be something unhelpful like latin1
