### PR TITLE
deleted packages (state=deleted) cannot be read by the owner

### DIFF
--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -96,7 +96,7 @@ def package_show(context, data_dict):
     package = get_package_object(context, data_dict)
     # draft state indicates package is still in the creation process
     # so we need to check we have creation rights.
-    if package.state.startswith('draft'):
+    if package.state.startswith('draft') or package.state == 'deleted':
         auth = new_authz.is_authorized('package_update',
                                        context, data_dict)
         authorized = auth.get('success')


### PR DESCRIPTION
This causes the v1/2 REST package update API to fail with access denied because after successfully updating the package, the user no longer has permission to read it to generate the dict-like response.

Revised the auth logic to treat 'deleted' like 'draft', meaning only editors can read these packages.

Maybe there's a better way to do this.
