### PR TITLE
Accessibility standards require <th scope='row|col'> attributes (again, now for CKAN 2)

### DIFF
--- a/ckan/templates/admin/authz.html
+++ b/ckan/templates/admin/authz.html
@@ -14,9 +14,9 @@
       {% endfor %}
     </colgroup>
     <tr>
-      <th>{{ _('User') }}</th>
+      <th scope="col">{{ _('User') }}</th>
       {% for role in roles %}
-      <th> {{ role }} </th>
+      <th scope="col"> {{ role }} </th>
       {% endfor %}
     </tr>
     {% for user in users %}
@@ -49,9 +49,9 @@
       {% endfor %}
     </colgroup>
     <tr>
-      <th>{{ _('User') }}</th>
+      <th scope="col">{{ _('User') }}</th>
       {% for role in roles %}
-        <th> {{ role }} </th>
+        <th scope="col"> {{ role }} </th>
       {% endfor %}
     </tr>
     <tr>
@@ -77,9 +77,9 @@
       {% endfor %}
     </colgroup>
     <tr>
-      <th>{{ _('User Group') }}</th>
+      <th scope="col">{{ _('User Group') }}</th>
       {% for role in roles %}
-      <th> {{ role }} </th>
+      <th scope="col"> {{ role }} </th>
       {% endfor %}
     </tr>
     {% for user in users %}
@@ -112,9 +112,9 @@
       {% endfor %}
     </colgroup>
     <tr>
-      <th>User Group</th>
+      <th scope="col">User Group</th>
       {% for role in roles %}
-      <th> {{ role }} </th>
+      <th scope="col"> {{ role }} </th>
       {% endfor %}
     </tr>
     <tr>

--- a/ckan/templates/ajax_snippets/api_info.html
+++ b/ckan/templates/ajax_snippets/api_info.html
@@ -39,19 +39,19 @@ Example
             <thead></thead>
             <tbody>
               <tr>
-                <th>Create</th>
+                <th scope="row">Create</th>
                 <td><code>{{ datastore_root_url }}/datastore_create</code></td>
               </tr>
               <tr>
-                <th>Update / Insert</th>
+                <th scope="row">Update / Insert</th>
                 <td><code>{{ datastore_root_url }}/datastore_upsert</code></td>
               </tr>
               <tr>
-                <th>Query</th>
+                <th scope="row">Query</th>
                 <td><code>{{ datastore_root_url }}/datastore_search</code></td>
               </tr>
               <tr>
-                <th>Query (via SQL)</th>
+                <th scope="row">Query (via SQL)</th>
                 <td><code>{{ datastore_root_url }}/datastore_search_sql</code></td>
               </tr>
 

--- a/ckan/templates/organization/members.html
+++ b/ckan/templates/organization/members.html
@@ -11,9 +11,9 @@
       <col width="15" />
       <thead>
         <tr>
-          <th>{{ _('User') }}</th>
-          <th>{{ _('Role') }}</th>
-          <th></th>
+          <th scope="col">{{ _('User') }}</th>
+          <th scope="col">{{ _('Role') }}</th>
+          <th scope="col"></th>
         </tr>
       </thead>
       <tbody>

--- a/ckan/templates/package/resource_read.html
+++ b/ckan/templates/package/resource_read.html
@@ -79,13 +79,13 @@
           <table class="table table-striped table-bordered table-condensed">
             <thead>
               <tr>
-                <th>Field</th>
-                <th>Value</th>
+                <th scope="col">Field</th>
+                <th scope="col">Value</th>
               </tr>
             </thead>
             <tbody>
               {% for key, value in h.format_resource_items(res.items()) %}
-                <tr><th>{{ key }}</th><td>{{ value }}</td></tr>
+                <tr><th scope="row">{{ key }}</th><td>{{ value }}</td></tr>
               {% endfor %}
             </tbody>
           </table>

--- a/ckan/templates/package/snippets/additional_info.html
+++ b/ckan/templates/package/snippets/additional_info.html
@@ -3,52 +3,52 @@
   <table class="table table-striped table-bordered table-condensed">
     <thead>
       <tr>
-        <th>{{ _('Field') }}</th>
-        <th>{{ _('Value') }}</th>
+        <th scope="col">{{ _('Field') }}</th>
+        <th scope="col">{{ _('Value') }}</th>
       </tr>
     </thead>
     <tbody>
       {% if pkg_dict.url %}
         <tr>
-          <th class="dataset-label">{{ _('Source') }}</th>
+          <th scope="row" class="dataset-label">{{ _('Source') }}</th>
           <td class="dataset-details" property="foaf:homepage">{{ h.link_to(pkg_dict.url, pkg_dict.url, rel='foaf:homepage', target='_blank') }}</td>
         </tr>
       {% endif %}
 
       {% if pkg_dict.author_email %}
         <tr>
-          <th class="dataset-label">{{ _("Author") }}</th>
+          <th scope="row" class="dataset-label">{{ _("Author") }}</th>
           <td class="dataset-details" property="dc:creator">{{ h.mail_to(email_address=pkg_dict.author_email, name=pkg_dict.author) }}</td>
         </tr>
       {% elif pkg_dict.author %}
         <tr>
-          <th class="dataset-label">{{ _("Author") }}</th>
+          <th scope="row" class="dataset-label">{{ _("Author") }}</th>
           <td class="dataset-details" property="dc:creator">{{ pkg_dict.author }}</td>
         </tr>
       {% endif %}
 
       {% if pkg_dict.maintainer_email %}
         <tr>
-          <th class="dataset-label">{{ _('Maintainer') }}</th>
+          <th scope="row" class="dataset-label">{{ _('Maintainer') }}</th>
           <td class="dataset-details" property="dc:contributor">{{ h.mail_to(email_address=pkg_dict.maintainer_email, name=pkg_dict.maintainer) }}</td>
         </tr>
       {% elif pkg_dict.maintainer %}
         <tr>
-          <th class="dataset-label">{{ _('Maintainer') }}</th>
+          <th scope="row" class="dataset-label">{{ _('Maintainer') }}</th>
           <td class="dataset-details" property="dc:contributor">{{ pkg_dict.maintainer }}</td>
         </tr>
       {% endif %}
 
       {% if pkg_dict.version %}
         <tr>
-          <th class="dataset-label">{{ _("Version") }}</th>
+          <th scope="row" class="dataset-label">{{ _("Version") }}</th>
           <td class="dataset-details">{{ pkg_dict.version }}</td>
         </tr>
       {% endif %}
 
       {% if h.check_access('package_update',{'id':pkg_dict.id}) %}
         <tr>
-          <th class="dataset-label">{{ _("State") }}</th>
+          <th scope="row" class="dataset-label">{{ _("State") }}</th>
           <td class="dataset-details">{{ pkg_dict.state }}</td>
         </tr>
       {% endif %}
@@ -56,7 +56,7 @@
       {% for extra in h.sorted_extras(pkg_dict.extras) %}
         {% set key, value = extra %}
         <tr rel="dc:relation" resource="_:extra{{ i }}">
-          <th class="dataset-label" property="rdfs:label">{{ _(key) }}</th>
+          <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key) }}</th>
           <td class="dataset-details" property="rdf:value">{{ value }}</td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
I first submitted this in pull request #124 (commit 50aad8db481e75d2a9d99d1cf86da99b6397ef2f against CKAN 1.7) which @amercader re-submitted in pull request #129, which was applied to release-v1.8, but it was never applied to the new templates in master.

This is a requirement for U.S. federal government websites (or at least ours), so it's a blocker for the HealthData.gov project.

Sorry about submitting this against release-v2.0 rather than against master. Keeping all of the branches straight is tricky...
