### PR TITLE
Allow selecting DISTINCT values on datastore_search

### DIFF
--- a/ckanext/datastore/db.py
+++ b/ckanext/datastore/db.py
@@ -868,14 +868,20 @@ def search_data(context, data_dict):
     limit = query_dict['limit']
     offset = query_dict['offset']
 
+    if query_dict.get('distinct'):
+        distinct = 'DISTINCT'
+    else:
+        distinct = ''
+
     if sort:
         sort_clause = 'ORDER BY %s' % ', '.join(sort)
     else:
         sort_clause = ''
 
-    sql_string = u'''SELECT {select}
+    sql_string = u'''SELECT {distinct} {select}
                     FROM "{resource}" {ts_query}
                     {where} {sort} LIMIT {limit} OFFSET {offset}'''.format(
+        distinct=distinct,
         select=select_columns,
         resource=data_dict['resource_id'],
         ts_query=ts_query,

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -276,6 +276,8 @@ def datastore_search(context, data_dict):
     :type filters: dictionary
     :param q: full text query (optional)
     :type q: string
+    :param distinct: return only distinct rows (optional, default: false)
+    :type distinct: bool
     :param plain: treat as plain text query (optional, default: true)
     :type plain: bool
     :param language: language of the full text query (optional, default: english)

--- a/ckanext/datastore/logic/schema.py
+++ b/ckanext/datastore/logic/schema.py
@@ -119,6 +119,7 @@ def datastore_search_schema():
         'offset': [ignore_missing, int_validator],
         'fields': [ignore_missing, list_of_strings_or_string],
         'sort': [ignore_missing, list_of_strings_or_string],
+        'distinct': [ignore_missing, boolean_validator],
         '__junk': [empty],
         '__before': [rename('id', 'resource_id')]
     }

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -296,6 +296,11 @@ class DatastorePlugin(p.SingletonPlugin):
             if isinstance(plain, bool):
                 del data_dict['plain']
 
+        distinct = data_dict.get('distinct')
+        if distinct:
+            if isinstance(distinct, bool):
+                del data_dict['distinct']
+
         sort_clauses = data_dict.get('sort')
         if sort_clauses:
             invalid_clauses = [c for c in sort_clauses
@@ -361,6 +366,7 @@ class DatastorePlugin(p.SingletonPlugin):
         select_cols = [u'"{0}"'.format(field_id) for field_id in field_ids] +\
                       [u'count(*) over() as "_full_count" %s' % rank_column]
 
+        query_dict['distinct'] = data_dict.get('distinct', False)
         query_dict['select'] += select_cols
         query_dict['ts_query'] = ts_query
         query_dict['sort'] += sort

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -198,6 +198,20 @@ class TestDatastoreSearch(tests.WsgiAppCase):
         assert result['records'] == [{u'b\xfck': 'annakarenina', 'author': 'tolstoy'},
                     {u'b\xfck': 'warandpeace', 'author': 'tolstoy'}], result['records']
 
+    def test_search_distinct(self):
+        data = {'resource_id': self.data['resource_id'],
+                'fields': [u'author'],
+                'distinct': True}
+        postparams = '%s=1' % json.dumps(data)
+        auth = {'Authorization': str(self.normal_user.apikey)}
+        res = self.app.post('/api/action/datastore_search', params=postparams,
+                            extra_environ=auth)
+        res_dict = json.loads(res.body)
+        assert res_dict['success'] is True
+        result = res_dict['result']
+        assert result['total'] == 2
+        assert result['records'] == [{u'author': 'tolstoy'}], result['records']
+
     def test_search_filters(self):
         data = {'resource_id': self.data['resource_id'],
                 'filters': {u'b\xfck': 'annakarenina'}}


### PR DESCRIPTION
(This is needed for #1792)

It would be useful to be able to query `datastore_search` with something like:

``` json
{
    "resource_id": "the_resource_id",
    "q": "Wash",
    "fields": "state",
    "unique": true
}
```

And then it would return only distinct rows with these parameters.

As we're modifying the datastore quite heavily on #1725, it's good to start working on this only after that's merged.
