### PR TITLE
"Clear all" link within each facet block is unnecessary 

### DIFF
--- a/ckan/public/base/less/iehacks.less
+++ b/ckan/public/base/less/iehacks.less
@@ -200,11 +200,6 @@
     .media-content {
       position: relative;
     }
-    .action {
-      position: absolute;
-      top: 9px;
-      right: 10px;
-    }
     .media-image img {
       float: left;
     }

--- a/ckan/public/base/less/module.less
+++ b/ckan/public/base/less/module.less
@@ -13,17 +13,6 @@
   border-bottom: 1px solid @moduleHeadingBorderColor;
 }
 
-.module-heading .action {
-  float: right;
-  color: @moduleHeadingActionTextColor;
-  font-size: 12px;
-  line-height: @baseLineHeight;
-  text-decoration: underline;
-  &:hover {
-    color: @layoutTextColor;
-  }
-}
-
 .module-content {
   padding: 0 @gutterX;
   margin: 20px 0;

--- a/ckan/templates/development/snippets/facet.html
+++ b/ckan/templates/development/snippets/facet.html
@@ -1,6 +1,6 @@
 <section class="module module-narrow">
   {% with items=(("First", true), ("Second", false), ("Third", true), ("Fourth", false), ("Last", false)) %}
-    <h2 class="module-heading"><i class="icon-medium icon-filter"></i>  Facet List <a href="#" class="action">Clear All</a></h2>
+    <h2 class="module-heading"><i class="icon-medium icon-filter"></i>  Facet List</h2>
     <nav>
       <ul class="unstyled nav nav-simple nav-facet">
         {% for value, active in items %}

--- a/ckan/templates/development/snippets/module.html
+++ b/ckan/templates/development/snippets/module.html
@@ -3,7 +3,7 @@
     {% if heading_link %}
       <h{{ hn }} class="module-heading"><a href="#">{{ heading }}</a></h{{ hn }}>
     {% elif heading_action %}
-      <h{{ hn }} class="module-heading">{{ heading }} <a href="#" class="action">Clear All</a></h{{ hn }}>
+      <h{{ hn }} class="module-heading">{{ heading }}</h{{ hn }}>
     {% elif heading_icon %}
       <h{{ hn }} class="module-heading"><i class="icon-medium icon-wrench"></i> {{ heading }}</h{{ hn }}>
     {% else %}

--- a/ckan/templates/snippets/facet_list.html
+++ b/ckan/templates/snippets/facet_list.html
@@ -50,7 +50,6 @@ within_tertiary
         <i class="icon-medium icon-filter"></i>
         {% set title = title or h.get_facet_title(name) %}
         {{ title }}
-        <a href="{{ h.remove_url_param(name, extras=extras, alternative_url=alternative_url) }}" class="action">{{ _('Clear All') }}</a>
       </h2>
       {% if items %}
         <nav>


### PR DESCRIPTION
Although the "Clear all" link is positioned within each facet block the term "clear all" suggests that it would remove all applied filters. 

I think we should remove these links entirely as they don't add useful functionality for most users and add clutter to the interface. 

@johnmartin What do you think?
