### PR TITLE
[#2057] Fix filename munging

### DIFF
--- a/ckan/lib/munge.py
+++ b/ckan/lib/munge.py
@@ -4,6 +4,7 @@
 # improved.
 
 import re
+import os.path
 
 from ckan import model
 
@@ -111,6 +112,37 @@ def munge_filename(filename):
     filename = re.sub(r'[^a-zA-Z0-9. ]', '', filename).replace(' ', '-')
     filename = _munge_to_length(filename, 3, 100)
     return filename
+
+
+def munge_filename_ext_safe(filename):
+    ''' Munge the filename but keep the extension
+    this allows data that has not had it's format set
+    but relies on the extention for its type eg .csv
+    We also remove the path if one is given by a browser etc'''
+
+    # just get the filename ignore the path
+    path, filename = os.path.split(filename)
+    # clean up
+    filename = substitute_ascii_equivalents(filename)
+    filename = filename.lower().strip()
+    filename = re.sub(r'[^a-zA-Z0-9. ]', '', filename).replace(' ', '-')
+    # resize if needed but keep extension
+    name, ext = os.path.splitext(filename)
+    # limit overly long extensions
+    if len(ext) > 21:
+        ext = ext[:21]
+    # reduce filename as needed
+    maxsize = 100 - len(ext)
+    if len(name) > maxsize:
+        name = name[:maxsize]
+
+    filename = name + ext
+    # enlarge name to at least 3 chars
+    if len(filename) < 3:
+        filename += '_' * (3 - len(filename))
+
+    return filename
+
 
 def _munge_to_length(string, min_length, max_length):
     '''Pad/truncates a string'''

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -170,7 +170,7 @@ class ResourceUpload(object):
 
         if isinstance(upload_field_storage, cgi.FieldStorage):
             self.filename = upload_field_storage.filename
-            self.filename = munge.munge_filename(self.filename)
+            self.filename = munge.munge_filename_ext_safe(self.filename)
             resource['url'] = self.filename
             resource['url_type'] = 'upload'
             self.upload_file = upload_field_storage.file


### PR DESCRIPTION
Issue #2057 

If we upload a file with a huge name then the extension gets eaten and we end up with the datastore not being able to import the file correctly if the format has not been set for the resource

Also it seems browsers on windows 7 seem to pass the whole path along with the file name so this creates problems for these users.

So we remove the path and try to keep the extension - really long extensions (over 20 chars) get truncated but these are probably erroneous extensions anyway.