### PR TITLE
URL encode call_action_api parameters

### DIFF
--- a/ckan/tests/__init__.py
+++ b/ckan/tests/__init__.py
@@ -15,6 +15,7 @@ from unittest import TestCase
 from nose.tools import assert_equal, assert_not_equal, make_decorator
 from nose.plugins.skip import SkipTest
 import time
+import urllib
 
 from pylons import config
 from pylons.test import pylonsapp
@@ -457,7 +458,7 @@ def call_action_api(app, action, apikey=None, status=200, **kwargs):
     :rtype: dictionary
 
     '''
-    params = json.dumps(kwargs)
+    params = urllib.quote(json.dumps(kwargs))
     response = app.post('/api/action/{0}'.format(action), params=params,
             extra_environ={'Authorization': str(apikey)}, status=status)
     assert '/api/3/action/help_show?name={0}'.format(action) \


### PR DESCRIPTION
CKAN's call_action_api function is useful for testing custom extensions through API but we came across problems with some parameters that should be URL encoded. 

ckan.tests.call_action_api only converts input data to a JSON string, but does not URL encode it. This results in plus (+) signs being converted to spaces using this function (and very likely other issues). This added 'urllib.quote' should fix the issue.

