### PR TITLE
datapusher and harvester collision

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -6,6 +6,8 @@ import datetime
 import sys
 from pprint import pprint
 import re
+import ckan.logic as logic
+import ckan.model as model
 import ckan.include.rjsmin as rjsmin
 import ckan.include.rcssmin as rcssmin
 import ckan.lib.fanstatic_resources as fanstatic_resources
@@ -101,6 +103,19 @@ class CkanCommand(paste.script.command.Command):
         self.translator_obj = MockTranslator()
         self.registry.register(pylons.translator, self.translator_obj)
 
+        if model.user_table.exists():
+            # If the DB has already been initialized, create and register
+            # a pylons context object, and add the site user to it, so the
+            # auth works as in a normal web request
+            c = pylons.util.AttribSafeContextObj()
+
+            self.registry.register(pylons.c, c)
+
+            self.site_user = logic.get_action('get_site_user')({'ignore_auth': True}, {})
+
+            pylons.c.user = self.site_user['name']
+            pylons.c.userobj = model.User.get(self.site_user['name'])
+
         ## give routes enough information to run url_for
         parsed = urlparse.urlparse(conf.get('ckan.site_url', 'http://0.0.0.0'))
         request_config = routes.request_config()
@@ -144,6 +159,7 @@ class ManageDb(CkanCommand):
 
         cmd = self.args[0]
         if cmd == 'init':
+
             model.repo.init_db()
             if self.verbose:
                 print 'Initialising DB: SUCCESS'


### PR DESCRIPTION
EDIT (amercader): Mock pylons context object on paster commands
When calling a paster command, we create and register a Pylons context object (c), and add to site user to it (c.user and c.auth_user_object). This ensures that the auth will work in exactly the same way as in a web request. This will fix eg the harvest and DataPusher incompatibility.

We already do a similar thing registering a MockTranslator for the thread.

---

Original report:

The datapusher works very fine from the UI,all data is nicely imported, but when I harvest csv datasets I get an error and the harvesting job fails inthe fetcher.

Running CKAN 2.2 and harvester from the main branch.

(I could have posted in those 2 issue queues, but thought this was the most appropriate.)

```
Traceback (most recent call last):
  File "/usr/lib/ckan/default/src/ckanext-harvest/ckanext/harvest/harvesters/base.py", line 208, in _create_or_update_package
    new_package = get_action('package_create_rest')(context, package_dict)
  File "/usr/lib/ckan/default/src/ckan/ckan/logic/__init__.py", line 419, in wrapped
    result = _action(context, data_dict, **kw)
  File "/usr/lib/ckan/default/src/ckan/ckan/logic/action/create.py", line 923, in package_create_rest
    dictized_after = _get_action('package_create')(context, dictized_package)
  File "/usr/lib/ckan/default/src/ckan/ckan/logic/__init__.py", line 419, in wrapped
    result = _action(context, data_dict, **kw)
  File "/usr/lib/ckan/default/src/ckan/ckan/logic/action/create.py", line 187, in package_create
    model.repo.commit()
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/vdm/sqlalchemy/tools.py", line 102, in commit
    self.session.commit()
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/orm/scoping.py", line 114, in do
    return getattr(self.registry(), name)(*args, **kwargs)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/orm/session.py", line 656, in commit
    self.transaction.commit()
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/orm/session.py", line 314, in commit
    self._prepare_impl()
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/orm/session.py", line 290, in _prepare_impl
    self.session.dispatch.before_commit(self.session)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/event.py", line 291, in __call__
    fn(*args, **kw)
  File "/usr/lib/ckan/default/src/ckan/ckan/model/extension.py", line 112, in before_commit
    methodcaller('before_commit', session)
  File "/usr/lib/ckan/default/src/ckan/ckan/model/extension.py", line 92, in notify_observers
    func(observer)
  File "/usr/lib/ckan/default/src/ckan/ckan/model/modification.py", line 47, in before_commit
    self.notify(obj, domain_object.DomainObjectOperation.new)
  File "/usr/lib/ckan/default/src/ckan/ckan/model/modification.py", line 79, in notify
    observer.notify(entity, operation)
  File "/usr/lib/ckan/default/src/ckan/ckanext/datapusher/plugin.py", line 103, in notify
    'resource_id': entity.id
  File "/usr/lib/ckan/default/src/ckan/ckan/logic/__init__.py", line 419, in wrapped
    result = _action(context, data_dict, **kw)
  File "/usr/lib/ckan/default/src/ckan/ckanext/datapusher/logic/action.py", line 51, in datapusher_submit
    user = p.toolkit.get_action('user_show')(context, {'id': context['user']})
KeyError: 'user'
2014-02-07 19:06:59,839 DEBUG [ckanext.harvest.harvesters.base] KeyError('user',)
2014-02-07 19:07:00,096 INFO  [ckanext.harvest.queue] Received harvest object id: 48b909e9-1e7e-434b-b82c-0a4e607df2e4
```
