### PR TITLE
#726 Fix page zoom out render issue

### DIFF
--- a/ckan/public/base/less/layout.less
+++ b/ckan/public/base/less/layout.less
@@ -28,8 +28,7 @@
 }
 
 [role=main] .primary {
-  width: 719px;
-  margin-left: 1px;
+  width: 717px;
   float: right;
 }
 

--- a/ckan/public/base/less/mixins.less
+++ b/ckan/public/base/less/mixins.less
@@ -134,8 +134,6 @@ a.tag:hover {
 
 .box {
   background-color: #FFF;
-  margin-left: -1px;
-  margin-right: -1px;
   border: 1px solid @layoutTrimBorderColor;
   .border-radius(4px);
   .box-shadow(0 0 0 4px rgba(0, 0, 0, 0.05));


### PR DESCRIPTION
Fixes #726 

**Requires**: a `./bin/less --production` after merge

**Note:** This fix works up to 4 levels of zoom out. Once you get past `zoom: 0.6` this still happens. However in order to fix this in cases where the user zooms out < 0.6 it'd involve some very horrible JS [1] to detect a difference in zoom level and then adjust some item widths accordingly. I don't really want to add JS module for such a minor edge case.

[1] http://stackoverflow.com/questions/1713771/how-to-detect-page-zoom-level-in-all-modern-browsers/5078596#5078596
