### PR TITLE
Licence filter is always blank in LH column

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -221,7 +221,7 @@ class PackageController(base.BaseController):
                     'groups': _('Groups'),
                     'tags': _('Tags'),
                     'res_format': _('Formats'),
-                    'license': _('Licence'),
+                    'license_id': _('Licence'),
                     }
 
             for facet in g.facets:

--- a/ckan/lib/app_globals.py
+++ b/ckan/lib/app_globals.py
@@ -47,7 +47,7 @@ config_details = {
     'ckan.api_url': {},
 
     # split string
-    'search.facets': {'default': 'organization groups tags res_format license',
+    'search.facets': {'default': 'organization groups tags res_format license_id',
                       'type': 'split',
                       'name': 'facets'},
     'package_hide_extras': {'type': 'split'},

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1345,6 +1345,12 @@ def package_search(context, data_dict):
                     new_facet_dict['display_name'] = group.display_name
                 else:
                     new_facet_dict['display_name'] = key_
+            elif key == 'license_id':
+                license = model.Package.get_license_register().get(key_)
+                if license:
+                    new_facet_dict['display_name'] = license.title
+                else:
+                    new_facet_dict['display_name'] = key_
             else:
                 new_facet_dict['display_name'] = key_
             new_facet_dict['count'] = value_


### PR DESCRIPTION
The licence filter in the LH column always shows the message "There are no filters for this search" even though there are multiple licences in use.  

This seems to be the case on all 2.0 sites I've tested (SA, beta, master and demo) 

![search for a dataset - ckan beta](https://f.cloud.github.com/assets/199920/445051/67b07958-b1b2-11e2-97eb-a7b6dc26552d.png)
