### PR TITLE
Fix #1818

### DIFF
--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -135,7 +135,7 @@ def resource_show(context, data_dict):
         raise logic.NotFound(_('No package found for this resource, cannot check auth.'))
 
     pkg_dict = {'id': pkg.id}
-    authorized = package_show(context, pkg_dict).get('success')
+    authorized = new_authz.is_authorized('package_show', context, pkg_dict).get('success')
 
     if not authorized:
         return {'success': False, 'msg': _('User %s not authorized to read resource %s') % (user, resource.id)}


### PR DESCRIPTION
`resource_show` now delegates in `new_auth` to check if a user is able to view a package. With this improvement, `resource_show` uses the `package_show` defined across all the system (maybe in a plugin) and no the one set by default.
Fix #1818 issue
