### PR TITLE
Catch NotFound error in resources page

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -316,6 +316,8 @@ class PackageController(base.BaseController):
 
         try:
             check_access('package_update', context, data_dict)
+        except NotFound:
+            abort(404, _('Dataset not found'))
         except NotAuthorized, e:
             abort(401, _('User %r not authorized to edit %s') % (c.user, id))
         # check if package exists


### PR DESCRIPTION
```
Stacktrace (most recent call last):

  File "raven/middleware.py", line 35, in __call__
    iterable = self.application(environ, start_response)
  File "ckan/config/middleware.py", line 373, in __call__
    return self.app(environ, start_response)
  File "/usr/lib/ckan/demo/lib/python2.7/site-packages/paste/cascade.py", line 130, in __call__
    return self.apps[-1](environ, start_response)
  File "ckan/config/middleware.py", line 238, in __call__
    return self.app(environ, start_response)
  File "/usr/lib/ckan/demo/lib/python2.7/site-packages/paste/registry.py", line 379, in __call__
    app_iter = self.application(environ, start_response)
  File "/usr/lib/ckan/demo/lib/python2.7/site-packages/repoze/who/middleware.py", line 107, in __call__
    app_iter = app(environ, wrapper.wrap_start_response)
  File "webob/dec.py", line 147, in __call__
    resp = self.call_func(req, *args, **self.kwargs)
  File "webob/dec.py", line 208, in call_func
    return self.func(req, *args, **kwargs)
  File "fanstatic/publisher.py", line 234, in __call__
    return request.get_response(self.app)
  File "webob/request.py", line 1053, in get_response
    application, catch_exc_info=False)
  File "webob/request.py", line 1022, in call_application
    app_iter = application(self.environ, start_response)
  File "webob/dec.py", line 147, in __call__
    resp = self.call_func(req, *args, **self.kwargs)
  File "webob/dec.py", line 208, in call_func
    return self.func(req, *args, **kwargs)
  File "fanstatic/injector.py", line 54, in __call__
    response = request.get_response(self.app)
  File "webob/request.py", line 1053, in get_response
    application, catch_exc_info=False)
  File "webob/request.py", line 1022, in call_application
    app_iter = application(self.environ, start_response)
  File "beaker/middleware.py", line 73, in __call__
    return self.app(environ, start_response)
  File "beaker/middleware.py", line 155, in __call__
    return self.wrap_app(environ, session_start_response)
  File "routes/middleware.py", line 131, in __call__
    response = self.app(environ, start_response)
  File "pylons/wsgiapp.py", line 125, in __call__
    response = self.dispatch(controller, environ, start_response)
  File "pylons/wsgiapp.py", line 324, in dispatch
    return controller(environ, start_response)
  File "ckan/lib/base.py", line 346, in __call__
    res = WSGIController.__call__(self, environ, start_response)
  File "pylons/controllers/core.py", line 221, in __call__
    response = self._dispatch_call()
  File "pylons/controllers/core.py", line 172, in _dispatch_call
    response = self._inspect_call(func)
  File "pylons/controllers/core.py", line 107, in _inspect_call
    result = self._perform_call(func, args)
  File "ckan/controllers/package.py", line 318, in resources
    check_access('package_update', context, data_dict)
  File "ckan/logic/__init__.py", line 287, in check_access
    logic_authorization = new_authz.is_authorized(action, context, data_dict)
  File "ckan/new_authz.py", line 187, in is_authorized
    return auth_function(context, data_dict)
  File "ckan/logic/__init__.py", line 596, in wrapper
    return action(context, data_dict)
  File "ckan/logic/auth/update.py", line 16, in package_update
    package = logic_auth.get_package_object(context, data_dict)
  File "ckan/logic/auth/__init__.py", line 34, in get_package_object
    return _get_object(context, data_dict, 'package', 'Package')
  File "ckan/logic/auth/__init__.py", line 23, in _get_object
    raise logic.NotFound
```
