### PR TITLE
Changed external http:// links to // protocol-independent paths

### DIFF
--- a/ckan/templates/footer.html
+++ b/ckan/templates/footer.html
@@ -13,7 +13,7 @@
               {% set api_url = 'http://docs.ckan.org/en/{0}/api.html'.format(g.ckan_doc_version) %}
               <li><a href="{{ api_url }}">{{ _('CKAN API') }}</a></li>
               <li><a href="http://www.okfn.org/">{{ _('Open Knowledge Foundation') }}</a></li>
-              <li><a href="http://www.opendefinition.org/okd/"><img src="http://assets.okfn.org/images/ok_buttons/od_80x15_blue.png"></a></li>
+              <li><a href="http://www.opendefinition.org/okd/"><img src="//assets.okfn.org/images/ok_buttons/od_80x15_blue.png"></a></li>
             {% endblock %}
           </ul>
         {% endblock %}

--- a/ckan/templates/snippets/license.html
+++ b/ckan/templates/snippets/license.html
@@ -26,7 +26,7 @@
                 {{ license_string(pkg_dict) }}
                 {% if pkg_dict.isopen %}
                   <a href="http://opendefinition.org/okd/" title="{{ _('This dataset satisfies the Open Definition.') }}">
-                    <img class="open-data" src="http://assets.okfn.org/images/ok_buttons/od_80x15_blue.png" alt="[Open Data]" />
+                    <img class="open-data" src="//assets.okfn.org/images/ok_buttons/od_80x15_blue.png" alt="[Open Data]" />
                   </a>
                 {% endif %}
               {% endblock %}

--- a/ckan/templates/user/snippets/recaptcha.html
+++ b/ckan/templates/user/snippets/recaptcha.html
@@ -1,9 +1,9 @@
 <div class="control-group">
   <div class="controls">
 
-    <script type="text/javascript" src="http://www.google.com/recaptcha/api/challenge?k={{ public_key }}"></script>
+    <script type="text/javascript" src="//www.google.com/recaptcha/api/challenge?k={{ public_key }}"></script>
     <noscript>
-      <iframe src="http://www.google.com/recaptcha/api/noscript?k={{ public_key }}" height="300" width="500" frameborder="0"></iframe><br>
+      <iframe src="//www.google.com/recaptcha/api/noscript?k={{ public_key }}" height="300" width="500" frameborder="0"></iframe><br>
       <textarea name="recaptcha_challenge_field" rows="3" cols="40"></textarea>
       <input type="hidden" name="recaptcha_response_field" value="manual_challenge">
     </noscript>


### PR DESCRIPTION
When serving CKAN on https://, browsers will complain when parts of a rendered page attempt to get data over http://. 

This actually prevents reCAPTCHA from rendering at all on a new user form when CKAN is on https://.  Luckily, most of the external services referenced in CKAN are available over http:// and https://.  This fix allows for the right protocol to be chosen automatically.
