### PR TITLE
allow package_create without name by setting name=id

### DIFF
--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -304,6 +304,8 @@ def package_dict_save(pkg_dict, context):
 
     if not pkg.id:
         pkg.id = str(uuid.uuid4())
+    if not pkg.name:
+        pkg.name = pkg.id
 
     package_resource_list_save(pkg_dict.get("resources"), pkg, context)
     package_tag_list_save(pkg_dict.get("tags"), pkg, context)


### PR DESCRIPTION
We don't yet have a way to generate a 'name' for the datasets we are importing or for ones that will be created through the web interface.

We are using existing UUIDs to identify datasets we are importing, setting both 'id' and 'name' to this value.  We want new datasets created by the web interface to have new uuids created and we don't have the normally required 'name' value to pass.  This change, along with an IDatasetForm that makes the 'name' field optional, makes ckan assign the same value for the 'name' and 'id' fields, just like the data we have imported.
