### PR TITLE
[#2435] Raise ValidationError on package_update if no id or name

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -286,7 +286,9 @@ def package_update(context, data_dict):
     '''
     model = context['model']
     user = context['user']
-    name_or_id = data_dict.get("id") or data_dict['name']
+    name_or_id = data_dict.get('id') or data_dict.get('name')
+    if not name_or_id:
+        raise ValidationError('You must provide either an id or a name')
 
     pkg = model.Package.get(name_or_id)
     if pkg is None:

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -443,6 +443,41 @@ class TestUpdate(object):
             helpers.call_action('package_show', id='unchanging')['type'],
             'dataset')
 
+    def test_update_dataset_by_id(self):
+        dataset = factories.Dataset(
+            title='Title 1')
+
+        dataset = helpers.call_action(
+            'package_update',
+            id=dataset['id'],
+            title='Title 2')
+
+        assert_equals(dataset['title'], 'Title 2')
+        assert_equals(
+            helpers.call_action('package_show', id=dataset['id'])['title'],
+            'Title 2')
+
+    def test_update_dataset_by_name(self):
+        dataset = factories.Dataset(
+            title='Title 1')
+
+        dataset = helpers.call_action(
+            'package_update',
+            name=dataset['name'],
+            title='Title 2')
+
+        assert_equals(dataset['title'], 'Title 2')
+        assert_equals(
+            helpers.call_action('package_show', id=dataset['id'])['title'],
+            'Title 2')
+
+    def test_update_dataset_no_id_no_name_raises_validation_error(self):
+        dataset = factories.Dataset()
+
+        assert_raises(logic.ValidationError, helpers.call_action,
+                      'package_update',
+                      title=dataset['title'])
+
     def test_update_organization_cant_change_type(self):
         user = factories.User()
         context = {'user': user['name']}


### PR DESCRIPTION
Instead of just crashing

Fixes #2435 
