### PR TITLE
Allow normal users (non sysadmins) to change and remove owner_org from datasets

### DIFF
--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -34,13 +34,9 @@ def owner_org_validator(key, data, errors, context):
     model = context['model']
     user = context['user']
     user = model.User.get(user)
-    if value == '' :
+    if value == '':
         if not new_authz.check_config_permission('create_unowned_dataset'):
             raise Invalid(_('A organization must be supplied'))
-        package = context.get('package')
-        # only sysadmins can remove datasets from org
-        if package and package.owner_org and not user.sysadmin:
-            raise Invalid(_('You cannot remove a dataset from an existing organization'))
         return
 
     group = model.Group.get(value)

--- a/ckan/new_tests/controllers/test_package.py
+++ b/ckan/new_tests/controllers/test_package.py
@@ -148,6 +148,137 @@ class TestPackageControllerNew(helpers.FunctionalTestBase):
         pkg = model.Package.by_name(u'previous-next-maintains-draft')
         assert_equal(pkg.state, 'draft')
 
+    def test_dataset_edit_org_dropdown_visible_to_normal_user_with_orgs_available(self):
+        '''
+        The 'Organization' dropdown is available on the dataset create/edit
+        page to normal (non-sysadmin) users who have organizations available
+        to them.
+        '''
+        user = factories.User()
+        # user is admin of org.
+        org = factories.Organization(name="my-org",
+                                     users=[{'name': user['id'], 'capacity': 'admin'}])
+
+        app = self._get_test_app()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        response = app.get(
+            url=url_for(controller='package', action='new'),
+            extra_environ=env,
+        )
+
+        # organization dropdown available in create page.
+        assert 'id="field-organizations"' in response
+
+        # create dataset
+        form = response.forms['dataset-edit']
+        form['name'] = u'my-dataset'
+        form['owner_org'] = org['id']
+        response = submit_and_follow(app, form, env, 'save')
+
+        # add a resource to make the pkg active
+        resource_form = response.forms['resource-edit']
+        resource_form['url'] = u'http://example.com/resource'
+        submit_and_follow(app, resource_form, env, 'save', 'go-metadata')
+        pkg = model.Package.by_name(u'my-dataset')
+        assert_equal(pkg.state, 'active')
+
+        # edit package page response
+        url = url_for(controller='package',
+                      action='edit',
+                      id=pkg.id)
+        pkg_edit_response = app.get(url=url, extra_environ=env)
+        # A field with the correct id is in the response
+        assert 'id="field-organizations"' in pkg_edit_response
+        # The organization id is in the response in a value attribute
+        assert 'value="{0}"'.format(org['id']) in pkg_edit_response
+
+    def test_dataset_edit_org_dropdown_not_visible_to_normal_user_with_no_orgs_available(self):
+        '''
+        The 'Organization' dropdown is not available on the dataset
+        create/edit page to normal (non-sysadmin) users who have no
+        organizations available to them.
+        '''
+        user = factories.User()
+        # user isn't admin of org.
+        org = factories.Organization(name="my-org")
+
+        app = self._get_test_app()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        response = app.get(
+            url=url_for(controller='package', action='new'),
+            extra_environ=env,
+        )
+
+        # organization dropdown available in create page.
+        assert 'id="field-organizations"' not in response
+
+        # create dataset
+        form = response.forms['dataset-edit']
+        form['name'] = u'my-dataset'
+        response = submit_and_follow(app, form, env, 'save')
+
+        # add a resource to make the pkg active
+        resource_form = response.forms['resource-edit']
+        resource_form['url'] = u'http://example.com/resource'
+        submit_and_follow(app, resource_form, env, 'save', 'go-metadata')
+        pkg = model.Package.by_name(u'my-dataset')
+        assert_equal(pkg.state, 'active')
+
+        # edit package response
+        url = url_for(controller='package',
+                      action='edit',
+                      id=model.Package.by_name(u'my-dataset').id)
+        pkg_edit_response = app.get(url=url, extra_environ=env)
+        # A field with the correct id is in the response
+        assert 'id="field-organizations"' not in pkg_edit_response
+        # The organization id is in the response in a value attribute
+        assert 'value="{0}"'.format(org['id']) not in pkg_edit_response
+
+    def test_dataset_edit_org_dropdown_visible_to_sysadmin_with_no_orgs_available(self):
+        '''
+        The 'Organization' dropdown is available to sysadmin users regardless
+        of whether they personally have an organization they administrate.
+        '''
+        user = factories.User()
+        sysadmin = factories.Sysadmin()
+        # user is admin of org.
+        org = factories.Organization(name="my-org",
+                                     users=[{'name': user['id'], 'capacity': 'admin'}])
+
+        app = self._get_test_app()
+        # user in env is sysadmin
+        env = {'REMOTE_USER': sysadmin['name'].encode('ascii')}
+        response = app.get(
+            url=url_for(controller='package', action='new'),
+            extra_environ=env,
+        )
+
+        # organization dropdown available in create page.
+        assert 'id="field-organizations"' in response
+
+        # create dataset
+        form = response.forms['dataset-edit']
+        form['name'] = u'my-dataset'
+        form['owner_org'] = org['id']
+        response = submit_and_follow(app, form, env, 'save')
+
+        # add a resource to make the pkg active
+        resource_form = response.forms['resource-edit']
+        resource_form['url'] = u'http://example.com/resource'
+        submit_and_follow(app, resource_form, env, 'save', 'go-metadata')
+        pkg = model.Package.by_name(u'my-dataset')
+        assert_equal(pkg.state, 'active')
+
+        # edit package page response
+        url = url_for(controller='package',
+                      action='edit',
+                      id=pkg.id)
+        pkg_edit_response = app.get(url=url, extra_environ=env)
+        # A field with the correct id is in the response
+        assert 'id="field-organizations"' in pkg_edit_response
+        # The organization id is in the response in a value attribute
+        assert 'value="{0}"'.format(org['id']) in pkg_edit_response
+
 
 class TestPackageResourceRead(helpers.FunctionalTestBase):
     @classmethod

--- a/ckan/templates/package/snippets/package_basic_fields.html
+++ b/ckan/templates/package/snippets/package_basic_fields.html
@@ -56,7 +56,7 @@
   {% set dataset_has_organization = data.owner_org or data.group_id %}
   {% set organizations_available = h.organizations_available('create_dataset') %}
   {% set user_is_sysadmin = h.check_access('sysadmin') %}
-  {% set show_organizations_selector = organizations_available and (user_is_sysadmin or dataset_is_draft) %}
+  {% set show_organizations_selector = organizations_available %}
   {% set show_visibility_selector = dataset_has_organization or (organizations_available and (user_is_sysadmin or dataset_is_draft)) %}
 
   {% if show_organizations_selector and show_visibility_selector %}


### PR DESCRIPTION
This PR allows normal users, who have available organizations, to change the `owner_org` property for datasets they can edit using the web ui. The ability to change `owner_org` was previously only available via the API.

Normal users can also now remove the value of `owner_org` from their datasets (if `ckan.auth.create_unowned_dataset` is `True`), both using the web ui and API. Previously, this was only available to sysadmins.

The commits make the organization dropdown visible to normal users when creating/editing a dataset. And change the `owner_org_validator` method that previously restricted `owner_org` removal to just sysadmins.

Fixes #2218.