### PR TITLE
Unable to pass more than one key=value argument to user creation

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -697,7 +697,7 @@ class UserCmd(CkanCommand):
     '''
     summary = __doc__.split('\n')[0]
     usage = __doc__
-    max_args = 4
+    max_args = None
     min_args = 0
 
     def command(self):


### PR DESCRIPTION
I was trying to create a new user from paster, passing all the user information on the command line, but:

```
% paster --plugin=ckan user --config=$VIRTUAL_ENV/etc/ckan/production.ini add admin apikey=my-admin-api-key password=admin email=admin@example.com
You must provide no more than 4 arguments
>>> exited 2
```

Apparently, user creation only works when passing **exactly** one extra argument: `email` (which is required). The password will be then asked with prompt, etc.

I had a look at the code, and this is due to `max_args = 4` being (incorrectly) set on the `UserCmd`  command (incorrrectly as it is supposed to accept a variable number of arguments).
