### PR TITLE
speed up package_list action by only retrieving column we need (not whole package) from db

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -72,7 +72,7 @@ def package_list(context, data_dict):
 
     _check_access('package_list', context, data_dict)
 
-    from ckan.model.package import package_revision_table
+    package_revision_table = model.package_revision_table
     col = (package_revision_table.c.id
         if api == 2 else package_revision_table.c.name)
     query = _select([col])


### PR DESCRIPTION
importing package_revision_table here might be frowned on.  What sorts of optimizations would you consider acceptable?

It would be even faster if we did some `select array(...)` magic in our query, but that might be taking it a little too far.

edit: performance numbers from comments below:

| option | time(s) | improvement |
| --- | --: | --: |
| original | 0.479 | 1.0x |
| this PR | 0.048 | 10.0x |
| select array | 0.027 | 17.7x |
