### PR TITLE
[superseded ignore] 500 on non-ascii url

### DIFF
--- a/ckan/controllers/template.py
+++ b/ckan/controllers/template.py
@@ -29,11 +29,11 @@ class TemplateController(base.BaseController):
         """
         try:
             return base.render(url)
-        except TemplateNotFound:
+        except (TemplateNotFound, UnicodeEncodeError):
             if url.endswith('.html'):
                 base.abort(404)
             url += '.html'
             try:
                 return base.render(url)
-            except TemplateNotFound:
+            except (TemplateNotFound, UnicodeEncodeError):
                 base.abort(404)


### PR DESCRIPTION
Hi.

If i point my webbrowser to eg.
http://datahub.io/r%C3%A4ksm%C3%B6rg%C3%A5s

Instead of giving me a 404 it gives me a 500 and sends a stacktrace to the configured admin.
