### PR TITLE
Change block name in theming tutorial

### DIFF
--- a/ckanext/example_theme/v16_initialize_a_javascript_module/templates/snippets/package_item.html
+++ b/ckanext/example_theme/v16_initialize_a_javascript_module/templates/snippets/package_item.html
@@ -1,6 +1,6 @@
 {% ckan_extends %}
 
-{% block package_item_content %}
+{% block content %}
   {{ super() }}
 
   {# Use Fanstatic to include our custom JavaScript module.


### PR DESCRIPTION
Change content block name from "package_item_content" to "content" to match block name in source package_item.html snippet
