### PR TITLE
Javascript error when adding a dataset in IE7

### DIFF
--- a/ckan/public/base/javascript/modules/autocomplete.js
+++ b/ckan/public/base/javascript/modules/autocomplete.js
@@ -80,6 +80,12 @@ this.ckan.module('autocomplete', function (jQuery, _) {
         // This is not part of the plugins API and so may break at any time.
         select2.search.on('keydown', this._onKeydown);
       }
+
+      // This prevents Internet Explorer from causing a window.onbeforeunload
+      // even from firing unnecessarily
+      $('.select2-choice', select2.container).on('click', function() {
+        return false;
+      });
     },
 
     /* Looks up the completions for the current search term and passes them


### PR DESCRIPTION
Tested on Master in IE7. (http://master.ckan.org/dataset/new - running 956a1b6)

When you choose any of the drop down menus (e.g. Licence) on the add dataset page you get a JS error. 

See screenshot

![ie7 clean running](https://f.cloud.github.com/assets/199920/590477/cfca4eda-c9e3-11e2-8782-a84b4571b3ab.png)
