### PR TITLE
Test factories should not use the site user

### DIFF
--- a/ckan/new_tests/logic/action/test_get.py
+++ b/ckan/new_tests/logic/action/test_get.py
@@ -90,8 +90,9 @@ class TestGet(object):
 
     def test_organization_list(self):
 
-        org1 = factories.Organization()
-        org2 = factories.Organization()
+        user = factories.User()
+        org1 = factories.Organization(user=user)
+        org2 = factories.Organization(user=user)
 
         org_list = helpers.call_action('organization_list')
 
@@ -100,7 +101,7 @@ class TestGet(object):
 
     def test_organization_show(self):
 
-        org = factories.Organization()
+        org = factories.Organization(user=factories.User())
 
         org_dict = helpers.call_action('organization_show', id=org['id'])
 
@@ -110,9 +111,8 @@ class TestGet(object):
 
     def test_organization_show_packages_returned(self):
 
-        user_name = helpers.call_action('get_site_user')['name']
-
-        org = factories.Organization()
+        user = factories.User()
+        org = factories.Organization(user=user)
 
         datasets = [
             {'name': 'dataset_1', 'owner_org': org['name']},
@@ -121,7 +121,7 @@ class TestGet(object):
 
         for dataset in datasets:
             helpers.call_action('package_create',
-                                context={'user': user_name},
+                                context={'user': user['name']},
                                 **dataset)
 
         org_dict = helpers.call_action('organization_show', id=org['id'])
@@ -131,9 +131,8 @@ class TestGet(object):
 
     def test_organization_show_private_packages_not_returned(self):
 
-        user_name = helpers.call_action('get_site_user')['name']
-
-        org = factories.Organization()
+        user = factories.User()
+        org = factories.Organization(user=user)
 
         datasets = [
             {'name': 'dataset_1', 'owner_org': org['name']},
@@ -142,7 +141,7 @@ class TestGet(object):
 
         for dataset in datasets:
             helpers.call_action('package_create',
-                                context={'user': user_name},
+                                context={'user': user['name']},
                                 **dataset)
 
         org_dict = helpers.call_action('organization_show', id=org['id'])

--- a/ckan/new_tests/test_factories.py
+++ b/ckan/new_tests/test_factories.py
@@ -32,18 +32,21 @@ class TestFactories(object):
         assert_not_equals(sysadmin1['id'], sysadmin2['id'])
 
     def test_group_factory(self):
-        group1 = factories.Group()
-        group2 = factories.Group()
+        user = factories.User()
+        group1 = factories.Group(user=user)
+        group2 = factories.Group(user=user)
         assert_not_equals(group1['id'], group2['id'])
 
     def test_organization_factory(self):
-        organization1 = factories.Organization()
-        organization2 = factories.Organization()
+        user = factories.User()
+        organization1 = factories.Organization(user=user)
+        organization2 = factories.Organization(user=user)
         assert_not_equals(organization1['id'], organization2['id'])
 
     def test_related_factory(self):
-        related1 = factories.Related()
-        related2 = factories.Related()
+        user = factories.User()
+        related1 = factories.Related(user=user)
+        related2 = factories.Related(user=user)
         assert_not_equals(related1['id'], related2['id'])
 
     def test_dataset_factory(self):


### PR DESCRIPTION
I'm writing a simple function to return the IDs of all a site's editors and admins:

```
def editors_and_admins():
    '''Return the IDs of all group or organization editors and admins.

    Return a set of the user IDs of all users who are editors or admins of one
    or more groups or organizations.

    '''
    import ckan.model
    query = ckan.model.Session.query(ckan.model.Member)
    query = query.filter_by(table_name='user')
    query = query.filter(ckan.model.Member.capacity.in_(('editor', 'admin')))
    return set([member.table_id for member in query.all()])
```

Here's a simple unit test for the function:

```
def test_editors_and_admins_with_1_duplicate_editor_and_admin():

    helpers.reset_db()
    group = factories.Group()
    user = factories.User()
    helpers.call_action('group_member_create', id=group['id'],
                        username=user['name'], role='editor')

    assert plugin.editors_and_admins() == set([user['id']])
```

There's nothing wrong with the function, but the test fails because `editors_and_admins()` returns two different user IDs, instead of the one user ID as expected.

The reason is that in CKAN, a user is required to create a group or organization because that user will become the first admin of the group or org. The factories hide this, they let you create a group or org without passing any arguments, and they silently insert the site user into the context. So now, `editors_and_admins()` returns two user IDs: the user who I explicitedly added to the group as an editor, and the site user who was inserted as the group's first admin.

I think this is confusing - from reading the test code it looks like I created a group with no members, then added one member to it. In fact I created a group with one member (the site user), then added a second member to it. We should make the first member explicit in the test code, by making the factory require it as a param:

```
def test_editors_and_admins_with_1_duplicate_editor_and_admin():

    helpers.reset_db()
    user = factories.User()
    group = factories.Group(user=user)

    assert plugin.editors_and_admins() == set([user['id']])
```

Also, creating groups and orgs with the site user is weird - that would never happen in normal usage of the CKAN API or web interface, so it probably shouldn't be what we do in the tests either.