### PR TITLE
Fix organization pagination

### DIFF
--- a/ckan/templates/organization/index.html
+++ b/ckan/templates/organization/index.html
@@ -34,7 +34,7 @@
     {% endif %}
   {% endblock %}
   {% block page_pagination %}
-    {{ c.page.pager() }}
+    {{ c.page.pager(q=c.q, sort=c.sort_by_selected) }}
   {% endblock %}
 {% endblock %}
 


### PR DESCRIPTION
Organization pagination resets search parameters.

On demo.ckan.org

http://demo.ckan.org/organization?q=a&sort=name+asc

at pagination "2" or next button resets search to

http://demo.ckan.org/organization?page=2
