### PR TITLE
Update Publishing Datasets docs for 2.0

### DIFF
--- a/doc/publishing-datasets.rst
+++ b/doc/publishing-datasets.rst
@@ -16,7 +16,7 @@ Dataset
     Datasets contain resources.
 
 Resource
-    A resource represent individual data items in a dataset.
+    A resource represents individual data items in a dataset.
     For example: a ``csv`` file, the URL of an API, etc.
 
 Both datasets and resources can have information (metadata) associated with
@@ -33,7 +33,7 @@ that represent the same underlying data in different formats
 Storing data in CKAN and external resources
 ===========================================
 
-A CKAN resource be simply a URL that links to a data item that resides on a
+A CKAN resource may be simply a URL that links to a data item that resides on a
 different server (for example: a link to an online ``csv`` file).
 These resources are said to be *external* as they are not actually part of
 the CKAN site.


### PR DESCRIPTION
http://docs.ckan.org/en/latest/publishing-datasets.html

Embedding a google docs presentation into the docs seems bad, won't this break things like linking/referencing between docs pages, search engine hits, the printed/pdf version of the docs, etc.? Also the presentation is only four slides long and is all text what's the point! Just put it in the docs

The point of this chapter in the docs seems to be to explain some of CKAN's key concepts: dataset, resource, metadata, linking to files hosted elsewhere files vs uploading them to the filestore ... This seems like a good idea but it needs bringing up to date with CKAN's current feature set (some key features seem to be missing) and it should probably be moved nearer the beginning of the docs.
- [x] Change the google docs presentation into normal documentation text
- [x] Update the text to reflect CKAN 2.0's feature set
- [x] Add links, e.g. it mentions that you can upload files to CKAN, this should link ot the filestore page of the docs
- [ ] Move it to a better place in the docs
- [x] Remove the links to old blog posts about CKAN 1.x (We should probably document things in the docs not by linking to blog posts, as with the google presentation it'll break stuff like the pdf version)
