### PR TITLE
Don't lowercase the names of uploaded files

### DIFF
--- a/ckan/lib/munge.py
+++ b/ckan/lib/munge.py
@@ -107,7 +107,7 @@ def munge_tag(tag):
 
 def munge_filename(filename):
     filename = substitute_ascii_equivalents(filename)
-    filename = filename.lower().strip()
+    filename = filename.strip()
     filename = re.sub(r'[^a-zA-Z0-9. ]', '', filename).replace(' ', '-')
     filename = _munge_to_length(filename, 3, 100)
     return filename


### PR DESCRIPTION
In https://github.com/ckan/ckanext-b2 if someone creates or updates a resource with no name I'm getting the 'url' item out of the resource dict at validation time in resource_create and resource_update and setting this as the name. The resource name then gets used as the filename, when you download a zip file of a dataset and all its resources. I don't want to change the names of users' uploaded files to lower-case. Is there a reason these need to be lower-cased in CKAN, or can I just remove it?
