### PR TITLE
Preview fails on private datastore resources

### DIFF
--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -300,9 +300,7 @@ def datastore_search(context, data_dict):
         raise p.toolkit.ValidationError(errors)
 
     res_id = data_dict['resource_id']
-    data_dict['connection_url'] = pylons.config.get(
-        'ckan.datastore.read_url',
-        pylons.config['ckan.datastore.write_url'])
+    data_dict['connection_url'] = pylons.config['ckan.datastore.write_url']
 
     resources_sql = sqlalchemy.text(u'''SELECT alias_of FROM "_table_metadata"
                                         WHERE name = :id''')


### PR DESCRIPTION
When trying to preview a resource that belongs to a private dataset, the loading animation goes on forever. The request to `datastore_search` confusingly returns a 409. After some digging, it seems to be raised here:

https://github.com/okfn/ckan/blob/master/ckanext/datastore/db.py#L1126

Basically the user has no permission over the table. If that's the case, a better exception should be shown in the frontend.

(I would expect that logged in users could access the datastore resource but that's another matter)
