### PR TITLE
Ensure flash_messages is declared within the flash_inner block scope

### DIFF
--- a/ckan/templates/page.html
+++ b/ckan/templates/page.html
@@ -21,10 +21,9 @@
       <div id="content" class="container">
         {% block main_content %}
           {% block flash %}
-            {% set flash_messages = h.flash.pop_messages() | list %}
             <div class="flash-messages">
               {% block flash_inner %}
-                {% for message in flash_messages %}
+                {% for message in h.flash.pop_messages() | list %}
                   <div class="alert fade in {{ message.category }}">
                     {{ h.literal(message) }}
                   </div>


### PR DESCRIPTION
As per issue #1743:

Flash messages added programatically server side (using ckan.lib.helpers.flash_notice, etc.) are not displayed on the page.

The issue was caused by commit 4ec3ac0c17a09a9022a8cf8c6f1d7186436ecb8b which added a Jinja block `block_inner` within the section that displayed the flash messages in [page.html](https://github.com/ckan/ckan/blob/master/ckan/templates/page.html). The block in question caused the variable `flash_messages` to become out of scope, and thus no flash messages are ever displayed.

The fix is simple: simply move the assignment of flash_messages within the block.
