### PR TITLE
update actions to use correct names

### DIFF
--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -260,6 +260,10 @@ def get_action(action):
     :rtype: callable
 
     '''
+
+    # clean the action names
+    action = new_authz.clean_action_name(action)
+
     if _actions:
         if not action in _actions:
             raise KeyError("Action '%s' not found" % action)
@@ -278,6 +282,7 @@ def get_action(action):
             if not k.startswith('_'):
                 # Only load functions from the action module.
                 if isinstance(v, types.FunctionType):
+                    k = new_authz.clean_action_name(k)
                     _actions[k] = v
 
                     # Whitelist all actions defined in logic/action/get.py as
@@ -290,6 +295,7 @@ def get_action(action):
     fetched_actions = {}
     for plugin in p.PluginImplementations(p.IActions):
         for name, auth_function in plugin.get_actions().items():
+            name = new_authz.clean_action_name(name)
             if name in resolved_action_plugins:
                 raise Exception(
                     'The action %r is already implemented in %r' % (

--- a/ckan/new_authz.py
+++ b/ckan/new_authz.py
@@ -1,4 +1,5 @@
 import sys
+import re
 from logging import getLogger
 
 from pylons import config
@@ -17,6 +18,12 @@ class AuthFunctions:
 
 def clear_auth_functions_cache():
     AuthFunctions._functions.clear()
+
+
+def clean_action_name(action_name):
+    ''' Used to convert old style action names into new style ones '''
+    return re.sub('package', 'dataset', action_name)
+
 
 def is_sysadmin(username):
     ''' returns True is username is a sysadmin '''
@@ -62,6 +69,7 @@ def is_authorized(action, context, data_dict=None):
     if is_sysadmin(context.get('user')):
         return {'success': True}
 
+    action = clean_action_name(action)
     auth_function = _get_auth_function(action)
     if auth_function:
         return auth_function(context, data_dict)
@@ -245,6 +253,7 @@ def _get_auth_function(action, profile=None):
 
         for key, v in module.__dict__.items():
             if not key.startswith('_'):
+                key = clean_action_name(key)
                 AuthFunctions._functions[key] = v
 
     # Then overwrite them with any specific ones in the plugins:
@@ -252,6 +261,7 @@ def _get_auth_function(action, profile=None):
     fetched_auth_functions = {}
     for plugin in p.PluginImplementations(p.IAuthFunctions):
         for name, auth_function in plugin.get_auth_functions().items():
+            name = clean_action_name(name)
             if name in resolved_auth_function_plugins:
                 raise Exception(
                     'The auth function %r is already implemented in %r' % (


### PR DESCRIPTION
eg `package_show` should be `dataset_show`

we need to ensure that the old names continue to work etc - probably best to patch this via get_action - need to ensure that auth functions also behave the same way.
