### PR TITLE
Use only one Solr connection

### DIFF
--- a/ckan/lib/app_globals.py
+++ b/ckan/lib/app_globals.py
@@ -172,6 +172,7 @@ class _Globals(object):
         self._init()
         self._config_update = None
         self._mutex = Lock()
+        self._solr_connection = None
 
     def _check_uptodate(self):
         ''' check the config is uptodate needed when several instances are


### PR DESCRIPTION
[#2451]

This fixes  Error 99 "Cannot assign requested address" in some Linux distros particularly by calling the API package_create several times. The fix creates only one connection (_solr_connection) in the pylons global environment and uses it both in index and query files.

Tested against master and Release 2.3 with over a 1000 package_create calls