### PR TITLE
Non-existent user profile should give error

### DIFF
--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -68,7 +68,7 @@ class UserController(base.BaseController):
         try:
             user_dict = get_action('user_show')(context, data_dict)
         except NotFound:
-            h.redirect_to(controller='user', action='login', id=None)
+            abort(404, _('User not found'))
         except NotAuthorized:
             abort(401, _('Not authorized to see this page'))
         c.user_dict = user_dict
@@ -117,10 +117,6 @@ class UserController(base.BaseController):
                    'for_view': True}
         data_dict = {'id': id,
                      'user_obj': c.userobj}
-        try:
-            check_access('user_show', context, data_dict)
-        except NotAuthorized:
-            abort(401, _('Not authorized to see this page'))
 
         context['with_related'] = True
 


### PR DESCRIPTION
Trying to visit the profile page of a non-existent user, e.g. /user/zzzzzzzz, should give a "Sorry, that user doesn't exist" page. Currently it redirects to user/login?id=None.
