### PR TITLE
Remove redundant API call in Recline grid preview

### DIFF
--- a/ckanext/reclineview/theme/public/recline_view.js
+++ b/ckanext/reclineview/theme/public/recline_view.js
@@ -63,7 +63,7 @@ this.ckan.module('recline_view', function (jQuery, _) {
         });
       }
 
-      dataset.query(query);
+      dataset.queryState.set(query.toJSON(), {silent: true});
 
       errorMsg = this.options.i18n.errorLoadingPreview + ': ' + this.options.i18n.errorDataStore;
       dataset.fetch()


### PR DESCRIPTION
As described in #2009, the recline grid view sends multiple requests to the `datastore_search` API. In particular two of those queries are exactly the same, and include the full search terms - making this a significant performance hits on slower queries.

The problem is in `ckanext/reclineview/theme/public/recline_view.js`, in the `loadView` method of the `recline_view` module.

See the code at https://github.com/ckan/ckan/blob/master/ckanext/reclineview/theme/public/recline_view.js#L66 :
- `dataset.query(query)` is called. This has two effects:
  1. It sets the dataset's `queryState` to the given query;
  2. It runs the actual query by invoking the datastore search API on the server;
- `dataset.fetch()` is called. This has two effects:
  1. It invokes the datastore search API with an empty query, to initialize the dataset;
  2. It calls `dataset.query()` again, without parameters, which causes the previously applied query to be run again (by invoking the datastore API on the server).

Of the three queries, really only one should be needed. The second query (the empty query) is done internally by Recline - however the third query can be avoided at CKAN level. Indeed, given that `dataset.query` is invoked by `dataset.fetch`, the only point in calling `dataset.query(query)` in the first instance was to set the query parameters on the dataset object.

A better approach which avoids this extra query is to set the query parameters directly - which is what this PR does.
