### PR TITLE
[#236] Stripped tags from description fields from within popovers

### DIFF
--- a/ckan/templates/ajax_snippets/popover_context_dataset.html
+++ b/ckan/templates/ajax_snippets/popover_context_dataset.html
@@ -1,5 +1,6 @@
 <div class="popover-context profile-info">
 	{% if notes != 'null' %}
+		{% set notes = notes|striptags %}
 		<p class="about">
 			{{ h.truncate(notes, length=160, whole_word=True) }}
 		</p>

--- a/ckan/templates/ajax_snippets/popover_context_group.html
+++ b/ckan/templates/ajax_snippets/popover_context_group.html
@@ -1,5 +1,6 @@
 <div class="popover-context profile-info">
-	{% if notes != 'null' %}
+	{% if description != 'null' %}
+		{% set description = description|striptags %}
 		<p class="about">
 			{{ h.truncate(description, length=160, whole_word=True) }}
 		</p>

--- a/ckan/templates/ajax_snippets/popover_context_user.html
+++ b/ckan/templates/ajax_snippets/popover_context_user.html
@@ -1,5 +1,6 @@
 <div class="popover-context profile-info">
 	{% if about != 'null' %}
+		{% set about = about|striptags %}
 		<p class="about">
 			{{ h.truncate(about, length=160, whole_word=True) }}
 		</p>


### PR DESCRIPTION
Just adds `|striptags` to descriptions within popovers in order to prevent HTML from appearing within the popover.
