### PR TITLE
Resource views formatting lost on master and 2.3

### DIFF
--- a/ckan/templates/package/snippets/resource_views_list_item.html
+++ b/ckan/templates/package/snippets/resource_views_list_item.html
@@ -1,4 +1,5 @@
 {% set action = 'edit_view' if is_edit else 'resource_read' %}
+
 {% if current_filters %}
   {% set url = h.url_for(controller='package', action=action, id=pkg.name,
                          resource_id=view.resource_id, view_id=view.id,
@@ -7,18 +8,11 @@
   {% set url = h.url_for(controller='package', action=action, id=pkg.name,
                          resource_id=view.resource_id, view_id=view.id) %}
 {% endif %}
-<li class="resource-view-item{% if is_selected %} active{% endif %}" data-id="{{ view.id }}">
+
+<li{% if is_selected %} class="active"{% endif %} data-id="{{ view.id }}">
+
   <a href="{{ url }}" data-id="{{ view.id }}">
-    <span class="icon">
-      <i class="icon icon-{{ h.resource_view_icon(view) }}"></i>
-    </span>
-    <h3>{{ view.title }}</h3>
-    <p class="description">
-      {% if view.description %}
-        {{ view.description }}
-      {% else %}
-        <span class="empty">No description</span>
-      {% endif %}
-    </p>
+    <i class="icon icon-{{ h.resource_view_icon(view) }}"></i>
+    {{ view.title }}
   </a>
 </li>


### PR DESCRIPTION
The list of available views should look like this:
![fzlj8ot](https://cloud.githubusercontent.com/assets/200230/5775445/d6b9750a-9d71-11e4-9e5b-ee52570298ce.png)


But it looks like this:
![jfw6s4l](https://cloud.githubusercontent.com/assets/200230/5777926/e14377e2-9d8e-11e4-94f2-c62e1df63c97.png)


This was fixed back in October on #1920 but there probably has been a wrong merge on the way.
