### PR TITLE
Fixes broken test on master when celery is installed.

### DIFF
--- a/ckan/tests/logic/test_action.py
+++ b/ckan/tests/logic/test_action.py
@@ -990,9 +990,9 @@ class TestAction(WsgiAppCase):
                             params=json.dumps({'id': '749cdcf2-3fc8-44ae-aed0-5eff8cc5032c'}),
                             status=200).body)
 
-        assert resource_status_show in res['help']
+        assert "/api/3/action/help_show?name=resource_status_show" in res['help']
         assert res['success'] is True
-        assert res['result'] == [{"status": "FAILURE", "entity_id": "749cdcf2-3fc8-44ae-aed0-5eff8cc5032c", "task_type": "qa", "last_updated": "2012-04-20T21:32:45.553986", "date_done": "2012-04-20T21:33:01.622557", "entity_type": "resource", "traceback": "Traceback", "value": "51f2105d-85b1-4393-b821-ac11475919d9", "state": None, "key": "celery_task_id", "error": "", "id": "5753adae-cd0d-4327-915d-edd832d1c9a3"}]
+        assert res['result'] == [{"status": None, "entity_id": "749cdcf2-3fc8-44ae-aed0-5eff8cc5032c", "task_type": "qa", "last_updated": "2012-04-20T21:32:45.553986", "date_done": None, "entity_type": "resource", "traceback": None, "value": "51f2105d-85b1-4393-b821-ac11475919d9", "state": None, "key": "celery_task_id", "error": "", "id": "5753adae-cd0d-4327-915d-edd832d1c9a3"}], res['result']
 
     def test_41_missing_action(self):
         try:


### PR DESCRIPTION
It appears that test_40_task_resource_status was never run if you do not have celery installed, and so didn't show up on travis.  The fix was to install celery, and to wrap the 'resource_status_show' with the correct url as a string.  This threw up another problem in that the results from the resource status check did not match what the tests assumed they did.

Either this has changed since it last caused a problem for someone, or it has been hidden for a very long time by the SkipTest :(

@davidread this should fix your problem running tests on master.
