### PR TITLE
[#1649] Stats extension. Tag counter works properly

### DIFF
--- a/ckanext/stats/stats.py
+++ b/ckanext/stats/stats.py
@@ -75,15 +75,19 @@ class Stats(object):
         assert returned_tag_info in ('name', 'id', 'object')
         tag = table('tag')
         package_tag = table('package_tag')
-        #TODO filter out tags with state=deleted
+        package = table('package')
         if returned_tag_info == 'name':
             from_obj = [package_tag.join(tag)]
             tag_column = tag.c.name
         else:
             from_obj = None
             tag_column = package_tag.c.tag_id
+        j = join(package_tag, package,
+                 package_tag.c.package_id == package.c.id)
         s = select([tag_column, func.count(package_tag.c.package_id)],
-                    from_obj=from_obj)
+                    from_obj=from_obj).\
+            select_from(j).\
+            where(and_(package_tag.c.state=='active', package.c.private == False, package.c.state == 'active' ))
         s = s.group_by(tag_column).\
             order_by(func.count(package_tag.c.package_id).desc()).\
             limit(limit)

--- a/ckanext/stats/tests/test_stats_lib.py
+++ b/ckanext/stats/tests/test_stats_lib.py
@@ -84,8 +84,7 @@ class TestStatsPlugin(StatsFixture):
     def test_top_tags(self):
         tags = Stats.top_tags()
         tags = [(tag.name, count) for tag, count in tags]
-        assert_equal(tags, [('tag1', 3),
-                            ('tag2', 1)])
+        assert_equal(tags, [('tag1', 1L)])
 
     def test_top_package_owners(self):
         owners = Stats.top_package_owners()


### PR DESCRIPTION
Currently on 'Top Tags' tab displayed total amount of tags which includes deleted ones, private and deleted packages

After this change, tags with state=deleted, deleted packages, private packages are filtered out