### PR TITLE
Map view - Auto zoom to features 

### DIFF
--- a/ckanext/reclineview/theme/public/vendor/recline/recline.js
+++ b/ckanext/reclineview/theme/public/vendor/recline/recline.js
@@ -1875,7 +1875,7 @@ my.Map = Backbone.View.extend({
 
   initialize: function(options) {
     var self = this;
-    this.visible = true;
+    this.visible = this.$el.is(':visible');
     this.mapReady = false;
     // this will be the Leaflet L.Map object (setup below)
     this.map = null;


### PR DESCRIPTION
In beta of CKAN 2.3, go to a record with spatial info e.g. http://beta.ckan.org/dataset/afghanistan-election-districts/resource/50f6abfc-1ff3-4885-8d8b-ec452605f159?view_id=c701331a-c022-4246-997f-d69ddc97f212

Click in to Data Explorer, and then map - the view shows the entire world, and does not zoom to the points in the data.

If you untick "Auto zoom to features", and then tick it again, the screen refreshes and the zooming works (same if you tick 'Cluster markers').  The zoom is forgotten if you leave the resource and then come back in and look at the map again.