### PR TITLE
Site footer links don't stack correctly in IE7

### DIFF
--- a/ckan/public/base/less/iehacks.less
+++ b/ckan/public/base/less/iehacks.less
@@ -170,14 +170,6 @@
     }
   }
 
-  // Footer
-  .footer-links {
-    .clearfix;
-    li {
-      float: left;  
-    }
-  }
-
   // Navs
   .module-narrow .nav-item.image {
     .clearfix;


### PR DESCRIPTION
It looks like:

![Screen Shot 2013-04-23 at 10 56 11](https://f.cloud.github.com/assets/67366/413711/2837442a-abfc-11e2-81ac-08cbee3b9d4c.png)

It's because of this:

![Screen Shot 2013-04-23 at 10 56 46](https://f.cloud.github.com/assets/67366/413713/2bb02d92-abfc-11e2-9332-7d278c64bfa0.png)
