### PR TITLE
#487 Removes "add another dataset" to search listings

### DIFF
--- a/ckan/templates/package/search.html
+++ b/ckan/templates/package/search.html
@@ -58,9 +58,9 @@
           {% endfor %}
         </div>
         {% if request.params and c.page.item_count == 0 %}
-          <p class="extra">Try another search term,
-          browse the datasets below or <a href="{{ h.url_for(controller='package', action='new') }}">{{ _('add your own data') }}</a>.
-          </p>
+          {% trans %}
+            <p class="extra">Please try another search.</p>
+          {% endtrans %}
         {% endif %}
       </div>
 


### PR DESCRIPTION
See #487 for context
