### PR TITLE
Refering to non-existing action when creating new dataset

### DIFF
--- a/ckan/config/routing.py
+++ b/ckan/config/routing.py
@@ -222,7 +222,6 @@ def make_map():
                   ])))
         m.connect('/dataset/{action}/{id}',
                   requirements=dict(action='|'.join([
-                      'new_metadata',
                       'new_resource',
                       'history',
                       'read_ajax',

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -695,9 +695,13 @@ class PackageController(base.BaseController):
                         errors = {}
                         error_summary = {_('Error'): msg}
                         return self.new_resource(id, data, errors, error_summary)
-                # we have a resource so let them add metadata
+                # XXX race condition if another user edits/deletes
+                data_dict = get_action('package_show')(context, {'id': id})
+                get_action('package_update')(
+                    dict(context, allow_state_change=True),
+                    dict(data_dict, state='active'))
                 redirect(h.url_for(controller='package',
-                                   action='new_metadata', id=id))
+                                   action='read', id=id))
 
             data['package_id'] = id
             try:


### PR DESCRIPTION
This causes 404 Not Found http error

When creating new dataset you can replicate this error with following steps:
1. Click create new dataset
2. go to second "new resource" stage, input the info for the resource and click "Save & add another"
3. click "Finish" button

The cause is commit https://github.com/ckan/ckan/commit/beef24f7e0956ee5a5a00db0237da37ea8a52aa4
in ckan/controllers/package.py removes the new_metadata action, but its still referenced in new_resource method [here](https://github.com/ckan/ckan/blob/b5c43f0ece24f8ff2fd4dd05651a11c1f8e9e23d/ckan/controllers/package.py#L673-L700) (line 700)


its also referenced in the [_save_new](https://github.com/ckan/ckan/blob/b5c43f0ece24f8ff2fd4dd05651a11c1f8e9e23d/ckan/controllers/package.py#L933-L937) method, but I couldn't confirm the steps to cause this error.

and in the [ckan/config/routing.py](https://github.com/ckan/ckan/blob/b5c43f0ece24f8ff2fd4dd05651a11c1f8e9e23d/ckan/config/routing.py#L225) it wasn't removed