### PR TITLE
[#1471] Fix deletion of unowned datasets

### DIFF
--- a/ckan/logic/auth/delete.py
+++ b/ckan/logic/auth/delete.py
@@ -14,7 +14,7 @@ def user_delete(context, data_dict):
 def package_delete(context, data_dict):
     # Defer auhtorization for package_delete to package_update, as deletions
     # are essentially changing the state field
-    return logic.get_action('package_update')(context, data_dict)
+    return logic.check_access('package_update')(context, data_dict)
 
 def resource_delete(context, data_dict):
     model = context['model']


### PR DESCRIPTION
We are basically deferring the whole package_delete auth function to
package_update, because deletions are basically changing the state field
of a dataset from 'active' to 'deleted'.
