### PR TITLE
Do not create coverage report and make travis run all tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
   - paster --plugin=ckan db init
   - sed -i -e 's/ -W//g' ckanext/datastore/bin/datastore_setup.py
   - paster datastore set-permissions postgres
-script: "nosetests --ckan ckan && nosetests --ckan --with-pylons=test-core.ini --nologcapture --cover-package=ckanext.datastore ckanext/datastore/tests -x"
+script: "nosetests --ckan ckan && nosetests --ckan --with-pylons=test-core.ini --nologcapture ckanext/datastore/tests"
 notifications:
   irc:
     channels:


### PR DESCRIPTION
Removing the `--cover-package=ckanext.datastore` will prevent coverage reports. This makes tests run faster.

Removig the `-x` option will run all tests not just until one test fails. This allows us to see what is broken.
