### PR TITLE
Extend IDomainObjectModification

### DIFF
--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -185,6 +185,9 @@ class IDomainObjectModification(Interface):
     def notify(self, entity, operation):
         pass
 
+    def notify_after_commit(self, entity, operation):
+        pass
+
 
 class IResourceUrlChange(Interface):
     """


### PR DESCRIPTION
Currently the notify signal is sent before the database commit has occurred. It
is not possible to listen for modification events and know that the changes
have made it to the database. This can lead to a race condition if you try to
get a record from the database.

For an example see:

https://github.com/ckan/ckanext-archiver/issues/6

This extension of the interface would allow notification after the database
commit has occurred.
