### PR TITLE
Fix typo in db pass configuration

### DIFF
--- a/contrib/docker/my_init.d/50_configure
+++ b/contrib/docker/my_init.d/50_configure
@@ -34,7 +34,7 @@ write_config () {
 
 link_postgres_url () {
   local user=$DB_ENV_POSTGRESQL_USER
-  local pass=$DB_ENV_POSTGRESQL_USER
+  local pass=$DB_ENV_POSTGRESQL_PASS
   local db=$DB_ENV_POSTGRESQL_DB
   local host=$DB_PORT_5432_TCP_ADDR
   local port=$DB_PORT_5432_TCP_PORT


### PR DESCRIPTION
Current docker image ignores password from *ckan/postgres* container.