### PR TITLE
organization_item.html shows package list instead of count

### DIFF
--- a/ckan/templates/organization/snippets/organization_item.html
+++ b/ckan/templates/organization/snippets/organization_item.html
@@ -30,7 +30,7 @@ Example:
       <p class="empty">{{ _('This organization has no description') }}</p>
     {% endif %}
     {% if organization.packages %}
-      <a class="btn btn-small btn-primary" href="{{ url }}">{{ ungettext('{num} Dataset', '{num} Datasets', organization.packages).format(num=organization.packages) }}</a>
+      <a class="btn btn-small btn-primary" href="{{ url }}">{{ ungettext('{num} Dataset', '{num} Datasets', organization.packages).format(num=organization.package_count) }}</a>
     {% else %}
     <span class="btn btn-small disabled">{{ _('0 Datasets') }}</span>
     {% endif %}


### PR DESCRIPTION
If an organization has more than 0 datasets then organization_item.html shows the list of packages (as an unformatted json list) instead of the count
