### PR TITLE
[#619] Fix broken dumps link on dataset page

### DIFF
--- a/ckan/templates/package/search.html
+++ b/ckan/templates/package/search.html
@@ -75,15 +75,15 @@
         {% set api_link = h.link_to(_('API'), h.url_for(controller='api', action='get_api', ver=3)) %}
         {% set api_doc_link = h.link_to(_('API Docs'), 'http://docs.ckan.org/{0}/{1}/api.html'.format(request.environ.CKAN_LANG, g.ckan_doc_version)) %}
         {% if g.dumps_url -%}
-          {% trans %}
-            You can also access this registry using the {{ api_link }} (see {{ api_doc_link}}).
-          {% endtrans %}
-        {% else %}
-          {% set dump = h.link_to(_('full {format} dump').format(format=g.dumps_format), g.dumps_url) %}
+          {% set dump_link = h.link_to(_('full {format} dump').format(format=g.dumps_format), g.dumps_url) %}
           {% trans %}
             You can also access this registry using the {{ api_link }} (see {{ api_doc_link }}) or download a {{ dump_link }}.
           {% endtrans %}
-        {%- endif %}.
+        {% else %}
+          {% trans %}
+            You can also access this registry using the {{ api_link }} (see {{ api_doc_link}}).
+          {% endtrans %}
+        {%- endif %}
       </small>
     </div>
   </section>


### PR DESCRIPTION
An if statement in a template was wrong, so if dumps_url was _not_ set
then ckan would try to show the dumps link and would render an empty
string. Reversing the if statements fixes it.
