### PR TITLE
[#1350] Remove misleading resource format notice

### DIFF
--- a/ckan/templates/package/snippets/resource_form.html
+++ b/ckan/templates/package/snippets/resource_form.html
@@ -35,10 +35,6 @@
     {% block basic_fields_format %}
       {% set format_attrs = {'data-module': 'autocomplete', 'data-module-source': '/api/2/util/resource/format_autocomplete?incomplete=?'} %}
       {% call form.input('format', id='field-format', label=_('Format'), placeholder=_('eg. CSV, XML or JSON'), value=data.format, error=errors.format, classes=['control-medium'], attrs=format_attrs) %}
-        <span class="info-block info-block-small">
-          <i class="icon-info-sign"></i>
-          {{ _('This is generated automatically. You can edit if you wish') }}
-        </span>
       {% endcall %}
     {% endblock %}
 


### PR DESCRIPTION
For 2.2 until is properly fixed in #1350 on 2.3
