### PR TITLE
Allow modification of resource data after validation. 

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -982,9 +982,13 @@ def package_show(context, data_dict):
             package_dict, errors = lib_plugins.plugin_validate(
                 package_plugin, context, package_dict, schema,
                 'package_show')
-
+    
     for item in plugins.PluginImplementations(plugins.IPackageController):
         item.after_show(context, package_dict)
+
+    for resource_dict in package_dict['resources']:
+        for item in plugins.PluginImplementations(plugins.IResourceController):
+            resource_dict = item.after_show(resource_dict)
 
     return package_dict
 

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -686,7 +686,7 @@ class IResourceController(Interface):
 
     def before_show(self, resource_dict):
         '''
-        Extensions will receive the validated data dict before the resource
+        Extensions will receive the unvalidated data dict before the resource
         is ready for display.
 
         Be aware that this method is not only called for UI display, but also
@@ -695,6 +695,12 @@ class IResourceController(Interface):
         '''
         return resource_dict
 
+    def after_show(self, resource_dict):
+        '''
+        Extensions will receive the validated data dict after the resource
+        is ready for display.
+        '''
+        return resource_dict
 
 class IPluginObserver(Interface):
     """


### PR DESCRIPTION
Validation was turning my dictionary into a string prior to template display. Hence, at the very least it is incorrect to write that "Extensions will receive the *validated* data dict...". (https://github.com/smartlane/ckan/blob/bc9f114b17f572e839180c83c1590fd6b6907913/ckan/logic/action/get.py#L972)

Overall the interfacing possibilities for resources seem to be quite crippled compared to datasets?