### PR TITLE
Add command to run when installing from source

### DIFF
--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -139,7 +139,8 @@ Then you can use this connection to set the permissions::
 
 .. note::
    If you performed a source install, you will need to replace all references to
-   ``sudo ckan ...`` with ``paster --plugin=ckan ...``
+   ``sudo ckan ...`` with ``paster --plugin=ckan ...`` and provide the path to
+   the config file, e.g. ``paster --plugin=ckan datastore set-permissions postgres -c /etc/ckan/default/development.ini``
 
 If your database server is not local, but you can access it over SSH, you can
 pipe the permissions script over SSH::


### PR DESCRIPTION
I came to this page from the "install CKAN from source" page. The set permissions part did not work for me - I replaced sudo ckan with paster --plugin=ckan but that was not enough.

I took the command from http://docs.ckan.org/en/ckan-2.0/datastore-setup.html and that one worked - included the "postgres" keyword and configuration file path. It would be helpful to include it directly to the note dedicated to the ones installing from source.