### PR TITLE
270 Different sysadmins won't get the list of all organizations

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -456,6 +456,14 @@ def organization_list_for_user(context, data_dict):
     user = context['user']
 
     _check_access('organization_list_for_user',context, data_dict)
+    sysadmin = new_authz.is_sysadmin(user)
+
+    orgs_q = model.Session.query(model.Group) \
+        .filter(model.Group.is_organization == True) \
+        .filter(model.Group.state == 'active')
+
+    if sysadmin:
+        return [{'id':org.id,'name':org.name} for org in orgs_q.all()]
 
     permission = data_dict.get('permission', 'edit_group')
 
@@ -471,6 +479,7 @@ def organization_list_for_user(context, data_dict):
         .filter(model.Member.table_name == 'user') \
         .filter(model.Member.capacity.in_(roles)) \
         .filter(model.Member.table_id == user_id)
+
     group_ids = []
     for row in q.all():
         group_ids.append(row.group_id)
@@ -478,10 +487,8 @@ def organization_list_for_user(context, data_dict):
     if not group_ids:
         return []
 
-    q = model.Session.query(model.Group) \
-        .filter(model.Group.id.in_(group_ids)) \
-        .filter(model.Group.is_organization == True) \
-        .filter(model.Group.state == 'active')
+    q = orgs_q.filter(model.Group.id.in_(group_ids))
+
     return [{'id':org.id,'name':org.name} for org in q.all()]
 
 def group_revision_list(context, data_dict):


### PR DESCRIPTION
@tobes a quick one for you. See issue #270 for details.

If a diferent sysadmin than the one who created the organizations requests `organization_list_for_user`, they will get an empty list (thus not showing the orgs selector on the dataset form)
