### PR TITLE
[#598] Merge @seanh's basic orientation to CKAN devs into our docs

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -1,7 +1,7 @@
 .. _action-api:
 
-The Action API
-==============
+Action API
+==========
 
 CKAN's Action API is a powerful, RPC-style API that exposes all of CKAN's core
 features to API clients. All of a CKAN website's core functionality (everything

--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -3,11 +3,55 @@ CKAN Code Architecture
 ======================
 
 This section tries to give some guidelines for writing code that is consistent
-with the intended, overall design and architecture of CKAN.
+with the intended, overall design and architecture of CKAN, going from the lowest
+to the highest layers.
+
+
+Database
+========
+
+CKAN uses `SQLAlchemy <http://www.sqlalchemy.org/>`_ to handle communication between
+CKAN source code and the `PostgreSQL database <http://www.postgresql.org/>`_.
+
+
+Migrations
+----------
+
+When changes are made to the model classes in ``ckan.model`` that alter CKAN's
+database schema, a migration script has to be added to migrate old CKAN
+databases to the new database schema when they upgrade their copies of CKAN.
+See :doc:`migration`.
+
+
+Model
+=====
+
+The ``ckan/model/`` package corresponds to the model in the `Model-View-Controller
+concept
+<http://www.codinghorror.com/blog/2008/05/understanding-model-view-controller.html>`_
+and contains classes for each of the entities stored in CKAN's database, e.g.
+``ckan/model/package.py`` contains a ``Package`` class that represents CKAN data
+packages, and contains the SQLAlchemy code for mapping between Package objects
+in the CKAN source code and their corresponding table in the database.
+
+.. note::
+
+    Packages are now called 'datasets' in the CKAN interface, but in the source
+    code you'll still find many places where they're referred to as packages.
+    They mean the same thing.
+
+
+Dictization
+-----------
+
+``ckan/lib/dictization/`` contains functions that transform CKAN model objects
+such as Packages, Resources, etc. into dictionaries and vice-versa. The
+templates that render the CKAN web interface and the JSON format used by the
+CKAN API both work with these dictionary representations.
 
 
 Encapsulate SQLAlchemy in ``ckan.model``
-````````````````````````````````````````
+----------------------------------------
 
 Ideally SQLAlchemy should only be used within ``ckan.model`` and not from other
 packages such as ``ckan.logic``.  For example instead of using an SQLAlchemy
@@ -24,16 +68,64 @@ we add a ``get()`` method to ``ckan.model.user.User``::
 
 Now we can call this method from the logic package.
 
-Database Migrations
-```````````````````
 
-When changes are made to the model classes in ``ckan.model`` that alter CKAN's
-database schema, a migration script has to be added to migrate old CKAN
-databases to the new database schema when they upgrade their copies of CKAN.
-See :doc:`migration`.
+Logic
+=====
+
+``ckan/logic/`` contains all the functions that the API_, WUI_ and CLI_ use for
+accessing and manipulating the data stored in CKAN. Whenever you want to get,
+create, update or delete some object from CKAN's model you use some function
+from the ``ckan/logic/action/`` package, for example there are functions
+``package_show()``, ``package_create()``, ``package_update()`` and
+``package_delete()`` for working with packages.
+
+All communication with the model should be done in the logic layer, and not in
+higher-level layers such as the controllers, which should use the logic layer
+instead of accessing the model themselves.
+
+
+Validation
+----------
+
+The logic action functions use schema defined in ``ckan.logic.schema`` to
+validate data in the ``data_dict`` that is posted to CKAN by users via the
+API_, WUI_ or CLI_. The schema in turn draw on validation and conversion
+functions defined in ``ckan.logic.validators`` and ``ckan.logic.converters``.
+
+An action function should first check for a custom schema provided in the
+context, and failing that should retrieve its default schema directly, and
+then call ``_validate()`` to validate and convert the data. For example, here
+is the validation code from the ``user_create()`` action function::
+
+   schema = context.get('schema') or ckan.logic.schema.default_user_schema()
+   session = context['session']
+   validated_data_dict, errors = _validate(data_dict, schema, context)
+   if errors:
+       session.rollback()
+       raise ValidationError(errors)
+
+
+Auth Functions
+--------------
+
+Each action function defined in ``ckan.logic.action`` should use its own
+corresponding auth function defined in ``ckan.logic.auth`` to check if the user
+is authorized to call it. Instead of calling its auth function directly, an
+action function should go through ``ckan.logic.check_access()`` (which is aliased
+``_check_access`` in the action modules) because this allows plugins to override
+auth functions using the ``IAuthFunctions`` plugin interface. For example::
+
+    def package_show(context, data_dict):
+        _check_access('package_show', context, data_dict)
+
+``check_access`` will raise an exception if the user is not authorized, which
+the action function should not catch. When this happens the user will be shown
+an authorization error in their browser (or will receive one in their response
+from the API_).
+
 
 Always go through the Action Functions
-``````````````````````````````````````
+--------------------------------------
 
 Whenever some code, for example in ``ckan.lib`` or ``ckan.controllers``, wants
 to get, create, update or delete an object from CKAN's model it should do so by
@@ -41,23 +133,59 @@ calling a function from the ``ckan.logic.action`` package, and *not* by
 accessing ``ckan.model`` directly.
 
 
-Action Functions are Exposed in the API
-```````````````````````````````````````
+Never call ``logic.action`` methods directly
+--------------------------------------------
 
-The functions in ``ckan.logic.action`` are exposed to the world as the
-:doc:`api`.  The API URL for an action function is automatically generated
-from the function name, for example
-``ckan.logic.action.create.package_create()`` is exposed at
+Use ``get_action()`` instead. This allows plugins to override action functions
+using the ``IActions`` plugin interface. For example::
+
+    ckan.logic.get_action('group_activity_list_html')(...)
+
+Instead of ::
+
+    ckan.logic.action.get.group_activity_list_html(...)
+
+
+Safely accessing data provided by the user
+------------------------------------------
+
+The ``data_dict`` parameter of logic action functions may be user provided, so
+required keys may be invalid or absent. Naive Code like::
+
+  id = data_dict['id']
+
+may raise a ``KeyError`` and cause CKAN to crash with a 500 Server Error
+and no message to explain what went wrong. Instead do::
+
+  id = _get_or_bust(data_dict, "id")
+
+which will raise ``ValidationError`` if ``"id"`` is not in ``data_dict``. The
+``ValidationError`` will be caught and the user will get a 400 Bad Request
+response and an error message explaining the problem.
+
+
+
+Interfaces
+==========
+
+.. _API:
+
+API
+---
+
+The :doc:`api` exposes the functions in ``ckan.logic.action`` to the world. The
+API URL for an action function is automatically generated from the function
+name, for example ``ckan.logic.action.create.package_create()`` is exposed at
 ``/api/action/package_create``. See `Steve Yegge's Google platforms rant
 <https://plus.google.com/112678702228711889851/posts/eVeouesvaVX>`_ for some
 interesting discussion about APIs.
 
 **All** publicly visible functions in the
 ``ckan.logic.action.{create,delete,get,update}`` namespaces will be exposed
-through the :doc:`api`. **This includes functions imported** by those
-modules, **as well as any helper functions** defined within those modules.  To
-prevent inadvertent exposure of non-action functions through the action api,
-care should be taken to:
+through the :doc:`api`. **This includes functions imported** by those modules,
+**as well as any helper functions** defined within those modules.  To prevent
+inadvertent exposure of non-action functions through the action api, care should
+be taken to:
 
 1. Import modules correctly (see :ref:`imports`).  For example::
 
@@ -77,92 +205,59 @@ care should be taken to:
      _get_or_bust = logic.get_or_bust
 
 
-Use ``get_action()``
-````````````````````
+.. _WUI:
 
-Don't call ``logic.action`` functions directly, instead use ``get_action()``.
-This allows plugins to override action functions using the ``IActions`` plugin
-interface. For example::
+Web User Interface (WUI)
+------------------------
 
-    ckan.logic.get_action('group_activity_list_html')(...)
+CKAN's Web User Interface is implemented by the controller classes in
+``ckan/controllers/``. These classes call functions from ``ckan/logic/action/`` to
+manipulate data, and return rendered template files from ``ckan/templates/``.
+``ckan/config/routing.py`` contains the routing definitions that control which
+requests get sent to which controller classes according to which URL was
+requested (it uses `http://routes.groovie.org`).
 
-Instead of ::
-
-    ckan.logic.action.get.group_activity_list_html(...)
-
-
-Auth Functions and ``check_access()``
-`````````````````````````````````````
-
-Each action function defined in ``ckan.logic.action`` should use its own
-corresponding auth function defined in ``ckan.logic.auth``. Instead of calling
-its auth function directly, an action function should go through
-``ckan.logic.check_access`` (which is aliased ``_check_access`` in the action
-modules) because this allows plugins to override auth functions using the
-``IAuthFunctions`` plugin interface. For example::
-
-    def package_show(context, data_dict):
-        _check_access('package_show', context, data_dict)
-
-``check_access`` will raise an exception if the user is not authorized, which
-the action function should not catch. When this happens the user will be shown
-an authorization error in their browser (or will receive one in their response
-from the API).
+Currently CKAN templates use the `Genshi template engine <http://genshi.edgewall.org>`_
+but the upcoming CKAN 2.0 release will move to the much nicer and friendlier
+`Jinja2 <http://jinja.pocoo.org>`_ by default. Genshi will still be supported so
+that existing CKAN themes don't break.
 
 
-``logic.get_or_bust()``
-```````````````````````
+.. _CLI:
 
-The ``data_dict`` parameter of logic action functions may be user provided, so
-required files may be invalid or absent. Naive Code like::
+Command Line Interface (CLI)
+----------------------------
 
-  id = data_dict['id']
-
-may raise a ``KeyError`` and cause CKAN to crash with a 500 Server Error
-and no message to explain what went wrong. Instead do::
-
-  id = _get_or_bust(data_dict, "id")
-
-which will raise ``ValidationError`` if ``"id"`` is not in ``data_dict``. The
-``ValidationError`` will be caught and the user will get a 400 Bad Request
-response and an error message explaining the problem.
+CKAN has a Command Line Interface that you can use to do lots of actions such as
+managing datasets and users, etc. (Do ``paster --plugin=ckan --help`` from
+CKAN's dir to see what's available.) It's implemented using `Paste Script
+<http://pythonpaste.org/script/developer.html>`_.
 
 
-Validation and ``ckan.logic.schema``
-````````````````````````````````````
+Extensions
+==========
 
-Logic action functions can use schema defined in ``ckan.logic.schema`` to
-validate the contents of the ``data_dict`` parameters that users pass to them.
 
-An action function should first check for a custom schema provided in the
-context, and failing that should retrieve its default schema directly, and
-then call ``_validate()`` to validate and convert the data. For example, here
-is the validation code from the ``user_create()`` action function::
-
- schema = context.get('schema') or ckan.logic.schema.default_user_schema()
- session = context['session']
- validated_data_dict, errors = _validate(data_dict, schema, context)
- if errors:
-     session.rollback()
-     raise ValidationError(errors)
+Extensions are a way for an external code to hook up into CKAN and add or alter
+behavior. See :doc:`writing-extensions` for more information.
 
 
 Controller & Template Helper Functions
---------------------------------------
+======================================
 
 ``ckan.lib.helpers`` contains helper functions that can be used from
-``ckan.controllers`` or from templates. When developing for ckan core, only use
+``ckan.controllers`` or from templates. When developing for CKAN core, only use
 the helper functions found in ``ckan.lib.helpers.__allowed_functions__``.
 
 
 .. _Testing:
 
 Testing
--------
+=======
 
 - Functional tests which test the behaviour of the web user interface, and the
   APIs should be placed within ``ckan/tests/functional``.  These tests can be a
-  lot slower to run that unit tests which don't access the database or solr.  So
+  lot slower to run than unit tests which don't access the database or solr.  So
   try to bear that in mind, and attempt to cover just what is neccessary, leaving
   what can be tested via unit-testing in unit-tests.
 
@@ -170,20 +265,15 @@ Testing
   in Python>=2.7.  So import them from ``ckan.tests``, which will provide
   alternatives if they're not available.
 
-- the `mock`_ library can be used to create and interrogate mock objects.
+- The `mock`_ library can be used to create and interrogate mock objects.
 
 See :doc:`test` for further information on testing in CKAN.
 
 .. _mock: http://pypi.python.org/pypi/mock
 
-Writing Extensions
-------------------
 
-Please see :doc:`writing-extensions` for information about writing ckan
-extensions, including details on the API available to extensions.
-
-Deprecation
------------
+Code Deprecation
+=================
 
 - Anything that may be used by extensions (see :doc:`writing-extensions`) needs
   to maintain backward compatibility at call-site.  ie - template helper
@@ -204,3 +294,18 @@ Deprecation
         """
         # rest of function definition.
 
+
+Further Reading
+===============
+
+:doc:`python-coding-standards`
+
+:doc:`javascript-coding-standards`
+
+:doc:`html-coding-standards`
+
+:doc:`css-coding-standards`
+
+:doc:`release-cycle`
+
+:doc:`i18n`


### PR DESCRIPTION
I tried to organize the existing sections into Sean's architectural layers. The only thing that I found odd was the `Controller & Template Helper Functions` section, that doesn't seem to fit in. Maybe because we're not talking about controllers there...
