### PR TITLE
Upgrade zope.interfaces to 4.1.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -27,5 +27,5 @@ vdm==0.13
 sqlparse==0.1.11
 WebHelpers==1.3
 WebOb==1.0.8
-zope.interface==4.0.1
+zope.interface==4.1.1
 unicodecsv>=0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,4 +43,4 @@ sqlparse==0.1.11
 unicodecsv==0.9.4
 vdm==0.13
 wsgiref==0.1.2
-zope.interface==4.0.1
+zope.interface==4.1.1


### PR DESCRIPTION
I don't think it makes any practical difference, but repoze.who 2.0 requires 4.1.1 (master is currently on 4.0.1). Pypi has the changelog here: https://pypi.python.org/pypi/zope.interface/4.1.1
