### PR TITLE
add text to account links

### DIFF
--- a/ckan/public/base/less/masthead.less
+++ b/ckan/public/base/less/masthead.less
@@ -20,9 +20,17 @@
           font-weight: bold;
           padding: 0 10px;
           line-height: 31px;
-          span.username {
+          span.username,
+          span.text {
             margin: 0 2px 0 4px;
           }
+          
+          span.text {
+            position: absolute;
+            top: -9999px;
+            left: -9999px;
+          }
+          
           &:hover {
             color: mix(@mastheadBackgroundColor, @mastheadLinkColor, 15%);
             background-color: darken(@mastheadBackgroundColor, 15%);
@@ -40,12 +48,14 @@
     }
     .notifications {
       a {
-        span {
+        span.badge {
           font-size: 12px;
           margin-left: 3px;
           padding: 1px 6px;
           background-color: darken(@mastheadBackgroundColor, 15%);
           .border-radius(4px);
+          text-shadow:none;
+          color: mix(@mastheadBackgroundColor, @mastheadLinkColor, 25%);
         }
         &:hover span {
           color: @mastheadLinkColor;
@@ -53,7 +63,7 @@
         }
       }
       &.notifications-important a {
-        span {
+        span.badge {
           color: @mastheadLinkColor;
           background-color: @notificationsBg;
         }

--- a/ckan/templates/header.html
+++ b/ckan/templates/header.html
@@ -10,7 +10,8 @@
               {% if c.userobj.sysadmin %}
                 <li>
                   <a href="{{ h.url_for(controller='admin', action='index') }}" title="{{ _('Sysadmin settings') }}">
-                    <i class="icon-legal"></i>
+                    <i class="icon-legal" aria-hidden="true"></i>
+                    <span class="text">{{ _('Admin') }}</span>
                   </a>
                 </li>
               {% endif %}
@@ -24,21 +25,24 @@
               <li class="notifications {% if new_activities > 0 %}notifications-important{% endif %}">
                 {% set notifications_tooltip = ngettext('Dashboard (%(num)d new item)', 'Dashboard (%(num)d new items)', new_activities) %}
                 <a href="{{ h.url_for(controller='user', action='dashboard') }}" title="{{ notifications_tooltip }}">
-                  <i class="icon-dashboard"></i>
-                  <span>{{ new_activities }}</span>
+                  <i class="icon-dashboard" aria-hidden="true"></i>
+                  <span class="text">{{ _('Dashboard') }}</span>
+                  <span class="badge">{{ new_activities }}</span>
                 </a>
               </li>
               {% block header_account_settings_link %}
                 <li>
                   <a href="{{ h.url_for(controller='user', action='edit', id=c.userobj.name) }}" title="{{ _('Edit settings') }}">
-                    <i class="icon-cog"></i>
+                    <i class="icon-cog" aria-hidden="true"></i>
+                    <span class="text">{{ _('Settings') }}</span>
                   </a>
                 </li>
               {% endblock %}
               {% block header_account_log_out_link %}
                 <li>
                   <a href="{{ h.url_for('/user/_logout') }}" title="{{ _('Log out') }}">
-                    <i class="icon-signout"></i>
+                    <i class="icon-signout" aria-hidden="true"></i>
+                    <span class="text">{{ _('Log out') }}</span>
                   </a>
                 </li>
               {% endblock %}


### PR DESCRIPTION
Adds text to the account-masthead links. This addresses https://github.com/ckan/ckan/issues/1541 (text browser support), as well as giving more options when theming (without the need to edit the template).