### PR TITLE
Removes site-read auth check.

### DIFF
--- a/ckan/controllers/api.py
+++ b/ckan/controllers/api.py
@@ -51,19 +51,6 @@ class ApiController(base.BaseController):
             routes_dict['ver'] = int(api_version)
 
         self._identify_user()
-        try:
-            context = {'model': model, 'user': c.user or c.author,
-                       'auth_user_obj': c.userobj}
-            logic.check_access('site_read', context)
-        except NotAuthorized:
-            response_msg = self._finish(403,
-                                        _('Not authorized to see this page'))
-            # Call start_response manually instead of the parent __call__
-            # because we want to end the request instead of continuing.
-            response_msg = response_msg.encode('utf8')
-            body = '%i %s' % (response.status_int, response_msg)
-            start_response(body, response.headers.items())
-            return [response_msg]
 
         # avoid status_code_redirect intercepting error responses
         environ['pylons.status_code_redirect'] = True
@@ -200,7 +187,7 @@ class ApiController(base.BaseController):
             return_dict['error'] = {'__type': 'Authorization Error',
                                     'message': _('Access denied')}
             return_dict['success'] = False
-            
+
             if e.extra_msg:
                 return_dict['error']['message'] += ': %s' % e.extra_msg
 

--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -145,10 +145,6 @@ class GroupController(base.BaseController):
         sort_by = c.sort_by_selected = request.params.get('sort')
         if sort_by:
             data_dict['sort'] = sort_by
-        try:
-            self._check_access('site_read', context)
-        except NotAuthorized:
-            abort(401, _('Not authorized to see this page'))
 
         # pass user info to context as needed to view private datasets of
         # orgs correctly

--- a/ckan/controllers/home.py
+++ b/ckan/controllers/home.py
@@ -19,27 +19,6 @@ dirty_cached_group_stuff = None
 class HomeController(base.BaseController):
     repo = model.repo
 
-    def __before__(self, action, **env):
-        try:
-            base.BaseController.__before__(self, action, **env)
-            context = {'model': model, 'user': c.user or c.author,
-                       'auth_user_obj': c.userobj}
-            logic.check_access('site_read', context)
-        except logic.NotAuthorized:
-            base.abort(401, _('Not authorized to see this page'))
-        except (sqlalchemy.exc.ProgrammingError,
-                sqlalchemy.exc.OperationalError), e:
-            # postgres and sqlite errors for missing tables
-            msg = str(e)
-            if ('relation' in msg and 'does not exist' in msg) or \
-                    ('no such table' in msg):
-                # table missing, major database problem
-                base.abort(503, _('This site is currently off-line. Database '
-                                  'is not initialised.'))
-                # TODO: send an email to the admin person (#1285)
-            else:
-                raise
-
     def index(self):
         try:
             # package search

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -137,13 +137,6 @@ class PackageController(base.BaseController):
 
         package_type = self._guess_package_type()
 
-        try:
-            context = {'model': model, 'user': c.user or c.author,
-                       'auth_user_obj': c.userobj}
-            check_access('site_read', context)
-        except NotAuthorized:
-            abort(401, _('Not authorized to see this page'))
-
         # unicode format (decoded from utf8)
         q = c.q = request.params.get('q', u'')
         c.query_error = False

--- a/ckan/controllers/revision.py
+++ b/ckan/controllers/revision.py
@@ -25,10 +25,6 @@ class RevisionController(base.BaseController):
                 c.revision_change_state_allowed = False
         else:
             c.revision_change_state_allowed = False
-        try:
-            logic.check_access('site_read', context)
-        except logic.NotAuthorized:
-            base.abort(401, _('Not authorized to see this page'))
 
     def index(self):
         return self.list()

--- a/ckan/controllers/tag.py
+++ b/ckan/controllers/tag.py
@@ -13,15 +13,6 @@ LIMIT = 25
 
 class TagController(base.BaseController):
 
-    def __before__(self, action, **env):
-        base.BaseController.__before__(self, action, **env)
-        try:
-            context = {'model': model, 'user': c.user or c.author,
-                       'auth_user_obj': c.userobj}
-            logic.check_access('site_read', context)
-        except logic.NotAuthorized:
-            base.abort(401, _('Not authorized to see this page'))
-
     def index(self):
         c.q = request.params.get('q', '')
 

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -34,15 +34,6 @@ unflatten = dictization_functions.unflatten
 
 
 class UserController(base.BaseController):
-    def __before__(self, action, **env):
-        base.BaseController.__before__(self, action, **env)
-        try:
-            context = {'model': model, 'user': c.user or c.author,
-                       'auth_user_obj': c.userobj}
-            check_access('site_read', context)
-        except NotAuthorized:
-            if c.action not in ('login', 'request_reset', 'perform_reset',):
-                abort(401, _('Not authorized to see this page'))
 
     ## hooks for subclasses
     new_user_form = 'user/new_user_form.html'

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -91,15 +91,6 @@ def _package_list_with_resources(context, package_revision_list):
     return package_list
 
 
-def site_read(context, data_dict=None):
-    '''Return ``True``.
-
-    :rtype: boolean
-    '''
-    _check_access('site_read', context, data_dict)
-    return True
-
-
 @logic.validate(logic.schema.default_pagination_schema)
 def package_list(context, data_dict):
     '''Return a list of the names of the site's datasets (packages).

--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -9,18 +9,6 @@ def sysadmin(context, data_dict):
     ''' This is a pseudo check if we are a sysadmin all checks are true '''
     return {'success': False, 'msg': _('Not authorized')}
 
-
-def site_read(context, data_dict):
-    """\
-    This function should be deprecated. It is only here because we couldn't
-    get hold of Friedrich to ask what it was for.
-
-    ./ckan/controllers/api.py
-    """
-
-    # FIXME we need to remove this for now we allow site read
-    return {'success': True}
-
 def package_search(context, data_dict):
     # Everyone can search by default
     return {'success': True}

--- a/ckan/model/authz.py
+++ b/ckan/model/authz.py
@@ -57,7 +57,6 @@ class Action(Enum):
     EDIT_PERMISSIONS = u'edit-permissions'
     PACKAGE_CREATE = u'create-package'
     GROUP_CREATE = u'create-group'
-    SITE_READ = u'read-site'
     USER_READ = u'read-user'
     USER_CREATE = u'create-user'
     UPLOAD_ACTION = u'file-upload'
@@ -78,19 +77,16 @@ default_role_actions = [
     (Role.EDITOR, Action.GROUP_CREATE),
     (Role.EDITOR, Action.USER_CREATE),
     (Role.EDITOR, Action.USER_READ),
-    (Role.EDITOR, Action.SITE_READ),
     (Role.EDITOR, Action.READ),
     (Role.EDITOR, Action.UPLOAD_ACTION),
     (Role.ANON_EDITOR, Action.EDIT),
     (Role.ANON_EDITOR, Action.PACKAGE_CREATE),
     (Role.ANON_EDITOR, Action.USER_CREATE),
     (Role.ANON_EDITOR, Action.USER_READ),
-    (Role.ANON_EDITOR, Action.SITE_READ),
     (Role.ANON_EDITOR, Action.READ),
     (Role.ANON_EDITOR, Action.UPLOAD_ACTION),
     (Role.READER, Action.USER_CREATE),
     (Role.READER, Action.USER_READ),
-    (Role.READER, Action.SITE_READ),
     (Role.READER, Action.READ),
     ]
 


### PR DESCRIPTION
The check always returns true, and the action function only returns
True.  Nobody knows why it was there, so it's been removed.

This should close #2087 
