### PR TITLE
Fix search layout in organization bulk edit page

### DIFF
--- a/ckan/public/base/less/layout.less
+++ b/ckan/public/base/less/layout.less
@@ -132,7 +132,7 @@
   .tertiary {
     float: left;
     width: 180px;
-    margin-left: 20px;
+    margin-left: 18px;
     margin-bottom: 20px;
   }
 }

--- a/ckan/public/base/less/search.less
+++ b/ckan/public/base/less/search.less
@@ -114,4 +114,10 @@
     float:right;
     margin-left:15px;
   }
+  .tertiary {
+    .search-form .control-order-by {
+      float: none;
+      margin: 0;
+    }
+  }
 }


### PR DESCRIPTION
Looks like some layout issues were introduced in this obscure page when responsive work was done on the main search pages. This PR moves the search and facet fields back to the right side of the page. Fixes #2267. 