### PR TITLE
Apply better/more logical font sizes to all headings

### DIFF
--- a/ckan/public/base/less/prose.less
+++ b/ckan/public/base/less/prose.less
@@ -1,3 +1,23 @@
+h1 {
+  font-size: 28px;
+}
+h2 {
+  font-size: 21px;
+}
+h3 {
+  font-size: 18px;
+}
+h4 {
+  font-size: @baseFontSize;
+}
+
+h1, h2, h3, h4 {
+  line-height: 1.5;
+  small {
+    font-size: @baseFontSize;
+  }
+}
+
 .prose {
   h1, heading-1
   h2, heading-2 {


### PR DESCRIPTION
Currently the headings are running of the default font sizes within bootstrap and they are slightly too big. Especially since there is user generated content appearing within `<h1>`s.

We should simplify the sizes to be smaller in general and make sure all instances of where we use headings (markdown included) is the same.
