### PR TITLE
Pin phantomjs version

### DIFF
--- a/bin/travis-install-dependencies
+++ b/bin/travis-install-dependencies
@@ -37,7 +37,7 @@ pip install -r dev-requirements.txt --allow-all-external
 python setup.py develop
 
 # Install npm dpes for mocha
-npm install -g mocha-phantomjs phantomjs
+npm install -g mocha-phantomjs@3.5.0 phantomjs@~1.9.1
 
 paster db init -c test-core.ini
 


### PR DESCRIPTION
Fix a travis npm error

```
npm ERR! peerinvalid The package phantomjs does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer mocha-phantomjs@3.5.0 wants phantomjs@~1.9.1
```

https://travis-ci.org/ckan/ckan/jobs/34413828#L1068
