### PR TITLE
add template block for extras in package/snippets/additional_info.html

### DIFF
--- a/ckan/templates/package/snippets/additional_info.html
+++ b/ckan/templates/package/snippets/additional_info.html
@@ -54,13 +54,16 @@
         </tr>
       {% endif %}
 
-      {% for extra in h.sorted_extras(pkg_dict.extras) %}
-        {% set key, value = extra %}
-        <tr rel="dc:relation" resource="_:extra{{ i }}">
-          <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key) }}</th>
-          <td class="dataset-details" property="rdf:value">{{ value }}</td>
-        </tr>
+      {% block extras scoped %}
+        {% for extra in h.sorted_extras(pkg_dict.extras) %}
+          {% set key, value = extra %}
+          <tr rel="dc:relation" resource="_:extra{{ i }}">
+            <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key) }}</th>
+            <td class="dataset-details" property="rdf:value">{{ value }}</td>
+          </tr>
         {% endfor %}
+      {% endblock %}
+
       {% endblock %}
     </tbody>
   </table>


### PR DESCRIPTION
Additional block in the tempalte for users to override, so they don't have to override the entire template if they're adding custom field handling in their own plugin.
