### PR TITLE
[#1647] Stats extension. 'Largest Groups' links lead either to organizations or to groups page

### DIFF
--- a/ckanext/stats/templates/ckanext/stats/index.html
+++ b/ckanext/stats/templates/ckanext/stats/index.html
@@ -117,7 +117,7 @@
           <tbody>
             {% for group, num_packages in c.largest_groups %}
               <tr>
-                <td>{{ h.link_to(group.title or group.name, h.url_for(controller='group', action='read', id=group.name)) }}</td>
+                <td>{{ h.link_to(group.title or group.name, h.url_for(controller=group.type, action='read', id=group.name)) }}</td>
                 <td class="metric">{{ num_packages }}</td>
               </tr>
             {% endfor %}


### PR DESCRIPTION
Currently all links under the 'Largest Groups' refer to groups page.

After this change links refer to group page for groups and to organization page for organizations