### PR TITLE
Misleading HTML comment about scripts in base.html template

### DIFF
--- a/ckan/templates/base.html
+++ b/ckan/templates/base.html
@@ -102,17 +102,9 @@
     {%- block page %}{% endblock -%}
 
     {#
-    The scripts block allows you to add additonal scripts to the page. Use the
-    super() function to load the default scripts before/after your own.
-    NOTE: Scripts should be loaded by the {% resource %} tag except
-    in very special circumstances DO NOT USE THIS METHOD FOR ADDING SCRIPTS.
-
-    Example:
-
-      {% block scripts %}
-        {{ super() }}
-        <script src="/base/js/custom.js"></script>
-      {% endblock %}
+    DO NOT USE THIS BLOCK FOR ADDING SCRIPTS
+    Scripts should be loaded by the {% resource %} tag except in very special
+    circumstances
     #}
     {%- block scripts %}
     {% endblock -%}


### PR DESCRIPTION
This line is misleading as we now us fanstatic. So the comment should be updated to be a better example:

https://github.com/okfn/ckan/blob/master/ckan/templates/base.html#L104
