### PR TITLE
Default configurations allow anyone to "pretend they hacked the site"

### DIFF
--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -62,10 +62,10 @@ ckan.site_url =
 ## Authorization Settings
 
 ckan.auth.anon_create_dataset = false
-ckan.auth.create_unowned_dataset = true
-ckan.auth.create_dataset_if_not_in_organization = true
-ckan.auth.user_create_groups = true
-ckan.auth.user_create_organizations = true
+ckan.auth.create_unowned_dataset = false
+ckan.auth.create_dataset_if_not_in_organization = false
+ckan.auth.user_create_groups = false
+ckan.auth.user_create_organizations = false
 ckan.auth.user_delete_groups = true
 ckan.auth.user_delete_organizations = true
 ckan.auth.create_user_via_api = false

--- a/doc/maintaining/installing/install-from-package.rst
+++ b/doc/maintaining/installing/install-from-package.rst
@@ -120,3 +120,9 @@ page, which will look something like this:
 
 You can now move on to :doc:`/maintaining/getting-started` to begin using and customizing
 your CKAN site.
+
+.. note:: The default authorization settings on a new install are deliberately
+    restrictive. Regular users won't be able to create datasets or organizations.
+    You should check the :doc:`/maintaining/authorization` documentation, configure CKAN accordingly
+    and grant other users the relevant permissions using the :ref:`sysadmin account <create-admin-user>`.
+

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -375,6 +375,10 @@ Now that you've installed CKAN, you should:
 
 * Begin using and customizing your site, see :doc:`/maintaining/getting-started`.
 
+.. note:: The default authorization settings on a new install are deliberately
+    restrictive. Regular users won't be able to create datasets or organizations.
+    You should check the :doc:`/maintaining/authorization` documentation, configure CKAN accordingly
+    and grant other users the relevant permissions using the :ref:`sysadmin account <create-admin-user>`.
 
 ------------------------------
 Source install troubleshooting


### PR DESCRIPTION
I just noticed that someone used the default configurations to pretend they hacked a site by just creating a new dataset which does not look good for those who installed CKAN without configuring the authentication.

I propose we change the default configurations to require users to be in organisations to create datasets (and disallow unowned datasets).

That is change the ``ckan.auth.create_unowned_dataset`` and ``ckan.auth.create_dataset_if_not_in_organization`` defaults to ``False`` instead of ``True``.