### PR TITLE
Bad response codes from the API

### DIFF
--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -85,6 +85,7 @@ def resource_list_dictize(res_list, context):
 
     return sorted(result_list, key=lambda x: x["position"])
 
+
 def related_list_dictize(related_list, context):
     result_list = []
     for res in related_list:


### PR DESCRIPTION
I was testing the API, while I found this:

```
% http http://127.0.0.1:5000/api/3/action/package_revision_list             
HTTP/1.0 409 Conflict
```

The same happens with other methods that require the `id` argument. This indeed should return an error, but the code should be `400 Bad Request`, not `409 Conflict` (which isn't supposed to be returned in response to a GET request, btw..)

Situation is different when trying the same thing with `related_list`, which abruptly dies with a 500:

```
% http http://127.0.0.1:5000/api/3/action/related_list          
HTTP/1.0 500 Internal Server Error

% http http://127.0.0.1:5000/api/3/action/related_list\?id\=invalid
HTTP/1.0 500 Internal Server Error
```

(I'd expect the first one to be a `400`, the second one to be a `404`).
