### PR TITLE
268 datastore setup instructions don't work

### DIFF
--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -52,7 +52,8 @@ app_instance_uuid = ${app_instance_uuid}
 # List the names of CKAN extensions to activate.
 # Note: This line is required to be here for packaging, even if it is empty.
 # Note: Add ``pdf_preview`` to enable the resource preview for PDFs
-#		Add the resource_proxy plugin to enable resorce proxying and get around the same origin policy
+#		Add the ``resource_proxy`` plugin to enable resorce proxying and get around the same origin policy
+#       Add ``datastore`` to enable the CKAN DataStore extension
 ckan.plugins = stats json_preview recline_preview
 
 # If you'd like to fine-tune the individual locations of the cache data dirs
@@ -68,8 +69,8 @@ sqlalchemy.url = postgresql://ckanuser:pass@localhost/ckantest
 #sqlalchemy.url = sqlite:///
 #sqlalchemy.url = sqlite:///%(here)s/somedb.db
 
-# Datastore
-# Uncommment to set the datastore urls
+# Un-comment and specify the URLs for the DataStore database.
+# * Postgres is required
 #ckan.datastore.write_url = postgresql://ckanuser:pass@localhost/datastore
 #ckan.datastore.read_url = postgresql://readonlyuser:pass@localhost/datastore
 

--- a/ckanext/datastore/bin/datastore_setup.py
+++ b/ckanext/datastore/bin/datastore_setup.py
@@ -16,14 +16,14 @@ def _run_cmd(command_line, inputstring=''):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE)
     stdout_value, stderr_value = p.communicate(input=inputstring)
-    if stderr_value:
+    if stderr_value or p.returncode:
         print '\nAn error occured: {0}'.format(stderr_value)
         sys.exit(1)
 
 
 def _run_sql(sql, as_sql_user, database='postgres'):
     logging.debug("Executing: \n#####\n", sql, "\n####\nOn database:", database)
-    _run_cmd("sudo -u '{username}' psql --dbname='{database}' -W".format(
+    _run_cmd("sudo -u '{username}' psql --dbname='{database}' --set ON_ERROR_STOP=1".format(
         username=as_sql_user,
         database=database
     ), inputstring=sql)

--- a/doc/datastore-setup.rst
+++ b/doc/datastore-setup.rst
@@ -112,7 +112,13 @@ Copy the ``set_permissions.sql`` file to the server that the database runs on. M
 3. Test the set-up
 ==================
 
-The datastore is now set-up. To test the set-up you can create a new DataStore. To do so you can run the following command::
+The DataStore is now set-up. To test the set-up you can list all resources that are in the DataStore::
+
+ curl -X GET "http://127.0.0.1:5000/api/3/action/datastore_search?resource_id=_table_metadata"
+
+This should return a JSON page without errors.
+
+To test the whether the set-up allows writing you can create a new resource in the DataStore. To do so, run the following command::
 
  curl -X POST http://127.0.0.1:5000/api/3/action/datastore_create -H "Authorization: {YOUR-API-KEY}" -d '{"resource_id": "{RESOURCE-ID}", "fields": [ {"id": "a"}, {"id": "b"} ], "records": [ { "a": 1, "b": "xyz"}, {"a": 2, "b": "zzz"} ]}'
 

--- a/doc/install-from-source.rst
+++ b/doc/install-from-source.rst
@@ -172,7 +172,19 @@ You should see ``Initialising DB: SUCCESS``.
 
         paster --plugin=ckan db init --config=test.ckan.net.ini
 
-7. Create the data and sstore directories
+7. Set up the DataStore
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note ::
+  Setting up the DataStore is optional. However, if you do skip this step,
+  the :doc:`DataStore features<datastore>` will not be available and the
+  DataStore tests will fail.
+
+Follow the instructions in :doc:`datastore-setup` to create the required
+databases and users, set the right permissions and set the appropriate values
+in your CKAN config file.
+
+8. Create the data and sstore directories
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Create the ``data`` and ``sstore`` directories, in the same directory that
@@ -188,7 +200,7 @@ the ``who.ini`` file.
 The location of the ``data`` directory, which CKAN uses as its Pylons cache, is
 is specified by the ``cache_dir`` setting in your CKAN config file.
 
-8. Link to who.ini
+9. Link to who.ini
 ~~~~~~~~~~~~~~~~~~
 
 ``who.ini`` (the Repoze.who configuration file) needs to be accessible in the
@@ -198,7 +210,7 @@ symbolic link to ``who.ini``. e.g.::
 
     ln -s ~/pyenv/src/ckan/who.ini
 
-9. Run CKAN in the development web server
+10. Run CKAN in the development web server
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can use the Paste development server to serve CKAN from the command-line.
@@ -219,13 +231,13 @@ front page.
  `w3m` in a separate ssh session to the one running `paster serve`.
 
 
-10. Run the CKAN Tests
+11. Run the CKAN Tests
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Now that you've installed CKAN, you should run CKAN's tests to make sure that
 they all pass. See :doc:`test`.
 
-11. You're done!
+12. You're done!
 ~~~~~~~~~~~~~~~~
 
 You can now proceed to :doc:`post-installation` which covers creating a CKAN


### PR DESCRIPTION
Corresponding issue: https://github.com/okfn/ckan/issues/268

@amercader @domoritz Suggest one of you probably wants to review this

What I'm trying to do here is make it so that if someone follows the source install instructions and then the datastore setup instructions and just copy-pastes all the commands, and just uncomments the lines from the default ini file without changing them, everything should work. Currently it's not the case but I think this pull request mostly fixes it.

I also tried to move unnecessary waffle, keep it short and sweet, people just want datastore to work asap (from a CKAN user's point of view, it's infuriating that CKAN doesn't just "store data" by default without needing any further setup, since they do need further setup let's try and keep it as short and simple as possible)

This can be reviewed not but **let's not merge this one quite yet**, I'd like to wait for an answer to [this email thread](http://lists.okfn.org/pipermail/ckan-dev/2013-January/003695.html), and also to test stepping through the source install instructions followed by the new datastore setup instructions on a fresh Ubuntu VM to make sure there are no more problems.
