### PR TITLE
Pass whole package dict to extensions on after_delete

### DIFF
--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -39,6 +39,9 @@ def package_delete(context, data_dict):
     rev.author = user
     rev.message = _(u'REST API: Delete Package: %s') % entity.name
 
+    # Pass the whole dict to extensions, not just the id
+    data_dict = model_dictize.package_dictize(entity, context)
+
     for item in plugins.PluginImplementations(plugins.IPackageController):
         item.delete(entity)
 

--- a/ckan/tests/functional/test_package.py
+++ b/ckan/tests/functional/test_package.py
@@ -78,6 +78,10 @@ class MockPackageControllerPlugin(SingletonPlugin):
 
     def after_delete(self, context, data_dict):
         self.calls['after_delete'] += 1
+
+        assert 'name' in data_dict
+        assert 'title' in data_dict
+
         return data_dict
 
     def after_show(self, context, data_dict):


### PR DESCRIPTION
Otherwise it is really difficult to perform any custom action based eg on the dataset type, org, etc
