### PR TITLE
`reclinepreview` uses global version of jQuery

### DIFF
--- a/ckanext/reclinepreview/theme/public/resource.config
+++ b/ckanext/reclinepreview/theme/public/resource.config
@@ -15,6 +15,7 @@ main = base/main
 [groups]
 
 main =
+    vendor/jquery/1.7.1/jquery.js
     vendor/underscore/1.4.2/underscore.js
     vendor/backbone/0.9.2/backbone.js
     vendor/mustache/0.5.0-dev/mustache.js


### PR DESCRIPTION
It should use it's sandboxed 1.7.1 version as it's causing issues with `$.browser` being dropped in jQuery 1.9.
