### PR TITLE
#1977 adding multilingual support for some missing views

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -1129,7 +1129,7 @@ class PackageController(base.BaseController):
 
     def resource_read(self, id, resource_id):
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'auth_user_obj': c.userobj}
+                   'user': c.user or c.author, 'auth_user_obj': c.userobj, "for_view":True}
 
         try:
             c.resource = get_action('resource_show')(context,

--- a/ckanext/multilingual/plugin.py
+++ b/ckanext/multilingual/plugin.py
@@ -1,7 +1,7 @@
 import sets
 import ckan
 from ckan.plugins import SingletonPlugin, implements, IPackageController
-from ckan.plugins import IGroupController, IOrganizationController, ITagController
+from ckan.plugins import IGroupController, IOrganizationController, ITagController, IResourceController
 import pylons
 from ckan.logic import get_action
 from pylons import config
@@ -32,7 +32,13 @@ def translate_data_dict(data_dict):
             continue
         else:
             for item in value:
-                terms.add(item)
+                if isinstance(value, dict):
+                    if key == (u'organization',) and item == 'description':
+                        terms.add(value[item])
+                    else:
+                        terms.add(item)
+                else:
+                    terms.add(item)
 
     # Get the translations of all the terms (as a list of dictionaries).
     translations = get_action('term_translation_show')(
@@ -76,7 +82,10 @@ def translate_data_dict(data_dict):
                         value, value)
 
         elif isinstance(value, (int, long, dict)):
-            translated_flattened[key] = value
+            if key == (u'organization',):
+                translated_flattened[key] = translate_data_dict(value);
+            else:
+                translated_flattened[key] = value
 
         else:
             translated_value = []
@@ -89,6 +98,92 @@ def translate_data_dict(data_dict):
                     )
             translated_flattened[key] = translated_value
 
+    # Finally unflatten and return the translated data dict.
+    translated_data_dict = (ckan.lib.navl.dictization_functions
+            .unflatten(translated_flattened))
+    return translated_data_dict
+
+def translate_resource_data_dict(data_dict):
+    '''Return the given dict with as many of its fields
+    as possible translated into the desired or the fallback language.
+
+    '''
+    desired_lang_code = pylons.request.environ['CKAN_LANG']
+    fallback_lang_code = pylons.config.get('ckan.locale_default', 'en')
+
+    # Get a flattened copy of data_dict to do the translation on.
+    flattened = ckan.lib.navl.dictization_functions.flatten_dict(
+            data_dict)
+
+    # Get a simple flat list of all the terms to be translated, from the
+    # flattened data dict.
+    terms = sets.Set()
+    for (key, value) in flattened.items():
+        if value in (None, True, False):
+            continue
+        elif isinstance(value, basestring):
+            terms.add(value)
+        elif isinstance(value, (int, long)):
+            continue
+        else:
+            for item in value:
+                 terms.add(item)
+
+    # Get the translations of all the terms (as a list of dictionaries).
+    translations = ckan.logic.action.get.term_translation_show(
+            {'model': ckan.model},
+            {'terms': terms,
+                'lang_codes': (desired_lang_code, fallback_lang_code)})
+    # Transform the translations into a more convenient structure.
+    desired_translations = {}
+    fallback_translations = {}
+    for translation in translations:
+        if translation['lang_code'] == desired_lang_code:
+            desired_translations[translation['term']] = (
+                    translation['term_translation'])
+        else:
+            assert translation['lang_code'] == fallback_lang_code
+            fallback_translations[translation['term']] = (
+                    translation['term_translation'])
+
+    # Make a copy of the flattened data dict with all the terms replaced by
+    # their translations, where available.
+    translated_flattened = {}
+    for (key, value) in flattened.items():
+
+        # Don't translate names that are used for form URLs.
+        if key == ('name',):
+            if value in desired_translations:
+                translated_flattened[key] = desired_translations[value]
+            elif value in fallback_translations:
+                translated_flattened[key] = fallback_translations.get(value, value)
+            else:
+                translated_flattened[key] = value
+
+        elif value in (None, True, False):
+            # Don't try to translate values that aren't strings.
+            translated_flattened[key] = value
+
+        elif isinstance(value, basestring):
+            if value in desired_translations:
+                translated_flattened[key] = desired_translations[value]
+            else:
+                translated_flattened[key] = fallback_translations.get(
+                        value, value)
+
+        elif isinstance(value, (int, long, dict)):
+            translated_flattened[key] = value
+
+        else:
+            translated_value = []
+            for item in value:
+                if item in desired_translations:
+                    translated_value.append(desired_translations[item])
+                else:
+                    translated_value.append(
+                        fallback_translations.get(item, item)
+                    )
+            translated_flattened[key] = translated_value
     # Finally unflatten and return the translated data dict.
     translated_data_dict = (ckan.lib.navl.dictization_functions
             .unflatten(translated_flattened))
@@ -274,4 +369,15 @@ class MultilingualTag(SingletonPlugin):
 
     def before_view(self, data_dict):
         translated_data_dict = translate_data_dict(data_dict)
+        return translated_data_dict
+
+class MultilingualResource(SingletonPlugin):
+   '''The MultilinguaResource plugin translate the selected resource name and description on resource
+   preview page.
+
+   '''
+   implements(IResourceController, inherit=True)
+
+   def before_show(self, data_dict):
+        translated_data_dict = translate_resource_data_dict(data_dict)
         return translated_data_dict

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ entry_points = {
         'multilingual_dataset = ckanext.multilingual.plugin:MultilingualDataset',
         'multilingual_group = ckanext.multilingual.plugin:MultilingualGroup',
         'multilingual_tag = ckanext.multilingual.plugin:MultilingualTag',
+        'multilingual_resource = ckanext.multilingual.plugin:MultilingualResource',    
         'organizations = ckanext.organizations.forms:OrganizationForm',
         'organizations_dataset = ckanext.organizations.forms:OrganizationDatasetForm',
         'datastore = ckanext.datastore.plugin:DatastorePlugin',


### PR DESCRIPTION
added multilingual support for:
* Organization title and description in the sidebar widget in the dataset view (corresponding to snippets/organization.html
* in the resource preview (package/resource_read.html) page are now properly translated these elements: 
  * *page title* where there are the dataset name and resource name, 
  * *breadcrumb* same as page title
  * *resource name*
  * *resource description* 
