### PR TITLE
Map recline: Sidebar not displayed on IE

### DIFF
--- a/ckanext/reclinepreview/theme/public/vendor/recline/recline.js
+++ b/ckanext/reclinepreview/theme/public/vendor/recline/recline.js
@@ -3716,7 +3716,6 @@ my.MapMenu = Backbone.View.extend({
           Cluster markers</label> \
       </div> \
       <input type="hidden" class="editor-id" value="map-1" /> \
-      </div> \
     </form> \
   ',
 

--- a/ckanext/reclinepreview/theme/public/vendor/recline/recline.min.js
+++ b/ckanext/reclinepreview/theme/public/vendor/recline/recline.min.js
@@ -337,7 +337,6 @@ return null;},_zoomToFeatures:function(){var bounds=this.features.getBounds();if
           Cluster markers</label> \
       </div> \
       <input type="hidden" class="editor-id" value="map-1" /> \
-      </div> \
     </form> \
   ',events:{'click .editor-update-map':'onEditorSubmit','change .editor-field-type':'onFieldTypeChange','click #editor-auto-zoom':'onAutoZoomChange','click #editor-cluster':'onClusteringChange'},initialize:function(options){var self=this;this.el=$(this.el);_.bindAll(this,'render');this.model.fields.bind('change',this.render);this.state=new recline.Model.ObjectState(options.state);this.state.bind('change',this.render);this.render();},render:function(){var self=this;htmls=Mustache.render(this.template,this.model.toTemplateJSON());$(this.el).html(htmls);if(this._geomReady()&&this.model.fields.length){if(this.state.get('geomField')){this._selectOption('editor-geom-field',this.state.get('geomField'));this.el.find('#editor-field-type-geom').attr('checked','checked').change();}else{this._selectOption('editor-lon-field',this.state.get('lonField'));this._selectOption('editor-lat-field',this.state.get('latField'));this.el.find('#editor-field-type-latlon').attr('checked','checked').change();}}
 if(this.state.get('autoZoom')){this.el.find('#editor-auto-zoom').attr('checked','checked');}else{this.el.find('#editor-auto-zoom').removeAttr('checked');}


### PR DESCRIPTION
I'm using recline plugin to display some datasets on maps. It is working fine on Firefox and Chrome but on Internet Explorer 8, the sidebar with the latitude and logitude fields does not appear.

On Internet Explorer 8:
![ie](https://f.cloud.github.com/assets/5096674/862392/d4c34288-f5ef-11e2-93e1-b2f232816cf0.png)

On Firefox:
![ff](https://f.cloud.github.com/assets/5096674/862393/dd10fd72-f5ef-11e2-8d03-5056d365d560.png)
