### PR TITLE
Toolkit update

### DIFF
--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -51,6 +51,14 @@ class _Toolkit(object):
         'ValidationError',      # model update validation error
         'CkanCommand',          # class for providing cli interfaces
         'DefaultDatasetForm',   # base class for IDatasetForm plugins
+        'response',             # response object for cookies etc
+        'BaseController',       # Allow controllers to be created
+        'abort',                # abort actions
+        'redirect_to',          # allow redirections
+        'url_for',              # create urls
+        'get_or_bust',          # helpful for actions
+        'side_effect_free',     # actions can be accessed via api
+        'auth_sysadmins_check', # allow auth functions to be checked for sysadmins
 
         ## Fully defined in this file ##
         'add_template_directory',
@@ -71,9 +79,11 @@ class _Toolkit(object):
         import ckan
         import ckan.lib.base as base
         import ckan.logic as logic
+        import ckan.lib.helpers as h
         import ckan.lib.cli as cli
         import ckan.lib.plugins as lib_plugins
         import ckan.common as common
+        import pylons
 
         # Allow class access to these modules
         self.__class__.ckan = ckan
@@ -104,6 +114,15 @@ class _Toolkit(object):
 
         t['CkanCommand'] = cli.CkanCommand
         t['DefaultDatasetForm'] = lib_plugins.DefaultDatasetForm
+
+        t['response'] = pylons.response
+        t['BaseController'] = base.BaseController
+        t['abort'] = base.abort
+        t['redirect_to'] = h.redirect_to
+        t['url_for'] = h.url_for
+        t['get_or_bust'] = logic.get_or_bust
+        t['side_effect_free'] = logic.side_effect_free
+        t['auth_sysadmins_check'] = logic.auth_sysadmins_check
 
         # class functions
         t['render_snippet'] = self._render_snippet

--- a/doc/toolkit.rst
+++ b/doc/toolkit.rst
@@ -42,6 +42,10 @@ templates via h.example_helper() ::
 
 The following functions, classes and exceptions are provided by the toolkit.
 
+*class* **BAseController**
+  Base class for building controllers.
+
+
 *class* **CkanCommand**
   Base class for building paster functions.
 
@@ -150,3 +154,36 @@ The following functions, classes and exceptions are provided by the toolkit.
 **requires_ckan_version** (*min_version, max_version=None*)
   Check that the ckan version is correct for the plugin.
 
+
+**request** object
+  This is the http request and contains the environ, cookies etc.
+
+
+**response** object
+  This is the http response.
+
+
+**abort** (*error_code, error_message*)
+  Aborts the current request.
+
+
+**redirect**
+  This causes a http redirect to be returned to the client.
+
+
+**url_for**
+  This function can be used to create urls.
+
+
+**side_effect_free** decorator
+  This marks action functions as accessible via the action api.
+
+
+**auth_sysadmins_check** decorator
+  This marks auth functions as needing to be run for sys admins.  Usually
+  sysadmins are automatically allowed to run actions etc.
+
+
+**get_or_bust** (*data_dict, keys*)
+    Try and get values from dictionary and if they are not there
+    raise a ValidationError.


### PR DESCRIPTION
#665 is related issue

adds some extra functions etc

```
    'response',             # response object for cookies etc
    'BaseController',       # Allow controllers to be created
    'abort',                # abort actions
    'redirect_to',          # allow redirections
    'url_for',              # create urls
    'get_or_bust',          # helpful for actions
    'side_effect_free',     # actions can be accessed via api
    'auth_sysadmins_check', # allow auth functions to be checked for sysadmins
```
