### PR TITLE
My Datasets view on dashboard is empty

### DIFF
--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -640,7 +640,7 @@ class UserController(base.BaseController):
     def dashboard_datasets(self):
         context = {'for_view': True, 'user': c.user or c.author,
                    'auth_user_obj': c.userobj}
-        data_dict = {'user_obj': c.userobj}
+        data_dict = {'user_obj': c.userobj, 'include_datasets': True}
         self._setup_template_variables(context, data_dict)
         return render('user/dashboard_datasets.html')
 

--- a/ckan/new_tests/controllers/test_user.py
+++ b/ckan/new_tests/controllers/test_user.py
@@ -1,0 +1,42 @@
+from nose.tools import assert_true, assert_false
+
+from routes import url_for
+
+import ckan.new_tests.helpers as helpers
+import ckan.new_tests.factories as factories
+
+
+class TestPackageControllerNew(helpers.FunctionalTestBase):
+
+    def test_own_datasets_show_up_on_user_dashboard(self):
+        user = factories.User()
+        dataset_title = 'My very own dataset'
+        factories.Dataset(user=user,
+                          name='my-own-dataset',
+                          title=dataset_title)
+
+        app = self._get_test_app()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        response = app.get(
+            url=url_for(controller='user', action='dashboard_datasets'),
+            extra_environ=env,
+        )
+
+        assert_true(dataset_title in response)
+
+    def test_other_datasets_dont_show_up_on_user_dashboard(self):
+        user1 = factories.User()
+        user2 = factories.User()
+        dataset_title = 'Someone else\'s dataset'
+        factories.Dataset(user=user1,
+                          name='someone-elses-dataset',
+                          title=dataset_title)
+
+        app = self._get_test_app()
+        env = {'REMOTE_USER': user2['name'].encode('ascii')}
+        response = app.get(
+            url=url_for(controller='user', action='dashboard_datasets'),
+            extra_environ=env,
+        )
+
+        assert_false(dataset_title in response)


### PR DESCRIPTION
Beta 2.3 site pre existing data (loaded up during previous version beta testing) is not appearing in users dashboard | my dataset view, but IS showing up if I click on my user name at the top.
![missing dataset list](https://cloud.githubusercontent.com/assets/4842751/6277387/08cf965e-b8f3-11e4-99c4-130b6f29ba93.png)