### PR TITLE
CkanVersionException wrongly raised

### DIFF
--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -348,7 +348,7 @@ content type, cookies, etc.
             else:
                 error = 'Requires ckan version between %s and %s' % \
                             (min_version, max_version)
-            raise cls.CkanVersionException(error)
+            raise CkanVersionException(error)
 
     def __getattr__(self, name):
         ''' return the function/object requested '''


### PR DESCRIPTION
An exception is raised if `toolkit.requires_ckan_version` fails, but not the one expected :)
