### PR TITLE
Inserting empty arrays in JSON type fields in datastore fails

### DIFF
--- a/ckanext/datastore/db.py
+++ b/ckanext/datastore/db.py
@@ -621,7 +621,7 @@ def upsert_data(context, data_dict):
 
             for field in fields:
                 value = record.get(field['id'])
-                if value and field['type'].lower() == 'nested':
+                if value is not None and field['type'].lower() == 'nested':
                     ## a tuple with an empty second value
                     record[field['id']] = (json.dumps(value), '')
 


### PR DESCRIPTION
As stated in the comment to question http://stackoverflow.com/questions/24207065/inserting-empty-arrays-in-json-type-fields-in-datastore, this could be a bug.
