### PR TITLE
[#974] Disable email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - PGVERSION=8.4
 script: ./bin/travis-build
 notifications:
+  email: false
   irc:
     channels:
       - "irc.freenode.org#ckan"


### PR DESCRIPTION
Disable all email notifications from Travis. At the moment Travis doesn't seem to have a way to say "Don't email this email address" Or "Don't email repo owner".
