### PR TITLE
I can see there's no description, thanks

### DIFF
--- a/ckan/templates/group/about.html
+++ b/ckan/templates/group/about.html
@@ -7,8 +7,6 @@
   {% block group_description %}
     {% if c.group_dict.description %}
       {{ h.render_markdown(c.group_dict.description) }}
-    {% else %}
-      <p class="empty">{{ _('There is no description for this group') }}</p>
   	{% endif %}
   {% endblock %}
 

--- a/ckan/templates/group/snippets/group_item.html
+++ b/ckan/templates/group/snippets/group_item.html
@@ -23,8 +23,6 @@ Example:
   {% block description %}
     {% if group.description %}
       <p>{{ h.markdown_extract(group.description, extract_length=80) }}</p>
-    {% else %}
-      <p class="empty">{{ _('This group has no description') }}</p>
     {% endif %}
   {% endblock %}
   {% block datasets %}

--- a/ckan/templates/group/snippets/info.html
+++ b/ckan/templates/group/snippets/info.html
@@ -11,8 +11,6 @@
         {{ h.markdown_extract(group.description, 180) }}
         {% link_for _('read more'), controller='group', action='about', id=group.name %}
       </p>
-    {% else %}
-      <p class="empty">{{ _('There is no description for this group') }}</p>
     {% endif %}
     {% if show_nums %}
       <div class="nums">

--- a/ckan/templates/organization/about.html
+++ b/ckan/templates/organization/about.html
@@ -7,8 +7,6 @@
   {% block organization_description %}
     {% if c.group_dict.description %}
       {{ h.render_markdown(c.group_dict.description) }}
-    {% else %}
-      <p class="empty">{{ _('There is no description for this organization') }}</p>
     {% endif %}
   {% endblock %}
   {% block organization_extras %}

--- a/ckan/templates/organization/bulk_process.html
+++ b/ckan/templates/organization/bulk_process.html
@@ -77,8 +77,6 @@
                       </h3>
                       {% if notes %}
                         <p>{{ notes|urlize }}</p>
-                      {% else %}
-                        <p class="empty">{{ _("This dataset has no description") }}</p>
                       {% endif %}
                     </td>
                   </tr>

--- a/ckan/templates/organization/snippets/organization_item.html
+++ b/ckan/templates/organization/snippets/organization_item.html
@@ -22,8 +22,6 @@ Example:
   {% block description %}
     {% if organization.description %}
       <p>{{ h.markdown_extract(organization.description, extract_length=80) }}</p>
-    {% else %}
-      <p class="empty">{{ _('This organization has no description') }}</p>
     {% endif %}
   {% endblock %}
   {% block datasets %}

--- a/ckan/templates/package/resource_read.html
+++ b/ckan/templates/package/resource_read.html
@@ -61,8 +61,6 @@
           <div class="prose notes" property="rdfs:label">
             {% if res.description %}
               {{ h.render_markdown(res.description) }}
-            {% else %}
-              <p class="empty">{{ _('There is no description for this resource') }}</p>
             {% endif %}
             {% if not res.description and c.package.notes %}
               <h3>{{ _('From the dataset abstract') }}</h3>

--- a/ckan/templates/package/snippets/package_context.html
+++ b/ckan/templates/package/snippets/package_context.html
@@ -6,8 +6,6 @@
         {{ h.markdown_extract(pkg.notes, 180) }}
         {% link_for _('read more'), controller='package', action='about', id=pkg.name %}
       </p>
-    {% else %}
-      <p class="empty">{{ _('There is no description for this dataset') }}</p>
     {% endif %}
     <div class="nums">
       <dl>

--- a/ckan/templates/package/snippets/resource_item.html
+++ b/ckan/templates/package/snippets/resource_item.html
@@ -12,8 +12,6 @@
   <p class="description">
     {% if res.description %}
       {{ h.markdown_extract(res.description, extract_length=80) }}
-    {% else %}
-      <span class="empty">{{ _('No description for this resource') }}</span>
     {% endif %}
   </p>
   {% block resource_item_explore %}

--- a/ckan/templates/related/snippets/related_item.html
+++ b/ckan/templates/related/snippets/related_item.html
@@ -19,8 +19,6 @@ Example:
   <h3 class="media-heading">{{ related.title }}</h3>
   {% if related.description %}
     <div class="prose">{{ h.render_markdown(related.description) }}</div>
-  {% else %}
-    <p class="empty">{{ _('This item has no description') }}</p>
   {% endif %}
   <a class="media-view" href="{{ related.url }}" target="_blank" title="{{ tooltip }}">
     <span>{{ tooltip }}</span>

--- a/ckan/templates/snippets/group.html
+++ b/ckan/templates/snippets/group.html
@@ -20,8 +20,6 @@ Example:
         <h3 class="media-heading"><a href={{ url }}>{{ group.title or group.name }}</a></h3>
         {% if group.description %}
           <p>{{ h.markdown_extract(group.description, truncate) }}</p>
-        {% else %}
-          <p class="empty">{{ _('There is no description for this group') }}</p>
         {% endif %}
       </div>
     </div>

--- a/ckan/templates/snippets/group_item.html
+++ b/ckan/templates/snippets/group_item.html
@@ -14,8 +14,6 @@
       {% else %}
         <p>{{ h.markdown_extract(group.description, truncate)|urlize }}</p>
       {% endif %}
-    {% else %}
-      <p class="empty">{{ _('There is no description for this group') }}</p>
     {% endif %}
   </header>
   {% set list_class = "unstyled dataset-list" %}

--- a/ckan/templates/snippets/organization_item.html
+++ b/ckan/templates/snippets/organization_item.html
@@ -12,8 +12,6 @@
       {% else %}
         <p>{{ h.markdown_extract(organization.description, truncate)|urlize }}</p>
       {% endif %}
-    {% else %}
-      <p class="empty">{{ _('There is no description for this organization') }}</p>
     {% endif %}
   </header>
   {% set list_class = "unstyled dataset-list" %}

--- a/ckan/templates/snippets/package_item.html
+++ b/ckan/templates/snippets/package_item.html
@@ -41,8 +41,6 @@ Example:
       {% endif %}
       {% if notes %}
         <div>{{ notes|urlize }}</div>
-      {% else %}
-        <p class="empty">{{ _("This dataset has no description") }}</p>
       {% endif %}
     </div>
     {% if package.resources and not hide_resources %}


### PR DESCRIPTION
The text 'This organization has no description." (e.g. at http://demo.ckan.org/organization for every org with no description) is completely unnecessary and looks bad. It should just be deleted.
