### PR TITLE
Can't compile bootstrap with less v2+

### DIFF
--- a/ckan/public/base/vendor/bootstrap/less/navbar.less
+++ b/ckan/public/base/vendor/bootstrap/less/navbar.less
@@ -196,7 +196,7 @@
 .navbar-static-top .container,
 .navbar-fixed-top .container,
 .navbar-fixed-bottom .container {
-  #grid > .core > .span(@gridColumns);
+  width: (@gridColumnWidth * @gridColumns) + (@gridGutterWidth * (@gridColumns - 1));
 }
 
 // Fixed to top

--- a/ckan/public/base/vendor/bootstrap/less/navbar.less
+++ b/ckan/public/base/vendor/bootstrap/less/navbar.less
@@ -196,7 +196,7 @@
 .navbar-static-top .container,
 .navbar-fixed-top .container,
 .navbar-fixed-bottom .container {
-  width: (@gridColumnWidth * @gridColumns) + (@gridGutterWidth * (@gridColumns - 1));
+  #grid > .core > .span(@gridColumns);
 }
 
 // Fixed to top

--- a/doc/contributing/frontend/index.rst
+++ b/doc/contributing/frontend/index.rst
@@ -58,7 +58,7 @@ style script.
 
 ::
 
-    $ npm install less nodewatch
+    $ npm install less@1.7.5 nodewatch
 
 --------------
 File structure


### PR DESCRIPTION
Following the docs, [Frontend Development Guidelines](http://docs.ckan.org/en/latest/contributing/frontend/index.html), to install less and run `./bin/less` results in this failure:

>An error occurred running the less command:
Command failed: NameError: #grid > .core > .span is undefined in /Users/brew/virtualenvs/ckan2.6/src/ckan/ckan/public/base/vendor/bootstrap/less/navbar.less on line 199, column 3:
198 .navbar-fixed-bottom .container {
199   #grid > .core > .span(@gridColumns);
200 }

Suggest either changing the docs to require an older version of less:

`npm install less@1.7.5`

or fix the `less/navbar.less` file as per this stackoverflow answer: http://stackoverflow.com/a/26628310/1187437