### PR TITLE
Don't delete all cookies whose names start with "ckan"

### DIFF
--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -347,15 +347,9 @@ class BaseController(WSGIController):
         finally:
             model.Session.remove()
 
-        # Clean out any old cookies as they may contain api keys etc
-        # This also improves the cachability of our pages as cookies
-        # prevent proxy servers from caching content unless they have
-        # been configured to ignore them.
         for cookie in request.cookies:
-            if cookie.startswith('ckan') and cookie not in ['ckan']:
-                response.delete_cookie(cookie)
             # Remove the ckan session cookie if not used e.g. logged out
-            elif cookie == 'ckan' and not c.user:
+            if cookie == 'ckan' and not c.user:
                 # Check session for valid data (including flash messages)
                 # (DGU also uses session for a shopping basket-type behaviour)
                 is_valid_cookie_data = False


### PR DESCRIPTION
I'm writing a CKAN extension and I had to set my own cookie (I couldn't use the beaker session, because I need my cookie to be set and persist when the user is not logged in. and CKAN or Pylons seems to clear the session on each page load when you're not logged in). I created my cookie and called it "ckanext-oauth2waad-state". The cookie is correctly set and stored in my browser, but for some reason the browser does not send the cookie back to CKAN on subsequent page requests.

Half a day later, I found that in its response to the `/en` URL which is requested as part of every page load, CKAN finds all cookies whose names start with "ckan" and deletes them.
