### PR TITLE
UX problem with previous and next during dataset creation

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -931,6 +931,8 @@ class PackageController(base.BaseController):
                     # This is actually an update not a save
                     data_dict['id'] = data_dict['pkg_name']
                     del data_dict['pkg_name']
+                    # don't change the dataset state
+                    data_dict['state'] = 'draft'
                     # this is actually an edit not a save
                     pkg_dict = get_action('package_update')(context, data_dict)
 


### PR DESCRIPTION
- Start creating a dataset.
- Get to resource page.
- Hit "Previous".
- Now hit "Next".

You've now landed in the "Add a resource" page from where you can't get to the Stage 3 of adding a dataset page. Kind of confusing for anyone using the previous and next buttons.
