### PR TITLE
header debug info has been hidden via css please bring it back asap

### DIFF
--- a/ckan/public/base/less/ckan.less
+++ b/ckan/public/base/less/ckan.less
@@ -138,7 +138,3 @@ iframe {
 }
 
 @import "iehacks.less";
-
-.debug {
-  display: none;
-}


### PR DESCRIPTION
This is really useful and hidden via a config option not by css - please bring it back as it is really useful
