### PR TITLE
[#1936] Avoid private and deleted datasets on stats plugin

### DIFF
--- a/ckan/lib/create_test_data.py
+++ b/ckan/lib/create_test_data.py
@@ -19,6 +19,7 @@ class CreateTestData(object):
     pkg_core_fields = ['name', 'title', 'version', 'url', 'notes',
                        'author', 'author_email',
                        'maintainer', 'maintainer_email',
+                       'private',
                        ]
     @classmethod
     def create_basic_test_data(cls):

--- a/ckanext/stats/stats.py
+++ b/ckanext/stats/stats.py
@@ -1,7 +1,7 @@
 import datetime
 
 from pylons import config
-from sqlalchemy import Table, select, func, and_
+from sqlalchemy import Table, select, join, func, and_
 
 import ckan.plugins as p
 import ckan.model as model
@@ -29,6 +29,7 @@ class Stats(object):
         package = table('package')
         rating = table('rating')
         sql = select([package.c.id, func.avg(rating.c.rating), func.count(rating.c.rating)], from_obj=[package.join(rating)]).\
+              where(and_(package.c.private==False, package.c.state=='active')). \
               group_by(package.c.id).\
               order_by(func.avg(rating.c.rating).desc(), func.count(rating.c.rating).desc()).\
               limit(limit)
@@ -39,7 +40,10 @@ class Stats(object):
     @classmethod
     def most_edited_packages(cls, limit=10):
         package_revision = table('package_revision')
-        s = select([package_revision.c.id, func.count(package_revision.c.revision_id)]).\
+        package = table('package')
+
+        s = select([package_revision.c.id, func.count(package_revision.c.revision_id)], from_obj=[package_revision.join(package)]).\
+            where(and_(package.c.private==False, package.c.state=='active', )).\
             group_by(package_revision.c.id).\
             order_by(func.count(package_revision.c.revision_id).desc()).\
             limit(limit)
@@ -50,9 +54,15 @@ class Stats(object):
     @classmethod
     def largest_groups(cls, limit=10):
         member = table('member')
+        package = table('package')
+
+        j = join(member, package,
+                 member.c.table_id == package.c.id)
+
         s = select([member.c.group_id, func.count(member.c.table_id)]).\
+            select_from(j).\
             group_by(member.c.group_id).\
-            where(and_(member.c.group_id!=None, member.c.table_name=='package')).\
+            where(and_(member.c.group_id!=None, member.c.table_name=='package', package.c.private==False, package.c.state=='active')).\
             order_by(func.count(member.c.table_id).desc()).\
             limit(limit)
 
@@ -88,9 +98,11 @@ class Stats(object):
     def top_package_owners(cls, limit=10):
         package_role = table('package_role')
         user_object_role = table('user_object_role')
-        s = select([user_object_role.c.user_id, func.count(user_object_role.c.role)], from_obj=[user_object_role.join(package_role)]).\
+        package = table('package')
+        s = select([user_object_role.c.user_id, func.count(user_object_role.c.role)], from_obj=[user_object_role.join(package_role).join(package)]).\
             where(user_object_role.c.role==model.authz.Role.ADMIN).\
             where(user_object_role.c.user_id!=None).\
+            where(and_(package.c.private==False, package.c.state=='active')). \
             group_by(user_object_role.c.user_id).\
             order_by(func.count(user_object_role.c.role).desc()).\
             limit(limit)

--- a/ckanext/stats/tests/test_stats_lib.py
+++ b/ckanext/stats/tests/test_stats_lib.py
@@ -10,12 +10,15 @@ from ckanext.stats.tests import StatsFixture
 class TestStatsPlugin(StatsFixture):
     @classmethod
     def setup_class(cls):
+
         super(TestStatsPlugin, cls).setup_class()
+
+        model.repo.rebuild_db()
 
         CreateTestData.create_arbitrary([
             {'name':'test1', 'groups':['grp1'], 'tags':['tag1']},
             {'name':'test2', 'groups':['grp1', 'grp2'], 'tags':['tag1']},
-            {'name':'test3', 'groups':['grp1', 'grp2'], 'tags':['tag1', 'tag2']},
+            {'name':'test3', 'groups':['grp1', 'grp2'], 'tags':['tag1', 'tag2'], 'private': True},
             {'name':'test4'},
             ],
             extra_user_names=['bob'],
@@ -54,8 +57,11 @@ class TestStatsPlugin(StatsFixture):
 
     @classmethod
     def teardown_class(cls):
-        CreateTestData.delete()
-        
+
+        model.repo.rebuild_db()
+
+        model.Session.remove()
+
     def test_top_rated_packages(self):
         pkgs = Stats.top_rated_packages()
         assert pkgs == []
@@ -63,16 +69,17 @@ class TestStatsPlugin(StatsFixture):
     def test_most_edited_packages(self):
         pkgs = Stats.most_edited_packages()
         pkgs = [(pkg.name, count) for pkg, count in pkgs]
-        assert_equal(pkgs[0], ('test3', 3))
-        assert_equal(pkgs[1][1], 2) 
-        assert_equal(pkgs[2][1], 2) 
-        assert_equal(pkgs[3], ('test1', 1)) 
+        # test2 does not come up because it was deleted
+        # test3 does not come up because it is private
+        assert_equal(pkgs[0], ('test4', 2))
+        assert_equal(pkgs[1], ('test1', 1))
 
     def test_largest_groups(self):
         grps = Stats.largest_groups()
         grps = [(grp.name, count) for grp, count in grps]
-        assert_equal(grps, [('grp1', 3),
-                            ('grp2', 2)])
+        # test2 does not come up because it was deleted
+        # test3 does not come up because it is private
+        assert_equal(grps, [('grp1', 1), ])
 
     def test_top_tags(self):
         tags = Stats.top_tags()
@@ -83,7 +90,8 @@ class TestStatsPlugin(StatsFixture):
     def test_top_package_owners(self):
         owners = Stats.top_package_owners()
         owners = [(owner.name, count) for owner, count in owners]
-        assert_equal(owners, [('bob', 4)])
+        # Only 2 shown because one of them was deleted and the other one is private
+        assert_equal(owners, [('bob', 2)])
 
     def test_new_packages_by_week(self):
         new_packages_by_week = RevisionStats.get_by_week('new_packages')


### PR DESCRIPTION
There are a number of metrics displayed that don't take into account if the dataset is private or deleted. The stats plugin code is heavily unmaintained, but it should be all right to plug the main leaks.
