### PR TITLE
[Trivial] Remove some lines of code that have somehow crept back in during some merges

### DIFF
--- a/ckan/lib/app_globals.py
+++ b/ckan/lib/app_globals.py
@@ -172,10 +172,6 @@ class _Globals(object):
                 self._mutex.release()
 
     def _init(self):
-        self.favicon = config.get('ckan.favicon', '/images/icons/ckan.ico')
-        facets = config.get('search.facets', 'groups tags res_format license capacity')
-        self.facets = facets.split()
-
         # process the config_details to set globals
         for name, options in config_details.items():
             if 'name' in options:


### PR DESCRIPTION
This is a trivial fix to remove some lines of code that are unwanted.

These items are pulled out of the config and defined in lib.app_globals.config_details dict
