### PR TITLE
Update .gitmodules do get sphinx throught https on github

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "doc/_themes/sphinx-theme-okfn"]
 	path = doc/_themes/sphinx-theme-okfn
-	url = git://github.com/okfn/sphinx-theme-okfn.git
+	url = https://github.com/okfn/sphinx-theme-okfn.git


### PR DESCRIPTION
Update .gitmodules to get sphinx through https on github. Goo for networks that block the git ports on their firewall
