### PR TITLE
Remove group_package_show

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1230,39 +1230,6 @@ def organization_show(context, data_dict):
     return _group_or_org_show(context, data_dict, is_org=True)
 
 
-def group_package_show(context, data_dict):
-    '''Return the datasets (packages) of a group.
-
-    :param id: the id or name of the group
-    :type id: string
-    :param limit: the maximum number of datasets to return (optional)
-    :type limit: int
-
-    :rtype: list of dictionaries
-
-    '''
-    model = context['model']
-    group_id = _get_or_bust(data_dict, 'id')
-
-    # FIXME: What if limit is not an int? Schema and validation needed.
-    limit = data_dict.get('limit')
-
-    group = model.Group.get(group_id)
-    context['group'] = group
-    if group is None:
-        raise NotFound
-
-    _check_access('group_show', context, data_dict)
-
-    result = []
-    for pkg_rev in group.packages(
-            limit=limit,
-            return_query=context.get('return_query')):
-        result.append(model_dictize.package_dictize(pkg_rev, context))
-
-    return result
-
-
 def tag_show(context, data_dict):
     '''Return the details of a tag and all its datasets.
 

--- a/ckan/tests/logic/test_action.py
+++ b/ckan/tests/logic/test_action.py
@@ -853,41 +853,6 @@ class TestAction(WsgiAppCase):
         user = model.Session.query(model.User).filter_by(name=site_id).one()
         assert user
 
-    def test_28_group_package_show(self):
-        group_id = model.Group.get('david').id
-        group_packages = get_action('group_package_show')(
-            {'model': model, 'user': self.normal_user.name, 'ignore_auth': True},
-            {'id': group_id}
-        )
-        assert len(group_packages) == 2, group_packages
-        group_names = set([g.get('name') for g in group_packages])
-        assert group_names == set(['annakarenina', 'warandpeace']), group_names
-
-    def test_29_group_package_show_pending(self):
-        context = {'model': model, 'session': model.Session, 'user': self.sysadmin_user.name, 'api_version': 2, 'ignore_auth': True}
-        group = {
-            'name': 'test_group_pending_package',
-            'packages': [{'id': model.Package.get('annakarenina').id}]
-        }
-        group = get_action('group_create')(context, group)
-
-        pkg = {
-            'name': 'test_pending_package',
-            'groups': [{'id': group['id']}]
-        }
-        pkg = get_action('package_create')(context, pkg)
-        # can't seem to add a package with 'pending' state, so update it
-        pkg['state'] = 'pending'
-        get_action('package_update')(context, pkg)
-
-        group_packages = get_action('group_package_show')(context, {'id': group['id']})
-        assert len(group_packages) == 2, (len(group_packages), group_packages)
-        group_names = set([g.get('name') for g in group_packages])
-        assert group_names == set(['annakarenina', 'test_pending_package']), group_names
-
-        get_action('group_delete')(context, group)
-        get_action('package_delete')(context, pkg)
-
     def test_30_status_show(self):
         postparams = '%s=1' % json.dumps({})
         res = self.app.post('/api/action/status_show', params=postparams)


### PR DESCRIPTION
See #1557 

The same output can be obtained by calling `package_search` with the `fq=groups:group_id` filter
