### PR TITLE
Default sort ordering is by created, not modified

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1262,7 +1262,7 @@ def package_search(context, data_dict):
     abort = data_dict.get('abort_search',False)
 
     if data_dict.get('sort') in (None, 'rank'):
-        data_dict['sort'] = 'score desc, metadata_created desc'
+        data_dict['sort'] = 'score desc, metadata_modified desc'
 
     results = []
     if not abort:


### PR DESCRIPTION
The default sort ordering for dataset searches is supposed to be most-recently-modified first, but it's actually most-recently-created first. This appears to have been a typo/accidental change in this commit: https://github.com/okfn/ckan/commit/bc496ffd758cf3053dc24e6e24e02f495553f71f 
