### PR TITLE
[#1963] Improve error messages on datastore upload page.

### DIFF
--- a/ckan/templates/package/resource_data.html
+++ b/ckan/templates/package/resource_data.html
@@ -46,15 +46,13 @@
         <td>{{ _('Never') }}</td>
       {% endif %}
     </tr>
-    {% if status.task_info and status.task_info.error %}
+    {% if status.task_info and status.task_info.error and status.task_info.error.response %}
       {% for error_key, error_value in status.task_info.error.response.error.iteritems() %}
         <tr>
           <th>Error {{ error_key }}</th>
           <td>{{ error_value }}</td>
         </tr>
       {% endfor %}
-    {% endif %}
-    {% if status.task_info.error.response %}
     <tr class="toggle-more">
       <th>{{ _('Error Raw Response') }}</th>
       <td>{{ status.task_info.error.response }}</td>


### PR DESCRIPTION
- Show the log even when the job has errored. (Users probably only really care about the log when jobs have errored, so we shouldn't hide it)
- Split up parts the flash error message to the status table
- If the error contains more detailed job info, show that in the status
  table. Add the raw response to the table but hidden

also requires https://github.com/ckan/ckan-service-provider/pull/19 and https://github.com/ckan/datapusher/pull/51.

All three of these combined gives the slightly more user friendly.
![datastore_error](https://cloud.githubusercontent.com/assets/241130/4773921/d6310474-5ba7-11e4-83b0-08e3c024861f.png)
