### PR TITLE
group_show, organization_show: exclude datasets by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,12 @@ API changes and deprecations
   revisions, rather than the activity stream. If you want the actual activity
   stream for a user, call ``user_activity_list`` instead.
 
+* The ``group_show`` and ``organization_show`` API calls do not return
+  ``datasets`` by default any more.
+
+  Custom templates or users of this API call will need to pass
+  ``include_datasets=True`` to include datasets in the response.
+
 * ``helpers.get_action()`` (or ``h.get_action()`` in templates) is deprecated.
 
   Since action functions raise exceptions and templates cannot catch

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1141,9 +1141,7 @@ def _group_or_org_show(context, data_dict, is_org=False):
     group = model.Group.get(id)
     context['group'] = group
 
-    include_datasets = data_dict.get('include_datasets', False)
-    if isinstance(include_datasets, basestring):
-        include_datasets = (include_datasets.lower() in ('false', '0'))
+    include_datasets = asbool(data_dict.get('include_datasets', False))
     packages_field = 'datasets' if include_datasets \
                      else 'none_but_include_package_count'
 

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1141,9 +1141,9 @@ def _group_or_org_show(context, data_dict, is_org=False):
     group = model.Group.get(id)
     context['group'] = group
 
-    include_datasets = data_dict.get('include_datasets', True)
+    include_datasets = data_dict.get('include_datasets', False)
     if isinstance(include_datasets, basestring):
-        include_datasets = (include_datasets.lower() in ('true', '1'))
+        include_datasets = (include_datasets.lower() in ('false', '0'))
     packages_field = 'datasets' if include_datasets \
                      else 'none_but_include_package_count'
 
@@ -1197,7 +1197,7 @@ def group_show(context, data_dict):
     :param id: the id or name of the group
     :type id: string
     :param include_datasets: include a list of the group's datasets
-         (optional, default: ``True``)
+         (optional, default: ``False``)
     :type id: boolean
 
     :rtype: dictionary
@@ -1214,7 +1214,7 @@ def organization_show(context, data_dict):
     :param id: the id or name of the organization
     :type id: string
     :param include_datasets: include a list of the organization's datasets
-         (optional, default: ``True``)
+         (optional, default: ``False``)
     :type id: boolean
 
     :rtype: dictionary

--- a/ckan/new_tests/logic/action/test_get.py
+++ b/ckan/new_tests/logic/action/test_get.py
@@ -148,11 +148,12 @@ class TestGet(object):
 
         group = factories.Group(user=factories.User())
 
-        group_dict = helpers.call_action('group_show', id=group['id'])
+        group_dict = helpers.call_action('group_show', id=group['id'],
+                                         include_datasets=True)
 
         # FIXME: Should this be returned by group_create?
         group_dict.pop('num_followers', None)
-        assert group_dict == group
+        eq(group_dict, group)
 
     def test_group_show_error_not_found(self):
 
@@ -184,7 +185,8 @@ class TestGet(object):
                                 context={'user': user_name},
                                 **dataset)
 
-        group_dict = helpers.call_action('group_show', id=group['id'])
+        group_dict = helpers.call_action('group_show', id=group['id'],
+                                         include_datasets=True)
 
         assert len(group_dict['packages']) == 2
         assert group_dict['package_count'] == 2
@@ -206,6 +208,7 @@ class TestGet(object):
                                 **dataset)
 
         group_dict = helpers.call_action('group_show', id=group['id'],
+                                         include_datasets=True,
                                          context={'for_view': True})
 
         assert len(group_dict['packages']) == 2
@@ -277,11 +280,12 @@ class TestGet(object):
 
         org = factories.Organization()
 
-        org_dict = helpers.call_action('organization_show', id=org['id'])
+        org_dict = helpers.call_action('organization_show', id=org['id'],
+                                       include_datasets=True)
 
         # FIXME: Should this be returned by organization_create?
         org_dict.pop('num_followers', None)
-        assert org_dict == org
+        eq(org_dict, org)
 
     def test_organization_show_error_not_found(self):
 
@@ -313,7 +317,8 @@ class TestGet(object):
                                 context={'user': user_name},
                                 **dataset)
 
-        org_dict = helpers.call_action('organization_show', id=org['id'])
+        org_dict = helpers.call_action('organization_show', id=org['id'],
+                                       include_datasets=True)
 
         assert len(org_dict['packages']) == 2
         assert org_dict['package_count'] == 2
@@ -334,7 +339,8 @@ class TestGet(object):
                                 context={'user': user_name},
                                 **dataset)
 
-        org_dict = helpers.call_action('organization_show', id=org['id'])
+        org_dict = helpers.call_action('organization_show', id=org['id'],
+                                       include_datasets=True)
 
         assert len(org_dict['packages']) == 1
         assert org_dict['packages'][0]['name'] == 'dataset_1'
@@ -574,7 +580,7 @@ class TestGet(object):
                 context = {'user': user['name']}
 
             group = helpers.call_action('group_show', id=group['id'],
-                                        context=context)
+                                        include_datasets=True, context=context)
 
             assert private_dataset['id'] not in [dataset['id'] for dataset
                                                  in group['packages']], (

--- a/ckan/tests/functional/api/test_dashboard.py
+++ b/ckan/tests/functional/api/test_dashboard.py
@@ -246,8 +246,9 @@ class TestDashboard(object):
 
         # Make someone that the user is not following update a group that the
         # user is following.
-        group = self.post('group_show', {'id': 'roger'},
-        apikey=self.testsysadmin['apikey'])
+        group = self.post('group_show',
+                          {'id': 'roger', 'include_datasets':True},
+                          apikey=self.testsysadmin['apikey'])
         group['description'] = 'updated'
         self.post('group_update', group, apikey=self.testsysadmin['apikey'])
 


### PR DESCRIPTION
Prefer to not include datasets for the common case of just querying the group/org information (performance win). This brings the `include_datasets` parameter default in line with `include_datasets` parameter on user_show and `include_tags`, `include_groups` and `include_extras` in group_list and organization_list.