### PR TITLE
group/organization_member_create do not return a value.

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -1320,7 +1320,8 @@ def _group_or_org_member_create(context, data_dict, is_org=False):
         'session': session,
         'ignore_auth': context.get('ignore_auth'),
     }
-    logic.get_action('member_create')(member_create_context, member_dict)
+    return logic.get_action('member_create')(member_create_context,
+                                             member_dict)
 
 
 def group_member_create(context, data_dict):

--- a/ckan/new_tests/logic/action/test_create.py
+++ b/ckan/new_tests/logic/action/test_create.py
@@ -181,3 +181,44 @@ class TestResourceCreate(object):
 
         assert_raises(logic.ValidationError, helpers.call_action,
                       'resource_create', **data_dict)
+
+
+class TestMemberCreate(object):
+    @classmethod
+    def setup_class(cls):
+        helpers.reset_db()
+
+    def setup(self):
+        model.repo.rebuild_db()
+
+    def test_group_member_creation(self):
+        user = factories.User()
+        group = factories.Group()
+
+        new_membership = helpers.call_action(
+            'group_member_create',
+            id=group['id'],
+            username=user['name'],
+            role='member',
+        )
+
+        assert_equals(new_membership['group_id'], group['id'])
+        assert_equals(new_membership['table_name'], 'user')
+        assert_equals(new_membership['table_id'], user['id'])
+        assert_equals(new_membership['capacity'], 'member')
+
+    def test_organization_member_creation(self):
+        user = factories.User()
+        organization = factories.Organization()
+
+        new_membership = helpers.call_action(
+            'organization_member_create',
+            id=organization['id'],
+            username=user['name'],
+            role='member',
+        )
+
+        assert_equals(new_membership['group_id'], organization['id'])
+        assert_equals(new_membership['table_name'], 'user')
+        assert_equals(new_membership['table_id'], user['id'])
+        assert_equals(new_membership['capacity'], 'member')


### PR DESCRIPTION
member_create returns the dictized member https://github.com/ckan/ckan/blob/194d6c16149a3961111484ae43acfc0db8166e50/ckan/logic/action/create.py#L566 

but _group_or_org_member_create does not https://github.com/ckan/ckan/blob/194d6c16149a3961111484ae43acfc0db8166e50/ckan/logic/action/create.py#L1323, 

so https://github.com/ckan/ckan/blob/194d6c16149a3961111484ae43acfc0db8166e50/ckan/logic/action/create.py#L1364 group_member_create and organization_member_create have no return value.

e: just needs to add a return and add a test.
