### PR TITLE
Call logic.NotFound instead of ObjectNotFound

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1713,7 +1713,7 @@ def featured_group_org(items, get_action, list_action, count):
 
         try:
             out = logic.get_action(get_action)(context, data_dict)
-        except logic.ObjectNotFound:
+        except logic.NotFound:
             return None
         return out
 


### PR DESCRIPTION
In #1126, we call `logic.ObjectNotFound` instead of `logic.NotFound` which raises an exception when there are no featured groups.
