### PR TITLE
[#1141] Fix bug where we weren't raising Exception when we couldn't find plugin

### DIFF
--- a/ckan/plugins/core.py
+++ b/ckan/plugins/core.py
@@ -237,15 +237,13 @@ def _get_service(plugin_name):
 
     if isinstance(plugin_name, basestring):
         for group in GROUPS:
-            try:
-                (plugin,) = iter_entry_points(
-                    group=group,
-                    name=plugin_name
-                )
+            iterator = iter_entry_points(
+                group=group,
+                name=plugin_name
+            )
+            plugin = next(iterator, None)
+            if plugin:
                 return plugin.load()(name=plugin_name)
-            except ValueError:
-                pass
-            else:
-                raise PluginNotFoundException(plugin_name)
+        raise PluginNotFoundException(plugin_name)
     else:
         raise TypeError('Expected a plugin name', plugin_name)

--- a/ckan/tests/test_plugins.py
+++ b/ckan/tests/test_plugins.py
@@ -164,3 +164,7 @@ class TestPlugins(object):
         with plugins.use_plugin('auth_plugin'):
             assert new_authz.is_authorized('package_list', {}) != package_list_original
         assert new_authz.is_authorized('package_list', {}) == package_list_original
+
+    @raises(plugins.PluginNotFoundException)
+    def test_inexistent_plugin_loading(self):
+        plugins.load('inexistent-plugin')


### PR DESCRIPTION
If `iter_entry_points` wasn't never able to find the `plugin_name`, it would simply keep raising `ValueError`, which we are ignoring. The `raise PluginNotFoundException` was never executed.
