### PR TITLE
Exception on group dictize due to 'with_capacity' on context

### DIFF
--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -355,8 +355,6 @@ def group_dictize(group, context):
     result_dict['extras'] = extras_dict_dictize(
         group._extras, context)
 
-    context['with_capacity'] = True
-
     include_datasets = context.get('include_datasets', True)
 
     q = {
@@ -384,6 +382,7 @@ def group_dictize(group, context):
 
     result_dict['package_count'] = search_results['count']
 
+    context['with_capacity'] = True
     result_dict['tags'] = tag_list_dictize(
         _get_members(context, group, 'tags'),
         context)


### PR DESCRIPTION
This one is a bit obscure but bumped into it when upgrading master and beta.

The symptoms:

```
[Fri Dec 13 12:32:28 2013] [error] [client 127.0.0.1] File '/usr/lib/ckan/master/src/ckan/ckan/logic/action/get.py', line 989 in _group_or_org_show
[Fri Dec 13 12:32:28 2013] [error] [client 127.0.0.1]   group_dict = model_dictize.group_dictize(group, context)
[Fri Dec 13 12:32:28 2013] [error] [client 127.0.0.1] File '/usr/lib/ckan/master/src/ckan/ckan/lib/dictization/model_dictize.py', line 380 in group_dictize
[Fri Dec 13 12:32:28 2013] [error] [client 127.0.0.1]   search_results = logic.get_action('package_search')(context, q)
[Fri Dec 13 12:32:28 2013] [error] [client 127.0.0.1] File '/usr/lib/ckan/master/src/ckan/ckan/logic/__init__.py', line 419 in wrapped
[Fri Dec 13 12:32:28 2013] [error] [client 127.0.0.1]   result = _action(context, data_dict, **kw)
[Fri Dec 13 12:32:28 2013] [error] [client 127.0.0.1] File '/usr/lib/ckan/master/src/ckan/ckan/logic/action/get.py', line 1507 in package_search
[Fri Dec 13 12:32:28 2013] [error] [client 127.0.0.1]   results.append(model_dictize.package_dictize(pkg,context))
[Fri Dec 13 12:32:28 2013] [error] [client 127.0.0.1] File '/usr/lib/ckan/master/src/ckan/ckan/lib/dictization/model_dictize.py', line 257 in package_dictize
[Fri Dec 13 12:32:28 2013] [error] [client 127.0.0.1]   result_dict["tags"] = d.obj_list_dictize(result, context, lambda x: x["name"])
[Fri Dec 13 12:32:28 2013] [error] [client 127.0.0.1] File '/usr/lib/ckan/master/src/ckan/ckan/lib/dictization/__init__.py', line 65 in obj_list_dictize
[Fri Dec 13 12:32:28 2013] [error] [client 127.0.0.1]   obj, capacity = obj 
[Fri Dec 13 12:32:28 2013] [error] [client 127.0.0.1] ValueError: too many values to unpack
```

The cause is passing `context['with_capacity'] = True` to `package_search` on group_dictize.

This only surfaced because beta and master where using and old version of the Solr schema without `validated_data_dict`. When requesting the groups for the homepage and dictizing them, package_search [was calling package_dictize](https://github.com/okfn/ckan/blob/master/ckan/logic/action/get.py#L1507), as the validated_data_dict was empty.
