### PR TITLE
Improve description when using social sharing links

### DIFF
--- a/ckan/templates/package/read_base.html
+++ b/ckan/templates/package/read_base.html
@@ -7,6 +7,13 @@
     <link rel="alternate" type="application/rdf+xml" href="{{ h.url_for(controller='package', action='read', id=pkg.id, format='rdf', qualified=True) }}"/>
 {% endblock -%}
 
+{% block head_extras -%}
+  {{ super() }}
+  {% set description = h.markdown_extract(pkg.notes, extract_length=200)|forceescape %}
+  <meta property="og:title" content="{{ h.dataset_display_name(pkg) }} - {{ g.site_title }}">
+  <meta property="og:description" content="{{ description|forceescape }}">
+{% endblock -%}
+
 {% block actions_content %}
   {# NOTE: Not implemented in stage 1 #}
   {# <li>{% link_for _('History'), controller='package', action='history', id=pkg.name, class_='btn', icon='undo' %}</li> #}

--- a/ckan/templates/package/resource_read.html
+++ b/ckan/templates/package/resource_read.html
@@ -2,6 +2,13 @@
 
 {% set res = c.resource %}
 
+{% block head_extras -%}
+  {{ super() }}
+  {% set description = h.markdown_extract(res.description, extract_length=200) if res.description else h.markdown_extract(c.package.notes, extract_length=200) %}
+  <meta property="og:title" content="{{ h.dataset_display_name(c.package) }} - {{ h.resource_display_name(res) }} - {{ g.site_title }}">
+  <meta property="og:description" content="{{ description|forceescape }}">
+{% endblock -%}
+
 {% block subtitle %}{{ h.dataset_display_name(c.package) }} - {{ h.resource_display_name(res) }}{% endblock %}
 
 {% block breadcrumb_content_selected %}{% endblock %}


### PR DESCRIPTION
When sharing a dataset (using the social links in the left column of the dataset page or resource page), the default copy needs to be improved.  (Currently includes lots of irrelevant detail, see screenshot of example from Google Plus)

![share on google](https://f.cloud.github.com/assets/199920/445007/689f0f38-b1b1-11e2-8c24-4718ea9ed49f.png)

Default copy for a dataset should be:
Dataset name - Site name, 
Dataset description, URL

Default copy for a resource should be
Dataset name - Resource name- Site name, 
Resource description, URL
