### PR TITLE
Added ISearchFacets plugin interface

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -248,7 +248,7 @@ class PackageController(BaseController):
                           'tags': _('Tags'),
                           'res_format': _('Formats'),
                           'license': _('Licence'), }
-        for plugin in plugins.PluginImplementations(plugins.ISearchFacets):
+        for plugin in plugins.PluginImplementations(plugins.IPackageController):
             c.facet_titles = plugin.update_facet_titles(c.facet_titles)
 
 

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -16,7 +16,6 @@ __all__ = [
     'IGroupForm',
     'ITagController',
     'ITemplateHelpers',
-    'ISearchFacets',
 ]
 
 from inspect import isclass
@@ -297,6 +296,18 @@ class IPackageController(Interface):
         '''
 
         return search_results
+        
+    def update_facet_titles(self, facet_titles):
+        '''
+            Update the dictionary mapping facet names to facet titles.
+            
+            Example: {'facet_name': 'The title of the facet'}
+            
+            Called after the search operation was performed and 
+            before the search page will be displayed.
+            The titles show up on the search page.
+        '''
+        return facet_titles
 
     def before_index(self, pkg_dict):
         '''
@@ -671,20 +682,3 @@ class IGroupForm(Interface):
         """
 
     ##### End of hooks                                                   #####
-
-
-class ISearchFacets(Interface):
-    '''
-    Allow (re-)defining facet titles.
-    Additional SOLR facets should be added to
-    the 'search.facets' config via the IConfigurer interface.
-    '''
-    def update_facet_titles(self, facet_titles):
-        '''
-        Update the dictionary mapping facet names to facet titles.
-        Example: {'facet_name': 'The title of the facet'}
-        Called after the serach operations are performed and 
-        before the search page will be displayed.
-        The titles show up on the search page.
-        '''
-


### PR DESCRIPTION
This commit added a new plugin interface: ISearchFacets.
This interface will allow extensions to manipulate the search facet titles displayed on the search page.
