### PR TITLE
Insecure content warning when running Recline under SSL

### DIFF
--- a/ckanext/reclinepreview/theme/public/vendor/recline/recline.js
+++ b/ckanext/reclinepreview/theme/public/vendor/recline/recline.js
@@ -3625,8 +3625,8 @@ my.Map = Backbone.View.extend({
     var self = this;
     this.map = new L.Map(this.$map.get(0));
 
-    var mapUrl = "http://otile{s}.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png";
-    var osmAttribution = 'Map data &copy; 2011 OpenStreetMap contributors, Tiles Courtesy of <a href="http://www.mapquest.com/" target="_blank">MapQuest</a> <img src="http://developer.mapquest.com/content/osm/mq_logo.png">';
+    var mapUrl = "//otile{s}-s.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png";
+    var osmAttribution = 'Map data &copy; 2011 OpenStreetMap contributors, Tiles Courtesy of <a href="http://www.mapquest.com/" target="_blank">MapQuest</a> <img src="//developer.mapquest.com/content/osm/mq_logo.png">';
     var bg = new L.TileLayer(mapUrl, {maxZoom: 18, attribution: osmAttribution ,subdomains: '1234'});
     this.map.addLayer(bg);
 


### PR DESCRIPTION
**Note**: This is not to be merged to master. The patch will get there as part of #1251 
The commit needs to be backported to 2.2.1 and 2.1.3

This is caused by requesting the http version of the MapQuest tiles and an image in the attribution in [1]

This has been fixed upstream in Recline (okfn/recline@efdf87db), we need to upgrade or patch with this change.

[1] https://github.com/ckan/ckan/blob/master/ckanext/reclinepreview/theme/public/vendor/recline/recline.js#L3628
