### PR TITLE
Make it possible to add a dataset without adding data.

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -935,6 +935,14 @@ class PackageController(base.BaseController):
                         url = h.url_for(controller='package',
                                         action='new_metadata',
                                         id=pkg_dict['name'])
+                    elif request.params['save'] == 'finish':
+                        # don't add resources
+                        data_dict['state'] = 'active'
+                        # this is actually an edit not a save
+                        pkg_dict = get_action('package_update')(context, data_dict)
+                        url = h.url_for(controller='package',
+                                        action='read',
+                                        id=pkg_dict['name'])
                     else:
                         # redirect to add dataset resources
                         url = h.url_for(controller='package',
@@ -951,10 +959,19 @@ class PackageController(base.BaseController):
             context['message'] = data_dict.get('log_message', '')
             pkg_dict = get_action('package_create')(context, data_dict)
 
-            if ckan_phase:
+            if ckan_phase and request.params['save'] != 'finish':
                 # redirect to add dataset resources
                 url = h.url_for(controller='package',
                                 action='new_resource',
+                                id=pkg_dict['name'])
+                redirect(url)
+            else:
+                # don't add resources
+                data_dict['state'] = 'active'
+                # this is actually an edit not a save
+                pkg_dict = get_action('package_update')(context, data_dict)
+                url = h.url_for(controller='package',
+                                action='read',
                                 id=pkg_dict['name'])
                 redirect(url)
 

--- a/ckan/templates/package/snippets/package_form.html
+++ b/ckan/templates/package/snippets/package_form.html
@@ -41,7 +41,8 @@ then itself be extended to add/remove blocks of functionality. #}
         {% endif %}
       {% endblock %}
       {% block save_button %}
-        <button class="btn btn-primary" type="submit" name="save">{% block save_button_text %}{{ _('Next: Add Data') }}{% endblock %}</button>
+         <button class="btn btn-primary" type="submit" name="save">{% block save_button_text %}{{ _('Next: Add Data') }}{% endblock %}</button>
+        <button class="btn btn-primary" type="submit" name="save" value='finish'>{% block finish_button_text %}{{ _('Finish') }}{% endblock %}</button>
       {% endblock %}
       {{ form.required_message() }}
     </div>


### PR DESCRIPTION
This has probably been discussed before somewhere so I expect this will be rejected. But one use case is when a user is unsure whether the data upload will be successful and doesn't want to risk creating an orphaned dataset and hence lose the name (slug). I'm sure there are a few edge CKAN use cases where a user does not want to add any resources.

This code is probably not the best, I did this in a hurry. If the feature is actually desired I can work on it some more.