### PR TITLE
error using curl test after following datastore setup instructions

### DIFF
--- a/doc/datastore-setup.rst
+++ b/doc/datastore-setup.rst
@@ -118,15 +118,21 @@ The DataStore is now set-up. To test the set-up, (re)start CKAN and run the foll
 
 This should return a JSON page without errors.
 
-To test the whether the set-up allows writing you can create a new resource in the DataStore. To do so, run the following command::
+To test the whether the set-up allows writing, you can create a new resource in the DataStore. To do so, run the following command::
 
  curl -X POST http://127.0.0.1:5000/api/3/action/datastore_create -H "Authorization: {YOUR-API-KEY}" -d '{"resource_id": "{RESOURCE-ID}", "fields": [ {"id": "a"}, {"id": "b"} ], "records": [ { "a": 1, "b": "xyz"}, {"a": 2, "b": "zzz"} ]}'
+
+Note that you will need to replace ``{YOUR-API-KEY}`` with a valid API key and ``{RESOURCE-ID}`` with a resource id of an existing CKAN resource.
 
 A table named after the resource id should have been created on your DataStore
 database. Visiting the following URL should return a response from the DataStore with
 the records inserted above::
 
  http://127.0.0.1:5000/api/3/action/datastore_search?resource_id={RESOURCE_ID}
+
+You can now delete the DataStore table with::
+
+ curl -X POST http://127.0.0.1:5000/api/3/action/datastore_delete -H "Authorization: {YOUR-API-KEY}" -d '{"resource_id": "{RESOURCE-ID}"}'
 
 To find out more about the DataStore API, go to :doc:`datastore-api`.
 


### PR DESCRIPTION
This is a follow on related to comment https://github.com/okfn/ckan/pull/269#issuecomment-12519785 and follow on comments.  I installed from source master branch.

I followed through the data store setup instructions and things went smoothly.  To test it out I tried the curl command suggested:

```
curl -X GET "http://127.0.0.1:5000/api/3/action/datastore_search?resource_id=_table_metadata"
```

At first this wasn't working.  I was getting the same error as @seanh as mentioned in the comment.  To test other parts of the system, I ran the development server from the command line, i.e.

  paster serve development.ini

I then registered a user and clicked on a few links.  Surmising that the database may have been initialized in some way, possibly addressing the problem, I tried the curl request/query again, and it worked.  It will be hard to reproduce this, since I'd need to reinstall again from scratch, but hopefully it will provide some hints toward a fix.
