### PR TITLE
Do not provide email configuration in default config file

### DIFF
--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -159,10 +159,10 @@ ckan.hide_activity_from_users = %(ckan.site_id)s
 
 ## Email settings
 
-email_to = you@yourdomain.com
-error_email_from = paste@localhost
-smtp.server = localhost
-smtp.starttls = False
+#email_to = you@yourdomain.com
+#error_email_from = paste@localhost
+#smtp.server = localhost
+#smtp.starttls = False
 #smtp.user = your_username@gmail.com
 #smtp.password = your_password
 #smtp.mail_from =


### PR DESCRIPTION
The default config file provides an email address. This can lead to interesting side effects thanks to how Pylons works. An exception is printed to stdout if and only if there's no email address provided. If the provided one doesn't work, it just leads to an error about failing to send email. See [my post](http://nigelb.me/2014-08-18-arrrrrgh-tracebacks-and-exceptions.html) for more details.