### PR TITLE
paster datastore set-permissions fails if database name contains "-"

### DIFF
--- a/ckanext/datastore/bin/set_permissions.sql
+++ b/ckanext/datastore/bin/set_permissions.sql
@@ -14,9 +14,9 @@ To run the script, execute:
 */
 
 -- name of the main CKAN database
-\set maindb '{ckandb}'
+\set maindb "{ckandb}"
 -- the name of the datastore database
-\set datastoredb '{datastoredb}'
+\set datastoredb "{datastoredb}"
 -- username of the ckan postgres user
 \set ckanuser "{ckanuser}"
 -- username of the datastore user that can write


### PR DESCRIPTION
It seems to just need to be quoted with double quotes instead of single (in set_permissions.sql), not sure why this was not done initially.
