### PR TITLE
Allow more than one IValidator plugin to be installed

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -366,6 +366,7 @@ def update_config():
 
     # clear other caches
     logic.clear_actions_cache()
+    logic.clear_validators_cache()
     new_authz.clear_auth_functions_cache()
 
     # Here we create the site user if they are not already in the database

--- a/ckan/plugins/core.py
+++ b/ckan/plugins/core.py
@@ -138,8 +138,6 @@ def load(*plugins):
     '''
     Load named plugin(s).
     '''
-    from ckan.logic import clear_validators_cache
-
     output = []
 
     observers = PluginImplementations(interfaces.IPluginObserver)
@@ -157,8 +155,6 @@ def load(*plugins):
         if interfaces.IGenshiStreamFilter in service.__interfaces__:
             log.warn("Plugin '%s' is using deprecated interface "
                      'IGenshiStreamFilter' % plugin)
-        if interfaces.IValidators in service.__interfaces__:
-            clear_validators_cache()
 
         _PLUGINS.append(plugin)
         _PLUGINS_CLASS.append(service.__class__)


### PR DESCRIPTION
An oversight on my part: the IValidator cache is reset each time an IValidator plugin is installed instead of when update_config is called.
