### PR TITLE
Autocomplete double encodes search terms

### DIFF
--- a/ckan/public/base/javascript/client.js
+++ b/ckan/public/base/javascript/client.js
@@ -20,7 +20,7 @@
      */
     url: function (path) {
       if (!(/^https?:\/\//i).test(path)) {
-        path = this.endpoint + '/' + encodeURI(path).replace(/^\//, '');
+        path = this.endpoint + '/' + path.replace(/^\//, '');
       }
       return path;
     },

--- a/ckan/public/base/javascript/modules/autocomplete.js
+++ b/ckan/public/base/javascript/modules/autocomplete.js
@@ -115,7 +115,7 @@ this.ckan.module('autocomplete', function (jQuery, _) {
     getCompletions: function (string, fn) {
       var parts  = this.options.source.split('?');
       var end    = parts.pop();
-      var source = parts.join('?') + string + end;
+      var source = parts.join('?') + encodeURIComponent(string) + end;
       var client = this.sandbox.client;
       var options = {
         format: function(data) {

--- a/ckan/public/base/javascript/modules/autocomplete.js
+++ b/ckan/public/base/javascript/modules/autocomplete.js
@@ -115,7 +115,7 @@ this.ckan.module('autocomplete', function (jQuery, _) {
     getCompletions: function (string, fn) {
       var parts  = this.options.source.split('?');
       var end    = parts.pop();
-      var source = parts.join('?') + encodeURIComponent(string) + end;
+      var source = parts.join('?') + string + end;
       var client = this.sandbox.client;
       var options = {
         format: function(data) {


### PR DESCRIPTION
Autocomplete.js double encodes search terms and therefore doesn't find tags that have alphabets that need encoding for example scandivavian å, ä and ö.

This pull request removes the second encoding.