### PR TITLE
Can't find main.debug.css error

### DIFF
--- a/doc/contributing/frontend/index.rst
+++ b/doc/contributing/frontend/index.rst
@@ -24,9 +24,9 @@ The front end stylesheets are written using
 `LESS <http://lesscss.org/>`_ (this depends on
 `node.js <http://nodejs.org/>`_ being installed on the system)
 
-Instructions for installing node can be found on the `node.js
-website <http://nodejs.org/>`_. On Ubuntu node.js (and npm node.js's package
-manager) need to be installed via a `PPA
+Instructions for installing node can be found on the `node.js website
+<http://nodejs.org/>`_. On Ubuntu 12.04 to 13.04, node.js (and npm node.js's
+package manager) need to be installed via a `PPA
 <https://launchpad.net/~chris-lea/+archive/node.js/>`_:
 
 ::
@@ -39,6 +39,15 @@ Now run the command to install nodejs from the repository:
 ::
 
     $ sudo apt-get install nodejs
+
+On Ubuntu versions later than 13.04, npm can be installed directly from Ubuntu
+packages
+
+::
+    $ sudo apt-get install npm
+
+For more information, refer to the `Node wiki
+<https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager#ubuntu-mint-elementary-os>`_.
 
 LESS can then be installed via the node package manager which is bundled
 with node (or installed with apt as it is not bundled with node.js on

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -408,3 +408,9 @@ error, install frontend dependencies. See :doc:`/contributing/frontend/index`.
 
 After installing the dependencies, run `bin/less` and then start paster server
 again.
+
+If you do not want to compile CSS, you can also copy the main.css to
+main.debug.css to get CKAN running.
+
+    cp /usr/lib/ckan/default/src/ckan/ckan/public/base/css/main.css \
+    /usr/lib/ckan/default/src/ckan/ckan/public/base/css/main.debug.css


### PR DESCRIPTION
When setting up a new ckan instance and running it on debug mode, this is a common error. The fix is in the [Frontend Guidelines](http://docs.ckan.org/en/latest/contributing/frontend/index.html). However, that is now out-of-date because npm is hipster

![hipster cat](http://stream1.gifsoup.com/view5/3553806/dubstep-hipster-cat-o.gif)

By which,I mean, the version of npm in Ubuntu repositories are too old.

1) We should mention this under Troubleshooting.
2) Update the frontend guidelines to talk about installing nodejs from [PPA](https://launchpad.net/~chris-lea/+archive/node.js/)
