### PR TITLE
ckan-create-instance broken! use pip install instead of easy_install

### DIFF
--- a/ckan_deb/usr/lib/ckan/common.sh
+++ b/ckan_deb/usr/lib/ckan/common.sh
@@ -178,7 +178,7 @@ ckan_create_wsgi_handler () {
             sudo -u ckan${INSTANCE} /var/lib/ckan/${INSTANCE}/pyenv/bin/easy_install --upgrade "pip>=1.0" "pip<=1.0.99"
             echo "done."
             echo "Attempting to install 'paster' pypi.python.org into pyenv ..."
-            sudo -u ckan${INSTANCE} /var/lib/ckan/${INSTANCE}/pyenv/bin/easy_install --ignore-installed "pastescript"
+            sudo -u ckan${INSTANCE} /var/lib/ckan/${INSTANCE}/pyenv/bin/pip install --ignore-installed "pastescript"
             echo "done."
             cat <<- EOF > /var/lib/ckan/${INSTANCE}/packaging_version.txt
 	1.5


### PR DESCRIPTION
Does it make sense to pull this into master? Also in branches release1.8 or release-1.8.1, i.e. will there be a 1.8.x or 1.9 as APT release? 
