### PR TITLE
'allow-partial-update' documented for 2 action funcs

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -619,8 +619,8 @@ def group_update(context, data_dict):
     :rtype: dictionary
 
     '''
-    # Callers that set context['allow_partial_update'] = True can choose not
-    # to specify particular keys and they will not be left at their existing
+    # Callers that set context['allow_partial_update'] = True can choose to not
+    # to specify particular keys and they will be left at their existing
     # values. This includes: packages, users, groups, tags, extras
     return _group_or_org_update(context, data_dict)
 
@@ -642,8 +642,8 @@ def organization_update(context, data_dict):
     :rtype: dictionary
 
     '''
-    # Callers that set context['allow_partial_update'] = True can choose not
-    # to specify particular keys and they will not be left at their existing
+    # Callers that set context['allow_partial_update'] = True can choose to not
+    # to specify particular keys and they will be left at their existing
     # values. This includes: users, groups, tags, extras
     return _group_or_org_update(context, data_dict, is_org=True)
 

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -620,7 +620,7 @@ def group_update(context, data_dict):
 
     '''
     # Callers that set context['allow_partial_update'] = True can choose to not
-    # to specify particular keys and they will be left at their existing
+    # specify particular keys and they will be left at their existing
     # values. This includes: packages, users, groups, tags, extras
     return _group_or_org_update(context, data_dict)
 
@@ -643,7 +643,7 @@ def organization_update(context, data_dict):
 
     '''
     # Callers that set context['allow_partial_update'] = True can choose to not
-    # to specify particular keys and they will be left at their existing
+    # specify particular keys and they will be left at their existing
     # values. This includes: users, groups, tags, extras
     return _group_or_org_update(context, data_dict, is_org=True)
 

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -619,6 +619,9 @@ def group_update(context, data_dict):
     :rtype: dictionary
 
     '''
+    # Callers that set context['allow_partial_update'] = True can choose not
+    # to specify particular keys and they will not be left at their existing
+    # values. This includes: packages, users, groups, tags, extras
     return _group_or_org_update(context, data_dict)
 
 def organization_update(context, data_dict):
@@ -639,6 +642,9 @@ def organization_update(context, data_dict):
     :rtype: dictionary
 
     '''
+    # Callers that set context['allow_partial_update'] = True can choose not
+    # to specify particular keys and they will not be left at their existing
+    # values. This includes: users, groups, tags, extras
     return _group_or_org_update(context, data_dict, is_org=True)
 
 def user_update(context, data_dict):


### PR DESCRIPTION
Not in docstring to stop it showing over the API where it cannot be set - this option is just for internal callers.

Issue: https://github.com/ckan/ckan/issues/2095