### PR TITLE
#748 Changes page title on /organization index

### DIFF
--- a/ckan/templates/organization/index.html
+++ b/ckan/templates/organization/index.html
@@ -1,6 +1,6 @@
 {% extends "page.html" %}
 
-{% block subtitle %}{{ _('Organizations of Datasets') }}{% endblock %}
+{% block subtitle %}{{ _('Organizations') }}{% endblock %}
 
 {% block breadcrumb_content %}
   <li class="active">{% link_for _('Organizations'), controller='organization', action='index' %}</li>


### PR DESCRIPTION
Super simple fix for page title on /organization.

Fixes #748 
