### PR TITLE
[wip] Can't delete related item tests

### DIFF
--- a/ckan/controllers/related.py
+++ b/ckan/controllers/related.py
@@ -212,11 +212,6 @@ class RelatedController(base.BaseController):
                    'user': c.user or c.author}
 
         try:
-            logic.check_access('related_delete', context, {'id': id})
-        except logic.NotAuthorized:
-            base.abort(401, _('Unauthorized to delete package %s') % '')
-
-        try:
             if base.request.method == 'POST':
                 logic.get_action('related_delete')(context, {'id': related_id})
                 h.flash_notice(_('Related item has been deleted.'))


### PR DESCRIPTION
I created a related item on a dataset on publicdata.eu:

http://publicdata.eu/dataset/-ausgewaehlte-volkswirtschaftliche-kennziffern-2002-2010/related

When I then try to delete it, (> edit > delete), I get a confirmation popup, then a 500 internal server error. The item is not deleted.
