### PR TITLE
379 Data API button not shown (g.plugins empty)

### DIFF
--- a/ckan/lib/app_globals.py
+++ b/ckan/lib/app_globals.py
@@ -49,7 +49,7 @@ config_details = {
                       'type': 'split',
                       'name': 'facets'},
     'package_hide_extras': {'type': 'split'},
-    'plugins': {'type': 'split'},
+    'ckan.plugins': {'type': 'split'},
 
     # bool
     'openid_enabled': {'default': 'true', 'type' : 'bool'},


### PR DESCRIPTION
On the resource page, the "Data API" button is never shown even if the datastore plugin is activated. That's because g.plugins seems to be empty.

```
  {% if 'datastore' in g.plugins %}
    <li>{% snippet 'package/snippets/data_api_button.html', resource=res, datastore_root_url=c.datastore_api %}</li>
  {% endif %}
```
