### PR TITLE
Unicode site title breaks CKAN

### DIFF
--- a/ckan/lib/app_globals.py
+++ b/ckan/lib/app_globals.py
@@ -109,9 +109,15 @@ def reset():
             value = model.get_system_info(key)
         else:
             value = None
+        config_value = config.get(key)
+        # sort encodeings if needed
+        if isinstance(config_value, str):
+            try:
+                config_value = config_value.decode('utf-8')
+            except UnicodeDecodeError:
+                config_value = config_value.decode('latin-1')
         # we want to store the config the first time we get here so we can
         # reset them if needed
-        config_value = config.get(key)
         if key not in _CONFIG_CACHE:
             _CONFIG_CACHE[key] = config_value
         if value is not None:


### PR DESCRIPTION
We are using CKAN v1.8 and we noticed that if we use a site title that contains greek characters, an exception is thrown:

UnicodeDecodeError: 'ascii' codec can't decode byte 0xce in position 0: ordinal not in range(128)

In our local installation we managed to overcome this by 'overriding' every template file that used the site title. You might use the unicode() function to output the string correctly
