### PR TITLE
Improve datapusher error messages

### DIFF
--- a/ckan/templates/package/resource_data.html
+++ b/ckan/templates/package/resource_data.html
@@ -20,7 +20,7 @@
     </div>
   {% elif status.task_info and status.task_info.error %}
     <div class="alert alert-error">
-      <strong>{{ _('Error:') }}</strong> {{ status.task_info.error }}
+      <strong>{{ _('Error:') }}</strong> {{ status.task_info.error.message }}
     </div>
   {% endif %}
 

--- a/ckan/templates/package/resource_data.html
+++ b/ckan/templates/package/resource_data.html
@@ -21,6 +21,13 @@
   {% elif status.task_info and status.task_info.error %}
     <div class="alert alert-error">
       <strong>{{ _('Error:') }}</strong> {{ status.task_info.error.message }}
+      {% for error_key, error_value in status.task_info.error.iteritems() %}
+        {% if error_key != "message" and error_value %}
+          <br>
+          <strong>{{ error_key }}</strong>:
+          {{ error_value }}
+        {% endif %}
+      {% endfor %}
     </div>
   {% endif %}
 

--- a/ckan/templates/package/resource_data.html
+++ b/ckan/templates/package/resource_data.html
@@ -20,14 +20,19 @@
     </div>
   {% elif status.task_info and status.task_info.error %}
     <div class="alert alert-error">
-      <strong>{{ _('Error:') }}</strong> {{ status.task_info.error.message }}
-      {% for error_key, error_value in status.task_info.error.iteritems() %}
-        {% if error_key != "message" and error_value %}
-          <br>
-          <strong>{{ error_key }}</strong>:
-          {{ error_value }}
-        {% endif %}
-      {% endfor %}
+      {% if status.task_info.error is string %}
+        {# DataPusher < 0.0.3 #}
+        <strong>{{ _('Error:') }}</strong> {{ status.task_info.error }}
+      {% elif status.task_info.error is iterable %}
+        <strong>{{ _('Error:') }}</strong> {{ status.task_info.error.message }}
+        {% for error_key, error_value in status.task_info.error.iteritems() %}
+          {% if error_key != "message" and error_value %}
+            <br>
+            <strong>{{ error_key }}</strong>:
+            {{ error_value }}
+          {% endif %}
+        {% endfor %}
+      {% endif %}
     </div>
   {% endif %}
 

--- a/ckan/templates/package/resource_data.html
+++ b/ckan/templates/package/resource_data.html
@@ -19,7 +19,6 @@
       <strong>{{ _('Upload error:') }}</strong> {{ status.error.message }}
     </div>
   {% elif status.task_info and status.task_info.error %}
-    {% set show_table = false %}
     <div class="alert alert-error">
       <strong>{{ _('Error:') }}</strong> {{ status.task_info.error }}
     </div>

--- a/ckanext/datastore/db.py
+++ b/ckanext/datastore/db.py
@@ -634,7 +634,9 @@ def upsert_data(context, data_dict):
         try:
             context['connection'].execute(sql_string, rows)
         except sqlalchemy.exc.DataError as err:
-            raise InvalidDataError(str(err))
+            raise InvalidDataError(
+                toolkit._("The data was invalid (for example: a numeric value "
+                    "is out of range)."))
 
     elif method in [_UPDATE, _UPSERT]:
         unique_keys = _get_unique_key(context, data_dict)

--- a/ckanext/datastore/db.py
+++ b/ckanext/datastore/db.py
@@ -636,7 +636,8 @@ def upsert_data(context, data_dict):
         except sqlalchemy.exc.DataError as err:
             raise InvalidDataError(
                 toolkit._("The data was invalid (for example: a numeric value "
-                          "is out of range)."))
+                          "is out of range or was inserted into a text field)."
+                          ))
 
     elif method in [_UPDATE, _UPSERT]:
         unique_keys = _get_unique_key(context, data_dict)

--- a/ckanext/datastore/db.py
+++ b/ckanext/datastore/db.py
@@ -636,7 +636,7 @@ def upsert_data(context, data_dict):
         except sqlalchemy.exc.DataError as err:
             raise InvalidDataError(
                 toolkit._("The data was invalid (for example: a numeric value "
-                    "is out of range)."))
+                          "is out of range)."))
 
     elif method in [_UPDATE, _UPSERT]:
         unique_keys = _get_unique_key(context, data_dict)

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -135,7 +135,11 @@ def datastore_create(context, data_dict):
     if not legacy_mode and resource.package.private:
         data_dict['private'] = True
 
-    result = db.create(context, data_dict)
+    try:
+        result = db.create(context, data_dict)
+    except db.InvalidDataError as err:
+        raise p.toolkit.ValidationError(str(err))
+
     result.pop('id', None)
     result.pop('private', None)
     result.pop('connection_url')

--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -843,5 +843,4 @@ class TestDatastoreCreate(tests.WsgiAppCase):
 
         assert res_dict['success'] is False
         assert res_dict['error']['__type'] == 'Validation Error'
-        assert res_dict['error']['message'].startswith(
-            '(DataError) invalid input syntax for type numeric:')
+        assert res_dict['error']['message'].startswith('The data was invalid')

--- a/ckanext/datastore/tests/test_db.py
+++ b/ckanext/datastore/tests/test_db.py
@@ -1,6 +1,8 @@
 import mock
 import nose
 
+import sqlalchemy.exc
+
 import ckan.new_tests.helpers as helpers
 
 import ckanext.datastore.db as db
@@ -96,3 +98,43 @@ class TestCreateIndexes(object):
 
         assert was_called, ("Expected 'connection.execute' to have been ",
                             "called with a string containing '%s'" % sql_str)
+
+
+@mock.patch("ckanext.datastore.db._get_fields")
+def test_upsert_with_insert_method_and_invalid_data(
+        mock_get_fields_function):
+    """upsert_data() should raise InvalidDataError if given invalid data.
+
+    If the type of a field is numeric and upsert_data() is given a whitespace
+    value like "   ", it should raise DataError.
+
+    In this case we're testing with "method": "insert" in the data_dict.
+
+    """
+    mock_connection = mock.Mock()
+    mock_connection.execute.side_effect = sqlalchemy.exc.DataError(
+        "statement", "params", "orig", connection_invalidated=False)
+
+    context = {
+        "connection": mock_connection,
+    }
+    data_dict = {
+        "fields": [{"id": "value", "type": "numeric"}],
+        "records": [
+            {"value": 0},
+            {"value": 1},
+            {"value": 2},
+            {"value": 3},
+            {"value": "   "},  # Invalid numeric value.
+            {"value": 5},
+            {"value": 6},
+            {"value": 7},
+        ],
+        "method": "insert",
+        "resource_id": "fake-resource-id",
+    }
+
+    mock_get_fields_function.return_value = data_dict["fields"]
+
+    nose.tools.assert_raises(
+        db.InvalidDataError, db.upsert_data, context, data_dict)


### PR DESCRIPTION
This is a rewrite of https://github.com/ckan/ckan/pull/2000 based on recent CKAN Service Provider and DataPusher refactoring.

This only works with DataPusher 0.0.2, it's not backwards-compatible with DataPusher 0.0.1 and I don't think we should bother with backwards-compatibility.

The job dicts that DataPusher 0.0.2 sends to CKAN to report the outcome of a job *always* contain an "error" key. The value for this key is either `None` (or an empty dict) if there was no error, or if there was an error then the value is always a dict with a "message" key whose value is a human-readable string. The error dict may also contain other keys specific to the type of error, and DataPusher now uses these extra keys to report specific information about HTTP errors (status code, the URL that errored, etc).

This pr changes CKAN's templates to display all keys from these new error objects:

![screenshot from 2014-12-12 21 02 47](https://cloud.githubusercontent.com/assets/22498/5437380/d547d46e-8467-11e4-8fec-91c5ee481652.png)

![screenshot from 2014-12-12 20 51 19](https://cloud.githubusercontent.com/assets/22498/5437384/e6ed44ec-8467-11e4-9c08-f621da5b3164.png)

This pr also changes the datapusher page to always show the upload log, even when the job has errored

Note that https://github.com/ckan/ckan/pull/2000 also 

