### PR TITLE
Can not use filters on datastore_search on a GET request

### DIFF
--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -1,5 +1,6 @@
 import logging
 import pylons
+import json
 import ckan.logic as logic
 import ckan.plugins as p
 import ckanext.datastore.db as db
@@ -223,6 +224,12 @@ def datastore_search(context, data_dict):
     if 'id' in data_dict:
         data_dict['resource_id'] = data_dict['id']
     res_id = _get_or_bust(data_dict, 'resource_id')
+
+    if 'filters' in data_dict and isinstance(data_dict['filters'], basestring):
+        try:
+            data_dict['filters'] = json.loads(data_dict['filters'])
+        except ValueError:
+            pass
 
     data_dict['connection_url'] = pylons.config.get('ckan.datastore.read_url',
             pylons.config['ckan.datastore.write_url'])

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -157,6 +157,16 @@ class TestDatastoreSearch(tests.WsgiAppCase):
         assert result['total'] == 1
         assert result['records'] == [self.expected_records[0]]
 
+    def test_search_filters_get(self):
+        filters = {u'b\xfck': 'annakarenina'}
+        res = self.app.get('/api/action/datastore_search?resource_id={0}&filters={1}'.format(
+                    self.data['resource_id'], json.dumps(filters)))
+        res_dict = json.loads(res.body)
+        assert res_dict['success'] is True
+        result = res_dict['result']
+        assert result['total'] == 1
+        assert result['records'] == [self.expected_records[0]]
+
     def test_search_array_filters(self):
         data = {'resource_id': self.data['resource_id'],
                 'filters': {u'characters': [u'Princess Anna', u'Sergius']}}


### PR DESCRIPTION
The JSON object does not get decoded and returns an error:

http://beta.ckan.org/api/action/datastore_search?resource_id=50f6abfc-1ff3-4885-8d8b-ec452605f159&filters={%22Unit_Type%22:%22District%22,%22Prov_Name%22:%22Farah%22}

```
{"success": false, "error": {"__type": "Validation Error", "filters": ["Not a json object"]}}
```
