### PR TITLE
comments_template() is unused

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -75,9 +75,6 @@ class PackageController(base.BaseController):
     def _edit_template(self, package_type):
         return lookup_package_plugin(package_type).edit_template()
 
-    def _comments_template(self, package_type):
-        return lookup_package_plugin(package_type).comments_template()
-
     def _search_template(self, package_type):
         return lookup_package_plugin(package_type).search_template()
 
@@ -356,27 +353,6 @@ class PackageController(base.BaseController):
         template = template[:template.index('.') + 1] + format
 
         return render(template, loader_class=loader)
-
-    def comments(self, id):
-        package_type = self._get_package_type(id)
-        context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author}
-
-        # check if package exists
-        try:
-            c.pkg_dict = get_action('package_show')(context, {'id': id})
-            c.pkg = context['package']
-        except NotFound:
-            abort(404, _('Dataset not found'))
-        except NotAuthorized:
-            abort(401, _('Unauthorized to read package %s') % id)
-
-        # used by disqus plugin
-        c.current_package_id = c.pkg.id
-
-        # render the package
-        package_saver.PackageSaver().render_package(c.pkg_dict)
-        return render(self._comments_template(package_type))
 
     def history(self, id):
         package_type = self._get_package_type(id.split('@')[0])

--- a/ckan/lib/plugins.py
+++ b/ckan/lib/plugins.py
@@ -220,9 +220,6 @@ class DefaultDatasetForm(object):
     def edit_template(self):
         return 'package/edit.html'
 
-    def comments_template(self):
-        return 'package/comments.html'
-
     def search_template(self):
         return 'package/search.html'
 

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -688,16 +688,6 @@ class IDatasetForm(Interface):
 
         '''
 
-    def comments_template(self):
-        '''Return the path to the template for the dataset comments page.
-
-        The path should be relative to the plugin's templates dir, e.g.
-        ``'package/comments.html'``.
-
-        :rtype: string
-
-        '''
-
     def search_template(self):
         '''Return the path to the template for use in the dataset search page.
 

--- a/ckanext/example_idatasetform/plugin.py
+++ b/ckanext/example_idatasetform/plugin.py
@@ -56,7 +56,6 @@ class ExampleIDatasetFormPlugin(plugins.SingletonPlugin,
     num_times_new_template_called = 0
     num_times_read_template_called = 0
     num_times_edit_template_called = 0
-    num_times_comments_template_called = 0
     num_times_search_template_called = 0
     num_times_history_template_called = 0
     num_times_package_form_called = 0
@@ -149,10 +148,6 @@ class ExampleIDatasetFormPlugin(plugins.SingletonPlugin,
     def edit_template(self):
         ExampleIDatasetFormPlugin.num_times_edit_template_called += 1
         return super(ExampleIDatasetFormPlugin, self).edit_template()
-
-    def comments_template(self):
-        ExampleIDatasetFormPlugin.num_times_comments_template_called += 1
-        return super(ExampleIDatasetFormPlugin, self).comments_template()
 
     def search_template(self):
         ExampleIDatasetFormPlugin.num_times_search_template_called += 1

--- a/ckanext/test_tag_vocab_plugin.py
+++ b/ckanext/test_tag_vocab_plugin.py
@@ -31,9 +31,6 @@ class MockVocabTagsPlugin(plugins.SingletonPlugin):
     def edit_template(self):
         return 'package/edit.html'
 
-    def comments_template(self):
-        return 'package/comments.html'
-
     def search_template(self):
         return 'package/search.html'
 


### PR DESCRIPTION
IDatasetForm has a `comments_template()` method (with a corresponding implementation in `DefaultPackageForm` but it never gets called. There's a `_comments_template()` in `PackageController` that looks up the IDatasetForm's comments_template() method, but _comments_template() is never called.

I'm not sure what this is for. Remove it?

(If so it should also be removed from ExampleIDatasetForm and its tests)
