### PR TITLE
[#1912] Allow sysadmin to change featured image, image link and text in ...

### DIFF
--- a/ckan/controllers/admin.py
+++ b/ckan/controllers/admin.py
@@ -46,6 +46,9 @@ class AdminController(base.BaseController):
             {'name': 'ckan.site_logo', 'control': 'input', 'label': _('Site Tag Logo'), 'placeholder': ''},
             {'name': 'ckan.site_about', 'control': 'markdown', 'label': _('About'), 'placeholder': _('About page text')},
             {'name': 'ckan.site_intro_text', 'control': 'markdown', 'label': _('Intro Text'), 'placeholder': _('Text on home page')},
+            {'name': 'ckan.featured_image', 'control': 'input', 'label': _('Featured Image'), 'placeholder': ''},
+            {'name': 'ckan.featured_link', 'control': 'input', 'label': _('Featured Link'), 'placeholder': ''},
+            {'name': 'ckan.featured_text', 'control': 'input', 'label': _('Featured Text'), 'placeholder': ''},
             {'name': 'ckan.site_custom_css', 'control': 'textarea', 'label': _('Custom CSS'), 'placeholder': _('Customisable css inserted into the page header')},
             {'name': 'ckan.homepage_style', 'control': 'select', 'options': homepages, 'label': _('Homepage'), 'placeholder': ''},
         ]

--- a/ckan/templates/admin/config.html
+++ b/ckan/templates/admin/config.html
@@ -37,6 +37,12 @@
           <a href="{{ about_url }}">about page</a>.</p>
         <p><strong>Intro Text:</strong> This text will appear on this CKAN instances
           <a href="{{ home_url }}">home page</a> as a welcome to visitors.</p>
+        <p><strong>Featured Image</strong> This is the image that appears in the Introductory area on the
+          <a href="{{ home_url }}">home page</a>.</p>
+        <p><strong>Featured Link</strong> This is the link for the image that appears in the Introductory area on the
+          <a href="{{ home_url }}">home page</a>.</p>
+        <p><strong>Featured Text</strong> This is the text that appears below the featured image in the Introductory area on the
+          <a href="{{ home_url }}">home page</a>.</p>
         <p><strong>Custom CSS:</strong> This is a block of CSS that appears in
           <code>&lt;head&gt;</code> tag of every page. If you wish to customize
           the templates more fully we recommend

--- a/ckan/templates/home/snippets/promoted.html
+++ b/ckan/templates/home/snippets/promoted.html
@@ -16,10 +16,10 @@
 
   {% block home_image %}
     <section class="featured media-overlay hidden-phone">
-      <h2 class="media-heading">{% block home_image_caption %}{{ _("This is a featured section") }}{% endblock %}</h2>
+      <h2 class="media-heading">{% block home_image_caption %}{{ g.featured_text if g.featured_text else _("This is a featured section") }}{% endblock %}</h2>
       {% block home_image_content %}
-        <a class="media-image" href="#">
-          <img src="http://placehold.it/420x220" alt="Placeholder" width="420" height="220" />
+        <a class="media-image" href="{{ g.featured_link if g.featured_link else '#' }}">
+          <img src="{{ g.featured_image if g.featured_image else 'http://placehold.it/420x220' }}" alt="Placeholder" width="420" height="220" />
         </a>
       {% endblock %}
     </section>


### PR DESCRIPTION
...the home page  Introductory area.

With this change, sysadmin will see 3 new fields on the ckan-admin/config page to control
- The image
- The image link
- The short line of text under the feature image.