### PR TITLE
Support for named routes + dataset types on _make_menu_item

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -440,13 +440,12 @@ def _make_menu_item(menu_item, title, **kw):
     item = copy.copy(_menu_items[menu_item])
     item.update(kw)
     active =  _link_active(item)
-    controller = item.pop('controller')
     needed = item.pop('needed')
     for need in needed:
         if need not in kw:
             raise Exception('menu item `%s` need parameter `%s`'
                             % (menu_item, need))
-    link = nav_link(title, controller, suppress_active_class=True, **item)
+    link = nav_named_link(title, menu_item, suppress_active_class=True, **item)
     if active:
         return literal('<li class="active">') + link + literal('</li>')
     return literal('<li>') + link + literal('</li>')


### PR DESCRIPTION
Background: when bulding a nav link for a named url for a dataset type, the returned URL is that of the main dataset type not the custom,eg

When calling this:

```
h.build_nav_icon('harvest_source_edit', _('Edit'), id=source.name, icon='edit')
```

you get this:

http://localhost:5000/dataset/edit/dsadasdasdas

instead of this:

http://localhost:5000/harvest_source/edit/dsadasdasdas

Eventually, `build_nav_icon` goes to `_make_menu_item` which according to the apidocs:

```
    :param menu_item: the name of the defined menu item defined in
    config/routing as the named route of the same name
```

So it would make sense that it called `nav_named_link` instead of `nav_link` (see PR)

(aside: it seems to me that the whole bunch of helper functions for creating links are a bit confusing and could be much simplified, but that may be another issue)
