### PR TITLE
fix paster db clean again

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -115,6 +115,7 @@ class CkanCommand(paste.script.command.Command):
 
             pylons.c.user = self.site_user['name']
             pylons.c.userobj = model.User.get(self.site_user['name'])
+            model.Session.commit()
 
         ## give routes enough information to run url_for
         parsed = urlparse.urlparse(conf.get('ckan.site_url', 'http://0.0.0.0'))


### PR DESCRIPTION
User.get()  creates a transaction that aquires an exclusive lock on the tables that does not get closed before the the drop tables is run.

This just adds a model.Session.commit(). We could also do a rollback or try and change the command so this section of code is never executed for the db command
