### PR TITLE
[#1812] Make docker install's apache filenames consistent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,9 @@ RUN ln -s $CKAN_HOME/src/ckan/ckan/config/who.ini $CKAN_CONFIG/who.ini
 ADD ./contrib/docker/apache.wsgi $CKAN_CONFIG/apache.wsgi
 
 # Configure apache
-ADD ./contrib/docker/apache.conf /etc/apache2/sites-available/ckan.conf
+ADD ./contrib/docker/apache.conf /etc/apache2/sites-available/ckan_default.conf
 RUN echo "Listen 8080" > /etc/apache2/ports.conf
-RUN a2ensite ckan
+RUN a2ensite ckan_default
 RUN a2dissite 000-default
 
 # Configure nginx

--- a/contrib/docker/apache.conf
+++ b/contrib/docker/apache.conf
@@ -9,6 +9,6 @@
     WSGIScriptAlias / ${CKAN_CONFIG}/apache.wsgi
     WSGIPassAuthorization On
 
-    ErrorLog /var/log/apache2/ckan.error.log
-    CustomLog /var/log/apache2/ckan.custom.log combined
+    ErrorLog /var/log/apache2/ckan_default.error.log
+    CustomLog /var/log/apache2/ckan_default.custom.log combined
 </VirtualHost>


### PR DESCRIPTION
ckan_default is ugly, but I don't want to have different config and log
file paths in docker installs compared to source or package installs.

Fixes #1812
