### PR TITLE
Docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+ckan:
+  image: ckan/ckan
+  links:
+    - db
+    - solr
+  ports:
+    - 80:80
+
+db:
+  image: ckan/postgresql
+
+solr:
+  image: ckan/solr
+


### PR DESCRIPTION
### What does this PR do?
Adds docker-compose (replacement for fig) capability. 

It uses the image from the [docker-hub](https://registry.hub.docker.com/u/ckan/ckan/) and depends on the other [images](https://registry.hub.docker.com/repos/ckan/) from the hub.
But each of these can be easily replaced. 

#### How can this help?
Instead of using three commands on the command line
```shell
$ docker run -d --name db ckan/postgresql
$ docker run -d --name solr ckan/solr
$ docker run -d -p 80:80 --link db:db --link solr:solr ckan/ckan
```
you will only run one command
```shell
$ docker-compose up -d
```

## Important
This PR should only be merged after the ckan solr image on the hub is updated. 
See related #2255