### PR TITLE
Don't assume resource format is there on text view plugin `can_view` method

### DIFF
--- a/ckanext/textview/plugin.py
+++ b/ckanext/textview/plugin.py
@@ -69,7 +69,7 @@ class TextView(p.SingletonPlugin):
 
     def can_view(self, data_dict):
         resource = data_dict['resource']
-        format_lower = resource['format'].lower()
+        format_lower = resource.get('format', '').lower()
         proxy_enabled = p.plugin_loaded('resource_proxy')
         same_domain = datapreview.on_same_domain(data_dict)
         if format_lower in self.jsonp_formats:


### PR DESCRIPTION
Sometimes is not, eg in 

```
curl -X POST http://127.0.0.1:5000/api/3/action/datastore_create -H "Authorization: {YOUR-API-KEY}" -d '{"resource": {"package_id": "{PACKAGE-ID}"}, "fields": [ {"id": "a"}, {"id": "b"} ], "records": [ { "a": 1, "b": "xyz"}, {"a": 2, "b": "zzz"} ]}'
```