### PR TITLE
Forgotten details or password?

### DIFF
--- a/ckan/templates/user/login.html
+++ b/ckan/templates/user/login.html
@@ -29,7 +29,7 @@
   </section>
 
   <section class="module module-narrow module-shallow">
-    <h2 class="module-heading">{{ _('Forgotten your details?') }}</h2>
+    <h2 class="module-heading">{{ _('Forgotten your password?') }}</h2>
     <div class="module-content">
       <p>{% trans %}No problem, use our password recovery form to reset it.{% endtrans %}</p>
       <p class="action">


### PR DESCRIPTION
On http://demo.ckan.org/user/login, a user that is not logged in, sees "Forgotten your details?" where I would assume that it talks about username _or_ password. However, in fact we only mean the password. I suggest, we change the text to "Forgotten your password?" or even better, allow people to recover their username using their email address. 
