### PR TITLE
Fix dataset-purge Paster command

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -930,7 +930,7 @@ class DatasetCmd(CkanCommand):
         # Purge membership to several groups
         q_member = model.Session.query(model.Member).filter(and_(
             model.Member.table_name == 'package',
-            model.Member.table_id == dataset_ref))
+            model.Member.table_id == dataset.id))
         for memb in q_member.all():
             memb.purge()
         # Purge actual dataset

--- a/ckan/model/group.py
+++ b/ckan/model/group.py
@@ -102,13 +102,14 @@ class Member(vdm.sqlalchemy.RevisionedObjectMixin,
             id=self.table_id).all()
 
     def __unicode__(self):
-        # refer to objects by name, not ID, to help debugging
+        # Try to refer to objects by name, not ID, to help debugging
+        # Note A referenced object may be already deleted into the same transaction 
         if self.table_name == 'package':
-            table_info = 'package=%s' % meta.Session.query(_package.Package).\
-                get(self.table_id).name
+            pkg = meta.Session.query(_package.Package).get(self.table_id)
+            table_info = 'package=%s' % (pkg.name if pkg else self.table_id)
         elif self.table_name == 'group':
-            table_info = 'group=%s' % meta.Session.query(Group).\
-                get(self.table_id).name
+            grp = meta.Session.query(Group).get(self.table_id)
+            table_info = 'group=%s' % (grp.name if grp else self.table_id)
         else:
             table_info = 'table_name=%s table_id=%s' % (self.table_name,
                                                         self.table_id)


### PR DESCRIPTION
The `dataset purge` command leaves dangling references to purged datasets in "member"
table (so this fix takes care to remove those membership records before).

I came across this issue when trying to purge an organization (whose datasets were supposed to be purged before) and received a 5xx server error. This was happening because the process of purging an organization includes purging of membership records (but of course, the actual member datasets were now absent).

I have only tested this against 2.2.2, but from a quick look i think this also applies to 2.2.3.
