### PR TITLE
Clear solr search index in FunctionalTestBase setup

### DIFF
--- a/ckan/new_tests/helpers.py
+++ b/ckan/new_tests/helpers.py
@@ -21,6 +21,7 @@ import webtest
 from pylons import config
 import nose.tools
 
+import ckan.lib.search as search
 import ckan.config.middleware
 import ckan.model as model
 import ckan.logic as logic
@@ -185,7 +186,9 @@ class FunctionalTestBase(object):
         pass
 
     def setup(self):
+        '''Reset the database and clear the search indexes.'''
         reset_db()
+        search.clear()
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
I'm getting package objects persisting in the search index across test runs. This seems like a sensible place to clear them.
