### PR TITLE
Add resource-url-analytics CSS class to 'Raw Data' links

### DIFF
--- a/ckan/templates/package/snippets/resource_item.html
+++ b/ckan/templates/package/snippets/resource_item.html
@@ -15,6 +15,6 @@
   </p>
   <p class="btn-group">
     <a class="btn btn-primary" href="{{ url }}">{{ _('Explore Data') }}</a>
-    <a class="btn" href="{{ res.url }}" target="_blank">{{ _('Raw Data') }}</a>
+    <a class="btn resource-url-analytics" href="{{ res.url }}" target="_blank">{{ _('Raw Data') }}</a>
   </p>
 </li>


### PR DESCRIPTION
ckanext-googleanalytics uses the resource-url-analytics CSS class to
find links to add Google Analytics Event Tracking to. The Download links
on resource read pages already have this class. Add it to the Raw Data
links next to the resources on dataset read pages as well.

If there are any other places where there are resource download links the class should be added there as well.

Alternatively we could reject this and make ckanext-googleanalytics find the resource download links in a more complex way.
