### PR TITLE
Trash purge action redirect broken for CKAN instances not at /

### DIFF
--- a/ckan/controllers/admin.py
+++ b/ckan/controllers/admin.py
@@ -149,4 +149,4 @@ class AdminController(base.BaseController):
 
             for msg in msgs:
                 h.flash_error(msg)
-            h.redirect_to(h.url_for('ckanadmin', action='trash'))
+            h.redirect_to(controller='admin', action='trash')


### PR DESCRIPTION
The call to h.redirect_to [1] breaks if the CKAN instance is not at /.

[1] https://github.com/okfn/ckan/blob/master/ckan/controllers/admin.py#L152
