### PR TITLE
[wip] [#519] Update deployment docs for CKAN 2.0

### DIFF
--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -46,7 +46,14 @@ use = egg:ckan
 full_stack = true
 cache_dir = %(here)s/data
 beaker.session.key = ckan
+
+# This is the secret token that the beaker library uses to hash the cookie sent
+# to the client. `paster make-config` generates a unique value for this each
+# time it generates a config file.
 beaker.session.secret = ${app_instance_secret}
+
+# `paster make-config` generates a unique value for this each time it generates
+# a config file.
 app_instance_uuid = ${app_instance_uuid}
 
 # List the names of CKAN extensions to activate.
@@ -302,24 +309,24 @@ ckan.debug_supress_header = false
 keys = root, ckan, ckanext
 
 [handlers]
-keys = console, file
+keys = console
 
 [formatters]
 keys = generic
 
 [logger_root]
 level = WARNING
-handlers = console, file
+handlers = console
 
 [logger_ckan]
 level = INFO
-handlers = console, file
+handlers = console
 qualname = ckan
 propagate = 0
 
 [logger_ckanext]
 level = DEBUG
-handlers = console, file
+handlers = console
 qualname = ckanext
 propagate = 0
 
@@ -329,11 +336,11 @@ args = (sys.stderr,)
 level = NOTSET
 formatter = generic
 
-[handler_file]
-class = logging.handlers.RotatingFileHandler
-formatter = generic
-level = NOTSET
-args = ("ckan.log", "a", 20000000, 9)
+#[handler_file]
+#class = logging.handlers.RotatingFileHandler
+#formatter = generic
+#level = NOTSET
+#args = ("ckan.log", "a", 20000000, 9)
 
 [formatter_generic]
 format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s

--- a/doc/datastore-setup.rst
+++ b/doc/datastore-setup.rst
@@ -32,17 +32,12 @@ Create users and databases
 
 .. tip::
 
- As is done in the example commands below, we recommend reusing your existing
- CKAN database user (``ckanuser`` in :doc:`install-from-source`) as the
- readwrite user for your datastore database.
+ If your CKAN database and DataStore databases are on different servers, then
+ you need to create a new database user on the server where the DataStore
+ database will be created. As in :doc:`install-from-source` we'll name the
+ database user ``masaq``, after the site we're creating::
 
- However, this might not be possible if the CKAN database and the DataStore
- database are on different servers. In this case, you should create a new
- database user on the server with the DataStore database::
-
-   sudo -u postgres createuser -S -D -R -P -l writeuser
-
- Then in the commands below, replace ``ckanuser`` with ``writeuser``.
+   sudo -u postgres createuser -S -D -R -P -l masaq
 
 Create a database user called ``readonlyuser``. This user will be given
 read-only access to your DataStore database in the `Set Permissions`_ step
@@ -50,19 +45,24 @@ below::
 
  sudo -u postgres createuser -S -D -R -P -l readonlyuser
 
-Create the database (owned by ``ckanuser``), which we'll call ``datastore``::
+Create the database (owned by ``masaq``), which we'll call
+``masaq-datastore``::
 
- sudo -u postgres createdb -O ckanuser datastore -E utf-8
+ sudo -u postgres createdb -O masaq masaq-datastore -E utf-8
 
 Set URLs
 --------
 
-Now, uncomment the ``ckan.datastore.write_url`` and ``ckan.datastore.read_url`` lines in your CKAN config file and edit them if necessary::
+Now, uncomment the ``ckan.datastore.write_url`` and ``ckan.datastore.read_url``
+lines in your CKAN config file and edit them, for example::
 
  # Datastore
  # Uncommment to set the datastore urls
- ckan.datastore.write_url = postgresql://ckanuser:pass@localhost/datastore
- ckan.datastore.read_url = postgresql://readonlyuser:pass@localhost/datastore
+ ckan.datastore.write_url = postgresql://masaq:pass@localhost/masaq-datastore
+ ckan.datastore.read_url = postgresql://readonlyuser:pass@localhost/masaq-datastore
+
+Replace ``pass`` with the passwords you created for your ``masaq`` and
+``readonlyuser`` database users.
 
 Set Permissions
 ---------------
@@ -78,7 +78,7 @@ This option is preferred if CKAN and PostgreSQL are on the same server.
 
 To set the permissions, use this paster command after you've set the database URLs (make sure to have your virtualenv activated)::
 
- paster datastore set-permissions postgres
+  paster datastore set-permissions postgres -c /etc/ckan/masaq/development.ini
 
 The ``postgres`` at the end of this command should be the name of a postgres
 user with permission to create new tables and users, grant permissions, etc.

--- a/doc/post-installation.rst
+++ b/doc/post-installation.rst
@@ -2,73 +2,66 @@
 Post-Installation Setup
 ========================
 
-After you have completed installation (from either package or source), follow this section for instructions on setting up an initial user, loading test data, and notes on deploying CKAN. 
+After you have completed installation (from either package or source), follow
+this section for instructions on setting up an initial user, loading test data,
+and notes on deploying CKAN.
 
 .. note::
 
-    If you installed CKAN from source, you will need to activate the virtualenv and switch to the ckan source directory.
-    In this case, you don't need to specifiy the `--plugin` or `--config` parameters when executing the paster commands, e.g.::
+  If you installed CKAN from source, you need to activate your virtualenv and
+  change to your CKAN directory in order for the commands on this page to
+  work. For example::
 
-        (pyenv):~/pyenv/src/ckan$ paster user list
+    . /usr/lib/ckan/masaq/bin/activate
+    cd /usr/lib/ckan/masaq/src/ckan
 
 
 .. _create-admin-user:
 
-Create an Admin User
-====================
+Create a Sysadmin User
+======================
 
-By default, CKAN has a set of locked-down permissions. To begin
-working with it you need to set up a user and some permissions. 
+You have to create your first CKAN sysadmin user from the command-line. Create
+a user called ``seanh`` and make him a sysadmin::
 
-First create an admin account from the command line (you must be root, ``sudo -s``):
+    paster sysadmin add seanh -c /etc/ckan/masaq/development.ini
 
-::
-
-    paster --plugin=ckan user add admin email=admin@example.com --config=development.ini
-
-When prompted, enter a password - this is the password you will use to log in to CKAN. In the resulting output, note that you will also get assigned a CKAN API key.
-
-.. note :: This command is your first introduction to some important CKAN concepts. **paster** is the script used to run CKAN commands. **std.ini** is the CKAN config file. You can change options in this file to configure CKAN. 
-
-For exploratory purposes, you might was well make the ``admin`` user a
-sysadmin. You obviously wouldn't give most users these rights as they would
-then be able to do anything. You can make the ``admin`` user a sysadmin like
-this:
-
-::
-
-    paster --plugin=ckan sysadmin add admin --config=development.ini
-
-You can now login to the CKAN frontend with the username ``admin`` and the password you set up.
+If a user called ``seanh`` already exists he will be promoted to a sysadmin. If
+the user account doesn't exist yet, it will be created.  You can now login to
+the CKAN web interface with your sysadmin account and promote more users to
+sysadmins using the web interface.
 
 .. _create-test-data:
 
 Load Test Data
 ==============
 
-It can be handy to have some test data to start with. You can get test data like this:
+It can be handy to have some test data to start with. You can get test data
+like this::
 
-::
+    paster create-test-data -c /etc/ckan/masaq/development.ini
 
-    paster --plugin=ckan create-test-data --config=/etc/ckan/std/std.ini
+You now have a CKAN instance that you can log in to, with some test data to
+check everything works.
 
-You now have a CKAN instance that you can log in to, with some test data to check everything
-works.
+You can also create various specialised test data collections for testing
+specific features of CKAN. For example, ``paster --plugin=ckan create-test-data
+translations`` creates some test data with some translations for testing the
+ckanext-multilingual extension. For more information, see::
 
-You can also create various specialised test data collections for testing specific features of CKAN. For example, ``paster --plugin=ckan create-test-data translations`` creates some test data with some translations for testing the ckanext-multilingual extension. For more information, see:
-
-::
-
-    paster --plugin=ckan create-test-data --help
+    paster create-test-data --help
 
 .. _deployment-notes:
 
-Deployment 
+Deployment
 ==========
 
-You may want to deploy your CKAN instance at this point, to share with others. 
+You may want to deploy your CKAN instance at this point, to share with others.
 
-If you have installed CKAN from packages, then Apache and WSGI deployment scripts are already configured for you in standard locations. 
+If you have installed CKAN from packages, then Apache and WSGI deployment
+scripts are already configured for you in standard locations.
 
-If you have installed CKAN from source, then the standard production deployment of CKAN is Apache and WSGI, which you will need to configure yourself. For more information, see :doc:`deployment`.
+If you have installed CKAN from source, then the standard production deployment
+of CKAN is Apache and WSGI, which you will need to configure yourself. For more
+information, see :doc:`deployment`.
 

--- a/doc/solr-setup.rst
+++ b/doc/solr-setup.rst
@@ -39,8 +39,8 @@ To install Solr (if you are following the :doc:`install-from-source` or
 
  sudo apt-get install solr-jetty openjdk-6-jdk
 
-You'll need to edit the Jetty configuration file (`/etc/default/jetty`) with the
-suitable values::
+You'll need to edit the Jetty configuration file (``/etc/default/jetty``) with
+the suitable values::
 
  NO_START=0            # (line 4)
  JETTY_HOST=127.0.0.1  # (line 15)
@@ -72,28 +72,29 @@ and the admin site::
 
         JAVA_HOME=/usr/lib/jvm/java-6-openjdk-i386/
 
-Now run::
-
-       sudo service jetty start
-
-
 This default setup will use the following locations in your file system:
 
-* `/usr/share/solr`: Solr home, with a symlink pointing to the configuration dir in `/etc`.
-* `/etc/solr/conf`: Solr configuration files. The more important ones are `schema.xml` and  `solrconfig.xml`.
-* `/var/lib/solr/data/`: This is where the index files are physically stored.
+``/usr/share/solr``
+  Solr home, with a symlink pointing to the configuration dir in ``/etc``.
 
-You will obviously need to replace the default `schema.xml` file with the CKAN one. To do
-so, create a symbolic link to the schema file in the config folder. Use the latest schema version
-supported by the CKAN version you are installing (it will generally be the highest one)::
+``/etc/solr/conf``
+  Solr configuration files. The more important ones are ``schema.xml`` and
+  ``solrconfig.xml``.
+
+``/var/lib/solr/data/``
+  This is where the index files are physically stored.
+
+You will obviously need to replace the default ``schema.xml`` file with the
+CKAN one. To do so, create a symbolic link to the schema file in the config
+folder. Use the latest schema version supported by the CKAN version you are
+installing (it will generally be the highest one)::
 
  sudo mv /etc/solr/conf/schema.xml /etc/solr/conf/schema.xml.bak
- sudo ln -s ~/pyenv/src/ckan/ckan/config/solr/schema-2.0.xml /etc/solr/conf/schema.xml
+ sudo ln -s /usr/lib/ckan/masaq/src/ckan/ckan/config/solr/schema-2.0.xml /etc/solr/conf/schema.xml
 
 Now restart jetty::
 
- sudo /etc/init.d/jetty stop
- sudo /etc/init.d/jetty start
+ sudo /etc/init.d/jetty restart
 
 And check that Solr is running by browsing http://localhost:8983/solr/ which should offer the Administration link.
 

--- a/doc/test.rst
+++ b/doc/test.rst
@@ -15,19 +15,20 @@ Some additional dependencies are needed to run the tests. Make sure you've
 created a config file at ``~/pyenv/ckan/development.ini``, then activate your
 virtual environment::
 
-    . ~/pyenv/bin/activate
+    . /usr/lib/ckan/masaq/bin/activate
 
 Install nose and other test-specific CKAN dependencies into your virtual
 environment::
 
-    pip install -r ~/pyenv/src/ckan/pip-requirements-test.txt
+    pip install -r /usr/lib/ckan/masaq/src/ckan/pip-requirements-test.txt
+
 
 Testing with SQLite
 -------------------
 
 To run the CKAN tests using SQLite as the database library::
 
-    cd ~/pyenv/src/ckan
+    cd /usr/lib/ckan/masaq/src/ckan
     nosetests --ckan ckan
 
 You *must* run the tests from the CKAN directory as shown above, otherwise the
@@ -61,8 +62,8 @@ Testing with PostgreSQL
 Starting in CKAN 2.1 tests are run in a separate postgres database by
 default.  You should create the test databases as follows::
 
-    sudo -u postgres createdb -O ckanuser ckan_test -E utf-8
-    sudo -u postgres createdb -O ckanuser ckan_test_datastore -E utf-8
+    sudo -u postgres createdb -O masaq ckan_test -E utf-8
+    sudo -u postgres createdb -O masaq ckan_test_datastore -E utf-8
     # create datastore user default password `pass`
     sudo -u postgres createuser -S -D -R -P -l readonlyuser
     # set the permissions for readonly user

--- a/test-core.ini
+++ b/test-core.ini
@@ -18,11 +18,11 @@ debug = false
 # Specify the database for SQLAlchemy to use:
 # * Postgres is currently required for a production CKAN deployment
 # * Sqlite (memory or file) can be used as a quick alternative for testing
-sqlalchemy.url = postgresql://ckanuser:pass@localhost/ckan_test
+sqlalchemy.url = postgresql://masaq:pass@localhost/ckan_test
 #sqlalchemy.url = sqlite:///
 
 ## Datastore
-ckan.datastore.write_url = postgresql://ckanuser:pass@localhost/ckan_test_datastore
+ckan.datastore.write_url = postgresql://masaq:pass@localhost/ckan_test_datastore
 ckan.datastore.read_url = postgresql://readonlyuser:pass@localhost/ckan_test_datastore
 
 ## Solr support


### PR DESCRIPTION
This is a fairly big rewrite of the deployment docs that also necessitates
changes to other docs (like the source install docs, etc.)

The idea is to document the deployment process that OKFN is currently using on
its servers, so that the deployment docs can become the docs for the OKFN dev
team and we can dogfood our own docs, instead of having a bunch of wiki pages,
READMEs, etc. that we follow and ignoring the "official" deployment docs. Hopefully those can all be deleted or cut down massively once this is done.

Secondly, this aims to merge source install and deployment into one process.
Deploying CKAN is just doing a source install, and then doing a couple of
extra things to create the WSGI and Apache config files. But because the
source install docs used `~/pyenv` and the deployment docs used
`/usr/local/demo.ckan.net`, it was much harder to do a deployment than it
should be. You would first have to follow the source install docs but replace
`~/pyenv` with `/usr/local/demo.ckan.net` everywhere and deal with all the
consequences. Then you would follow the deployment docs.

So both the Source Install and Deployment docs now describe the layout we use
on our servers, where there's space for multiple CKAN sites on the same
server, with virtualenvs in `/lib/ckan/` and config files in `/etc/ckan/`.

Since the multi-site layout requires a site name (for the name of the site's
virtualenv, etc.) I've invented a fictional CKAN site called `masaq` as an
example.
- [x] Update the deployment docs to use a virtualenv at `/lib/ckan/masaq`, config files at `/etc/ckan/masaq`, etc.
- [x] The deployment docs now use the WSGI and Apache config files that we're actually using on our servers, not the old versions that were in the docs
- [x] Deleted stuff about enabling CORS from deployment, apparently this is
  builtin since CKAN 1.5.
- [x] Update the install-from-source docs to use a virtualenv at `/lib/ckan/masaq`
  and config files at `/etc/ckan/masaq`, etc.
  
  The install-from-source and deployment now use the same `masaq` example
  with the same directory layout, database names, etc. So it's possible to
  step through the source install and the deployment docs exactly as written
  (copy-pasting everything without modification) and end up with a working
  deployed site.
- [x] Also added info to the install-from-source docs about how the filesystem
  layout etc is done and why
- [x] Update the DataStore Setup docs to use the `masaq` database user, and to
  call the datastore database `masaq-datastore`.
- [x] Update the solr-setup docs, this is just tweaking some formatting issues
  and updating some commands to follow the `masaq` example.
- [x] Update the post-install docs to fit with the `masaq` example as well
- [x] Update the testing docs to fit with the `masaq` example
- [x] Update `test-core.ini` to use the `masaq` postgres user name
- [x] Disable the log file in `deployment.ini_tmpl`, as we do on our servers, and
  rely only on the Apache logs

Still to do:
- [ ] Update filestore docs
- [ ] Incorporate @amercader's solr setup tweaks from https://github.com/okfn/ckan/pull/814
