### PR TITLE
Explore dropdown menu is hidden behind other resources in IE

### DIFF
--- a/ckan/public/base/less/iehacks.less
+++ b/ckan/public/base/less/iehacks.less
@@ -209,4 +209,22 @@
     zoom: 1;
   }
 
+  // Resource Item listing on dataset page
+  .resource-item {
+    position: static;
+    padding-bottom: 1px;
+    .heading {
+      position: relative;
+    }
+    .format-label {
+      left: -48px; 
+    }
+    .btn-group {
+      position: relative;
+      float: right;
+      top: -35px;
+      right: 0;
+    }
+  }
+
 }


### PR DESCRIPTION
- View a dataset with multiple resources in IE7 e.g. http://master.ckan.org/dataset/adur_district_spending
- Click on explore button of top resource
- The menu is hidden behind the resource below (see screenshot)

![ie7 clean running](https://f.cloud.github.com/assets/199920/536841/75b78ece-c161-11e2-8079-3021e11d5f52.png)
