### PR TITLE
Enables datapusher extension to send ODS files to datapusher service

### DIFF
--- a/ckanext/datapusher/plugin.py
+++ b/ckanext/datapusher/plugin.py
@@ -18,7 +18,8 @@ _get_or_bust = logic.get_or_bust
 DEFAULT_FORMATS = [
     'csv', 'xls', 'xlsx', 'tsv', 'application/csv',
     'application/vnd.ms-excel',
-    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'ods', 'application/vnd.oasis.opendocument.spreadsheet',
 ]
 
 


### PR DESCRIPTION
Adds ods as a format, and the mimetype as a, erm, mimetype so that the datapusher extension will submit ODS files through to the datapusher service for processing.