### PR TITLE
Create dataset in correct Organization

### DIFF
--- a/ckan/templates/package/snippets/package_basic_fields.html
+++ b/ckan/templates/package/snippets/package_basic_fields.html
@@ -64,7 +64,7 @@
   {% endif %}
 
   {% if show_organizations_selector %}
-    {% set existing_org = data.owner_org %}
+    {% set existing_org = data.owner_org or data.group_id %}
     <div class="control-group">
       <label for="field-organizations" class="control-label">{{ _('Organization') }}</label>
       <div class="controls">


### PR DESCRIPTION
From Organization X's home page, I select the 'Add dataset' button. Organization X should be pre-selected in the new dataset form. (At present, the user's alphabetically first available dataset is selected instead.)
