### PR TITLE
[#776] Show organization search facets by default

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -216,10 +216,13 @@ class PackageController(base.BaseController):
 
             facets = OrderedDict()
 
-            default_facet_titles = {'groups': _('Groups'),
-                              'tags': _('Tags'),
-                              'res_format': _('Formats'),
-                              'license': _('Licence'), }
+            default_facet_titles = {
+                    'organization': _('Organizations'),
+                    'groups': _('Groups'),
+                    'tags': _('Tags'),
+                    'res_format': _('Formats'),
+                    'license': _('Licence'),
+                    }
 
             for facet in g.facets:
                 if facet in default_facet_titles:

--- a/ckan/lib/app_globals.py
+++ b/ckan/lib/app_globals.py
@@ -47,7 +47,7 @@ config_details = {
     'ckan.api_url': {},
 
     # split string
-    'search.facets': {'default': 'groups tags res_format license',
+    'search.facets': {'default': 'organization groups tags res_format license',
                       'type': 'split',
                       'name': 'facets'},
     'package_hide_extras': {'type': 'split'},


### PR DESCRIPTION
Show faceting by organization by default on the dataset search page.
Fixes #776.
