### PR TITLE
Can not reactivate a deleted dataset from the UI

### DIFF
--- a/ckan/templates/package/snippets/package_basic_fields.html
+++ b/ckan/templates/package/snippets/package_basic_fields.html
@@ -99,4 +99,17 @@
     </div>
   {% endif %}
 
+
+  {% if data.id and h.check_access('package_delete', {'id': data.id}) and data.state != 'active' %}
+    <div class="control-group">
+      <label for="field-state" class="control-label">{{ _('State') }}</label>
+      <div class="controls">
+        <select id="field-state" name="state">
+          <option value="active" {% if data.get('state', 'none') == 'active' %} selected="selected" {% endif %}>{{ _('Active') }}</option>
+          <option value="deleted" {% if data.get('state', 'none') == 'deleted' %} selected="selected" {% endif %}>{{ _('Deleted') }}</option>
+        </select>
+      </div>
+    </div>
+  {% endif %}
+
 {% endblock %}

--- a/ckan/templates/package/snippets/package_form.html
+++ b/ckan/templates/package/snippets/package_form.html
@@ -33,7 +33,7 @@ then itself be extended to add/remove blocks of functionality. #}
         </p>
       {% endblock %}
       {% block delete_button %}
-        {% if h.check_access('package_delete', {'id': data.id})  %}
+        {% if h.check_access('package_delete', {'id': data.id}) and not data.state == 'deleted' %}
           {% set locale = h.dump_json({'content': _('Are you sure you want to delete this dataset?')}) %}
           <a class="btn btn-danger pull-left" href="{% url_for controller='package', action='delete', id=data.id %}" data-module="confirm-action" data-module-i18n="{{ locale }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
         {% endif %}


### PR DESCRIPTION
To delete a dataset you need to go the edit form and click on the lower left red button.

After deleting the dataset, if you return to the form to reactivate it the same "Delete" button is shown and there is no "state" field that can be used to set it to active again, so effectively you can't reactivate a deleted dataset.

![CKAN master](https://f.cloud.github.com/assets/200230/248540/0e80d572-8b14-11e2-9d27-7e92611e3137.png)
