### PR TITLE
Don't display number of members on Orgs, Groups

### DIFF
--- a/ckan/templates/snippets/organization.html
+++ b/ckan/templates/snippets/organization.html
@@ -43,10 +43,6 @@ Example:
             <dd>{{ h.SI_number_span(organization.num_followers) }}</dd>
           </dl>
           <dl>
-            <dt>{{ _('Members') }}</dt>
-            <dd>{{ h.SI_number_span(organization.members|length) }}</dd>
-          </dl>
-          <dl>
             <dt>{{ _('Datasets') }}</dt>
             <dd>{{ h.SI_number_span(organization.package_count) }}</dd>
           </dl>


### PR DESCRIPTION
On an Org/Gorup page, there is a displayed number of "Members". This number is always 0. The best fix would be to just delete it - there is no point in knowing the number of members. For most users the meaning will be unclear and it will just be confusing.
