### PR TITLE
Remove redundant less import

### DIFF
--- a/ckan/public/base/less/ckan.less
+++ b/ckan/public/base/less/ckan.less
@@ -20,7 +20,6 @@
 @import "activity.less";
 @import "dropdown.less";
 @import "dashboard.less";
-@import "resource-view-embed.less";
 @import "resource-view.less";
 @import "datapusher.less";
 


### PR DESCRIPTION
Removes redundant less import preventing compiling using `./bin/less`. Fixes #2197.