### PR TITLE
Validation errors on step 2 of dataset creation are flash messages

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -611,9 +611,16 @@ class PackageController(base.BaseController):
                     abort(401, _('Unauthorized to update dataset'))
                 if not len(data_dict['resources']):
                     # no data so keep on page
-                    h.flash_error(_('You must add at least one data resource'))
-                    redirect(h.url_for(controller='package',
-                                       action='new_resource', id=id))
+                    msg = _('You must add at least one data resource')
+                    # On new templates do not use flash message
+                    if g.legacy_templates:
+                        h.flash_error(msg)
+                        redirect(h.url_for(controller='package',
+                                           action='new_resource', id=id))
+                    else:
+                        errors = {}
+                        error_summary = {_('Error'): msg}
+                        return self.new_resource(id, data, errors, error_summary)
                 # we have a resource so let them add metadata
                 redirect(h.url_for(controller='package',
                                    action='new_metadata', id=id))

--- a/ckan/lib/app_globals.py
+++ b/ckan/lib/app_globals.py
@@ -57,6 +57,7 @@ config_details = {
     'openid_enabled': {'default': 'true', 'type' : 'bool'},
     'debug': {'default': 'false', 'type' : 'bool'},
     'ckan.debug_supress_header' : {'default': 'false', 'type' : 'bool'},
+    'ckan.legacy_templates' : {'default': 'false', 'type' : 'bool'},
 
     # int
     'ckan.datasets_per_page': {'default': '20', 'type': 'int'},


### PR DESCRIPTION
See:

![Add data to the dataset - CKAN](https://f.cloud.github.com/assets/200230/232892/dd3a1bbe-8743-11e2-9fc4-b1d5bc3ec726.png)

They should be like:

![Create dataset - CKAN](https://f.cloud.github.com/assets/200230/232889/d2618c40-8743-11e2-8092-b3d4ae19c046.png)
