### PR TITLE
fallback IDatasetForm plugins should force type, no fallback should force type='dataset'

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -134,7 +134,7 @@ def package_create(context, data_dict):
             package_type = package_plugin.package_types()[0]
         except (AttributeError, IndexError):
             package_type = 'dataset'
-            # in case a 'dataset' plugin was registeres w/o fallback
+            # in case a 'dataset' plugin was registered w/o fallback
             package_plugin = lib_plugins.lookup_package_plugin(package_type)
         data_dict['type'] = package_type
     else:


### PR DESCRIPTION
## Problem 1

IDatasetForm plugins may have an `is_fallback()` method that returns True. Such a plugin may also have a `package_types()` method that returns something _other_ than `['dataset']`.

In this case `package_create` with no `type` value will use the one plugin to validate dataset fields, but the dataset will be saved with `type='dataset'` possibly causing a different plugin to be used for `package_update`.
## Problem 2

IDatasetForm plugins may have an `is_fallback()` method that returns False. Such a plugin may also have a `package_types()` method that returns `['dataset']`.

In this case `package_create` with no `type` will use the DefaultDatasetForm validate dataset fields, but the dataset will be saved with `type='dataset'` causing the plugin to be used for `package_update`.
