### PR TITLE
Allow the symbol ':' in tags

### DIFF
--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -408,7 +408,7 @@ def tag_name_validator(value, context):
     tagname_match = re.compile('[\w \-.:]*$', re.UNICODE)
     if not tagname_match.match(value):
         raise Invalid(_('Tag "%s" must be alphanumeric '
-                        'characters or symbols: -_.') % (value))
+                        'characters or symbols: -_.:') % (value))
     return value
 
 def tag_not_uppercase(value, context):


### PR DESCRIPTION
Changed the tag name validation routine to permit colons in tags.
