### PR TITLE
Removes use of annakarenina.com to fix #2336

### DIFF
--- a/ckan/lib/create_test_data.py
+++ b/ckan/lib/create_test_data.py
@@ -416,7 +416,7 @@ class CreateTestData(object):
         model.Session.add(pkg1)
         pkg1.title = u'A Novel By Tolstoy'
         pkg1.version = u'0.7a'
-        pkg1.url = u'http://www.annakarenina.com'
+        pkg1.url = u'http://datahub.io'
         # put an & in the url string to test escaping
         if 'alt_url' in model.Resource.get_extra_columns():
             configured_extras = ({'alt_url': u'alt123'},
@@ -424,7 +424,7 @@ class CreateTestData(object):
         else:
             configured_extras = ({}, {})
         pr1 = model.Resource(
-            url=u'http://www.annakarenina.com/download/x=1&y=2',
+            url=u'http://datahub.io/download/x=1&y=2',
             format=u'plain text',
             description=u'Full text. Needs escaping: " Umlaut: \xfc',
             hash=u'abc123',
@@ -432,7 +432,7 @@ class CreateTestData(object):
             **configured_extras[0]
             )
         pr2 = model.Resource(
-            url=u'http://www.annakarenina.com/index.json',
+            url=u'http://datahub.io/index.json',
             format=u'JSON',
             description=u'Index of the novel',
             hash=u'def456',
@@ -509,7 +509,7 @@ left arrow <
         model.Session.add_all([
             model.User(name=u'tester', apikey=u'tester', password=u'tester'),
             model.User(name=u'joeadmin', password=u'joeadmin'),
-            model.User(name=u'annafan', about=u'I love reading Annakarenina. My site: http://anna.com', password=u'annafan'),
+            model.User(name=u'annafan', about=u'I love reading Annakarenina. My site: http://datahub.io', password=u'annafan'),
             model.User(name=u'russianfan', password=u'russianfan'),
             sysadmin,
             ])

--- a/ckan/tests/functional/api/base.py
+++ b/ckan/tests/functional/api/base.py
@@ -99,7 +99,7 @@ class ApiTestCase(object):
         assert '"extras": {' in msg, msg
         assert '"genre": "romantic novel"' in msg, msg
         assert '"original media": "book"' in msg, msg
-        assert 'annakarenina.com/download' in msg, msg
+        assert 'datahub.io/download' in msg, msg
         assert '"plain text"' in msg, msg
         assert '"Index of the novel"' in msg, msg
         assert '"id": "%s"' % self.anna.id in msg, msg
@@ -290,7 +290,7 @@ class Api1TestCase(Api1and2TestCase):
 
     def assert_msg_represents_anna(self, msg):
         super(Api1TestCase, self).assert_msg_represents_anna(msg)
-        assert '"download_url": "http://www.annakarenina.com/download/x=1&y=2"' in msg, msg
+        assert '"download_url": "http://datahub.io/download/x=1&y=2"' in msg, msg
 
 
 class Api2TestCase(Api1and2TestCase):

--- a/ckan/tests/functional/test_revision.py
+++ b/ckan/tests/functional/test_revision.py
@@ -109,7 +109,7 @@ class TestRevisionController(TestController):
         self.create_updating_revision(u'annakarenina',
             title=u"My Updated 'Annakarenina' Title",
             resources=[{
-                'url': u'http://www.annakarenina.com/download3',
+                'url': u'http://datahub.io/download3',
                 'format': u'zip file',
                 'description': u'Full text. Needs escaping: " Umlaut: \xfc',
                 'hash': u'def456',

--- a/ckan/tests/lib/test_dictization.py
+++ b/ckan/tests/lib/test_dictization.py
@@ -97,7 +97,7 @@ class TestBasicDictize:
                             u'size_extra': u'123',
                             u'url_type': None,
                             u'state': u'active',
-                            u'url': u'http://www.annakarenina.com/download/x=1&y=2',
+                            u'url': u'http://datahub.io/download/x=1&y=2',
                             u'webstore_last_updated': None,
                             u'webstore_url': None},
                            {u'alt_url': u'alt345',
@@ -116,7 +116,7 @@ class TestBasicDictize:
                             u'size': None,
                             u'size_extra': u'345',
                             u'state': u'active',
-                            u'url': u'http://www.annakarenina.com/index.json',
+                            u'url': u'http://datahub.io/index.json',
                             u'webstore_last_updated': None,
                             u'webstore_url': None}],
             u'state': u'active',
@@ -131,7 +131,7 @@ class TestBasicDictize:
                          u'state': u'active'}],
             u'title': u'A Novel By Tolstoy',
             u'type': u'dataset',
-            u'url': u'http://www.annakarenina.com',
+            u'url': u'http://datahub.io',
             u'version': u'0.7a',
             }
 

--- a/ckan/tests/lib/test_dictization_schema.py
+++ b/ckan/tests/lib/test_dictization_schema.py
@@ -81,18 +81,18 @@ class TestBasicDictize:
                            'format': u'plain text',
                            'hash': u'abc123',
                            'size_extra': u'123',
-                           'url': u'http://www.annakarenina.com/download/x=1&y=2'},
+                           'url': u'http://datahub.io/download/x=1&y=2'},
                           {'alt_url': u'alt345',
                            'description': u'Index of the novel',
                            'format': u'JSON',
                            'hash': u'def456',
                            'size_extra': u'345',
-                           'url': u'http://www.annakarenina.com/index.json'}],
+                           'url': u'http://datahub.io/index.json'}],
             'tags': [{'name': u'Flexible \u30a1'},
                      {'name': u'russian'},
                      {'name': u'tolstoy'}],
             'title': u'A Novel By Tolstoy',
-            'url': u'http://www.annakarenina.com',
+            'url': u'http://datahub.io',
             'version': u'0.7a'
         }
 

--- a/ckan/tests/logic/test_action.py
+++ b/ckan/tests/logic/test_action.py
@@ -52,7 +52,7 @@ class TestAction(WsgiAppCase):
             'resources': [{
                 'description': u'Full text.',
                 'format': u'plain text',
-                'url': u'http://www.annakarenina.com/download/'
+                'url': u'http://datahub.io/download/'
             }]
         }
         package.update(kwargs)
@@ -169,17 +169,17 @@ class TestAction(WsgiAppCase):
                            'format': u'plain text',
                            'hash': u'abc123',
                            'position': 0,
-                           'url': u'http://www.annakarenina.com/download/'},
+                           'url': u'http://datahub.io/download/'},
                           {'alt_url': u'alt345',
                            'description': u'Index of the novel',
                            'extras': {u'alt_url': u'alt345', u'size': u'345'},
                            'format': u'JSON',
                            'hash': u'def456',
                            'position': 1,
-                           'url': u'http://www.annakarenina.com/index.json'}],
+                           'url': u'http://datahub.io/index.json'}],
             'tags': [{'name': u'russian'}, {'name': u'tolstoy'}],
             'title': u'A Novel By Tolstoy',
-            'url': u'http://www.annakarenina.com',
+            'url': u'http://datahub.io',
             'version': u'0.7a'
         }
 
@@ -224,17 +224,17 @@ class TestAction(WsgiAppCase):
                            'format': u'plain text',
                            'hash': u'abc123',
                            'position': 0,
-                           'url': u'http://www.annakarenina.com/download/'},
+                           'url': u'http://datahub.io/download/'},
                           {'alt_url': u'alt345',
                            'description': u'Index of the novel',
                            'extras': {u'alt_url': u'alt345', u'size': u'345'},
                            'format': u'JSON',
                            'hash': u'def456',
                            'position': 1,
-                           'url': u'http://www.annakarenina.com/index.json'}],
+                           'url': u'http://datahub.io/index.json'}],
             'tags': [{'name': u'russian'}, {'name': u'tolstoy'}],
             'title': u'A Novel By Tolstoy',
-            'url': u'http://www.annakarenina.com',
+            'url': u'http://datahub.io',
             'owner_org': organization['id'],
             'version': u'0.7a',
         }
@@ -278,7 +278,7 @@ class TestAction(WsgiAppCase):
             'notes': u'Some test now',
             'tags': [{'name': u'russian'}, {'name': u'tolstoy'}],
             'title': u'A Novel By Tolstoy',
-            'url': u'http://www.annakarenina.com',
+            'url': u'http://datahub.io',
         }
 
         wee = json.dumps(package)
@@ -518,10 +518,10 @@ class TestAction(WsgiAppCase):
                 'format': u'plain text',
                 'hash': u'abc123',
                 'position': 0,
-                'url': u'http://www.annakarenina.com/download/'
+                'url': u'http://datahub.io/download/'
             }],
             'title': u'A Novel By Tolstoy',
-            'url': u'http://www.annakarenina.com',
+            'url': u'http://datahub.io',
         }
 
         postparams = '%s=1' % json.dumps(package)
@@ -1562,7 +1562,7 @@ class TestResourceAction(WsgiAppCase):
             'resources': [{
                 'description': u'Full text.',
                 'format': u'plain text',
-                'url': u'http://www.annakarenina.com/download/'
+                'url': u'http://datahub.io/download/'
             }]
         }
         package.update(kwargs)
@@ -1665,7 +1665,7 @@ class TestRelatedAction(WsgiAppCase):
             'resources': [{
                 'description': u'Full text.',
                 'format': u'plain text',
-                'url': u'http://www.annakarenina.com/download/'
+                'url': u'http://datahub.io/download/'
             }]
         }
         package.update(kwargs)

--- a/ckan/tests/test_dumper.py
+++ b/ckan/tests/test_dumper.py
@@ -32,11 +32,11 @@ class TestSimpleDump(TestController):
         assert 'russian' in res, res
         assert 'genre' in res, res
         assert 'romantic novel' in res, res
-        assert 'annakarenina.com/download' in res, res
+        assert 'datahub.io/download' in res, res
         assert 'Index of the novel' in res, res
         assert 'joeadmin' not in res, res
         self.assert_correct_field_order(res)
-        
+
     def test_simple_dump_json(self):
         dump_file = tempfile.TemporaryFile()
         simple_dumper.dump(dump_file, 'json')
@@ -74,7 +74,7 @@ class TestDumper(object):
         model.repo.rebuild_db()
 
     def test_dump(self):
-        assert os.path.exists(self.outpath) 
+        assert os.path.exists(self.outpath)
         dumpeddata = json.load(open(self.outpath))
         assert dumpeddata['version'] == ckan.__version__
         tables = dumpeddata.keys()


### PR DESCRIPTION
The tests referenced annakarenina.com which is now a domain with dodgy popups.  THis PR just switches the domain names to point at datahub.io which is under OK control and probably safer.