### PR TITLE
Auth aware group and org list action functions should return dictized objects

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -424,8 +424,8 @@ def group_list_authz(context, data_dict):
       (optional, default: False)
     :type am-member: boolean
 
-    :returns: the names of groups that the user is authorized to edit
-    :rtype: list of strings
+    :returns: list of dictized groups that the user is authorized to edit
+    :rtype: list of dicts
 
     '''
     model = context['model']
@@ -479,8 +479,8 @@ def organization_list_for_user(context, data_dict):
       (optional, default: ``edit_group``)
     :type permission: string
 
-    :returns: the names of organizations the user is authorized to do specific permission
-    :rtype: list of strings
+    :returns: list of dictized organizations that the user is authorized to edit
+    :rtype: list of dicts
 
     '''
     model = context['model']


### PR DESCRIPTION
`organization_list_for_user` and `group_list_authz` create a dict with the Group objects before returning the list, when they should be calling `model_dictize.group_list_dictize` as the rest.

The whole groups list thing is a bit messy, with wrong docstrings, inconsistent docstrings and duplicated code. `organization_list_for_user` , `group_list_authz` and `_group_or_org_list` should all share the same code if possible, that you can be a separate issue.
