### PR TITLE
Fix organization pagination sort value

### DIFF
--- a/ckan/templates/organization/index.html
+++ b/ckan/templates/organization/index.html
@@ -34,7 +34,7 @@
     {% endif %}
   {% endblock %}
   {% block page_pagination %}
-    {{ c.page.pager(q=c.q, sort=c.sort_by_selected) }}
+    {{ c.page.pager(q=c.q or '', sort=c.sort_by_selected or '') }}
   {% endblock %}
 {% endblock %}
 


### PR DESCRIPTION
Previous pull [2141] breaks normal organization pagination, because sort value is set to 'None'. This should fix the it.

[2141] https://github.com/ckan/ckan/pull/2141
