### PR TITLE
Add resource screen breadcrumb incorrect

### DIFF
--- a/ckan/templates/package/base.html
+++ b/ckan/templates/package/base.html
@@ -1,6 +1,6 @@
 {% extends "page.html" %}
 
-{% set pkg = c.pkg_dict %}
+{% set pkg = c.pkg_dict or pkg_dict %}
 
 {% block breadcrumb_content_selected %} class="active"{% endblock %}
 

--- a/ckan/templates/package/new_resource.html
+++ b/ckan/templates/package/new_resource.html
@@ -8,6 +8,12 @@
 
 {% block subtitle %}{{ _('Add data to the dataset') }}{% endblock %}
 
+{% block breadcrumb_content_selected %}{% endblock %}
+{% block breadcrumb_content %}
+  {{ super() }}
+  <li class="active"><a href="#">{{ _('Add New Resource') }}</a></li>
+{% endblock %}
+
 {% block form %}{% snippet 'package/snippets/resource_form.html', data=data, errors=errors, error_summary=error_summary, include_metadata=false, pkg_name=pkg_name, stage=stage, allow_upload=g.ofs_impl and logged_in %}{% endblock %}
 
 {% block secondary_content %}


### PR DESCRIPTION
When editing an existing datset and adding a resource, e.g. at

http://beta.ckan.org/dataset/new_resource/test

the page should be called 'Datasets / Test / Add resource', not 'Datasets / Create dataset'. The dataset is old, it is not being created.
