### PR TITLE
Adds auth for vocabulary_list and vocabulary_show.

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -2266,6 +2266,8 @@ def vocabulary_list(context, data_dict):
     :rtype: list of dictionaries
 
     '''
+    _check_access('vocabulary_list', context, data_dict)
+
     model = context['model']
     vocabulary_objects = model.Session.query(model.Vocabulary).all()
     return model_dictize.vocabulary_list_dictize(vocabulary_objects, context)
@@ -2280,6 +2282,8 @@ def vocabulary_show(context, data_dict):
     :rtype: dictionary
 
     '''
+    _check_access('vocabulary_show', context, data_dict)
+
     model = context['model']
     vocab_id = data_dict.get('id')
     if not vocab_id:

--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -66,6 +66,10 @@ def license_list(context, data_dict):
     # Licenses list is visible by default
     return {'success': True}
 
+def vocabulary_list(context, data_dict):
+    # List of all vocabularies are visible by default
+    return {'success': True}
+
 def tag_list(context, data_dict):
     # Tags list is visible by default
     return {'success': True}
@@ -155,6 +159,10 @@ def group_show(context, data_dict):
 
 def organization_show(context, data_dict):
     # anyone can see a organization
+    return {'success': True}
+
+def vocabulary_show(context, data_dict):
+    # Allow viewing of vocabs by default
     return {'success': True}
 
 def tag_show(context, data_dict):

--- a/ckan/tests/test_coding_standards.py
+++ b/ckan/tests/test_coding_standards.py
@@ -776,8 +776,6 @@ class TestActionAuth(object):
         'get: user_activity_list_html',
         'get: user_followee_count',
         'get: user_follower_count',
-        'get: vocabulary_list',
-        'get: vocabulary_show',
         'update: package_relationship_update_rest',
         'update: task_status_update_many',
         'update: term_translation_update_many',


### PR DESCRIPTION
Adds auth for vocabulary_list and vocabulary_show as they were currently missing and causing problems in both the coding_standard tests and when overriden in an extension.

Fixes #2104, with other relevant detail at #2128 
