### PR TITLE
[#369] updating packages to deleted state had permission issues [for 2.0]

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -288,6 +288,8 @@ def package_update(context, data_dict):
 
     return_id_only = context.get('return_id_only', False)
 
+    # we could update the dataset so we should still be able to read it.
+    context['ignore_auth'] = True
     output = data_dict['id'] if return_id_only \
             else _get_action('package_show')(context, {'id': data_dict['id']})
 


### PR DESCRIPTION
This causes the v1/2 REST package update API to fail with access denied
because after successfully updating the package, the user no longer has
permission to read it to generate the dict-like response.

Just allow us to read the updated packeage
