### PR TITLE
fix possible KeyError in before_show of datastore plugin

### DIFF
--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -285,7 +285,7 @@ class DatastorePlugin(p.SingletonPlugin):
         ''' Modify the resource url of datastore resources so that
         they link to the datastore dumps.
         '''
-        if resource_dict['url_type'] == 'datastore':
+        if resource_dict.get('url_type') == 'datastore':
             resource_dict['url'] = p.toolkit.url_for(
                 controller='ckanext.datastore.controller:DatastoreController',
                 action='dump', resource_id=resource_dict['id'])


### PR DESCRIPTION
default_resource_schema 'url_type' has an ignore_missing validator, but the datastore plugin explictly looks up this key
