### PR TITLE
66-67 Data migration is broken

### DIFF
--- a/ckan/migration/versions/067_turn_extras_to_strings.py
+++ b/ckan/migration/versions/067_turn_extras_to_strings.py
@@ -7,7 +7,7 @@ def upgrade(migrate_engine):
         revision_tables = 'package_extra_revision group_extra_revision'
 
         for table in tables.split():
-            sql = """select id, value from {table} where substr(value,0,1) = '"' """.format(table=table)
+            sql = """select id, value from {table} where substr(value,1,1) = '"' """.format(table=table)
             results = connection.execute(sql)
             for result in results:
                 id, value = result
@@ -16,7 +16,7 @@ def upgrade(migrate_engine):
                                    json.loads(value), id)
 
         for table in revision_tables.split():
-            sql = """select id, revision_id, value from {table} where substr(value,0,1) = '"' """.format(table=table)
+            sql = """select id, revision_id, value from {table} where substr(value,1,1) = '"' """.format(table=table)
 
             results = connection.execute(sql)
             for result in results:


### PR DESCRIPTION
067_turn_extras_to_strings.py is currently broken due to okfn/ckan@7677d69e , this is an example from a dump of pdeu before the change, after the change and what query should be executing.

```
pdeu=# select count(id) from package_extra  where left(value,1) = '"';
 count  
--------
 274194
(1 row)

pdeu=# select count(id) from package_extra  where substr(value,0,1) = '"';
 count 
-------
     0
(1 row)

pdeu=# select count(id) from package_extra  where substr(value,1,1) = '"';
 count  
--------
 274194
(1 row)
```

substr counts from 1, see examples in [postgres docs](http://www.postgresql.org/docs/9.1/static/functions-string.html)
