### PR TITLE
Follow Debian convention for naming the CKAN package

### DIFF
--- a/doc/install-from-package.rst
+++ b/doc/install-from-package.rst
@@ -24,7 +24,7 @@ CKAN:
 
 #. Download the CKAN package::
 
-    wget http://packaging.ckan.org/python-ckan-2.0_amd64.deb
+    wget http://packaging.ckan.org/python-ckan_2.0_amd64.deb
 
    .. note:: If ``wget`` is not present, you can install it
        via::
@@ -33,7 +33,7 @@ CKAN:
 
 #. Install the CKAN package::
 
-    sudo dpkg -i python-ckan-2.0_amd64.deb
+    sudo dpkg -i python-ckan_2.0_amd64.deb
 
 .. note:: If you get the following error it means that for some reason the
  Apache WSGI module was not enabled::


### PR DESCRIPTION
The convention for naming the Debian packages is:

```
<foo>_<VersionNumber>-<DebianRevisionNumber>_<DebianArchitecture>.deb
```

We are currently naming it as such in the docs:

```
python-ckan-2.0_amd64.deb
```

It should be (notice the underscore):

```
python-ckan_2.0_amd64.deb
```

The necessary 301 redirect is already in place in the packaging server.
