### PR TITLE
Ideas 31 resourceproxy max file size configurable

### DIFF
--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -143,6 +143,10 @@ ckan.feeds.author_link =
 #ckan.datapusher.formats = csv xls xlsx tsv application/csv application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
 #ckan.datapusher.url = http://127.0.0.1:8800/
 
+# Resource Proxy settings
+# Preview size limit, default: 1MB
+#ckan.resource_proxy.max_file_size = 1 * 1024 * 1024
+
 ## Activity Streams Settings
 
 #ckan.activity_streams_enabled = true

--- a/ckanext/resourceproxy/controller.py
+++ b/ckanext/resourceproxy/controller.py
@@ -13,8 +13,7 @@ import ckan.plugins.toolkit as toolkit
 log = getLogger(__name__)
 
 MAX_FILE_SIZE = toolkit.asint(
-                    config.get('ckan.resource_proxy.max_file_size',
-                                1024 * 1024))  # default: 1MB
+    config.get('ckan.resource_proxy.max_file_size', 1024 * 1024))
 CHUNK_SIZE = 512
 
 

--- a/ckanext/resourceproxy/controller.py
+++ b/ckanext/resourceproxy/controller.py
@@ -3,13 +3,18 @@ import urlparse
 
 import requests
 
+import pylons.config as config
+
 import ckan.logic as logic
 import ckan.lib.base as base
 from ckan.common import _
+import ckan.plugins.toolkit as toolkit
 
 log = getLogger(__name__)
 
-MAX_FILE_SIZE = 1024 * 1024  # 1MB
+MAX_FILE_SIZE = toolkit.asint(
+                    config.get('ckan.resource_proxy.max_file_size',
+                                1024 * 1024))  # default: 1MB
 CHUNK_SIZE = 512
 
 

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -663,6 +663,20 @@ Default value:  ``True``
 
 This controls if we'll use the 1 day cache for stats.
 
+ckan.resource_proxy.max_file_size
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+    ckan.resource_proxy.max_file_size = 1 * 1024 * 1024
+
+Default value:  ``1 * 1024 * 1024`` (1 MB)
+
+This sets the upper file size limit for in-line previews. 
+Increasing the value allows CKAN to preview larger files (e.g. PDFs) in-line; 
+however, this might cause time-outs, or unresponsive browsers for CKAN users 
+with lower bandwidth.
+
 
 Front-End Settings
 ------------------

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -674,8 +674,8 @@ Default value:  ``1 * 1024 * 1024`` (1 MB)
 
 This sets the upper file size limit for in-line previews. 
 Increasing the value allows CKAN to preview larger files (e.g. PDFs) in-line; 
-however, this might cause time-outs, or unresponsive browsers for CKAN users 
-with lower bandwidth.
+however, a higher value might cause time-outs, or unresponsive browsers for CKAN users 
+with lower bandwidth. If left commented out, CKAN will default to 1 MB.
 
 
 Front-End Settings


### PR DESCRIPTION
Addressing roadmap [issue #31](https://github.com/ckan/ideas-and-roadmap/issues/31), this introduces a config-based resource_proxy.max_file_size.

* The config template has now a new, commented-out, section "Resource Proxy" with setting ckan.resource_proxy.max_file_size showing the default value
* The Resource Proxy controller seeks this setting, or defaults to the previously hard-coded 1MB.

Next steps:
* Write tests
* Determine sane limits for max_file_size
* Handle errors caused by extreme max_file_size settings with informative log messages