### PR TITLE
Doc language fix

### DIFF
--- a/ckan/templates/admin/config.html
+++ b/ckan/templates/admin/config.html
@@ -22,7 +22,7 @@
     <div class="module-content">
       {% set about_url = h.url_for(controller='home', action='about') %}
       {% set home_url = h.url_for(controller='home', action='index') %}
-      {% set docs_url = "http://docs.ckan.org/{0}/{1}/theming.html".format(request.environ.CKAN_LANG[:2], g.ckan_doc_version) %}
+      {% set docs_url = "http://docs.ckan.org/{0}/theming.html".format(g.ckan_doc_version) %}
       {% trans %}
         <p><strong>Site Title:</strong> This is the title of this CKAN instance
           It appears in various places throughout CKAN.</p>

--- a/ckan/templates/admin/index.html
+++ b/ckan/templates/admin/index.html
@@ -15,7 +15,7 @@
       {{ _('What are sysadmins?') }}
     </h2>
     <div class="module-content">
-      {% set docs_url = "http://docs.ckan.org/{0}/{1}/paster.html#sysadmin-give-sysadmin-rights".format(request.environ.CKAN_LANG[:2], g.ckan_doc_version) %}
+      {% set docs_url = "http://docs.ckan.org/{0}/paster.html#sysadmin-give-sysadmin-rights".format(g.ckan_doc_version) %}
       {% trans %}
         <p>A sysadmin is someone that has full control over a CKAN instance.
           You can only add CKAN sysadmins via the <code>sysadmin</code> paster

--- a/ckan/templates/footer.html
+++ b/ckan/templates/footer.html
@@ -10,7 +10,7 @@
           </ul>
           <ul class="unstyled">
             {% block footer_links_ckan %}
-              {% set api_url = 'http://docs.ckan.org/{0}/{1}/api.html'.format(request.environ.CKAN_LANG[:2], g.ckan_doc_version) %}
+              {% set api_url = 'http://docs.ckan.org/{0}/api.html'.format(g.ckan_doc_version) %}
               <li><a href="{{ api_url }}">{{ _('CKAN API') }}</a></li>
               <li><a href="http://www.okfn.org/">{{ _('Open Knowledge Foundation') }}</a></li>
               <li><a href="http://www.opendefinition.org/okd/"><img src="http://assets.okfn.org/images/ok_buttons/od_80x15_blue.png"></a></li>

--- a/ckan/templates/package/search.html
+++ b/ckan/templates/package/search.html
@@ -49,7 +49,7 @@
     <div class="module-content">
       <small>
         {% set api_link = h.link_to(_('API'), h.url_for(controller='api', action='get_api', ver=3)) %}
-        {% set api_doc_link = h.link_to(_('API Docs'), 'http://docs.ckan.org/{0}/{1}/api.html'.format(request.environ.CKAN_LANG[:2], g.ckan_doc_version)) %}
+        {% set api_doc_link = h.link_to(_('API Docs'), 'http://docs.ckan.org/{0}/api.html'.format(g.ckan_doc_version)) %}
         {% if g.dumps_url -%}
           {% set dump_link = h.link_to(_('full {format} dump').format(format=g.dumps_format), g.dumps_url) %}
           {% trans %}


### PR DESCRIPTION
wrong url for api docs with none base languages eg `en_GB` `pt_BR`
