### PR TITLE
GETable actions always need a URL parameter even if not required

### DIFF
--- a/ckan/controllers/api.py
+++ b/ckan/controllers/api.py
@@ -832,8 +832,11 @@ class ApiController(base.BaseController):
                 raise ValueError(msg)
             cls.log.debug('Retrieved request body: %r' % request.body)
             if not request_data:
-                msg = "No request body data"
-                raise ValueError(msg)
+                if not try_url_params:
+                    msg = "No request body data"
+                    raise ValueError(msg)
+                else:
+                    request_data = {}
         if request_data:
             try:
                 request_data = h.json.loads(request_data, encoding='utf8')

--- a/ckan/tests/logic/test_action.py
+++ b/ckan/tests/logic/test_action.py
@@ -1,5 +1,6 @@
 import re
 import json
+import urllib
 from pprint import pprint
 from nose.tools import assert_equal, assert_raises
 from nose.plugins.skip import SkipTest
@@ -65,6 +66,12 @@ class TestAction(WsgiAppCase):
         assert 'annakarenina' in res['result']
         assert res['help'].startswith(
             "Return a list of the names of the site's datasets (packages).")
+
+        # Test GET request
+        res = json.loads(self.app.get('/api/action/package_list').body)
+        assert len(res['result']) == 2
+        assert 'warandpeace' in res['result']
+        assert 'annakarenina' in res['result']
 
     def test_01_package_show(self):
         anna_id = model.Package.by_name(u'annakarenina').id
@@ -452,6 +459,11 @@ class TestAction(WsgiAppCase):
         assert res_obj['success'] is True
         assert res_obj['help'].startswith(
                 "Return a list of the names of the site's groups.")
+
+        # Test GET request
+        res = self.app.get('/api/action/group_list')
+        res_obj = json.loads(res.body)
+        assert res_obj['result'] == ['david', 'roger']
 
         #Get all fields
         postparams = '%s=1' % json.dumps({'all_fields':True})
@@ -1176,17 +1188,44 @@ class TestActionPackageSearch(WsgiAppCase):
         model.repo.rebuild_db()
 
     def test_1_basic(self):
-        postparams = '%s=1' % json.dumps({
+        params = {
                 'q':'tolstoy',
                 'facet.field': ('groups', 'tags', 'res_format', 'license'),
                 'rows': 20,
                 'start': 0,
-            })
+            }
+        postparams = '%s=1' % json.dumps(params)
         res = self.app.post('/api/action/package_search', params=postparams)
         res = json.loads(res.body)
         result = res['result']
         assert_equal(res['success'], True)
         assert_equal(result['count'], 1)
+        assert_equal(result['results'][0]['name'], 'annakarenina')
+
+        # Test GET request
+        url_params = urllib.urlencode(params)
+        res = self.app.get('/api/action/package_search?{0}'.format(url_params))
+        res = json.loads(res.body)
+        result = res['result']
+        assert_equal(res['success'], True)
+        assert_equal(result['count'], 1)
+        assert_equal(result['results'][0]['name'], 'annakarenina')
+
+    def test_1_basic_no_params(self):
+        postparams = '%s=1' % json.dumps({})
+        res = self.app.post('/api/action/package_search', params=postparams)
+        res = json.loads(res.body)
+        result = res['result']
+        assert_equal(res['success'], True)
+        assert_equal(result['count'], 2)
+        assert_equal(result['results'][0]['name'], 'annakarenina')
+
+        # Test GET request
+        res = self.app.get('/api/action/package_search')
+        res = json.loads(res.body)
+        result = res['result']
+        assert_equal(res['success'], True)
+        assert_equal(result['count'], 2)
         assert_equal(result['results'][0]['name'], 'annakarenina')
 
     def test_2_bad_param(self):


### PR DESCRIPTION
http://demo.ckan.org/api/3/action/package_list?foo

This is just silly - :chicken:
