### PR TITLE
Wrong labels on logout first templates

### DIFF
--- a/ckan/templates/user/logout_first.html
+++ b/ckan/templates/user/logout_first.html
@@ -7,14 +7,9 @@
 
 {% block form %}
   <div class="alert alert-error">{{ _("You're already logged in as {user}.").format(user=c.user) }} <a href="{{ logout_url }}">{{ _('Logout') }}</a>?</div>
-  <div class="form-horizontal">
-      {{ form.input('login', label="{{ _(Username') }}", id='field-login', value="", error="", classes=["control-full"], attrs={"disabled": "disabled"}) }}
-    {{ form.input('password', label="{{ _(Password') }}", id='field-password', type="password", value="", error="", classes=["control-full"], attrs={"disabled": "disabled"}) }}
-    {{ form.checkbox('remember', label="{{ _(Remember me') }}", id='field-remember', checked=true, attrs={"disabled": "disabled"}) }}
-    <div class="form-actions">
-      <button class="btn btn-primary disabled" type="submit" disabled>{{ _('Log in') }}</button>
-    </div>
-  </div>
+
+  {% snippet "user/snippets/login_form.html", action=c.login_handler, error_summary=error_summary, disabled=True %}
+
 {% endblock %}
 
 {% block secondary_content %}

--- a/ckan/templates/user/snippets/login_form.html
+++ b/ckan/templates/user/snippets/login_form.html
@@ -3,6 +3,8 @@ Renders the login form.
 
 action        - The url that the form should be submitted to.
 error_summary - A tuple/list of form errors.
+disabled      - Whether the form fields should be disabled (ie in the logout
+                first template)
 
 Example:
 
@@ -13,15 +15,17 @@ Example:
 
 {% set username_error = true if error_summary %}
 {% set password_error = true if error_summary %}
+{% set attrs = {"disabled": "disabled"} if disabled else {} %}
+
 
 <form action="{{ action }}" method="post" class="form-horizontal">
   {{ form.errors(errors=error_summary) }}
 
-  {{ form.input('login', label=_("Username"), id='field-login', value="", error=username_error, classes=["control-medium"]) }}
+  {{ form.input('login', label=_("Username"), id='field-login', value="", error=username_error, classes=["control-medium"], attrs=attrs) }}
 
-  {{ form.input('password', label=_("Password"), id='field-password', type="password", value="", error=password_error, classes=["control-medium"]) }}
+  {{ form.input('password', label=_("Password"), id='field-password', type="password", value="", error=password_error, classes=["control-medium"], attrs=attrs) }}
 
-  {{ form.checkbox('remember', label=_("Remember me"), id='field-remember', checked=true, value="63072000") }}
+  {{ form.checkbox('remember', label=_("Remember me"), id='field-remember', checked=true, value="63072000", attrs=attrs) }}
 
   <div class="form-actions">
     <button class="btn btn-primary" type="submit">{{ _('Log in') }}</button>


### PR DESCRIPTION
This bug was introduced on the last template translation review on templates/user/snippets/logout_first.html.

This page should use the login form snippet anyway.

![Login - CKAN master](https://f.cloud.github.com/assets/200230/241591/d39b3f08-89bd-11e2-87e3-ac4aba6b4499.png)
