### PR TITLE
Resource view information, warnings and re-enabled DataProxy

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -1562,7 +1562,8 @@ class PackageController(base.BaseController):
                 'data': data,
                 'errors': errors,
                 'error_summary': error_summary,
-                'to_preview': to_preview}
+                'to_preview': to_preview,
+                'datastore_available': p.plugin_loaded('datastore')}
         vars.update(
             view_plugin.setup_template_variables(context, data_dict) or {})
         vars.update(data_dict)

--- a/ckan/templates/package/new_view.html
+++ b/ckan/templates/package/new_view.html
@@ -13,6 +13,15 @@
 {% endblock %}
 
 {% block form %}
+  {% if resource_view.view_type == 'recline_view' and not datastore_available %}
+    <p class="text-info">
+      <i class="icon-info-sign"></i>
+      {% trans %}
+      Data Explorer views may be slow and less reliable without the DataStore extension enable. For more information, please see the <a href='http://docs.ckan.org/en/latest/maintaining/data-viewer.html#viewing-structured-data-the-data-explorer' target='_blank'>Data Explorer documentation</a>.
+      {% endtrans %}
+    </p>
+  {% endif %}
+
   <form class="dataset-form dataset-resource-form form-horizontal" method="post" data-module="basic-form resource-form">
     {% include 'package/snippets/view_form.html' %}
     <div class="form-actions">

--- a/ckan/templates/package/new_view.html
+++ b/ckan/templates/package/new_view.html
@@ -17,7 +17,7 @@
     <p class="text-info">
       <i class="icon-info-sign"></i>
       {% trans %}
-      Data Explorer views may be slow and less reliable without the DataStore extension enable. For more information, please see the <a href='http://docs.ckan.org/en/latest/maintaining/data-viewer.html#viewing-structured-data-the-data-explorer' target='_blank'>Data Explorer documentation</a>.
+      Data Explorer views may be slow and unreliable unless the DataStore extension is enabled. For more information, please see the <a href='http://docs.ckan.org/en/latest/maintaining/data-viewer.html#viewing-structured-data-the-data-explorer' target='_blank'>Data Explorer documentation</a>.
       {% endtrans %}
     </p>
   {% endif %}

--- a/ckan/templates/package/resource_read.html
+++ b/ckan/templates/package/resource_read.html
@@ -118,11 +118,11 @@
               {{ _('Click here for more information.') }}</a>
           </p>
           <div id="data-view-info" class="collapse">
-            <p>Here are some reasons you may not be seeing expected views:</p>
+            <p>{{ _('Here are some reasons you may not be seeing expected views:') }}</p>
             <ul>
-              <li>No view has been created that is suitable for this resource</li>
-              <li>The site administrators may not have enabled the relevant view plugins</li>
-              <li>If a view requires the DataStore, the DataStore plugin may not be enabled, or the data may not have been pushed to the DataStore, or the DataStore hasn't finished processing the data yet</li>
+              <li>{{ _("No view has been created that is suitable for this resource")}}</li>
+              <li>{{ _("The site administrators may not have enabled the relevant view plugins")}}</li>
+              <li>{{ _("If a view requires the DataStore, the DataStore plugin may not be enabled, or the data may not have been pushed to the DataStore, or the DataStore hasn't finished processing the data yet")}}</li>
             </ul>
           </div>
         </div>

--- a/ckan/templates/package/resource_read.html
+++ b/ckan/templates/package/resource_read.html
@@ -106,25 +106,30 @@
                     {% endif %}
                   {% endfor %}
                 {% endif %}
+              {% else %}
+                {# Views not created #}
+                <div class="module-content data-viewer-info">
+                  <p>{{ _("There are no views created for this resource yet.") }}</p>
+                  {% if h.check_access('resource_view_create') %}
+                    <p class="muted">
+                      <i class="icon-info-sign"></i>
+                      {{ _("Not seeing the views you were expecting?")}}
+                      <a href="javascript:void(0);" data-toggle="collapse" data-target="#data-view-info">
+                        {{ _('Click here for more information.') }}</a>
+                    </p>
+                    <div id="data-view-info" class="collapse">
+                      <p>{{ _('Here are some reasons you may not be seeing expected views:') }}</p>
+                      <ul>
+                        <li>{{ _("No view has been created that is suitable for this resource")}}</li>
+                        <li>{{ _("The site administrators may not have enabled the relevant view plugins")}}</li>
+                        <li>{{ _("If a view requires the DataStore, the DataStore plugin may not be enabled, or the data may not have been pushed to the DataStore, or the DataStore hasn't finished processing the data yet")}}</li>
+                      </ul>
+                    </div>
+                  {% endif %}
+                </div>
               {% endif %}
             </div>
           {% endblock %}
-        </div>
-        <div class="module-content data-viewer-info">
-          <p class="muted">
-            <i class="icon-info-sign"></i>
-            {{ _("Not seeing the views you were expecting?")}}
-            <a href="javascript:void(0);" data-toggle="collapse" data-target="#data-view-info">
-              {{ _('Click here for more information.') }}</a>
-          </p>
-          <div id="data-view-info" class="collapse">
-            <p>{{ _('Here are some reasons you may not be seeing expected views:') }}</p>
-            <ul>
-              <li>{{ _("No view has been created that is suitable for this resource")}}</li>
-              <li>{{ _("The site administrators may not have enabled the relevant view plugins")}}</li>
-              <li>{{ _("If a view requires the DataStore, the DataStore plugin may not be enabled, or the data may not have been pushed to the DataStore, or the DataStore hasn't finished processing the data yet")}}</li>
-            </ul>
-          </div>
         </div>
       {% endblock %}
       {% endblock %}

--- a/ckan/templates/package/resource_read.html
+++ b/ckan/templates/package/resource_read.html
@@ -122,7 +122,7 @@
             <ul>
               <li>No view has been created that is suitable for this resource</li>
               <li>The site administrators may not have enabled the relevant view plugins</li>
-              <li>If this view requires the DataStore, the DataStore plugin may not be enabled, or the data may not have been pushed to the DataStore, or the DataStore hasn't finished processing the data yet</li>
+              <li>If a view requires the DataStore, the DataStore plugin may not be enabled, or the data may not have been pushed to the DataStore, or the DataStore hasn't finished processing the data yet</li>
             </ul>
           </div>
         </div>

--- a/ckan/templates/package/resource_read.html
+++ b/ckan/templates/package/resource_read.html
@@ -92,9 +92,7 @@
             <div class="resource-view">
               {% set resource_preview = h.resource_preview(c.resource, c.package) %}
               {% set views_created = res.has_views or resource_preview %}
-              {% if not views_created %}
-                {{ _("There're no views created for this resource yet.") }}
-              {% else %}
+              {% if views_created %}
                 {% if resource_preview and not current_resource_view %}
                   {{ h.resource_preview(c.resource, c.package) }}
                 {% else %}
@@ -111,6 +109,26 @@
               {% endif %}
             </div>
           {% endblock %}
+        </div>
+        <div class="module-content data-viewer-info">
+          <p class="muted">
+            <i class="icon-info-sign"></i>
+            {{ _("Not seeing the views you were expecting?")}}
+            <a href="javascript:void(0);" data-toggle="collapse" data-target="#data-view-info">
+              {{ _('Click here for more information.') }}</a>
+          </p>
+          <div id="data-view-info" class="collapse">
+            <p>Here are some reasons you may not be seeing expected views:</p>
+            <ul>
+  <!--             There are no views suitable for this format
+  The admins haven't enabled the relevant view plugin on the config file
+  The admins haven't defined the relevant view plugin on the config file as one of the ones to be created by default
+  If the view plugin requires data to be in the DataStore, data is not yet on on the DataStore -->
+              <li>No view has been created that is suitable for this resource</li>
+              <li>The site administrators may not have enabled the relevant view plugins</li>
+              <li>If this view requires the DataStore, the DataStore plugin may not be enabled, or the data may not have been pushed to the DataStore, or the DataStore hasn't finished processing the data yet</li>
+            </ul>
+          </div>
         </div>
       {% endblock %}
       {% endblock %}

--- a/ckan/templates/package/resource_read.html
+++ b/ckan/templates/package/resource_read.html
@@ -120,10 +120,6 @@
           <div id="data-view-info" class="collapse">
             <p>Here are some reasons you may not be seeing expected views:</p>
             <ul>
-  <!--             There are no views suitable for this format
-  The admins haven't enabled the relevant view plugin on the config file
-  The admins haven't defined the relevant view plugin on the config file as one of the ones to be created by default
-  If the view plugin requires data to be in the DataStore, data is not yet on on the DataStore -->
               <li>No view has been created that is suitable for this resource</li>
               <li>The site administrators may not have enabled the relevant view plugins</li>
               <li>If this view requires the DataStore, the DataStore plugin may not be enabled, or the data may not have been pushed to the DataStore, or the DataStore hasn't finished processing the data yet</li>

--- a/ckan/templates/package/snippets/view_form.html
+++ b/ckan/templates/package/snippets/view_form.html
@@ -8,7 +8,7 @@
 {{ form.input('title', id='field-title', label=_('Title'), placeholder=_('eg. My View'), value=data.title, error=errors.title, classes=['control-full', 'control-large'], is_required=true) }}
 {{ form.markdown('description', id='field-description', label=_('Description'), placeholder=_('eg. Information about my view'), value=data.description, error=errors.description) }}
 
-{# form template is defined in ResouceView extention point #} 
+{# form template is defined in ResourceView extension point #}
 {% if form_template %}
   {% include form_template %}
 {% endif %}

--- a/ckanext/reclineview/plugin.py
+++ b/ckanext/reclineview/plugin.py
@@ -58,9 +58,7 @@ class ReclineViewBase(p.SingletonPlugin):
         toolkit.add_resource('theme/public', 'ckanext-reclineview')
 
     def can_view(self, data_dict):
-        if data_dict['resource'].get('datastore_active'):
-            return True
-        return False
+        return data_dict['resource'].get('datastore_active')
 
     def setup_template_variables(self, context, data_dict):
         return {'resource_json': json.dumps(data_dict['resource']),
@@ -78,7 +76,17 @@ class ReclineView(ReclineViewBase):
     def info(self):
         return {'name': 'recline_view',
                 'title': 'Data Explorer',
+                'requires_datastore': False,
                 'icon': 'table'}
+
+    def can_view(self, data_dict):
+        if data_dict['resource'].get('datastore_active'):
+            return True
+        resource_format = data_dict['resource'].get('format', None)
+        if resource_format:
+            return resource_format.lower() in ['csv', 'xls', 'tsv']
+        else:
+            return False
 
 
 class ReclineGridView(ReclineViewBase):

--- a/ckanext/reclineview/plugin.py
+++ b/ckanext/reclineview/plugin.py
@@ -76,7 +76,6 @@ class ReclineView(ReclineViewBase):
     def info(self):
         return {'name': 'recline_view',
                 'title': 'Data Explorer',
-                'requires_datastore': False,
                 'icon': 'table'}
 
     def can_view(self, data_dict):

--- a/ckanext/reclineview/tests/test_view.py
+++ b/ckanext/reclineview/tests/test_view.py
@@ -56,6 +56,27 @@ class TestReclineView(BaseTestReclineViewBase):
         schema = self.p.info().get('schema')
         assert schema is None, schema
 
+    def test_can_view_format_no_datastore(self):
+        '''
+        Test can_view with acceptable formats when datastore_active is False
+        (DataProxy in use).
+        '''
+        formats = ['CSV', 'XLS', 'TSV', 'csv', 'xls', 'tsv']
+        for resource_format in formats:
+            data_dict = {'resource': {'datastore_active': False,
+                                      'format': resource_format}}
+            assert self.p.can_view(data_dict)
+
+    def test_can_view_bad_format_no_datastore(self):
+        '''
+        Test can_view with incorrect formats when datastore_active is False.
+        '''
+        formats = ['TXT', 'txt', 'doc', 'JSON']
+        for resource_format in formats:
+            data_dict = {'resource': {'datastore_active': False,
+                                      'format': resource_format}}
+            assert not self.p.can_view(data_dict)
+
 
 class TestReclineGridView(BaseTestReclineViewBase):
     view_type = 'recline_grid_view'

--- a/ckanext/reclineview/theme/public/recline_view.js
+++ b/ckanext/reclineview/theme/public/recline_view.js
@@ -49,8 +49,13 @@ this.ckan.module('recline_view', function (jQuery, _) {
 
       var errorMsg, dataset;
 
-      resourceData.backend =  'ckan';
-      resourceData.endpoint = jQuery('body').data('site-root') + 'api';
+      if (!resourceData.datastore_active) {
+          recline.Backend.DataProxy.timeout = 10000;
+          resourceData.backend =  'dataproxy';
+      } else {
+          resourceData.backend =  'ckan';
+          resourceData.endpoint = jQuery('body').data('site-root') + 'api';
+      }
 
       dataset = new recline.Model.Dataset(resourceData);
 


### PR DESCRIPTION
Related to #2140. This PR:

- re-enables the DataProxy for recline_view (Data Explorer). 
- adds an information reveal for resource view creators detailing possible reasons they may not be seeing the views they expect. 
- adds a warning when creating recline_view views in the absence of the DataStore (that would display using the DataProxy), to warn the view may be slow and unreliable.