### PR TITLE
show package/resource revision_ids, disallow setting them

### DIFF
--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -66,7 +66,7 @@ def default_resource_schema():
 
     schema = {
         'id': [ignore_empty, unicode],
-        'revision_id': [ignore_missing, unicode],
+        'revision_id': [ignore],
         'resource_group_id': [ignore],
         'package_id': [ignore],
         'url': [not_empty, unicode],#, URL(add_http=False)],
@@ -204,6 +204,7 @@ def default_show_package_schema():
         'cache_last_updated': [ckan.lib.navl.validators.ignore_missing],
         'webstore_last_updated': [ckan.lib.navl.validators.ignore_missing],
         'revision_timestamp': [],
+        'revision_id': [],
         'resource_group_id': [],
         'cache_last_updated': [],
         'webstore_last_updated': [],
@@ -223,6 +224,7 @@ def default_show_package_schema():
         'state': [ckan.lib.navl.validators.ignore_missing],
         'isopen': [ignore_missing],
         'license_url': [ignore_missing],
+        'revision_id': [],
         })
 
     schema['groups'].update({


### PR DESCRIPTION
avoid a 500 server error on user sending a revision_id to package_update, and otherwise just do the right thing all the time with revision_id in packages and resources.
