### PR TITLE
Fixes a direct import in action/delete

### DIFF
--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -1,7 +1,5 @@
 '''API functions for deleting data from CKAN.'''
 
-from sqlalchemy import or_
-
 import ckan.logic
 import ckan.logic.action
 import ckan.plugins as plugins
@@ -97,7 +95,7 @@ def resource_delete(context, data_dict):
     package_id = entity.get_package_id()
 
     pkg_dict = _get_action('package_show')(context, {'id': package_id})
-    
+
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.before_delete(context, data_dict,
                              pkg_dict.get('resources', []))
@@ -280,6 +278,8 @@ def _group_or_org_delete(context, data_dict, is_org=False):
     :type id: string
 
     '''
+    from sqlalchemy import or_
+
     model = context['model']
     user = context['user']
     id = _get_or_bust(data_dict, 'id')


### PR DESCRIPTION
Direct imports in action modules are bad because it generates documentation for them. This moves the import into the appropriate function (where it is used).