### PR TITLE
Datapusher extension throws an authorization error which it should have caught

### DIFF
--- a/ckanext/datapusher/plugin.py
+++ b/ckanext/datapusher/plugin.py
@@ -10,6 +10,8 @@ import ckan.logic as logic
 import ckan.model as model
 import ckan.plugins.toolkit as toolkit
 
+from ckan.common import _
+
 log = logging.getLogger(__name__)
 _get_or_bust = logic.get_or_bust
 
@@ -61,6 +63,8 @@ class ResourceDataController(base.BaseController):
             )
         except logic.NotFound:
             datapusher_status = {}
+        except logic.NotAuthorized:
+            base.abort(401, _('Not authorized to see this page'))
 
         return base.render('package/resource_data.html',
                            extra_vars={'status': datapusher_status})


### PR DESCRIPTION
If you visit the "DataStore" (from the edit page of the resource), it throws a traceback. Ideally, the datapusher should catch this one through a 403.
