### PR TITLE
1980 clearer error message for username

### DIFF
--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -342,12 +342,12 @@ def name_validator(value, context):
         raise Invalid(_('That name cannot be used'))
 
     if len(value) < 2:
-        raise Invalid(_('Name must be at least %s characters long') % 2)
+        raise Invalid(_('Must be at least %s characters long') % 2)
     if len(value) > PACKAGE_NAME_MAX_LENGTH:
         raise Invalid(_('Name must be a maximum of %i characters long') % \
                       PACKAGE_NAME_MAX_LENGTH)
     if not name_match.match(value):
-        raise Invalid(_('Url must be purely lowercase alphanumeric '
+        raise Invalid(_('Must be purely lowercase alphanumeric '
                         '(ascii) characters and these symbols: -_'))
     return value
 

--- a/ckan/tests/lib/test_dictization_schema.py
+++ b/ckan/tests/lib/test_dictization_schema.py
@@ -130,7 +130,7 @@ class TestBasicDictize:
                                           default_update_package_schema(),
                                           self.context)
         assert errors == {
-            'name': [u'Url must be purely lowercase alphanumeric (ascii) '
+            'name': [u'Must be purely lowercase alphanumeric (ascii) '
                      'characters and these symbols: -_'],
             'resources': [{}, {'url': [u'Missing value']}]
         }, pformat(errors)

--- a/ckan/tests/logic/test_action.py
+++ b/ckan/tests/logic/test_action.py
@@ -520,13 +520,13 @@ class TestAction(WsgiAppCase):
                 {'user_dict': {'id': self.normal_user.id,
                           'name':'',
                           'email':'test@test.com'},
-                 'messages': [('name','Name must be at least 2 characters long')]},
+                 'messages': [('name','Must be at least 2 characters long')]},
 
             # Invalid characters in name
                 {'user_dict': {'id': self.normal_user.id,
                           'name':'i++%',
                           'email':'test@test.com'},
-                 'messages': [('name','Url must be purely lowercase alphanumeric')]},
+                 'messages': [('name','Must be purely lowercase alphanumeric')]},
             # Existing name
                 {'user_dict': {'id': self.normal_user.id,
                           'name':self.sysadmin_user.name,

--- a/ckan/tests/schema/test_schema.py
+++ b/ckan/tests/schema/test_schema.py
@@ -16,11 +16,11 @@ class TestPackage:
 
         good_names = ('blah', 'ab', 'ab1', 'some-random-made-up-name', 'has_underscore', 'annakarenina')
         bad_names = (('', [u'Missing value']),
-                     ('blAh', [u'Url must be purely lowercase alphanumeric (ascii) characters and these symbols: -_']),
-                     ('a', [u'Name must be at least 2 characters long', u'Name NAME length is less than minimum 2']),
-                     ('dot.in.name', [u'Url must be purely lowercase alphanumeric (ascii) characters and these symbols: -_']),
-                     (u'unicode-\xe0', [u'Url must be purely lowercase alphanumeric (ascii) characters and these symbols: -_']),
-                     ('percent%', [u'Url must be purely lowercase alphanumeric (ascii) characters and these symbols: -_']),
+                     ('blAh', [u'Must be purely lowercase alphanumeric (ascii) characters and these symbols: -_']),
+                     ('a', [u'Must be at least 2 characters long', u'Name NAME length is less than minimum 2']),
+                     ('dot.in.name', [u'Must be purely lowercase alphanumeric (ascii) characters and these symbols: -_']),
+                     (u'unicode-\xe0', [u'Must be purely lowercase alphanumeric (ascii) characters and these symbols: -_']),
+                     ('percent%', [u'Must be purely lowercase alphanumeric (ascii) characters and these symbols: -_']),
                      ('p'*101, [u'Name must be a maximum of 100 characters long', u'Name NAME length is more than maximum 100']),
                      )
 


### PR DESCRIPTION
This fixes the un-clear message that a user gets when they try to register with a username that contains non-alphanumeric characters. 

Needed to fix up a few tests too because they tried to match the old message string containing 'Url'