### PR TITLE
Make vdm 0.11 a PyPI package dependency

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -7,7 +7,7 @@ sqlalchemy-migrate==0.7.2
 sqlalchemy==0.7.8
 webhelpers==1.3
 pyutilib.component.core==4.5.3
--e git+https://github.com/okfn/vdm.git@vdm-0.11#egg=vdm
+vdm==0.11
 solrpy==0.9.5
 formalchemy==1.4.2
 pairtree==0.7.1-T


### PR DESCRIPTION
I just had to install CKAN in an offline environment. It would have helped if the CKAN dependencies were all non-editable ie. published as packages on PyPI (e.g. [like this](http://stackoverflow.com/a/14447068/114462)).

`vdm` is the only editable dependency left because `vdm==0.11` is not published on PyPI (see https://github.com/okfn/vdm/issues/5 ).
