### PR TITLE
org / group search is case sensitive

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -334,9 +334,9 @@ def _group_or_org_list(context, data_dict, is_org=False):
     if q:
         q = u'%{0}%'.format(q)
         query = query.filter(_or_(
-            model.GroupRevision.name.like(q),
-            model.GroupRevision.title.like(q),
-            model.GroupRevision.description.like(q),
+            model.GroupRevision.name.ilike(q),
+            model.GroupRevision.title.ilike(q),
+            model.GroupRevision.description.ilike(q),
         ))
 
 


### PR DESCRIPTION
Please make this not so. Makes the search confusing and unusable until you discover why it's not just working.

If this is difficult to fix, then we need to add some text to say 'search is case sensitive'
