### PR TITLE
Wrong datapusher hook callback URL on non-root deployments

### DIFF
--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -46,11 +46,7 @@ def datapusher_submit(context, data_dict):
     datapusher_url = pylons.config.get('ckan.datapusher.url')
 
     site_url = pylons.config['ckan.site_url']
-
-    callback_url = site_url.rstrip('/') + p.toolkit.url_for(
-        controller='api', action='action',
-        logic_function='datapusher_hook', ver=3
-    )
+    callback_url = site_url.rstrip('/') + '/api/3/action/datapusher_hook'
 
     user = p.toolkit.get_action('user_show')(context, {'id': context['user']})
 


### PR DESCRIPTION
This [1] creates a wrong URL on a non root deployment (eg http://test.com/ckan)

https://github.com/ckan/ckan/blob/master/ckanext/datapusher/logic/action.py#L50
