### PR TITLE
Create a publisher mode that does not allow any new user registrations

### DIFF
--- a/ckan/logic/auth/create.py
+++ b/ckan/logic/auth/create.py
@@ -99,7 +99,8 @@ def user_create(context, data_dict=None):
     user = context['user']
 
     if ('api_version' in context
-            and not new_authz.check_config_permission('create_user_via_api')):
+            and not new_authz.check_config_permission('create_user_via_api')) \
+            or not new_authz.check_config_permission('create_user'):
         return {'success': False, 'msg': _('User %s not authorized to create users') % user}
     else:
         return {'success': True}

--- a/ckan/new_authz.py
+++ b/ckan/new_authz.py
@@ -243,6 +243,7 @@ CONFIG_PERMISSIONS_DEFAULTS = {
     'user_delete_groups': True,
     'user_delete_organizations': True,
     'create_user_via_api': False,
+    'create_user': True,
 }
 
 CONFIG_PERMISSIONS = {}

--- a/doc/organizations_and_groups.rst
+++ b/doc/organizations_and_groups.rst
@@ -230,6 +230,7 @@ The following config options have been created.
 ckan.auth.user_create_organizations
 ckan.auth.user_create_groups
 
+ckan.auth.create_user
 ckan.auth.create_user_via_api
 ckan.auth.create_dataset_if_not_in_organization
 


### PR DESCRIPTION
This patch adds a new option ckan.auth.create_user which when set to true prevents all new user registrations (via site and API). It is false by default.

This is useful in a setup where the site should take no unauthorized user input.

We can't deploy CKAN 2 without this at HealthData.gov.
