### PR TITLE
[WIP] Tell travis to use containers to run the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python:
   - "2.6"


### PR DESCRIPTION
According to http://docs.travis-ci.com/user/workers/container-based-infrastructure/ doing this tells travis to use containers which gives ..

```
* start up faster
* allow the use of caches for public repositories
* disallow the use of sudo, setuid and setgid executables
```
