### PR TITLE
IE bug with tracking.js

### DIFF
--- a/ckan/public/base/javascript/tracking.js
+++ b/ckan/public/base/javascript/tracking.js
@@ -2,7 +2,6 @@ $(function (){
   // Tracking
   var url = location.pathname;
   // remove any site root from url
-  console.log($('body').data('site-root'));
   url = url.substring($('body').data('locale-root'), url.length);
   // trim any trailing /
   url = url.replace(/\/*$/, '');


### PR DESCRIPTION
`console.log` in tracking.js. See:

https://github.com/okfn/ckan/blob/master/ckan/public/base/javascript/tracking.js#L5

And this breaks IE when that file get's loaded.
