### PR TITLE
Use a more secure default for the repoze secret key

### DIFF
--- a/ckan/config/middleware.py
+++ b/ckan/config/middleware.py
@@ -18,6 +18,7 @@ from pylons.wsgiapp import PylonsApp
 from routes.middleware import RoutesMiddleware
 from repoze.who.config import WhoConfig
 from repoze.who.middleware import PluggableAuthenticationMiddleware
+from repoze.who.plugins.auth_tkt import make_plugin as auth_tkt_make_plugin
 from fanstatic import Fanstatic
 
 from ckan.plugins import PluginImplementations
@@ -182,6 +183,11 @@ def make_app(conf, full_stack=True, static_files=True, **app_conf):
         app = TrackingMiddleware(app, config)
 
     return app
+
+def ckan_auth_tkt_make_app(**kw):
+    if not len(kw.get('secret', '')) or kw.get('secret') == 'somesecret':
+        kw['secret'] = config['beaker.session.secret']
+    return auth_tkt_make_plugin(**kw)
 
 
 class I18nMiddleware(object):

--- a/ckan/config/who.ini
+++ b/ckan/config/who.ini
@@ -1,6 +1,7 @@
 [plugin:auth_tkt]
-use = repoze.who.plugins.auth_tkt:make_plugin
-secret = somesecret
+use = ckan.config.middleware:ckan_auth_tkt_make_app
+# If no secret key is defined here, beaker.session.secret will be used
+#secret = somesecret
 
 [plugin:friendlyform]
 use = repoze.who.plugins.friendlyform:FriendlyFormPlugin


### PR DESCRIPTION
The who.ini file has a secret key used during authentication. To make sure users don't forget to update it we can use the beaker session secret which is generated randomly when creating the ckan ini file.
