### PR TITLE
Can add, but not remove datasets to groups I don't own

### DIFF
--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -229,7 +229,8 @@ def package_membership_list_save(group_dicts, package, context):
             group = session.query(model.Group).get(id)
         else:
             group = session.query(model.Group).filter_by(name=name).first()
-        groups.add(group)
+        if group:
+            groups.add(group)
 
     ## need to flush so we can get out the package id
     model.Session.flush()

--- a/ckan/tests/lib/test_dictization.py
+++ b/ckan/tests/lib/test_dictization.py
@@ -359,6 +359,7 @@ class TestBasicDictize:
     def test_08_package_save(self):
 
         context = {"model": model,
+                   "user": 'testsysadmin',
                    "session": model.Session}
 
         anna1 = model.Session.query(model.Package).filter_by(name='annakarenina').one()


### PR DESCRIPTION
As an admin / owner of an organisation, I can edit datasets belonging to my org and tag them to any group which exists in the instance. There are no error messages if I try to add to other people's groups. However, if I try and remove (or untag) my dataset from a group, it does not save unless i'm removing from a group i created and hence own.

I.e. I seem to have rights to add to other people's groups but not remove. This is inconsistent & we need a better clearer logic of who can do what.
