### PR TITLE
#629 Fixes overflow of 'clear all' within facets

### DIFF
--- a/ckan/public/base/less/module.less
+++ b/ckan/public/base/less/module.less
@@ -3,6 +3,7 @@
 }
 
 .module-heading {
+  .clearfix;
   margin: 0;
   padding: 7px @gutterX;
   font-size: 14px;


### PR DESCRIPTION
Fixes #629 

Was:

![Screen Shot 2013-03-14 at 13 57 56](https://f.cloud.github.com/assets/67366/258938/46eac174-8caf-11e2-9b1b-185d3bc481b7.png)

Now:

![Screen Shot 2013-03-19 at 10 41 12](https://f.cloud.github.com/assets/67366/275227/ff160d50-9081-11e2-96f4-23872de7e93f.png)
