### PR TITLE
Error when deleting custom tags

### DIFF
--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -562,7 +562,7 @@ def vocabulary_tag_list_save(new_tag_dicts, vocabulary_obj, context):
 
     # First delete any tags not in new_tag_dicts.
     for tag in vocabulary_obj.tags:
-        if tag.name not in [tag['name'] for tag in new_tag_dicts]:
+        if tag.name not in [t['name'] for t in new_tag_dicts]:
             tag.delete()
     # Now add any new tags.
     for tag_dict in new_tag_dicts:


### PR DESCRIPTION
Hi,
I created a new multivalued field in my form dataset.
It works the same way as the "tags" field.
The autocompletion of this field is based on a vocabulary. The elements of this vocabulary are loaded from the .ini file.
To update vocabularies I use the action "vocabulary_update" from the API
When I delete or modify an element in my list I have this error 
"Error - <type 'exceptions.AttributeError'>: 'dict' object has no attribute 'delete'

It seems this come from the function "vocabulary_tag_list_save" from ckan/lib/dictization/model_save.py

The first loop deletes any tags not in new_tags_dicts
The variable tag is used for run through the list of tags "vocabulary_obj.tags" AND to create the list of tag names.

<code>for tag in vocabulary_obj.tags:
        if tag.name not in [<b>tag</b>['name'] for <b>tag</b> in new_tag_dicts]:</code>

Change the name of the variable used to create the list of tag names solves the problem.

Hope it help.
