### PR TITLE
[#1027] Fixes celery configuration to allow overriding from config

### DIFF
--- a/ckan/lib/celery_app.py
+++ b/ckan/lib/celery_app.py
@@ -57,7 +57,7 @@ try:
 except ConfigParser.NoSectionError:
     pass
 
-# Thes update of configuration means it is only possible to set each 
+# Thes update of configuration means it is only possible to set each
 # key once so this is done once all of the options have been decided.
 celery.conf.update(default_config)
 celery.loader.conf.update(default_config)


### PR DESCRIPTION
Patch allows for the overriding of celery settings to work by only setting the config options once.  Attempts to override the values once they are submitted to celery have no effect.

Also removed an unused (commented-out) import.
