### PR TITLE
#243 Popovers work in activity streams after load more

### DIFF
--- a/ckan/public/base/javascript/modules/activity-stream.js
+++ b/ckan/public/base/javascript/modules/activity-stream.js
@@ -113,7 +113,10 @@ this.ckan.module('activity-stream', function($, _) {
 			options.offset += 30;
 			$('.load-less', result).remove();
 			$('.load-more', this.el).remove();
-			$('li', result).appendTo(this.el);
+			var items = $('li', result).appendTo(this.el);
+			$('[data-module="popover-context"]', items).each(function() {
+				ckan.module.initializeElement(this);
+			});
 			this._onBuildLoadMore();
 			options.loading = false;
 		}


### PR DESCRIPTION
Does exactly what it says on the tin. Essentially whenever the more activity stream items get loaded into the page we re-initialize all the `[data-module="popover"]`s within the list.
