### PR TITLE
`paster less` does not properly build other colour schemes

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -1851,7 +1851,7 @@ class LessCommand(CkanCommand):
 
     custom_css = {
         'fuchsia': '''
-            @layoutLinkColor: #8B49A7;
+            @layoutLinkColor: #E73892;
             @footerTextColor: mix(#FFF, @layoutLinkColor, 60%);
             @footerLinkColor: @footerTextColor;
             @mastheadBackgroundColor: @layoutLinkColor;


### PR DESCRIPTION
Super simple fix as `@mastheadBackgroundColorStart` no longer exists and is replaced with `@mastheadBackgroundColor`
