### PR TITLE
Fix documentation for form.select in macro/form.html

### DIFF
--- a/ckan/templates/macros/form.html
+++ b/ckan/templates/macros/form.html
@@ -79,7 +79,7 @@ is_required - Boolean of whether this input is requred for the form to validate
 Examples:
 
   {% import 'macros/form.html' as form %}
-  {{ form.select('year', label=_('Year'), options=[{'name':2010, 'value': 2010}{'name': 2011, 'value': 2011}], selected=2011, error=errors.year) }}
+  {{ form.select('year', label=_('Year'), options=[{'name':2010, 'value': 2010},{'name': 2011, 'value': 2011}], selected=2011, error=errors.year) }}
 
 #}
 {% macro select(name, id='', label='', options='', selected='', error='', classes=[], attrs={}, is_required=false) %}


### PR DESCRIPTION
Changed options from a dict to a list of dicts in the comment describing how to use form.select.
