### PR TITLE
#2283 pack template legacy resources - fix in v2.2.1

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ recursive-include ckan/config *.ini
 recursive-include ckan/config *.xml
 recursive-include ckan/i18n *
 recursive-include ckan/templates *
+recursive-include ckan/templates_legacy *
 recursive-include ckan *.ini
 
 recursive-include ckanext/*/i18n *


### PR DESCRIPTION
Currently, there is a bug (#2283- template_legacy resources was missing after an installation) so that when a user runs an installation via command python setup.py install then the user is unable to get to trash page - ckan-admin/trash - http://docs.ckan.org/en/latest/sysadmin-guide.html#permanently-deleting-datasets

After this change, the user can delete the datasets permanently and the resources of template_legacy is exported after an installation via python setup.py install