### PR TITLE
[#2147] allow files with the same name to replace datastore contents

### DIFF
--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -27,6 +27,12 @@ def resource_dict_save(res_dict, context):
     table = class_mapper(model.Resource).mapped_table
     fields = [field.name for field in table.c]
 
+    # url_type __upload__ is a special condition to trigger uploading of a file
+    # to the datastore when the filename has not changed but the file has been
+    # newly updated and so needs to be loaded
+    if res_dict.get('url_type') == '__upload__':
+        obj.url_changed = True
+
     for key, value in res_dict.iteritems():
         if isinstance(value, list):
             continue

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -172,7 +172,11 @@ class ResourceUpload(object):
             self.filename = upload_field_storage.filename
             self.filename = munge.munge_filename(self.filename)
             resource['url'] = self.filename
-            resource['url_type'] = 'upload'
+            # The url_type will be changed to 'upload' when we save the resource
+            # but we need to change the models data to trigger the upload
+            # by changing the url_type we can trigger this and then fix the
+            # value once the trigger has occurred
+            resource['url_type'] = '__upload__'
             self.upload_file = upload_field_storage.file
         elif self.clear:
             resource['url_type'] = ''

--- a/ckan/model/modification.py
+++ b/ckan/model/modification.py
@@ -50,6 +50,11 @@ class DomainObjectModificationExtension(plugins.SingletonPlugin):
                 self.notify(obj, domain_object.DomainObjectOperation.deleted)
         for obj in set(changed):
             if isinstance(obj, resource.Resource):
+                # __upload__ is used to trigger the reuploading of files into the
+                # datastore where the file name has not changed.  We can now
+                # correct the value to what it should be.
+                if obj.url_type == '__upload__':
+                    obj.url_type = 'upload'
                 self.notify(obj, domain_object.DomainObjectOperation.changed)
             if getattr(obj, 'url_changed', False):
                 for item in plugins.PluginImplementations(plugins.IResourceUrlChange):


### PR DESCRIPTION
issue #2147

If we change a resource by uploading a new file and it has the same name ckan does not see the resource as having changed and therefore there is no trigger for IResourceUrlChange therefore we do not update the datastore