### PR TITLE
fix resource_dict_save for field values matching .format

### DIFF
--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -41,8 +41,9 @@ def resource_dict_save(res_dict, context):
             # this is an internal field so ignore
             # FIXME This helps get the tests to pass but is a hack and should
             # be fixed properly. basically don't update the format if not needed
-            if (key == 'format' and value == obj.format
-                    or value == d.model_dictize._unified_resource_format(obj.format)):
+            if (key == 'format' and (value == obj.format
+                    or value == d.model_dictize._unified_resource_format(
+                    obj.format))):
                 continue
             setattr(obj, key, value)
         else:


### PR DESCRIPTION
Core resource fields with a value that happens to match the value of the format field (current or previously saved, depending on the field) are silently not saved to the database by resource_dict_save.
