### PR TITLE
Placeholder images broken on non-root locations

### DIFF
--- a/ckan/templates/group/snippets/group_item.html
+++ b/ckan/templates/group/snippets/group_item.html
@@ -14,7 +14,7 @@ Example:
 {% set url = h.url_for(group.type ~ '_read', action='read', id=group.name) %}
 <li class="media-item">
   {% block image %}
-    <img src="{{ group.image_url or '/base/images/placeholder-group.png' }}" alt="{{ group.name }}" class="media-image">
+    <img src="{{ group.image_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="{{ group.name }}" class="media-image">
   {% endblock %}
   {% block title %}
     <h3 class="media-heading">{{ group.display_name }}</h3>

--- a/ckan/templates/organization/snippets/organization_item.html
+++ b/ckan/templates/organization/snippets/organization_item.html
@@ -14,7 +14,7 @@ Example:
 {% set url = h.url_for(organization.type ~ '_read', action='read', id=organization.name) %}
 <li class="media-item">
   {% block image %}
-    <img src="{{ organization.image_url or '/base/images/placeholder-organization.png' }}" alt="{{ organization.name }}" class="media-image">
+    <img src="{{ organization.image_url or h.url_for_static('/base/images/placeholder-organization.png') }}" alt="{{ organization.name }}" class="media-image">
   {% endblock %}
   {% block title %}
     <h3 class="media-heading">{{ organization.display_name }}</h3>

--- a/ckan/templates/related/snippets/related_item.html
+++ b/ckan/templates/related/snippets/related_item.html
@@ -11,11 +11,11 @@ Example:
 
 #}
 {% set placeholder_map = {
-'application':'/base/images/placeholder-application.png'
+'application': h.url_for_static('/base/images/placeholder-application.png')
 } %}
 {% set tooltip = _('Go to {related_item_type}').format(related_item_type=related.type|replace('_', ' ')|title) %}
 <li class="related-item media-item" data-module="related-item">
-  <img src="{{ related.image_url or placeholder_map[related.type] or '/base/images/placeholder-image.png' }}" alt="{{ related.title }}" class="media-image">
+  <img src="{{ related.image_url or placeholder_map[related.type] or h.url_for_static('/base/images/placeholder-image.png') }}" alt="{{ related.title }}" class="media-image">
   <h3 class="media-heading">{{ related.title }}</h3>
   {% if related.description %}
     <div class="prose">{{ h.render_markdown(related.description) }}</div>


### PR DESCRIPTION
Because they don't use `h.url_for_static`
