### PR TITLE
Homepage Featured Box Heading Background (IE)

### DIFF
--- a/ckan/public/base/less/iehacks.less
+++ b/ckan/public/base/less/iehacks.less
@@ -227,4 +227,9 @@
     }
   }
 
+  // Adds proper BG color for IE7
+  .media-overlay .media-heading {
+    background-color: #000;
+  }
+
 }


### PR DESCRIPTION
.media-overlay .media-heading fall-back background colour (for browsers without RGBa support) is not working. Possibly needs to be declared as rgb rather than hex.. https://github.com/okfn/ckan/blob/master/ckan/public/base/css/main.css#L5176
