### PR TITLE
Trash page doesn't know I'm logged in

### DIFF
--- a/ckan/config/routing.py
+++ b/ckan/config/routing.py
@@ -401,6 +401,8 @@ def make_map():
                 action='index', ckan_icon='legal')
     map.connect('ckanadmin_config', '/ckan-admin/config', controller='admin',
                 action='config', ckan_icon='check')
+    map.connect('ckanadmin_trash', '/ckan-admin/trash', controller='admin',
+                action='trash', ckan_icon='trash')
     map.connect('ckanadmin', '/ckan-admin/{action}', controller='admin')
 
     # Storage routes

--- a/ckan/templates/admin/base.html
+++ b/ckan/templates/admin/base.html
@@ -7,4 +7,5 @@
 {% block content_primary_nav %}
   {{ h.build_nav_icon('ckanadmin_index', _('Sysadmins')) }}
   {{ h.build_nav_icon('ckanadmin_config', _('Config')) }}
+  {{ h.build_nav_icon('ckanadmin_trash', _('Trash')) }}
 {% endblock %}

--- a/ckan/templates/admin/trash.html
+++ b/ckan/templates/admin/trash.html
@@ -1,0 +1,38 @@
+{% extends "admin/base.html" %}
+
+{% block primary_content_inner %}
+  {% set truncate = truncate or 180 %}
+  {% set truncate_title = truncate_title or 80 %}
+  <ul class="user-list">
+    {% for pkg in c.deleted_packages %}
+      {% set title = pkg.title or pkg.name %}
+      <li>{{ h.link_to(h.truncate(title, truncate_title), h.url_for(controller='package', action='read', id=pkg.name)) }}</li>
+    {% endfor %}
+
+  </ul>
+  <form method="POST" id="form-purge-packages">
+    <button
+      type="submit"
+      name="purge-packages"
+      value="purge"
+      class="btn btn-danger"
+      >
+      {% trans %}Purge{% endtrans %}
+    </button>
+  </form>
+{% endblock %}
+
+{% block secondary_content %}
+  <div class="module module-narrow module-shallow">
+    <h2 class="module-heading">
+      <i class="icon-info-sign"></i>
+      {{ _('Trash') }}
+    </h2>
+    <div class="module-content">
+      {% trans %}
+        <p>Purge deleted datasets forever and irreversably.</p>
+      {% endtrans %}
+    </div>
+  </div>
+{% endblock %}
+


### PR DESCRIPTION
E.g. demo.ckan.org/ckan-admin/trash shows 'login / register' links. See image. I am logged in as a sysadmin (of course, otherwise I couldn't even see the page).

![ckan-admin-trash](https://f.cloud.github.com/assets/1260290/2259260/5fca0ea2-9e33-11e3-986d-b9457bdcf65a.png)
