### PR TITLE
[wip] turn off OpenID by default. Deprecation warning if enabled

### DIFF
--- a/ckan/config/middleware.py
+++ b/ckan/config/middleware.py
@@ -5,6 +5,7 @@ import logging
 import json
 import hashlib
 import os
+import warnings
 
 import sqlalchemy as sa
 from beaker.middleware import CacheMiddleware, SessionMiddleware
@@ -109,7 +110,8 @@ def make_app(conf, full_stack=True, static_files=True, **app_conf):
     who_parser = WhoConfig(conf['here'])
     who_parser.parse(open(app_conf['who.config_file']))
 
-    if asbool(config.get('openid_enabled', 'true')):
+    if asbool(config.get('openid_enabled', 'false')):
+        warnings.warn("OpenID auth is deprecated", DeprecationWarning)
         from repoze.who.plugins.openid.identification import OpenIdIdentificationPlugin
         # Monkey patches for repoze.who.openid
         # Fixes #1659 - enable log-out when CKAN mounted at non-root URL

--- a/ckan/lib/app_globals.py
+++ b/ckan/lib/app_globals.py
@@ -55,7 +55,7 @@ config_details = {
     'ckan.plugins': {'type': 'split'},
 
     # bool
-    'openid_enabled': {'default': 'true', 'type' : 'bool'},
+    'openid_enabled': {'default': 'false', 'type' : 'bool'},
     'debug': {'default': 'false', 'type' : 'bool'},
     'ckan.debug_supress_header' : {'default': 'false', 'type' : 'bool'},
     'ckan.legacy_templates' : {'default': 'false', 'type' : 'bool'},

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -817,7 +817,7 @@ def user_create(context, data_dict):
     :type fullname: string
     :param about: a description of the new user (optional)
     :type about: string
-    :param openid: (optional)
+    :param openid: (optional, deprecated)
     :type openid: string
 
     :returns: the newly created yser


### PR DESCRIPTION
turn off OpenID by default, this by default switches off the message #1542. I didn't just want to remove a small amount of the openid code
