### PR TITLE
[#445] Only lookup strings in term translation table

### DIFF
--- a/ckanext/multilingual/plugin.py
+++ b/ckanext/multilingual/plugin.py
@@ -124,14 +124,11 @@ class MultilingualDataset(SingletonPlugin):
         for key, value in search_data.iteritems():
             if key in KEYS_TO_IGNORE or key.startswith('title'):
                 continue
-            if isinstance(value, list):
-                for item in value:
-                    if isinstance(item, basestring):
-                        all_terms.append(item)
-            elif not isinstance(value, basestring):
-                continue
-            else:
-                all_terms.append(value)
+            if not isinstance(value, list):
+                value = [value]
+            for item in value:
+                if isinstance(item, basestring):
+                    all_terms.append(item)
 
         field_translations = action_get.term_translation_show(
                           {'model': ckan.model},


### PR DESCRIPTION
This fixes the multilingual tests that are currently failing on master.

It seems that when the multilingual extension was written, package dicts
never contained ints as values. Now they do. But postgres cannot compare
an int to a string so it crashes. This commit changes the multilingual
plugin so that it only tries to lookup strings in the term translation
table, other types are just skipped.

Fixes #445.
