### PR TITLE
data-site-root and data-locale-root are always http

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -106,7 +106,7 @@ def url(*args, **kw):
     '''Create url adding i18n information if selected
     wrapper for pylons.url'''
     locale = kw.pop('locale', None)
-    if request.scheme and not kw.get('protocol'):
+    if kw.get('qualified') and (request.scheme and not kw.get('protocol')):
         kw['protocol'] = request.scheme
     my_url = _pylons_default_url(*args, **kw)
     return _add_i18n_to_url(my_url, locale=locale, **kw)


### PR DESCRIPTION
The `data-site-root` and `data-locale-root` parameters on the body tag is used in JS. It should either adopt to HTTP and HTTPS or only output `//` instead of `http://`
