### PR TITLE
Groups on front page vary in height

### DIFF
--- a/ckan/public/base/less/homepage.less
+++ b/ckan/public/base/less/homepage.less
@@ -76,8 +76,14 @@
     max-height: 53px;
     .box-shadow(0 0 0 2px rgba(255, 255, 255, 0.5));
   }
+  .group-listing .box {
+    min-height: 275px;
+  }
   .group-list {
     margin-bottom: 0;
+    .dataset-content {
+      min-height: 70px;
+    }
   }
   .box .module {
     margin-top: 0;

--- a/ckan/templates/home/index.html
+++ b/ckan/templates/home/index.html
@@ -85,7 +85,7 @@
     {% for group in c.group_package_stuff %}
       <div class="span6">
         <div class="box">
-          {% snippet 'snippets/group_item.html', group=group.group_dict, truncate=100 %}
+          {% snippet 'snippets/group_item.html', group=group.group_dict, truncate=50, truncate_title=35 %}
         </div>
       </div>
     {% endfor %}

--- a/ckan/templates/snippets/group_item.html
+++ b/ckan/templates/snippets/group_item.html
@@ -1,12 +1,18 @@
 <section class="group-list module module-narrow module-shallow">
   <header class="module-heading media">
-    {% set url=h.url_for(controller='group', action='read', id=group.name) %}
-    {% set truncate=truncate or 0 %}
+    {% set url = h.url_for(controller='group', action='read', id=group.name) %}
+    {% set truncate = truncate or 0 %}
+    {% set truncate_title = truncate_title or 0 %}
+    {% set title = group.title or group.name %}
     <a class="media-image" href="{{ url }}">
       <img src="{{ group.image_url or h.url_for_static('/base/images/placeholder-group.png') }}" width="85" alt="{{ group.name }}" />
     </a>
     <div class="media-content">
-      <h3 class="media-heading"><a href={{ url }}>{{ group.title or group.name }}</a></h3>
+      <h3 class="media-heading">
+        <a href={{ url }}>
+          {{ title if truncate_title == 0 else h.truncate(title, truncate_title) }}
+        </a>
+      </h3>
       {% if group.description %}
         {% if truncate == 0 %}
           <p>{{ h.markdown_extract(group.description)|urlize }}</p>


### PR DESCRIPTION
The groups on the front page vary in height:

![Screenshot from 2013-03-25 13:23:49](https://f.cloud.github.com/assets/22498/297783/f5453174-9546-11e2-8010-c749e559454c.png)

There are a number of issues:
1. If a group's title doesn't fit on one line, then it wraps and the group block becomes taller than the blocks of other groups with shorter titles (this probably also happens if one group has a longer description than the other)
2. The number of datasets shown per group varies.
3. Do the datasets themselves also vary in height, if they have different length titles and descriptions?

For 2, we could limit the number of datasets shown per group to a fixed maximum, and if the group has more datasets add a "More datasets >" link at the bottom. They would still vary in height if one group had less datasets than the limit.
