### PR TITLE
Autocomplete JS module issues

### DIFF
--- a/ckan/public/base/javascript/modules/autocomplete.js
+++ b/ckan/public/base/javascript/modules/autocomplete.js
@@ -158,9 +158,7 @@ this.ckan.module('autocomplete', function (jQuery, _) {
             module._last.abort();
           }
 
-          module._last = module.getCompletions(term, function (terms) {
-            fn(terms);
-          });
+          module._last = module.getCompletions(term, fn);
         }, this.options.interval);
 
         // This forces the ajax throbber to appear, because we've called the


### PR DESCRIPTION
- [x] Fails when another search is stacked: essentially `module._last.abort();` doesn't work because `module._last` doesn't have method `abort()`
- [x] Once your start typing new searches after the first search has returned results it stacks inputs on keyup as new items even though they don't match your search term
