### PR TITLE
DB migration scripts are noisy

### DIFF
--- a/ckan/migration/versions/027_adjust_harvester.py
+++ b/ckan/migration/versions/027_adjust_harvester.py
@@ -1,26 +1,31 @@
+import warnings
+
+from sqlalchemy import exc as sa_exc
 from sqlalchemy import *
 from migrate import *
 import migrate.changeset
 
-
 def upgrade(migrate_engine):
-    metadata = MetaData()
-    metadata.bind = migrate_engine
+    # ignore reflection warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=sa_exc.SAWarning)
+        metadata = MetaData()
+        metadata.bind = migrate_engine
 
-    harvest_source_table = Table('harvest_source', metadata, autoload=True)
-    package_table = Table('package', metadata, autoload=True)
+        harvest_source_table = Table('harvest_source', metadata, autoload=True)
+        package_table = Table('package', metadata, autoload=True)
 
-    harvested_document_table = Table('harvested_document', metadata,
-        Column('url', UnicodeText, nullable=False),
-        Column('guid', UnicodeText, default=u''),
-        Column('source_id', UnicodeText, ForeignKey('harvest_source.id')),
-        Column('package_id', UnicodeText, ForeignKey('package.id')),
-    )
+        harvested_document_table = Table('harvested_document', metadata,
+            Column('url', UnicodeText, nullable=False),
+            Column('guid', UnicodeText, default=u''),
+            Column('source_id', UnicodeText, ForeignKey('harvest_source.id')),
+            Column('package_id', UnicodeText, ForeignKey('package.id')),
+        )
 
-    harvested_document_table.c.url.drop()
-    harvested_document_table.c.guid.create(harvested_document_table)
-    harvested_document_table.c.source_id.create(harvested_document_table)
-    harvested_document_table.c.package_id.create(harvested_document_table)
+        harvested_document_table.c.url.drop()
+        harvested_document_table.c.guid.create(harvested_document_table)
+        harvested_document_table.c.source_id.create(harvested_document_table)
+        harvested_document_table.c.package_id.create(harvested_document_table)
 
 def downgrade(migrate_engine):
     raise NotImplementedError()

--- a/ckan/migration/versions/045_user_name_unique.py
+++ b/ckan/migration/versions/045_user_name_unique.py
@@ -1,11 +1,17 @@
+import warnings
+
+from sqlalchemy import exc as sa_exc
 from sqlalchemy import *
 from migrate import *
 from migrate.changeset.constraint import UniqueConstraint
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
-    metadata.bind = migrate_engine
-    user_table = Table('user', metadata, autoload=True)
-#    name_column = user_table.c.name
-    unique_name_constraint = UniqueConstraint('name', table=user_table)
-    unique_name_constraint.create()
+    # ignore reflection warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=sa_exc.SAWarning)
+        metadata = MetaData()
+        metadata.bind = migrate_engine
+        user_table = Table('user', metadata, autoload=True)
+    #    name_column = user_table.c.name
+        unique_name_constraint = UniqueConstraint('name', table=user_table)
+        unique_name_constraint.create()


### PR DESCRIPTION
some newer version files cause sa warnings - these should be cleaned up.  It may be difficult to determine which files cause the issue but then easy to resolve.
