### PR TITLE
i18n: Close a tag in French translation in Markdown syntax link

### DIFF
--- a/ckan/i18n/fr/LC_MESSAGES/ckan.po
+++ b/ckan/i18n/fr/LC_MESSAGES/ckan.po
@@ -3028,7 +3028,7 @@ msgstr "éléments connexes"
 msgid ""
 "You can use <a href=\"http://daringfireball.net/projects/markdown/syntax\" "
 "target=\"_blank\">Markdown formatting</a> here"
-msgstr "Vous pouvez utiliser <a href=\"http://daringfireball.net/projects/markdown/syntax\" target=\"_blank\">le formatage Markdown> ici"
+msgstr "Vous pouvez utiliser <a href=\"http://daringfireball.net/projects/markdown/syntax\" target=\"_blank\">le formatage Markdown</a> ici"
 
 #: ckan/templates/macros/form.html:264
 msgid "This field is required"


### PR DESCRIPTION
The a tag was wrongly closed in French translation. As a result, the link (automatically closed by browsers) would span too much leading to some actions not being usual in French.
