### PR TITLE
IValidator/IConverter reset cache automatically after plugin load

### DIFF
--- a/ckan/plugins/core.py
+++ b/ckan/plugins/core.py
@@ -138,6 +138,7 @@ def load(*plugins):
     '''
     Load named plugin(s).
     '''
+    from ckan.logic import clear_validators_cache, clear_converters_cache
 
     output = []
 
@@ -156,6 +157,10 @@ def load(*plugins):
         if interfaces.IGenshiStreamFilter in service.__interfaces__:
             log.warn("Plugin '%s' is using deprecated interface "
                      'IGenshiStreamFilter' % plugin)
+        if interfaces.IValidators in service.__interfaces__:
+            clear_validators_cache()
+        if interfaces.IConverters in service.__interfaces__:
+            clear_converters_cache()
 
         _PLUGINS.append(plugin)
         _PLUGINS_CLASS.append(service.__class__)

--- a/ckanext/example_ivalidators_iconverters/tests/test_ivalidators_iconverters.py
+++ b/ckanext/example_ivalidators_iconverters/tests/test_ivalidators_iconverters.py
@@ -2,7 +2,6 @@ from nose.tools import assert_equals, assert_raises
 import pylons.config as config
 
 from ckan.plugins.toolkit import get_validator, get_converter, Invalid
-from ckan.logic import clear_converters_cache, clear_validators_cache
 from ckan import plugins
 
 
@@ -10,7 +9,6 @@ class TestIValidators(object):
     @classmethod
     def setup_class(cls):
         plugins.load('example_ivalidators')
-        clear_validators_cache()
 
     @classmethod
     def teardown_class(cls):
@@ -29,7 +27,6 @@ class TestIConverters(object):
     @classmethod
     def setup_class(cls):
         plugins.load('example_iconverters')
-        clear_converters_cache()
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
cache invalidation is hard, but this seems like the correct time to do it (and it removes a special hack in the unit tests)
