### PR TITLE
[#1982] Add max-height to text resource view

### DIFF
--- a/ckanext/textview/theme/public/css/text.css
+++ b/ckanext/textview/theme/public/css/text.css
@@ -1,5 +1,7 @@
 body {
   width: 500px;
+  max-height: 600px;
+  overflow-y: scroll;
 }
 
 pre {


### PR DESCRIPTION
As described in #1982. Ensures large text files don't create massively long pages.
