### PR TITLE
[#2377] Add spacing in body text

### DIFF
--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -117,7 +117,7 @@ def get_reset_link_body(user):
 
 def get_invite_body(user):
     invite_message = _(
-    "You have been invited to {site_title}. A user has already been created"
+    "You have been invited to {site_title}. A user has already been created "
     "to you with the username {user_name}. You can change it later.\n"
     "\n"
     "To accept this invite, please reset your password at:\n"


### PR DESCRIPTION
Issue for response containing "createdto" so in body the concatenated text would result as "A user has already been createdto you with the username"