### PR TITLE
 #2145 Improve datapusher error messages

### DIFF
--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -115,6 +115,29 @@ def get_reset_link_body(user):
         }
     return reset_link_message.format(**d)
 
+def get_crash_body(user, error, action, data):
+    crash_message = _(
+    "Something wrong happened on {site_title} during execution of API call to {action}.\n"
+    "\n"
+    "Error message:\n"
+    "\n"
+    "   {e_message}\n"
+    "\n"
+    "Data contained in request:"
+    "\n"
+    "   {data}"
+    "\n"
+    "Please, contact with site administrator in order to find out more details."
+    )
+
+    d = {
+        'e_message': error.message,
+        'site_title': g.site_title,
+        'action': action,
+        'data': data
+        }
+    return crash_message.format(**d)
+
 def get_invite_body(user):
     invite_message = _(
     "You have been invited to {site_title}. A user has already been created"
@@ -149,6 +172,14 @@ def send_invite(user):
     create_reset_key(user)
     body = get_invite_body(user)
     subject = _('Invite for {site_title}'.format(site_title=g.site_title))
+    mail_user(user, subject, body)
+
+def send_crash_mail(user, **kargs):
+    action = kargs.get('action', 'undefined action')
+    data = kargs['data']
+    error = kargs['error']
+    body = get_crash_body(user, error, action, data)
+    subject = _('Error at {site_title} during {action}'.format(site_title=g.site_title, action=action))
     mail_user(user, subject, body)
 
 def create_reset_key(user):

--- a/ckan/templates/package/snippets/resource_item.html
+++ b/ckan/templates/package/snippets/resource_item.html
@@ -1,6 +1,7 @@
 {% set can_edit = h.check_access('package_update', {'id':pkg.id }) %}
 {% set url_action = 'resource_edit' if url_is_edit and can_edit else 'resource_read' %}
 {% set url = h.url_for(controller='package', action=url_action, id=pkg.name, resource_id=res.id) %}
+{% set show_datapusher_label = can_edit and 'datapusher' in g.plugins %}
 
 <li class="resource-item" data-id="{{ res.id }}">
   {% block resource_item_title %}
@@ -8,6 +9,12 @@
     {{ h.resource_display_name(res) | truncate(50) }}<span class="format-label" property="dc:format" data-format="{{ res.format.lower() or 'data' }}">{{ res.format }}</span>
     {{ h.popular('views', res.tracking_summary.total, min=10) }}
   </a>
+  {% if show_datapusher_label %}
+    {% set status = h.get_action('datapusher_status', {'resource_id': res.id}) %}
+    {% if status.error and status.error.message or status.task_info and status.task_info.error %}
+      {% link_for _('Datapusher error'), controller='ckanext.datapusher.plugin:ResourceDataController', action='resource_data', id=pkg.name, resource_id=res.id, class_='label label-warning', icon='warning-sign' %}
+    {% endif %}
+  {% endif %}
   {% endblock %}
   {% block resource_item_description %}
     <p class="description">

--- a/ckanext/datastore/db.py
+++ b/ckanext/datastore/db.py
@@ -21,7 +21,7 @@ import ckan.plugins.toolkit as toolkit
 import ckanext.datastore.interfaces as interfaces
 import ckanext.datastore.helpers as datastore_helpers
 from ckan.common import OrderedDict
-
+from ckan.logic import in_case_of_crash_notify_user_from_context
 log = logging.getLogger(__name__)
 
 if not os.environ.get('DATASTORE_LOAD'):
@@ -288,7 +288,7 @@ def convert(data, type_name):
         return data
     return unicode(data)
 
-
+@in_case_of_crash_notify_user_from_context(exception=ProgrammingError)
 def create_table(context, data_dict):
     '''Create table from combination of fields and first row of data.'''
 
@@ -524,7 +524,7 @@ def _drop_indexes(context, data_dict, unique=False):
         context['connection'].execute(
             sql_drop_index.format(index[0]).replace('%', '%%'))
 
-
+@in_case_of_crash_notify_user_from_context(exception=ProgrammingError)
 def alter_table(context, data_dict):
     '''alter table from combination of fields and first row of data
     return: all fields of the resource table'''


### PR DESCRIPTION
Add label near the resourche title on the dataset detail list
Add decorator to send messages to user in case of api call's crash

Notifying is turned on by setting directive <notify.crash_mail_sent_to_guilty> in config file to true
decorator can take named argument <exception> which defines type(or types if tuple used) of exceptions which will be provided with email to user who make something that raise error
Example:
        from ckan.logic import in_case_of_crash_notify_user_from_context
        @in_case_of_crash_notify_user_from_context(exception=EXCEPTION_CLASS)
        def create_table(context, data_dict):
            ...
Datastore functions 'alter_table' and 'create_table' wrapped by new decorator