### PR TITLE
Make placeholder images https enabled.

### DIFF
--- a/ckan/templates/home/snippets/promoted.html
+++ b/ckan/templates/home/snippets/promoted.html
@@ -19,7 +19,7 @@
       <h2 class="media-heading">{% block home_image_caption %}{{ _("This is a featured section") }}{% endblock %}</h2>
       {% block home_image_content %}
         <a class="media-image" href="#">
-          <img src="http://placehold.it/420x220" alt="Placeholder" width="420" height="220" />
+          <img src="//dummyimage.com/420x220/ccc/888" alt="Placeholder" width="420" height="220" />
         </a>
       {% endblock %}
     </section>

--- a/ckan/templates/snippets/related.html
+++ b/ckan/templates/snippets/related.html
@@ -4,7 +4,7 @@
     {% if item %}
       {% with url = h.url_for(controller='related', action='list', id=pkg_name) %}
         <a class="image logo" href="{{ url }}">
-          <img src="{{ item.image_url or "http://placehold.it/200x125" }}" width="200" height="125" alt="{{ item.title }}" />
+          <img src="{{ item.image_url or "//dummyimage.com/200x125/ccc/888" }}" width="200" height="125" alt="{{ item.title }}" />
         </a>
         <div class="media-content">
           <h3 class="media-heading"><a href="{{ url }}">{{ item.title }}</a></h3>


### PR DESCRIPTION
Loading http resources on https connection causes warnings and browsers,
depending on their configuration, will refuse to load them.

The change from placehold.it to dummyimage.com was necessitated by the
lack of https support on the later.
