### PR TITLE
Enable resource proxy by default

### DIFF
--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -80,9 +80,7 @@ ckan.site_id = default
 
 # Note: Add ``datastore`` to enable the CKAN DataStore
 #       Add ``pdf_preview`` to enable the resource preview for PDFs
-#		Add ``resource_proxy`` to enable resorce proxying and get around the
-#		same origin policy
-ckan.plugins = stats text_preview recline_preview
+ckan.plugins = stats resource_proxy text_preview recline_preview
 
 
 ## Front-End Settings


### PR DESCRIPTION
Many requests on the mailing list are caused by the fact that the resource proxy is not enabled. When I first submitted a pull request for the resource proxy, we decided not to enable it by default because we weren't sure about the consequences. IMHO, we can now be confident that it is not a big problem. 
