### PR TITLE
Deprecation warning in default set up

### DIFF
--- a/ckan/lib/maintain.py
+++ b/ckan/lib/maintain.py
@@ -29,7 +29,7 @@ def deprecated(message=''):
                             'It must include the word `deprecated`.'
                             % (fn.__name__, fn.__module__))
         # Log deprecated functions
-        log.info('Function %s() in module %s has been deprecated. %s'
+        log.debug('Function %s() in module %s has been deprecated. %s'
                             % (fn.__name__, fn.__module__, message))
 
         def wrapped(*args, **kw):


### PR DESCRIPTION
There is a deprecation warning when running CKAN with `paster serve development.ini`

```
[ckan.lib.maintain] Function subnav_named_route() in module lib.helpers has been deprecated. h.subnav_named_route is deprecated please use h.nav_named_link
```
