### PR TITLE
Use default title if available when creating a new views

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -1557,11 +1557,14 @@ class PackageController(base.BaseController):
         view_template = view_plugin.view_template(context, data_dict)
         form_template = view_plugin.form_template(context, data_dict)
 
+        default_view_title = view_plugin.info().get('default_title', '')
+
         vars = {'form_template': form_template,
                 'view_template': view_template,
                 'data': data,
                 'errors': errors,
                 'error_summary': error_summary,
+                'default_title': default_view_title,
                 'to_preview': to_preview,
                 'datastore_available': p.plugin_loaded('datastore')}
         vars.update(

--- a/ckan/new_tests/lib/test_datapreview.py
+++ b/ckan/new_tests/lib/test_datapreview.py
@@ -39,7 +39,7 @@ class TestDataPreview(object):
 
 class MockDatastoreBasedResourceView(p.SingletonPlugin):
 
-    p.implements(p.IResourceView)
+    p.implements(p.IResourceView, inherit=True)
 
     def info(self):
         return {

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -220,8 +220,9 @@ class IResourceView(Interface):
         :param title: title of the view type, will be displayed on the
             frontend. This should be translatable (ie wrapped on
             ``toolkit._('Title')``).
-        :param default_title: default title that will be used if the view is
-            created automatically (optional, defaults to 'View').
+        :param default_title: title that will be used on the form by default or
+            if the view is created automatically (optional, defaults to
+            'View').
         :param default_description: default description that will be used if
             the view is created automatically (optional, defaults to '').
         :param icon: icon for the view type. Should be one of the

--- a/ckan/templates/package/snippets/view_form.html
+++ b/ckan/templates/package/snippets/view_form.html
@@ -5,7 +5,7 @@
 
 {{ form.errors(error_summary) }}
 
-{{ form.input('title', id='field-title', label=_('Title'), placeholder=_('eg. My View'), value=data.title, error=errors.title, classes=['control-full', 'control-large'], is_required=true) }}
+{{ form.input('title', id='field-title', label=_('Title'), placeholder=_('eg. My View'), value=data.title or default_title or '', error=errors.title, classes=['control-full', 'control-large'], is_required=true) }}
 {{ form.markdown('description', id='field-description', label=_('Description'), placeholder=_('eg. Information about my view'), value=data.description, error=errors.description) }}
 
 {% block view_form_filters %}


### PR DESCRIPTION
If I have a tabular data resource, which CKAN does not automatically recognise and offer the Data Exploer view, but for which i can manually add a Data Explorer view, then I think it would be good if the view name defaulted to 'Data Explorer' so as to match the automatic view label.  A user can over ride if there is a reason, but otherwise this ensures consistency for other people discovering and exploring datasets.
