### PR TITLE
Rewrite ckan.logic.converters.convert_to_extras 

### DIFF
--- a/ckan/logic/converters.py
+++ b/ckan/logic/converters.py
@@ -8,6 +8,8 @@ from ckan.common import _
 
 
 def convert_to_extras(key, data, errors, context):
+    if ('extras', ) in data:
+        del data[('extras', )]
     # There is no tally for the number of fields converted to extras.
     extras = [k for k in data.keys() if k[0] == 'extras' and len(k) > 1]
     new_pos = 0

--- a/ckan/logic/converters.py
+++ b/ckan/logic/converters.py
@@ -8,15 +8,14 @@ from ckan.common import _
 
 
 def convert_to_extras(key, data, errors, context):
-
-    # Get the current extras index
-    current_indexes = [k[1] for k in data.keys()
-                       if len(k) > 1 and k[0] == 'extras']
-
-    new_index = max(current_indexes) + 1 if current_indexes else 0
-
-    data[('extras', new_index, 'key')] = key[-1]
-    data[('extras', new_index, 'value')] = data[key]
+    # There is no tally for the number of fields converted to extras.
+    extras = [k for k in data.keys() if k[0] == 'extras' and len(k) > 1]
+    new_pos = 0
+    if extras:
+        extras.sort()
+        new_pos = extras[-1][-2] + 1  # e.g. ('extras', 5, 'value')
+    data[('extras', new_pos, 'key')] = key[-1]
+    data[('extras', new_pos, 'value')] = data[key]
 
 
 def convert_from_extras(key, data, errors, context):

--- a/ckan/new_tests/logic/test_converters.py
+++ b/ckan/new_tests/logic/test_converters.py
@@ -55,6 +55,46 @@ class TestConvertToExtras(unittest.TestCase):
 
         eq_(errors, {})
 
+    def test_convert_to_extras_with_added_extras_output_unflattened(self):
+        """
+        See https://github.com/ckan/ckan/issues/2150 for origin of this
+        test.
+
+        tl;dr - the existence of the ('extras', ) key/value pair brought about
+        by customizing a data set with named metadata fields stored as extras
+        (as outlined in the CKAN docs) interfered with the unflattening
+        process.
+        """
+
+        data = {
+            ('foo', ): 'bar',
+            ('baz', ): 'quux',
+            ('extras',): [{'key': 'foo', 'value': u'bar'},
+                          {'key': 'baz', 'value': u'quux'}, ],
+            ('extras', 0, 'key'): u'qwe',
+            ('extras', 0, 'value'): u'qwe',
+            ('extras', 1, 'key'): u'wer',
+            ('extras', 1, 'value'): u'wer',
+        }
+        errors = {}
+        context = {}
+
+        converters.convert_to_extras(('foo',), data, errors, context)
+        converters.convert_to_extras(('baz',), data, errors, context)
+
+        eq_(data[('extras', 0, 'key')], 'qwe')
+        eq_(data[('extras', 0, 'value')], 'qwe')
+        eq_(data[('extras', 1, 'key')], 'wer')
+        eq_(data[('extras', 1, 'value')], 'wer')
+        eq_(data[('extras', 2, 'key')], 'foo')
+        eq_(data[('extras', 2, 'value')], 'bar')
+        eq_(data[('extras', 3, 'key')], 'baz')
+        eq_(data[('extras', 3, 'value')], 'quux')
+
+        assert not ('extras',) in data
+
+        eq_(errors, {})
+
     def test_convert_to_extras_output_unflattened_with_correct_index(self):
 
         key = ('test_field',)


### PR DESCRIPTION
This branch introduces a single change:
- Rewrite the `convert_to_extras` function so it behaves in a way that doesn't interfere with other extras and complements the related convert_from_extras function.

I notice there is no test coverage for these.

Fixes #2150.
