### PR TITLE
Implement additional page for resource so that user will be able to play with api

### DIFF
--- a/ckan/config/routing.py
+++ b/ckan/config/routing.py
@@ -276,6 +276,9 @@ def make_map():
                   action='resource_view')
         m.connect('/dataset/{id}/resource/{resource_id}/view/',
                   action='resource_view')
+        m.connect('resource_api_sandbox',
+                  '/dataset/{id}/resource/{resource_id}/api-sandbox/',
+                  action='resource_api_sandbox')
 
     # group
     map.redirect('/groups', '/group')

--- a/ckan/controllers/admin.py
+++ b/ckan/controllers/admin.py
@@ -38,6 +38,9 @@ class AdminController(base.BaseController):
                      {'value': '2', 'text': 'Search, stats, introductory area, featured organization and featured group'},
                      {'value': '3', 'text': 'Search, introductory area and stats'}]
 
+        dev_modes = [{'value': 'false', 'text': 'Disabled'},
+                     {'value': 'true', 'text': 'Enabled'}]
+
         items = [
             {'name': 'ckan.site_title', 'control': 'input', 'label': _('Site Title'), 'placeholder': ''},
             {'name': 'ckan.main_css', 'control': 'select', 'options': styles, 'label': _('Style'), 'placeholder': ''},
@@ -47,6 +50,7 @@ class AdminController(base.BaseController):
             {'name': 'ckan.site_intro_text', 'control': 'markdown', 'label': _('Intro Text'), 'placeholder': _('Text on home page')},
             {'name': 'ckan.site_custom_css', 'control': 'textarea', 'label': _('Custom CSS'), 'placeholder': _('Customisable css inserted into the page header')},
             {'name': 'ckan.homepage_style', 'control': 'select', 'options': homepages, 'label': _('Homepage'), 'placeholder': ''},
+            {'name': 'ckan.developer_mode', 'control': 'select', 'options': dev_modes, 'label': _('Developer Mode (API in UI)'), 'placeholder': ''},
         ]
         return items
 

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -1683,7 +1683,6 @@ class PackageController(base.BaseController):
 
         api_list = (
             'resource_show',
-            'resource_update',
             'resource_view_show',
             'resource_view_list',
             'resource_status_show',
@@ -1692,10 +1691,7 @@ class PackageController(base.BaseController):
             'resource_create',
             'resource_view_create',
             'resource_create_default_resource_views',
-            'resource_update',
-            'resource_view_update',
             'resource_view_reorder',
-            'resource_patch',
             'resource_delete',
             'resource_view_clear',
         )

--- a/ckan/lib/app_globals.py
+++ b/ckan/lib/app_globals.py
@@ -47,6 +47,7 @@ config_details = {
     'ckan.dumps_format': {},
     'ofs.impl': {'name': 'ofs_impl'},
     'ckan.homepage_style': {'default': '1'},
+    'ckan.developer_mode' : {},
 
     # split string
     'search.facets': {'default': 'organization groups tags res_format license_id',
@@ -60,7 +61,6 @@ config_details = {
     'ckan.debug_supress_header' : {'default': 'false', 'type' : 'bool'},
     'ckan.legacy_templates' : {'default': 'false', 'type' : 'bool'},
     'ckan.tracking_enabled' : {'default': 'false', 'type' : 'bool'},
-    'ckan.developer_mode' : {'default': 'false', 'type' : 'bool'},
 
     # int
     'ckan.datasets_per_page': {'default': '20', 'type': 'int'},

--- a/ckan/lib/app_globals.py
+++ b/ckan/lib/app_globals.py
@@ -30,6 +30,7 @@ auto_update = [
     'ckan.site_intro_text',
     'ckan.site_custom_css',
     'ckan.homepage_style',
+    'ckan.developer_mode',
 ]
 
 config_details = {
@@ -59,6 +60,7 @@ config_details = {
     'ckan.debug_supress_header' : {'default': 'false', 'type' : 'bool'},
     'ckan.legacy_templates' : {'default': 'false', 'type' : 'bool'},
     'ckan.tracking_enabled' : {'default': 'false', 'type' : 'bool'},
+    'ckan.developer_mode' : {'default': 'false', 'type' : 'bool'},
 
     # int
     'ckan.datasets_per_page': {'default': '20', 'type': 'int'},

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -310,11 +310,13 @@ def resource_create(context, data_dict):
     ## package_show until after commit
     upload.upload(context['package'].resources[-1].id,
                   uploader.get_max_resource_size())
-    model.repo.commit()
 
     ##  Run package show again to get out actual last_resource
     updated_pkg_dict = _get_action('package_show')(context, {'id': package_id})
     resource = updated_pkg_dict['resources'][-1]
+
+    if not data_dict.get('sandbox'):
+        model.repo.commit()
 
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.after_create(context, resource)
@@ -378,7 +380,7 @@ def resource_view_create(context, data_dict):
     data['order'] = order
 
     resource_view = model_save.resource_view_dict_save(data, context)
-    if not context.get('defer_commit'):
+    if not context.get('defer_commit') and not data_dict.get('sandbox'):
         model.repo.commit()
     return model_dictize.resource_view_dictize(resource_view, context)
 

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -112,7 +112,8 @@ def resource_delete(context, data_dict):
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.after_delete(context, pkg_dict.get('resources', []))
 
-    model.repo.commit()
+    if not data_dict.get('sandbox'):
+        model.repo.commit()
 
 
 def resource_view_delete(context, data_dict):
@@ -150,7 +151,8 @@ def resource_view_clear(context, data_dict):
 
     view_types = data_dict.get('view_types')
     model.ResourceView.delete_all(view_types)
-    model.repo.commit()
+    if not data_dict.get('sandbox'):
+        model.repo.commit()
 
 
 def package_relationship_delete(context, data_dict):

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -254,7 +254,8 @@ def resource_view_reorder(context, data_dict):
     for num, view in enumerate(new_order):
         model.Session.query(model.ResourceView).\
             filter_by(id=view).update({"order": num + 1})
-    model.Session.commit()
+    if not data_dict.get('sandbox'):
+        model.Session.commit()
     return {'id': id, 'order': new_order}
 
 

--- a/ckan/public/base/javascript/modules/developer-mode-sandbox.js
+++ b/ckan/public/base/javascript/modules/developer-mode-sandbox.js
@@ -1,0 +1,246 @@
+/* Loads the API Info snippet into a modal dialog. Retrieves the snippet
+ * url from the data-snippet-url on the module element.
+ *
+ * template - The url to the template to display in a modal.
+ *
+ * Examples
+ *
+ *   <a data-module="api-info" data-module-template="http://example.com/path/to/template">API</a>
+ *
+ */
+ "use strict";
+ this.ckan.module('developer-mode-sandbox', function (jQuery, _) {
+  return {
+
+    options: {
+
+
+    },
+
+    // in_progres flag
+    inProgress: false,
+
+    // base url to ckan api
+    actionsUrl: 'api/3/action/',
+
+    // select field with all actions
+    selector: null,
+
+    // form container with API forms
+    formContainer: null,
+
+    // placeholder not_chosen
+    notChosenContainer: null,
+
+    // container for request results
+    resultContainer: null,
+
+    // is placeholder not_chosen shown?
+    notChosen: true,
+
+    // investigated action
+    currentAction: null,
+
+    // input markdown
+    input:
+    '<div class="control-group ">' +
+      '<label class="control-label" for="sandbox-generated-{{name}}">{{label}}</label>' +
+      '<div class="controls ">' +
+        '<input id="sandbox-generated-{{name}}" type="text" name="{{name}}" value="" placeholder="{{label}}">' +
+      '</div>' +
+    '</div>',
+
+    submit:
+      '<div class="form-actions"><button class="btn btn-primary" type="submit" name="save"><i class="icon-play-circle"></i></button></div>',
+
+    // regexp to search params
+    getParams: function(data){
+      var result = [];
+      var regexp = /(?::param\s*)(\w*?):/g;
+
+      var match = null;
+
+      while ((match = regexp.exec(data)) != null) {
+          result.push(match[1]);
+      }
+
+      return result;
+    },
+
+    generateUrl: function (action) {
+      return this.sandbox.client.url(this.actionsUrl + action);
+    },
+
+    /* Initialize page.
+     *
+     * Returns nothing.
+     */
+    initialize: function () {
+      jQuery.proxyAll(this, /_on/);
+
+      // find select with actions and add EventListener
+      this.selector = this.el.find('#field-action-selector');
+      this.selector.on('change', this._onSelectAction);
+
+      // find container for our future forms
+      this.formContainer = this.el.find('#action-form');
+      this.formContainer.on('submit', this._onSubmitAction);
+
+      // find container for not_chosen and request errors
+      this.notChosenContainer = this.el.find('.not-chosen-action');
+
+      // find container for not_chosen and request errors
+      this.resultContainer = this.el.find('#request-result');
+
+      // make blank default value that doesn't appear in options
+      this.selector.prop('selectedIndex', -1);
+
+      // find conteiner for help text
+      this.helpArea = this.el.find('#action-help');
+
+    },
+
+    /* After change of select value.
+     *
+     * Returns nothing.
+     */
+    _onSelectAction: function (event) {
+      // only single request at time
+      if (this.inProgress)
+        return;
+
+      // request_in_progress flag
+      this.selector.attr('disabled', true);
+      this.inProgress = true;
+
+      this.helpArea.text('');
+      this.formContainer.text('');
+      this.resultContainer.text('');
+
+      // hide hot_chosen placeholder
+      if (this.notChosen){
+        this.notChosenContainer.hide();
+        this.notChosen = false;
+      }
+
+      // change investigated action
+      this.currentAction = this.selector.val();
+
+      // generate url to receive help text
+      var help_url = this.generateUrl('help_show');
+
+      // make request's body
+      var request = $.get( help_url, {name: this.currentAction});
+
+      // Event listeners for success, error and any result
+      request.done(this._onReceiveHelp);
+      request.fail(this._onFailHelp);
+      request.always(this._onHelpFinished);
+    },
+
+    /* After success help request.
+     * Change text area content and generate form.
+     *
+     * Returns nothing.
+     */
+    _onReceiveHelp: function(data){
+      var content = data.result;
+      // put description in helpArea
+      this.helpArea.text(content.trim());
+
+      // parse all available params
+      var params = this.getParams(content);
+      var len = params.length;
+
+      // add field for each param
+      for(var i = 0; i < len; i++){
+        var input = this.input.replace(/{{label}}|{{name}}/g, params[i]);
+        this.formContainer.append(input);
+      }
+
+      // add submit button
+      this.formContainer.append(this.submit);
+
+    },
+
+    /* After failed help request.
+     * Clear helpArea and forms. Show error.
+     *
+     * Returns nothing.
+     */
+    _onFailHelp: function (data, status, msg) {
+      this.notChosenContainer.text(status + ': ' + msg).show();
+      this.notChosen = true;
+    },
+
+    /* After any help request.
+     * Enable action selector.
+     *
+     * Returns nothing.
+     */
+    _onHelpFinished: function (data, status, msg) {
+      this.selector.attr('disabled', false);
+      this.inProgress = false;
+    },
+
+    /* Instead of action submit.
+     *
+     * Returns nothing.
+     */
+    _onSubmitAction: function (event) {
+      //
+      if (this.inProgress)
+        return;
+
+      // generate url for API request
+      var url = this.generateUrl(this.currentAction);
+
+      var fields = this.formContainer.find('[type=text]');
+      var len = fields.length;
+      var data = {};
+
+      for (var i = 0; i < len; i++){
+        var val = fields[i].value;
+        if (val)
+          data[fields[i].name] = val;
+      }
+
+
+      // request_in_progress flag
+      this.selector.attr('disabled', true);
+      this.inProgress = true;
+
+      // in case of POST
+      data = JSON.stringify(data);
+      // make request's body
+      var request = $.post(url, data);
+
+      // // Event listeners for success, error and any result
+      request.done(this._onActionDone);
+      request.fail(this._onActionFail);
+      request.always(this._onActionAfter);
+
+      event.preventDefault();
+      return false;
+    },
+
+    // after success API request
+    _onActionDone: function (data, status, msg) {
+
+      this.resultContainer.text(JSON.stringify(data.result, null, '\n'));
+    },
+
+    // after wrong api request
+    _onActionFail: function (data, status, msg) {
+      this.resultContainer.text(JSON.stringify(JSON.parse(data.responseText), null, '\n'));
+    },
+
+    // after any api request
+    _onActionAfter: function (data, status, msg) {
+      // here we are using small hack to escape html and save newlines
+      this.resultContainer.html(this.resultContainer.html().replace(/\n/g,'<br/>'));
+      this._onHelpFinished(data, status, msg);
+    },
+
+  };
+});

--- a/ckan/public/base/javascript/resource.config
+++ b/ckan/public/base/javascript/resource.config
@@ -45,6 +45,7 @@ ckan =
     modules/dataset-visibility.js
     modules/media-grid.js
     modules/image-upload.js
+    modules/developer-mode-sandbox.js
 
 main =
     apply_html_class

--- a/ckan/templates/package/resource_api_sandbox.html
+++ b/ckan/templates/package/resource_api_sandbox.html
@@ -1,0 +1,15 @@
+{% extends "package/resource_api_sandbox_base.html" %}
+
+
+{% block subtitle %}{{ _('API Sandbox') }} - {{ h.resource_display_name(res) }} - {{ h.dataset_display_name(pkg) }}{% endblock %}
+
+{% block form %}
+  {% snippet 'package/snippets/api_sandbox_form.html',
+    data=data,
+    errors=errors,
+    error_summary=error_summary,
+    pkg_name=pkg.name,
+    form_action=c.form_action,
+    available_actions=available_actions
+  %}
+{% endblock %}

--- a/ckan/templates/package/resource_api_sandbox_base.html
+++ b/ckan/templates/package/resource_api_sandbox_base.html
@@ -1,0 +1,32 @@
+{% extends "package/base.html" %}
+
+{% set logged_in = true if c.userobj else false %}
+{% set res = c.resource %}
+
+{% block breadcrumb_content_selected %}{% endblock %}
+
+{% block breadcrumb_content %}
+  {{ super() }}
+  {% if res %}
+    <li>{% link_for h.resource_display_name(res)|truncate(30), controller='package', action='resource_read', id=pkg.name, resource_id=res.id %}</li>
+    <li{% block breadcrumb_edit_selected %} class="active"{% endblock %}><a href="">{{ _('API Sandbox') }}</a></li>
+  {% endif %}
+{% endblock %}
+
+{% block content_action %}
+  {% if res %}
+    {% link_for _('View resource'), controller='package', action='resource_read', id=pkg.name, resource_id=res.id, class_='btn', icon='eye-open' %}
+  {% endif %}
+{% endblock %}
+
+{% block content_primary_nav %}
+{% endblock %}
+
+{% block primary_content_inner %}
+  <h1 class="hide-heading">{% block form_title %}{{ _('API Sandbox') }}{% endblock %}</h1>
+  {% block form %}{% endblock %}
+{% endblock %}
+
+{% block secondary_content %}
+  {% snippet 'package/snippets/resource_info.html', res=res %}
+{% endblock %}

--- a/ckan/templates/package/resource_api_sandbox_base.html
+++ b/ckan/templates/package/resource_api_sandbox_base.html
@@ -28,5 +28,18 @@
 {% endblock %}
 
 {% block secondary_content %}
-  {% snippet 'package/snippets/resource_info.html', res=res %}
+  <div class="module context-info">
+  <div class="module-content">
+    <h1 class="heading">{{ _('About') }} {{ res.name or res.id }}</h1>
+    <div class="nums">
+      {% for key in res %}
+        <p>
+          <strong>{{ key }}</strong><br>
+          <em>{{ res[key] }}</em>
+        </p>
+      {% endfor %}
+    </div>
+  </div>
+</div>
+
 {% endblock %}

--- a/ckan/templates/package/resource_read.html
+++ b/ckan/templates/package/resource_read.html
@@ -1,7 +1,7 @@
 {% extends "package/base.html" %}
 
 {% set res = c.resource %}
-
+{% set dev_mode_sandbox = g.developer_mode and h.asbool(g.developer_mode) %}
 {% block head_extras -%}
   {{ super() }}
   {% set description = h.markdown_extract(res.description, extract_length=200) if res.description else h.markdown_extract(c.package.notes, extract_length=200) %}
@@ -27,6 +27,9 @@
           {% block resource_actions %}
           <ul>
             {% block resource_actions_inner %}
+            {% if dev_mode_sandbox %}
+              <li>{% link_for _('API Sandbox'), controller='package', action='resource_api_sandbox', id=pkg.name, resource_id=res.id, class_='btn', icon='question-sign' %}</li>
+            {% endif %}
             {% if h.check_access('package_update', {'id':pkg.id }) %}
               <li>{% link_for _('Manage'), controller='package', action='resource_edit', id=pkg.name, resource_id=res.id, class_='btn', icon='wrench' %}</li>
             {% endif %}

--- a/ckan/templates/package/snippets/api_sandbox_form.html
+++ b/ckan/templates/package/snippets/api_sandbox_form.html
@@ -17,6 +17,7 @@
     {% block auto_action %}
       <div class="form-horizontal">
         {{ form.select('action', id='field-action-selector', label=_('Action'), options=available_actions,  error=data.error, classes=['action-selector']) }}
+        {{ form.checkbox('is-sandbox', id='checkbox-is-sandbox', label=_('Sandbox mode')) }}
       </div>
     {% endblock %}
   <div class='action-help-container'>
@@ -35,6 +36,13 @@
     <legend>Request result</legend>
     <em class="not-chosen-action">{{ not_chosen }}</em>
     <div id="request-result"></div>
-    </form>
+  </div>
+  <div class="action-form-container">
+    <legend>Request examples</legend>
+    <em class="not-chosen-action">{{ not_chosen }}</em>
+    <div id="request-result"></div>
+    <pre>
+     <div id="request-code"></div>
+    </pre>
   </div>
 </div>

--- a/ckan/templates/package/snippets/api_sandbox_form.html
+++ b/ckan/templates/package/snippets/api_sandbox_form.html
@@ -1,0 +1,40 @@
+{% import 'macros/form.html' as form %}
+
+{% set stage = stage or 1 %}
+{% set include_metadata = include_metadata or false %}
+{% set not_chosen =  _("Action isn't chosen yet") %}
+
+
+
+{% set data = data or {} %}
+{% set errors = errors or {} %}
+{% set action = form_action or h.url_for(controller='package', action='new_resource', id=pkg_name) %}
+
+
+
+
+<div data-module="developer-mode-sandbox" data-module-input="">
+    {% block auto_action %}
+      <div class="form-horizontal">
+        {{ form.select('action', id='field-action-selector', label=_('Action'), options=available_actions,  error=data.error, classes=['action-selector']) }}
+      </div>
+    {% endblock %}
+  <div class='action-help-container'>
+  <legend>{{ _("Action info") }}</legend>
+    <em class="not-chosen-action">{{ not_chosen }}</em>
+    <pre id="action-help">
+    </pre>
+  </div>
+  <div class="action-form-container">
+    <legend>Action form</legend>
+    <em class="not-chosen-action">{{ not_chosen }}</em>
+    <form id="action-form" class="form-horizontal">
+    </form>
+  </div>
+  <div class="action-form-container">
+    <legend>Request result</legend>
+    <em class="not-chosen-action">{{ not_chosen }}</em>
+    <div id="request-result"></div>
+    </form>
+  </div>
+</div>

--- a/ckan/templates/user/edit_user_form.html
+++ b/ckan/templates/user/edit_user_form.html
@@ -21,6 +21,8 @@
       {% endcall %}
     {% endif %}
 
+    {{ form.checkbox('developer_mode', label=_('DevMode'), id='field-dev-mode', value=data.developer_mode, error=errors.developer_mode) }}
+
   </fieldset>
 
   <fieldset>


### PR DESCRIPTION
Added page with url /dataset/{id}/resource/{resource_id}/api-sandbox/ which also available through new button on resource view page "API Sandbox", that appears on page after admin enables 'Developer Mode' at config page.

On this page user can chose one of predefined actions. After that, this action's help will be shown and form with fields for this action's parameters will be generated
User can fill few(or all) fields and submit form. In that case below the form will be displayed server's response and few examples of request (using CURL and JavaScript for the moment)
Also user allowed to check option "Sandbox mode". In that case response will be shown, but no changes for actions like resource_create, resource_delete, etc. will be commited

This ability implemented by adding param 'sandbox'. Such actions check presence of this parameter and don't make Session.commit() or repo.commit() in that case
