### PR TITLE
The reset password e-mail is using an incorrect translation string

### DIFF
--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -102,27 +102,27 @@ def mail_user(recipient, subject, body, headers={}):
 
 def get_reset_link_body(user):
     reset_link_message = _(
-    "You have requested your password on %(site_title)s to be reset.\n"
+    "You have requested your password on {site_title} to be reset.\n"
     "\n"
     "Please click the following link to confirm this request:\n"
     "\n"
-    "   %(reset_link)s\n"
+    "   {reset_link}\n"
     )
 
     d = {
         'reset_link': get_reset_link(user),
         'site_title': g.site_title
         }
-    return reset_link_message % d
+    return reset_link_message.format(**d)
 
 def get_invite_body(user):
     invite_message = _(
-    "You have been invited to %(site_title)s. A user has already been created"
-    "to you with the username %(user_name)s. You can change it later.\n"
+    "You have been invited to {site_title}. A user has already been created"
+    "to you with the username {user_name}. You can change it later.\n"
     "\n"
     "To accept this invite, please reset your password at:\n"
     "\n"
-    "   %(reset_link)s\n"
+    "   {reset_link}\n"
     )
 
     d = {
@@ -130,7 +130,7 @@ def get_invite_body(user):
         'site_title': g.site_title,
         'user_name': user.name,
         }
-    return invite_message % d
+    return invite_message.format(**d)
 
 def get_reset_link(user):
     return urljoin(g.site_url,


### PR DESCRIPTION
We're using:

``` python
    reset_link_message = _(
    '''You have requested your password on %(site_title)s to be reset.

    Please click the following link to confirm this request:

       %(reset_link)s
    ''')
```

Which ends up creating a string with extra whitespace before the paragraphs,
like "...to be reset\n\n    Please click the following...".

But the i18n message key doesn't have these whitespaces, so we always send
that in English. To solve it, we could either fix the message key in all .po
files, or change how we construct the string in `mailer.py`. I prefer the
latter.
