### PR TITLE
[#803] Warn users before deleting an organization

### DIFF
--- a/ckan/templates/organization/snippets/organization_form.html
+++ b/ckan/templates/organization/snippets/organization_form.html
@@ -74,7 +74,7 @@
   <div class="form-actions">
       {% block delete_button %}
         {% if h.check_access('organization_delete', {'id': data.id})  %}
-          {% set locale = h.dump_json({'content': _('Are you sure you want to delete this Organization?')}) %}
+          {% set locale = h.dump_json({'content': _('Are you sure you want to delete this Organization? This will delete all the public and private datasets belonging to this organization.')}) %}
           <a class="btn btn-danger pull-left" href="{% url_for controller='organization', action='delete', id=data.id %}" data-module="confirm-action" data-module-i18n="{{ locale }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
         {% endif %}
       {% endblock %}


### PR DESCRIPTION
Deleting an organization deletes all the public and private datasets
belonging to the organization. Add a warning to the delete confirmation
about this.
