### PR TITLE
Add stats group block for extendability of stats.html template

### DIFF
--- a/ckan/templates/home/snippets/stats.html
+++ b/ckan/templates/home/snippets/stats.html
@@ -4,6 +4,7 @@
   <div class="inner">
     <h3>{{ _('{0} statistics').format(g.site_title) }}</h3>
     <ul>
+      {% block stats_group %}
       <li>
         <a href="{{ h.url_for(controller='package', action='search') }}">
           <b>{{ h.SI_number_span(stats.dataset_count) }}</b>
@@ -28,6 +29,7 @@
           {{ _('related item') if stats.related_count == 1 else _('related items') }}
         </a>
       </li>
+      {% endblock %}
     </ul>
   </div>
 </div>


### PR DESCRIPTION
Surround the stats items in `home/snippets/stats.html` in a `stats_group` block to make it slightly easier to extend the home page sites stats from extensions. Closes #2389.