### PR TITLE
namespace boilerplate for paster ckanext templates

### DIFF
--- a/ckan/pastertemplates/template/ckanext/__init__.py
+++ b/ckan/pastertemplates/template/ckanext/__init__.py
@@ -1,0 +1,7 @@
+# this is a namespace package
+try:
+    import pkg_resources
+    pkg_resources.declare_namespace(__name__)
+except ImportError:
+    import pkgutil
+    __path__ = pkgutil.extend_path(__path__, __name__)


### PR DESCRIPTION
Add `__init__.py` namespace boilerplate to ckanext templates, as mentioned here: ckan/ckanext-showcase#2  
