### PR TITLE
Resource views fixes

### DIFF
--- a/ckan/lib/datapreview.py
+++ b/ckan/lib/datapreview.py
@@ -18,7 +18,7 @@ from ckan.common import _
 log = logging.getLogger(__name__)
 
 
-DEFAULT_RESOURCE_VIEW_TYPES = ['image_view']
+DEFAULT_RESOURCE_VIEW_TYPES = ['image_view', 'recline_view']
 
 
 def res_format(resource):

--- a/ckan/lib/datapreview.py
+++ b/ckan/lib/datapreview.py
@@ -140,32 +140,6 @@ def get_allowed_view_plugins(data_dict):
     return can_view
 
 
-# TODO: remove
-def get_new_resources(context, data_dict):
-    '''
-    Returns a list of all new resources in this transaction
-
-    This is to be used only before commiting eg on `package_create` or
-    `package_update` as it uses a cache object stored in the Session and
-    filled on flushig it.
-
-    The `context` dict must contain a `model` key
-
-    Returns a list of new dictized resources.
-    '''
-    model = context['model']
-    session = model.Session()
-    session.flush()
-    if hasattr(session, '_object_cache'):
-        import ckan.lib.dictization.model_dictize as model_dictize
-        new_objs = session._object_cache['new']
-        new_resources = [obj for obj in new_objs
-                         if isinstance(obj, model.Resource)]
-        return model_dictize.resource_list_dictize(new_resources, context)
-    else:
-        return []
-
-
 def get_default_view_plugins(get_datastore_views=False):
     '''
     Returns the list of view plugins to be created by default on new resources

--- a/ckan/migration/versions/076_rename_view_plugins_2.py
+++ b/ckan/migration/versions/076_rename_view_plugins_2.py
@@ -1,0 +1,14 @@
+def upgrade(migrate_engine):
+    migrate_engine.execute(
+        '''
+        BEGIN;
+
+        UPDATE resource_view
+        SET view_type = 'text_view' WHERE view_type = 'text';
+
+        UPDATE resource_view
+        SET view_type = 'pdf_view' WHERE view_type = 'pdf';
+
+        COMMIT;
+        '''
+    )

--- a/ckan/new_tests/lib/test_datapreview.py
+++ b/ckan/new_tests/lib/test_datapreview.py
@@ -54,6 +54,8 @@ class TestDefaultViewsConfig(object):
     def setup_class(cls):
         if not p.plugin_loaded('image_view'):
             p.load('image_view')
+        if not p.plugin_loaded('recline_view'):
+            p.load('recline_view')
         if not p.plugin_loaded('webpage_view'):
             p.load('webpage_view')
         if not p.plugin_loaded('test_datastore_view'):
@@ -62,6 +64,7 @@ class TestDefaultViewsConfig(object):
     @classmethod
     def teardown_class(cls):
         p.unload('image_view')
+        p.unload('recline_view')
         p.unload('webpage_view')
         p.unload('test_datastore_view')
 

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -51,7 +51,6 @@ class _Toolkit(object):
         'auth_sysadmins_check', # allow auth functions to be checked for sysadmins
         'auth_allow_anonymous_access', # allow anonymous access to an auth function
         'auth_disallow_anonymous_access', # disallow anonymous access to an auth function
-        'get_new_resources', # gets all new resources in current commit
 
         ## Fully defined in this file ##
         'add_template_directory',
@@ -188,7 +187,6 @@ content type, cookies, etc.
         t['auth_sysadmins_check'] = logic.auth_sysadmins_check
         t['auth_allow_anonymous_access'] = logic.auth_allow_anonymous_access
         t['auth_disallow_anonymous_access'] = logic.auth_disallow_anonymous_access
-        t['get_new_resources'] = datapreview.get_new_resources
 
         # class functions
         t['render_snippet'] = self._render_snippet

--- a/ckan/templates/package/snippets/resource_view.html
+++ b/ckan/templates/package/snippets/resource_view.html
@@ -9,7 +9,6 @@
     <i class="icon-code"></i>
     {{ _("Embed") }}
   </a>
-  <h1>{{ resource_view['title'] }}</h1>
   <p class="desc">{{ resource_view['description'] }}</p>
   <div class="m-top ckanext-datapreview">
     {% if not to_preview and h.resource_view_is_filterable(resource_view) %}

--- a/ckanext/imageview/plugin.py
+++ b/ckanext/imageview/plugin.py
@@ -18,7 +18,7 @@ class ImageView(p.SingletonPlugin):
 
     def info(self):
         return {'name': 'image_view',
-                'title': 'Image',
+                'title': p.toolkit._('Image'),
                 'icon': 'picture',
                 'schema': {'image_url': [ignore_empty, unicode]},
                 'iframed': False,

--- a/ckanext/pdfview/plugin.py
+++ b/ckanext/pdfview/plugin.py
@@ -16,7 +16,7 @@ class PdfView(p.SingletonPlugin):
     proxy_is_enabled = False
 
     def info(self):
-        return {'name': 'pdf',
+        return {'name': 'pdf_view',
                 'title': 'PDF',
                 'icon': 'file-text',
                 'default_title': 'PDF',

--- a/ckanext/pdfview/plugin.py
+++ b/ckanext/pdfview/plugin.py
@@ -11,13 +11,16 @@ class PdfView(p.SingletonPlugin):
     p.implements(p.IConfigurer, inherit=True)
     p.implements(p.IConfigurable, inherit=True)
     p.implements(p.IResourceView, inherit=True)
-    p.implements(p.IPackageController, inherit=True)
 
     PDF = ['pdf', 'x-pdf', 'acrobat', 'vnd.pdf']
     proxy_is_enabled = False
 
     def info(self):
-        return {'name': 'pdf', 'title': 'Pdf', 'icon': 'file-text'}
+        return {'name': 'pdf',
+                'title': 'PDF',
+                'icon': 'file-text',
+                'default_title': 'PDF',
+                }
 
     def update_config(self, config):
         p.toolkit.add_public_directory(config, 'theme/public')
@@ -36,27 +39,8 @@ class PdfView(p.SingletonPlugin):
         same_domain = datapreview.on_same_domain(data_dict)
 
         if format_lower in self.PDF:
-            if same_domain or proxy_enabled:
-                return True
+            return same_domain or proxy_enabled
         return False
 
     def view_template(self, context, data_dict):
         return 'pdf.html'
-
-    def add_default_views(self, context, data_dict):
-        resources = datapreview.get_new_resources(context, data_dict)
-        for resource in resources:
-            if self.can_view({'package': data_dict, 'resource': resource}):
-                view = {'title': 'PDF View',
-                        'description': 'PDF view of the resource.',
-                        'resource_id': resource['id'],
-                        'view_type': 'pdf'}
-                p.toolkit.get_action('resource_view_create')(
-                    {'defer_commit': True}, view
-                )
-
-    def after_update(self, context, data_dict):
-        self.add_default_views(context, data_dict)
-
-    def after_create(self, context, data_dict):
-        self.add_default_views(context, data_dict)

--- a/ckanext/pdfview/tests/test_view.py
+++ b/ckanext/pdfview/tests/test_view.py
@@ -28,7 +28,7 @@ def _create_test_view(view_type):
 
 
 class TestPdfView(tests.WsgiAppCase):
-    view_type = 'pdf'
+    view_type = 'pdf_view'
 
     @classmethod
     def setup_class(cls):

--- a/ckanext/reclineview/plugin.py
+++ b/ckanext/reclineview/plugin.py
@@ -78,7 +78,7 @@ class ReclineView(ReclineViewBase):
                 'title': 'Data Explorer',
                 'filterable': True,
                 'icon': 'table',
-                'requires_datastore': True,
+                'requires_datastore': False,
                 'default_title': p.toolkit._('Data Explorer'),
                 }
 

--- a/ckanext/reclineview/theme/public/recline_view.js
+++ b/ckanext/reclineview/theme/public/recline_view.js
@@ -73,7 +73,12 @@ this.ckan.module('recline_view', function (jQuery, _) {
 
       dataset.queryState.set(query.toJSON(), {silent: true});
 
-      errorMsg = this.options.i18n.errorLoadingPreview + ': ' + this.options.i18n.errorDataStore;
+      errorMsg = this.options.i18n.errorLoadingPreview + ': '
+      if (resourceData.backend == 'ckan') {
+        errorMsg += this.options.i18n.errorDataStore;
+      } else if (resourceData.backend == 'dataproxy'){
+        errorMsg += this.options.i18n.errorDataProxy;
+      }
       dataset.fetch()
         .done(function(dataset){
             self.initializeView(dataset, reclineView);

--- a/ckanext/textview/plugin.py
+++ b/ckanext/textview/plugin.py
@@ -49,7 +49,7 @@ class TextView(p.SingletonPlugin):
         p.toolkit.add_resource('theme/public', 'ckanext-textview')
 
     def info(self):
-        return {'name': 'text',
+        return {'name': 'text_view',
                 'title': p.toolkit._('Text'),
                 'icon': 'file-text-alt',
                 'default_title': p.toolkit._('Text'),

--- a/ckanext/textview/plugin.py
+++ b/ckanext/textview/plugin.py
@@ -7,7 +7,7 @@ import ckan.lib.datapreview as datapreview
 
 log = logging.getLogger(__name__)
 
-DEFAULT_TEXT_FORMATS = ['text/plain', 'txt', 'plain', 'csv', 'tsv']
+DEFAULT_TEXT_FORMATS = ['text/plain', 'txt', 'plain']
 DEFAULT_XML_FORMATS = ['xml', 'rdf', 'rdf+xm', 'owl+xml', 'atom', 'rss']
 DEFAULT_JSON_FORMATS = ['json', 'gjson', 'geojson']
 DEFAULT_JSONP_FORMATS = ['jsonp']
@@ -19,7 +19,6 @@ class TextView(p.SingletonPlugin):
     p.implements(p.IConfigurer, inherit=True)
     p.implements(p.IConfigurable, inherit=True)
     p.implements(p.IResourceView, inherit=True)
-    p.implements(p.IPackageController, inherit=True)
 
     proxy_is_enabled = False
     text_formats = []
@@ -50,7 +49,11 @@ class TextView(p.SingletonPlugin):
         p.toolkit.add_resource('theme/public', 'ckanext-textview')
 
     def info(self):
-        return {'name': 'text', 'title': 'Text', 'icon': 'file-text-alt'}
+        return {'name': 'text',
+                'title': p.toolkit._('Text'),
+                'icon': 'file-text-alt',
+                'default_title': p.toolkit._('Text'),
+                }
 
     def can_view(self, data_dict):
         resource = data_dict['resource']
@@ -60,8 +63,7 @@ class TextView(p.SingletonPlugin):
         if format_lower in self.jsonp_formats:
             return True
         if format_lower in self.no_jsonp_formats:
-            if proxy_enabled or same_domain:
-                return True
+            return proxy_enabled or same_domain
         return False
 
     def setup_template_variables(self, context, data_dict):
@@ -84,28 +86,3 @@ class TextView(p.SingletonPlugin):
 
     def form_template(self, context, data_dict):
         return 'text_form.html'
-
-    def add_default_views(self, context, data_dict):
-        resources = datapreview.get_new_resources(context, data_dict)
-        for resource in resources:
-            if self.can_view({'package': data_dict, 'resource': resource}):
-                format = resource.get('format', '')
-                if format.lower() in ['csv', 'tsv']:
-                    continue
-                view = {
-                    'title': 'Text View',
-                    'description': 'View of the {format} file'.format(
-                        format=format.upper()
-                    ),
-                    'resource_id': resource['id'],
-                    'view_type': 'text'
-                }
-                p.toolkit.get_action('resource_view_create')(
-                    {'defer_commit': True}, view
-                )
-
-    def after_update(self, context, data_dict):
-        self.add_default_views(context, data_dict)
-
-    def after_create(self, context, data_dict):
-        self.add_default_views(context, data_dict)

--- a/ckanext/textview/tests/test_view.py
+++ b/ckanext/textview/tests/test_view.py
@@ -28,7 +28,7 @@ def _create_test_view(view_type):
 
 
 class TestTextView(tests.WsgiAppCase):
-    view_type = 'text'
+    view_type = 'text_view'
 
     @classmethod
     def setup_class(cls):

--- a/ckanext/webpageview/plugin.py
+++ b/ckanext/webpageview/plugin.py
@@ -16,7 +16,7 @@ class WebPageView(p.SingletonPlugin):
 
     def info(self):
         return {'name': 'webpage_view',
-                'title': 'Web Page',
+                'title': p.toolkit._('Website'),
                 'schema': {'page_url': [ignore_empty, unicode]},
                 'iframed': False,
                 'icon': 'link',


### PR DESCRIPTION
Various minor internal resource views stuff

- [x] Remove `IPackageController` stuff from text and PDF view plugin, views are now automatically created via `ckan.views.default_views` config option (#1852) 
- [x] Remove `gen_new_resources` from `lib/datapreview` and the toolkit
- [x] Add `recline_view` to DEFAULT_RESOURCE_VIEW_TYPES
- [x] Rename text and pdf view plugins for consistency
- [x] Remove redundant title from view page