### PR TITLE
Fix recline view embedding across domains

### DIFF
--- a/ckanext/reclineview/theme/public/recline_view.js
+++ b/ckanext/reclineview/theme/public/recline_view.js
@@ -61,14 +61,17 @@ this.ckan.module('recline_view', function (jQuery, _) {
       var query = new recline.Model.Query();
       query.set({ size: reclineView.limit || 100 });
       query.set({ from: reclineView.offset || 0 });
-      if (window.parent.ckan.views && window.parent.ckan.views.filters) {
-        var defaultFilters = reclineView.filters || {},
-            urlFilters = window.parent.ckan.views.filters.get(),
-            filters = $.extend({}, defaultFilters, urlFilters);
-        $.each(filters, function (field,values) {
-          query.addFilter({type: 'term', field: field, term: values});
-        });
-      }
+
+      try {
+        if (window.parent.ckan.views && window.parent.ckan.views.filters) {
+          var defaultFilters = reclineView.filters || {},
+              urlFilters = window.parent.ckan.views.filters.get(),
+              filters = $.extend({}, defaultFilters, urlFilters);
+          $.each(filters, function (field,values) {
+            query.addFilter({type: 'term', field: field, term: values});
+          });
+        }
+      } catch(e) {}
 
       dataset.queryState.set(query.toJSON(), {silent: true});
 


### PR DESCRIPTION
A recline view embedded in a site hosted on a different domain to the view will not have access to the `window.parent.ckan` property. This causes an error that prevents the view being loaded. The try/catch suppresses the error, allowing the view to load and run. One consequence is that externally embedded views can't use default filters. Closes #2335 & #2238.