### PR TITLE
[Trivial] Minor cleanup of model_dictize.py

### DIFF
--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -1,10 +1,8 @@
 import datetime
 from pylons import config
 from sqlalchemy.sql import select
-import datetime
 import ckan.authz
-import ckan.model
-import ckan.misc
+import ckan.misc as misc
 import ckan.logic as logic
 import ckan.plugins as plugins
 import ckan.lib.helpers as h
@@ -486,7 +484,7 @@ def package_to_api(pkg, context):
     dictized['license'] = pkg.license.title if pkg.license else None
     dictized['ratings_average'] = pkg.get_average_rating()
     dictized['ratings_count'] = len(pkg.ratings)
-    dictized['notes_rendered'] = ckan.misc.MarkdownFormat().to_html(pkg.notes)
+    dictized['notes_rendered'] = misc.MarkdownFormat().to_html(pkg.notes)
 
     site_url = config.get('ckan.site_url', None)
     if site_url:


### PR DESCRIPTION
datetime is imported twice

ckan.model is never used

ckan.misc imported as misc as it makes it easier to catch unused imports
