### PR TITLE
[#491] Add WebTest==1.4.3 to our pip-requirements.txt

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -28,3 +28,4 @@ paste==1.7.5.1
 Jinja2==2.6
 fanstatic==0.12
 requests==0.14
+WebTest==1.4.3


### PR DESCRIPTION
WebTest >= 2.0 requires WebOb>=1.2, but we have WebOb==1.0.8 in our
requirements.txt (and we need it), so we're stuck with an older WebTest
version.

Fixes #491.
