### PR TITLE
2054-fix meta property og:description

### DIFF
--- a/ckan/templates/package/read_base.html
+++ b/ckan/templates/package/read_base.html
@@ -11,7 +11,7 @@
   {{ super() }}
   {% set description = h.markdown_extract(pkg.notes, extract_length=200)|forceescape %}
   <meta property="og:title" content="{{ h.dataset_display_name(pkg) }} - {{ g.site_title }}">
-  <meta property="og:description" content="{{ description|forceescape }}">
+  <meta property="og:description" content="{{ description|forceescape|trim }}">
 {% endblock -%}
 
 {% block content_action %}


### PR DESCRIPTION
fixes #2054 by trimming whitespace
