### PR TITLE
add a helpful response to SearchIndexError exceptions raised within the action API

### DIFF
--- a/ckan/controllers/api.py
+++ b/ckan/controllers/api.py
@@ -228,7 +228,7 @@ class ApiController(base.BaseController):
         except search.SearchIndexError, e:
             return_dict['error'] = {'__type': 'Search Index Error',
                     'message': 'Unable to add package to search index: %s' %
-                    request_data}
+                    str(e)}
             return_dict['success'] = False
             return self._finish(500, return_dict, content_type='json')
         return self._finish_ok(return_dict)


### PR DESCRIPTION
This is a fix for #835

This doesn't address improving CKAN's behaviour when SearchIndexError happens, but it does at least bring the Action API response in line with the rest API.
