### PR TITLE
Remove user id from redirect to dashboard after logging in.

### DIFF
--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -137,8 +137,7 @@ class UserController(base.BaseController):
             h.redirect_to(locale=locale, controller='user', action='login',
                           id=None)
         user_ref = c.userobj.get_reference_preferred_for_uri()
-        h.redirect_to(locale=locale, controller='user', action='dashboard',
-                      id=user_ref)
+        h.redirect_to(locale=locale, controller='user', action='dashboard')
 
     def register(self, data=None, errors=None, error_summary=None):
         context = {'model': model, 'session': model.Session, 'user': c.user,


### PR DESCRIPTION
After logging in to CKAN, the user is redirected to their own dashboard, with a url like this: myckaninstance.org/dashboard?__no_cache__=True&id=admin. This involves sending the user ID as a GET parameter, which was pointed out in a penetration test as a potential security issue.

The user ID is not necessary to render user/dashboard.html, so I have removed it from the redirect.