### PR TITLE
Fix to MANIFEST.in to explicitly include sub-directories (fixes #1338)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,17 +6,6 @@ recursive-include ckan/i18n *
 recursive-include ckan/templates *
 recursive-include ckan *.ini
 
-##------------------------------------------------------------
-## Warning: ``**`` glob patterns are equivalent to ``*``,
-## they *do not* match any level of sub-directories but
-## just one. We need to list all the directories
-## explicitly for this to work!
-##------------------------------------------------------------
-
-#recursive-include ckanext/**/public *
-#recursive-include ckanext/**/templates *
-#recursive-include ckanext/**/i18n *
-
 recursive-include ckanext/*/i18n *
 recursive-include ckanext/*/public *
 recursive-include ckanext/*/templates *


### PR DESCRIPTION
The `**` pattern _doesn't_ match "any" sub-level, we need to list
all the patterns explicitly.
