### PR TITLE
[#2188] Do not allow public to view deleted groups. 

### DIFF
--- a/ckan/logic/auth/__init__.py
+++ b/ckan/logic/auth/__init__.py
@@ -16,7 +16,7 @@ def _get_object(context, data_dict, name, class_name):
             data_dict = {}
         id = data_dict.get('id', None)
         if not id:
-            raise logic.ValidationError('Missig id, can not get {0} object'
+            raise logic.ValidationError('Missing id, can not get {0} object'
                                         .format(class_name))
         obj = getattr(model, class_name).get(id)
         if not obj:

--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -150,12 +150,19 @@ def revision_show(context, data_dict):
     return {'success': True}
 
 def group_show(context, data_dict):
-    # anyone can see a group
-    return {'success': True}
+    user = context.get('user')
+    group = get_group_object(context, data_dict)
+    if group.state == 'active':
+        return {'success': True}
+    authorized = new_authz.has_user_permission_for_group_or_org(
+        group.id, user, 'read')
+    if authorized:
+        return {'success': True}
+    else:
+        return {'success': False, 'msg': _('User %s not authorized to read group %s') % (user, group.id)}
 
 def organization_show(context, data_dict):
-    # anyone can see a organization
-    return {'success': True}
+    return group_show(context, data_dict)
 
 def tag_show(context, data_dict):
     # No authz check in the logic function

--- a/ckan/new_tests/logic/auth/test_get.py
+++ b/ckan/new_tests/logic/auth/test_get.py
@@ -1,0 +1,70 @@
+'''Unit tests for ckan/logic/auth/get.py.
+
+'''
+
+from nose.tools import assert_raises
+
+import ckan.new_tests.helpers as helpers
+import ckan.new_tests.factories as factories
+import ckan.logic as logic
+from ckan import model
+
+
+class TestGet(object):
+
+    def setup(self):
+        helpers.reset_db()
+
+    def test_package_show__deleted_dataset_is_hidden_to_public(self):
+        dataset = factories.Dataset(state='deleted')
+        context = {'model': model}
+        context['user'] = ''
+
+        assert_raises(logic.NotAuthorized, helpers.call_auth,
+                      'package_show', context=context,
+                      id=dataset['name'])
+
+    def test_package_show__deleted_dataset_is_visible_to_editor(self):
+
+        fred = factories.User(name='fred')
+        fred['capacity'] = 'editor'
+        org = factories.Organization(users=[fred])
+        dataset = factories.Dataset(owner_org=org['id'], state='deleted')
+        context = {'model': model}
+        context['user'] = 'fred'
+
+        ret = helpers.call_auth('package_show', context=context,
+                                id=dataset['name'])
+        assert ret
+
+    def test_group_show__deleted_group_is_hidden_to_public(self):
+        group = factories.Group(state='deleted')
+        context = {'model': model}
+        context['user'] = ''
+
+        assert_raises(logic.NotAuthorized, helpers.call_auth,
+                      'group_show', context=context,
+                      id=group['name'])
+
+    def test_group_show__deleted_group_is_visible_to_its_member(self):
+
+        fred = factories.User(name='fred')
+        org = factories.Group(users=[fred])
+        context = {'model': model}
+        context['user'] = 'fred'
+
+        ret = helpers.call_auth('group_show', context=context,
+                                id=org['name'])
+        assert ret
+
+    def test_group_show__deleted_org_is_visible_to_its_member(self):
+
+        fred = factories.User(name='fred')
+        fred['capacity'] = 'editor'
+        org = factories.Organization(users=[fred])
+        context = {'model': model}
+        context['user'] = 'fred'
+
+        ret = helpers.call_auth('group_show', context=context,
+                                id=org['name'])
+        assert ret

--- a/ckan/templates/group/snippets/info.html
+++ b/ckan/templates/group/snippets/info.html
@@ -10,7 +10,12 @@
     </div>
     {% endblock %}
     {% block heading %}
-    <h1 class="heading">{{ group.display_name }}</h1>
+    <h1 class="heading">
+      {{ group.display_name }}
+      {% if group.state == 'deleted' %}
+        [{{ _('Deleted') }}]
+      {% endif %}
+    </h1>
     {% endblock %}
     {% block description %}
     {% if group.description %}

--- a/ckan/templates/package/read.html
+++ b/ckan/templates/package/read.html
@@ -17,6 +17,9 @@
         {% if pkg.state.startswith('draft') %}
           [{{ _('Draft') }}]
         {% endif %}
+        {% if pkg.state == 'deleted' %}
+          [{{ _('Deleted') }}]
+        {% endif %}
       {% endblock %}
     </h1>
     {% block package_notes %}

--- a/ckan/templates/snippets/organization.html
+++ b/ckan/templates/snippets/organization.html
@@ -32,7 +32,11 @@ Example:
         </div>
       {% endblock %}
       {% block heading %}
-      <h1 class="heading">{{ organization.title or organization.name }}</h1>
+      <h1 class="heading">{{ organization.title or organization.name }}
+        {% if organization.state == 'deleted' %}
+          [{{ _('Deleted') }}]
+        {% endif %}
+      </h1>
       {% endblock %}
       {% block description %}
       {% if organization.description %}

--- a/ckan/tests/functional/api/test_activity.py
+++ b/ckan/tests/functional/api/test_activity.py
@@ -223,7 +223,6 @@ class TestActivity:
             extra_environ = {'Authorization': str(apikey)}
         else:
             extra_environ = None
-        print '@@@@@@@@', extra_environ
         response = self.app.get("/api/2/rest/dataset/%s/activity" % package_id,
                 extra_environ=extra_environ)
         return json.loads(response.body)
@@ -831,6 +830,10 @@ class TestActivity:
         timestamp = datetime_from_string(activity['timestamp'])
         assert timestamp >= before['time'] and timestamp <= after['time'], \
             str(activity['timestamp'])
+
+        # Tidy up - undelete the group for following tests
+        group_dict = {'id': group['id'], 'state': 'active'}
+        group_update(self.app, group_dict, user['apikey'])
 
     def _update_group(self, group, user):
         """


### PR DESCRIPTION
Fixes: #2188 

Also, show in template when a pkg/group/org is deleted. These pages are only visible by a sysadmin (or the org editor/admin or group member) when they go to the direct URL (or via the trash for packages). But it it is helpful to see they are deleted, to avoid confusion.