### PR TITLE
discard revision_id on resource_update

### DIFF
--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -105,6 +105,7 @@ def default_resource_schema():
 
 def default_update_resource_schema():
     schema = default_resource_schema()
+    schema['revision_id'] = [ignore]
     return schema
 
 def default_tags_schema():


### PR DESCRIPTION
example traceback if you pass a revision_id along with your resources:

```python-traceback
  File "/home/ian/git/ckan/ckan/logic/action/update.py", line 343, in package_update
    pkg = model_save.package_dict_save(data, context)
  File "/home/ian/git/ckan/ckan/lib/dictization/model_save.py", line 313, in package_dict_save
    package_membership_list_save(pkg_dict.get("groups"), pkg, context)
  File "/home/ian/git/ckan/ckan/lib/dictization/model_save.py", line 235, in package_membership_list_save
    model.Session.flush()
  File "/home/ian/ckan23env27/local/lib/python2.7/site-packages/sqlalchemy/orm/scoping.py", line 149, in do
    return getattr(self.registry(), name)(*args, **kwargs)
  File "/home/ian/ckan23env27/local/lib/python2.7/site-packages/sqlalchemy/orm/session.py", line 1907, in flush
    self._flush(objects)
  File "/home/ian/ckan23env27/local/lib/python2.7/site-packages/sqlalchemy/orm/session.py", line 2025, in _flush
    transaction.rollback(_capture_exception=True)
  File "/home/ian/ckan23env27/local/lib/python2.7/site-packages/sqlalchemy/util/langhelpers.py", line 57, in __exit__
    compat.reraise(exc_type, exc_value, exc_tb)
  File "/home/ian/ckan23env27/local/lib/python2.7/site-packages/sqlalchemy/orm/session.py", line 1989, in _flush
    flush_context.execute()
  File "/home/ian/ckan23env27/local/lib/python2.7/site-packages/sqlalchemy/orm/unitofwork.py", line 371, in execute
    rec.execute(self)
  File "/home/ian/ckan23env27/local/lib/python2.7/site-packages/sqlalchemy/orm/unitofwork.py", line 524, in execute
    uow
  File "/home/ian/ckan23env27/local/lib/python2.7/site-packages/sqlalchemy/orm/persistence.py", line 59, in save_obj
    mapper, table, update)
  File "/home/ian/ckan23env27/local/lib/python2.7/site-packages/sqlalchemy/orm/persistence.py", line 516, in _emit_update_statements
    execute(statement, params)
  File "/home/ian/ckan23env27/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 727, in execute
    return meth(self, multiparams, params)
  File "/home/ian/ckan23env27/local/lib/python2.7/site-packages/sqlalchemy/sql/elements.py", line 322, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/home/ian/ckan23env27/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 824, in _execute_clauseelement
    compiled_sql, distilled_params
  File "/home/ian/ckan23env27/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 954, in _execute_context
    context)
  File "/home/ian/ckan23env27/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1116, in _handle_dbapi_exception
    exc_info
  File "/home/ian/ckan23env27/local/lib/python2.7/site-packages/sqlalchemy/util/compat.py", line 189, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb)
  File "/home/ian/ckan23env27/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 947, in _execute_context
    context)
  File "/home/ian/ckan23env27/local/lib/python2.7/site-packages/sqlalchemy/engine/default.py", line 435, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.IntegrityError: (IntegrityError) insert or update on table "resource" violates foreign key constraint "resource_revision_id_fkey"
DETAIL:  Key (revision_id)=(87d89865-0006-4cf7-a2f9-59479f7baa94) is not present in table "revision".
 'UPDATE resource SET revision_id=%(revision_id)s WHERE resource.id = %(resource_id)s' {'revision_id': u'87d89865-0006-4cf7-a2f9-59479f7baa94', 'resource_id': u'5ecfd946-c8ee-4f71-bbff-57c048eeb4d8'}
```