### PR TITLE
Does not load site_user during db upgrade

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -135,7 +135,7 @@ class CkanCommand(paste.script.command.Command):
         fileConfig(self.filename)
         return appconfig('config:' + self.filename)
 
-    def _load_config(self):
+    def _load_config(self, load_site_user=True):
         conf = self._get_config()
         assert 'ckan' not in dir() # otherwise loggers would be disabled
         # We have now loaded the config. Now we can import ckan for the
@@ -149,7 +149,7 @@ class CkanCommand(paste.script.command.Command):
         self.translator_obj = MockTranslator()
         self.registry.register(pylons.translator, self.translator_obj)
 
-        if model.user_table.exists():
+        if model.user_table.exists() and load_site_user:
             # If the DB has already been initialized, create and register
             # a pylons context object, and add the site user to it, so the
             # auth works as in a normal web request
@@ -199,11 +199,12 @@ class ManageDb(CkanCommand):
     min_args = 1
 
     def command(self):
-        self._load_config()
+        cmd = self.args[0]
+
+        self._load_config(cmd!='upgrade')
         import ckan.model as model
         import ckan.lib.search as search
 
-        cmd = self.args[0]
         if cmd == 'init':
 
             model.repo.init_db()


### PR DESCRIPTION
Fixes #2029 by ensuring we do not attempt to load site_user during a db upgrade.  This is a workaround because loading the site_user will fail because of a failed user change.  Should also avoid the problem in
future.
