### PR TITLE
[#294] Add default values to migration 64

### DIFF
--- a/ckan/migration/versions/064_add_email_last_sent_column.py
+++ b/ckan/migration/versions/064_add_email_last_sent_column.py
@@ -6,5 +6,5 @@ def upgrade(migrate_engine):
     metadata.bind = migrate_engine
     migrate_engine.execute('''
 ALTER TABLE dashboard
-    ADD COLUMN email_last_sent timestamp without time zone NOT NULL;
+    ADD COLUMN email_last_sent timestamp without time zone NOT NULL DEFAULT LOCALTIMESTAMP;
     ''')


### PR DESCRIPTION
Add a default value to the email_last_sent column that is added in
migration script 64. This fixes a crash when upgrading the database, if
the dashboard table already contained data.

Fixes #294.

To reproduce this you have to checkout a commit from just before migration script 64 was added (one where the dashboard table exists, but doesn't have the email_last_sent column yet), initialise your db, run ckan, register a user, follow something, then checkout master and run paster db upgrade, it'll crash. With this fix, it works.

Migration tests are passing too.
