### PR TITLE
Fixes #1596 by ensuring it only shows active membership.

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -565,7 +565,8 @@ def organization_list_for_user(context, data_dict):
         q = model.Session.query(model.Member) \
             .filter(model.Member.table_name == 'user') \
             .filter(model.Member.capacity.in_(roles)) \
-            .filter(model.Member.table_id == user_id)
+            .filter(model.Member.table_id == user_id) \
+            .filter(model.Member.state == 'active')
 
         group_ids = []
         for row in q.all():


### PR DESCRIPTION
Currently removing a user from a group/org (marking membership as deleted) it still gets returned in dataset/new as a viable organisation/group to choose when it isn't (as the user is not actually still a member).
