### PR TITLE
package_show: exclude tracking info by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,12 @@ API changes and deprecations
   revisions, rather than the activity stream. If you want the actual activity
   stream for a user, call ``user_activity_list`` instead.
 
+* The ``package_show`` API call does not return the ``tracking_summary``,
+  keys in the dataset or resources by default any more.
+
+  Any custom templates or users of this API call that use these values will
+  need to pass: ``include_tracking=True``.
+
 * ``helpers.get_action()`` (or ``h.get_action()`` in templates) is deprecated.
 
   Since action functions raise exceptions and templates cannot catch

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -328,7 +328,7 @@ class PackageController(base.BaseController):
         context = {'model': model, 'session': model.Session,
                    'user': c.user or c.author, 'for_view': True,
                    'auth_user_obj': c.userobj}
-        data_dict = {'id': id}
+        data_dict = {'id': id, 'include_tracking': True}
 
         try:
             check_access('package_update', context, data_dict)
@@ -369,7 +369,7 @@ class PackageController(base.BaseController):
         context = {'model': model, 'session': model.Session,
                    'user': c.user or c.author, 'for_view': True,
                    'auth_user_obj': c.userobj}
-        data_dict = {'id': id}
+        data_dict = {'id': id, 'include_tracking': True}
 
         # interpret @<revision_id> or @<date> suffix
         split = id.split('@')

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -185,9 +185,11 @@ class PackageSearchIndex(SearchIndex):
            pkg_dict['organization'] = None
 
         # tracking
-        if tracking_summary:
-            pkg_dict['views_total'] = tracking_summary['total']
-            pkg_dict['views_recent'] = tracking_summary['recent']
+        if not tracking_summary:
+            tracking_summary = model.TrackingSummary.get_for_package(
+                pkg_dict['id'])
+        pkg_dict['views_total'] = tracking_summary['total']
+        pkg_dict['views_recent'] = tracking_summary['recent']
 
         resource_fields = [('name', 'res_name'),
                            ('description', 'res_description'),

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -106,6 +106,11 @@ class PackageSearchIndex(SearchIndex):
         if pkg_dict is None:
             return
 
+        # tracking summary values will be stale, never store them
+        pkg_dict.pop('tracking_summary', None)
+        for r in pkg_dict.get('resources', []):
+            r.pop('tracking_summary', None)
+
         if config.get('ckan.cache_validated_datasets', True):
             package_plugin = lib_plugins.lookup_package_plugin(
                 pkg_dict.get('type'))

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -107,7 +107,7 @@ class PackageSearchIndex(SearchIndex):
             return
 
         # tracking summary values will be stale, never store them
-        pkg_dict.pop('tracking_summary', None)
+        tracking_summary = pkg_dict.pop('tracking_summary', None)
         for r in pkg_dict.get('resources', []):
             r.pop('tracking_summary', None)
 
@@ -185,7 +185,6 @@ class PackageSearchIndex(SearchIndex):
            pkg_dict['organization'] = None
 
         # tracking
-        tracking_summary = pkg_dict.pop('tracking_summary', None)
         if tracking_summary:
             pkg_dict['views_total'] = tracking_summary['total']
             pkg_dict['views_recent'] = tracking_summary['recent']

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -999,6 +999,9 @@ def resource_show(context, data_dict):
 
     :param id: the id of the resource
     :type id: string
+    :param include_tracking: add tracking information to dataset and
+        resources (default: False)
+    :type include_tracking: bool
 
     :rtype: dictionary
 
@@ -1016,7 +1019,8 @@ def resource_show(context, data_dict):
 
     pkg_dict = logic.get_action('package_show')(
         dict(context),
-        {'id': resource.package.id})
+        {'id': resource.package.id,
+        'include_tracking': asbool(data_dict.get('include_tracking', False))})
 
     for resource_dict in pkg_dict['resources']:
         if resource_dict['id'] == id:

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -897,7 +897,9 @@ def package_show(context, data_dict):
     :param use_default_schema: use default package schema instead of
         a custom schema defined with an IDatasetForm plugin (default: False)
     :type use_default_schema: bool
-
+    :param include_tracking: add tracking information to dataset and
+        resources (default: False)
+    :type include_tracking: bool
     :rtype: dictionary
 
     '''
@@ -916,6 +918,7 @@ def package_show(context, data_dict):
 
     if data_dict.get('use_default_schema', False):
         context['schema'] = ckan.logic.schema.default_show_package_schema()
+    include_tracking = asbool(data_dict.get('include_tracking', False))
 
     package_dict = None
     use_cache = (context.get('use_cache', True)
@@ -945,19 +948,13 @@ def package_show(context, data_dict):
         package_dict = model_dictize.package_dictize(pkg, context)
         package_dict_validated = False
 
-    # Add page-view tracking summary data to the package dict.
-    # If the package_dict came from the Solr cache then it will already have a
-    # potentially outdated tracking_summary, this will overwrite it with a
-    # current one.
-    package_dict['tracking_summary'] = model.TrackingSummary.get_for_package(
-        package_dict['id'])
+    if include_tracking:
+        # page-view tracking summary data
+        package_dict['tracking_summary'] = (
+            model.TrackingSummary.get_for_package(package_dict['id']))
 
-    # Add page-view tracking summary data to the package's resource dicts.
-    # If the package_dict came from the Solr cache then each resource dict will
-    # already have a potentially outdated tracking_summary, this will overwrite
-    # it with a current one.
-    for resource_dict in package_dict['resources']:
-        _add_tracking_summary_to_resource_dict(resource_dict, model)
+        for resource_dict in package_dict['resources']:
+            _add_tracking_summary_to_resource_dict(resource_dict, model)
 
     if context.get('for_view'):
         for item in plugins.PluginImplementations(plugins.IPackageController):

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -266,7 +266,7 @@ def default_show_package_schema():
     schema['owner_org'] = []
     schema['private'] = []
     schema['revision_id'] = []
-    schema['tracking_summary'] = []
+    schema['tracking_summary'] = [ignore_missing]
     schema['license_title'] = []
 
     return schema

--- a/ckan/tests/functional/test_tracking.py
+++ b/ckan/tests/functional/test_tracking.py
@@ -104,7 +104,8 @@ class TestTracking(object):
         # The API should return 0 recent views and 0 total views for the
         # unviewed package.
         package = tests.call_action_api(app, 'package_show',
-                                        id=package['name'])
+                                        id=package['name'],
+                                        include_tracking=True)
         tracking_summary = package['tracking_summary']
         assert tracking_summary['recent'] == 0, ("A package that has not "
                                                  "been viewed should have 0 "
@@ -122,7 +123,8 @@ class TestTracking(object):
         # The package_show() API should return 0 recent views and 0 total
         # views for the unviewed resource.
         package = tests.call_action_api(app, 'package_show',
-                                        id=package['name'])
+                                        id=package['name'],
+                                        include_tracking=True)
         assert len(package['resources']) == 1
         resource = package['resources'][0]
         tracking_summary = resource['tracking_summary']
@@ -136,7 +138,8 @@ class TestTracking(object):
         # The resource_show() API should return 0 recent views and 0 total
         # views for the unviewed resource.
         resource = tests.call_action_api(app, 'resource_show',
-                                         id=resource['id'])
+                                         id=resource['id'],
+                                         include_tracking=True)
         tracking_summary = resource['tracking_summary']
         assert tracking_summary['recent'] == 0, ("A resource that has not "
                                                  "been viewed should have 0 "
@@ -157,7 +160,8 @@ class TestTracking(object):
 
         self._update_tracking_summary()
 
-        package = tests.call_action_api(app, 'package_show', id=package['id'])
+        package = tests.call_action_api(app, 'package_show', id=package['id'],
+                                        include_tracking=True)
         tracking_summary = package['tracking_summary']
         assert tracking_summary['recent'] == 1, ("A package that has been "
                                                  "viewed once should have 1 "
@@ -189,7 +193,8 @@ class TestTracking(object):
 
         self._update_tracking_summary()
 
-        package = tests.call_action_api(app, 'package_show', id=package['id'])
+        package = tests.call_action_api(app, 'package_show', id=package['id'],
+                                        include_tracking=True)
         assert len(package['resources']) == 1
         resource = package['resources'][0]
 
@@ -224,7 +229,8 @@ class TestTracking(object):
         self._post_to_tracking(app, resource['url'], type_='resource')
         self._update_tracking_summary()
 
-        package = tests.call_action_api(app, 'package_show', id=package['id'])
+        package = tests.call_action_api(app, 'package_show', id=package['id'],
+                                        include_tracking=True)
         assert len(package['resources']) == 1
         resource = package['resources'][0]
         assert package['tracking_summary']['recent'] == 0, (
@@ -242,7 +248,8 @@ class TestTracking(object):
 
         # The resource_show() API should return the same result.
         resource = tests.call_action_api(app, 'resource_show',
-                                         id=resource['id'])
+                                         id=resource['id'],
+                                         include_tracking=True)
         tracking_summary = resource['tracking_summary']
         assert tracking_summary['recent'] == 1, (
             "Downloading a resource should increase the resource's recent "
@@ -297,7 +304,8 @@ class TestTracking(object):
 
         self._update_tracking_summary()
 
-        package = tests.call_action_api(app, 'package_show', id=package['id'])
+        package = tests.call_action_api(app, 'package_show', id=package['id'],
+                                        include_tracking=True)
         tracking_summary = package['tracking_summary']
         assert tracking_summary['recent'] == 3, (
             "A package that has been viewed 3 times recently should have 3 "
@@ -329,7 +337,8 @@ class TestTracking(object):
 
         self._update_tracking_summary()
 
-        package = tests.call_action_api(app, 'package_show', id=package['id'])
+        package = tests.call_action_api(app, 'package_show', id=package['id'],
+                                        include_tracking=True)
         assert len(package['resources']) == 1
         resource = package['resources'][0]
         tracking_summary = resource['tracking_summary']
@@ -409,7 +418,8 @@ class TestTracking(object):
 
         self._update_tracking_summary()
 
-        package = tests.call_action_api(app, 'package_show', id=package['id'])
+        package = tests.call_action_api(app, 'package_show', id=package['id'],
+                                        include_tracking=True)
         tracking_summary = package['tracking_summary']
         assert tracking_summary['recent'] == 1, ("Repeat dataset views should "
                                                  "not add to recent views "
@@ -435,7 +445,8 @@ class TestTracking(object):
         self._update_tracking_summary()
 
         resource = tests.call_action_api(app, 'resource_show',
-                                         id=resource['id'])
+                                         id=resource['id'],
+                                         include_tracking=True)
         tracking_summary = resource['tracking_summary']
         assert tracking_summary['recent'] == 1, (
             "Repeat resource downloads should not add to recent views count")

--- a/ckan/tests/logic/test_action.py
+++ b/ckan/tests/logic/test_action.py
@@ -793,11 +793,6 @@ class TestAction(WsgiAppCase):
         res = self.app.post('/api/action/resource_show', params=postparams)
         result = json.loads(res.body)['result']
 
-        # Remove tracking data from the result dict. This tracking data is
-        # added by the logic, so the other resource dict taken straight from
-        # resource_dictize() won't have it.
-        del result['tracking_summary']
-
         resource_dict = resource_dictize(resource, {'model': model})
         assert result == resource_dict, (result, resource_dict)
 


### PR DESCRIPTION
This enables the significant speed-up in #1105 with the assumption that most users don't need the tracking stats on datasets and resources.

Tracking info is stripped before packages are stored in solr and only added to datasets when the user requests them.