### PR TITLE
Fix cache_dir and beaker paths on deployment.ini_tmpl

### DIFF
--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -24,16 +24,13 @@ port = 5000
 [app:main]
 use = egg:ckan
 full_stack = true
-cache_dir = %(here)s/data
+cache_dir = /tmp/%(ckan.site_id)s/
 beaker.session.key = ckan
 
 # This is the secret token that the beaker library uses to hash the cookie sent
 # to the client. `paster make-config` generates a unique value for this each
 # time it generates a config file.
 beaker.session.secret = ${app_instance_secret}
-
-beaker.cache.data_dir = %(here)s/data/cache
-beaker.session.data_dir = %(here)s/data/sessions
 
 # `paster make-config` generates a unique value for this each time it generates
 # a config file.

--- a/ckan/config/who.ini
+++ b/ckan/config/who.ini
@@ -18,7 +18,7 @@ post_logout_url = /user/logged_out
 [plugin:openid]
 use = repoze.who.plugins.openid:make_identification_plugin
 store = file
-store_file_path = %(here)s/sstore
+store_file_path = /tmp/sstore
 #openid_field = openid
 openid_field = openid_identifier
 came_from_field = came_from

--- a/doc/install-from-source.rst
+++ b/doc/install-from-source.rst
@@ -231,23 +231,7 @@ Follow the instructions in :doc:`datastore-setup` to create the required
 databases and users, set the right permissions and set the appropriate values
 in your CKAN config file.
 
-8. Create the ``data`` and ``sstore`` directories
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Create the ``data`` and ``sstore`` directories:
-
-.. parsed-literal::
-
-    mkdir |data_dir| |sstore|
-
-The location of the ``sstore`` directory, which CKAN uses as its Repoze.who
-OpenID session directory, is specified by the ``store_file_path`` setting in
-the ``who.ini`` file.
-
-The location of the ``data`` directory, which CKAN uses as its Pylons cache, is
-is specified by the ``cache_dir`` setting in your CKAN config file.
-
-9. Link to ``who.ini``
+8. Link to ``who.ini``
 ~~~~~~~~~~~~~~~~~~~~~~
 
 ``who.ini`` (the Repoze.who configuration file) needs to be accessible in the
@@ -257,7 +241,7 @@ same directory as your CKAN config file, so create a symlink to it:
 
     ln -s |virtualenv|/src/ckan/who.ini |config_dir|/who.ini
 
-10. Run CKAN in the development web server
+9. Run CKAN in the development web server
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can use the Paste development server to serve CKAN from the command-line.
@@ -273,13 +257,13 @@ Apache or Nginx (see :doc:`post-installation`).
 Open http://127.0.0.1:5000/ in your web browser, and you should see the CKAN
 front page.
 
-11. Run the CKAN Tests
+10. Run the CKAN Tests
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Now that you've installed CKAN, you should run CKAN's tests to make sure that
 they all pass. See :doc:`test`.
 
-12. You're done!
+11. You're done!
 ~~~~~~~~~~~~~~~~
 
 You can now proceed to :doc:`post-installation` which covers creating a CKAN


### PR DESCRIPTION
Right now there are these on deployment.ini_tmpl:

```
cache_dir = %(here)s/data
beaker.cache.data_dir = %(here)s/data/cache
beaker.session.data_dir = %(here)s/data/sessions
```

This means that directories are created on `/etc/ckan/default/` which apart from creating permissions problems is a horrible place to put caching stuff.

This should be simplified to:

```
cache_dir = /tmp/%(ckan.site_id)s/
```

Beaker will create all necessary dirs under this one.
