### PR TITLE
[wip] Get a package's groups from the member table

### DIFF
--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -243,14 +243,14 @@ def package_dictize(pkg, context):
     tracking = model.TrackingSummary.get_for_package(pkg.id)
     result_dict['tracking_summary'] = tracking
     #groups
-    member_rev = model.member_revision_table
+    member = model.member_table
     group = model.group_table
-    q = select([group, member_rev.c.capacity],
-               from_obj=member_rev.join(group, group.c.id == member_rev.c.group_id)
-               ).where(member_rev.c.table_id == pkg.id)\
-                .where(member_rev.c.state == 'active') \
+    q = select([group, member.c.capacity],
+               from_obj=member.join(group, group.c.id == member.c.group_id)
+               ).where(member.c.table_id == pkg.id)\
+                .where(member.c.state == 'active') \
                 .where(group.c.is_organization == False)
-    result = _execute_with_revision(q, member_rev, context)
+    result = model.Session.execute(q)
     result_dict["groups"] = d.obj_list_dictize(result, context)
     #owning organization
     group_rev = model.group_revision_table


### PR DESCRIPTION
Get a package's groups from the member table, not the member_revision
table.

After migrating a CKAN 1.3 database to CKAN 2.0, all of the group pages
showed no packages. On investigating, I found:

group_show() would report "num_packages": 0 for a group, but under
"packages" there would be a non-empty list of packages.

package_show() for those same packages would show "groups": [].

Solr search queries would return no packages for the groups.

So the various ways of getting a count or list of a group's packages or
a package's groups were contradicting eachother.

The reason was that the member table in the database contained NULL for
the revision_id column for every row. Whether NULL should have been in
this column, or how it got there, I don't know. (Perhaps this is a bug
in the database migration scripts.)

When finding a group's list of packages, group_dictize() looks at the
member table, so it was finding the packages no problem.

But when finding a package's list of groups, package_dictize() does a
query on the member_revision table, not on the member table. Since in
this migrated database, the member table rows do not seem to have any
member_revisions, it was finding no groups for a package.

Since it's package dicts, not groups, that get indexed in Solr, each package
was indexed with no groups, and so Solr queries for packages in a group
returned 0.

This commit changes package_dictize() to use the member table not the
member_revision table to find a package's groups. After making this
change, I was able to rebuild the solr search index and my packages
reappeared on the group pages.
