### PR TITLE
Datastore input parameter validation leads to 500 if validation fails

### DIFF
--- a/ckanext/datastore/db.py
+++ b/ckanext/datastore/db.py
@@ -770,8 +770,8 @@ def _sort(context, data_dict, field_ids):
 
         if field not in field_ids:
             raise ValidationError({
-                'sort': [u'field "{0}" not it table'.format(
-                    unicode(field, 'utf-8'))]
+                'sort': [u'field "{0}" not in table'.format(
+                    field)]
             })
         if sort.lower() not in ('asc', 'desc'):
             raise ValidationError({
@@ -1071,7 +1071,7 @@ def search(context, data_dict):
         id = data_dict['resource_id']
         result = context['connection'].execute(
             u"(SELECT 1 FROM pg_tables where tablename = '{0}') union"
-             u"(SELECT 1 FROM pg_views where viewname = '{0}')".format(id)
+            u"(SELECT 1 FROM pg_views where viewname = '{0}')".format(id)
         ).fetchone()
         if not result:
             raise ValidationError({

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -196,6 +196,17 @@ class TestDatastoreSearch(tests.WsgiAppCase):
 
         assert result['records'] == self.expected_records[::-1]
 
+    def test_search_invalid(self):
+        data = {'resource_id': self.data['resource_id'],
+                'sort': u'f\xfc\xfc asc'}
+        postparams = '%s=1' % json.dumps(data)
+        auth = {'Authorization': str(self.sysadmin_user.apikey)}
+        res = self.app.post('/api/action/datastore_search', params=postparams,
+                            extra_environ=auth, status=409)
+        res_dict = json.loads(res.body)
+        assert res_dict['success'] is False
+        assert res_dict['error']['sort'][0] == u'field "f\xfc\xfc" not in table'
+
     def test_search_limit(self):
         data = {'resource_id': self.data['resource_id'],
                 'limit': 1}


### PR DESCRIPTION
The problem is that we called unicode on a unicode string which basically ended up in a server error if the parameter validation failed.
