### PR TITLE
[#544] Run tests with Postgres 8.4 and 9.1 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,30 +2,10 @@ language: python
 python:
   - "2.6"
   - "2.7"
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq solr-jetty
-install:
-  - "pip install -r pip-requirements.txt --use-mirrors"
-  - "pip install -r pip-requirements-test.txt --use-mirrors"
-before_script:
-  - psql -c 'CREATE DATABASE ckantest;' -U postgres
-  - psql -c 'CREATE DATABASE datastore;' -U postgres
-  - psql -c 'CREATE USER readonlyuser;' -U postgres
-  - python setup.py develop
-  - paster make-config ckan development.ini --no-interactive
-  - sed -i -e 's/.*solr_url.*/solr_url = http:\/\/127.0.0.1:8983\/solr/' development.ini
-  - sed -i -e 's/.*ckan\.site_id.*/ckan.site_id = travis_ci/' development.ini
-  - sed -i -e 's/^sqlalchemy.url.*/sqlalchemy.url = postgresql:\/\/postgres@localhost\/ckantest/' development.ini
-  - sed -i -e 's/.*datastore.write_url.*/ckan.datastore.write_url = postgresql:\/\/postgres@localhost\/datastore/' development.ini
-  - sed -i -e 's/.*datastore.read_url.*/ckan.datastore.read_url = postgresql:\/\/readonlyuser@localhost\/datastore/' development.ini
-  - cat development.ini
-  - echo -e "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8983\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty
-  - sudo cp ckan/config/solr/schema-2.0.xml /etc/solr/conf/schema.xml
-  - sudo service jetty restart
-  - paster --plugin=ckan db init
-  - paster datastore set-permissions postgres
-script: "nosetests --ckan --with-pylons=test-core.ini --nologcapture ckan ckanext"
+env:
+  - PGVERSION=9.1
+  - PGVERSION=8.4
+script: ./bin/travis-build
 notifications:
   irc:
     channels:

--- a/bin/travis-build
+++ b/bin/travis-build
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# Drop Travis' postgres cluster if we're building using a different pg version
+TRAVIS_PGVERSION='9.1'
+if [ $PGVERSION != $TRAVIS_PGVERSION ]
+then
+  sudo -u postgres pg_dropcluster --stop $TRAVIS_PGVERSION main
+  # Make psql use $PGVERSION
+  export PGCLUSTER=$PGVERSION/main
+fi
+
+# Install postgres and solr
+# We need this ppa so we can install postgres-8.4
+sudo add-apt-repository -yy ppa:pitti/postgresql
+sudo apt-get update -qq
+sudo apt-get install solr-jetty postgresql-$PGVERSION
+
+# Don't require a password to access DB
+sudo sed -i -e 's/ident/trust/g' /etc/postgresql/$PGVERSION/main/pg_hba.conf 
+
+sudo service postgresql reload
+
+pip install -r pip-requirements.txt --use-mirrors
+pip install -r pip-requirements-test.txt --use-mirrors
+
+psql -c 'CREATE DATABASE ckantest;' -U postgres
+psql -c 'CREATE DATABASE datastore;' -U postgres
+
+python setup.py develop
+
+# Configure CKAN's configuration file
+paster make-config ckan development.ini --no-interactive
+sed -i -e 's/.*solr_url.*/solr_url = http:\/\/127.0.0.1:8983\/solr/' development.ini
+sed -i -e 's/.*ckan\.site_id.*/ckan.site_id = travis_ci/' development.ini
+sed -i -e 's/^sqlalchemy.url.*/sqlalchemy.url = postgresql:\/\/postgres@\/ckantest/' development.ini
+sed -i -e 's/.*datastore.write_url.*/ckan.datastore.write_url = postgresql:\/\/postgres@\/datastore/' development.ini
+
+# Configure Solr
+echo "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8983\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty
+sudo cp ckan/config/solr/schema-2.0.xml /etc/solr/conf/schema.xml
+sudo service jetty restart
+
+paster --plugin=ckan db init
+
+# If Postgres >= 9.0, we don't need to use datastore's legacy mode.
+if [ $PGVERSION != '8.4' ]
+then
+  psql -c 'CREATE USER readonlyuser;' -U postgres
+  sed -i -e 's/.*datastore.read_url.*/ckan.datastore.read_url = postgresql:\/\/readonlyuser@\/datastore/' development.ini
+  paster datastore set-permissions postgres
+fi
+
+
+# And finally, run the tests
+nosetests --ckan --with-pylons=test-core.ini --nologcapture ckan ckanext


### PR DESCRIPTION
We support both 9.1 and 8.4 (do we support 9.0 as well, @kindly?), so we should run our tests in both.

Issue #560 is about fixing the failures in 8.4.
