### PR TITLE
Add dependencies needed by python requests for SNI support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -q -y install \
         apache2 \
         libapache2-mod-wsgi \
         postfix \
-        build-essential
+        build-essential \
+        libffi-dev
 
 # Install CKAN
 RUN virtualenv $CKAN_HOME

--- a/bin/travis-install-dependencies
+++ b/bin/travis-install-dependencies
@@ -14,7 +14,7 @@ fi
 
 # Install postgres and solr
 sudo apt-get update -qq
-sudo apt-get install postgresql-$PGVERSION solr-jetty libcommons-fileupload-java:amd64=1.2.2-1
+sudo apt-get install postgresql-$PGVERSION solr-jetty libcommons-fileupload-java:amd64=1.2.2-1 libffi-dev
 
 if [ $PGVERSION == '8.4' ]
 then

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -22,7 +22,7 @@ work on CKAN.
 If you're using a Debian-based operating system (such as Ubuntu) install the
 required packages with this command::
 
-    sudo apt-get install python-dev postgresql libpq-dev python-pip python-virtualenv git-core solr-jetty openjdk-6-jdk
+    sudo apt-get install python-dev postgresql libpq-dev python-pip python-virtualenv git-core solr-jetty openjdk-6-jdk libffi-dev
 
 If you're not using a Debian-based operating system, find the best way to
 install the following packages on your operating system (see

--- a/requirements.in
+++ b/requirements.in
@@ -33,3 +33,4 @@ WebHelpers==1.3
 WebOb==1.0.8
 zope.interface==4.0.1
 unicodecsv>=0.9
+pip>=1.5.6

--- a/requirements.in
+++ b/requirements.in
@@ -20,6 +20,9 @@ repoze.who-friendlyform==1.0.8
 repoze.who.plugins.openid==0.5.3
 repoze.who==1.0.19
 requests==2.3.0
+ndg-httpsclient==0.3.2 # needed for requests lib to work with SNI (https://en.wikipedia.org/wiki/Server_Name_Indication)
+pyasn1==0.1.7 # needed for requests lib to work with SNI
+pyOpenSSL==0.14 # needed for requests lib to work with SNI
 Routes==1.13
 solrpy==0.9.5
 sqlalchemy-migrate==0.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ ndg-httpsclient==0.3.2
 nose==1.3.0
 ofs==0.4.1
 passlib==1.6.2
+pip==1.5.6
 psycopg2==2.4.5
 pyOpenSSL==0.14
 pyasn1==0.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,12 +21,19 @@ WebOb==1.0.8
 WebTest==1.4.3
 apachemiddleware==0.1.1
 argparse==1.2.1
+cffi==0.8.6
+cryptography==0.5.4
 decorator==3.4.0
+distribute==0.6.24
 fanstatic==0.12
+ndg-httpsclient==0.3.2
 nose==1.3.0
 ofs==0.4.1
 passlib==1.6.2
 psycopg2==2.4.5
+pyOpenSSL==0.14
+pyasn1==0.1.7
+pycparser==2.10
 python-dateutil==1.5
 python-openid==2.2.5
 pyutilib.component.core==4.5.3
@@ -36,6 +43,7 @@ repoze.who-friendlyform==1.0.8
 repoze.who.plugins.openid==0.5.3
 requests==2.3.0
 simplejson==3.3.1
+six==1.8.0
 solrpy==0.9.5
 sqlalchemy-migrate==0.7.2
 sqlparse==0.1.11


### PR DESCRIPTION
The default python requests library for python2 is not able to handle
SNI enabled sites (sites with multiple https configurations per IP, see
https://en.wikipedia.org/wiki/Server_Name_Indication for more info).

To correct this, one needs to install pyOpenSSL, ndg-httpsclient and
pyasn1 (recommended packages for urllib3 in some distros, e.g. debian -
https://packages.debian.org/sid/python-urllib3 )