### PR TITLE
Now installing *.json files from configuration too

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include ckan/config/deployment.ini_tmpl
 recursive-include ckan/public *
 recursive-include ckan/config *.ini
+recursive-include ckan/config *.json
 recursive-include ckan/config *.xml
 recursive-include ckan/i18n *
 recursive-include ckan/templates *


### PR DESCRIPTION
Otherwise, `resource_formats.json` wouldn't get installed by `pip install`, causing this kind of issues: http://paste.pound-python.org/show/OlykESJdUBcEw3SgJ7aA/
