### PR TITLE
[#320] Press enter should submit form just like clicking the primary sub...

### DIFF
--- a/ckan/public/base/javascript/modules/basic-form.js
+++ b/ckan/public/base/javascript/modules/basic-form.js
@@ -9,7 +9,7 @@ this.ckan.module('basic-form', function (jQuery, _) {
       this._setupFormSubmitCallbackOnIE7();
     },
 
-    /* Event listener for when user clicks on secondaries elements that have
+    /* Event listener for when user clicks on secondary elements that have
      * attribute [data-type="submit"]
      *
      * Returns nothing.

--- a/ckan/public/base/javascript/modules/basic-form.js
+++ b/ckan/public/base/javascript/modules/basic-form.js
@@ -3,16 +3,38 @@ this.ckan.module('basic-form', function (jQuery, _) {
     initialize: function () {
       var message = _('There are unsaved modifications to this form').fetch();
       this.el.incompleteFormWarning(message);
+
+      this.el.on('click', '[data-type="submit"]', this._onSubmitElementClick);
+
       // Internet Explorer 7 fix for forms with <button type="submit">
       if ($('html').hasClass('ie7')) {
-        this.el.on('submit', function() {
-          var form = $(this);
-          $('button', form).each(function() {
-            var button = $(this);
-            $('<input type="hidden">').prop('name', button.prop('name')).prop('value', button.val()).appendTo(form);
-          });
-        });
+        this.el.on('submit', this._onFormSubmit);
       }
+    },
+
+    /* Event listener for when user clicks on secondaries elements that have
+     * attribute data-type="submit"
+     *
+     * Returns nothing.
+     */
+    _onSubmitElementClick: function() {
+      var button = $(this);
+      var form = button.closest('form');
+      $('<input type="hidden">').prop('name', button.data('name')).prop('value', button.data('value')).appendTo(form);
+      form.submit();
+    },
+
+    /* Event listener for when form is submitted and user is using IE7
+     * as you can see at line 9
+     *
+     * Returns nothing.
+     */
+    _onFormSubmit: function() {
+      var form = $(this);
+      $('button', form).each(function() {
+        var button = $(this);
+        $('<input type="hidden">').prop('name', button.prop('name')).prop('value', button.val()).appendTo(form);
+      });
     }
   };
 });

--- a/ckan/public/base/javascript/modules/basic-form.js
+++ b/ckan/public/base/javascript/modules/basic-form.js
@@ -3,17 +3,14 @@ this.ckan.module('basic-form', function (jQuery, _) {
     initialize: function () {
       var message = _('There are unsaved modifications to this form').fetch();
       this.el.incompleteFormWarning(message);
-
       this.el.on('click', '[data-type="submit"]', this._onSubmitElementClick);
 
-      // Internet Explorer 7 fix for forms with <button type="submit">
-      if ($('html').hasClass('ie7')) {
-        this.el.on('submit', this._onFormSubmit);
-      }
+      // Internet Explorer 7 fix for forms with
+      this._setupFormSubmitCallbackOnIE7();
     },
 
     /* Event listener for when user clicks on secondaries elements that have
-     * attribute data-type="submit"
+     * attribute [data-type="submit"]
      *
      * Returns nothing.
      */
@@ -24,17 +21,21 @@ this.ckan.module('basic-form', function (jQuery, _) {
       form.submit();
     },
 
-    /* Event listener for when form is submitted and user is using IE7
-     * as you can see at line 9
+    /* Setup callback for form submission in IE7 as fallback
+     * due <button type="submit"> not be working.
      *
      * Returns nothing.
      */
-    _onFormSubmit: function() {
-      var form = $(this);
-      $('button', form).each(function() {
-        var button = $(this);
-        $('<input type="hidden">').prop('name', button.prop('name')).prop('value', button.val()).appendTo(form);
-      });
+    _setupFormSubmitCallbackOnIE7: function() {
+      if ($('html').hasClass('ie7')) {
+        this.el.on('submit', function() {
+          var form = $(this);
+          $('button', form).each(function() {
+            var button = $(this);
+            $('<input type="hidden">').prop('name', button.prop('name')).prop('value', button.val()).appendTo(form);
+          });
+        });
+      }
     }
   };
 });

--- a/ckan/public/base/javascript/plugins/jquery.slug-preview.js
+++ b/ckan/public/base/javascript/plugins/jquery.slug-preview.js
@@ -70,7 +70,7 @@
       '<div class="slug-preview">',
       '<strong></strong>',
       '<span class="slug-preview-prefix"></span><span class="slug-preview-value"></span>',
-      '<button class="btn btn-mini"></button>',
+      '<button class="btn btn-mini" type="button"></button>',
       '</div>'
     ].join('\n')
   };

--- a/ckan/templates/package/snippets/package_metadata_form.html
+++ b/ckan/templates/package/snippets/package_metadata_form.html
@@ -12,7 +12,7 @@
   <div class="form-actions">
     {# TODO: Go back to previous resource form #}
     {% block previous_action %}
-    <button class="btn" name="save" value="go-resources" type="submit">{{ _('Previous') }}</button>
+    <button class="btn" data-name="save" data-value="go-resources" data-type="submit" type="button">{{ _('Previous') }}</button>
     {% endblock %}
     {% block save_action %}
     <button class="btn btn-primary" name="save" value="finish" type="submit">{{ _('Finish') }}</button>

--- a/ckan/templates/package/snippets/resource_form.html
+++ b/ckan/templates/package/snippets/resource_form.html
@@ -69,10 +69,10 @@
     {% endblock %}
     {% if stage %}
       {% block previous_button %}
-        <button class="btn" name="save" value="go-dataset" type="submit">{{ _('Previous') }}</button>
+        <button class="btn" data-name="save" data-value="go-dataset" data-type="submit" type="button">{{ _('Previous') }}</button>
       {% endblock %}
       {% block again_button %}
-        <button class="btn" name="save" value="again" type="submit">{{ _('Save & add another') }}</button>
+        <button class="btn" data-name="save" data-value="again" data-type="submit" type="button">{{ _('Save & add another') }}</button>
         {% endblock %}
       {% block save_button %}
       <button class="btn btn-primary" name="save" value="go-metadata" type="submit">{% block save_button_text %}{{ _('Next: Additional Info') }}{% endblock %}</button>

--- a/ckan/templates/package/snippets/stages.html
+++ b/ckan/templates/package/snippets/stages.html
@@ -24,7 +24,7 @@ Example:
     {% if s1 != 'complete' %}
       <span class="highlight">{{ _('Create dataset') }}</span>
     {% else %}
-      <a href="javascript:;" class="highlight" data-name="save" data-value="go-dataset" data-type="submit">{{ _('Create dataset') }}</a>
+      <button class="highlight" data-name="save" data-value="go-dataset" data-type="submit" type="button">{{ _('Create dataset') }}</button>
     {% endif %}
   </li>
   <li class="middle {{ s2 }}">
@@ -33,7 +33,7 @@ Example:
     {% else %}
       {% if s1 == 'active' or s3 == 'active'%}
         {# stage 1 #}
-        <a href="javascript:;" class="highlight" data-name="save" data-value="go-resources" data-type="submit">{{ _('Add data') }}</a>
+        <button class="highlight" data-name="save" data-value="go-resources" data-type="submit" type="button">{{ _('Add data') }}</button>
       {% else %}
         {% link_for _('Add data'), controller='package', action='new', class_="highlight" %}
       {% endif %}
@@ -45,7 +45,7 @@ Example:
     {% else %}
       {% if s1 == 'active' or s2 == 'active' %}
         {# stage 1 #}
-        <a href="javascript:;" class="highlight" data-name="save" data-value="go-metadata" data-type="submit">{{ _('Additional info') }}</a>
+        <button class="highlight" data-name="save" data-value="go-metadata" data-type="submit" type="button">{{ _('Additional info') }}</button>
       {% else %}
         {% link_for _('Additional info'), controller='package', action='new', class_="highlight" %}{{ s2 }}
       {% endif %}

--- a/ckan/templates/package/snippets/stages.html
+++ b/ckan/templates/package/snippets/stages.html
@@ -24,7 +24,7 @@ Example:
     {% if s1 != 'complete' %}
       <span class="highlight">{{ _('Create dataset') }}</span>
     {% else %}
-      <button class="highlight" name="save" value="go-dataset" type="submit">{{ _('Create dataset') }}</button>
+      <a href="javascript:;" class="highlight" data-name="save" data-value="go-dataset" data-type="submit">{{ _('Create dataset') }}</a>
     {% endif %}
   </li>
   <li class="middle {{ s2 }}">
@@ -33,7 +33,7 @@ Example:
     {% else %}
       {% if s1 == 'active' or s3 == 'active'%}
         {# stage 1 #}
-        <button class="highlight" name="save" value="go-resources" type="submit">{{ _('Add data') }}</button>
+        <a href="javascript:;" class="highlight" data-name="save" data-value="go-resources" data-type="submit">{{ _('Add data') }}</a>
       {% else %}
         {% link_for _('Add data'), controller='package', action='new', class_="highlight" %}
       {% endif %}
@@ -45,7 +45,7 @@ Example:
     {% else %}
       {% if s1 == 'active' or s2 == 'active' %}
         {# stage 1 #}
-        <button class="highlight" name="save" value="go-metadata" type="submit">{{ _('Additional info') }}</button>
+        <a href="javascript:;" class="highlight" data-name="save" data-value="go-metadata" data-type="submit">{{ _('Additional info') }}</a>
       {% else %}
         {% link_for _('Additional info'), controller='package', action='new', class_="highlight" %}{{ s2 }}
       {% endif %}


### PR DESCRIPTION
...mit button

The context is the dataset creation wizard (see #320).

One of the things I did was change the wizard clickable steps from `<button>` to `<a>` because I thought that it would make more sense semantically speaking. I also added "type=button" to the others `<button>` to avoid the submit when the user hits enter because it comes first than the primary (blue) one.

For each of those elements, I added the data-* attribute to store the name and value.
I retrieve the data and add the a input hidden when user clicks on one of them.

Feel free to ask or suggest any modification.

Best,
Vítor Avelino.