### PR TITLE
Blockify package_basic_fields.html

### DIFF
--- a/ckan/templates/package/snippets/package_basic_fields.html
+++ b/ckan/templates/package/snippets/package_basic_fields.html
@@ -13,6 +13,9 @@
 {{ form.prepend('name', id='field-name', label=_('URL'), prepend=prefix, placeholder=_('eg. my-dataset'), value=data.name, error=errors.name, attrs=attrs) }}
 {% endblock %}
 
+{% block package_basic_fields_custom %}
+{% endblock %}
+
 {% block package_basic_fields_description %}
 {{ form.markdown('notes', id='field-notes', label=_('Description'), placeholder=_('eg. Some useful notes about the data'), value=data.notes, error=errors.notes) }}
 {% endblock %}

--- a/ckanext/example_idatasetform/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/example_idatasetform/templates/package/snippets/package_basic_fields.html
@@ -1,0 +1,5 @@
+{% ckan_extends %}
+
+{% block package_basic_fields_custom %}
+  {{ form.input('custom_text', label=_('Custom Text'), id='field-custom_text', placeholder=_('custom text'), value=data.custom_text, error=errors.custom_text, classes=['control-medium']) }}
+{% endblock %}

--- a/ckanext/example_idatasetform/templates/package/snippets/package_metadata_fields.html
+++ b/ckanext/example_idatasetform/templates/package/snippets/package_metadata_fields.html
@@ -19,7 +19,6 @@ won't work. #}
       </select>
     </div>
   </div>
-  {{ form.input('custom_text', label=_('Custom Text'), id='field-custom_text', placeholder=_('custom text'), value=data.custom_text, error=errors.custom_text, classes=['control-medium']) }}
 
   {{ super() }}
 


### PR DESCRIPTION
IDatasetForm plugins often want to add custom fields to the first page of the three-stage dataset creation form, but currently they have to copy the entire `package_basic_fields.html` into their extension because it doesn't contain any blocks. Add a block that can be overridden to add custom fields to the form, as is already done in `package_metadata_fields.html` (the third page of the dataset creation form).
