### PR TITLE
#498 Able to add groups to dataset

### DIFF
--- a/ckan/public/base/javascript/client.js
+++ b/ckan/public/base/javascript/client.js
@@ -163,15 +163,16 @@
       var raw = jQuery.isArray(data) ? data : data.ResultSet && data.ResultSet.Result || {};
 
       var items = jQuery.map(raw, function (item) {
-        item = typeof item === 'string' ? item : item.name || item.Name || item.Format || '';
-        item = jQuery.trim(item);
+        var text = typeof item === 'string' ? item : item.title ||item.name || item.Name || item.Format || '';
+        text = jQuery.trim(text);
+        var id = typeof item.id != 'undefined' ? item.id : text;
 
-        var lowercased = item.toLowerCase();
+        var lowercased = text.toLowerCase();
         var returnObject = options && options.objects === true;
 
         if (lowercased && !map[lowercased]) {
           map[lowercased] = 1;
-          return returnObject ? {id: item, text: item} : item;
+          return returnObject ? {id: id, text: text} : text;
         }
 
         return null;

--- a/ckan/templates/package/snippets/package_metadata_fields.html
+++ b/ckan/templates/package/snippets/package_metadata_fields.html
@@ -41,7 +41,7 @@
         </div>
       </div>
     {% endif %}
-    {% set group_name = 'groups__%s__name' % data.groups|length %}
+    {% set group_name = 'groups__%s__id' % data.groups|length %}
     {% set group_attrs = {'data-module': 'autocomplete', 'data-module-source': '/api/2/util/group/autocomplete?q=?'} %}
     {{ form.input(group_name, label=_('Add Group'), id="field-group", value=data[group_name], classes=['control-medium'], attrs=group_attrs) }}
   {% endblock %}


### PR DESCRIPTION
Fixes #498 

Essentially the fix is that it was trying to add new groups by 'name'. Which the select2 box wasn't selecting on. Therefore I've made it so that select2 autocomplete ajax callbacks now format results with an id if they are within the response.

:boom:
