### PR TITLE
[wip] API exposes non-salted MD5 hashes of email addresses by default

### DIFF
--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -487,7 +487,6 @@ def user_dictize(user, context):
     del result_dict['reset_key']
 
     result_dict['display_name'] = user.display_name
-    result_dict['email_hash'] = user.email_hash
     result_dict['number_of_edits'] = user.number_of_edits()
     result_dict['number_administered_packages'] = user.number_administered_packages()
 


### PR DESCRIPTION
From the CKAN API (e.g. http://demo.ckan.org/api/3/action/user_list), unregistered visitors can get MD5 hashes of email addresses for all users. As these hashes are also not salted, one can use rainbow tables to revert the hashes into email addresses. There are many precomputed rainbow tables and even search engines available that can be used for this.

Is there any need for the API to expose the email hash? Furthermore, maybe it would be better to use similar means as with a password. I know that in general, an email address is not really a secret, but now users have no choice whether their email address can be obtained.

Relates to #1530 
