### PR TITLE
Recline view converts all https resource urls to http

### DIFF
--- a/ckanext/reclineview/theme/public/recline_view.js
+++ b/ckanext/reclineview/theme/public/recline_view.js
@@ -35,7 +35,6 @@ this.ckan.module('recline_view', function (jQuery, _) {
         window.parent.ckan.pubsub.publish('data-viewer-error', msg);
       }
 
-      resourceData.url  = this.normalizeUrl(resourceData.url);
       if (resourceData.formatNormalized === '') {
         var tmp = resourceData.url.split('/');
         tmp = tmp[tmp.length - 1];
@@ -192,14 +191,6 @@ this.ckan.module('recline_view', function (jQuery, _) {
       });
 
       return dataExplorer;
-    },
-
-    normalizeUrl: function (url) {
-      if (url.indexOf('https') === 0) {
-        return 'http' + url.slice(5);
-      } else {
-        return url;
-      }
     },
 
     _renderControls: function (el, controls, className) {


### PR DESCRIPTION
It ["normalizes"](https://github.com/ckan/ckan/blob/5eb8d03b2ae10ad330eb1d57d086a2d172c6e2d4/ckanext/reclineview/theme/public/recline_view.js#L197) resource url that start with `https://` to `http://`.

I can't think of a sane reason for doing this, so it needs to be removed.

BTW this is only an issue when using DataProxy, as DataStore will use different endpoints.