### PR TITLE
DataProxy did not respond after 5 seconds

### DIFF
--- a/ckanext/reclinepreview/theme/public/preview_recline.js
+++ b/ckanext/reclinepreview/theme/public/preview_recline.js
@@ -39,6 +39,8 @@ this.ckan.module('reclinepreview', function (jQuery, _) {
           .html(msg);
       }
 
+      recline.Backend.DataProxy.timeout = 10000;
+
       // 2 situations
       // a) something was posted to the datastore - need to check for this
       // b) csv or xls (but not datastore)

--- a/ckanext/reclinepreview/theme/public/vendor/recline/recline.js
+++ b/ckanext/reclinepreview/theme/public/vendor/recline/recline.js
@@ -423,7 +423,7 @@ this.recline.Backend.DataProxy = this.recline.Backend.DataProxy || {};
   my.dataproxy_url = 'http://jsonpdataproxy.appspot.com';
   // Timeout for dataproxy (after this time if no response we error)
   // Needed because use JSONP so do not receive e.g. 500 errors 
-  my.timeout = 10000;
+  my.timeout = 5000;
 
   // ## load
   //


### PR DESCRIPTION
I really think we should change the default timeout from 5 to 10s or more, as I get a lot of users of different CKAN sites telling me that data preview does not work because they get this error
