### PR TITLE
h. markdown_extract() & < > issue [2.0]

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -626,7 +626,7 @@ def markdown_extract(text, extract_length=190):
         return ''
     plain = re.sub(r'<.*?>', '', markdown(text))
     if not extract_length or len(plain) < extract_length:
-        return plain
+        return literal(plain)
     return literal(unicode(truncate(plain, length=extract_length, indicator='...', whole_word=True)))
 
 


### PR DESCRIPTION
h. markdown_extract() sometimes returns a literal and sometimes not.

This causes problems of over escaping for example in the dataset listings with short descriptions. 
