### PR TITLE
Recline preview grid hangs when filter query fails

### DIFF
--- a/ckanext/reclinepreview/theme/public/vendor/recline/recline.js
+++ b/ckanext/reclinepreview/theme/public/vendor/recline/recline.js
@@ -59,6 +59,9 @@ this.recline.Backend.Ckan = this.recline.Backend.Ckan || {};
       };
       dfd.resolve(out);  
     });
+    jqxhr.fail(function() {
+      dfd.reject();
+    });
     return dfd.promise();
   };
 
@@ -107,6 +110,9 @@ this.recline.Backend.Ckan = this.recline.Backend.Ckan || {};
         hits: results.result.records
       };
       dfd.resolve(out);  
+    });
+    jqxhr.fail(function(){
+      dfd.reject();
     });
     return dfd.promise();
   };


### PR DESCRIPTION
When using the recline preview grid, if the user enters a filter query which for some reason fails on the server, then the page hangs with the 'Loading....' spinner remaining on the page forever.
