### PR TITLE
Missing close breadcrumb tag in org templates

### DIFF
--- a/ckan/templates/package/base.html
+++ b/ckan/templates/package/base.html
@@ -10,7 +10,7 @@
     {% if pkg.organization %}
       {% set organization = pkg.organization.title or pkg.organization.name %}
       <li>{% link_for _('Organizations'), controller='organization', action='index' %}</li>
-      <li>{% link_for organization|truncate(30), controller='organization', action='read', id=pkg.organization.name %}
+      <li>{% link_for organization|truncate(30), controller='organization', action='read', id=pkg.organization.name %}</li>
     {% else %}
       <li>{% link_for _('Datasets'), controller='package', action='search' %}</li>
     {% endif %}


### PR DESCRIPTION
When a dataset is part of a organization the breadcrumbs don't fully close properly after the organization name.
