### PR TITLE
[#1984] exclude trailing ,.; in external link

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1556,7 +1556,7 @@ RE_MD_INTERNAL_LINK = re.compile(
 
 # find external links eg http://foo.com, https://bar.org/foobar.html
 RE_MD_EXTERNAL_LINK = re.compile(
-    r'(\bhttps?:\/\/[\w\-\.,@?^=%&;:\/~\\+#]*)',
+    r'(\bhttps?:\/\/[\w\-\.,@?^=%&;:\/~\\+#]*[\w\-@?^=%&:\/~\\+#])',
     flags=re.UNICODE
 )
 


### PR DESCRIPTION
To fix issue #1984, the end char in the regex pattern can be anything but `,.;`
