### PR TITLE
No display of Organisation key value pair info

### DIFF
--- a/ckan/templates/group/about.html
+++ b/ckan/templates/group/about.html
@@ -12,5 +12,9 @@
 		<p class="empty">{{ _('There is no description for this group') }}</p>
 	{% endif %}
 	{% endblock %}
+
+    {% block group_extras %}
+      {% snippet 'snippets/additional_info.html', extras = h.sorted_extras(c.group_dict.extras) %}
+    {% endblock %}
 </section>
 {% endblock %}

--- a/ckan/templates/organization/about.html
+++ b/ckan/templates/organization/about.html
@@ -12,5 +12,9 @@
 		<p class="empty">{{ _('There is no description for this organization') }}</p>
 	{% endif %}
 	{% endblock %}
+
+    {% block organization_extras %}
+      {% snippet 'snippets/additional_info.html', extras = h.sorted_extras(c.group_dict.extras) %}
+    {% endblock %}
 </section>
 {% endblock %}

--- a/ckan/templates/snippets/additional_info.html
+++ b/ckan/templates/snippets/additional_info.html
@@ -1,0 +1,25 @@
+{# This snippet creates an Additional Info Table
+
+extras is a list of tuples of the form (key, value)
+
+#}
+{% if extras %}
+  <h3>{{ _('Additional Info') }}</h3>
+  <table class="table table-striped table-bordered table-condensed">
+    <thead>
+      <tr>
+        <th scope="col">{{ _('Field') }}</th>
+        <th scope="col">{{ _('Value') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for extra in extras %}
+        {% set key, value = extra %}
+        <tr rel="dc:relation" resource="_:extra{{ i }}">
+          <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key) }}</th>
+          <td class="dataset-details" property="rdf:value">{{ value }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endif %}


### PR DESCRIPTION
My org about page: http://master.ckan.org/organization/about/itest
does not show the extra fields that have been added (see below). Why do we need these fields? When did they get added to orgs? @tobes?

![Screen Shot 2013-02-26 at 12 36 22](https://f.cloud.github.com/assets/1260289/196235/3355eb20-8011-11e2-9373-cd600a5d0388.png)
