### PR TITLE
Selected config settings can be defined as env vars

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -238,7 +238,12 @@ ENV_VAR_WHITELIST = {
     'ckan.datastore.write_url': 'CKAN_DATASTORE_WRITE_URL',
     'ckan.datastore.read_url': 'CKAN_DATASTORE_READ_URL',
     'solr_url': 'CKAN_SOLR_URL',
-    'ckan.site_id': 'CKAN_SITE_ID'
+    'ckan.site_id': 'CKAN_SITE_ID',
+    'smtp.server': 'CKAN_SMTP_SERVER',
+    'smtp.starttls': 'CKAN_SMTP_STARTTLS',
+    'smtp.user': 'CKAN_SMTP_USER',
+    'smtp.password': 'CKAN_SMTP_PASSWORD',
+    'smtp.mail_from': 'CKAN_SMTP_MAIL_FROM'
 }
 
 

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -232,6 +232,16 @@ def load_environment(global_conf, app_conf):
     p.load_all(config)
 
 
+# A list of config settings that can be overridden by environmental variable.
+ENV_VAR_WHITELIST = {
+    'sqlalchemy.url': 'CKAN_SQLALCHEMY_URL',
+    'ckan.datastore.write_url': 'CKAN_DATASTORE_WRITE_URL',
+    'ckan.datastore.read_url': 'CKAN_DATASTORE_READ_URL',
+    'solr_url': 'CKAN_SOLR_URL',
+    'ckan.site_id': 'CKAN_SITE_ID'
+}
+
+
 def update_config():
     ''' This code needs to be run when the config is changed to take those
     changes into account. '''
@@ -241,11 +251,14 @@ def update_config():
         # config = plugin.update_config(config)
         plugin.update_config(config)
 
-    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    # Set whitelisted env vars on config object
     # This is set up before globals are initialized
-    site_id = os.environ.get('CKAN_SITE_ID')
-    if site_id:
-        config['ckan.site_id'] = site_id
+    for option in ENV_VAR_WHITELIST:
+        from_env = os.environ.get(ENV_VAR_WHITELIST[option], None)
+        if from_env:
+            config[option] = from_env
+
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
     site_url = config.get('ckan.site_url', '')
     ckan_host = config['ckan.host'] = urlparse(site_url).netloc

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -253,6 +253,14 @@ def update_config():
 
     # Set whitelisted env vars on config object
     # This is set up before globals are initialized
+
+    ckan_db = os.environ.get('CKAN_DB', None)
+    if ckan_db:
+        msg = 'Setting CKAN_DB as an env var is deprecated and will be' \
+            ' removed in a future release. Use CKAN_SQLALCHEMY_URL instead.'
+        log.warn(msg)
+        config['sqlalchemy.url'] = ckan_db
+
     for option in ENV_VAR_WHITELIST:
         from_env = os.environ.get(ENV_VAR_WHITELIST[option], None)
         if from_env:
@@ -353,10 +361,6 @@ def update_config():
 
     # CONFIGURATION OPTIONS HERE (note: all config options will override
     # any Pylons config options)
-
-    ckan_db = os.environ.get('CKAN_DB')
-    if ckan_db:
-        config['sqlalchemy.url'] = ckan_db
 
     # for postgresql we want to enforce utf-8
     sqlalchemy_url = config.get('sqlalchemy.url', '')

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -232,8 +232,8 @@ def load_environment(global_conf, app_conf):
     p.load_all(config)
 
 
-# A list of config settings that can be overridden by environmental variable.
-ENV_VAR_WHITELIST = {
+# A mapping of config settings that can be overridden by env vars.
+CONFIG_FROM_ENV_VARS = {
     'sqlalchemy.url': 'CKAN_SQLALCHEMY_URL',
     'ckan.datastore.write_url': 'CKAN_DATASTORE_WRITE_URL',
     'ckan.datastore.read_url': 'CKAN_DATASTORE_READ_URL',
@@ -266,8 +266,8 @@ def update_config():
         log.warn(msg)
         config['sqlalchemy.url'] = ckan_db
 
-    for option in ENV_VAR_WHITELIST:
-        from_env = os.environ.get(ENV_VAR_WHITELIST[option], None)
+    for option in CONFIG_FROM_ENV_VARS:
+        from_env = os.environ.get(CONFIG_FROM_ENV_VARS[option], None)
         if from_env:
             config[option] = from_env
 

--- a/ckan/tests/config/test_environment.py
+++ b/ckan/tests/config/test_environment.py
@@ -1,0 +1,81 @@
+import os
+from nose import tools as nosetools
+
+from pylons import config
+
+import ckan.plugins as p
+
+
+class TestUpdateConfig(object):
+
+    '''
+    Tests for config settings from env vars, set in
+    config.environment.update_config().
+    '''
+
+    def test_update_config_solr_url(self):
+        '''
+        Setting the solr url as an env var will set the appropriate option in
+        config object.
+        '''
+        nosetools.assert_equal(config['solr_url'],
+                               'http://127.0.0.1:8983/solr')
+        os.environ.setdefault('CKAN_SOLR_URL', 'http://mynewsolrurl/solr')
+        # plugin.load() will force the config to update
+        p.load()
+        nosetools.assert_equal(config['solr_url'],
+                               'http://mynewsolrurl/solr')
+
+    def test_update_config_sqlalchemy_url(self):
+        '''
+        Setting the sqlalchemy url as an env var will set the appropriate
+        option in config object.
+        '''
+        nosetools.assert_equal(config['sqlalchemy.url'],
+                               'postgresql://ckan_default:pass@localhost/ckan_test')
+        os.environ.setdefault('CKAN_SQLALCHEMY_URL',
+                              'postgresql://mynewsqlurl/')
+        # plugin.load() will force the config to update
+        p.load()
+        nosetools.assert_equal(config['sqlalchemy.url'],
+                               'postgresql://mynewsqlurl/')
+
+    def test_update_config_datastore_write_url(self):
+        '''
+        Setting the datastore write url as an env var will set the appropriate
+        option in config object.
+        '''
+        nosetools.assert_equal(config['ckan.datastore.write_url'],
+                               'postgresql://ckan_default:pass@localhost/datastore_test')
+        os.environ.setdefault('CKAN_DATASTORE_WRITE_URL',
+                              'http://mynewdbwriteurl/')
+        # plugin.load() will force the config to update
+        p.load()
+        nosetools.assert_equal(config['ckan.datastore.write_url'],
+                               'http://mynewdbwriteurl/')
+
+    def test_update_config_datastore_read_url(self):
+        '''
+        Setting the datastore read url as an env var will set the appropriate
+        option in config object.
+        '''
+        nosetools.assert_equal(config['ckan.datastore.read_url'],
+                               'postgresql://datastore_default:pass@localhost/datastore_test')
+        os.environ.setdefault('CKAN_DATASTORE_READ_URL',
+                              'http://mynewdbreadurl/')
+        # plugin.load() will force the config to update
+        p.load()
+        nosetools.assert_equal(config['ckan.datastore.read_url'],
+                               'http://mynewdbreadurl/')
+
+    def test_update_config_site_id(self):
+        '''
+        Setting the site id as an env var will set the appropriate option in
+        config object.
+        '''
+        nosetools.assert_equal(config['ckan.site_id'], 'test.ckan.net')
+        os.environ.setdefault('CKAN_SITE_ID', 'my-site')
+        # plugin.load() will force the config to update
+        p.load()
+        nosetools.assert_equal(config['ckan.site_id'],
+                               'my-site')

--- a/ckan/tests/config/test_environment.py
+++ b/ckan/tests/config/test_environment.py
@@ -20,7 +20,12 @@ class TestUpdateConfig(h.FunctionalTestBase):
         ('CKAN_DATASTORE_READ_URL', 'http://mynewdbreadurl/'),
         ('CKAN_SOLR_URL', 'http://mynewsolrurl/solr'),
         ('CKAN_SITE_ID', 'my-site'),
-        ('CKAN_DB', 'postgresql://mydeprectatesqlurl/')
+        ('CKAN_DB', 'postgresql://mydeprectatesqlurl/'),
+        ('CKAN_SMTP_SERVER', 'mail.example.com'),
+        ('CKAN_SMTP_STARTTLS', 'True'),
+        ('CKAN_SMTP_USER', 'my_user'),
+        ('CKAN_SMTP_PASSWORD', 'password'),
+        ('CKAN_SMTP_MAIL_FROM', 'server@example.com')
     ]
 
     def _setup_env_vars(self):
@@ -43,16 +48,19 @@ class TestUpdateConfig(h.FunctionalTestBase):
         '''
         self._setup_env_vars()
 
-        nosetools.assert_equal(config['solr_url'],
-                               'http://mynewsolrurl/solr')
+        nosetools.assert_equal(config['solr_url'], 'http://mynewsolrurl/solr')
         nosetools.assert_equal(config['sqlalchemy.url'],
                                'postgresql://mynewsqlurl/')
         nosetools.assert_equal(config['ckan.datastore.write_url'],
                                'http://mynewdbwriteurl/')
         nosetools.assert_equal(config['ckan.datastore.read_url'],
                                'http://mynewdbreadurl/')
-        nosetools.assert_equal(config['ckan.site_id'],
-                               'my-site')
+        nosetools.assert_equal(config['ckan.site_id'], 'my-site')
+        nosetools.assert_equal(config['smtp.server'], 'mail.example.com')
+        nosetools.assert_equal(config['smtp.starttls'], 'True')
+        nosetools.assert_equal(config['smtp.user'], 'my_user')
+        nosetools.assert_equal(config['smtp.password'], 'password')
+        nosetools.assert_equal(config['smtp.mail_from'], 'server@example.com')
 
     def test_update_config_db_url_precidence(self):
         '''CKAN_SQLALCHEMY_URL in the env takes precidence over CKAN_DB'''

--- a/ckan/tests/config/test_environment.py
+++ b/ckan/tests/config/test_environment.py
@@ -3,79 +3,51 @@ from nose import tools as nosetools
 
 from pylons import config
 
+import ckan.tests.helpers as h
 import ckan.plugins as p
 
 
-class TestUpdateConfig(object):
+class TestUpdateConfig(h.FunctionalTestBase):
 
     '''
     Tests for config settings from env vars, set in
     config.environment.update_config().
     '''
 
-    def test_update_config_solr_url(self):
-        '''
-        Setting the solr url as an env var will set the appropriate option in
-        config object.
-        '''
-        nosetools.assert_equal(config['solr_url'],
-                               'http://127.0.0.1:8983/solr')
-        os.environ.setdefault('CKAN_SOLR_URL', 'http://mynewsolrurl/solr')
+    ENV_VAR_LIST = [
+        ('CKAN_SQLALCHEMY_URL', 'postgresql://mynewsqlurl/'),
+        ('CKAN_DATASTORE_WRITE_URL', 'http://mynewdbwriteurl/'),
+        ('CKAN_DATASTORE_READ_URL', 'http://mynewdbreadurl/'),
+        ('CKAN_SOLR_URL', 'http://mynewsolrurl/solr'),
+        ('CKAN_SITE_ID', 'my-site')
+    ]
+
+    def _setup_env_vars(self):
+        for env_var, value in self.ENV_VAR_LIST:
+            os.environ.setdefault(env_var, value)
         # plugin.load() will force the config to update
         p.load()
+
+    def teardown(self):
+        for env_var, _ in self.ENV_VAR_LIST:
+            del os.environ[env_var]
+        # plugin.load() will force the config to update
+        p.load()
+
+    def test_update_config_env_vars(self):
+        '''
+        Setting an env var from the whitelist will set the appropriate option
+        in config object.
+        '''
+        self._setup_env_vars()
+
         nosetools.assert_equal(config['solr_url'],
                                'http://mynewsolrurl/solr')
-
-    def test_update_config_sqlalchemy_url(self):
-        '''
-        Setting the sqlalchemy url as an env var will set the appropriate
-        option in config object.
-        '''
-        nosetools.assert_equal(config['sqlalchemy.url'],
-                               'postgresql://ckan_default:pass@localhost/ckan_test')
-        os.environ.setdefault('CKAN_SQLALCHEMY_URL',
-                              'postgresql://mynewsqlurl/')
-        # plugin.load() will force the config to update
-        p.load()
         nosetools.assert_equal(config['sqlalchemy.url'],
                                'postgresql://mynewsqlurl/')
-
-    def test_update_config_datastore_write_url(self):
-        '''
-        Setting the datastore write url as an env var will set the appropriate
-        option in config object.
-        '''
-        nosetools.assert_equal(config['ckan.datastore.write_url'],
-                               'postgresql://ckan_default:pass@localhost/datastore_test')
-        os.environ.setdefault('CKAN_DATASTORE_WRITE_URL',
-                              'http://mynewdbwriteurl/')
-        # plugin.load() will force the config to update
-        p.load()
         nosetools.assert_equal(config['ckan.datastore.write_url'],
                                'http://mynewdbwriteurl/')
-
-    def test_update_config_datastore_read_url(self):
-        '''
-        Setting the datastore read url as an env var will set the appropriate
-        option in config object.
-        '''
-        nosetools.assert_equal(config['ckan.datastore.read_url'],
-                               'postgresql://datastore_default:pass@localhost/datastore_test')
-        os.environ.setdefault('CKAN_DATASTORE_READ_URL',
-                              'http://mynewdbreadurl/')
-        # plugin.load() will force the config to update
-        p.load()
         nosetools.assert_equal(config['ckan.datastore.read_url'],
                                'http://mynewdbreadurl/')
-
-    def test_update_config_site_id(self):
-        '''
-        Setting the site id as an env var will set the appropriate option in
-        config object.
-        '''
-        nosetools.assert_equal(config['ckan.site_id'], 'test.ckan.net')
-        os.environ.setdefault('CKAN_SITE_ID', 'my-site')
-        # plugin.load() will force the config to update
-        p.load()
         nosetools.assert_equal(config['ckan.site_id'],
                                'my-site')


### PR DESCRIPTION
To allow better support for cloud deployments and remote configuration (#2429), some config settings can be separated from the code by being set as environmental variables. Currently these settings are defined in [environment.py](https://github.com/ckan/ckan/blob/27aeccc8c47892349548476bf87bf7b98d344227/ckan/config/environment.py#L236-L247). 

```python
# A list of config settings that can be overridden by environmental variable.
ENV_VAR_WHITELIST = {
    'sqlalchemy.url': 'CKAN_SQLALCHEMY_URL',
    'ckan.datastore.write_url': 'CKAN_DATASTORE_WRITE_URL',
    'ckan.datastore.read_url': 'CKAN_DATASTORE_READ_URL',
    'solr_url': 'CKAN_SOLR_URL',
    'ckan.site_id': 'CKAN_SITE_ID',
    'smtp.server': 'CKAN_SMTP_SERVER',
    'smtp.starttls': 'CKAN_SMTP_STARTTLS',
    'smtp.user': 'CKAN_SMTP_USER',
    'smtp.password': 'CKAN_SMTP_PASSWORD',
    'smtp.mail_from': 'CKAN_SMTP_MAIL_FROM'
}
```

The list may be expanded in the future.