### PR TITLE
When editing resources causes a validation error other field changes are lost

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -570,7 +570,9 @@ class PackageController(base.BaseController):
                                   action='resource_edit',
                                   resource_id=resource_id,
                                   id=id)
-        data = resource_dict
+        if not data:
+            data = resource_dict
+
         errors = errors or {}
         error_summary = error_summary or {}
         vars = {'data': data, 'errors': errors,


### PR DESCRIPTION
Steps to reproduce:
1. Edit a resource in a dataset
2. make some changes to name/description/format
3. delete the resource url
4. submit

What you see: All the old values from name/description/format are now entered in the form

What I expected: The form should contain all the modified values, not just the resource url that caused the error.
