### PR TITLE
[ec] Paster command, "user add", uses defers to action layer.

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -578,9 +578,12 @@ class UserCmd(CkanCommand):
       user                            - lists users
       user list                       - lists users
       user <user-name>                - shows user properties
-      user add <user-name> [apikey=<apikey>] [password=<password>]
-                                      - add a user (prompts for password if
-                                        not supplied)
+      user add <user-name> [<field>=<value>]
+                                      - add a user (prompts for password
+                                        if not supplied).
+                                        Field can be: apikey
+                                                      password
+                                                      email
       user setpass <user-name>        - set user password (prompts)
       user remove <user-name>         - removes user from users
       user search <query>             - searches for a user name


### PR DESCRIPTION
Rather than directly creating the User, which as a consequence will bypass
any custom validation.
(cherry picked from commit e664c459f5d78987d3923ec138a3727b474272ea)
