### PR TITLE
Remove method redefinition in DefaultGroupForm class

### DIFF
--- a/ckan/lib/plugins.py
+++ b/ckan/lib/plugins.py
@@ -341,14 +341,6 @@ class DefaultGroupForm(object):
         """
         return 'group/bulk_process.html'
 
-    def about_template(self):
-        '''Return the path to the template for the group's 'about' page.
-
-        :rtype: string
-
-        '''
-        return 'group/about.html'
-
     def group_form(self):
         return 'group/new_group_form.html'
 


### PR DESCRIPTION
The about_template method has already been defined. This removes the one that's least like the others.
