### PR TITLE
1374 Fix Datastore loading/startup bug

### DIFF
--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -164,10 +164,9 @@ class DatastorePlugin(p.SingletonPlugin):
         try:
             write_connection.execute(u'CREATE TEMP TABLE _foo ()')
             for privilege in ['INSERT', 'UPDATE', 'DELETE']:
-                test_privilege_sql = u"SELECT has_table_privilege('{user}', '_foo', '{privilege}')"
-                sql = test_privilege_sql.format(user=read_connection_user,
-                                                privilege=privilege)
-                have_privilege = write_connection.execute(sql).first()[0]
+                test_privilege_sql = u"SELECT has_table_privilege(%s, '_foo', %s)"
+                have_privilege = write_connection.execute(
+                    test_privilege_sql, (read_connection_user, privilege)).first()[0]
                 if have_privilege:
                     return False
         finally:


### PR DESCRIPTION
fixes bug that causes this in error logs

```
2013-11-17 04:47:28 UTC ERROR:  relation "_foo" already exists
2013-11-17 04:47:28 UTC STATEMENT:  CREATE TABLE _foo ()
2013-11-17 04:47:28 UTC ERROR:  cache lookup failed for relation 236044
2013-11-17 04:47:28 UTC STATEMENT:  DROP TABLE IF EXISTS _foo
2013-11-17 04:48:18 UTC ERROR:  duplicate key value violates unique constraint "pg_type_typname_nsp_index"
2013-11-17 04:48:18 UTC DETAIL:  Key (typname, typnamespace)=(_foo, 2200) already exists.
2013-11-17 04:48:18 UTC STATEMENT:  CREATE TABLE _foo ()
```

As this bug affects startup of ckan process, it can silently break other plugins loaded on that process

related to #1374, not sure if it's the root cause of it or if it's just another bug masking another one. I've changed the `_read_connection_has_correct_priviliges` function to use one connection instead of two(a read and a write) just to use the write connection and to execute the privileges test using the read connection user as a parameter to the postgres function `has_table_privilege()` that we get from the read url. I'm using a temporary table as well so that different processes should not interfere with each other. Did a little refactoring as well.
