### PR TITLE
Alarming messages during setup

### DIFF
--- a/ckanext/stats/__init__.py
+++ b/ckanext/stats/__init__.py
@@ -1,1 +1,1 @@
-# empty file needed for pylons to find templates in this directory
+__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
While they are only warnings, and apparently pose no serious problem, the setup process shows several messages that may be alarming to someone new to ckan:

```
$ sudo pip install -e 'git+https://github.com/okfn/ckan.git#egg=ckan'
Obtaining ckan from git+https://github.com/okfn/ckan.git#egg=ckan
  Updating ./src/ckan clone
  Running setup.py egg_info for package ckan
    /usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'message_extractors'
      warnings.warn(msg)

    WARNING: ckanext.stats is a namespace package, but its __init__.py does
    not declare_namespace(); setuptools 0.7 will REQUIRE this!
    (See the setuptools manual under "Namespace Packages" for details.)

    warning: no files found matching '*' under directory 'ckanext/**/i18n'
    no previously-included directories found matching '.git'
Installing collected packages: ckan
  Running setup.py develop for ckan
    /usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'message_extractors'
      warnings.warn(msg)
    Checking .pth file support in /usr/local/lib/python2.7/dist-packages/
    /usr/bin/python -E -c pass
    TEST PASSED: /usr/local/lib/python2.7/dist-packages/ appears to support .pth files

    WARNING: ckanext.stats is a namespace package, but its __init__.py does
    not declare_namespace(); setuptools 0.7 will REQUIRE this!
    (See the setuptools manual under "Namespace Packages" for details.)

    warning: no files found matching '*' under directory 'ckanext/**/i18n'
    no previously-included directories found matching '.git'
    Creating /usr/local/lib/python2.7/dist-packages/ckan.egg-link (link to .)
    ckan 2.1a is already the active version in easy-install.pth
    Installing ckan-admin script to /usr/local/bin

    Installed /srv/ckan/src/ckan
Successfully installed ckan
Cleaning up...
```
