### PR TITLE
Source field linkifies even if not a URI scheme

### DIFF
--- a/ckan/templates/package/snippets/additional_info.html
+++ b/ckan/templates/package/snippets/additional_info.html
@@ -12,7 +12,11 @@
         {% if pkg_dict.url %}
           <tr>
             <th scope="row" class="dataset-label">{{ _('Source') }}</th>
-            <td class="dataset-details" property="foaf:homepage">{{ h.link_to(pkg_dict.url, pkg_dict.url, rel='foaf:homepage', target='_blank') }}</td>
+            {% if h.is_url(pkg_dict.url) %}
+              <td class="dataset-details" property="foaf:homepage">{{ h.link_to(pkg_dict.url, pkg_dict.url, rel='foaf:homepage', target='_blank') }}</td>
+            {% else %}
+              <td class="dataset-details" property="foaf:homepage">{{ pkg_dict.url }}</td>
+            {% endif %}
           </tr>
         {% endif %}
 


### PR DESCRIPTION
À propos to #1551, when the 'Source' field's metadata value is just text (i.e. not a [URI Scheme](http://www.iana.org/assignments/uri-schemes/uri-schemes.xml)), it's created as a link. This isn't exactly ideal.