### PR TITLE
Tests failing due to Jetty problems

### DIFF
--- a/bin/travis-install-dependencies
+++ b/bin/travis-install-dependencies
@@ -16,7 +16,7 @@ fi
 # We need this ppa so we can install postgres-8.4
 sudo add-apt-repository -yy ppa:pitti/postgresql
 sudo apt-get update -qq
-sudo apt-get install solr-jetty postgresql-$PGVERSION
+sudo apt-get install postgresql-$PGVERSION solr-jetty libcommons-fileupload-java:amd64=1.2.2-1
 
 sudo service postgresql reload
 


### PR DESCRIPTION
Apparently the latest update on Ubuntu 12.04 (12.04.3) includes a library that Jetty is not happy with:

http://askubuntu.com/questions/377021/solr-jetty-on-ubuntu-12-04-3

To fix it we need to install the following package:

```
apt-get install libcommons-fileupload-java:amd64=1.2.2-1
```

Should this go into the install instructions?
