### PR TITLE
Documentation and clarification about "CKAN Flavored Markdown"

### DIFF
--- a/ckan/templates/macros/form.html
+++ b/ckan/templates/macros/form.html
@@ -118,7 +118,7 @@ Examples:
 {% macro markdown(name, id='', label='', value='', placeholder='', error="", classes=[], attrs={}, is_required=false) %}
   {% set classes = (classes|list) %}
   {% do classes.append('control-full') %}
-  {% set markdown_tooltip = "<pre><p>__Bold text__ or _italic text_</p><p># title<br>## secondary title<br>### etc</p><p>* list<br>* of<br>* items</p></pre><p><b><a href='http://daringfireball.net/projects/markdown/syntax' target='_blank'>Full markdown syntax</a></b></p><p class='muted'><b>Please note:</b> CKAN flavoured markdown strips all HTML tags for security reasons</p>" %} 
+  {% set markdown_tooltip = "<pre><p>__Bold text__ or _italic text_</p><p># title<br>## secondary title<br>### etc</p><p>* list<br>* of<br>* items</p><p>http://auto.link.ed/</p></pre><p><b><a href='http://daringfireball.net/projects/markdown/syntax' target='_blank'>Full markdown syntax</a></b></p><p class='muted'><b>Please note:</b> HTML tags are stripped out for security reasons</p>" %} 
 
   {%- set extra_html = caller() if caller -%}
   {% call input_block(id or name, label or name, error, classes, control_classes=["editor"], extra_html=extra_html, is_required=is_required) %}


### PR DESCRIPTION
As stated on the [mailinglist](http://lists.okfn.org/pipermail/ckan-dev/2013-November/006175.html) and in some of the issues like #1270 , not all features of **Markdown** are supported, especially regarding embedding native HTML code. For example, adding an Image with `<img>` does unfortunately not work.

The problem is that the CKAN editor links to the documentation [Markdown: Syntax](http://daringfireball.net/projects/markdown/syntax), which describes that HTML code like `<img>` works. So, we need to clarify which features are supported. There should at least be a documentation about "what does not work" compared to the linked documentation.
