### PR TITLE
FAIL: ckan.tests.lib.test_resource_search.TestSearch.test_13_pagination

### DIFF
--- a/ckan/tests/lib/test_resource_search.py
+++ b/ckan/tests/lib/test_resource_search.py
@@ -136,7 +136,7 @@ class TestSearch(object):
 
     def test_13_pagination(self):
         # large search
-        options = search.QueryOptions(order_by='hash')
+        options = search.QueryOptions(order_by='id')
         fields = {'url':'site'}
         all_results = search.query_for(model.Resource).run(fields=fields, options=options)
         all_resources = all_results['results']
@@ -144,7 +144,7 @@ class TestSearch(object):
         assert all_resource_count >= 6, all_results
 
         # limit
-        options = search.QueryOptions(order_by='hash')
+        options = search.QueryOptions(order_by='id')
         options.limit = 2
         result = search.query_for(model.Resource).run(fields=fields, options=options)
         resources = result['results']
@@ -154,7 +154,7 @@ class TestSearch(object):
         assert resources == all_resources[:2], '%r, %r' % (resources, all_resources)
 
         # offset
-        options = search.QueryOptions(order_by='hash')
+        options = search.QueryOptions(order_by='id')
         options.limit = 2
         options.offset = 2
         result = search.query_for(model.Resource).run(fields=fields, options=options)
@@ -163,7 +163,7 @@ class TestSearch(object):
         assert resources == all_resources[2:4]
 
         # larger offset
-        options = search.QueryOptions(order_by='hash')
+        options = search.QueryOptions(order_by='id')
         options.limit = 2
         options.offset = 4
         result = search.query_for(model.Resource).run(fields=fields, options=options)


### PR DESCRIPTION
this test seems to have a race condition and often fails under travis example  https://travis-ci.org/okfn/ckan/builds/6605215

ckan.tests.lib.test_resource_search.TestSearch.test_13_pagination

```
======================================================================
FAIL: ckan.tests.lib.test_resource_search.TestSearch.test_13_pagination
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/virtualenv/python2.7/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/travis/build/okfn/ckan/ckan/tests/lib/test_resource_search.py", line 154, in test_13_pagination
    assert resources == all_resources[:2], '%r, %r' % (resources, all_resources)
AssertionError: [u'2537c680-fadb-4710-96dc-735f5711d56e', u'90d6b31f-ed98-46c4-949c-0982997dde25'], [u'90d6b31f-ed98-46c4-949c-0982997dde25', u'2537c680-fadb-4710-96dc-735f5711d56e', u'c164728f-4640-413f-a1ed-db1e6cfd73a9', u'51788d8c-d6ee-4e65-b058-604ebfe53e73', u'eec7bbc8-8424-453f-bed2-a90c587aea46', u'7a3e45d1-fde7-476d-8917-21b8dac5f701']
----------------------------------------------------------------------
```
