### PR TITLE
Don't get all datasets when loading the org in the dataset page

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1940,11 +1940,11 @@ def check_config_permission(permission):
     return new_authz.check_config_permission(permission)
 
 
-def get_organization(org=None):
+def get_organization(org=None, include_datasets=False):
     if org is None:
         return {}
     try:
-        return logic.get_action('organization_show')({}, {'id': org})
+        return logic.get_action('organization_show')({}, {'id': org, 'include_datasets': include_datasets})
     except (NotFound, ValidationError, NotAuthorized):
         return {}
 


### PR DESCRIPTION
In #1605 a helper is used to call `organization_show` to make sure all necessary fields are present for rendering the dataset page (eg `image_display_url`). This eventually calls `group_dictize`, which by default will return the orgs datasets.
This degrades performance unnecessarily so we should add `include_datasets: False` to the call.
