### PR TITLE
Deleted Users bug

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -389,7 +389,7 @@ class SearchIndexCommand(CkanCommand):
     Usage:
       search-index [-i] [-o] [-r] [-e] rebuild [dataset_name]  - reindex dataset_name if given, if not then rebuild
                                                                  full search index (all datasets)
-      search-index rebuild_fast                                - reindex using multiprocessing using all cores. 
+      search-index rebuild_fast                                - reindex using multiprocessing using all cores.
                                                                  This acts in the same way as rubuild -r [EXPERIMENTAL]
       search-index check                                       - checks for datasets not indexed
       search-index show DATASET_NAME                           - shows index of a dataset
@@ -746,7 +746,7 @@ class UserCmd(CkanCommand):
     def list(self):
         import ckan.model as model
         print 'Users:'
-        users = model.Session.query(model.User)
+        users = model.Session.query(model.User).filter_by(state = 'active')
         print 'count = %i' % users.count()
         for user in users:
             print self.get_user_str(user)


### PR DESCRIPTION
I am running ckan 2.2 and I deleted an user using the command : 
"paster user remove user_name -c /etc/ckan/default/production.ini"

this, removes the user from the list shown at the page myckanaddress/user but if I do "paster user list -c /etc/ckan/default/production.ini", the user that I deleted is still there. 

As @nigelbabu said: "This is because deleted users are not completely deleted from the database. The state is marked as deleted. However, you're right. We should either not show users in deleted state or show the state when `paster user` is called from the command-line"
