### PR TITLE
user_show include_datasets should only include datasets of type dataset by default

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1306,6 +1306,11 @@ def user_show(context, data_dict):
         that are draft or private.
         (optional, default:``False``, limit:50)
     :type include_datasets: boolean
+    :param include_all_dataset_types: If include_datasets is True, this will
+        include all custom dataset types, as well as the default type
+        ``dataset``. If False, this will only include datasets of type
+        ``dataset``. (optional, default:``False``)
+    :type include_all_dataset_types: boolean
     :param include_num_followers: Include the number of followers the user has
          (optional, default:``False``)
     :type include_num_followers: boolean
@@ -1357,6 +1362,10 @@ def user_show(context, data_dict):
         user_dict['datasets'] = []
         dataset_q = model.Session.query(model.Package) \
                          .filter_by(creator_user_id=user_dict['id'])
+
+        if not data_dict.get('include_all_dataset_types', False):
+            dataset_q = dataset_q.filter_by(type='dataset')
+
         if not include_private_and_draft_datasets:
             dataset_q = dataset_q \
                 .filter_by(state='active') \
@@ -1364,6 +1373,7 @@ def user_show(context, data_dict):
         else:
             dataset_q = dataset_q \
                 .filter(model.Package.state != 'deleted')
+
         dataset_q = dataset_q.limit(50)
 
         for dataset in dataset_q:

--- a/ckan/new_tests/logic/action/test_get.py
+++ b/ckan/new_tests/logic/action/test_get.py
@@ -561,6 +561,60 @@ class TestGet(object):
         assert dataset_deleted['name'] not in datasets_got
         assert got_user['number_created_packages'] == 3
 
+    def test_user_show_include_all_dataset_types_true(self):
+        '''
+        Included datasets will include custom dataset types.
+        '''
+        user = factories.User()
+        factories.Dataset(user=user)
+        factories.Dataset(user=user, type='custom-type')
+
+        got_user = helpers.call_action('user_show',
+                                       context={'user': user['name']},
+                                       include_datasets=True,
+                                       include_all_dataset_types=True,
+                                       id=user['id'])
+
+        assert len(got_user['datasets']) == 2
+        types = [ds['type'] for ds in got_user['datasets']]
+        assert 'custom-type' in types
+
+    def test_user_show_include_all_dataset_types_false(self):
+        '''
+        Included datasets won't include custom dataset types.
+        '''
+        user = factories.User()
+        factories.Dataset(user=user)
+        factories.Dataset(user=user, type='custom-type')
+
+        got_user = helpers.call_action('user_show',
+                                       context={'user': user['name']},
+                                       include_datasets=True,
+                                       include_all_dataset_types=False,
+                                       id=user['id'])
+
+        assert len(got_user['datasets']) == 1
+        types = [ds['type'] for ds in got_user['datasets']]
+        assert 'custom-type' not in types
+
+    def test_user_show_include_all_dataset_types_default(self):
+        '''
+        Included datasets won't include custom dataset types. Default is
+        False.
+        '''
+        user = factories.User()
+        factories.Dataset(user=user)
+        factories.Dataset(user=user, type='custom-type')
+
+        got_user = helpers.call_action('user_show',
+                                       context={'user': user['name']},
+                                       include_datasets=True,
+                                       id=user['id'])
+
+        assert len(got_user['datasets']) == 1
+        types = [ds['type'] for ds in got_user['datasets']]
+        assert 'custom-type' not in types
+
     def test_related_list_with_no_params(self):
         '''
         Test related_list with no parameters and default sort


### PR DESCRIPTION
Restricting user_show to only include datasets of type `dataset` by default will prevent inappropriate datasets with custom type from showing up in user_show when `include_datasets` is True.