### PR TITLE
Language dropdown broken in IE7-IE8

### DIFF
--- a/ckan/public/base/less/iehacks.less
+++ b/ckan/public/base/less/iehacks.less
@@ -66,6 +66,11 @@
     padding-bottom: 20px !important;
     margin-bottom: 0 !important;
   }
+  // Footer
+  .lang-dropdown {
+    position: relative !important;
+    top: -90px !important;
+  }
 }
 
 // Internet Explorer 7


### PR DESCRIPTION
**Reproduction steps**
- Visit a CKAN 2.0 or 2.01 site in IE7 e.g. http://data.sa.gov.au/
- Click on the language drop-down in the footer
- Rest of the page disappears and can only see the dropdown
