### PR TITLE
[#2082] Randomize table name created to test datastore permissions

### DIFF
--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -197,7 +197,7 @@ class DatastorePlugin(p.SingletonPlugin):
 
         # create a nice random table name
         chars = string.lowercase
-        table_name = ''.join(random.choice(chars) for _ in range(9))
+        table_name = '_' + ''.join(random.choice(chars) for _ in range(9))
         
         drop_foo_sql = u'DROP TABLE IF EXISTS ' + table_name
 


### PR DESCRIPTION
creates a random string for the table name created at startup time to test db privileges.
