### PR TITLE
Can't download resources with geojson extension

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -1236,7 +1236,8 @@ class PackageController(base.BaseController):
                abort(404, _('Resource data not found'))
             response.headers.update(dict(headers))
             content_type, content_enc = mimetypes.guess_type(rsc.get('url',''))
-            response.headers['Content-Type'] = content_type
+            if content_type:
+                response.headers['Content-Type'] = content_type
             response.status = status
             return app_iter
         elif not 'url' in rsc:


### PR DESCRIPTION
The problem is that `mimetypes.guess_type` in
https://github.com/ckan/ckan/blob/master/ckan/controllers/package.py#L1238-L1239
doesn't recognize the `.geojson` extension and returns None.

If you search in demo using
http://demo.ckan.org/api/3/action/resource_search?query=format:geojson, any
file with a `.geojson` extension won't work, but the ones with `.json`
will work just fine.

It doesn't break when running with paster, as it doesn't validate the
Content-Type and will simply serve the file with `Content-Type: None`.

Just for the record, the error message is:

```
[Fri Feb 21 17:58:30 2014] [error] [client 127.0.0.1] mod_wsgi (pid=30210): Exception occurred processing WSGI script '/etc/ckan/demo/apache.wsgi'.
[Fri Feb 21 17:58:30 2014] [error] [client 127.0.0.1] TypeError: expected byte string object for header value, value of type NoneType found
```
