### PR TITLE
Fix test failures associated with related_list

### DIFF
--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -90,8 +90,9 @@ def related_list_dictize(related_list, context):
     for res in related_list:
         related_dict = related_dictize(res, context)
         result_list.append(related_dict)
-
-    return result_list
+    if context.get('sorted'):
+        return result_list
+    return sorted(result_list, key=lambda x: x["created"], reverse=True)
 
 
 def extras_dict_dictize(extras_dict, context):

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -263,6 +263,7 @@ def related_list(context, data_dict=None):
         if data_dict.get('featured', False):
             related_list = related_list.filter(model.Related.featured == 1)
         related_items = related_list.all()
+        context['sorted'] = True
     else:
         relateds = model.Related.get_for_dataset(dataset, status='active')
         related_items = (r.related for r in relateds)

--- a/ckan/tests/functional/test_related.py
+++ b/ckan/tests/functional/test_related.py
@@ -467,7 +467,7 @@ class TestRelatedActionAPI(apibase.BaseModelApiTestCase):
         r = json.loads(res.body)
         assert r['success'] == True, r
         assert r['result'][0]['type'] == "idea"
-        assert r['result'][0]['title'] == "one", r
+        assert r['result'][0]['title'] == "two", r
 
         p.related.remove(one)
         p.related.remove(two)


### PR DESCRIPTION
The related_list dictization changes returned them as returned by
the database. This change gives it a default order if they're not
previously sorted.
