### PR TITLE
Replace all gravatar http URLs with https URLs

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -687,7 +687,7 @@ def gravatar(email_hash, size=100, default=None):
         # treat the default as a url
         default = urllib.quote(default, safe='')
 
-    return literal('''<img src="http://gravatar.com/avatar/%s?s=%d&amp;d=%s"
+    return literal('''<img src="//gravatar.com/avatar/%s?s=%d&amp;d=%s"
         class="gravatar" width="%s" height="%s" />'''
         % (email_hash, size, default, size, size)
         )

--- a/ckan/tests/functional/test_pagination.py
+++ b/ckan/tests/functional/test_pagination.py
@@ -20,11 +20,11 @@ def scrape_search_results(response, object_type):
 def test_scrape_user():
     html = '''
           <li class="username">
-          <img src="http://gravatar.com/avatar/d41d8cd98f00b204e9800998ecf8427e?s=16&amp;d=http://test.ckan.net/images/icons/user.png" /> <a href="/user/user_00">user_00</a>
+          <img src="//gravatar.com/avatar/d41d8cd98f00b204e9800998ecf8427e?s=16&amp;d=http://test.ckan.net/images/icons/user.png" /> <a href="/user/user_00">user_00</a>
           </li>
           ...
           <li class="username">
-          <img src="http://gravatar.com/avatar/d41d8cd98f00b204e9800998ecf8427e?s=16&amp;d=http://test.ckan.net/images/icons/user.png" /> <a href="/user/user_01">user_01</a>
+          <img src="//gravatar.com/avatar/d41d8cd98f00b204e9800998ecf8427e?s=16&amp;d=http://test.ckan.net/images/icons/user.png" /> <a href="/user/user_01">user_01</a>
           </li>
 
       '''

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -81,7 +81,7 @@ class TestHelpers(TestController):
     def test_gravatar(self):
         email = 'zephod@gmail.com'
         expected = ['<a href="https://gravatar.com/"',
-                '<img src="http://gravatar.com/avatar/7856421db6a63efa5b248909c472fbd2?s=200&amp;d=mm"', '</a>']
+                '<img src="//gravatar.com/avatar/7856421db6a63efa5b248909c472fbd2?s=200&amp;d=mm"', '</a>']
         # Hash the email address
         import hashlib
         email_hash = hashlib.md5(email).hexdigest()
@@ -94,7 +94,7 @@ class TestHelpers(TestController):
         email = 'zephod@gmail.com'
         default = config.get('ckan.gravatar_default', 'identicon')
         expected = ['<a href="https://gravatar.com/"',
-                   '<img src="http://gravatar.com/avatar/7856421db6a63efa5b248909c472fbd2?s=200&amp;d=%s"' % default,
+                   '<img src="//gravatar.com/avatar/7856421db6a63efa5b248909c472fbd2?s=200&amp;d=%s"' % default,
                    '</a>']
         # Hash the email address
         import hashlib
@@ -108,7 +108,7 @@ class TestHelpers(TestController):
         email = 'zephod@gmail.com'
         default = 'http://example.com/images/avatar.jpg'
         expected = ['<a href="https://gravatar.com/"',
-                   '<img src="http://gravatar.com/avatar/7856421db6a63efa5b248909c472fbd2?s=200&amp;d=http%3A%2F%2Fexample.com%2Fimages%2Favatar.jpg"',
+                   '<img src="//gravatar.com/avatar/7856421db6a63efa5b248909c472fbd2?s=200&amp;d=http%3A%2F%2Fexample.com%2Fimages%2Favatar.jpg"',
                    '</a>']
         # Hash the email address
         import hashlib


### PR DESCRIPTION
If the site is deployed under https the insecure gravatar image will prevent the browser from showing a nice green logo. It's a no-brainer to use https here, especially when the link to gravatar that is present in the code is already https.
