### PR TITLE
fix the organization image src link

### DIFF
--- a/ckan/templates/snippets/organization.html
+++ b/ckan/templates/snippets/organization.html
@@ -27,7 +27,7 @@ Example:
       {% block image %}
         <div class="image">
           <a href="{{ url }}">
-            <img src="{{ organization.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}" width="200" alt="{{ organization.name }}" />
+            <img src="{{ organization.image_url or h.url_for_static('/base/images/placeholder-organization.png') }}" width="200" alt="{{ organization.name }}" />
           </a>
         </div>
       {% endblock %}


### PR DESCRIPTION
The organization image is not properly displayed. Corrected to the proper image_url property
