### PR TITLE
Upgrade SQLAlchemy to version 0.9

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -24,8 +24,7 @@ Routes==1.13
 solrpy==0.9.5
 sqlalchemy-migrate==0.9.1
 SQLAlchemy==0.9.6
-# Temporal, this will be vdm=0.13
--e git+https://github.com/okfn/vdm@sqlalchemy-0.9-support
+vdm==0.13
 WebHelpers==1.3
 WebOb==1.0.8
 zope.interface==4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,6 @@ six==1.7.3
 solrpy==0.9.5
 sqlalchemy-migrate==0.9.1
 unicodecsv==0.9.4
-# Temporal, this will be vdm=0.13
--e git+https://github.com/okfn/vdm@sqlalchemy-0.9-support#egg=vdm
+vdm==0.13
 wsgiref==0.1.2
 zope.interface==4.0.1


### PR DESCRIPTION
Requires updates in vdm, see the [sqlalchemy-0.9-support](https://github.com/okfn/vdm/tree/sqlalchemy-0.9-support) branch.

Also affects ckan/ckanext-spatial#5 (PostGIS 2.0 support, the one on Ubuntu 14.04)
