### PR TITLE
[1541] Add empty alt tag to gravatar

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -774,7 +774,7 @@ def dict_list_reduce(list_, key, unique=True):
 def linked_gravatar(email_hash, size=100, default=None):
     return literal(
         '<a href="https://gravatar.com/" target="_blank" ' +
-        'title="%s">' % _('Update your avatar at gravatar.com') +
+        'title="%s" alt="">' % _('Update your avatar at gravatar.com') +
         '%s</a>' % gravatar(email_hash, size, default)
     )
 


### PR DESCRIPTION
Adds an empty alt tag to the gravatar link generated by helpers to fix #1541 
