### PR TITLE
[#2099] fixed mis-aligned nav elements in header.html

### DIFF
--- a/ckan/templates/header.html
+++ b/ckan/templates/header.html
@@ -89,7 +89,7 @@
 
     </hgroup>
 
-    <div class="nav-collapse collapse">
+    <div class="nav-collapse collapse content">
 
       {% block header_site_navigation %}
         <nav class="section navigation">


### PR DESCRIPTION
This meagre one-word change will fix the mis-alignment of nav elements and the search box from #2099.
