### PR TITLE
datastore fails on certain encodings

### DIFF
--- a/ckanext/datastore/db.py
+++ b/ckanext/datastore/db.py
@@ -799,8 +799,8 @@ def _to_full_text(fields, record):
         if not value:
             continue
 
-        if field['type'].lower() in ft_types and str(value):
-            full_text.append(str(value))
+        if field['type'].lower() in ft_types and unicode(value):
+            full_text.append(unicode(value))
         else:
             full_text.extend(json_get_values(value))
     return ' '.join(set(full_text))


### PR DESCRIPTION
When the datapusher attempts to push non-ascii encodings, datastore sometimes fails to load them properly. Possibly related to #2103 

```
URL: http://boot2docker:49156/api/3/action/datastore_create
File '/usr/lib/ckan/lib/python2.7/site-packages/weberror/errormiddleware.py', line 162 in __call__
  app_iter = self.application(environ, sr_checker)
File '/usr/lib/ckan/lib/python2.7/site-packages/webob/dec.py', line 147 in __call__
  resp = self.call_func(req, *args, **self.kwargs)
File '/usr/lib/ckan/lib/python2.7/site-packages/webob/dec.py', line 208 in call_func
  return self.func(req, *args, **kwargs)
File '/usr/lib/ckan/lib/python2.7/site-packages/fanstatic/publisher.py', line 234 in __call__
  return request.get_response(self.app)
File '/usr/lib/ckan/lib/python2.7/site-packages/webob/request.py', line 1053 in get_response
  application, catch_exc_info=False)
File '/usr/lib/ckan/lib/python2.7/site-packages/webob/request.py', line 1022 in call_application
  app_iter = application(self.environ, start_response)
File '/usr/lib/ckan/lib/python2.7/site-packages/webob/dec.py', line 147 in __call__
  resp = self.call_func(req, *args, **self.kwargs)
File '/usr/lib/ckan/lib/python2.7/site-packages/webob/dec.py', line 208 in call_func
  return self.func(req, *args, **kwargs)
File '/usr/lib/ckan/lib/python2.7/site-packages/fanstatic/injector.py', line 54 in __call__
  response = request.get_response(self.app)
File '/usr/lib/ckan/lib/python2.7/site-packages/webob/request.py', line 1053 in get_response
  application, catch_exc_info=False)
File '/usr/lib/ckan/lib/python2.7/site-packages/webob/request.py', line 1022 in call_application
  app_iter = application(self.environ, start_response)
File '/usr/lib/ckan/lib/python2.7/site-packages/beaker/middleware.py', line 73 in __call__
  return self.app(environ, start_response)
File '/usr/lib/ckan/lib/python2.7/site-packages/beaker/middleware.py', line 155 in __call__
  return self.wrap_app(environ, session_start_response)
File '/usr/lib/ckan/lib/python2.7/site-packages/routes/middleware.py', line 131 in __call__
  response = self.app(environ, start_response)
File '/usr/lib/ckan/lib/python2.7/site-packages/pylons/wsgiapp.py', line 125 in __call__
  response = self.dispatch(controller, environ, start_response)
File '/usr/lib/ckan/lib/python2.7/site-packages/pylons/wsgiapp.py', line 324 in dispatch
  return controller(environ, start_response)
File '/project/src/ckan/ckan/controllers/api.py', line 70 in __call__
  return base.BaseController.__call__(self, environ, start_response)
File '/project/src/ckan/ckan/lib/base.py', line 338 in __call__
  res = WSGIController.__call__(self, environ, start_response)
File '/usr/lib/ckan/lib/python2.7/site-packages/pylons/controllers/core.py', line 221 in __call__
  response = self._dispatch_call()
File '/usr/lib/ckan/lib/python2.7/site-packages/pylons/controllers/core.py', line 172 in _dispatch_call
  response = self._inspect_call(func)
File '/usr/lib/ckan/lib/python2.7/site-packages/pylons/controllers/core.py', line 107 in _inspect_call
  result = self._perform_call(func, args)
File '/usr/lib/ckan/lib/python2.7/site-packages/pylons/controllers/core.py', line 60 in _perform_call
  return func(**args)
File '/project/src/ckan/ckan/controllers/api.py', line 197 in action
  result = function(context, request_data)
File '/project/src/ckan/ckan/logic/__init__.py', line 424 in wrapped
  result = _action(context, data_dict, **kw)
File '/project/src/ckan/ckanext/datastore/logic/action.py', line 138 in datastore_create
  result = db.create(context, data_dict)
File '/project/src/ckan/ckanext/datastore/db.py', line 1021 in create
  insert_data(context, data_dict)
File '/project/src/ckan/ckanext/datastore/db.py', line 580 in insert_data
  return upsert_data(context, data_dict)
File '/project/src/ckan/ckanext/datastore/db.py', line 608 in upsert_data
  row.append(_to_full_text(fields, record))
File '/project/src/ckan/ckanext/datastore/db.py', line 761 in _to_full_text
  elif field['type'].lower() in ft_types and str(value):
UnicodeEncodeError: 'ascii' codec can't encode character u'\\xe9' in position 3: ordinal not in 
```