### PR TITLE
Exception when reseting password if first field is empty

### DIFF
--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -416,6 +416,9 @@ class UserController(base.BaseController):
         return render('user/request_reset.html')
 
     def perform_reset(self, id):
+        # FIXME 403 error for invalid key is a non helpful page
+        # FIXME We should reset the reset key when it is used to prevent
+        # reuse of the url
         context = {'model': model, 'session': model.Session,
                    'user': c.user,
                    'keep_sensitive_data': True}
@@ -473,6 +476,7 @@ class UserController(base.BaseController):
                 raise ValueError(_('The passwords you entered'
                                  ' do not match.'))
             return password1
+        raise ValueError(_('You must provide a password'))
 
     def followers(self, id=None):
         context = {'for_view': True}


### PR DESCRIPTION
Related: #264 and #510 

```
File '/home/adria/dev/pyenvs/ckan_plain/src/ckan/ckan/controllers/user.py', line 447 in perform_reset
  user = get_action('user_update')(context, user_dict)
File '/home/adria/dev/pyenvs/ckan_plain/src/ckan/ckan/logic/__init__.py', line 323 in wrapped
  return _action(context, data_dict, **kw)
File '/home/adria/dev/pyenvs/ckan_plain/src/ckan/ckan/logic/action/update.py', line 586 in user_update
  data, errors = _validate(data_dict, schema, context)
File '/home/adria/dev/pyenvs/ckan_plain/src/ckan/ckan/lib/navl/dictization_functions.py', line 228 in validate
  converted_data, errors = _validate(flattened, schema, context)
File '/home/adria/dev/pyenvs/ckan_plain/src/ckan/ckan/lib/navl/dictization_functions.py', line 290 in _validate
  convert(converter, key, converted_data, errors, context)
File '/home/adria/dev/pyenvs/ckan_plain/src/ckan/ckan/lib/navl/dictization_functions.py', line 186 in convert
  converter(key, converted_data, errors, context)
File '/home/adria/dev/pyenvs/ckan_plain/src/ckan/ckan/logic/validators.py', line 467 in user_password_validator
  if not value == '' and not isinstance(value, Missing) and not len(value) >= 4:
TypeError: object of type 'NoneType' has no len()
```
