### PR TITLE
Resource Views: Fix embed button when no view description

### DIFF
--- a/ckan/public/base/less/module.less
+++ b/ckan/public/base/less/module.less
@@ -183,6 +183,10 @@
 
 .ckanext-datapreview {
   position: relative;
+  clear: both;
+
+  padding-top: 15px;
+  margin-top: 0;
 
   & > iframe {
     min-height: 400px;
@@ -206,7 +210,7 @@
   margin-top: 0;
   margin-bottom: 0;
   .border-radius(3px 3px 0 0);
-  .actions { 
+  .actions {
     position: relative;
     float: right;
     top: -10px;


### PR DESCRIPTION
Allow the .ckanext-datapreview container to clear so embed button doesn't get over-layed and become inaccessible. Also add a little padding to embed button has more room on the resource preview page. Fixes #2269.