### PR TITLE
Tobes 2057 fix filename munging

### DIFF
--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -116,8 +116,7 @@ def resource_dictize(res, context):
     ## for_edit is only called at the times when the dataset is to be edited
     ## in the frontend. Without for_edit the whole qualified url is returned.
     if resource.get('url_type') == 'upload' and not context.get('for_edit'):
-        last_part = url.split('/')[-1]
-        cleaned_name = munge.munge_filename(last_part)
+        cleaned_name = munge.munge_filename(url)
         resource['url'] = h.url_for(controller='package',
                                     action='resource_download',
                                     id=resource['package_id'],
@@ -472,7 +471,7 @@ def group_dictize(group, context,
     if image_url and not image_url.startswith('http'):
         #munge here should not have an effect only doing it incase
         #of potential vulnerability of dodgy api input
-        image_url = munge.munge_filename(image_url)
+        image_url = munge.munge_filename_legacy(image_url)
         result_dict['image_display_url'] = h.url_for_static(
             'uploads/group/%s' % result_dict.get('image_url'),
             qualified=True

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -117,7 +117,7 @@ def resource_dictize(res, context):
     ## in the frontend. Without for_edit the whole qualified url is returned.
     if resource.get('url_type') == 'upload' and not context.get('for_edit'):
         last_part = url.split('/')[-1]
-        cleaned_name = munge.munge_filename_legacy(last_part)
+        cleaned_name = munge.munge_filename(last_part)
         resource['url'] = h.url_for(controller='package',
                                     action='resource_download',
                                     id=resource['package_id'],

--- a/ckan/lib/munge.py
+++ b/ckan/lib/munge.py
@@ -149,7 +149,7 @@ def munge_filename(filename):
         ext = ext[:21]
     # max/min size
     ext_length = len(ext)
-    name = _munge_to_length(name, 3 - ext_length, 100 - ext_length)
+    name = _munge_to_length(name, max(3 - ext_length, 1), 100 - ext_length)
     filename = name + ext
 
     return filename

--- a/ckan/lib/munge.py
+++ b/ckan/lib/munge.py
@@ -116,9 +116,9 @@ def munge_filename_legacy(filename):
     ''' Tidies a filename. NB: deprecated
 
     Unfortunately it mangles any path or filename extension, so is deprecated.
-    It needs to remain for use by model_dictize() because if this routine
-    changes then group images uploaded previous to the change may not be
-    viewable.
+    It needs to remain unchanged for use by group_dictize() and
+    Upload.update_data_dict() because if this routine changes then group images
+    uploaded previous to the change may not be viewable.
     '''
     filename = substitute_ascii_equivalents(filename)
     filename = filename.strip()
@@ -130,10 +130,8 @@ def munge_filename_legacy(filename):
 def munge_filename(filename):
     ''' Tidies a filename
 
-    Keeps the filename extension.
+    Keeps the filename extension (e.g. .csv).
     Strips off any path on the front.
-    It can be useful to keep the extension (e.g. .csv) in a resource when the
-    format field set.
     '''
 
     # just get the filename ignore the path

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -60,7 +60,7 @@ def get_max_resource_size():
 
 class Upload(object):
     def __init__(self, object_type, old_filename=None):
-        ''' Setup upload by creating  a subdirectory of the storage directory
+        ''' Setup upload by creating a subdirectory of the storage directory
         of name object_type. old_filename is the name of the file in the url
         field last time'''
 
@@ -127,7 +127,7 @@ class Upload(object):
             current_size = 0
             while True:
                 current_size = current_size + 1
-                # MB chuncks
+                # MB chunks
                 data = self.upload_file.read(2 ** 20)
                 if not data:
                     break

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -102,7 +102,7 @@ class Upload(object):
         if isinstance(self.upload_field_storage, cgi.FieldStorage):
             self.filename = self.upload_field_storage.filename
             self.filename = str(datetime.datetime.utcnow()) + self.filename
-            self.filename = munge.munge_filename(self.filename)
+            self.filename = munge.munge_filename_legacy(self.filename)
             self.filepath = os.path.join(self.storage_path, self.filename)
             data_dict[url_field] = self.filename
             self.upload_file = self.upload_field_storage.file
@@ -170,7 +170,7 @@ class ResourceUpload(object):
 
         if isinstance(upload_field_storage, cgi.FieldStorage):
             self.filename = upload_field_storage.filename
-            self.filename = munge.munge_filename_ext_safe(self.filename)
+            self.filename = munge.munge_filename(self.filename)
             resource['url'] = self.filename
             resource['url_type'] = 'upload'
             self.upload_file = upload_field_storage.file

--- a/ckan/new_tests/controllers/test_package.py
+++ b/ckan/new_tests/controllers/test_package.py
@@ -167,10 +167,10 @@ class TestPackageControllerNew(helpers.FunctionalTestBase):
         )
 
         # organization dropdown available in create page.
-        assert 'id="field-organizations"' in response
+        form = response.forms['dataset-edit']
+        assert 'owner_org' in form.fields
 
         # create dataset
-        form = response.forms['dataset-edit']
         form['name'] = u'my-dataset'
         form['owner_org'] = org['id']
         response = submit_and_follow(app, form, env, 'save')
@@ -188,9 +188,11 @@ class TestPackageControllerNew(helpers.FunctionalTestBase):
                       id=pkg.id)
         pkg_edit_response = app.get(url=url, extra_environ=env)
         # A field with the correct id is in the response
-        assert 'id="field-organizations"' in pkg_edit_response
+        form = pkg_edit_response.forms['dataset-edit']
+        assert 'owner_org' in form.fields
         # The organization id is in the response in a value attribute
-        assert 'value="{0}"'.format(org['id']) in pkg_edit_response
+        owner_org_options = [value for (value, _) in form['owner_org'].options]
+        assert org['id'] in owner_org_options
 
     def test_dataset_edit_org_dropdown_normal_user_can_remove_org(self):
         '''
@@ -255,11 +257,11 @@ class TestPackageControllerNew(helpers.FunctionalTestBase):
             extra_environ=env,
         )
 
-        # organization dropdown available in create page.
-        assert 'id="field-organizations"' not in response
+        # organization dropdown not in create page.
+        form = response.forms['dataset-edit']
+        assert 'owner_org' not in form.fields
 
         # create dataset
-        form = response.forms['dataset-edit']
         form['name'] = u'my-dataset'
         response = submit_and_follow(app, form, env, 'save')
 
@@ -276,7 +278,8 @@ class TestPackageControllerNew(helpers.FunctionalTestBase):
                       id=model.Package.by_name(u'my-dataset').id)
         pkg_edit_response = app.get(url=url, extra_environ=env)
         # A field with the correct id is in the response
-        assert 'id="field-organizations"' not in pkg_edit_response
+        form = pkg_edit_response.forms['dataset-edit']
+        assert 'owner_org' not in form.fields
         # The organization id is in the response in a value attribute
         assert 'value="{0}"'.format(org['id']) not in pkg_edit_response
 

--- a/ckan/new_tests/lib/test_munge.py
+++ b/ckan/new_tests/lib/test_munge.py
@@ -16,8 +16,11 @@ class TestMungeFilenameLegacy(object):
         ('2014-11-10 12:24:05.340603my_image.jpeg',
          '2014-11-10-122405.340603myimage.jpeg'),
         ('file.csv', 'file.csv'),
-        ('f'*100 + '.csv', 'f'*100),
+        ('f' * 100 + '.csv', 'f' * 100),
         ('path/to/file.csv', 'pathtofile.csv'),
+        ('.longextension', '.longextension'),
+        ('a.longextension', 'a.longextension'),
+        ('.1', '.1_'),
     ]
 
     def test_munge_filename(self):
@@ -34,8 +37,6 @@ class TestMungeFilenameLegacy(object):
             second_munge = munge_filename_legacy(first_munge)
             nose_tools.assert_equal(second_munge, exp)
 
-def test_dave():
-    nose_tools.assert_equal(munge_filename('bad-spaces'), 'bad-spaces')
 
 class TestMungeFilename(object):
 
@@ -49,8 +50,11 @@ class TestMungeFilename(object):
         ('2014-11-10 12:24:05.340603my_image.jpeg',
          '2014-11-10-122405.340603myimage.jpeg'),
         ('file.csv', 'file.csv'),
-        ('f'*100 + '.csv', 'f'*96 + '.csv'),
+        ('f' * 100 + '.csv', 'f' * 96 + '.csv'),
         ('path/to/file.csv', 'file.csv'),
+        ('.longextension', '.longextension'),
+        ('a.longextension', 'a.longextension'),
+        ('.1', '.1_'),
     ]
 
     def test_munge_filename(self):


### PR DESCRIPTION
Issue #2057

This PR is an improved version of Tobe's PR:
https://github.com/ckan/ckan/pull/2149/files

If we upload a file with a huge name then the extension gets eaten and we end up with the datastore not being able to import the file correctly if the format has not been set for the resource

Also it seems browsers on windows 7 seem to pass the whole path along with the file name so this creates problems for these users.

So we remove the path and try to keep the extension - really long extensions (over 20 chars) get truncated but these are probably erroneous extensions anyway.