### PR TITLE
[#2013] Fix for paster serve restart bug

### DIFF
--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -362,7 +362,7 @@ content type, cookies, etc.
         else:
             if name == '__bases__':
                 return self.__class__.__bases__
-            raise Exception('`%s` not found in plugins toolkit' % name)
+            raise AttributeError('`%s` not found in plugins toolkit' % name)
 
     def __dir__(self):
         if not self._toolkit:


### PR DESCRIPTION
Issue: #2013

paster's restart-monitor gets a list of files by iterating over sys.modules,
which appears to include Toolkit. It calls **file** and that causes the exception.
However paster catches an AttributeError fine and continues, whereas a plain
Exception causes the whole restart-monitor thread to crash. AttributeError also
makes more sense for a failed class attribute access.
