### PR TITLE
Dataset group ownership issues [2.0]

### DIFF
--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -18,7 +18,7 @@ def owner_org_validator(key, data, errors, context):
 
     value = data.get(key)
 
-    if value is missing or value is None:
+    if value is missing or not value:
         if not ckan.new_authz.check_config_permission('create_unowned_dataset'):
             raise Invalid(_('A organization must be supplied'))
         data.pop(key, None)

--- a/ckan/templates/package/snippets/package_basic_fields.html
+++ b/ckan/templates/package/snippets/package_basic_fields.html
@@ -46,10 +46,10 @@
       <label for="field-organizations" class="control-label">{{ _('Organization') }}</label>
       <div class="controls">
         <select id="field-organizations" name="owner_org" data-module="autocomplete">
-          <option value="">{{ _('Select an organization...') }}</option>
+          <option value="" {% if not selected_org and data.id %} selected="selected" {% endif %}>{{ _('Select an organization...') }}</option>
           {% for organization in organizations_available %}
             {# get out first org from users list only if there is not an existing org #}
-            {% set selected_org = (existing_org and existing_org == organization.id) or (not existing_org and organization.id == organizations_available[0].id) %}
+            {% set selected_org = (existing_org and existing_org == organization.id) or (not existing_org and not data.id and organization.id == organizations_available[0].id) %}
             <option value="{{ organization.id }}" {% if selected_org %} selected="selected" {% endif %}>{{ organization.name }}</option>
           {% endfor %}
         </select>


### PR DESCRIPTION
Issues
- [x] Validator is broken
- [x] Form defaults to first group even on existing dataset

Without this fix datasets can easily be assigned to groups when they are edited etc without the user being aware
this relies on config options so make sure `ckan.auth.create_unowned_dataset` is true
