### PR TITLE
Incorrect link in Organization snippet on dataset page

### DIFF
--- a/ckan/templates/snippets/organization.html
+++ b/ckan/templates/snippets/organization.html
@@ -14,7 +14,9 @@ Example:
 
 #}
 
-{% with truncate=truncate or 0, url=h.url_for(controller='organization', action='read', id=organization.name) %}
+{% set truncate = truncate or 0 %}
+{% set url = h.url_for(controller='organization', action='read', id=organization.name) %}
+
   {% block info %}
   <div class="module module-narrow module-shallow context-info">
     {% if has_context_title %}
@@ -65,4 +67,3 @@ Example:
     </section>
   </div>
   {% endblock %}
-{% endwith %}


### PR DESCRIPTION
![screenshot from 2014-08-13 12 16 09](https://cloud.githubusercontent.com/assets/200230/3904593/7c95ee52-22db-11e4-8d7c-444948e824cb.png)

Looks like if you define a variable inside a with statement on Jinja2 this variable is not available inside a block:

``` html
{% with truncate=truncate or 0, url=h.url_for(controller='organization', action='read', id=organization.name) %}
<!-- url defined here -->
  {% block info %}
  <div class="module module-narrow module-shallow context-info">
    {% if has_context_title %}
      <h2 class="module-heading"><i class="icon-building"></i> {{ _('Organization') }}</h2>
    {% endif %}
    <section class="module-content">
      {% block inner %}
      {% block image %}
        <div class="image">
          <a href="{{ url }}">      <!-- url not defined here -->
...

```

This means an empty href, which effectively links to the same dataset page.
