### PR TITLE
Incorrect case on Licence facet 

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -221,7 +221,7 @@ class PackageController(base.BaseController):
                     'groups': _('Groups'),
                     'tags': _('Tags'),
                     'res_format': _('Formats'),
-                    'license_id': _('License'),
+                    'license_id': _('Licenses'),
                     }
 
             for facet in g.facets:


### PR DESCRIPTION
When filtered the link to show all licences currently says "Show Only Popular License" should be "Show Only Popular Licenses"
