### PR TITLE
Add debug = false to test-core.ini

### DIFF
--- a/test-core.ini
+++ b/test-core.ini
@@ -9,6 +9,7 @@ port = 5000
 
 [app:main]
 use = config:development.ini
+debug = false
 
 #faster_db_test_hacks = True
 #sqlalchemy.url = sqlite:///


### PR DESCRIPTION
This fixes a couple of tests (in the pdfpreview and jsonpreview
extensions) that would fail if you had debug = true in your
development.ini, because the tests look for the presence of minified
files that are only present with debug = false.

This seems like a good thing to do anyway, regardless of these failing
tests.
