### PR TITLE
datastore plugin pgsql check on datastore DB, not main DB

### DIFF
--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -52,7 +52,7 @@ class DatastorePlugin(p.SingletonPlugin):
         else:
             self.read_url = self.config['ckan.datastore.read_url']
 
-        if not model.engine_is_pg():
+        if not self.write_url.startswith('postgresql'):
             log.warn('We detected that you do not use a PostgreSQL '
                      'database. The DataStore will NOT work and DataStore '
                      'tests will be skipped.')


### PR DESCRIPTION
I ran into a confusing situation here, getting "We detected that you do not use a PostgreSQL database. The DataStore will NOT work and DataStore tests will be skipped." I had the datastore as postgres://, so I tried changing to postgresql:// and got the same error. I googled, found PR 359 which says it's looking for 'postgresql', got more confused, looked through the code ...

Finally realized the code is checking the sqlalchemy.url, _not_ the datastore URL. This doesn't seem to be the right behavior or match the error message, so I made a simple patch to apply the same drivername startswith check to the datastore write_url directly, which seems the least-invasive way to make the behavior/error more understandable.
