### PR TITLE
More useful debug messages for custom action/auth functions on startup

### DIFF
--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -388,7 +388,7 @@ def get_action(action):
                         resolved_action_plugins[name]
                     )
                 )
-            log.debug('Auth function %r was inserted', plugin.name)
+            log.debug('Action function {0} from plugin {1} was inserted'.format(name, plugin.name))
             resolved_action_plugins[name] = plugin.name
             # Extensions are exempted from the auth audit for now
             # This needs to be resolved later

--- a/ckan/new_authz.py
+++ b/ckan/new_authz.py
@@ -83,7 +83,7 @@ class AuthFunctions:
                             resolved_auth_function_plugins[name]
                         )
                     )
-                log.debug('Auth function %r was inserted', plugin.name)
+                log.debug('Auth function {0} from plugin {1} was inserted'.format(name, plugin.name))
                 resolved_auth_function_plugins[name] = plugin.name
                 fetched_auth_functions[name] = auth_function
         # Use the updated ones in preference to the originals.


### PR DESCRIPTION
Instead of this:

```
2013-11-27 12:43:50,007 DEBUG [ckan.logic] Auth function 'datastore' was inserted
2013-11-27 12:43:50,007 DEBUG [ckan.logic] Auth function 'datastore' was inserted
```

get this:

```
2013-11-27 12:29:12,886 DEBUG [ckan.logic] Action function datastore_create from plugin datastore was inserted
2013-11-27 12:29:12,886 DEBUG [ckan.logic] Action function datastore_make_public from plugin datastore was inserted
```
