### PR TITLE
resource_show does not suport GET

### DIFF
--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -69,7 +69,7 @@ class DatastorePlugin(p.SingletonPlugin):
 
         ## Do light wrapping around action function to add datastore_active
         ## to resource dict.  Not using IAction extension as this prevents
-        ## other plugins from having a custom resource_read.
+        ## other plugins from having a custom resource_show.
 
         # Make sure actions are cached
         resource_show = p.toolkit.get_action('resource_show')


### PR DESCRIPTION
Going to `http://demo.ckan.org/api/action/package_show?id=foo` returns json.
Going to `http://demo.ckan.org/api/action/resource_show?id=foo` returns `"Bad request - JSON Error: No request body data"`.

POST requests work as expected.

The problem is that the datastore overwrites the `resource_show` method to inject some information. The method is not marked side effect free, though.
