### PR TITLE
Add quotes to package ID in Solr query in _bulk_update_dataset to prevent Solr errors with custom dataset IDs.

### DIFF
--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -264,7 +264,7 @@ class PackageSearchQuery(SearchQuery):
     def get_index(self,reference):
         query = {
             'rows': 1,
-            'q': 'name:%s OR id:%s' % (reference,reference),
+            'q': 'name:"%s" OR id:"%s"' % (reference,reference),
             'wt': 'json',
             'fq': 'site_id:"%s"' % config.get('ckan.site_id')}
 

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -1189,7 +1189,7 @@ def _bulk_update_dataset(context, data_dict, update_dict):
     count = 0
     q = []
     for id in datasets:
-        q.append('id:%s' % (id))
+        q.append('id:"%s"' % (id))
         count += 1
         if count % BATCH_SIZE == 0:
             process_solr(' OR '.join(q))


### PR DESCRIPTION
Bulk updating of datasets on Organization page doesn't work for our CKAN instance because of using URNs (which contain ":" characters) as dataset IDs. The dataset IDs should be in quotes in the Solr query to prevent errors.
