### PR TITLE
[#3026] Support icon param on nav_named_link helper function

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -332,6 +332,11 @@ def _link_class(kwargs):
 
 def nav_named_link(text, name, **kwargs):
     class_ = _link_class(kwargs)
+
+    icon = kwargs.pop('icon', None)
+    if icon:
+        text = literal('<i class="icon-large icon-%s"></i> ' % icon) + text
+
     return link_to(
         text,
         url_for(name, **kwargs),


### PR DESCRIPTION
@tobes a quick one for you when you have a chance.

nav_named_link won't include the nice icon even when passing the icon keyword param.

BTW. nav_link and nav_named_link seem to be sharing some code, perhaps make them call a common function once the url is generated?
