### PR TITLE
Validation problem in term_translation_update_many

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -764,11 +764,10 @@ def term_translation_update_many(context, data_dict):
     '''
     model = context['model']
 
-
-    if not data_dict.get('data') and isinstance(data_dict, list):
+    if not (data_dict.get('data') and isinstance(data_dict.get('data'), list)):
         raise ValidationError(
-            {'error':
-             'term_translation_update_many needs to have a list of dicts in field data'}
+            {'error': ['term_translation_update_many needs to have a '
+                       'list of dicts in field data']}
         )
 
     context['defer_commit'] = True


### PR DESCRIPTION
If no data is given then num is not defined here:
https://github.com/okfn/ckan/blob/master/ckan/logic/action/update.py#L776

This should be caught here, but for some reason we are also checking to see if data_dict is a list:
https://github.com/okfn/ckan/blob/master/ckan/logic/action/update.py#L768
