### PR TITLE
#486 Put's footer links into better columns

### DIFF
--- a/ckan/public/base/less/footer.less
+++ b/ckan/public/base/less/footer.less
@@ -22,10 +22,16 @@
   margin-left: 0;
 }
 
-.footer-links li {
-  display: inline-block;
-  width: 44%;
-  margin-right: 5%;
+.footer-links ul {
+  float: left;
+  .makeColumn(3);
+}
+
+.footer-links ul:first-child {
+  margin-left: 0;
+}
+
+.footer-links ul li {
   margin-bottom: 5px;
 }
 

--- a/ckan/templates/footer.html
+++ b/ckan/templates/footer.html
@@ -1,15 +1,19 @@
 <footer class="site-footer">
   <div class="container">
     {% block footer_content %}
-      <nav class="footer-links row-fluid">
+      <nav class="footer-links">
         {% block footer_nav %}
-          <ul class="unstyled row-fluid">
+          <ul class="unstyled">
             {% block footer_links %}
-              {% set api_url = 'http://docs.ckan.org/{0}/{1}/api.html'.format(request.environ.CKAN_LANG, g.ckan_doc_version) %}
               <li><a href="{{ h.url_for(controller='home', action='about') }}">{{ _('About {0}').format(g.site_title) }}</a></li>
+            {% endblock %}
+          </ul>
+          <ul class="unstyled">
+            {% block footer_links_ckan %}
+              {% set api_url = 'http://docs.ckan.org/{0}/{1}/api.html'.format(request.environ.CKAN_LANG, g.ckan_doc_version) %}
               <li><a href="{{ api_url }}">{{ _('CKAN API') }}</a></li>
-              <li><a href="http://www.opendefinition.org/okd/"><img src="http://assets.okfn.org/images/ok_buttons/od_80x15_blue.png"></a></li>
               <li><a href="http://www.okfn.org/">{{ _('Open Knowledge Foundation') }}</a></li>
+              <li><a href="http://www.opendefinition.org/okd/"><img src="http://assets.okfn.org/images/ok_buttons/od_80x15_blue.png"></a></li>
             {% endblock %}
           </ul>
         {% endblock %}


### PR DESCRIPTION
Fixes #486 

Makes default footer go from:

![Screen Shot 2013-03-21 at 12 04 00](https://f.cloud.github.com/assets/67366/285506/73d9acb6-921f-11e2-87ba-63783202740f.png)

To:

![Screen Shot 2013-03-21 at 12 03 38](https://f.cloud.github.com/assets/67366/285507/78d8d368-921f-11e2-8b91-f18853c81977.png)

**Note:** Extensions that use `{% block footer_links %}` within templates will need updating
