### PR TITLE
[#1707] Check that resource belongs to dataset on resource_read

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -1100,17 +1100,24 @@ class PackageController(base.BaseController):
                    'user': c.user or c.author, 'auth_user_obj': c.userobj}
 
         try:
-            c.resource = get_action('resource_show')(context,
-                                                     {'id': resource_id})
             c.package = get_action('package_show')(context, {'id': id})
-            # required for nav menu
-            c.pkg = context['package']
-            c.pkg_dict = c.package
-            dataset_type = c.pkg.type or 'dataset'
         except NotFound:
-            abort(404, _('Resource not found'))
+            abort(404, _('Dataset not found'))
         except NotAuthorized:
-            abort(401, _('Unauthorized to read resource %s') % id)
+            abort(401, _('Unauthorized to read dataset %s') % id)
+
+        for resource in c.package.get('resources', []):
+            if resource['id'] == resource_id:
+                c.resource = resource
+                break
+        if not c.resource:
+            abort(404, _('Resource not found'))
+
+        # required for nav menu
+        c.pkg = context['package']
+        c.pkg_dict = c.package
+        dataset_type = c.pkg.type or 'dataset'
+
         # get package license info
         license_id = c.package.get('license_id')
         try:

--- a/ckan/new_tests/controllers/test_package.py
+++ b/ckan/new_tests/controllers/test_package.py
@@ -179,6 +179,32 @@ class TestPackageResourceRead(helpers.FunctionalTestBase):
         app = self._get_test_app()
         app.get(url, status=404)
 
+    def test_existing_resource_with_associated_dataset(self):
+
+        dataset = factories.Dataset()
+        resource = factories.Resource(package_id=dataset['id'])
+
+        url = url_for(controller='package',
+                      action='resource_read',
+                      id=dataset['id'],
+                      resource_id=resource['id'])
+
+        app = self._get_test_app()
+        app.get(url, status=200)
+
+    def test_existing_resource_with_not_associated_dataset(self):
+
+        dataset = factories.Dataset()
+        resource = factories.Resource()
+
+        url = url_for(controller='package',
+                      action='resource_read',
+                      id=dataset['id'],
+                      resource_id=resource['id'])
+
+        app = self._get_test_app()
+        app.get(url, status=404)
+
 
 class TestPackageRead(helpers.FunctionalTestBase):
     @classmethod


### PR DESCRIPTION
Otherwise you can display resources from other datasets.

Refactored to just call package_show and not resource_show as well
