### PR TITLE
Update Data Viewer docs for 2.0

### DIFF
--- a/doc/data-viewer.rst
+++ b/doc/data-viewer.rst
@@ -50,7 +50,7 @@ the resource read page:
 * ``gif``
 
 The types of resources that are embedded directly can be specified in the
-CKAN config file. See :ref:`_ckan_preview_direct` for more information.
+CKAN config file. See :ref:`ckan.preview.direct` for more information.
 
 The following types of resources will be loaded in an iframe:
 
@@ -68,7 +68,7 @@ The following types of resources will be loaded in an iframe:
 * ``rss``
 
 The types of resources that are loaded in an iframe can be specified in the
-CKAN config file. See :ref:`_ckan_preview_loadable` for more information.
+CKAN config file. See :ref:`ckan.preview.loadable` for more information.
 
 
 Viewing structured data: the Data Explorer


### PR DESCRIPTION
I don't think this covers all of CKAN's data preview capabilities anymore: http://docs.ckan.org/en/latest/data-viewer.html

It should explain what files CKAN can preview and what needs to be done to enable each kind of preview. What previews are available out of the box? Which require an extension like the recline-, json- and pdf-preview extensions or the datastore? Does a file need to be added into the filestore or datastore for the preview to work, etc?
