### PR TITLE
Add a link to package history page

### DIFF
--- a/ckan/templates/package/activity.html
+++ b/ckan/templates/package/activity.html
@@ -6,5 +6,6 @@
   <h1 class="hide-heading">{% block page_heading %}{{ _('Activity Stream') }}{% endblock %}</h1>
   {% block activity_stream %}
     {{ c.package_activity_stream | safe }}
+    {% link_for _('History'), controller='package', action='history', id=pkg.name, class_='btn btn-primary' %}
   {% endblock %}
 {% endblock %}


### PR DESCRIPTION
 since it is not linked anywhere else anymore, it's hard to get to the revision diff from the regular interface, having it as a button at the end of the activity stream is a simple solution without overloading the tabs bar.
