### PR TITLE
[WIP] [#1852] First approach at db-less views

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -207,8 +207,9 @@ def package_create(context, data_dict):
         item.after_create(context, data)
 
     # Create default views for resources if necessary
-    if data.get('resources'):
-        datapreview.add_default_views_to_dataset_resources(context, data)
+    # Don't create db objects for now
+    #if data.get('resources'):
+    #    datapreview.add_default_views_to_dataset_resources(context, data)
 
     if not context.get('defer_commit'):
         model.repo.commit()

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -362,8 +362,9 @@ def package_update(context, data_dict):
         item.after_update(context, data)
 
     # Create default views for resources if necessary
-    if data.get('resources'):
-        datapreview.add_default_views_to_dataset_resources(context, data)
+    # Don't create db objects for now
+    # if data.get('resources'):
+    #     datapreview.add_default_views_to_dataset_resources(context, data)
 
     if not context.get('defer_commit'):
         model.repo.commit()


### PR DESCRIPTION
@wardi This is based off #1852 and will correctly render views on the resource page based on
`ckan.views.default_views`.

Problems start when you try to manage those, eg when editing one oft hem, as we don't know the view type.

I'm not super optimistic about this approach, but well worth a try :)