### PR TITLE
Login not working when running on nginx + apache

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -59,9 +59,30 @@ Template changes
   https://github.com/ckan/ckan/pull/1935
 
 Troubleshooting:
+
+ * Login does not work, for existing and new users.
+
+   You need to update your existing ``who.ini`` file.
+
+   - In the ``[plugin:auth_tkt]`` section, replace::
+
+       use = ckan.config.middleware:ckan_auth_tkt_make_app
+
+     with::
+
+       use = ckan.lib.auth_tkt:make_plugin
+
+   - In ``[authenticators]``, add the ``auth_tkt`` plugin
+
+   Also see the next point for OpenID related changes.
+
  * Exception on first load after upgrading from a previous CKAN version::
 
      ImportError: <module 'ckan.lib.authenticator' from '/usr/lib/ckan/default/src/ckan/ckan/lib/authenticator.py'> has no 'OpenIDAuthenticator' attribute
+
+   or::
+
+     ImportError: No module named openid
 
    There are OpenID related configuration options on your ``who.ini`` file which
    are no longer supported.
@@ -88,6 +109,7 @@ Troubleshooting:
 
     https://github.com/ckan/ckan/pull/2058/files#diff-2
 
+   Also see the previous point for other ``who.ini`` changes.
 
 v2.2.1 2014-10-15
 =================

--- a/doc/maintaining/upgrading/upgrade-package-to-minor-release.rst
+++ b/doc/maintaining/upgrading/upgrade-package-to-minor-release.rst
@@ -24,11 +24,11 @@ respectively.
 
    .. note::
 
-      If you have changed the |apache| or |nginx| configuration files, you will
-      get a prompt like the following, asking whether to keep your local changes
-      or replace the files. You generally would like to keep your local changes
-      (option ``N``, which is the default), but you can look at the differences
-      between versions by selecting option ``D``::
+      If you have changed the |apache|, |nginx| or ``who.ini`` configuration
+      files, you will get a prompt like the following, asking whether to keep
+      your local changes or replace the files. You generally would like to keep
+      your local changes (option ``N``, which is the default), but you can look
+      at the differences between versions by selecting option ``D``::
 
        Configuration file `/etc/apache2/sites-available/ckan_default'
         ==> File on system created by you or by a script.

--- a/doc/maintaining/upgrading/upgrade-package-to-patch-release.rst
+++ b/doc/maintaining/upgrading/upgrade-package-to-patch-release.rst
@@ -37,11 +37,11 @@ minor release they belong to, so for example CKAN ``2.0``, ``2.0.1``,
 
    .. note::
 
-      If you have changed the |apache| or |nginx| configuration files, you will
-      get a prompt like the following, asking whether to keep your local changes
-      or replace the files. You generally would like to keep your local changes
-      (option ``N``, which is the default), but you can look at the differences
-      between versions selecting option ``D``::
+      If you have changed the |apache|, |nginx| or ``who.ini`` configuration
+      files, you will get a prompt like the following, asking whether to keep
+      your local changes or replace the files. You generally would like to keep
+      your local changes (option ``N``, which is the default), but you can look
+      at the differences between versions by selecting option ``D``::
 
        Configuration file `/etc/apache2/sites-available/ckan_default'
         ==> File on system created by you or by a script.


### PR DESCRIPTION
When installing CKAN (current master) from a deb package [1], or on http://master.ckan.org,
after registering a new user you get redirected to the login page instead of the dashboard. Trying to login always fails even with good credentials. Creating a user on the command line and trying to login with it also fails

@brew I wonder if this has something to do with the recent repoze.who changes?

Here is the standard apache / nginx configuration that we generally use:

https://github.com/ckan/ckan-packaging/tree/master/etc

Any ideas?

[1] http://packaging.ckan.org/build/python-ckan_2.3-15_amd64.deb
