### PR TITLE
[#1612] Treat zero as infinity for facets

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -598,7 +598,8 @@ def get_facet_items_dict(facet, limit=None, exclude_active=False):
     facets = sorted(facets, key=lambda item: item['count'], reverse=True)
     if c.search_facets_limits and limit is None:
         limit = c.search_facets_limits.get(facet)
-    if limit is not None:
+    # zero treated as infinite for hysterical raisins
+    if limit is not None and limit > 0:
         return facets[:limit]
     return facets
 


### PR DESCRIPTION
For historical reasons, limit=0 needs to be treated as infinity.
