### PR TITLE
Group auth for any logged-in user

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -494,12 +494,7 @@ def group_list_authz(context, data_dict):
     if not user_id:
         return []
 
-    sysadmin = new_authz.is_sysadmin(user)
-    default_perms_name = 'default_group_or_org_permissions'
-    default_perms = new_authz.check_config_permission(default_perms_name)
-    anyone_can_manage_groups = 'manage_group' in default_perms
-    show_all_groups = not am_member and (sysadmin or anyone_can_manage_groups)
-
+    show_all_groups = not am_member and new_authz.can_manage_all_groups(user)
     if not show_all_groups:
         roles = ckan.new_authz.get_roles_with_permission('manage_group')
         if not roles:

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -490,20 +490,21 @@ def group_list_authz(context, data_dict):
 
     _check_access('group_list_authz', context, data_dict)
 
-    sysadmin = new_authz.is_sysadmin(user)
-    default_perms_name = 'default_group_or_org_permissions'
-    default_perms = new_authz.check_config_permission(default_perms_name)
-    anyone_can_manage_groups = 'manage_group' in default_perms
-    show_all_groups = (sysadmin or anyone_can_manage_groups) and not am_member
-
-    roles = ckan.new_authz.get_roles_with_permission('manage_group')
-    if not roles:
-        return []
     user_id = new_authz.get_user_id_for_username(user, allow_none=True)
     if not user_id:
         return []
 
+    sysadmin = new_authz.is_sysadmin(user)
+    default_perms_name = 'default_group_or_org_permissions'
+    default_perms = new_authz.check_config_permission(default_perms_name)
+    anyone_can_manage_groups = 'manage_group' in default_perms
+    show_all_groups = not am_member and (sysadmin or anyone_can_manage_groups)
+
     if not show_all_groups:
+        roles = ckan.new_authz.get_roles_with_permission('manage_group')
+        if not roles:
+            return []
+
         q = model.Session.query(model.Member) \
             .filter(model.Member.table_name == 'user') \
             .filter(model.Member.capacity.in_(roles)) \

--- a/ckan/new_authz.py
+++ b/ckan/new_authz.py
@@ -125,6 +125,14 @@ def _get_user(username):
     return model.User.get(username)
 
 
+def can_manage_all_groups(user):
+    sysadmin = is_sysadmin(user)
+    default_perms_name = 'default_group_or_org_permissions'
+    default_perms = check_config_permission(default_perms_name)
+    anyone_can_manage_groups = 'manage_group' in default_perms
+    return sysadmin or anyone_can_manage_groups
+
+
 def get_group_or_org_admin_ids(group_id):
     if not group_id:
         return []

--- a/ckan/new_tests/factories.py
+++ b/ckan/new_tests/factories.py
@@ -256,6 +256,33 @@ class Organization(factory.Factory):
         return group_dict
 
 
+class Member(factory.Factory):
+    '''A factory class for creating CKAN groups' members.'''
+
+    FACTORY_FOR = ckan.model.Member
+
+    object_type = 'user'
+    object = factory.LazyAttribute(lambda _: User()['id'])
+    id = factory.LazyAttribute(lambda _: Group()['id'])
+    capacity = 'admin'
+
+    @classmethod
+    def _build(cls, target_class, *args, **kwargs):
+        raise NotImplementedError(".build() isn't supported in CKAN")
+
+    @classmethod
+    def _create(cls, target_class, *args, **kwargs):
+        if args:
+            assert False, "Positional args aren't supported, use keyword args."
+
+        context = {'user': _get_action_user_name(kwargs)}
+
+        group_dict = helpers.call_action('member_create',
+                                         context=context,
+                                         **kwargs)
+        return group_dict
+
+
 class Related(factory.Factory):
     '''A factory class for creating related items.'''
 

--- a/ckan/new_tests/helpers.py
+++ b/ckan/new_tests/helpers.py
@@ -148,11 +148,13 @@ def change_config(key, value):
         def wrapper(*args, **kwargs):
             _original_config = config.copy()
             config[key] = value
+            return_value = None
 
-            return_value = func(*args, **kwargs)
-
-            config.clear()
-            config.update(_original_config)
+            try:
+                return_value = func(*args, **kwargs)
+            finally:
+                config.clear()
+                config.update(_original_config)
 
             return return_value
         return nose.tools.make_decorator(func)(wrapper)

--- a/ckan/new_tests/helpers.py
+++ b/ckan/new_tests/helpers.py
@@ -17,6 +17,9 @@ potential drawbacks.
 This module is reserved for these very useful functions.
 
 '''
+from pylons import config
+import nose.tools
+
 import ckan.model as model
 import ckan.logic as logic
 
@@ -120,3 +123,37 @@ def call_auth(auth_name, context, **kwargs):
                                 'context dict')
 
     return logic.check_access(auth_name, context, data_dict=kwargs)
+
+
+def change_config(key, value):
+    '''Decorator to temporarily changes Pylons' config to a new value
+
+    This allows you to easily create tests that need specific config values to
+    be set, making sure it'll be reverted to what it was originally, after your
+    test is run.
+
+    Usage::
+
+        @helpers.change_config('ckan.site_title', 'My Test CKAN')
+        def test_ckan_site_title(self):
+            assert pylons.config['ckan.site_title'] == 'My Test CKAN'
+
+    :param key: the config key to be changed, e.g. ``'ckan.site_title'``
+    :type key: string
+
+    :param value: the new config key's value, e.g. ``'My Test CKAN'``
+    :type value: string
+    '''
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            _original_config = config.copy()
+            config[key] = value
+
+            return_value = func(*args, **kwargs)
+
+            config.clear()
+            config.update(_original_config)
+
+            return return_value
+        return nose.tools.make_decorator(func)(wrapper)
+    return decorator

--- a/ckan/new_tests/logic/action/test_get.py
+++ b/ckan/new_tests/logic/action/test_get.py
@@ -359,10 +359,10 @@ class TestGroupListAuthz(object):
 
     def setup(self):
         helpers.reset_db()
-        new_authz.CONFIG_PERMISSIONS = {}
+        new_authz.clear_auth_functions_cache()
 
     def teardown(self):
-        new_authz.CONFIG_PERMISSIONS = {}
+        new_authz.clear_auth_functions_cache()
 
     def test_it_returns_the_groups_the_user_is_authorized_to_edit(self):
         user = factories.User()

--- a/ckan/new_tests/logic/action/test_get.py
+++ b/ckan/new_tests/logic/action/test_get.py
@@ -359,6 +359,7 @@ class TestGroupListAuthz(object):
 
     def setup(self):
         helpers.reset_db()
+        new_authz.CONFIG_PERMISSIONS = {}
 
     def teardown(self):
         new_authz.CONFIG_PERMISSIONS = {}

--- a/ckan/new_tests/logic/action/test_get.py
+++ b/ckan/new_tests/logic/action/test_get.py
@@ -425,16 +425,28 @@ class TestGroupListAuthz(object):
 
         assert_equals(result, [])
 
-    @helpers.change_config('ckan.auth.default_group_or_org_permissions', 'manage_group')
+    @helpers.change_config('ckan.auth.default_group_only_permissions', 'manage_group')
     def test_it_returns_all_groups_if_everyone_is_able_to_manage_groups(self):
         user = factories.User()
         group_id = factories.Group()['id']
+        org_id = factories.Organization()['id']
         context = {'user': user['name']}
 
         result = helpers.call_action('group_list_authz', context=context)
 
         assert_equals(len(result), 1)
         assert_equals(result[0]['id'], group_id)
+
+    @helpers.change_config('ckan.auth.default_group_only_permissions', 'manage_group')
+    @helpers.change_config('ckan.auth.default_org_only_permissions', 'manage_group')
+    def test_doesnt_return_organizations_even_if_everyone_is_able_to_manage_them(self):
+        user = factories.User()
+        org_id = factories.Organization()['id']
+        context = {'user': user['name']}
+
+        result = helpers.call_action('group_list_authz', context=context)
+
+        assert_equals(len(result), 0)
 
     @mock.patch('ckan.new_authz.get_roles_with_permission')
     def test_it_returns_empty_list_if_theres_no_role_able_to_manage_groups(self, get_roles_with_permission):
@@ -448,7 +460,7 @@ class TestGroupListAuthz(object):
         assert_equals(result, [])
 
     @mock.patch('ckan.new_authz.get_roles_with_permission')
-    @helpers.change_config('ckan.auth.default_group_or_org_permissions', 'manage_group')
+    @helpers.change_config('ckan.auth.default_group_only_permissions', 'manage_group')
     def test_it_returns_all_groups_if_everyone_is_able_to_manage_groups_even_if_theres_no_role_with_this_permission(self, get_roles_with_permission):
         get_roles_with_permission.return_value = []
         user = factories.User()

--- a/ckan/new_tests/logic/action/test_get.py
+++ b/ckan/new_tests/logic/action/test_get.py
@@ -435,6 +435,31 @@ class TestGroupListAuthz(object):
 
         assert_equals(result, [])
 
+    @mock.patch('ckan.new_authz.get_roles_with_permission')
+    def test_it_should_return_every_group_if_user_is_sysadmin_even_if_therere_no_roles_able_to_manage_groups(self, get_roles_with_permission):
+        get_roles_with_permission.return_value = []
+        sysadmin = factories.Sysadmin()
+        group_id = factories.Group()['id']
+        context = {'user': sysadmin['name']}
+
+        result = helpers.call_action('group_list_authz', context=context)
+
+        assert_equals(len(result), 1)
+        assert_equals(result[0]['id'], group_id)
+
+    @mock.patch('ckan.new_authz.get_roles_with_permission')
+    @helpers.change_config('ckan.auth.default_group_or_org_permissions', 'manage_group')
+    def test_it_should_return_every_group_if_everyone_is_able_to_manage_groups_even_if_therere_no_roles_with_this_permission(self, get_roles_with_permission):
+        get_roles_with_permission.return_value = []
+        user = factories.User()
+        group_id = factories.Group()['id']
+        context = {'user': user['name']}
+
+        result = helpers.call_action('group_list_authz', context=context)
+
+        assert_equals(len(result), 1)
+        assert_equals(result[0]['id'], group_id)
+
     @helpers.change_config('ckan.auth.default_group_or_org_permissions', 'manage_group')
     def test_it_returns_all_groups_if_ckan_is_configured_to_allow_everyone_to_manage_groups(self):
         user = factories.User()

--- a/ckan/new_tests/logic/action/test_get.py
+++ b/ckan/new_tests/logic/action/test_get.py
@@ -1,12 +1,15 @@
+import mock
 import nose.tools
 
 import ckan.logic as logic
 import ckan.lib.search as search
 import ckan.new_tests.helpers as helpers
 import ckan.new_tests.factories as factories
+import ckan.new_authz as new_authz
 
 
 eq = nose.tools.eq_
+assert_equals = nose.tools.assert_equals
 
 
 class TestGet(object):
@@ -350,3 +353,95 @@ class TestBadLimitQueryParameters(object):
         nose.tools.assert_raises(
             logic.ValidationError, helpers.call_action, 'package_search',
             **kwargs)
+
+
+class TestGroupListAuthz(object):
+
+    def setup(self):
+        helpers.reset_db()
+
+    def teardown(self):
+        new_authz.CONFIG_PERMISSIONS = {}
+
+    def test_it_returns_the_groups_the_user_is_authorized_to_edit(self):
+        user = factories.User()
+        group_id = factories.Group(user=user)['id']
+        factories.Group()
+        context = {'user': user['name']}
+
+        result = helpers.call_action('group_list_authz', context=context)
+
+        assert_equals(len(result), 1)
+        assert_equals(result[0]['id'], group_id)
+
+    def test_it_returns_all_groups_if_the_user_is_a_sysadmin(self):
+        sysadmin = factories.Sysadmin()
+        groups_ids = [
+            factories.Group(user=sysadmin)['id'],
+            factories.Group()['id']
+        ]
+        context = {'user': sysadmin['name']}
+
+        result = helpers.call_action('group_list_authz', context=context)
+        returned_groups_ids = [g['id'] for g in result]
+
+        assert_equals(set(returned_groups_ids), set(groups_ids))
+
+    def test_it_returns_empty_list_if_called_with_inexistent_user(self):
+        context = {'user': 'inexistent-user'}
+
+        result = helpers.call_action('group_list_authz', context=context)
+
+        assert_equals(result, [])
+
+    def test_am_member_option_returns_all_groups_the_user_is_a_member(self):
+        sysadmin = factories.Sysadmin()
+        group_id = factories.Group(user=sysadmin)['id']
+        factories.Group()
+        context = {'user': sysadmin['name']}
+
+        result = helpers.call_action('group_list_authz', context=context,
+                                     am_member=True)
+
+        assert_equals(len(result), 1)
+        assert_equals(result[0]['id'], group_id)
+
+    def test_it_doesnt_return_organizations(self):
+        sysadmin = factories.Sysadmin()
+        factories.Organization(user=sysadmin)
+        context = {'user': sysadmin['name']}
+
+        result = helpers.call_action('group_list_authz', context=context)
+
+        assert_equals(result, [])
+
+    def test_it_doesnt_return_deleted_groups(self):
+        sysadmin = factories.Sysadmin()
+        factories.Group(user=sysadmin, state='deleted')
+        context = {'user': sysadmin['name']}
+
+        result = helpers.call_action('group_list_authz', context=context)
+
+        assert_equals(result, [])
+
+    @mock.patch('ckan.new_authz.get_roles_with_permission')
+    def test_it_returns_empty_list_if_therere_no_roles_able_to_manage_groups(self, get_roles_with_permission):
+        get_roles_with_permission.return_value = []
+        user = factories.User()
+        factories.Group(user=user)
+        context = {'user': user['name']}
+
+        result = helpers.call_action('group_list_authz', context=context)
+
+        assert_equals(result, [])
+
+    @helpers.change_config('ckan.auth.default_group_or_org_permissions', 'manage_group')
+    def test_it_returns_all_groups_if_ckan_is_configured_to_allow_everyone_to_manage_groups(self):
+        user = factories.User()
+        group_id = factories.Group()['id']
+        context = {'user': user['name']}
+
+        result = helpers.call_action('group_list_authz', context=context)
+
+        assert_equals(len(result), 1)
+        assert_equals(result[0]['id'], group_id)

--- a/ckan/new_tests/logic/action/test_get.py
+++ b/ckan/new_tests/logic/action/test_get.py
@@ -425,8 +425,19 @@ class TestGroupListAuthz(object):
 
         assert_equals(result, [])
 
+    @helpers.change_config('ckan.auth.default_group_or_org_permissions', 'manage_group')
+    def test_it_returns_all_groups_if_everyone_is_able_to_manage_groups(self):
+        user = factories.User()
+        group_id = factories.Group()['id']
+        context = {'user': user['name']}
+
+        result = helpers.call_action('group_list_authz', context=context)
+
+        assert_equals(len(result), 1)
+        assert_equals(result[0]['id'], group_id)
+
     @mock.patch('ckan.new_authz.get_roles_with_permission')
-    def test_it_returns_empty_list_if_therere_no_roles_able_to_manage_groups(self, get_roles_with_permission):
+    def test_it_returns_empty_list_if_theres_no_role_able_to_manage_groups(self, get_roles_with_permission):
         get_roles_with_permission.return_value = []
         user = factories.User()
         factories.Group(user=user)
@@ -437,11 +448,12 @@ class TestGroupListAuthz(object):
         assert_equals(result, [])
 
     @mock.patch('ckan.new_authz.get_roles_with_permission')
-    def test_it_should_return_every_group_if_user_is_sysadmin_even_if_therere_no_roles_able_to_manage_groups(self, get_roles_with_permission):
+    @helpers.change_config('ckan.auth.default_group_or_org_permissions', 'manage_group')
+    def test_it_returns_all_groups_if_everyone_is_able_to_manage_groups_even_if_theres_no_role_with_this_permission(self, get_roles_with_permission):
         get_roles_with_permission.return_value = []
-        sysadmin = factories.Sysadmin()
+        user = factories.User()
         group_id = factories.Group()['id']
-        context = {'user': sysadmin['name']}
+        context = {'user': user['name']}
 
         result = helpers.call_action('group_list_authz', context=context)
 
@@ -449,23 +461,11 @@ class TestGroupListAuthz(object):
         assert_equals(result[0]['id'], group_id)
 
     @mock.patch('ckan.new_authz.get_roles_with_permission')
-    @helpers.change_config('ckan.auth.default_group_or_org_permissions', 'manage_group')
-    def test_it_should_return_every_group_if_everyone_is_able_to_manage_groups_even_if_therere_no_roles_with_this_permission(self, get_roles_with_permission):
+    def test_it_returns_all_groups_if_user_is_sysadmin_even_if_theres_no_role_able_to_manage_groups(self, get_roles_with_permission):
         get_roles_with_permission.return_value = []
-        user = factories.User()
+        sysadmin = factories.Sysadmin()
         group_id = factories.Group()['id']
-        context = {'user': user['name']}
-
-        result = helpers.call_action('group_list_authz', context=context)
-
-        assert_equals(len(result), 1)
-        assert_equals(result[0]['id'], group_id)
-
-    @helpers.change_config('ckan.auth.default_group_or_org_permissions', 'manage_group')
-    def test_it_returns_all_groups_if_ckan_is_configured_to_allow_everyone_to_manage_groups(self):
-        user = factories.User()
-        group_id = factories.Group()['id']
-        context = {'user': user['name']}
+        context = {'user': sysadmin['name']}
 
         result = helpers.call_action('group_list_authz', context=context)
 

--- a/ckan/new_tests/test_new_authz.py
+++ b/ckan/new_tests/test_new_authz.py
@@ -1,0 +1,87 @@
+import nose.tools
+
+import ckan.new_tests.helpers as helpers
+import ckan.new_tests.factories as factories
+import ckan.new_authz as new_authz
+
+assert_equals = nose.tools.assert_equals
+
+
+class TestHasUserPermissionForGroupOrOrg(object):
+
+    def setup(self):
+        helpers.reset_db()
+
+    def test_user_that_created_group_has_admin_permissions(self):
+        user = factories.User()
+        group = factories.Group(user=user)
+
+        result = new_authz.has_user_permission_for_group_or_org(group['id'],
+                                                                user['name'],
+                                                                'admin')
+
+        assert_equals(result, True)
+
+    def test_users_not_part_of_the_group_dont_have_read_permissions(self):
+        user = factories.User()
+        group = factories.Group()
+
+        result = new_authz.has_user_permission_for_group_or_org(group['id'],
+                                                                user['name'],
+                                                                'read')
+
+        assert_equals(result, False)
+
+    def test_users_with_configured_roles_have_permissions_on_all_children_groups(self):
+        config_name = 'roles_that_cascade_to_sub_groups'
+        original_roles = new_authz.check_config_permission(config_name)
+        new_authz.CONFIG_PERMISSIONS[config_name] = ['admin']
+
+        user = factories.User()
+        parent_group = factories.Group(user=user)
+        group = factories.Group(groups=[parent_group])
+
+        result = new_authz.has_user_permission_for_group_or_org(group['id'],
+                                                                user['name'],
+                                                                'admin')
+
+        assert_equals(result, True)
+
+        new_authz.CONFIG_PERMISSIONS[config_name] = original_roles
+
+    def test_it_allows_sysadmins_to_do_anything(self):
+        user = factories.Sysadmin()
+        group = factories.Group()
+
+        result = new_authz.has_user_permission_for_group_or_org(group['id'],
+                                                                user['name'],
+                                                                'admin')
+
+        assert_equals(result, True)
+
+    def test_it_requires_group_id(self):
+        user = factories.Sysadmin()
+
+        result = new_authz.has_user_permission_for_group_or_org(None,
+                                                                user['name'],
+                                                                'admin')
+
+        assert_equals(result, False)
+
+    def test_it_requires_valid_group_id(self):
+        user = factories.Sysadmin()
+
+        result = new_authz.has_user_permission_for_group_or_org('inexistent',
+                                                                user['name'],
+                                                                'admin')
+
+        assert_equals(result, False)
+
+    def test_it_requires_valid_user_name(self):
+        group = factories.Group()
+
+        result = new_authz.has_user_permission_for_group_or_org(group['id'],
+                                                                'inexistent',
+                                                                'admin')
+
+        assert_equals(result, False)

--- a/ckan/new_tests/test_new_authz.py
+++ b/ckan/new_tests/test_new_authz.py
@@ -11,6 +11,7 @@ class TestHasUserPermissionForGroupOrOrg(object):
 
     def setup(self):
         helpers.reset_db()
+        new_authz.CONFIG_PERMISSIONS = {}
 
     def teardown(self):
         new_authz.CONFIG_PERMISSIONS = {}

--- a/ckan/new_tests/test_new_authz.py
+++ b/ckan/new_tests/test_new_authz.py
@@ -100,7 +100,7 @@ class TestHasUserPermissionForGroupOrOrg(object):
 
         assert_equals(result, True)
 
-    @helpers.change_config('ckan.auth.default_group_or_org_permissions', 'read member_create')
+    @helpers.change_config('ckan.auth.default_group_only_permissions', 'read')
     def test_group_its_default_permissions_can_be_overriden_by_config_variable(self):
         user = factories.User()
         group = factories.Group()
@@ -111,7 +111,7 @@ class TestHasUserPermissionForGroupOrOrg(object):
 
         assert_equals(result, True)
 
-    @helpers.change_config('ckan.auth.default_group_or_org_permissions', 'read member_create')
+    @helpers.change_config('ckan.auth.default_org_only_permissions', 'read')
     def test_organization_its_default_permissions_can_be_overriden_by_config_variable(self):
         user = factories.User()
         org = factories.Organization()
@@ -121,6 +121,30 @@ class TestHasUserPermissionForGroupOrOrg(object):
                                                                 'read')
 
         assert_equals(result, True)
+
+    @helpers.change_config('ckan.auth.default_group_only_permissions', '')
+    @helpers.change_config('ckan.auth.default_org_only_permissions', 'read')
+    def test_group_default_org_permissions_dont_override_group_permissions(self):
+        user = factories.User()
+        group = factories.Group()
+
+        result = new_authz.has_user_permission_for_group_or_org(group['id'],
+                                                                user['name'],
+                                                                'read')
+
+        assert_equals(result, False)
+
+    @helpers.change_config('ckan.auth.default_group_only_permissions', 'read')
+    @helpers.change_config('ckan.auth.default_org_only_permissions', '')
+    def test_organization_default_group_permissions_dont_override_org_permissions(self):
+        user = factories.User()
+        org = factories.Organization()
+
+        result = new_authz.has_user_permission_for_group_or_org(org['id'],
+                                                                user['name'],
+                                                                'read')
+
+        assert_equals(result, False)
 
     def test_requires_group_or_organization_id(self):
         user = factories.Sysadmin()

--- a/ckan/new_tests/test_new_authz.py
+++ b/ckan/new_tests/test_new_authz.py
@@ -11,10 +11,10 @@ class TestHasUserPermissionForGroupOrOrg(object):
 
     def setup(self):
         helpers.reset_db()
-        new_authz.CONFIG_PERMISSIONS = {}
+        new_authz.clear_auth_functions_cache()
 
     def teardown(self):
-        new_authz.CONFIG_PERMISSIONS = {}
+        new_authz.clear_auth_functions_cache()
 
     def test_user_that_created_group_has_admin_permissions(self):
         user = factories.User()

--- a/ckan/tests/test_coding_standards.py
+++ b/ckan/tests/test_coding_standards.py
@@ -712,6 +712,8 @@ class TestPep8(object):
         'ckan/model/user.py',
         'ckan/model/vocabulary.py',
         'ckan/new_authz.py',
+        'ckan/new_tests/logic/action/test_get.py',
+        'ckan/new_tests/test_new_authz.py',
         'ckan/pastertemplates/__init__.py',
         'ckan/plugins/interfaces.py',
         'ckan/plugins/toolkit.py',

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -367,22 +367,41 @@ Makes role permissions apply to all the groups down the hierarchy from the group
 
 e.g. a particular user has the 'admin' role for group 'Department of Health'. If you set the value of this option to 'admin' then the user will automatically have the same admin permissions for the child groups of 'Department of Health' such as 'Cancer Research' (and its children too and so on).
 
-.. _ckan.auth.default_group_or_org_permissions:
+.. _ckan.auth.default_group_only_permissions:
 
-ckan.auth.default_group_or_org_permissions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ckan.auth.default_group_only_permissions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Example::
 
- ckan.auth.default_group_or_org_permissions = read manage_group
+ ckan.auth.default_group_only_permissions = read manage_group
 
 Default value: ``''``
 
 
-Change the default permissions every user has in every group and organization.
+Change the default permissions every user has in every group (but not
+organizations).
 
 e.g. if you want to allow any user to add datasets to any group, you could set
-the value of this option to 'manage_group'.
+this option to 'manage_group'.
+
+.. _ckan.auth.default_org_only_permissions:
+
+ckan.auth.default_org_only_permissions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+ ckan.auth.default_org_only_permissions = read manage_group
+
+Default value: ``''``
+
+
+Change the default permissions every user has in every organization (but not
+groups).
+
+e.g. if you want to allow any user to add datasets to any organization, you
+could set this option to 'manage_group'.
 
 .. end_config-authorization
 

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -367,6 +367,23 @@ Makes role permissions apply to all the groups down the hierarchy from the group
 
 e.g. a particular user has the 'admin' role for group 'Department of Health'. If you set the value of this option to 'admin' then the user will automatically have the same admin permissions for the child groups of 'Department of Health' such as 'Cancer Research' (and its children too and so on).
 
+.. _ckan.auth.default_group_or_org_permissions:
+
+ckan.auth.default_group_or_org_permissions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+ ckan.auth.default_group_or_org_permissions = read manage_group
+
+Default value: ``''``
+
+
+Change the default permissions every user has in every group and organization.
+
+e.g. if you want to allow any user to add datasets to any group, you could set
+the value of this option to 'manage_group'.
+
 .. end_config-authorization
 
 


### PR DESCRIPTION
Before CKAN 2.0 it was possible for a group admin to add group auth for 'any logged in user'.

This functionality should be restored as it would be useful for some use cases, see e.g. 

https://lists.okfn.org/pipermail/ckan-dev/2014-April/007301.html
