### PR TITLE
Datastore auth_function is NoneType

### DIFF
--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -44,6 +44,10 @@ class DatastorePlugin(p.SingletonPlugin):
         if sys.argv[0].split('/')[-1] == 'paster' and 'datastore' in sys.argv[1:]:
             log.warn('Omitting permission checks because you are '
                      'running paster commands.')
+
+            def not_implemented(context, data_dict):
+                raise NotImplementedError('Not implemented for paster commands.')
+            self.resource_show_action = not_implemented
             return
 
         self.ckan_url = self.config['sqlalchemy.url']


### PR DESCRIPTION
Following the next Datastore Setup guide http://docs.ckan.org/dv/latest/datastore.html#datastore-extension

When setting up the permissions of the Datastore with the command:

```
paster datastore set-permissions postgres -c /etc/ckan/default/development.ini
```

I get next error: 

```
Traceback (most recent call last):
  File "/home/vagrant/pyenv/bin/paster", line 9, in <module>
    load_entry_point('PasteScript==1.7.5', 'console_scripts', 'paster')()
  File "/home/vagrant/pyenv/local/lib/python2.7/site-packages/paste/script/command.py", line 104, in run
    invoke(command, command_name, options, args[1:])
  File "/home/vagrant/pyenv/local/lib/python2.7/site-packages/paste/script/command.py", line 143, in invoke
    exit_code = runner.run(args)
  File "/home/vagrant/pyenv/local/lib/python2.7/site-packages/paste/script/command.py", line 238, in run
    result = self.command()
  File "/home/vagrant/chef/ckanext/datastore/commands.py", line 41, in command
    self._load_config()
  File "/home/vagrant/chef/ckan/lib/cli.py", line 91, in _load_config
    load_environment(conf.global_conf, conf.local_conf)
  File "/home/vagrant/chef/ckan/config/environment.py", line 232, in load_environment
    p.load_all(config)
  File "/home/vagrant/chef/ckan/plugins/core.py", line 134, in load_all
    load(*plugins)
  File "/home/vagrant/chef/ckan/plugins/core.py", line 167, in load
    plugins_update()
  File "/home/vagrant/chef/ckan/plugins/core.py", line 116, in plugins_update
    environment.update_config()
  File "/home/vagrant/chef/ckan/config/environment.py", line 369, in update_config
    logic.get_action('get_site_user')({'ignore_auth': True}, None)
  File "/home/vagrant/chef/ckan/logic/__init__.py", line 327, in get_action
    auth_function.auth_audit_exempt = True
AttributeError: 'NoneType' object has no attribute 'auth_audit_exempt'
---- End output of paster datastore set-permissions postgres ----
```

I found out that in the file https://github.com/okfn/ckan/blob/master/ckanext/datastore/plugin.py#L44 the following lines: 

```
# Check whether we are running one of the paster commands which means
# that we should ignore the following tests.
if sys.argv[0].split('/')[-1] == 'paster' and 'datastore' in sys.argv[1:]:
    log.warn('Omitting permission checks because you are '
                  'running paster commands.')
  return
```

They return before changing the value `None` of the property `resource_shown_action` if executed with paster commands.

Check the `resource_shown_action` declaration here: 
https://github.com/okfn/ckan/blob/master/ckanext/datastore/plugin.py#L28

And then that property is being referenced here as an `auth_function` of the Datastore plugin:
https://github.com/CodeandoMexico/ckan/blob/deployment-config/ckan/logic/__init__.py#L325. Causing the `AttributeError`. 

I solved the issue removing the code that Checks if using a paster comand on https://github.com/okfn/ckan/blob/master/ckanext/datastore/plugin.py#L44

Although I'm not sure if that's a proper solution.
