### PR TITLE
[#542] Remove usage of postgres' function that's not available in < 9.1

### DIFF
--- a/ckan/migration/versions/067_turn_extras_to_strings.py
+++ b/ckan/migration/versions/067_turn_extras_to_strings.py
@@ -7,7 +7,7 @@ def upgrade(migrate_engine):
         revision_tables = 'package_extra_revision group_extra_revision'
 
         for table in tables.split():
-            sql = """select id, value from {table} where left(value,1) = '"' """.format(table=table)
+            sql = """select id, value from {table} where substr(value,0,1) = '"' """.format(table=table)
             results = connection.execute(sql)
             for result in results:
                 id, value = result
@@ -16,7 +16,7 @@ def upgrade(migrate_engine):
                                    json.loads(value), id)
 
         for table in revision_tables.split():
-            sql = """select id, revision_id, value from {table} where left(value,1) = '"' """.format(table=table)
+            sql = """select id, revision_id, value from {table} where substr(value,0,1) = '"' """.format(table=table)
 
             results = connection.execute(sql)
             for result in results:


### PR DESCRIPTION
The function left() was only added in Postgres 9.1, but we can easily use
substr() to achieve the same effect.

Fixes #542.
