### PR TITLE
docker: Don't do configuration in the runfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN mkdir /var/cache/nginx
 ADD ./contrib/docker/main.cf /etc/postfix/main.cf
 
 # Configure runit
+ADD ./contrib/docker/my_init.d /etc/my_init.d
 ADD ./contrib/docker/svc /etc/service
 CMD ["/sbin/my_init"]
 

--- a/contrib/docker/my_init.d/50_configure
+++ b/contrib/docker/my_init.d/50_configure
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+# URL for the primary database, in the format expected by sqlalchemy (required
+# unless linked to a container called 'db')
+: ${DATABASE_URL:=}
+# URL for solr (required unless linked to a container called 'solr')
+: ${SOLR_URL:=}
+# Email to which errors should be sent (optional, default: none)
+: ${ERROR_EMAIL:=}
+
+set -eu
+
+CONFIG="${CKAN_CONFIG}/ckan.ini"
+
+abort () {
+  echo "$@" >&2
+  exit 1
+}
+
+write_config () {
+  "$CKAN_HOME"/bin/paster make-config ckan "$CONFIG"
+
+  sed -i \
+      -e "s&^sqlalchemy\.url =.*&sqlalchemy.url = ${DATABASE_URL}&" \
+      -e "s&^#solr_url.*&solr_url = ${SOLR_URL}&" \
+      -e "s&^#ckan.storage_path.*&ckan.storage_path = /var/lib/ckan&" \
+      -e "s&^email_to.*&#email_to = disabled@example.com&" \
+      -e "s&^error_email_from.*&error_email_from = ckan@$(hostname -f)&" \
+      "${CONFIG}"
+
+  if [ -n "$ERROR_EMAIL" ]; then
+    sed -i -e "s&^#email_to.*&email_to = ${ERROR_EMAIL}&" "$CONFIG"
+  fi
+}
+
+link_postgres_url () {
+  local user=$DB_ENV_POSTGRESQL_USER
+  local pass=$DB_ENV_POSTGRESQL_USER
+  local db=$DB_ENV_POSTGRESQL_DB
+  local host=$DB_PORT_5432_TCP_ADDR
+  local port=$DB_PORT_5432_TCP_PORT
+  echo "postgresql://${user}:${pass}@${host}:${port}/${db}"
+}
+
+link_solr_url () {
+  local host=$SOLR_PORT_8983_TCP_ADDR
+  local port=$SOLR_PORT_8983_TCP_PORT
+  echo "http://${host}:${port}/solr/ckan"
+}
+
+# If we don't already have a config file, bootstrap
+if [ ! -e "$CONFIG" ]; then
+  if [ -z "$DATABASE_URL" ]; then
+    if ! DATABASE_URL=$(link_postgres_url); then
+      abort "no DATABASE_URL specified and linked container called 'db' was not found"
+    fi
+  fi
+  if [ -z "$SOLR_URL" ]; then
+    if ! SOLR_URL=$(link_solr_url); then
+      abort "no SOLR_URL specified and linked container called 'solr' was not found"
+    fi
+  fi
+  write_config
+fi

--- a/contrib/docker/my_init.d/70_initdb
+++ b/contrib/docker/my_init.d/70_initdb
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+"$CKAN_HOME"/bin/paster --plugin=ckan db init -c "${CKAN_CONFIG}/ckan.ini"

--- a/contrib/docker/svc/ckan/run
+++ b/contrib/docker/svc/ckan/run
@@ -1,71 +1,7 @@
 #!/bin/sh
 exec 2>&1
 
-# URL for the primary database, in the format expected by sqlalchemy (required
-# unless linked to a container called 'db')
-: ${DATABASE_URL:=}
-# URL for solr (required unless linked to a container called 'solr')
-: ${SOLR_URL:=}
-# Email to which errors should be sent (optional, default: none)
-: ${ERROR_EMAIL:=}
+set -e
 
-set -eu
-
-CONFIG="${CKAN_CONFIG}/ckan.ini"
-
-abort () {
-  echo "$@" >&2
-  exit 1
-}
-
-bootstrap () {
-  "$CKAN_HOME"/bin/paster make-config ckan "$CONFIG"
-
-  sed -i \
-      -e "s&^sqlalchemy\.url =.*&sqlalchemy.url = ${DATABASE_URL}&" \
-      -e "s&^#solr_url.*&solr_url = ${SOLR_URL}&" \
-      -e "s&^#ckan.storage_path.*&ckan.storage_path = /var/lib/ckan&" \
-      -e "s&^email_to.*&#email_to = disabled@example.com&" \
-      -e "s&^error_email_from.*&error_email_from = ckan@$(hostname -f)&" \
-      "${CONFIG}"
-
-  if [ -n "$ERROR_EMAIL" ]; then
-    sed -i -e "s&^#email_to.*&email_to = ${ERROR_EMAIL}&" "$CONFIG"
-  fi
-
-  cd "$CKAN_HOME"/src/ckan && "$CKAN_HOME"/bin/paster db init -c "$CONFIG"
-}
-
-link_postgres_url () {
-  local user=$DB_ENV_POSTGRESQL_USER
-  local pass=$DB_ENV_POSTGRESQL_USER
-  local db=$DB_ENV_POSTGRESQL_DB
-  local host=$DB_PORT_5432_TCP_ADDR
-  local port=$DB_PORT_5432_TCP_PORT
-  echo "postgresql://${user}:${pass}@${host}:${port}/${db}"
-}
-
-link_solr_url () {
-  local host=$SOLR_PORT_8983_TCP_ADDR
-  local port=$SOLR_PORT_8983_TCP_PORT
-  echo "http://${host}:${port}/solr/ckan"
-}
-
-# If we don't already have a config file, bootstrap
-if [ ! -e "$CONFIG" ]; then
-  if [ -z "$DATABASE_URL" ]; then
-    if ! DATABASE_URL=$(link_postgres_url); then
-      abort "no DATABASE_URL specified and linked container called 'db' was not found"
-    fi
-  fi
-  if [ -z "$SOLR_URL" ]; then
-    if ! SOLR_URL=$(link_solr_url); then
-      abort "no SOLR_URL specified and linked container called 'solr' was not found"
-    fi
-  fi
-  bootstrap
-fi
-
-set +u
 . /etc/apache2/envvars
 exec /usr/sbin/apache2 -D FOREGROUND


### PR DESCRIPTION
This commit extracts the config file generation and database initialisation parts of the CKAN service into separate scripts which are run at container "boot" rather than in the service file.

This is just a bit cleaner, and means that the scripts are guaranteed to only run once on boot, rather than every time CKAN is started (e.g. if CKAN crashes, runit will rerun the `run` file, but not the init scripts).

This also makes it easier to replace the configuration step with, for example, a standalone Python script if this is deemed easier to maintain.
