### PR TITLE
[WIP] Fixes to mimetype failures in #1534

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -2,6 +2,7 @@
 """Pylons environment configuration"""
 import os
 import logging
+import mimetypes
 import warnings
 from urlparse import urlparse
 
@@ -231,6 +232,9 @@ def load_environment(global_conf, app_conf):
     # load all CKAN plugins
     p.load_all(config)
 
+    # Pre-load some mimetypes.
+    register_mimetypes()
+
 
 def update_config():
     ''' This code needs to be run when the config is changed to take those
@@ -378,3 +382,9 @@ def update_config():
     # if an extension or our code does not finish
     # transaction properly db cli commands can fail
     model.Session.remove()
+
+def register_mimetypes():
+    ''' As some mimetypes are not very common, or at least not found in very
+    many /etc/mime.types we pre-register some here with the python mimetypes
+    module '''
+    mimetypes.add_type('application/json', '.geojson')

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -1236,7 +1236,7 @@ class PackageController(base.BaseController):
                abort(404, _('Resource data not found'))
             response.headers.update(dict(headers))
             content_type, content_enc = mimetypes.guess_type(rsc.get('url',''))
-            response.headers['Content-Type'] = content_type
+            response.headers['Content-Type'] = content_type or 'application/octet-stream'
             response.status = status
             return app_iter
         elif not 'url' in rsc:


### PR DESCRIPTION
Adds a default of application/octet-stream where the mimetype was not discernable.

During environment setup also calls a new function to preload some mimetypes based on extensions that are not often found in /etc/mime.types

Still needs tests.
