### PR TITLE
Include type in group controllers index method.

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -141,7 +141,7 @@ class GroupController(base.BaseController):
                    'with_private': False}
 
         q = c.q = request.params.get('q', '')
-        data_dict = {'all_fields': True, 'q': q}
+        data_dict = {'all_fields': True, 'q': q, 'type': group_type}
         sort_by = c.sort_by_selected = request.params.get('sort')
         if sort_by:
             data_dict['sort'] = sort_by


### PR DESCRIPTION
The index action in the group controller did not include 'type' in data_dict meaning any new custom group types will only have groups of type 'group' returned. 