### PR TITLE
Missing position argument causes broken test in Python 2.6

### DIFF
--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -270,7 +270,7 @@ def datastore_info(context, data_dict):
         # We need to make sure the resource_id is a valid resource_id before we use it like
         # this, we have done that above.
         meta_sql = sqlalchemy.text(u'''
-            SELECT count(_id) FROM "{}";
+            SELECT count(_id) FROM "{0}";
         '''.format(resource_id))
         meta_results = db._get_engine(data_dict).execute(meta_sql, resource_id=resource_id)
         info['meta']['count'] = meta_results.fetchone()[0]


### PR DESCRIPTION
In datastore/logic/action[1] there's a missing positional argument for the format string that's causing a test (ckanext.datastore.tests.test_info.TestDatastoreInfo.test_info_success) to break in python 2.6.

Not sure why this is passing on Travis, but it's broken on my local machine.

[1] https://github.com/ckan/ckan/blob/066c450be9b10629921db445f1309bd264fe6aeb/ckanext/datastore/logic/action.py#L273