### PR TITLE
[#446] Accept either .min.js or .js in ckanext/*preview tests

### DIFF
--- a/ckanext/jsonpreview/tests/test_preview.py
+++ b/ckanext/jsonpreview/tests/test_preview.py
@@ -83,12 +83,12 @@ class TestJsonPreview(tests.WsgiAppCase):
         result = self.app.get(url, status='*')
 
         assert result.status == 200, result.status
-        assert (('preview_json.js' in result.body) or ('preview_json.min.js' in result.body)), result.body
-        assert 'preload_resource' in result.body, result.body
-        assert 'data-module="jsonpreview"' in result.body, result.body
+        assert (('preview_json.js' in result.body) or ('preview_json.min.js' in result.body))
+        assert 'preload_resource' in result.body
+        assert 'data-module="jsonpreview"' in result.body
 
     def test_iframe_is_shown(self):
         url = h.url_for(controller='package', action='resource_read', id=self.package.name, resource_id=self.resource['id'])
         result = self.app.get(url)
-        assert 'data-module="data-viewer"' in result.body, result.body
-        assert '<iframe' in result.body, result.body
+        assert 'data-module="data-viewer"' in result.body
+        assert '<iframe' in result.body

--- a/ckanext/pdfpreview/tests/test_preview.py
+++ b/ckanext/pdfpreview/tests/test_preview.py
@@ -86,12 +86,12 @@ class TestPdfPreview(tests.WsgiAppCase):
         result = self.app.get(url, status='*')
 
         assert result.status == 200, result.status
-        assert (('preview_pdf.js' in result.body) or ('preview_pdf.min.js' in result.body)), result.body
-        assert 'preload_resource' in result.body, result.body
-        assert 'data-module="pdfpreview"' in result.body, result.body
+        assert (('preview_pdf.js' in result.body) or ('preview_pdf.min.js' in result.body))
+        assert 'preload_resource' in result.body
+        assert 'data-module="pdfpreview"' in result.body
 
     def test_iframe_is_shown(self):
         url = h.url_for(controller='package', action='resource_read', id=self.package.name, resource_id=self.resource['id'])
         result = self.app.get(url)
-        assert 'data-module="data-viewer"' in result.body, result.body
-        assert '<iframe' in result.body, result.body
+        assert 'data-module="data-viewer"' in result.body
+        assert '<iframe' in result.body

--- a/ckanext/reclinepreview/tests/test_preview.py
+++ b/ckanext/reclinepreview/tests/test_preview.py
@@ -115,12 +115,12 @@ class TestJsonPreview(tests.WsgiAppCase):
         result = self.app.get(url, status='*')
 
         assert result.status == 200, result.status
-        assert (('preview_recline.js' in result.body) or ('preview_recline.min.js' in result.body)), result.body
-        assert 'preload_resource' in result.body, result.body
-        assert 'data-module="reclinepreview"' in result.body, result.body
+        assert (('preview_recline.js' in result.body) or ('preview_recline.min.js' in result.body))
+        assert 'preload_resource' in result.body
+        assert 'data-module="reclinepreview"' in result.body
 
     def test_iframe_is_shown(self):
         url = h.url_for(controller='package', action='resource_read', id=self.package.name, resource_id=self.resource['id'])
         result = self.app.get(url)
-        assert 'data-module="data-viewer"' in result.body, result.body
-        assert '<iframe' in result.body, result.body
+        assert 'data-module="data-viewer"' in result.body
+        assert '<iframe' in result.body


### PR DESCRIPTION
We don't care if the page which one is added to the page, as long as
one of them is there.

Fixes #446.
