### PR TITLE
Visibility field value not kept if there are errors on the form

### DIFF
--- a/ckan/templates/package/snippets/package_basic_fields.html
+++ b/ckan/templates/package/snippets/package_basic_fields.html
@@ -86,8 +86,8 @@
         <label for="field-private" class="control-label">{{ _('Visibility') }}</label>
         <div class="controls">
           <select id="field-private" name="private">
-            {% for option in [(true, _('Private')), (false, _('Public'))] %}
-            <option value="{{ option[0] }}" {% if option[0] == data.private %}selected="selected"{% endif %}>{{ option[1] }}</option>
+            {% for option in [('True', _('Private')), ('False', _('Public'))] %}
+            <option value="{{ option[0] }}" {% if option[0] == data.private|trim %}selected="selected"{% endif %}>{{ option[1] }}</option>
             {% endfor %}
           </select>
         </div>


### PR DESCRIPTION
Steps to reproduce:
- Create a dataset within an org
- Select Visibility Public
- Click Next without entering a title

Visibility is now Private

Specially inconvenient on extensions that use single page forms
