### PR TITLE
Fix resource_view_create check preventing normal users viewing resources

### DIFF
--- a/ckan/new_tests/controllers/test_package.py
+++ b/ckan/new_tests/controllers/test_package.py
@@ -216,6 +216,55 @@ class TestPackageResourceRead(helpers.FunctionalTestBase):
         app = self._get_test_app()
         app.get(url, status=404)
 
+    def test_resource_read_logged_in_user(self):
+        '''
+        A logged-in user can view resource page.
+        '''
+        user = factories.User()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        dataset = factories.Dataset()
+        resource = factories.Resource(package_id=dataset['id'])
+
+        url = url_for(controller='package',
+                      action='resource_read',
+                      id=dataset['id'],
+                      resource_id=resource['id'])
+
+        app = self._get_test_app()
+        app.get(url, status=200, extra_environ=env)
+
+    def test_resource_read_anon_user(self):
+        '''
+        An anon user can view resource page.
+        '''
+        dataset = factories.Dataset()
+        resource = factories.Resource(package_id=dataset['id'])
+
+        url = url_for(controller='package',
+                      action='resource_read',
+                      id=dataset['id'],
+                      resource_id=resource['id'])
+
+        app = self._get_test_app()
+        app.get(url, status=200)
+
+    def test_resource_read_sysadmin(self):
+        '''
+        A sysadmin can view resource page.
+        '''
+        sysadmin = factories.Sysadmin()
+        env = {'REMOTE_USER': sysadmin['name'].encode('ascii')}
+        dataset = factories.Dataset()
+        resource = factories.Resource(package_id=dataset['id'])
+
+        url = url_for(controller='package',
+                      action='resource_read',
+                      id=dataset['id'],
+                      resource_id=resource['id'])
+
+        app = self._get_test_app()
+        app.get(url, status=200, extra_environ=env)
+
 
 class TestPackageRead(helpers.FunctionalTestBase):
     @classmethod

--- a/ckan/templates/package/resource_read.html
+++ b/ckan/templates/package/resource_read.html
@@ -110,7 +110,7 @@
                 {# Views not created #}
                 <div class="module-content data-viewer-info">
                   <p>{{ _("There are no views created for this resource yet.") }}</p>
-                  {% if h.check_access('resource_view_create') %}
+                  {% if h.check_access('resource_view_create', {'resource_id': c.resource.id}) %}
                     <p class="muted">
                       <i class="icon-info-sign"></i>
                       {{ _("Not seeing the views you were expecting?")}}


### PR DESCRIPTION
Fixes #2212. `h.check_access('resource_view_create')` wasn't passing the `resource_id`. I don't think it's useful to speculate who may have introduced this bug. Oops! :flushed: 