### PR TITLE
Allows creating dataset without the need to specify resource

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -646,7 +646,8 @@ class PackageController(base.BaseController):
                 except NotFound:
                     abort(404,
                       _('The dataset {id} could not be found.').format(id=id))
-                if not len(data_dict['resources']):
+                if asbool(config.get('ckan.dataset.create.require.resource', 'True')) and \
+                        not len(data_dict['resources']):
                     # no data so keep on page
                     msg = _('You must add at least one data resource')
                     # On new templates do not use flash message

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -759,6 +759,17 @@ When set to false, or no, this setting will hide the 'Apps, Ideas, etc' tab on t
 
 .. _ckan.preview.direct:
 
+ckan.dataset.create.require.resource
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+ ckan.dataset.create.require.resource = False
+
+Default value: True
+
+If False, it's not needed to specify resource when creating new dataset in /dataset/new the 2nd stage.
+
 ckan.preview.direct
 ^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Now in the second stage of creating dataset, it's needed to specify at least one resource. Otherwise it's not possible to continue to the next stage of creating dataset.

This enhancement adds new property "ckan.dataset.create.require.resource". If its not specified or has value "True", CKAN behaves normally (requires resource). If it's value is "False", you can continue to the next stage.