### PR TITLE
[#1594] Fix breakage in package groups page

### DIFF
--- a/ckan/templates/group/snippets/group_item.html
+++ b/ckan/templates/group/snippets/group_item.html
@@ -11,7 +11,8 @@ Example:
       {% endfor %}
     </ul>
 #}
-{% set url = h.url_for(group.type ~ '_read', action='read', id=group.name) %}
+{% set type = group.type or 'group' %}
+{% set url = h.url_for(type ~ '_read', action='read', id=group.name) %}
 {% block item %}
 <li class="media-item">
   {% block item_inner %}


### PR DESCRIPTION
The group.type field, when undefined and merged with a unicode string returns
a unicode, which causes a traceback thanks to `url_for` in pylons not
accepting unicode. Fixes #1594.
