### PR TITLE
[wip] Groups authorization bug

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -502,7 +502,8 @@ def group_list_authz(context, data_dict):
         q = model.Session.query(model.Member) \
             .filter(model.Member.table_name == 'user') \
             .filter(model.Member.capacity.in_(roles)) \
-            .filter(model.Member.table_id == user_id)
+            .filter(model.Member.table_id == user_id) \
+            .filter(model.Member.state == 'active')
         group_ids = []
         for row in q.all():
             group_ids.append(row.group_id)


### PR DESCRIPTION
I am running ckan2.2 and I faced a strange behaviour with the groups authorization.

If I set an user as administrator of a group (let's say Transport) and after I remove it from being an administrator, the user seems to still have the possibility to add datasets to that group and the group itself remains under the catalogue "My groups" of that user, causing Server Errors when the user tries to add (or remove) a dataset to that group.

To prove this behaviour I did "/api/3/action/group_list_authz" from my ckan instance and I actually receive as response the info related to the group Transport, for which the user is no longer an administrator.
