### PR TITLE
[#1152] Call check_access in member_roles_list

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -2826,4 +2826,5 @@ def member_roles_list(context, data_dict):
     :rtype: list of dictionaries
 
     '''
+    _check_access('member_roles_list', context, data_dict)
     return new_authz.roles_list()


### PR DESCRIPTION
I found this in `/group/member_new`, warned by the Auth Actions Audit. If the user is unauthorized to add a new member to a group, he shouldn't even be able to get to that page in the first place, as doesn't matter who he tries to add, he won't be able to.

Anyway, this fixes a small part of the problem.
