### PR TITLE
ValueError when showing resources whose "size" is not an int

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1457,7 +1457,12 @@ def format_resource_items(items):
             continue
         # size is treated specially as we want to show in MiB etc
         if key == 'size':
-            value = formatters.localised_filesize(int(value))
+            try:
+                value = formatters.localised_filesize(int(value))
+            except ValueError:
+                # Sometimes values that can't be converted to ints can sneak
+                # into the db. In this case, just leave them as they are.
+                pass
         elif isinstance(value, basestring):
             # check if strings are actually datetime/number etc
             if re.search(reg_ex_datetime, value):


### PR DESCRIPTION
Example: http://www.publicdata.eu/dataset/pks-register-of-tender-documentation/resource/07554517-5171-4ff8-9ed3-fa5b6431a296

It crashes because the resource's "size" is not an int: http://publicdata.eu/api/3/action/resource_show?id=07554517-5171-4ff8-9ed3-fa5b6431a296

```
File '/usr/lib/ckan/src/ckan/ckan/lib/helpers.py', line 1454 in format_resource_items
  value = formatters.localised_filesize(int(value))
ValueError: invalid literal for int() with base 10: 'None'
```
