### PR TITLE
CKAN 2's package .n3 output is not working

### DIFF
--- a/ckan/templates/package/read.n3
+++ b/ckan/templates/package/read.n3
@@ -5,10 +5,10 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
-<${ h.url_for(controller='package',action='read',id=c.pkg_dict['name'], qualified=True)}>
+{{ h.url_for(controller='package',action='read',id=c.pkg_dict['name'], qualified=True) }}
 a dcat:Dataset;
-     dct:description "${c.pkg_dict['notes']}";
-     dct:identifier "${c.pkg_dict['name']}";
+     dct:description "{{ c.pkg_dict['notes'] }}";
+     dct:identifier "{{ c.pkg_dict['name'] }}";
      dct:relation  [
          rdf:value "";
          :label "change_note" ],
@@ -39,7 +39,7 @@ a dcat:Dataset;
              [
          rdf:value "";
          :label "update_frequency" ];
-     dct:title "${c.pkg_dict['title']}";
-     :label "${c.pkg_dict['name']}";
-     = <urn:uuid:${c.pkg_dict['id']}>;
+     dct:title "{{ c.pkg_dict['title'] }}";
+     :label "{{ c.pkg_dict['name'] }}";
+     = <urn:uuid:{{ c.pkg_dict['id'] }}>;
      foaf:homepage <http://127.0.0.1:5000/dataset/testt> .


### PR DESCRIPTION
In CKAN 2, the template directives in templates_legacy/package/read.n3 are not being evaluated. They show up in the output, e.g.:

http://publicdata.eu/dataset/-ausgewaehlte-volkswirtschaftliche-kennziffern-2002-2010.n3

The read.rdf template seems to be working.

I would suggest removing support for N3 output in any case, since, as I raised on the mail list, the output is not guaranteed to be syntactically valid (and often won't be) because the template processor does not know that N3 string values must be escaped according to the rules of N3. Thread: http://lists.okfn.org/pipermail/ckan-dev/2012-September/003109.html