### PR TITLE
Percent encoded non-ascii characters in tag autocomplete query string

### DIFF
--- a/ckan/controllers/api.py
+++ b/ckan/controllers/api.py
@@ -718,7 +718,8 @@ class ApiController(base.BaseController):
         return self._finish_ok(resultSet)
 
     def tag_autocomplete(self):
-        q = request.params.get('incomplete', '')
+        q = request.str_params.get('incomplete', '')
+        q = unicode(urllib.unquote(q), 'utf-8')
         limit = request.params.get('limit', 10)
         tag_names = []
         if q:


### PR DESCRIPTION
Suppose I have an existing tag "ääkköset" and that I'm looking for it with the incomplete query string "ä". Performing a request to the endpoint /api/2/util/tag/autocomplete?incomplete=ä works as intended.

However, when using the UI autocomplete form element, the non-ascii characters in the query are percent encoded, so the same search becomes a request to /api/2/util/tag/autocomplete?incomplete=%C3%A4, which returns an empty list.

At present, these %-encoded characters are not cared for (except for being sanitized by escaping %-signs at https://github.com/ckan/ckan/blob/master/ckan/logic/action/get.py#L2049). I've fixed this by using urllib.unquote to decode the percent encoded characters in the query string back to their UTF-8 byte sequences before casting to unicode.