### PR TITLE
Update IE versions to test against.

### DIFF
--- a/doc/contributing/test.rst
+++ b/doc/contributing/test.rst
@@ -157,7 +157,7 @@ Front-end Testing
 All new CKAN features should be coded so that they work in the
 following browsers:
 
-* Internet Explorer: 9, 8 and 7
+* Internet Explorer: 11, 10, 9 & 8
 * Firefox: Latest + previous version
 * Chrome: Latest + previous version
 


### PR DESCRIPTION
Hooray we can drop support for IE7, according to our test of 1% usage on data.gov.uk:
http://data.gov.uk/data/site-usage?month=2014-12#browsers_versions

