### PR TITLE
#3015 - Fixes header in order to allow for dropdown to work without javascript

### DIFF
--- a/ckan/public/base/less/bootstrap-fixes.less
+++ b/ckan/public/base/less/bootstrap-fixes.less
@@ -1,0 +1,6 @@
+// Shows dropdown menu by default
+// ... and re-forces it to show on .open
+.dropdown-menu,
+.js .open .dropdown-menu {
+	display: block;
+}

--- a/ckan/public/base/less/ckan.less
+++ b/ckan/public/base/less/ckan.less
@@ -17,6 +17,7 @@
 @import "activity.less";
 @import "popover-context.less";
 @import "follower-list.less";
+@import "bootstrap-fixes.less";
 
 body {
   // Using the masthead/footer gradient prevents the color from changing

--- a/ckan/templates/header.html
+++ b/ckan/templates/header.html
@@ -21,7 +21,7 @@
             {{ h.gravatar((c.userobj.email_hash if c and c.userobj else ''),size=25) }}
             <i class="icon-caret-down"></i>
           </a>
-          <ul class="dropdown-menu pull-right" role="menu">
+          <ul id="user-menu" class="dropdown-menu pull-right js-hide" role="menu">
             <li>
               <a href="{{ h.url_for(controller='user', action='dashboard') }}">
                 <i class="icon-dashboard"></i> {{ _('Dashboard') }}


### PR DESCRIPTION
Simple fix for header dropdown (when logged in) to allow for clients without JS to see the dropdown links.
