### PR TITLE
Exception when running "paster front-end-build"

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -1769,10 +1769,11 @@ class MinifyCommand(CkanCommand):
             action='store_true', default=False, help='remove any minified files in the path')
 
     def command(self):
+        clean = getattr(self.options, 'clean', False)
         self._load_config()
         for base_path in self.args:
             if os.path.isfile(base_path):
-                if self.options.clean:
+                if clean:
                     self.clear_minifyed(base_path)
                 else:
                     self.minify_file(base_path)
@@ -1781,7 +1782,7 @@ class MinifyCommand(CkanCommand):
                     dirs[:] = [d for d in dirs if not d in self.exclude_dirs]
                     for filename in files:
                         path = os.path.join(root, filename)
-                        if self.options.clean:
+                        if clean:
                             self.clear_minifyed(path)
                         else:
                             self.minify_file(path)


### PR DESCRIPTION
```
paster front-end-build                                                                                                           master 
compile green.css
compile fuchsia.css
compile maroon.css
compile red.css
compile main.css
Generating hu
Generating sq
Generating de
Generating fr
Generating nl
Generating pt_BR
Generating el
Generating ro
Generating it
Generating sl
Generating ja
Generating no
Generating ca
Generating sk
Generating lv
Generating sr_Latn
Generating es
Generating sv
Generating cs_CZ
Generating lt
Generating bg
Generating ru
Generating sr
Generating fi
Generating pl
Completed generating JavaScript translations
Traceback (most recent call last):
  File "/home/adria/dev/pyenvs/ckan_plain/bin/paster", line 9, in <module>
    load_entry_point('PasteScript==1.7.5', 'console_scripts', 'paster')()
  File "/home/adria/dev/pyenvs/ckan_plain/local/lib/python2.7/site-packages/paste/script/command.py", line 104, in run
    invoke(command, command_name, options, args[1:])
  File "/home/adria/dev/pyenvs/ckan_plain/local/lib/python2.7/site-packages/paste/script/command.py", line 143, in invoke
    exit_code = runner.run(args)
  File "/home/adria/dev/pyenvs/ckan_plain/local/lib/python2.7/site-packages/paste/script/command.py", line 238, in run
    result = self.command()
  File "/home/adria/dev/pyenvs/ckan_plain/src/ckan/ckan/lib/cli.py", line 1951, in command
    cmd.command()
  File "/home/adria/dev/pyenvs/ckan_plain/src/ckan/ckan/lib/cli.py", line 1784, in command
    if self.options.clean:
AttributeError: Values instance has no attribute 'clean'
```
