### PR TITLE
an IPackageController raising a ValidationError during dataset metadata creation causes crash

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -685,14 +685,15 @@ class PackageController(BaseController):
     def new_metadata(self, id, data=None, errors=None, error_summary=None):
         ''' FIXME: This is a temporary action to allow styling of the
         forms. '''
+        context = {'model': model, 'session': model.Session,
+                   'user': c.user or c.author}
+
         if request.method == 'POST' and not data:
             save_action = request.params.get('save')
             data = data or clean_dict(unflatten(tuplize_dict(parse_params(
                 request.POST))))
             # we don't want to include save as it is part of the form
             del data['save']
-            context = {'model': model, 'session': model.Session,
-                       'user': c.user or c.author}
 
             data_dict = get_action('package_show')(context, {'id': id})
 
@@ -726,8 +727,6 @@ class PackageController(BaseController):
             redirect(h.url_for(controller='package', action='read', id=id))
 
         if not data:
-            context = {'model': model, 'session': model.Session,
-                       'user': c.user or c.author}
             data = get_action('package_show')(context, {'id': id})
         errors = errors or {}
         error_summary = error_summary or {}


### PR DESCRIPTION
Steps to reproduce issue:
1. install the spatial extension
2. add a 'spatial' extra field with an IDatasetForm to the fields and make it appear in package_metadata_fields.html
3. create a dataset using the form and leave the spatial field blank

What happens:

CKAN fails with this traceback:

```
Module ckan.controllers.package:697 in new_metadata
>>  return self.new_metadata(id, data, errors, error_summary)
Module ckan.controllers.package:721 in new_metadata
>>  self._setup_template_variables(context, {},
UnboundLocalError: local variable 'context' referenced before assignment
```

What I expected to happen:  An error should be displayed on the spatial field telling me to fill in a valid GeoJSON value.
