### PR TITLE
[wip] First stab at updating the CHANGELOG for 2.0

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,61 +1,73 @@
 CKAN CHANGELOG
 ++++++++++++++
 
-v2.0
-====
+v2.0 2013-05-10
+===============
 
-Note: In the v2.0 changelog issue numbers with four digits refer to
- trac.ckan.org tickets and issue numbers with three digits refer to GitHub
- issues. For example:
+.. note:: Starting on v2.0, issue numbers with four digits refer to the old
+ ticketing system at http://trac.ckan.org and the ones with three digits refer
+ to GitHub issues. For example:
 
-    - #3020 is http://trac.ckan.org/ticket/3020
-    - #271 is https://github.com/okfn/ckan/issues/271
+ * #3020 is http://trac.ckan.org/ticket/3020
+ * #271 is https://github.com/okfn/ckan/issues/271
 
  Some GitHub issues URLs will redirect to GitHub pull request pages.
 
-Note: v2.0 is a huge release so the changes listed here are just the
-highlights. Bug fixes are not listed.
+.. note:: v2.0 is a huge release so the changes listed here are just the
+ highlights. Bug fixes are not listed.
 
 Note: This version requires a requirements upgrade on source installations
+
 Note: This version requires a database upgrade
+
 Note: This version requires a Solr schema upgrade
 
-New frontend:
+Organizations based authorization (see :doc:`authorization`):
+ CKAN's new "organizations" feature replaces the old authorization system
+ with a new one based on publisher organizations. It replaces the "Publisher
+ Profile and Workflow" feature from CKAN 1.X, any instances relying on it will
+ need to be updated.
 
- * CKAN's frontend has been completely redesigned, inside and out
-   (#2375 and many other tickets)
-   - New default theme
-   - CSS "primer" page for theme developers
-   - We're now using LESS for CSS (new `paster less` command to build the CSS
-     files from the less source files, also see `paster front-end-build`)
-   - Scalable font icons (#2563)
-   - We've moved from Genshi to Jinja templates
-     - Block-based template inheritance
-     - Custom jinja tags:
-       - {% ckan_extends %} (#2503)
-       - {% snippet %} and {% url_for %} (#2502)
-    - Social sharing buttons (google plus, facebook, twitter)
-      (this replaces the ckanext-social extension)
-    - Three-stage dataset creation form (#2501)
+ * New organization-based authorization and organization of datasets
+ * Supports private datasets
+ * Publisher workflow
+ * New authorization ini file options
+
+
+New frontend (see :doc:`theming`):
+ CKAN's frontend has been completely redesigned, inside and out. There is
+ a new default theme and the template engine has moved from Genshi to
+ Jinja2. Any custom templates using Genshi will need to be updated, although
+ there is a :ref:`ckan.legacy_templates` setting to aid in the migration.
+
+ * Block-based template inheritance
+ * Custom jinja tags: {% ckan_extends %}, {% snippet %} and {% url_for %} (#2502, #2503)
+ * CSS "primer" page for theme developers
+ * We're now using LESS for CSS
+ * Scalable font icons (#2563)
+ * Social sharing buttons (google plus, facebook, twitter)
+   (this replaces the ckanext-social extension)
+ * Three-stage dataset creation form (#2501)
  * New `paster front-end-build` command does everything needed to build the
    frontend for a production CKAN site (runs `paster less` to compile the css
    files, `paster minify` to minify the css and js files, etc.)
- * Mocha JavaScript test suite added at /base/test,
-   e.g.: http://beta.ckan.org/base/test
 
-Organizations:
-
-This replaces the "Publisher Profile and Workflow" feature from CKAN 1.
-
- * CKAN's new "organizations" feature replaces the old authorization system
-   with a new one based on publisher organizations
-   - New organization-based authorization and organization of datasets
-   - Supports private datasets
-   - Publisher workflow
-   - New authorization ini file options
+Plugins & Extensions:
+ * New plugins toolkit provides a stable set of utility and helper functions
+   for CKAN plugins to depend on.
+ * The IDatasetForm plugin interface has been redesigned (note: this breaks
+   backwards-compatibility with existing IDatasetForm plugins) (#649)
+ * Many IDatasetForm bugs were fixed
+ * New example extensions in core, and better documentation for the relevant
+   plugin interfaces: example_itemplatehelpers (#447),
+   example_idatasetform (#2750), hopefully more to come in 2.1!
+ * New IFacets interface that allows to modify the facets shown on various
+   pages. (#400)
+ * The get_action() function now automatically adds 'model' and 'session' to
+   the context dict (this saves on boiler-plate code, and means plugins don't
+   have to import ckan.model in order to call get_action()) (#172)
 
 Activity Streams, Following & User Dashboard:
-
  * New visual design for activity streams (#2941)
  * Group activity streams now include activities for changes to any of the
    group's datasets (#1664)
@@ -74,17 +86,17 @@ Activity Streams, Following & User Dashboard:
    activities on your dashboard (#1635)
  * Infinite scrolling of activity streams (if you scroll to the bottom of a
    an activity stream, CKAN will automatically load more activities) (#3018)
- * Redesigned user dashboard (#3028)
+ * Redesigned user dashboard (#3028):
+
    - New dropdown-menu enables you to filter you dashboard activity stream to
      show only activities from a particular user, dataset, group or
      organization that you're following
    - New sidebar shows previews and unfollow buttons (when the activity stream
      is filtered)
- * New ``ckan.activity_streams_enabled`` config file setting allows you to
+ * New :ref:`ckan.activity_streams_enabled` config file setting allows you to
    disable the generation of activity streams (#654)
 
 Data Preview:
-
  * PDF files preview (#2203)
  * JSON files preview
  * HTML pages preview (in an iframe) (#2888)
@@ -93,29 +105,12 @@ Data Preview:
  * Improved Recline Data Explorer previews (CSV files, Excel files..)
  * Plain text files preview
 
-Plugins & Extensions:
-
- * The IDatasetForm plugin interface has been redesigned (note: this breaks
-   backwards-compatibility with existing IDatasetForm plugins) (#649)
- * Many IDatasetForm bugs were fixed
- * New example extensions in core, and better documentation for the relevant
-   plugin interfaces: example_itemplatehelpers (#447),
-   example_idatasetform (#2750), hopefully more to come in 2.1!
- * #198 New ISearchFacets plugin interface, allows plugins to manipulate the
-   search facet titles displayed on the search page (#198, srkunze)
- * New plugins toolkit provides a stable set of utility and helper functions
-   for CKAN plugins to depend on
- * The get_action() function now automatically adds 'model' and 'session' to
-   the context dict (this saves on boiler-plate code, and means plugins don't
-   have to import ckan.model in order to call get_action()) (#172)
 
 API:
-
  * The Action API is now CKAN's default API, and the API documentation has
    been rewritten (#357)
 
 Other highlights:
-
  * CKAN now has continuous integration testing at
    https://travis-ci.org/okfn/ckan/
  * Dataset pages now have <link rel="alternate" type="application/rdf+xml"
@@ -130,6 +125,7 @@ Other highlights:
    CSS (#2302, #2781)
  * New `paster color` command for creating color schemes
  * Fanstatic integration (#2371):
+
    - CKAN now uses Fanstatic to specify required static resource files
      (js, css..) for web pages
    - Enables each page to only include the static files that it needs,
@@ -152,7 +148,6 @@ Other highlights:
  * You can now change the sort ordering of datasets on the dataset search page
 
 Deprecated and removed:
-
  * The IGenshiStreamFilter plugin interface is deprecated (#271), use the
    ITemplateHelpers plugin interface instead
  * The Model, Search and Util APIs are deprecated, use the Action API instead
@@ -163,11 +158,23 @@ Deprecated and removed:
    check_access() instead (#2257)
  * Removed deprecated datetime_to_datestr() template helper function (#2257)
 
+
+v1.8.1 2013-05-10
+=================
+
+Bug fixes:
+ * Fixed possible XSS vulnerability on html input (#703)
+ * Fix unicode template 500 error (#808)
+ * Fix error on related controller
+
+
 v1.8 2012-10-19
 ===============
 
 Note: This version requires a requirements upgrade on source installations
+
 Note: This version requires a database upgrade
+
 Note: This version does not require a Solr schema upgrade
 
 Major
@@ -215,6 +222,13 @@ API changes and deprecation:
    `c.facets`) has been superseded by use of the improved facet data structure,
    `c.search_facets`.  The old data structure is still available on `c.facets`,
    but is deprecated, and will be removed in future versions. (#2313)
+
+
+v1.7.3 2013-05-10
+=================
+
+Bug fixes:
+ * Fixed possible XSS vulnerability on html input (#703)
 
 
 v1.7.2 2012-10-19


### PR DESCRIPTION
Probably more to do here..

Questions:
- Anything to add to new frontend?
  Split into user and technical?
- Anything to add to orgs?
- I need to look up summaries of 2.0 changes in recent dev-list emails, may contain something I missed
- Social-sharing buttons: Is it worth putting these in or
  were they already in 1.8? (datahub has them but not sure
  if that was an extension)
- 'Popular' badges on dataset and resource pages:
  I saw these in the git logs but not sure what they are
  or how to use them.
- SSL?
