### PR TITLE
No results / no entires message

### DIFF
--- a/ckan/templates/package/snippets/search_form.html
+++ b/ckan/templates/package/snippets/search_form.html
@@ -15,13 +15,12 @@
 </form>
 <div class="results">
   <strong>
-    {% if request.params and c.page.item_count %}
-      {{ c.page.item_count }} datasets{% if c.q %} found for &#147;{{ c.q }}&#148;{% endif %}
-    {% elif request.params and c.page.item_count == 0 %}
-      Sorry no datasets found{% if c.q %} for &#147;{{ c.q }}&#148;{% endif %}
+    {% if c.q %}
+      {{ _('{number} datasets found for "{query}"').format(query=c.q, number=c.page.item_count) }}
     {% else %}
-      All datasets
+      {{ _('{number} datasets found').format(number=c.page.item_count) }}
     {% endif %}
+
   </strong>
   <div class="filter-list">
     {% for field in c.fields_grouped %}
@@ -37,15 +36,13 @@
         </span>
       {% endfor %}
     {% endfor %}
-    {% if request.params and c.q and c.page.item_count == 0 %}
-      <p class="extra">Try another search term,
-      browse the datasets below or <a href="{{ h.url_for(action='new', id=None) }}">add your own data</a>.</p>
-    {% endif %}
   </div>
 </div>
 
 {% if c.query_error %}
   <p><strong>There was an error while searching.</strong> Please try again.</p>
+{% else %}
+  {% if c.page.items %}
+    {{ h.snippet('snippets/package_list.html', packages=c.page.items, bulk_processing=c.bulk_processing) }}
+  {% endif %}
 {% endif %}
-
-{{ h.snippet('snippets/package_list.html', packages=c.page.items, bulk_processing=c.bulk_processing) }}


### PR DESCRIPTION
When a group organisation or user has no datasets we should display a message such as:
"This group has no datasets"
or  "This group has no public datasets"
http://master.ckan.org/group/itestgroup

![Screen Shot 2013-02-26 at 10 55 34](https://f.cloud.github.com/assets/1260289/195917/18b1cac2-8003-11e2-9fe8-6f7643c6e3e7.png)
