### PR TITLE
Catch InvalidSchema exceptions on resource proxy

### DIFF
--- a/ckanext/resourceproxy/controller.py
+++ b/ckanext/resourceproxy/controller.py
@@ -1,4 +1,5 @@
 from logging import getLogger
+import urlparse
 
 import requests
 
@@ -15,12 +16,16 @@ def proxy_resource(context, data_dict):
     ''' Chunked proxy for resources. To make sure that the file is not too
     large, first, we try to get the content length from the headers.
     If the headers to not contain a content length (if it is a chinked
-    response), we only transfer as long as the transfered data is less
+    response), we only transfer as long as the transferred data is less
     than the maximum file size. '''
     resource_id = data_dict['resource_id']
     log.info('Proxify resource {id}'.format(id=resource_id))
     resource = logic.get_action('resource_show')(context, {'id': resource_id})
     url = resource['url']
+
+    parts = urlparse.urlsplit(url)
+    if not parts.scheme or not parts.netloc:
+        base.abort(409, detail='Invalid URL.')
 
     try:
         # first we try a HEAD request which may not be supported

--- a/ckanext/resourceproxy/tests/test_proxy.py
+++ b/ckanext/resourceproxy/tests/test_proxy.py
@@ -130,7 +130,17 @@ class TestProxyPrettyfied(tests.WsgiAppCase, unittest.TestCase):
         assert result.status == 409, result.status
         assert 'too large' in result.body, result.body
 
-    def test_resource_proxy_non_existent(self):
+    @httpretty.activate
+    def test_invalid_url(self):
+        self.data_dict = set_resource_url('javascript:downloadFile(foo)')
+
+        proxied_url = proxy.get_proxified_resource_url(self.data_dict)
+        result = self.app.get(proxied_url, status='*')
+        assert result.status == 409, result.status
+        assert 'Invalid URL' in result.body, result.body
+
+
+    def test_non_existent_url(self):
         self.data_dict = set_resource_url('http://foo.bar')
 
         def f1():


### PR DESCRIPTION
For wrong urls like this one:

http://beta.ckan.org/dataset/2012-global-hunger-index-data/resource/87131421-b199-493a-9a52-81c2ab11ab9b

Actual URL:

javascript:downloadFile('/FileDownload/?fileId=2323860&vdcId=90&xff=0&versionNumber=1')
