### PR TITLE
[#671] Use render_markdown() for custom about page text

### DIFF
--- a/ckan/templates/home/about.html
+++ b/ckan/templates/home/about.html
@@ -11,7 +11,7 @@
     <div class="module-content">
       {% block about %}
         {% if g.site_about %}
-          {{ h.markdown_extract(g.site_about) }}
+          {{ h.render_markdown(g.site_about) }}
         {% else %}
           <h1 class="page-heading">{{ _('About') }}</h1>
           {% snippet 'home/snippets/about_text.html' %}


### PR DESCRIPTION
Use render_markdown() not markdown_extract() for custom about page text,
so that the full text gets shown not just an extract. Fixes #671.
