### PR TITLE
tag_show, vocabulary_show, vocabulary_list: exclude datasets by default

### DIFF
--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -631,7 +631,7 @@ def group_to_api(group, context):
 def tag_to_api(tag, context):
     api_version = context.get('api_version')
     assert api_version, 'No api_version supplied in context'
-    dictized = tag_dictize(tag, context)
+    dictized = tag_dictize(tag, context, include_datasets=True)
     if api_version == 1:
         return sorted([package["name"] for package in dictized["packages"]])
     else:
@@ -710,8 +710,8 @@ def vocabulary_dictize(vocabulary, context, include_datasets=False):
             for tag in vocabulary.tags]
     return vocabulary_dict
 
-def vocabulary_list_dictize(vocabulary_list, context):
-    return [vocabulary_dictize(vocabulary, context)
+def vocabulary_list_dictize(vocabulary_list, context, include_datasets=False):
+    return [vocabulary_dictize(vocabulary, context, include_datasets)
             for vocabulary in vocabulary_list]
 
 def activity_dictize(activity, context):

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -505,24 +505,27 @@ def tag_list_dictize(tag_list, context):
 
     return result_list
 
-def tag_dictize(tag, context):
+def tag_dictize(tag, context, include_datasets=False):
     tag_dict = d.table_dictize(tag, context)
-    query = search.PackageSearchQuery()
 
-    tag_query = u'+capacity:public '
-    vocab_id = tag_dict.get('vocabulary_id')
+    package_dicts = []
+    if include_datasets:
+        query = search.PackageSearchQuery()
 
-    if vocab_id:
-        model = context['model']
-        vocab = model.Vocabulary.get(vocab_id)
-        tag_query += u'+vocab_{0}:"{1}"'.format(vocab.name, tag.name)
-    else:
-        tag_query += u'+tags:"{0}"'.format(tag.name)
+        tag_query = u'+capacity:public '
+        vocab_id = tag_dict.get('vocabulary_id')
 
-    q = {'q': tag_query, 'fl': 'data_dict', 'wt': 'json', 'rows': 1000}
+        if vocab_id:
+            model = context['model']
+            vocab = model.Vocabulary.get(vocab_id)
+            tag_query += u'+vocab_{0}:"{1}"'.format(vocab.name, tag.name)
+        else:
+            tag_query += u'+tags:"{0}"'.format(tag.name)
 
-    package_dicts = [h.json.loads(result['data_dict'])
-                     for result in query.run(q)['results']]
+        q = {'q': tag_query, 'fl': 'data_dict', 'wt': 'json', 'rows': 1000}
+
+        package_dicts = [h.json.loads(result['data_dict'])
+                         for result in query.run(q)['results']]
 
     # Add display_names to tags. At first a tag's display_name is just the
     # same as its name, but the display_name might get changed later (e.g.
@@ -700,11 +703,11 @@ def package_to_api(pkg, context):
 
     return dictized
 
-def vocabulary_dictize(vocabulary, context):
+def vocabulary_dictize(vocabulary, context, include_datasets=False):
     vocabulary_dict = d.table_dictize(vocabulary, context)
     assert not vocabulary_dict.has_key('tags')
-    vocabulary_dict['tags'] = [tag_dictize(tag, context) for tag
-            in vocabulary.tags]
+    vocabulary_dict['tags'] = [tag_dictize(tag, context, include_datasets)
+            for tag in vocabulary.tags]
     return vocabulary_dict
 
 def vocabulary_list_dictize(vocabulary_list, context):

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -2277,12 +2277,17 @@ def status_show(context, data_dict):
 def vocabulary_list(context, data_dict):
     '''Return a list of all the site's tag vocabularies.
 
+    :param include_datasets: include a list of datasets in each tag
+         (optional, default: ``False``)
+    :type include_datasets: boolean
     :rtype: list of dictionaries
 
     '''
     model = context['model']
+    include_datasets = asbool(data_dict.get('include_datasets', False))
     vocabulary_objects = model.Session.query(model.Vocabulary).all()
-    return model_dictize.vocabulary_list_dictize(vocabulary_objects, context)
+    return model_dictize.vocabulary_list_dictize(vocabulary_objects, context,
+                                                 include_datasets)
 
 
 def vocabulary_show(context, data_dict):

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1268,6 +1268,9 @@ def tag_show(context, data_dict):
 
     :param id: the name or id of the tag
     :type id: string
+    :param include_datasets: include a list of datasets with this tag
+         (optional, default: ``False``)
+    :type include_datasets: boolean
 
     :returns: the details of the tag, including a list of all of the tag's
         datasets and their details
@@ -1276,6 +1279,7 @@ def tag_show(context, data_dict):
 
     model = context['model']
     id = _get_or_bust(data_dict, 'id')
+    include_datasets = asbool(data_dict.get('include_datasets', False))
 
     tag = model.Tag.get(id)
     context['tag'] = tag
@@ -1284,7 +1288,7 @@ def tag_show(context, data_dict):
         raise NotFound
 
     _check_access('tag_show', context, data_dict)
-    return model_dictize.tag_dictize(tag, context)
+    return model_dictize.tag_dictize(tag, context, include_datasets)
 
 
 def user_show(context, data_dict):
@@ -2286,18 +2290,23 @@ def vocabulary_show(context, data_dict):
 
     :param id: the id or name of the vocabulary
     :type id: string
+    :param include_datasets: include a list of datasets in each tag
+         (optional, default: ``False``)
+    :type include_datasets: boolean
     :return: the vocabulary.
     :rtype: dictionary
 
     '''
     model = context['model']
     vocab_id = data_dict.get('id')
+    include_datasets = asbool(data_dict.get('include_datasets', False))
     if not vocab_id:
         raise ValidationError({'id': _('id not in data')})
     vocabulary = model.vocabulary.Vocabulary.get(vocab_id)
     if vocabulary is None:
         raise NotFound(_('Could not find vocabulary "%s"') % vocab_id)
-    vocabulary_dict = model_dictize.vocabulary_dictize(vocabulary, context)
+    vocabulary_dict = model_dictize.vocabulary_dictize(vocabulary, context,
+                                                       include_datasets)
     return vocabulary_dict
 
 

--- a/ckan/tests/functional/api/model/test_vocabulary.py
+++ b/ckan/tests/functional/api/model/test_vocabulary.py
@@ -827,7 +827,8 @@ class TestVocabulary(object):
         assert len(tags_in_pkg) == 1
 
         # Test that the package appears vocabulary_list.
-        vocabs = self._post('/api/action/vocabulary_list')['result']
+        vocabs = self._post('/api/action/vocabulary_list',
+                            params={'include_datasets': True})['result']
         genre_vocab = [vocab for vocab in vocabs if vocab['name'] == 'Genre']
         assert len(genre_vocab) == 1
         genre_vocab = genre_vocab[0]
@@ -840,7 +841,8 @@ class TestVocabulary(object):
 
         # Test that the tagged package appears in vocabulary_show.
         genre_vocab = self._post('/api/action/vocabulary_show',
-                params={'id': genre_vocab['id']})['result']
+                params={'id': genre_vocab['id'], 'include_datasets':True}
+                )['result']
         noise_tag = [tag_ for tag_ in genre_vocab['tags']
                 if tag_['name'] == 'noise']
         assert len(noise_tag) == 1

--- a/ckan/tests/logic/test_tag.py
+++ b/ckan/tests/logic/test_tag.py
@@ -81,7 +81,8 @@ class TestAction(WsgiAppCase):
         res = self.app.post('/api/action/tag_list', params=params, status=404)
 
     def test_07_tag_show(self):
-        postparams = '%s=1' % json.dumps({'id':'russian'})
+        postparams = '%s=1' % json.dumps({'id':'russian',
+                                          'include_datasets': True})
         res = self.app.post('/api/action/tag_show', params=postparams)
         res_obj = json.loads(res.body)
         assert '/api/3/action/help_show?name=tag_show' in res_obj['help']
@@ -108,7 +109,8 @@ class TestAction(WsgiAppCase):
         The flexible tag is the tag with spaces, punctuation and foreign
         characters in its name, that's created in `ckan/lib/create_test_data.py`.
         """
-        postparams = '%s=1' % json.dumps({'id':u'Flexible \u30a1'})
+        postparams = '%s=1' % json.dumps({'id':u'Flexible \u30a1',
+                                          'include_datasets': True})
         res = self.app.post('/api/action/tag_show', params=postparams)
         res_obj = json.loads(res.body)
         assert '/api/3/action/help_show?name=tag_show' in res_obj['help']
@@ -128,7 +130,8 @@ class TestAction(WsgiAppCase):
             'tags': u'tolstoy',
             'license': 'never_heard_of_it',
             }])
-        postparams = '%s=1' % json.dumps({'id':'tolstoy'})
+        postparams = '%s=1' % json.dumps({'id':'tolstoy',
+                                          'include_datasets': True})
         res = self.app.post('/api/action/tag_show', params=postparams)
         res_obj = json.loads(res.body)
         assert res_obj['success'] == True


### PR DESCRIPTION
This is a real performance problem for sites using tag vocabularies, especially with index_package calling `vocabulary_show` for each vocabulary tag in the dataset, which calls `tag_dictize` for each tag in the vocabulary, which pulls up to 1000 datasets from solr.

That's (vocab tags in dataset) * (tags in same vocab) * (up to 1000) package dicts generated just to get the vocabulary name. Yeah.

Like my other recent PRs this adds an `include_datasets` parameter to the API call, with a new default of False.