### PR TITLE
The redirect after renaming redirects to a page that does not exist

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -981,6 +981,7 @@ class PackageController(BaseController):
                     context, data_dict)
             c.pkg = context['package']
             c.pkg_dict = pkg
+
             self._form_save_redirect(pkg['name'], 'edit', package_type=package_type)
         except NotAuthorized:
             abort(401, _('Unauthorized to read package %s') % id)


### PR DESCRIPTION
If a user rename a dataset, he/ she should be redirected to the dataset page. However, one finds him-/ herself on a page that does not exist.
