### PR TITLE
[#238] Don't commit on package_owner_org_update when calling it from pac...

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -149,9 +149,10 @@ def package_create(context, data_dict):
     # Needed to let extensions know the package id
     model.Session.flush()
 
-    context_no_auth = context.copy()
-    context_no_auth['ignore_auth'] = True
-    _get_action('package_owner_org_update')(context_no_auth,
+    context_org_update = context.copy()
+    context_org_update['ignore_auth'] = True
+    context_org_update['defer_commit'] = True
+    _get_action('package_owner_org_update')(context_org_update,
                                             {'id': pkg.id,
                                              'organization_id': pkg.owner_org})
 

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -267,9 +267,10 @@ def package_update(context, data_dict):
 
     pkg = model_save.package_dict_save(data, context)
 
-    context_no_auth = context.copy()
-    context_no_auth['ignore_auth'] = True
-    _get_action('package_owner_org_update')(context_no_auth,
+    context_org_update = context.copy()
+    context_org_update['ignore_auth'] = True
+    context_org_update['defer_commit'] = True
+    _get_action('package_owner_org_update')(context_org_update,
                                             {'id': pkg.id,
                                              'organization_id': pkg.owner_org})
 
@@ -1069,4 +1070,5 @@ def package_owner_org_update(context, data_dict):
                                   state='active')
         model.Session.add(member_obj)
 
-    model.Session.commit()
+    if not context.get('defer_commit'):
+        model.Session.commit()


### PR DESCRIPTION
When calling package_owner_org_update a commit is fired, which triggers the notify hook. This will cause the dataset to be indexed before it is passed to extensions. We should pass a defer_commit flag on the context object.
