### PR TITLE
[#948] Use h.url_for_static for placeholder images

### DIFF
--- a/ckan/templates/group/snippets/group_item.html
+++ b/ckan/templates/group/snippets/group_item.html
@@ -17,7 +17,7 @@ Example:
 #}
 {% set url = h.url_for(group.type ~ '_read', action='read', id=group.name) %}
 <li class="media-item media media-vertical{% if first %} first{% endif %}{% if last %} last{% endif %}">
-  <a class="media-image" href="{{ url }}"><img src="{{ group.image_url or '/base/images/placeholder-group.png' }}" alt="{{ group.name }}" /></a>
+  <a class="media-image" href="{{ url }}"><img src="{{ group.image_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="{{ group.name }}" /></a>
   <div class="media-content">
     <h3 class="media-heading">
       <a href="{{ url }}" title="{{ _('View {name}').format(name=group.display_name) }}">

--- a/ckan/templates/organization/snippets/organization_item.html
+++ b/ckan/templates/organization/snippets/organization_item.html
@@ -17,7 +17,7 @@ Example:
 #}
 {% set url = h.url_for(organization.type ~ '_read', action='read', id=organization.name) %}
 <li class="media-item media media-vertical{% if first %} first{% endif %}{% if last %} last{% endif %}">
-  <a class="media-image" href="{{ url }}"><img src="{{ organization.image_url or '/base/images/placeholder-organization.png' }}" alt="{{ organization.name }}" /></a>
+  <a class="media-image" href="{{ url }}"><img src="{{ organization.image_url or h.url_for_static('/base/images/placeholder-organization.png') }}" alt="{{ organization.name }}" /></a>
   <div class="media-content">
     <h3 class="media-heading">
       <a href="{{ url }}" title="{{ _('View {name}').format(name=organization.display_name) }}">

--- a/ckan/templates/related/snippets/related_item.html
+++ b/ckan/templates/related/snippets/related_item.html
@@ -15,7 +15,7 @@ Example:
 } %}
 <li class="related-item media-item media media-vertical{% if first %} first{% endif %}{% if last %} last{% endif %}" data-module="related-item">
   <a class="media-image" href="{{ related.url }}">
-    <img src="{{ related.image_url or placeholder_map[related.type] or '/base/images/placeholder-image.png' }}" alt="{{ related.title }}" />
+    <img src="{{ related.image_url or placeholder_map[related.type] or h.url_for_static('/base/images/placeholder-image.png') }}" alt="{{ related.title }}" />
     <span class="banner">
       {%- if related.type == 'application' -%}
         app


### PR DESCRIPTION
Placeholder images in 3 templates were not using h.url_for_static,
causing placeholder images to be broken when CKAN is mounted on
non-root URL.

Fixes #948.
