### PR TITLE
'About datasets/orgs/groups' text is dreadful

### DIFF
--- a/ckan/templates/group/snippets/helper.html
+++ b/ckan/templates/group/snippets/helper.html
@@ -4,12 +4,13 @@
     {{ _('What are Groups?') }}
   </h2>
   <div class="module-content">
-    {% trans %}
-      <p>Groups allow you to group together datasets under a community (for
-        example, Civil Liberty data) or topic (e.g. Transport, Health,
-        Environment) to make it easier for users to browse datasets by theme.
-        Datasets can be part of a group, but do not belong to the group for
-        editing or authorisation purposes.</p>
-    {% endtrans %}
+    <p>
+      {% trans %}
+        You can use CKAN Groups to create and manage collections of datasets.
+        This could be to catalogue datasets for a particular project or team,
+        or on a particular theme, or as a very simple way to help people find
+        and search your own published datasets.
+      {% endtrans %}
+    </p>
   </div>
 </div>

--- a/ckan/templates/organization/snippets/helper.html
+++ b/ckan/templates/organization/snippets/helper.html
@@ -4,14 +4,12 @@
     {{ _('What are Organizations?') }}
   </h2>
   <div class="module-content">
-    {% trans %}
-      <p>Organizations act like publishing departments for datasets (for
-        example, the Department of Health). This means that datasets can be
-        published by and belong to a department instead of an individual
-        user.</p>
-      <p>Within organizations, admins can assign roles and authorisation its
-        members, giving individual users the right to publish datasets from
-        that particular organisation (e.g. Office of National Statistics).</p>
-    {% endtrans %}
+    <p>
+      {% trans %}
+        CKAN Organizations are used to create, manage and publish collections
+        of datasets. Users can have different roles within an Organization,
+        depending on their level of authorisation to create, edit and publish.
+      {% endtrans %}
+    </p>
   </div>
 </div>

--- a/ckan/templates/package/base_form_page.html
+++ b/ckan/templates/package/base_form_page.html
@@ -15,9 +15,9 @@
       <div class="module-content">
         <p>
           {% trans %}
-          Datasets are simply used to group related pieces of data. These
-          can then be found under a single url with a description and
-          licensing information.
+          A CKAN Dataset is a collection of data resources (such as files),
+          together with a description and other information, at a fixed URL.
+          Datasets are what users see when searching for data.
           {% endtrans %}
         </p>
       </div>


### PR DESCRIPTION
The default text currently called things like "What are groups?" is totally unhelpful. Use the following instead.

About Groups

You can use CKAN Groups to create and manage collections of datasets. This could be to catalogue datasets for a particular project or team, or on a particular theme, or as a very simple way to help people find and search your own published datasets.

About Datasets

A CKAN Dataset is a collection of data resources (such as files), together with a description and other information, at a fixed URL. Datasets are what users see when searching for data.

About Organizations

CKAN Organizations are used to create, manage and publish collections of datasets. Users can have different roles within an Organization, depending on their level of authorisation to create, edit and publish.
