### PR TITLE
Default search ordering on organization home page is broken

### DIFF
--- a/ckan/templates/group/read.html
+++ b/ckan/templates/group/read.html
@@ -11,7 +11,14 @@
       'translated_fields': c.translated_fields,
       'remove_field': c.remove_field }
     %}
-    {% snippet 'snippets/search_form.html', type='dataset', query=c.q, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, placeholder=_('Search datasets...'), show_empty=request.params %}
+    {% set sorting = [
+      (_('Relevance'), 'score desc, metadata_modified desc'),
+      (_('Name Ascending'), 'title_string asc'),
+      (_('Name Descending'), 'title_string desc'),
+      (_('Last Modified'), 'metadata_modified desc'),
+      (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
+    %}
+    {% snippet 'snippets/search_form.html', type='dataset', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, placeholder=_('Search datasets...'), show_empty=request.params %}
   {% endblock %}
   {% block packages_list %}
     {% if c.page.items %}

--- a/ckan/templates/organization/read.html
+++ b/ckan/templates/organization/read.html
@@ -15,7 +15,14 @@
         'translated_fields': c.translated_fields,
         'remove_field': c.remove_field }
       %}
-      {% snippet 'snippets/search_form.html', type='dataset', query=c.q, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, placeholder=_('Search datasets...'), show_empty=request.params %}
+      {% set sorting = [
+        (_('Relevance'), 'score desc, metadata_modified desc'),
+        (_('Name Ascending'), 'title_string asc'),
+        (_('Name Descending'), 'title_string desc'),
+        (_('Last Modified'), 'metadata_modified desc'),
+        (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
+      %}
+      {% snippet 'snippets/search_form.html', type='dataset', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, placeholder=_('Search datasets...'), show_empty=request.params %}
     {% endblock %}
   {% block packages_list %}
     {% if c.page.items %}


### PR DESCRIPTION
Can replicate at demo.ckan.org and datahub.io (2.1.1)

Go to http://demo.ckan.org/group/geo-examples

The ordering drop-down says Names ascending, but notice the results are not sorted correctly. If you choose Name descending, it works, and then choosing Name ascending will do the right thing.

Sounds like the controller needs to specify the default sort if none is passed.
