### PR TITLE
Upgrade requests version to 1.1.0

### DIFF
--- a/ckanext/resourceproxy/controller.py
+++ b/ckanext/resourceproxy/controller.py
@@ -18,7 +18,7 @@ def proxy_resource(context, data_dict):
         url = resource['url']
 
         try:
-            r = requests.get(url, prefetch=False)
+            r = requests.get(url)
             r.raise_for_status()
 
             # write body

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -27,4 +27,4 @@ routes==1.13
 paste==1.7.5.1
 Jinja2==2.6
 fanstatic==0.12
-requests==0.14
+requests==1.1.0


### PR DESCRIPTION
Reasons:
- Starting from 1.0.0, requests will have a stable API which didn't have up until now, also it included several fixes and enhancements
- requests requirement was added after 1.8 so it shouldn't break any applications built on the latest stable release
- The new spatial harvesters require this newer version, keeping an older one in core will cause a lot of pain

The only supported extensions that I know to be using requests are:
- resource_preview (core)
- datastorer
- archiver

For all of those I've done the necessary changes and updates, which will get pushed if this gets merged to master
