### PR TITLE
Fixes #2412 by checking for less correct 400 response

### DIFF
--- a/ckanext/resourceproxy/controller.py
+++ b/ckanext/resourceproxy/controller.py
@@ -40,7 +40,9 @@ def proxy_resource(context, data_dict):
         # first we try a HEAD request which may not be supported
         did_get = False
         r = requests.head(url)
-        if r.status_code == 405:
+        # 405 would be the appropriate response here, but 400 with
+        # the invalid method mentioned in the text is also possible (#2412)
+        if r.status_code in (400, 405):
             r = requests.get(url, stream=True)
             did_get = True
         r.raise_for_status()


### PR DESCRIPTION
Although the code checks for Error 405 which would be the correct response from a server when HEAD is not supported, I have come across a server where 400 is issued with the text "Invalid method in request", which essentially seems to mean the same thing. If we check for this too we can save problems with annoying servers.