### PR TITLE
[#2350] Fix validation of user schema.

### DIFF
--- a/ckan/templates/user/edit_user_form.html
+++ b/ckan/templates/user/edit_user_form.html
@@ -1,6 +1,6 @@
 {% import 'macros/form.html' as form %}
 
-<form class="dataset-form form-horizontal" method="post" action="{{ action }}">
+<form id="user-edit" class="user-form form-horizontal" method="post" action="{{ action }}">
   {{ form.errors(error_summary) }}
 
   <fieldset>

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -1,12 +1,15 @@
-from nose.tools import assert_true, assert_false
+from nose.tools import assert_true, assert_false, assert_equal
 
 from routes import url_for
 
 import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
+from ckan import model
+
+submit_and_follow = helpers.submit_and_follow
 
 
-class TestPackageControllerNew(helpers.FunctionalTestBase):
+class TestUser(helpers.FunctionalTestBase):
 
     def test_own_datasets_show_up_on_user_dashboard(self):
         user = factories.User()
@@ -40,3 +43,38 @@ class TestPackageControllerNew(helpers.FunctionalTestBase):
         )
 
         assert_false(dataset_title in response)
+
+    def test_edit_user(self):
+        user = factories.User()
+        app = self._get_test_app()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        response = app.get(
+            url=url_for(controller='user', action='edit'),
+            extra_environ=env,
+        )
+        # existing values in the form
+        form = response.forms['user-edit']
+        assert_equal(form['name'].value, user['name'])
+        assert_equal(form['fullname'].value, user['fullname'])
+        assert_equal(form['email'].value, user['email'])
+        assert_equal(form['about'].value, user['about'])
+        assert_equal(form['activity_streams_email_notifications'].value, None)
+        assert_equal(form['password1'].value, '')
+        assert_equal(form['password2'].value, '')
+
+        # new values
+        #form['name'] = 'new-name'
+        form['fullname'] = 'new full name'
+        form['email'] = 'new@example.com'
+        form['about'] = 'new about'
+        form['activity_streams_email_notifications'] = True
+        form['password1'] = 'newpass'
+        form['password2'] = 'newpass'
+        response = submit_and_follow(app, form, env, 'save')
+
+        user = model.Session.query(model.User).get(user['id'])
+        #assert_equal(user.name, 'new-name')
+        assert_equal(user.fullname, 'new full name')
+        assert_equal(user.email, 'new@example.com')
+        assert_equal(user.about, 'new about')
+        assert_equal(user.activity_streams_email_notifications, True)


### PR DESCRIPTION
See issue: https://github.com/ckan/ckan/issues/2350

I've not written any tests for this as it is a reasonably big job to setup a test extension, inherit UserController and setup routes. I don't think we're very happy with how the user schema is customized - it would make sense to convert to an IUserForm, so investing in this old way seems pointless. So I suggest we just fix this as @KrzysztofMadejski suggests and not worry about a test until this area is looked at properly by someone.

BTW @KrzysztofMadejski inherits UserController and adds an extra validator and a couple of new fields:
https://github.com/DanePubliczneGovPl/ckanext-danepubliczne/blob/develop/ckanext/danepubliczne/controllers/user.py#L79