### PR TITLE
674 More useful Solr exceptions

### DIFF
--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -258,6 +258,10 @@ class PackageSearchIndex(SearchIndex):
                 e.httpcode, e.reason, e.body[:1000] # limit huge responses
             )
             raise SearchIndexError(msg)
+        except socket.error, e:
+            err = 'Could not connect to Solr using {0}: {1}'.format(conn.url, str(e))
+            log.error(err)
+            raise SearchIndexError(err)
         finally:
             conn.close()
 


### PR DESCRIPTION
Instead of this rather useless message when indexing:

```
2013-03-20 15:14:35,140 ERROR [ckan.lib.search] Error while indexing dataset c85b3834-d251-4158-999b-8714f2ad339c: HTTP code=400, reason=Bad Request
```

Log the details of the Solr response so you can do some actual debugging:

```
2013-03-20 15:24:36,203 ERROR [ckan.lib.search] Error while indexing dataset c85b3834-d251-4158-999b-8714f2ad339c: Solr returned an error: 400 Bad Request - <?xml version="1.0" encoding="UTF-8"?>
<response>
<lst name="responseHeader"><int name="status">400</int><int name="QTime">2</int></lst><lst name="error"><str name="msg">ERROR: [doc=fad36361695b6614afc518db5e62115899ccd3fc] Error adding field 'spatial'='{"type": "Polygon", "coordinates": [[[-133.523868, 31.464947], [-133.523868, 31.481474], [-133.505218, 31.481474], [-133.505218, 31.464947], [-133.523868, 31.464947]]]}' msg=For input string: "{"type": "Polygon""</str><int name="code">400</int></lst>
</response>
```

Also just catch SolrExceptions so other issues can be found
