### PR TITLE
Make package item extensible

### DIFF
--- a/ckan/templates/snippets/package_item.html
+++ b/ckan/templates/snippets/package_item.html
@@ -19,6 +19,7 @@ Example:
 {% set notes = h.markdown_extract(package.notes, extract_length=truncate) %}
 
 <li class="{{ item_class or "dataset-item" }}">
+  {% block package_item_content %}
   <div class="dataset-content">
     <h3 class="dataset-heading">
       {{ h.link_to(h.truncate(title, truncate_title), h.url_for(controller='package', action='read', id=package.name)) }}
@@ -47,4 +48,5 @@ Example:
       {% endfor %}
     </ul>
   {% endif %}
+  {% endblock %}
 </li>


### PR DESCRIPTION
Adds a new block in the snippet package_item in order to let extensions extend search results and other package items.
