### PR TITLE
Data Hub: Automatic prepending of http:// to resource URLs breaks FTP and Git URLs

### DIFF
--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -1,5 +1,5 @@
 import datetime
-import re
+import urlparse
 
 from pylons import config
 from sqlalchemy.sql import select
@@ -12,7 +12,6 @@ import ckan.lib.dictization as d
 import ckan.new_authz as new_authz
 import ckan.lib.search as search
 
-RE_URL_SCHEME = re.compile('^[a-zA-Z][a-zA-Z0-9+.-]*:')
 ## package save
 
 def group_list_dictize(obj_list, context,
@@ -145,8 +144,8 @@ def resource_dictize(res, context):
     resource['format'] = _unified_resource_format(res.format)
     # some urls do not have the protocol this adds http:// to these
     url = resource['url']
-    if not RE_URL_SCHEME.match(url):
-        resource['url'] = u'http://' + url
+    if not urlparse.urlsplit(url).scheme:
+        resource['url'] = u'http://' + url.lstrip('/')
     return resource
 
 def related_dictize(rel, context):


### PR DESCRIPTION
On the Data Hub, when a resource is edited and saved, and the URL of the resource does _not_ start with `http://`, then `http://` is automatically prepended before the URL is saved. This is probably done so that `www.myserver.com/myresource` is automatically turned into `http://www.myserver.com/myresource`. But it breaks URLs that use any protocol other than HTTP, for example FTP or Git. As a result, URLs like this are common on the Data Hub:
- http://ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/rdf/
- http://git://eculture.cs.vu.nl/home/git/econnect/metadata/AHM.git

The solution is to check for the presence of a _scheme_ in the URL, not simply for the presence of `http`. The following regex matches any valid scheme according to RFC 3986:

```
^[a-zA-Z][a-zA-Z0-9+.-]*:
```

If it doesn't match, then prepending `http://` is probably reasonable. Otherwise, it is most definitely not.
