### PR TITLE
Datastore SQL search crashes on LIKE statements with '%'

### DIFF
--- a/ckanext/datastore/db.py
+++ b/ckanext/datastore/db.py
@@ -1108,7 +1108,7 @@ def search_sql(context, data_dict):
         context['connection'].execute(
             u'SET LOCAL statement_timeout TO {0}'.format(timeout))
         results = context['connection'].execute(
-            data_dict['sql']
+            data_dict['sql'].replace('%', '%%')
         )
         return format_results(context, results, data_dict)
 

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -513,6 +513,18 @@ class TestDatastoreSQL(tests.WsgiAppCase):
 
         assert result['records'] == res_dict_alias['result']['records']
 
+    def test_select_where_like_with_percent(self):
+        query = 'SELECT * FROM public."{0}" WHERE "author" LIKE \'tol%\''.format(self.data['resource_id'])
+        data = {'sql': query}
+        postparams = json.dumps(data)
+        auth = {'Authorization': str(self.sysadmin_user.apikey)}
+        res = self.app.post('/api/action/datastore_search_sql', params=postparams,
+                            extra_environ=auth)
+        res_dict = json.loads(res.body)
+        assert res_dict['success'] is True
+        result = res_dict['result']
+        assert result['records'] == self.expected_records
+
     def test_self_join(self):
         query = '''
             select a._id as first, b._id as second


### PR DESCRIPTION
A query like this one, which uses the SQL filter `"COMMONNAME" LIKE 'CAS%'` returns a 500.

```
http://localhost:5000/api/action/datastore_search_sql?sql=SELECT%20*%20from%20%22e9841cd0-a8b9-4023-a56b-a2904edd8abb%22%20WHERE%20%22COMMONNAME%22%20LIKE%20'CAS%'
```

```
...
File '/home/adria/dev/pyenvs/ckan_datastore/src/ckan/ckanext/datastore/logic/action.py', line 287 in datastore_search_sql
  result = db.search_sql(context, data_dict)
File '/home/adria/dev/pyenvs/ckan_datastore/src/ckan/ckanext/datastore/db.py', line 1109 in search_sql
  try:
File '/home/adria/dev/pyenvs/ckan_datastore/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py', line 1449 in execute
  params)
File '/home/adria/dev/pyenvs/ckan_datastore/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py', line 1628 in _execute_text
  statement, parameters
File '/home/adria/dev/pyenvs/ckan_datastore/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py', line 1691 in _execute_context
  context)
File '/home/adria/dev/pyenvs/ckan_datastore/local/lib/python2.7/site-packages/sqlalchemy/engine/default.py', line 331 in do_execute
  cursor.execute(statement, parameters)
TypeError: 'dict' object does not support indexing
```
