### PR TITLE
Make recently_changed_packages_activity_stream a helper

### DIFF
--- a/ckan/controllers/home.py
+++ b/ckan/controllers/home.py
@@ -104,11 +104,6 @@ class HomeController(BaseController):
             if msg:
                 h.flash_notice(msg, allow_html=True)
 
-        @property
-        def recently_changed_packages_activity_stream():
-            return ckan.logic.action.get.recently_changed_packages_activity_list_html(context, {})
-        c.recently_changed_packages_activity_stream = recently_changed_packages_activity_stream
-
         # START OF DIRTYNESS
         def get_group(id):
             def _get_group_type(id):

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1190,6 +1190,13 @@ def dashboard_activity_stream(user_id):
                                                             {'id': user_id})
 
 
+def recently_changed_packages_activity_stream():
+    import ckan.logic as logic
+    context = {'model': model, 'session': model.Session, 'user': c.user}
+    return logic.get_action('recently_changed_packages_activity_list_html')(
+            context, {})
+
+
 def escape_js(str_to_escape):
     '''Escapes special characters from a JS string.
 
@@ -1381,6 +1388,7 @@ __allowed_functions__ = [
            'add_url_param',
            'groups_available',
            'dashboard_activity_stream',
+           'recently_changed_packages_activity_stream',
            'escape_js',
            'get_pkg_dict_extra',
            'get_request_param',


### PR DESCRIPTION
@tobes Could you review this please? Unless I missed something 
`recently_changed_packages_activity_stream` was not working at all the way it was done. Either way, this is probably better.

Assuming you're happy with this, then perhaps other activity streams (dataset pages, group pages, user profile pages) should be moved to helper functions as well. I could also add tests for the helper functions, but they are just trivial wrappers of logic action functions.

---

`recently_changed_packages_activity_stream` was an `@property` of the
`HomeController`, but it wasn't working, accessing the property just
printed out a property object e.g. `<property object at 0x7f7210087e68>` not
the HTML string as desired.

I think this is because the `@property` was declared inside a method, and
properties only work at class-level.

The `@property` cannot simply be moved to class level because it uses
`context`, a param of the `index()` method it was defined in.

Instead move `recently_changed_packages_activity_stream` into `helpers.py`,
where any template (not just the front page) can access it like this:

```
{{ h.recently_changed_packages_activity_stream() }}
```

`dashboard_activity_stream` is already done the same way (but other
activity streams are not).

This means any existing `home/index.html` templates that were accessing
`recently_changed_packages_activity_stream` as an attribute of the
template context itself, will no longer work. However, apparently they
weren't working anyway.
