### PR TITLE
Primary site logo has leading slash inserted breaking remote logo image links

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -326,7 +326,6 @@ def update_config():
                     jinja_extensions.LinkForExtension,
                     jinja_extensions.ResourceExtension,
                     jinja_extensions.UrlForStaticExtension,
-                    jinja_extensions.UrlForStaticOrExternalExtension,
                     jinja_extensions.UrlForExtension]
     )
     env.install_gettext_callables(_, ungettext, newstyle=True)

--- a/ckan/lib/extract.py
+++ b/ckan/lib/extract.py
@@ -10,7 +10,6 @@ jinja_extensions = '''
                     ckan.lib.jinja_extensions.LinkForExtension,
                     ckan.lib.jinja_extensions.ResourceExtension,
                     ckan.lib.jinja_extensions.UrlForStaticExtension,
-                    ckan.lib.jinja_extensions.UrlForStaticOrExternalExtension,
                     ckan.lib.jinja_extensions.UrlForExtension
                    '''
 

--- a/ckan/lib/jinja_extensions.py
+++ b/ckan/lib/jinja_extensions.py
@@ -269,22 +269,6 @@ class UrlForStaticExtension(BaseExtension):
         assert len(args) == 1
         return h.url_for_static(args[0], **kwargs)
 
-class UrlForStaticOrExternalExtension(BaseExtension):
-    '''Custom url_for_static_or_external tag for getting a path for static
-    assets or external URLs.
-
-    {% url_for_static_or_external <path> %}
-
-    see lib.helpers.url_for_static_or_external() for more details.
-    '''
-
-    tags = set(['url_for_static_or_external'])
-
-    @classmethod
-    def _call(cls, args, kwargs):
-        assert len(args) == 1
-        return h.url_for_static_or_external(args[0], **kwargs)
-
 class UrlForExtension(BaseExtension):
     ''' Custom url_for tag
 

--- a/ckan/templates/header.html
+++ b/ckan/templates/header.html
@@ -73,7 +73,7 @@
 
       {% block header_logo %}
         {% if g.site_logo %}
-          <a class="logo" href="{{ h.url('home') }}"><img src="{% url_for_static_or_external g.site_logo %}" alt="{{ g.site_title }}" title="{{ g.site_title }}" /></a>
+          <a class="logo" href="{{ h.url('home') }}"><img src="{{ h.url_for_static_or_external(g.site_logo) }}" alt="{{ g.site_title }}" title="{{ g.site_title }}" /></a>
         {% else %}
           <h1>
             <a href="{{ h.url('home') }}">{{ g.site_title }}</a>

--- a/doc/contributing/frontend/templating.rst
+++ b/doc/contributing/frontend/templating.rst
@@ -280,19 +280,6 @@ Works exactly the same as ``h.url_for_static()``:
 
     <script src="{% url_for_static "/javascript/home.js" %}"></script>
 
-url\_for\_static\_or\_external
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-::
-
-    {% url_for_static_or_external path %}
-
-Works exactly the same as ``h.url_for_static_or_external()``:
-
-::
-
-    <script src="{% url_for_static_or_external "//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js" %}"></script>
-
 Form Macros
 -----------
 


### PR DESCRIPTION
Now have:

```
{{ h.url_for_static(g.site_logo) }}
```

url_for_static inserts leading slash which then breaks logos which are remote e.g. http://assets.okfn.org/p/ckan/img/ckan_logo_box.png

which becomes

http://localhost:5000/http://assets.okfn.org/p/ckan/img/ckan_logo_box.png

Suggest either do not use `url_for_static` or change that method to check whether url starts with http:// or https:// (or // even ...)
