### PR TITLE
Move the closing div inside the block

### DIFF
--- a/ckan/templates/package/resource_read.html
+++ b/ckan/templates/package/resource_read.html
@@ -68,8 +68,8 @@
               <blockquote>{{ h.markdown_extract(c.package.get('notes')) }}</blockquote>
               <p>{% trans dataset=c.package.title, url=h.url_for(controller='package', action='read', id=c.package['name']) %}Source: <a href="{{ url }}">{{ dataset }}</a>{% endtrans %}
             {% endif %}
-          {% endblock %}
-        </div>
+          </div>
+        {% endblock %}
       </div>
       {% block data_preview %}
         {{ h.resource_preview(c.resource, c.package) }}


### PR DESCRIPTION
Fixes #1619. Move the closing div inside the block since it's defined
in the block anyway.
