### PR TITLE
[#2216] user can now see his private & draft datasets again

### DIFF
--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -574,7 +574,9 @@ def user_dictize(user, context):
     result_dict['display_name'] = user.display_name
     result_dict['email_hash'] = user.email_hash
     result_dict['number_of_edits'] = user.number_of_edits()
-    result_dict['number_created_packages'] = user.number_created_packages()
+    result_dict['number_created_packages'] = user.number_created_packages(
+        include_private_and_draft=context.get(
+            'count_private_and_draft_datasets', False))
 
     requester = context.get('user')
 

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1362,10 +1362,8 @@ def user_show(context, data_dict):
                 .filter_by(private=False)
         else:
             dataset_q = dataset_q \
-                .filter(_or_(model.Package.state=='active',
-                             model.Package.state=='draft'))
+                .filter(model.Package.state != 'deleted')
         dataset_q = dataset_q.limit(50)
-
 
         for dataset in dataset_q:
             try:

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1303,7 +1303,7 @@ def user_show(context, data_dict):
     :param include_datasets: Include a list of datasets the user has created.
         If it is the same user or a sysadmin requesting, it includes datasets
         that are draft or private.
-         (optional, default:``False``, limit:50)
+        (optional, default:``False``, limit:50)
     :type include_datasets: boolean
     :param include_num_followers: Include the number of followers the user has
          (optional, default:``False``)
@@ -1340,6 +1340,8 @@ def user_show(context, data_dict):
         include_private_and_draft_datasets = \
             new_authz.is_sysadmin(requester) or \
             requester_looking_at_own_account
+    else:
+        include_private_and_draft_datasets = False
     context['count_private_and_draft_datasets'] = \
         include_private_and_draft_datasets
 

--- a/ckan/model/user.py
+++ b/ckan/model/user.py
@@ -196,13 +196,16 @@ class User(vdm.sqlalchemy.StatefulObjectMixin,
         revisions_q = revisions_q.filter_by(author=self.name)
         return revisions_q.count()
 
-    def number_created_packages(self):
+    def number_created_packages(self, include_private_and_draft=False):
         # have to import here to avoid circular imports
         import ckan.model as model
         q = meta.Session.query(model.Package)\
-            .filter_by(creator_user_id=self.id)\
-            .filter_by(state='active')\
-            .filter_by(private=False)
+            .filter_by(creator_user_id=self.id)
+        if include_private_and_draft:
+            q = q.filter(model.Package.state.in_(('active', 'draft')))
+        else:
+            q = q.filter_by(state='active')\
+                 .filter_by(private=False)
         return q.count()
 
     def activate(self):

--- a/ckan/model/user.py
+++ b/ckan/model/user.py
@@ -202,7 +202,7 @@ class User(vdm.sqlalchemy.StatefulObjectMixin,
         q = meta.Session.query(model.Package)\
             .filter_by(creator_user_id=self.id)
         if include_private_and_draft:
-            q = q.filter(model.Package.state.in_(('active', 'draft')))
+            q = q.filter(model.Package.state != 'deleted')
         else:
             q = q.filter_by(state='active')\
                  .filter_by(private=False)

--- a/ckan/new_tests/logic/action/test_get.py
+++ b/ckan/new_tests/logic/action/test_get.py
@@ -364,16 +364,78 @@ class TestGet(object):
         assert org_dict['packages'][0]['name'] == 'dataset_1'
         assert org_dict['package_count'] == 1
 
+    def test_user_list_default_values(self):
+
+        user = factories.User()
+
+        got_users = helpers.call_action('user_list')
+        remove_pseudo_users(got_users)
+
+        assert len(got_users) == 1
+        got_user = got_users[0]
+        assert got_user['id'] == user['id']
+        assert got_user['name'] == user['name']
+        assert got_user['fullname'] == user['fullname']
+        assert got_user['display_name'] == user['display_name']
+        assert got_user['created'] == user['created']
+        assert got_user['about'] == user['about']
+        assert got_user['sysadmin'] == user['sysadmin']
+        assert got_user['number_of_edits'] == 0
+        assert got_user['number_created_packages'] == 0
+        assert 'password' not in got_user
+        assert 'reset_key' not in got_user
+        assert 'apikey' not in got_user
+        assert 'email' not in got_user
+        assert 'datasets' not in got_user
+
+    def test_user_list_edits(self):
+
+        user = factories.User()
+        dataset = factories.Dataset(user=user)
+        dataset['title'] = 'Edited title'
+        helpers.call_action('package_update',
+                            context={'user': user['name']},
+                            **dataset)
+
+        got_users = helpers.call_action('user_list')
+        remove_pseudo_users(got_users)
+
+        assert len(got_users) == 1
+        got_user = got_users[0]
+        assert got_user['number_created_packages'] == 1
+        assert got_user['number_of_edits'] == 2
+
+    def test_user_list_excludes_deleted_users(self):
+
+        user = factories.User()
+        factories.User(state='deleted')
+
+        got_users = helpers.call_action('user_list')
+        remove_pseudo_users(got_users)
+
+        assert len(got_users) == 1
+        assert got_users[0]['name'] == user['name']
+
     def test_user_show_default_values(self):
 
         user = factories.User()
 
         got_user = helpers.call_action('user_show', id=user['id'])
 
+        assert got_user['id'] == user['id']
+        assert got_user['name'] == user['name']
+        assert got_user['fullname'] == user['fullname']
+        assert got_user['display_name'] == user['display_name']
+        assert got_user['created'] == user['created']
+        assert got_user['about'] == user['about']
+        assert got_user['sysadmin'] == user['sysadmin']
+        assert got_user['number_of_edits'] == 0
+        assert got_user['number_created_packages'] == 0
         assert 'password' not in got_user
         assert 'reset_key' not in got_user
         assert 'apikey' not in got_user
         assert 'email' not in got_user
+        assert 'datasets' not in got_user
 
     def test_user_show_keep_email(self):
 
@@ -401,6 +463,19 @@ class TestGet(object):
         assert 'password' not in got_user
         assert 'reset_key' not in got_user
 
+    def test_user_show_for_myself(self):
+
+        user = factories.User()
+
+        got_user = helpers.call_action('user_show',
+                                       context={'user': user['name']},
+                                       id=user['id'])
+
+        assert got_user['email'] == user['email']
+        assert got_user['apikey'] == user['apikey']
+        assert 'password' not in got_user
+        assert 'reset_key' not in got_user
+
     def test_user_show_sysadmin_values(self):
 
         user = factories.User()
@@ -415,6 +490,52 @@ class TestGet(object):
         assert got_user['apikey'] == user['apikey']
         assert 'password' not in got_user
         assert 'reset_key' not in got_user
+
+    def test_user_show_include_datasets(self):
+
+        user = factories.User()
+        dataset = factories.Dataset(user=user)
+
+        got_user = helpers.call_action('user_show',
+                                       include_datasets=True,
+                                       id=user['id'])
+
+        assert len(got_user['datasets']) == 1
+        assert got_user['datasets'][0]['name'] == dataset['name']
+
+    def test_user_show_include_datasets_excludes_draft_and_private(self):
+
+        user = factories.User()
+        org = factories.Organization(user=user)
+        dataset = factories.Dataset(user=user)
+        factories.Dataset(user=user, state='deleted')
+        factories.Dataset(user=user, state='draft')
+        factories.Dataset(user=user, private=True, owner_org=org['name'])
+
+        got_user = helpers.call_action('user_show',
+                                       include_datasets=True,
+                                       id=user['id'])
+
+        assert len(got_user['datasets']) == 1
+        assert got_user['datasets'][0]['name'] == dataset['name']
+
+    def test_user_show_include_datasets_includes_draft_and_private_for_myself(self):
+
+        user = factories.User()
+        org = factories.Organization(user=user)
+        factories.Dataset(user=user)
+        dataset_deleted = factories.Dataset(user=user, state='deleted')
+        factories.Dataset(user=user, state='draft')
+        factories.Dataset(user=user, private=True, owner_org=org['name'])
+
+        got_user = helpers.call_action('user_show',
+                                       context={'user': user['name']},
+                                       include_datasets=True,
+                                       id=user['id'])
+
+        assert len(got_user['datasets']) == 3
+        datasets_got = set([user_['name'] for user_ in got_user['datasets']])
+        assert dataset_deleted['name'] not in datasets_got
 
     def test_related_list_with_no_params(self):
         '''
@@ -1029,3 +1150,9 @@ class TestGetHelpShow(object):
         nose.tools.assert_raises(
             logic.NotFound,
             helpers.call_action, 'help_show', name=function_name)
+
+
+def remove_pseudo_users(user_list):
+    pseudo_users = set(('logged_in', 'visitor'))
+    user_list[:] = [user for user in user_list
+                    if user['name'] not in pseudo_users]

--- a/ckan/tests/logic/test_action.py
+++ b/ckan/tests/logic/test_action.py
@@ -313,67 +313,6 @@ class TestAction(WsgiAppCase):
         assert json.loads(res.body)['error'] ==  {"__type": "Validation Error", "created": ["Date format incorrect"]}
 
 
-
-    def test_04_user_list(self):
-        # Create deleted user to make sure he won't appear in the user_list
-        deleted_user = CreateTestData.create_user('deleted_user')
-        deleted_user.delete()
-        model.repo.commit()
-
-        postparams = '%s=1' % json.dumps({})
-        res = self.app.post('/api/action/user_list', params=postparams)
-        res_obj = json.loads(res.body)
-        assert "/api/3/action/help_show?name=user_list" in res_obj['help']
-        assert res_obj['success'] == True
-        assert len(res_obj['result']) == 7
-        assert res_obj['result'][0]['name'] == 'annafan'
-        assert res_obj['result'][0]['about'] == 'I love reading Annakarenina. My site: http://anna.com'
-        assert not 'apikey' in res_obj['result'][0]
-
-    def test_05_user_show(self):
-        # Anonymous request
-        postparams = '%s=1' % json.dumps({'id':'annafan'})
-        res = self.app.post('/api/action/user_show', params=postparams)
-        res_obj = json.loads(res.body)
-        assert "/api/3/action/help_show?name=user_show" in res_obj['help']
-        assert res_obj['success'] == True
-        result = res_obj['result']
-        assert result['name'] == 'annafan'
-        assert result['about'] == 'I love reading Annakarenina. My site: http://anna.com'
-        assert 'created' in result
-        assert 'display_name' in result
-        assert 'number_created_packages' in result
-        assert 'number_of_edits' in result
-        assert not 'apikey' in result
-        assert not 'reset_key' in result
-
-        # Same user can see his api key
-        res = self.app.post('/api/action/user_show', params=postparams,
-                            extra_environ={'Authorization': str(self.normal_user.apikey)})
-
-        res_obj = json.loads(res.body)
-        result = res_obj['result']
-        assert result['name'] == 'annafan'
-        assert 'apikey' in result
-
-        # Sysadmin user can see everyone's api key
-        res = self.app.post('/api/action/user_show', params=postparams,
-                            extra_environ={'Authorization': str(self.sysadmin_user.apikey)})
-
-        res_obj = json.loads(res.body)
-        result = res_obj['result']
-        assert result['name'] == 'annafan'
-        assert 'apikey' in result
-
-    def test_05b_user_show_datasets(self):
-        postparams = '%s=1' % json.dumps({'id':'annafan', 'include_datasets': True})
-        res = self.app.post('/api/action/user_show', params=postparams)
-        res_obj = json.loads(res.body)
-        result = res_obj['result']
-        datasets = result['datasets']
-        assert_equal(len(datasets), 0)  # No datasets created
-
-
     def test_10_user_create_parameters_missing(self):
         user_dict = {}
 


### PR DESCRIPTION
My recent commit https://github.com/ckan/ckan/commit/b2dfccc8932947711d4f9b0f2500be4c40208b21 stopped draft and private datasets from being returned by user_show, because other general users should not know about these datasets that they cannot view. However it was rightly pointed out by @benjaminlaot that when a user views his own user page (or a sysadmin views it) it makes sense to show these draft and private datasets to him. So I've added logic for this in this PR.

Similar logic is added to the number_created_packages property (user_show). However user_list's number_created_packages excludes draft&private datasets for everyone (for simplicity) - before it just excluded draft ones. This is now also documented and tested.