### PR TITLE
user template broken

### DIFF
--- a/ckan/templates/user/read_base.html
+++ b/ckan/templates/user/read_base.html
@@ -9,31 +9,15 @@
   {{ h.build_nav('user_datasets', user.display_name|truncate(35), id=user.name) }}
 {% endblock %}
 
-{% block actions_content %}
+{% block content_action %}
 {% if h.check_access('user_update', user) %}
-  <li>{% link_for _('Edit'), controller='user', action='edit', id=user.name, class_='btn btn-primary', icon='wrench' %}</li>
-{% endif %}
-{% if c.is_myself == false %}
-  <li>{{ h.follow_button('user', user.id) }}</li>
+  {% link_for _('Edit'), controller='user', action='edit', id=user.name, class_='btn', icon='wrench' %}
 {% endif %}
 {% endblock %}
 
-{% block primary_content %}
-  <article class="module profile">
-    {% block page_header %}
-      <header class="module-content page-header">
-        <ul class="nav nav-tabs">
-          {% block content_primary_nav %}
-            {{ h.build_nav_icon('user_datasets', _('Datasets'), id=user.name) }}
-            {{ h.build_nav_icon('user_activity_stream', _('Activity Stream'), id=user.name) }}
-          {% endblock %}
-        </ul>
-      </header>
-    {% endblock %}
-    <section class="module-content">
-      {% block primary_content_inner %}{% endblock %}
-    </section>
-  </article>
+{% block content_primary_nav %}
+  {{ h.build_nav_icon('user_datasets', _('Datasets'), id=user.name) }}
+  {{ h.build_nav_icon('user_activity_stream', _('Activity Stream'), id=user.name) }}
 {% endblock %}
 
 {% block secondary_content %}
@@ -67,6 +51,11 @@
           <dd>{{ h.SI_number_span(user.number_of_edits) }}</dd>
         </dl>
       </div>
+      {% if c.is_myself == false %}
+        <div class="follow_button">
+          {{ h.follow_button('user', user.id) }}</li>
+        </div>
+      {% endif %}
       <div class="info">
         <dl>
           {% if user.name.startswith('http://') or user.name.startswith('https://') %}


### PR DESCRIPTION
looking at #1103 it seems the user templates have issues

basically the edit user button is not showing.  It looks like `user/read_base.html` is the problem as it does not include the button block.  I'm not sure if this is a minor oversight or a bigger templating issue that makes it hard to consistently add template buttons.

This affects 2.1 and master and is a regression and needs backporting.

@amercader mentioning you to keep you informed
