### PR TITLE
[#861] Change the logic for sorting dataset search

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1264,7 +1264,7 @@ def package_search(context, data_dict):
     abort = data_dict.get('abort_search',False)
 
     if data_dict.get('sort') in (None, 'rank'):
-        if data_dict['q']:
+        if data_dict.get('q'):
             data_dict['sort'] = 'score desc, metadata_modified desc'
         else:
             data_dict['sort'] = 'metadata_modified desc'


### PR DESCRIPTION
Default to metadata_modified desc if no query and relevance if there is
a query.

This breaks a whole lot of tests and I'm not sure if I'm doing the right thing. @seanh, if you could take a look at a fix and tell me if I'm going in the right direction, that'd be great.
