### PR TITLE
[#2112] added ckanext/datastore/set_permissions.sql template to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,7 @@ recursive-include ckanext/*/public *
 recursive-include ckanext/*/templates *
 recursive-include ckanext/*/theme/public *
 recursive-include ckanext/*/theme/templates *
+include ckanext/datastore/set_permissions.sql
 
 prune .git
 include CHANGELOG.txt


### PR DESCRIPTION
Fixes #2112 by adding datastore's set_permissions.sql template to the manifest. This makes `python setup.py install` copy the template over to the installed ckan egg, where paster set-permissions will look for it.
