### PR TITLE
Invalid request causes 500 through ValueError in search facet

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -264,8 +264,14 @@ class PackageController(base.BaseController):
             c.page = h.Page(collection=[])
         c.search_facets_limits = {}
         for facet in c.search_facets.keys():
-            limit = int(request.params.get('_%s_limit' % facet,
-                                           g.facets_default_number))
+            try:
+                limit = int(request.params.get('_%s_limit' % facet,
+                                               g.facets_default_number))
+            except ValueError:
+                abort(400, _('Parameter "{parameter_name}" is not '
+                             'an integer').format(
+                                 parameter_name='_%s_limit' % facet
+                             ))
             c.search_facets_limits[facet] = limit
 
         maintain.deprecate_context_item(


### PR DESCRIPTION
[This line](https://github.com/okfn/ckan/blob/master/ckan/controllers/package.py#L267) should be wrapped in a `try-except-ValueError` similar to [this line](https://github.com/okfn/ckan/blob/master/ckan/controllers/package.py#L126).
