### PR TITLE
Added Vagrant support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ ckan_deb/DEBIAN/prerm
 
 # node.js
 node_modules/
+
+# Vagrant
+/.vagrant

--- a/.vagrant-scripts/setup-ckan.sh
+++ b/.vagrant-scripts/setup-ckan.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+## Install CKAN for the current user
+
+set -e
+
+pip install --user virtualenv virtualenvwrapper
+
+source "$HOME"/.local/bin/virtualenvwrapper.sh
+export PATH="${HOME}/.local/bin/:${PATH}"
+
+echo 'source ~/.local/bin/virtualenvwrapper.sh' >> ~/.bashrc
+echo 'export PATH="${HOME}/.local/bin/:${PATH}"' >> ~/.bashrc
+
+set +e
+mkvirtualenv ckan
+workon ckan
+set -e
+
+## Install ckan + requirements
+cd /vagrant/
+pip install -r requirements.txt
+#pip install -r dev-requirements.txt
+python setup.py develop
+
+
+## Create configuration file
+mkdir -p "$VIRTUAL_ENV"/etc/ckan
+CONF_FILE="$VIRTUAL_ENV"/etc/ckan/development.ini
+paster --plugin=ckan make-config --no-install ckan "$CONF_FILE"
+
+SA_URL="postgresql://ckan:pass@localhost/ckan"
+SA_DS_RW_URL="postgresql://ckan:pass@localhost/ckan_datastore"
+SA_DS_RO_URL="postgresql://ckan_ro:pass@localhost/ckan_datastore"
+
+## Hackish way to change configuration options..
+sed -f - -i $CONF_FILE <<EOF
+s%^#*\s*sqlalchemy.url\s*=.*\$%sqlalchemy.url = $SA_URL%
+s%^#*\s*ckan.datastore.write_url\s*=.*\$%ckan.datastore.write_url = $SA_DS_RW_URL%
+s%^#*\s*ckan.datastore.read_url\s*=.*\$%ckan.datastore.read_url = $SA_DS_RO_URL%
+s%^#*\s*solr_url\s*=.*\$%solr_url = http://localhost:8983/solr%
+EOF
+
+## Copy other configuration files
+cp -t "$VIRTUAL_ENV"/etc/ckan/ /vagrant/who.ini
+
+
+## Installation completed message
+cat <<EOF
+CKAN installation complete
+--------------------------
+
+What to do now:
+
+* Check that the configuration file is OK.
+  File: $CONF_FILE
+
+* Initialize the database::
+
+    paster --plugin=ckan db --config=$CONF_FILE init
+
+* Rebuild the search index (?)::
+
+    paster --plugin=ckan search-index --config=$CONF_FILE rebuild
+
+* Run paster server to serve the thing::
+
+    paster --plugin=ckan serve $CONF_FILE
+
+* Offer me a beer :)
+
+EOF

--- a/.vagrant-scripts/setup-server.sh
+++ b/.vagrant-scripts/setup-server.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+##====================================================================
+## Script to prepare the machine for running a CKAN development
+## environment
+##====================================================================
+
+## Terminate immediately if any command fails
+set -e
+
+## Install dependencies
+apt-get update -y -qq
+xargs apt-get install -y -qq <<EOF
+python-dev
+
+solr-jetty
+openjdk-6-jdk
+
+postgresql-9.1
+postgresql-contrib-9.1
+postgresql-server-dev-9.1
+EOF
+
+
+##--------------------------------------------------------------------
+## Setup PostgreSQL users/databases
+
+sudo -u postgres psql <<EOF
+CREATE USER ckan WITH PASSWORD 'pass';
+CREATE USER ckan_ro WITH PASSWORD 'pass';
+
+CREATE DATABASE ckan
+    WITH OWNER ckan
+    ENCODING = 'UTF8'
+    LC_CTYPE = 'en_US.utf8'
+    LC_COLLATE = 'en_US.utf8'
+    TEMPLATE template0;
+
+CREATE DATABASE ckan_datastore
+    WITH OWNER ckan
+    ENCODING = 'UTF8'
+    LC_CTYPE = 'en_US.utf8'
+    LC_COLLATE = 'en_US.utf8'
+    TEMPLATE template0;
+EOF
+
+
+##--------------------------------------------------------------------
+## Configure Solr/Jetty
+
+if [ -z "$JAVA_HOME" ]; then
+    ## todo: any better way to do this?
+    JAVA_HOME=/usr/lib/jvm/java-6-openjdk-amd64/
+fi
+
+cat > /etc/default/jetty <<EOF
+NO_START=0
+JETTY_HOST=127.0.0.1
+JETTY_PORT=8983
+JAVA_HOME=$JAVA_HOME
+EOF
+
+## Copy Solr schema over, from the CKAN directory
+cp /vagrant/ckan/config/solr/schema-2.0.xml /etc/solr/conf/schema.xml
+
+echo "Configured Jetty. Restarting..."
+service jetty restart
+
+
+##--------------------------------------------------------------------
+## Install Python dependencies
+
+apt-get install -y -qq python-dev python-pip git
+
+## Install CKAN, as the "vagrant" user
+cd /home/vagrant/
+su - vagrant -c '/bin/bash /vagrant/.vagrant-scripts/setup-ckan.sh'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,29 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+## Vagrantfile for CKAN development machine
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "precise64"
+
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+
+  # Provisioning configuration
+  config.vm.provision :shell, :path => ".vagrant-scripts/setup-server.sh"
+
+  # Network configuration
+  # We just forward paster default port (5000) as port 8080 on the
+  # host machine.
+  config.vm.network :forwarded_port, guest: 5000, host: 8080,
+    auto_correct: true
+end


### PR DESCRIPTION
Automated installation in a VM is now working (although quite rudimentary).
Now you can just run::

```
vagrant up
```

to setup the vm, then::

```
vagrant ssh
```

to connect to the vm, and then just initialize the database and
run paster::

```
workon ckan
paster --plugin=ckan db --config=$VIRTUAL_ENV/etc/ckan/development.ini init
paster --plugin=ckan serve $VIRTUAL_ENV/etc/ckan/development.ini
```
