### PR TITLE
group_show should never return private data

### DIFF
--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -451,7 +451,7 @@ class UserController(base.BaseController):
         # reuse of the url
         context = {'model': model, 'session': model.Session,
                    'user': id,
-                   'keep_sensitive_data': True}
+                   'keep_email': True}
 
         try:
             check_access('user_reset', context)
@@ -462,10 +462,6 @@ class UserController(base.BaseController):
             data_dict = {'id': id}
             user_dict = get_action('user_show')(context, data_dict)
 
-            # Be a little paranoid, and get rid of sensitive data that's
-            # not needed.
-            user_dict.pop('apikey', None)
-            user_dict.pop('reset_key', None)
             user_obj = context['user_obj']
         except NotFound, e:
             abort(404, _('User not found'))

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -452,6 +452,9 @@ def user_list_dictize(obj_list, context,
 
     for obj in obj_list:
         user_dict = user_dictize(obj, context)
+        user_dict.pop('reset_key', None)
+        user_dict.pop('apikey', None)
+        user_dict.pop('email', None)
         result_list.append(user_dict)
     return sorted(result_list, key=sort_key, reverse=reverse)
 
@@ -476,13 +479,24 @@ def user_dictize(user, context):
 
     requester = context.get('user')
 
-    if not (new_authz.is_sysadmin(requester) or
-            requester == user.name or
-            context.get('keep_sensitive_data', False)):
-        # If not sysadmin or the same user, strip sensible info
-        result_dict.pop('apikey', None)
-        result_dict.pop('reset_key', None)
-        result_dict.pop('email', None)
+    reset_key = result_dict.pop('reset_key', None)
+    apikey = result_dict.pop('apikey', None)
+    email = result_dict.pop('email', None)
+
+    if context.get('keep_email', False):
+        result_dict['email'] = email
+
+    if context.get('keep_apikey', False):
+        result_dict['apikey'] = email
+
+    if requester == user.name:
+        result_dict['apikey'] = apikey
+        result_dict['email'] = email
+
+    ## this should not really really be needed but tests r it
+    if new_authz.is_sysadmin(requester):
+        result_dict['apikey'] = apikey
+        result_dict['email'] = email
 
     model = context['model']
     session = model.Session
@@ -653,3 +667,20 @@ def user_following_dataset_dictize(follower, context):
 
 def user_following_group_dictize(follower, context):
     return d.table_dictize(follower, context)
+
+    base_columns = set(['id', 'resource_id', 'title', 'description',
+                        'view_type', 'order', 'config'])
+
+def resource_view_dictize(resource_view, context):
+    dictized = d.table_dictize(resource_view, context)
+    dictized.pop('order')
+    config = dictized.pop('config', {})
+    dictized.update(config)
+    return dictized
+
+def resource_view_list_dictize(resource_views, context):
+    resource_view_dicts = []
+    for view in resource_views:
+        resource_view_dicts.append(resource_view_dictize(view, context))
+    return resource_view_dicts
+

--- a/ckan/lib/email_notifications.py
+++ b/ckan/lib/email_notifications.py
@@ -221,7 +221,7 @@ def get_and_send_notifications_for_user(user):
 
 def get_and_send_notifications_for_all_users():
     context = {'model': model, 'session': model.Session, 'ignore_auth': True,
-            'keep_sensitive_data': True}
+            'keep_email': True}
     users = logic.get_action('user_list')(context, {})
     for user in users:
         get_and_send_notifications_for_user(user)

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -835,7 +835,8 @@ def user_create(context, data_dict):
     #
     # The context is copied so as not to clobber the caller's context dict.
     user_dictize_context = context.copy()
-    user_dictize_context['keep_sensitive_data'] = True
+    user_dictize_context['keep_apikey'] = True
+    user_dictize_context['keep_email'] = True
     user_dict = model_dictize.user_dictize(user, user_dictize_context)
 
     context['user_obj'] = user


### PR DESCRIPTION
If a sysadmin calls `group_show`, it returns private data of all the users who are members of the group. If a user who's a member of a group calls `group_show`, it returns that user's private data as part of the group dict. This is unexpected and dangerous behavior.
