### PR TITLE
CKAN does not respect the ckan.i18n_directory config option when looking for locales

### DIFF
--- a/ckan/lib/i18n.py
+++ b/ckan/lib/i18n.py
@@ -34,7 +34,10 @@ def _get_locales():
     locale_order = config.get('ckan.locale_order', '').split()
 
     locales = ['en']
-    i18n_path = os.path.dirname(ckan.i18n.__file__)
+    if config.get('ckan.i18n_directory'):
+        i18n_path = os.path.join(config.get('ckan.i18n_directory'), 'i18n')
+    else:
+        i18n_path = os.path.dirname(ckan.i18n.__file__)
     locales += [l for l in os.listdir(i18n_path) if localedata.exists(l)]
 
     assert locale_default in locales, \


### PR DESCRIPTION
See: https://github.com/okfn/ckan/blob/release-v2.0/ckan/lib/i18n.py#L37

This line should use ckan.i18n_directory if available
