### PR TITLE
Fixes the problem finding development.ini

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -124,7 +124,7 @@ class CkanCommand(paste.script.command.Command):
             self.filename = os.environ.get('CKAN_INI')
             config_source = '$CKAN_INI'
         else:
-            self.filename = 'development.ini'
+            self.filename = os.path.join(os.getcwd(), 'development.ini')
             config_source = 'default value'
 
         if not os.path.exists(self.filename):


### PR DESCRIPTION
Unfortunately the code forgot to use os.cwd() to  ensure config was
loaded with an absolute path, and was trying to load it relative without
knowing from where.
