### PR TITLE
Title edit for existing dataset changes the URL

### DIFF
--- a/ckan/public/base/javascript/modules/slug-preview.js
+++ b/ckan/public/base/javascript/modules/slug-preview.js
@@ -11,17 +11,17 @@ this.ckan.module('slug-preview-target', {
 
     // Make sure there isn't a value in the field already...
     if (el.val() == '') {
-    // Once the preview box is modified stop watching it.
-    sandbox.subscribe('slug-preview-modified', function () {
-      el.off('.slug-preview');
-    });
+      // Once the preview box is modified stop watching it.
+      sandbox.subscribe('slug-preview-modified', function () {
+        el.off('.slug-preview');
+      });
 
-    // Watch for updates to the target field and update the hidden slug field
-    // triggering the "change" event manually.
-    el.on('keyup.slug-preview', function (event) {
-      sandbox.publish('slug-target-changed', this.value);
-      //slug.val(this.value).trigger('change');
-    });
+      // Watch for updates to the target field and update the hidden slug field
+      // triggering the "change" event manually.
+      el.on('keyup.slug-preview', function (event) {
+        sandbox.publish('slug-target-changed', this.value);
+        //slug.val(this.value).trigger('change');
+      });
     }
   }
 });


### PR DESCRIPTION
When editing a title for an existing dataset, the system suggests another URL for that dataset. However, when checking the activity stream, the old name correctly is shown. Since new URL is automatically generated, the system allows for changing it practically without noticing this change.

This is very tricky especially for users who had already bookmarked this URL and use it elsewhere - they get HTTP 404 Error.

Normally URL must not be changed after dataset is created.
