### PR TITLE
`get_site_user` performs a commit on each call

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -147,12 +147,10 @@ class CkanCommand(paste.script.command.Command):
 
             self.registry.register(pylons.c, c)
 
-            self.site_user = logic.get_action('get_site_user')({'ignore_auth': True,
-                'defer_commit': True}, {})
+            self.site_user = logic.get_action('get_site_user')({'ignore_auth': True}, {})
 
             pylons.c.user = self.site_user['name']
             pylons.c.userobj = model.User.get(self.site_user['name'])
-            model.repo.commit_and_remove()
 
         ## give routes enough information to run url_for
         parsed = urlparse.urlparse(conf.get('ckan.site_url', 'http://0.0.0.0'))

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -2091,8 +2091,7 @@ def get_site_user(context, data_dict):
     '''Return the ckan site user
 
     :param defer_commit: by default (or if set to false) get_site_user will
-        commit and clean up the current transaction, it will also close and
-        discard the current session in the context. If set to true, caller
+        commit and clean up the current transaction. If set to true, caller
         is responsible for commiting transaction after get_site_user is
         called. Leaving open connections can cause cli commands to hang!
         (optional, default: False)
@@ -2111,8 +2110,8 @@ def get_site_user(context, data_dict):
         user.sysadmin = True
         model.Session.add(user)
         model.Session.flush()
-    if not context.get('defer_commit'):
-        model.repo.commit_and_remove()
+        if not context.get('defer_commit'):
+            model.repo.commit()
 
     return {'name': user.name,
             'apikey': user.apikey}

--- a/ckan/model/__init__.py
+++ b/ckan/model/__init__.py
@@ -231,6 +231,7 @@ class Repository(vdm.sqlalchemy.Repository):
         log.info('Database initialised')
 
     def clean_db(self):
+        self.commit_and_remove()
         meta.metadata = MetaData(self.metadata.bind)
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', '.*(reflection|tsvector).*')


### PR DESCRIPTION
Unless you provide `defer_commit` in the context. This is caused by a bad indentation.

This causes `DetachedInstanceError` SQLAlchemy errors, which are notoriously difficult to debug

**Update:** Turns out we might need to do the commit after all because we're using sqlalchemy scoped sessions, which opens a transaction even if you just do a select.
