### PR TITLE
Cast string to unicode to allow resources that include a BOM

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1832,7 +1832,7 @@ def resource_view_full_page(resource_view):
 
 def remove_linebreaks(string):
     '''Remove linebreaks from string to make it usable in JavaScript'''
-    return str(string).replace('\n', '')
+    return unicode(string).replace('\n', '')
 
 
 def list_dict_filter(list_, search_field, output_field, value):

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -91,13 +91,13 @@ class TestHelpersRemoveLineBreaks(object):
         assert result.find('\n') == -1,\
             '"remove_linebreaks" should remove line breaks'
 
-    def test_remove_linebreaks_casts_into_str(self):
-        class StringLike(str):
+    def test_remove_linebreaks_casts_into_unicode(self):
+        class UnicodeLike(unicode):
             pass
 
-        test_string = StringLike('foo')
+        test_string = UnicodeLike('foo')
         result = h.remove_linebreaks(test_string)
 
-        strType = ''.__class__
+        strType = u''.__class__
         assert result.__class__ == strType,\
-            '"remove_linebreaks" casts into str()'
+            '"remove_linebreaks" casts into unicode()'


### PR DESCRIPTION
In the template helper `remove_linebreaks `, casting the string to `str` causes an error for characters outside of the ascii range. Notably, BOM at the beginning of documents. Casting to unicode fixes this. Fixes #2401.