### PR TITLE
Ordering a dataset listing loses the existing filters

### DIFF
--- a/ckan/templates/group/read.html
+++ b/ckan/templates/group/read.html
@@ -18,7 +18,7 @@
       (_('Last Modified'), 'metadata_modified desc'),
       (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
     %}
-    {% snippet 'snippets/search_form.html', type='dataset', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, placeholder=_('Search datasets...'), show_empty=request.params %}
+    {% snippet 'snippets/search_form.html', type='dataset', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, placeholder=_('Search datasets...'), show_empty=request.params, fields=c.fields %}
   {% endblock %}
   {% block packages_list %}
     {% if c.page.items %}

--- a/ckan/templates/organization/read.html
+++ b/ckan/templates/organization/read.html
@@ -22,7 +22,7 @@
         (_('Last Modified'), 'metadata_modified desc'),
         (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
       %}
-      {% snippet 'snippets/search_form.html', type='dataset', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, placeholder=_('Search datasets...'), show_empty=request.params %}
+      {% snippet 'snippets/search_form.html', type='dataset', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, placeholder=_('Search datasets...'), show_empty=request.params, fields=c.fields %}
     {% endblock %}
   {% block packages_list %}
     {% if c.page.items %}

--- a/ckan/templates/package/search.html
+++ b/ckan/templates/package/search.html
@@ -32,7 +32,7 @@
           (_('Last Modified'), 'metadata_modified desc'),
           (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
         %}
-        {% snippet 'snippets/search_form.html', type='dataset', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, show_empty=request.params, error=c.query_error %}
+        {% snippet 'snippets/search_form.html', type='dataset', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, show_empty=request.params, error=c.query_error, fields=c.fields %}
       {% endblock %}
       {% block package_search_results_list %}
         {{ h.snippet('snippets/package_list.html', packages=c.page.items) }}


### PR DESCRIPTION
1. Go to /dataset
2. Select a couple of filters on the left facets column
3. Change the ordering

The filters are lost.

There is a `form.hidden_from_list` macro call in the `search_form.html` snippet that does not get the `fields` variable it needs to create the hidden necessary inputs. Fix is passing `fields=c.fields` when calling the `search_form.html` snippet.
