### PR TITLE
Add space between rows of chosen facets on search result page

### DIFF
--- a/ckan/public/base/less/dataset.less
+++ b/ckan/public/base/less/dataset.less
@@ -86,6 +86,10 @@
 
 .filter-list {
   color: @layoutTextColor;
+  line-height: 32px;
+  .pill {
+    line-height: 21px;
+  }
 }
 
 .filter-list .extra {


### PR DESCRIPTION
So that the tag bubbles are slightly separated, see:
http://demo.ckan.org/dataset?res_format=CSV&tags=transparency&license_id=notspecified&groups=data-explorer
