### PR TITLE
Tests should be grouped by class

### DIFF
--- a/doc/contributing/testing.rst
+++ b/doc/contributing/testing.rst
@@ -156,15 +156,31 @@ updating things in CKAN. This means that
 number of test functions.
 
 So as well as the name of each test method explaining the intent of the test,
-it's important to name the test function after the function it's testing, for
-example all the tests for ``user_update`` should be named
-``test_user_update_*``.
+tests should be grouped by a test class that aggregates tests against a model
+entity or action type, for instance::
+
+    class TestPackageCreate(object):
+        # ...
+        def test_it_validates_name(self):
+            # ...
+
+        def test_it_validates_url(self):
+            # ...
+
+
+    class TestResourceCreate(object)
+        # ...
+        def test_it_validates_package_id(self):
+            # ...
+
+    # ...
+
 
 Good test names:
 
-* ``test_user_update_with_id_that_does_not_exist``
-* ``test_user_update_with_no_id``
-* ``test_user_update_with_invalid_name``
+* ``TestUserUpdate.test_update_with_id_that_does_not_exist``
+* ``TestUserUpdate.test_update_with_no_id``
+* ``TestUserUpdate.test_update_with_invalid_name``
 
 Bad test names:
 


### PR DESCRIPTION
Our testing coding standards tells us to group related tests by using the same
prefix. For example, every test for `package_create` would begin with
`test_package_create_*`. Instead of doing that, I'm proposing to group the
tests by class. For example, right now, the tests will look like:

``` python
class TestCreate(object):
    # ...

    def test_package_create_validates_name(self):
        # ...

    def test_package_create_validates_url(self):
        # ...

    def test_resource_create_validates_package_id(self):
        # ...

    # ...
```

With this new proposal, this would change to:

``` python
class TestPackageCreate(object):
    # ...
    def test_package_create_validates_name(self):
        # ...

    def test_package_create_validates_url(self):
        # ...


class TestResourceCreate(object)
    # ...
    def test_resource_create_validates_package_id(self):
        # ...

# ...
```

This makes it possible to run just the tests for a single action method, and
IMO makes the tests more organized, specially on the logic layer's tests.
