### PR TITLE
Added fields_to_hidden

### DIFF
--- a/ckan/templates/macros/form.html
+++ b/ckan/templates/macros/form.html
@@ -337,10 +337,10 @@ except       - list of name-value pairs to be excluded
 
 
 Example:
-    {% form.hidden(fields=c.fields, except=[('topic', 'xyz')]) %}
-    {% form.hidden(fields=c.fields, except_names=['time_min', 'time_max']) %}
+    {% form.hidden_from_list(fields=c.fields, except=[('topic', 'xyz')]) %}
+    {% form.hidden_from_list(fields=c.fields, except_names=['time_min', 'time_max']) %}
 #}
-{% macro hidden_list(fields, except_names=None, except=None) %}
+{% macro hidden_from_list(fields, except_names=None, except=None) %}
   {% set except_names = except_names or [] %}
   {% set except = except or [] %}
 

--- a/ckan/templates/package/search.html
+++ b/ckan/templates/package/search.html
@@ -20,7 +20,7 @@
 
         {% if c.fields -%}
           <span>
-            {{ form.hidden_list(fields=c.fields) }}
+            {{ form.hidden_from_list(fields=c.fields) }}
           </span>
         {%- endif %}
 


### PR DESCRIPTION
This add the ability to create a list of input type=hidden fields out of a list of name-value pairs.
[('k1', 'n1'), ('k21, 'n2'), ...]
two additional parameters add flexibility to filter out the inadequate pairs (except_names and except)

Additionally, the application is shown via the regular search interface by replacing a piece of code.

This pull request is essential for subscriptions coming in a subsequent pull request.
