### PR TITLE
Minor but important fix on custom fields tutorial

### DIFF
--- a/doc/extensions/adding-custom-fields.rst
+++ b/doc/extensions/adding-custom-fields.rst
@@ -158,9 +158,9 @@ This overrides the custom_fields block with an empty block so the default CKAN
 custom fields form does not render.
 
 
-.. versionadded:: 2.2.1
+.. versionadded:: 2.3
 
-    Starting from CKAN 2.2.1 you can combine free extras with custom fields
+    Starting from CKAN 2.3 you can combine free extras with custom fields
     handled with ``convert_to_extras`` and ``convert_from_extras``. On prior
     versions you'll always need to remove the free extras handling.
 


### PR DESCRIPTION
The ability to combine free extras and custom fields was added on 2.3,
not 2.2.1