### PR TITLE
_tracking page should only respond to POST

### DIFF
--- a/ckan/config/middleware.py
+++ b/ckan/config/middleware.py
@@ -345,7 +345,8 @@ class TrackingMiddleware(object):
 
     def __call__(self, environ, start_response):
         path = environ['PATH_INFO']
-        if path == '/_tracking':
+        method = environ.get('REQUEST_METHOD')
+        if path == '/_tracking' and method == 'POST':
             # do the tracking
             # get the post data
             payload = environ['wsgi.input'].read()


### PR DESCRIPTION
The `_tracking` page when hit with a GET request throws a traceback. It should ideally just accept `POST`.

```
Stacktrace (most recent call last):

  File "raven/middleware.py", line 35, in __call__
    iterable = self.application(environ, start_response)
  File "ckan/config/middleware.py", line 355, in __call__
    k, v = part.split('=')

```
