### PR TITLE
strip leading whitespace from title string when indexing

### DIFF
--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -213,8 +213,9 @@ class PackageSearchIndex(SearchIndex):
         pkg_dict = new_dict
 
         for k in ('title', 'notes', 'title_string'):
-            if k in pkg_dict and pkg_dict[k]:
-                pkg_dict[k] = escape_xml_illegal_chars(pkg_dict[k])
+            value = pkg_dict.get(k, None)
+            if value:
+                pkg_dict[k] = escape_xml_illegal_chars(value)
 
         # modify dates (SOLR is quite picky with dates, and only accepts ISO dates
         # with UTC time (i.e trailing Z)
@@ -228,13 +229,10 @@ class PackageSearchIndex(SearchIndex):
         # Strip a selection of the fields.
         # These fields are possible candidates for sorting search results on,
         # so we strip leading spaces because solr will sort " " before "a" or "A".
-        for field_name in ['title']:
-            try:
-                value = pkg_dict.get(field_name)
-                if value:
-                    pkg_dict[field_name] = value.lstrip()
-            except KeyError:
-                pass
+        for field_name in ['title', 'title_string']:
+            value = pkg_dict.get(field_name)
+            if value:
+                pkg_dict[field_name] = value.lstrip()
 
         # add a unique index_id to avoid conflicts
         import hashlib


### PR DESCRIPTION
[title_string is added for sorting](https://github.com/okfn/ckan/blob/master/ckan/lib/search/index.py#L107) but does not actually have it's whitespace stripped before being added to the index.

see [pdeu](https://github.com/okfn/ckanext-pdeu/issues/65) for example
