### PR TITLE
Update .tx/config to new servers

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,5 +1,5 @@
 [main]
-host = http://www.transifex.net
+host = https://www.transifex.com
 
 [ckan.2-0]
 file_filter = ckan/i18n/<lang>/LC_MESSAGES/ckan.po


### PR DESCRIPTION
We need to update the host in `.tx/config` from http://www.transifex.net to https://www.transifex.com.

Otherwise it complains when using the cli client, and our docs use this host anyway:
http://docs.ckan.org/en/latest/release-process.html#doing-a-beta-release

```
Hostname http://www.transifex.net should be changed to https://www.transifex.com.
Change it now? [Y/n]
```

You'll proabably need to update your ~/.transifexrc file as well.
