### PR TITLE
[#2167] Remove ActionError.extra_msg.

### DIFF
--- a/ckan/controllers/api.py
+++ b/ckan/controllers/api.py
@@ -209,15 +209,15 @@ class ApiController(base.BaseController):
                                     'message': _('Access denied')}
             return_dict['success'] = False
             
-            if e.extra_msg:
-                return_dict['error']['message'] += ': %s' % e.extra_msg
+            if e.message:
+                return_dict['error']['message'] += ': %s' % e.message
 
             return self._finish(403, return_dict, content_type='json')
         except NotFound, e:
             return_dict['error'] = {'__type': 'Not Found Error',
                                     'message': _('Not found')}
-            if e.extra_msg:
-                return_dict['error']['message'] += ': %s' % e.extra_msg
+            if e.message:
+                return_dict['error']['message'] += ': %s' % e.message
             return_dict['success'] = False
             return self._finish(404, return_dict, content_type='json')
         except ValidationError, e:
@@ -289,11 +289,9 @@ class ApiController(base.BaseController):
         try:
             return self._finish_ok(action(context, {'id': id}))
         except NotFound, e:
-            extra_msg = e.extra_msg
-            return self._finish_not_found(extra_msg)
+            return self._finish_not_found(e.message)
         except NotAuthorized, e:
-            extra_msg = e.extra_msg
-            return self._finish_not_authz(extra_msg)
+            return self._finish_not_authz(e.message)
 
     def show(self, ver=None, register=None, subregister=None,
              id=None, id2=None):
@@ -321,11 +319,9 @@ class ApiController(base.BaseController):
         try:
             return self._finish_ok(action(context, data_dict))
         except NotFound, e:
-            extra_msg = e.extra_msg
-            return self._finish_not_found(extra_msg)
+            return self._finish_not_found(e.message)
         except NotAuthorized, e:
-            extra_msg = e.extra_msg
-            return self._finish_not_authz(extra_msg)
+            return self._finish_not_authz(e.message)
 
     def _represent_package(self, package):
         return package.as_dict(ref_package_by=self.ref_package_by,
@@ -371,11 +367,9 @@ class ApiController(base.BaseController):
             return self._finish_ok(response_data,
                                    resource_location=location)
         except NotAuthorized, e:
-            extra_msg = e.extra_msg
-            return self._finish_not_authz(extra_msg)
+            return self._finish_not_authz(e.message)
         except NotFound, e:
-            extra_msg = e.extra_msg
-            return self._finish_not_found(extra_msg)
+            return self._finish_not_found(e.message)
         except ValidationError, e:
             # CS: nasty_string ignore
             log.error('Validation error: %r' % str(e.error_dict))
@@ -428,11 +422,9 @@ class ApiController(base.BaseController):
             response_data = action(context, data_dict)
             return self._finish_ok(response_data)
         except NotAuthorized, e:
-            extra_msg = e.extra_msg
-            return self._finish_not_authz(extra_msg)
+            return self._finish_not_authz(e.message)
         except NotFound, e:
-            extra_msg = e.extra_msg
-            return self._finish_not_found(extra_msg)
+            return self._finish_not_found(e.message)
         except ValidationError, e:
             # CS: nasty_string ignore
             log.error('Validation error: %r' % str(e.error_dict))
@@ -477,11 +469,9 @@ class ApiController(base.BaseController):
             response_data = action(context, data_dict)
             return self._finish_ok(response_data)
         except NotAuthorized, e:
-            extra_msg = e.extra_msg
-            return self._finish_not_authz(extra_msg)
+            return self._finish_not_authz(e.message)
         except NotFound, e:
-            extra_msg = e.extra_msg
-            return self._finish_not_found(extra_msg)
+            return self._finish_not_found(e.message)
         except ValidationError, e:
             # CS: nasty_string ignore
             log.error('Validation error: %r' % str(e.error_dict))

--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -817,11 +817,11 @@ class GroupController(base.BaseController):
             h.flash_success(_("You are now following {0}").format(
                 group_dict['title']))
         except ValidationError as e:
-            error_message = (e.extra_msg or e.message or e.error_summary
+            error_message = (e.message or e.error_summary
                              or e.error_dict)
             h.flash_error(error_message)
         except NotAuthorized as e:
-            h.flash_error(e.extra_msg)
+            h.flash_error(e.message)
         h.redirect_to(controller='group', action='read', id=id)
 
     def unfollow(self, id):
@@ -836,11 +836,11 @@ class GroupController(base.BaseController):
             h.flash_success(_("You are no longer following {0}").format(
                 group_dict['title']))
         except ValidationError as e:
-            error_message = (e.extra_msg or e.message or e.error_summary
+            error_message = (e.message or e.error_summary
                              or e.error_dict)
             h.flash_error(error_message)
         except (NotFound, NotAuthorized) as e:
-            error_message = e.extra_msg or e.message
+            error_message = e.message
             h.flash_error(error_message)
         h.redirect_to(controller='group', action='read', id=id)
 

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -1213,11 +1213,11 @@ class PackageController(base.BaseController):
             h.flash_success(_("You are now following {0}").format(
                 package_dict['title']))
         except ValidationError as e:
-            error_message = (e.extra_msg or e.message or e.error_summary
+            error_message = (e.message or e.error_summary
                     or e.error_dict)
             h.flash_error(error_message)
         except NotAuthorized as e:
-            h.flash_error(e.extra_msg)
+            h.flash_error(e.message)
         h.redirect_to(controller='package', action='read', id=id)
 
     def unfollow(self, id):
@@ -1232,11 +1232,11 @@ class PackageController(base.BaseController):
             h.flash_success(_("You are no longer following {0}").format(
                 package_dict['title']))
         except ValidationError as e:
-            error_message = (e.extra_msg or e.message or e.error_summary
+            error_message = (e.message or e.error_summary
                     or e.error_dict)
             h.flash_error(error_message)
         except (NotFound, NotAuthorized) as e:
-            error_message = e.extra_msg or e.message
+            error_message = e.message
             h.flash_error(error_message)
         h.redirect_to(controller='package', action='read', id=id)
 

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -671,11 +671,11 @@ class UserController(base.BaseController):
             h.flash_success(_("You are now following {0}").format(
                 user_dict['display_name']))
         except ValidationError as e:
-            error_message = (e.extra_msg or e.message or e.error_summary
+            error_message = (e.message or e.error_summary
                              or e.error_dict)
             h.flash_error(error_message)
         except NotAuthorized as e:
-            h.flash_error(e.extra_msg)
+            h.flash_error(e.message)
         h.redirect_to(controller='user', action='read', id=id)
 
     def unfollow(self, id):
@@ -691,10 +691,10 @@ class UserController(base.BaseController):
             h.flash_success(_("You are no longer following {0}").format(
                 user_dict['display_name']))
         except (NotFound, NotAuthorized) as e:
-            error_message = e.extra_msg or e.message
+            error_message = e.message
             h.flash_error(error_message)
         except ValidationError as e:
-            error_message = (e.error_summary or e.message or e.extra_msg
+            error_message = (e.error_summary or e.message
                              or e.error_dict)
             h.flash_error(error_message)
         h.redirect_to(controller='user', action='read', id=id)

--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -34,23 +34,7 @@ class AttributeDict(dict):
 
 
 class ActionError(Exception):
-    def __init__(self, extra_msg=None):
-        self.extra_msg = extra_msg
-
-    def __str__(self):
-        try:
-            return str(self.__unicode__())
-        except UnicodeEncodeError:
-            # Encode unicode characters using backslashreplace, just as
-            # Exception.__str__ does
-            return self.__unicode__().encode('ascii', 'backslashreplace')
-
-    def __unicode__(self):
-        err_msgs = (super(ActionError, self).__str__(),
-                    self.extra_msg)
-        return ' - '.join([unicode(err_msg) for err_msg in err_msgs
-                           if err_msg])
-
+    pass
 
 class NotFound(ActionError):
     '''Exception raised by logic functions when a given object is not found.
@@ -93,7 +77,7 @@ class ValidationError(ActionError):
             error_dict['tags'] = tag_errors
         self.error_dict = error_dict
         self._error_summary = error_summary
-        self.extra_msg = extra_msg
+        super(ValidationError, self).__init__(extra_msg)
 
     @property
     def error_summary(self):


### PR DESCRIPTION
See: https://github.com/ckan/ckan/issues/2167

The key to this is `ActionError.__init__` which clearly only allows one message, and stores it in self.extra_msg, so self.message is always blank, making it a bit stupid to have the complexity in **str**/**unicode** functions.

NB This PR is not to merge to master, it is to merge to another branch (2165). This is because 2165 highlights issues with unicode and adds a couple of extra tests that exercise NotFound, showing this patch works.
