### PR TITLE
can not edit read-only resources -- datastore test problem

### DIFF
--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -167,16 +167,19 @@ This should return a JSON page without errors.
 To test the whether the set-up allows writing, you can create a new DataStore resource.
 To do so, run the following command::
 
- curl -X POST http://127.0.0.1:5000/api/3/action/datastore_create -H "Authorization: {YOUR-API-KEY}" -d '{"resource_id": "{RESOURCE-ID}", "fields": [ {"id": "a"}, {"id": "b"} ], "records": [ { "a": 1, "b": "xyz"}, {"a": 2, "b": "zzz"} ]}'
+ curl -X POST http://127.0.0.1:5000/api/3/action/datastore_create -H "Authorization: {YOUR-API-KEY}" -d '{"resource": {"package_id": "{PACKAGE-ID}"}, "fields": [ {"id": "a"}, {"id": "b"} ], "records": [ { "a": 1, "b": "xyz"}, {"a": 2, "b": "zzz"} ]}'
 
-Replace ``{YOUR-API-KEY}`` with a valid API key and ``{RESOURCE-ID}`` with the
-id of an existing CKAN resource.
+Replace ``{YOUR-API-KEY}`` with a valid API key and ``{PACKAGE-ID}`` with the
+id of an existing CKAN dataset.
 
 A table named after the resource id should have been created on your DataStore
 database. Visiting this URL should return a response from the DataStore with
 the records inserted above::
 
  http://127.0.0.1:5000/api/3/action/datastore_search?resource_id={RESOURCE_ID}
+
+Replace ``{RESOURCE-ID}`` with the resource id that was returned as part of the
+response of the previous API call.
 
 You can now delete the DataStore table with::
 


### PR DESCRIPTION
when i run the test up for datastore with api curl -X POST http://127.0.0.1:5000/api/3/action/datastore_create -H "Authorization: {YOUR-API-KEY}" -d '{"resource_id": "{RESOURCE-ID}", "fields": [ {"id": "a"}, {"id": "b"} ], "records": [ { "a": 1, "b": "xyz"}, {"a": 2, "b": "zzz"} ]}' 

i changed the api key and resource id

i received that can not edit read-only resources, either pass force=true or change url type

then where to add force=true ?

thanks
