### PR TITLE
Fixes #2007 by ensuring the datastore_active flag is always present.

### DIFF
--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -273,6 +273,9 @@ class DatastorePlugin(p.SingletonPlugin):
                 action='dump', resource_id=resource_dict['id'])
 
         connection = None
+
+        resource_dict['datastore_active'] = False
+
         try:
             connection = self.read_engine.connect()
             result = connection.execute(
@@ -281,8 +284,6 @@ class DatastorePlugin(p.SingletonPlugin):
             ).fetchone()
             if result:
                 resource_dict['datastore_active'] = True
-            else:
-                resource_dict['datastore_active'] = False
         finally:
             if connection:
                 connection.close()


### PR DESCRIPTION
In the plugins before_show the datastore_active flag in the resource
dict would not be set if the sql query generated an exception.  This had
implications with pg 8.4 where the flag was not present because of a
query failure, but it was checked for in tests.

Have set the default to false and just overwrites it if
1. The query does not explode 
2. It returns a result.
