### PR TITLE
Getting Start docs specify nonexistent development.ini

### DIFF
--- a/doc/maintaining/getting-started.rst
+++ b/doc/maintaining/getting-started.rst
@@ -36,7 +36,7 @@ example, to create a user called ``seanh`` and make him a sysadmin:
 
 .. parsed-literal::
 
-   paster sysadmin add seanh -c |development.ini|
+   paster sysadmin add seanh -c |production.ini|
 
 If a user called ``seanh`` already exists he will be promoted to a sysadmin. If
 the user account doesn't exist yet you'll be prompted to enter a password and
@@ -61,7 +61,7 @@ command line with the ``create-test-data`` command:
 
 .. parsed-literal::
 
-   paster create-test-data -c |development.ini|
+   paster create-test-data -c |production.ini|
 
 If you later want to delete this test data and start again with an empty
 database, you can use the ``db clean`` command, see :ref:`paster db`.


### PR DESCRIPTION
[The "Creating a Sysadmin User" portion of the "Getting Started" documentation](http://docs.ckan.org/en/latest/maintaining/getting-started.html#create-admin-user) specifies invoking paster with `paster sysadmin add seanh -c /etc/ckan/default/development.ini`. This does not work in a package installation, as the package doesn't include a `development.ini` file. Instead, it includes only:

``` bash
$ ls /etc/ckan/default
apache.wsgi  production.ini  who.ini
```

I was able to proceed with `paster sysadmin add seanh -c /etc/ckan/default/production.ini`.

The fix is, presumably, to either specify the correct filename in the documentation or to include `development.ini` in the in `http://packaging.ckan.org/python-ckan-2.0_amd64.deb`.
