### PR TITLE
Upgrade beaker requirement

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,7 @@ Babel>=0.9.6,<1.0.0  # newer versions cause problems with when switching languag
 Jinja2==2.6  # newer version causes problem in CkanInternationalizationExtension.parse
 			 # when creating a new dataset
 Pylons==0.9.7
+Beaker==1.7.0 # need to pin this because of https://github.com/bbangert/beaker/commit/fc511ceda4305fcf54919b3f081fed7790e2fef3
 Genshi==0.6
 WebTest==1.4.3  # need to pin this so that Pylons does not install a newer version that conflicts with WebOb==1.0.8
 fanstatic==0.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Babel==0.9.6
-Beaker==1.6.4
+Beaker==1.7.0
 FormEncode==1.2.6
 Genshi==0.6
 Jinja2==2.6


### PR DESCRIPTION
Because of [this issue](https://github.com/bbangert/beaker/commit/fc511ceda4305fcf54919b3f081fed7790e2fef3) you get an exception when using the Beaker database backend on the version CKAN is targeting now (Beaker==1.6.4)

Looking at the CHANGELOG, there aren't any breaking changes listed, so I suggest we upgrade to the latest 1.7.0 version:

https://github.com/bbangert/beaker/blob/master/CHANGELOG