### PR TITLE
[wip] [#577] Set formencode's translation languages

### DIFF
--- a/ckan/lib/navl/dictization_functions.py
+++ b/ckan/lib/navl/dictization_functions.py
@@ -1,8 +1,10 @@
 import copy
-import formencode as fe
 import inspect
 from pylons.i18n import _
 from pylons import config
+import formencode as fe
+fe.api.set_stdtranslation(domain="FormEncode",
+        languages=config.get('ckan.locale_order'))
 
 class Missing(object):
     def __unicode__(self):


### PR DESCRIPTION
Tell `formencode` to use CKAN's `ckan.locale_order` config setting instead
of getting one for itself from the system.

This fixes a couple of tests in `ckan.tests.lib.test_navl` that would fail
if your computer was not set to English.

Changing formencode's translation languages in one module seems to change it everywhere we import formencode. I just did it in the main module where we seem to be using formencode, just to keep all the formencode usage in one place. I'm not sure if this was the best place to do this
