### PR TITLE
[#1811] Make the docker container naming style consistent

### DIFF
--- a/contrib/docker/svc/ckan/run
+++ b/contrib/docker/svc/ckan/run
@@ -2,7 +2,7 @@
 exec 2>&1
 
 # URL for the primary database, in the format expected by sqlalchemy (required
-# unless linked to a container called 'db')
+# unless linked to a container called 'postgresql')
 : ${DATABASE_URL:=}
 # URL for solr (required unless linked to a container called 'solr')
 : ${SOLR_URL:=}
@@ -37,11 +37,11 @@ bootstrap () {
 }
 
 link_postgres_url () {
-  local user=$DB_ENV_POSTGRESQL_USER
-  local pass=$DB_ENV_POSTGRESQL_USER
-  local db=$DB_ENV_POSTGRESQL_DB
-  local host=$DB_PORT_5432_TCP_ADDR
-  local port=$DB_PORT_5432_TCP_PORT
+  local user=$POSTGRESQL_ENV_POSTGRESQL_USER
+  local pass=$POSTGRESQL_ENV_POSTGRESQL_USER
+  local db=$POSTGRESQL_ENV_POSTGRESQL_DB
+  local host=$POSTGRESQL_PORT_5432_TCP_ADDR
+  local port=$POSTGRESQL_PORT_5432_TCP_PORT
   echo "postgresql://${user}:${pass}@${host}:${port}/${db}"
 }
 
@@ -55,7 +55,7 @@ link_solr_url () {
 if [ ! -e "$CONFIG" ]; then
   if [ -z "$DATABASE_URL" ]; then
     if ! DATABASE_URL=$(link_postgres_url); then
-      abort "no DATABASE_URL specified and linked container called 'db' was not found"
+      abort "no DATABASE_URL specified and linked container called 'postgresql' was not found"
     fi
   fi
   if [ -z "$SOLR_URL" ]; then

--- a/doc/maintaining/installing/install-using-docker.rst
+++ b/doc/maintaining/installing/install-using-docker.rst
@@ -36,9 +36,9 @@ Installing CKAN
 In the simplest case, installing CKAN should be a matter of running three
 commands: to run |postgres|, |solr|, and CKAN::
 
-    $ docker run -d --name db ckan/postgresql
+    $ docker run -d --name postgresql ckan/postgresql
     $ docker run -d --name solr ckan/solr
-    $ docker run -d -p 80:80 --link db:db --link solr:solr ckan/ckan
+    $ docker run -d -p 80:80 --link postgresql:postgresql --link solr:solr ckan/ckan
 
 This start a new CKAN container in the background, connected to default
 installations of |postgres| and |solr| also running in containers.
@@ -62,7 +62,7 @@ like the following::
     $ docker ps
     CONTAINER ID        IMAGE                         COMMAND               CREATED             STATUS              PORTS                     NAMES
     cab6e63c77b1        ckan/ckan:latest              /sbin/my_init         30 days ago         Up 1 minutes        0.0.0.0:80->80/tcp        jovial_perlman
-    fb47b3744d6d        ckan/postgresql:latest        /usr/local/bin/run    9 days ago          Up 1 minutes        5432/tcp                  db,jovial_perlman/db
+    fb47b3744d6d        ckan/postgresql:latest        /usr/local/bin/run    9 days ago          Up 1 minutes        5432/tcp                  postgresql,jovial_perlman/postgresql
     96e963812fc9        ckan/solr:latest              java -jar start.jar   15 days ago         Up 1 minutes        8983/tcp                  solr,jovial_perlman/solr
 
 Using the CKAN container id (here it's ``cab6e63c77b1``), you can perform other
@@ -99,7 +99,7 @@ You can run maintenance commands in their own ephemeral container by specifying
 a custom command for the container. For example, to create a sysadmin user
 called ``joebloggs``::
 
-    $ docker run -i -t --link db:db --link solr:solr \
+    $ docker run -i -t --link postgresql:postgresql --link solr:solr \
         ckan/ckan \
         /sbin/my_init -- \
         /bin/bash -c \


### PR DESCRIPTION
Make the container and container link naming styles consistent. It should be
ckan/solr and solr:solr, and ckan/postgresql and postgresql:postgresql
(not db:db).

Fixes #1811 
