### PR TITLE
Homepage Group Images IE10

### DIFF
--- a/ckan/public/base/less/group.less
+++ b/ckan/public/base/less/group.less
@@ -31,4 +31,7 @@
 .group-list .module-heading .media-image {
   overflow: hidden;
   max-height: 60px;
+  img {
+    max-width: 85px;
+  }
 }


### PR DESCRIPTION
The group thumbnails do not scale as expected in IE10.
