### PR TITLE
Error 500 when listing datasets with empty database

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -105,7 +105,9 @@ def package_list(context, data_dict):
     offset = data_dict.get('offset')
     if offset:
         query = query.offset(offset)
-    return list(zip(*query.execute())[0])
+
+    ## Returns the first field in each result record
+    return [r[0] for r in query.execute()]
 
 def current_package_list_with_resources(context, data_dict):
     '''Return a list of the site's datasets (packages) and their resources.


### PR DESCRIPTION
How to reproduce:
- Install CKAN
- Initialize empty database
- Go to http://127.0.0.1:5000/api/3/action/package_list

Complete error trace:

```
Error - <type 'exceptions.IndexError'>: list index out of range
URL: http://localhost:5000/api/3/action/package_list
File '/tmp/tmpdJUWjF/venv/local/lib/python2.7/site-packages/weberror/errormiddleware.py', line 162 in __call__
  app_iter = self.application(environ, sr_checker)
File '/tmp/tmpdJUWjF/venv/local/lib/python2.7/site-packages/webob/dec.py', line 147 in __call__
  resp = self.call_func(req, *args, **self.kwargs)
File '/tmp/tmpdJUWjF/venv/local/lib/python2.7/site-packages/webob/dec.py', line 208 in call_func
  return self.func(req, *args, **kwargs)
File '/tmp/tmpdJUWjF/venv/local/lib/python2.7/site-packages/fanstatic/publisher.py', line 234 in __call__
  return request.get_response(self.app)
File '/tmp/tmpdJUWjF/venv/local/lib/python2.7/site-packages/webob/request.py', line 1053 in get_response
  application, catch_exc_info=False)
File '/tmp/tmpdJUWjF/venv/local/lib/python2.7/site-packages/webob/request.py', line 1022 in call_application
  app_iter = application(self.environ, start_response)
File '/tmp/tmpdJUWjF/venv/local/lib/python2.7/site-packages/webob/dec.py', line 147 in __call__
  resp = self.call_func(req, *args, **self.kwargs)
File '/tmp/tmpdJUWjF/venv/local/lib/python2.7/site-packages/webob/dec.py', line 208 in call_func
  return self.func(req, *args, **kwargs)
File '/tmp/tmpdJUWjF/venv/local/lib/python2.7/site-packages/fanstatic/injector.py', line 54 in __call__
  response = request.get_response(self.app)
File '/tmp/tmpdJUWjF/venv/local/lib/python2.7/site-packages/webob/request.py', line 1053 in get_response
  application, catch_exc_info=False)
File '/tmp/tmpdJUWjF/venv/local/lib/python2.7/site-packages/webob/request.py', line 1022 in call_application
  app_iter = application(self.environ, start_response)
File '/tmp/tmpdJUWjF/venv/local/lib/python2.7/site-packages/beaker/middleware.py', line 73 in __call__
  return self.app(environ, start_response)
File '/tmp/tmpdJUWjF/venv/local/lib/python2.7/site-packages/beaker/middleware.py', line 155 in __call__
  return self.wrap_app(environ, session_start_response)
File '/tmp/tmpdJUWjF/venv/local/lib/python2.7/site-packages/routes/middleware.py', line 131 in __call__
  response = self.app(environ, start_response)
File '/tmp/tmpdJUWjF/venv/local/lib/python2.7/site-packages/pylons/wsgiapp.py', line 125 in __call__
  response = self.dispatch(controller, environ, start_response)
File '/tmp/tmpdJUWjF/venv/local/lib/python2.7/site-packages/pylons/wsgiapp.py', line 324 in dispatch
  return controller(environ, start_response)
File '/tmp/tmpdJUWjF/venv/src/ckan/ckan/controllers/api.py', line 70 in __call__
  return base.BaseController.__call__(self, environ, start_response)
File '/tmp/tmpdJUWjF/venv/src/ckan/ckan/lib/base.py', line 346 in __call__
  res = WSGIController.__call__(self, environ, start_response)
File '/tmp/tmpdJUWjF/venv/local/lib/python2.7/site-packages/pylons/controllers/core.py', line 221 in __call__
  response = self._dispatch_call()
File '/tmp/tmpdJUWjF/venv/local/lib/python2.7/site-packages/pylons/controllers/core.py', line 172 in _dispatch_call
  response = self._inspect_call(func)
File '/tmp/tmpdJUWjF/venv/local/lib/python2.7/site-packages/pylons/controllers/core.py', line 107 in _inspect_call
  result = self._perform_call(func, args)
File '/tmp/tmpdJUWjF/venv/local/lib/python2.7/site-packages/pylons/controllers/core.py', line 60 in _perform_call
  return func(**args)
File '/tmp/tmpdJUWjF/venv/src/ckan/ckan/controllers/api.py', line 189 in action
  result = function(context, request_data)
File '/tmp/tmpdJUWjF/venv/src/ckan/ckan/logic/__init__.py', line 419 in wrapped
  result = _action(context, data_dict, **kw)
File '/tmp/tmpdJUWjF/venv/src/ckan/ckan/logic/action/get.py', line 108 in package_list
  return list(zip(*query.execute())[0])
IndexError: list index out of range
```

This is clearly due to that `zip()` being performed on an empty list.
I'd replace that line with `return [r[0] for r in query.execute()]`, which is way more readable too..

If you want a complete installation log: https://travis-ci.org/rshk/ckan-blackbox-testing/builds/15036108

(@rossjones, @seanh: first bug found thanks to [the thing I was talking about yesterday..](https://github.com/rshk/ckan-blackbox-testing))
