### PR TITLE
Update db.py

### DIFF
--- a/ckanext/datastore/db.py
+++ b/ckanext/datastore/db.py
@@ -104,7 +104,9 @@ def _get_engine(data_dict):
     if not engine:
         import pylons
         extras = {'url': connection_url}
-        engine = sqlalchemy.engine_from_config(pylons.config, 'ckan.datastore.sqlalchemy.', **extras)
+        engine = sqlalchemy.engine_from_config(pylons.config,
+                                               'ckan.datastore.sqlalchemy.', 
+                                               **extras)
         _engines[connection_url] = engine
     return engine
 

--- a/ckanext/datastore/db.py
+++ b/ckanext/datastore/db.py
@@ -105,7 +105,7 @@ def _get_engine(data_dict):
         import pylons
         extras = {'url': connection_url}
         engine = sqlalchemy.engine_from_config(pylons.config,
-                                               'ckan.datastore.sqlalchemy.', 
+                                               'ckan.datastore.sqlalchemy.',
                                                **extras)
         _engines[connection_url] = engine
     return engine

--- a/ckanext/datastore/db.py
+++ b/ckanext/datastore/db.py
@@ -102,7 +102,9 @@ def _get_engine(data_dict):
     engine = _engines.get(connection_url)
 
     if not engine:
-        engine = sqlalchemy.create_engine(connection_url)
+        import pylons
+        extras = {'url': connection_url}
+        engine = sqlalchemy.engine_from_config(pylons.config, 'ckan.datastore.sqlalchemy.', **extras)
         _engines[connection_url] = engine
     return engine
 


### PR DESCRIPTION
That change enables the user to provide custom sqlalchemy properties through the config file using the 'ckan.datastore.sqlalchemy.' prefix.
Example:
```
ckan.datastore.sqlalchemy.pool_size=10
ckan.datastore.sqlalchemy.max_overflow=20
```

The 'url' property is passed as param in the 'extras' map to avoid changing the structure of the current config file.

For further details please look at https://github.com/ckan/ckan/issues/2232