### PR TITLE
Support DataStore only resources in recline view

### DIFF
--- a/ckanext/reclineview/plugin.py
+++ b/ckanext/reclineview/plugin.py
@@ -58,7 +58,9 @@ class ReclineViewBase(p.SingletonPlugin):
         toolkit.add_resource('theme/public', 'ckanext-reclineview')
 
     def can_view(self, data_dict):
-        return data_dict['resource'].get('datastore_active')
+        resource = data_dict['resource']
+        return (resource.get('datastore_active') or
+                resource.get('url') == '_datastore_only_resource')
 
     def setup_template_variables(self, context, data_dict):
         return {'resource_json': json.dumps(data_dict['resource']),
@@ -83,9 +85,12 @@ class ReclineView(ReclineViewBase):
                 }
 
     def can_view(self, data_dict):
-        if data_dict['resource'].get('datastore_active'):
+        resource = data_dict['resource']
+
+        if (resource.get('datastore_active') or
+                resource.get('url') == '_datastore_only_resource'):
             return True
-        resource_format = data_dict['resource'].get('format', None)
+        resource_format = resource.get('format', None)
         if resource_format:
             return resource_format.lower() in ['csv', 'xls', 'xlsx', 'tsv']
         else:

--- a/ckanext/reclineview/tests/test_view.py
+++ b/ckanext/reclineview/tests/test_view.py
@@ -88,11 +88,11 @@ class TestReclineViewDatastoreOnly(helpers.FunctionalTestBase):
             p.load('recline_view')
         if not p.plugin_loaded('datastore'):
             p.load('datastore')
-
-        config['ckan.legacy_templates'] = 'false'
-        config['ckan.plugins'] = 'recline_view datastore'
-        config['ckan.views.default_views'] = 'recline_view'
-        wsgiapp = middleware.make_app(config['global_conf'], **config)
+        app_config = config.copy()
+        app_config['ckan.legacy_templates'] = 'false'
+        app_config['ckan.plugins'] = 'recline_view datastore'
+        app_config['ckan.views.default_views'] = 'recline_view'
+        wsgiapp = middleware.make_app(config['global_conf'], **app_config)
         cls.app = paste.fixture.TestApp(wsgiapp)
 
     @classmethod
@@ -108,7 +108,7 @@ class TestReclineViewDatastoreOnly(helpers.FunctionalTestBase):
             'resource': {'package_id': dataset['id']},
             'fields': [{'id': 'a'}, {'id': 'b'}],
             'records': [{'a': 1, 'b': 'xyz'}, {'a': 2, 'b': 'zzz'}]
-            }
+        }
         result = helpers.call_action('datastore_create', **data)
 
         resource_id = result['resource_id']

--- a/ckanext/reclineview/tests/test_view.py
+++ b/ckanext/reclineview/tests/test_view.py
@@ -9,6 +9,8 @@ import ckanext.reclineview.plugin as plugin
 import ckan.lib.create_test_data as create_test_data
 import ckan.config.middleware as middleware
 
+from ckan.new_tests import helpers, factories
+
 
 class BaseTestReclineViewBase(tests.WsgiAppCase):
     @classmethod
@@ -76,6 +78,47 @@ class TestReclineView(BaseTestReclineViewBase):
             data_dict = {'resource': {'datastore_active': False,
                                       'format': resource_format}}
             assert not self.p.can_view(data_dict)
+
+
+class TestReclineViewDatastoreOnly(helpers.FunctionalTestBase):
+
+    @classmethod
+    def setup_class(cls):
+        if not p.plugin_loaded('recline_view'):
+            p.load('recline_view')
+        if not p.plugin_loaded('datastore'):
+            p.load('datastore')
+
+        config['ckan.legacy_templates'] = 'false'
+        config['ckan.plugins'] = 'recline_view datastore'
+        config['ckan.views.default_views'] = 'recline_view'
+        wsgiapp = middleware.make_app(config['global_conf'], **config)
+        cls.app = paste.fixture.TestApp(wsgiapp)
+
+    @classmethod
+    def teardown_class(cls):
+        if p.plugin_loaded('recline_view'):
+            p.unload('recline_view')
+        if p.plugin_loaded('datastore'):
+            p.unload('datastore')
+
+    def test_create_datastore_only_view(self):
+        dataset = factories.Dataset()
+        data = {
+            'resource': {'package_id': dataset['id']},
+            'fields': [{'id': 'a'}, {'id': 'b'}],
+            'records': [{'a': 1, 'b': 'xyz'}, {'a': 2, 'b': 'zzz'}]
+            }
+        result = helpers.call_action('datastore_create', **data)
+
+        resource_id = result['resource_id']
+
+        url = h.url_for(controller='package', action='resource_read',
+                        id=dataset['id'], resource_id=resource_id)
+
+        result = self.app.get(url)
+
+        assert 'data-module="data-viewer"' in result.body
 
 
 class TestReclineGridView(BaseTestReclineViewBase):


### PR DESCRIPTION
If you create a DataStore only resource via 

```
curl -X POST http://127.0.0.1:5000/api/3/action/datastore_create -H "Authorization: {YOUR-API-KEY}" -d '{"resource": {"package_id": "{PACKAGE-ID}"}, "fields": [ {"id": "a"}, {"id": "b"} ], "records": [ { "a": 1, "b": "xyz"}, {"a": 2, "b": "zzz"} ]}'
```

Then the `recline_*` view won't be created because the `can_view` check relies on `datastore_active=True`, which is set later on. It should only check for `url=_datastore_only_resource` as well

