### PR TITLE
Fix for using harvesters with organization setup

### DIFF
--- a/ckanext/organizations/forms.py
+++ b/ckanext/organizations/forms.py
@@ -247,6 +247,29 @@ class OrganizationDatasetForm(SingletonPlugin):
         schema['__after'] = [group_required]
         return schema
 
+    def form_to_db_schema_options(self, options):
+        ''' This allows us to select different schemas for different
+        purpose eg via the web interface or via the api or creation vs
+        updating. It is optional and if not available form_to_db_schema
+        should be used.
+        If a context is provided, and it contains a schema, it will be
+        returned.
+        '''
+        schema = options.get('context', {}).get('schema', None)
+        if not schema:
+            if options.get('api'):
+                if options.get('type') == 'create':
+                    schema = self.form_to_db_schema_api_create()
+                else:
+                    assert options.get('type') == 'update'
+                    schema = self.form_to_db_schema_api_update()
+            else:
+                schema = self.form_to_db_schema()
+
+        schema['groups']['capacity'] = [ignore_missing, unicode]
+        schema['__after'] = [group_required]
+        return schema
+
     def check_data_dict(self, data_dict, schema=None):
         '''Check if the return data is correct, mostly for checking out
         if spammers are submitting only part of the form'''


### PR DESCRIPTION
With organization setup the harvesting process raises a ValidationError exception

```
2013-02-13 11:18:21,670 DEBUG [ckanext.patstatweb.harvesters] In PatStatWebHarvester fetch_stage
2013-02-13 11:18:21,981 DEBUG [ckanext.patstatweb.harvesters] In PatStatWebHarvester import_stage
2013-02-13 11:18:22,357 INFO  [ckanext.harvest.harvesters.base] Package with GUID 9d15e19d1b17ac432dd704542a384304f7a37992 does not exist, let's create it
2013-02-13 11:18:22,384 ERROR [ckanext.harvest.harvesters.base] {'  junk': 'The input field __junk was not expected.'}
Traceback (most recent call last):
  File "/home/ckan/pyenv/src/ckanext-harvest/ckanext/harvest/harvesters/base.py", line 165, in _create_or_update_package
    new_package = get_action('package_create_rest')(context, package_dict)
  File "/home/ckan/pyenv/src/ckan/ckan/logic/action/create.py", line 723, in     package_create_rest
    dictized_after = _get_action('package_create')(context, dictized_package)
  File "/home/ckan/pyenv/src/ckan/ckan/logic/action/create.py", line 137, in package_create
    raise ValidationError(errors)
ValidationError: {'  junk': 'The input field __junk was not expected.'}
2013-02-13 11:18:22,392 ERROR [ckanext.harvest.harvesters.base] Invalid package with GUID 9d15e19d1b17ac432dd704542a384304f7a37992: {'__junk': ['The input field __junk was not expected.']}
```

This was caused by the absence of `form_to_db_schema_options` so it fallbacks to `form_to_db_schema` that doesn't take care of the context (that was patched by the harvester plugin, see https://github.com/okfn/ckanext-harvest/blob/master/ckanext/harvest/harvesters/base.py#L117)
