### PR TITLE
No "resource-url-analytics" class on the recline fail "download resource" button

### DIFF
--- a/ckan/templates/dataviewer/snippets/data_preview.html
+++ b/ckan/templates/dataviewer/snippets/data_preview.html
@@ -13,7 +13,7 @@
     </p>
     <p id="data-view-error" class="collapse"></p>
     <p>
-      <a href="{{ raw_resource_url }}" class="btn btn-large" target="_blank">
+      <a href="{{ raw_resource_url }}" class="btn btn-large resource-url-analytics" target="_blank">
         <i class="icon-large icon-download"></i>
         {{ _('Download resource') }}
       </a>


### PR DESCRIPTION
This is causing events to be not logged on that download button. This will fix: https://github.com/okfn/ckanext-googleanalytics/issues/4

See: http://sa.staging.ckanhosted.com/dataset/sa-memory2/resource/116091f1-3064-48c4-b642-815b9d4b2ea0# for example
