### PR TITLE
Add "organizations" to the default facet titles

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -278,7 +278,8 @@ class GroupController(base.BaseController):
 
             facets = OrderedDict()
 
-            default_facet_titles = {'groups': _('Groups'),
+            default_facet_titles = {'organization': _('Organizations'),
+                                    'groups': _('Groups'),
                                     'tags': _('Tags'),
                                     'res_format': _('Formats'),
                                     'license_id': _('License')}

--- a/ckan/controllers/home.py
+++ b/ckan/controllers/home.py
@@ -67,6 +67,7 @@ class HomeController(base.BaseController):
             c.search_facets = query['search_facets']
 
             c.facet_titles = {
+                'organization': _('Organizations'),
                 'groups': _('Groups'),
                 'tags': _('Tags'),
                 'res_format': _('Formats'),

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -597,7 +597,8 @@ def get_facet_title(name):
     if config_title:
         return config_title
 
-    facet_titles = {'groups': _('Groups'),
+    facet_titles = {'organization': _('Organizations'),
+                    'groups': _('Groups'),
                     'tags': _('Tags'),
                     'res_format': _('Formats'),
                     'license': _('License'), }


### PR DESCRIPTION
Currently this is only set in the package controller, so on all other pages that display the facets the title is not displayed correctly
