### PR TITLE
Fix broken boolean validator

### DIFF
--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -103,11 +103,12 @@ def is_positive_integer(value, context):
 def boolean_validator(value, context):
     '''
     Return a boolean for value.
-    Return value when value is a python bool type.  
+    Return value when value is a python bool type.
     Return True for strings 'true', 'yes', 't', 'y', and '1'.
-    Return False in all other cases, including when value is None
+    Return False in all other cases, including when value is an empty string or
+    None
     '''
-    if value is missing:
+    if value is missing or value is None:
         return False
     if isinstance(value, bool):
         return value

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -101,6 +101,12 @@ def is_positive_integer(value, context):
     return value
 
 def boolean_validator(value, context):
+    '''
+    Return a boolean for value.
+    Return value when value is a python bool type.  
+    Return True for strings 'true', 'yes', 't', 'y', and '1'.
+    Return False in all other cases, including when value is None
+    '''
     if value is missing:
         return False
     if isinstance(value, bool):

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -101,6 +101,8 @@ def is_positive_integer(value, context):
     return value
 
 def boolean_validator(value, context):
+    if value is missing:
+        return False
     if isinstance(value, bool):
         return value
     if value.lower() in ['true', 'yes', 't', 'y', '1']:

--- a/ckan/tests/logic/test_validators.py
+++ b/ckan/tests/logic/test_validators.py
@@ -499,6 +499,29 @@ class TestIntValidator(object):
             warnings.filterwarnings('ignore', category=DeprecationWarning)
             raises_Invalid(validators.int_validator)(1 + 0j, {})
 
+class TestBoolValidator(object):
+
+    def test_bool_true(self):
+        assert_equals(validators.boolean_validator(True, None), True)
+
+    def test_bool_false(self):
+        assert_equals(validators.boolean_validator(False, None), False)
+
+    def test_missing(self):
+        assert_equals(validators.boolean_validator('', None), False)
+
+    def test_none(self):
+        assert_equals(validators.boolean_validator(None, None), False)
+
+    def test_string_true(self):
+        assert_equals(validators.boolean_validator('true', None), True)
+        assert_equals(validators.boolean_validator('yes', None), True)
+        assert_equals(validators.boolean_validator('t', None), True)
+        assert_equals(validators.boolean_validator('y', None), True)
+        assert_equals(validators.boolean_validator('1', None), True)
+
+    def test_string_false(self):
+        assert_equals(validators.boolean_validator('f', None), False)
 
 #TODO: Need to test when you are not providing owner_org and the validator
 #      queries for the dataset with package_show

--- a/ckan/tests/logic/test_validators.py
+++ b/ckan/tests/logic/test_validators.py
@@ -499,6 +499,7 @@ class TestIntValidator(object):
             warnings.filterwarnings('ignore', category=DeprecationWarning)
             raises_Invalid(validators.int_validator)(1 + 0j, {})
 
+
 class TestBoolValidator(object):
 
     def test_bool_true(self):


### PR DESCRIPTION
The boolean validator treats missing values as True. They should be treated as False, both semantically and because unchecked  HTML checkboxes in forms transmit empty values on form submits.