### PR TITLE
activity query performance improvements part 1

### DIFF
--- a/ckan/model/activity.py
+++ b/ckan/model/activity.py
@@ -93,7 +93,7 @@ def _activities_union_all(*qlist):
     and remove duplicates
     '''
     import ckan.model as model
-    return model.Session.query(model.Activity).select_from(
+    return model.Session.query(model.Activity).select_entity_from(
         union_all(*[q.subquery().select() for q in qlist])
         ).distinct(model.Activity.timestamp)
 


### PR DESCRIPTION
This is an attempt at a "minimal" fix for #2008 

"minimal" in quotes because this change makes the original query even larger by passing down the limits to each subquery. The effect is to limit the run time of the query in the most common cases without changing the structure of the query, in the hope that this can be treated as a fix and be allowed in to 2.3

Part 2 would be a rewrite of this query, hopefully:
1. not using subqueries
2. using joins instead of passing in lists of values queried separately
3. adding a parameter to limit the activity date ranges that we're interested in (no older than..) so that the every-single-page dashboard query of unseen activities can be made faster
