### PR TITLE
prettifying ValidationErrors makes them less useful

### DIFF
--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -95,7 +95,7 @@ class ValidationError(ParameterError):
 
     def __str__(self):
         err_msgs = (super(ValidationError, self).__str__(),
-                    self.error_summary)
+                    self.error_dict)
         return ' - '.join([str(err_msg) for err_msg in err_msgs if err_msg])
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
I often get this sort of traceback in tests:

```
ValidationError: {u'Resources': u'Package resource(s) invalid', u'  type': u'V'}
```

There is no field named "Resources" and what's "type" thing with two spaces in front? With this change I now get:

```
ValidationError: {u'__type': u'Validation Error', u'resources': [{u'resource_type': [u'Missing value'], u'language': [u'Missing value']}]}
```

Look at that!  I can tell what fields failed validation and everything.  Beautiful!
