### PR TITLE
[#2161] Update multilingual schema with changes from #2078 #1905 #1495.

### DIFF
--- a/ckan/config/solr/schema.xml
+++ b/ckan/config/solr/schema.xml
@@ -16,6 +16,13 @@
  limitations under the License.
 -->
 
+<!--
+     NB Please copy changes to this file into the multilingual schema:
+        ckanext/multilingual/solr/schema.xml
+-->
+
+<!-- Version should match the CKAN version
+     (x.y but not x.y.z since it needs to be a float) -->
 <schema name="ckan" version="2.3">
 
 <types>

--- a/ckan/config/solr/schema.xml
+++ b/ckan/config/solr/schema.xml
@@ -21,8 +21,9 @@
         ckanext/multilingual/solr/schema.xml
 -->
 
-<!-- Version should match the CKAN version
-     (x.y but not x.y.z since it needs to be a float) -->
+<!-- We update the version when there is a backward-incompatible change to this
+schema. In this case the version should be set to the next CKAN version number.
+(x.y but not x.y.z since it needs to be a float) -->
 <schema name="ckan" version="2.3">
 
 <types>

--- a/ckanext/multilingual/solr/schema.xml
+++ b/ckanext/multilingual/solr/schema.xml
@@ -373,12 +373,15 @@
     <field name="ratings_average" type="float" indexed="true" stored="false" />
     <field name="tags" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="groups" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="organization" type="string" indexed="true" stored="true" multiValued="false"/>
 
     <field name="capacity" type="string" indexed="true" stored="true" multiValued="false"/>
 
+    <field name="res_name" type="textgen" indexed="true" stored="true" multiValued="true" />
     <field name="res_description" type="textgen" indexed="true" stored="true" multiValued="true"/>
     <field name="res_format" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="res_url" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="res_type" type="string" indexed="true" stored="true" multiValued="true"/>
 
     <!-- catchall field, containing all other searchable text fields (implemented
          via copyField further on in this schema  -->
@@ -466,6 +469,8 @@
 <copyField source="notes" dest="text"/>
 <copyField source="tags" dest="text"/>
 <copyField source="groups" dest="text"/>
+<copyField source="organization" dest="text"/>
+<copyField source="res_name" dest="text"/>
 <copyField source="res_description" dest="text"/>
 <copyField source="maintainer" dest="text"/>
 <copyField source="author" dest="text"/>


### PR DESCRIPTION
See issue: https://github.com/ckan/ckan/issues/2161

I tested this manually as follows:
```
sudo cp /vagrant/src/ckan/ckanext/multilingual/solr/* /usr/share/solr/solr-4.3.1/example/solr/collection1/conf/
sudo service jetty restart

ckanapi -c $CKAN_INI action package_create name=t1
ckanapi -c $CKAN_INI action resource_create package_id=t1 name=test url=test1
ckanapi -c $CKAN_INI action resource_create package_id=t1 name=test url=test2

# error message appears with the old version of the schema:
ckan.lib.search.common.SearchIndexError: Solr returned an error: 400 Bad Request - <?xml version="1.0" encoding="UTF-8"?>
<response>
<lst name="responseHeader"><int name="status">400</int><int name="QTime">2</int></lst><lst name="error"><str name="msg">ERROR: [doc=32c19a046cd46f1ba52ae96dacb0b74c] multiple values encountered for non multiValued field res_name: [test, test]</str><int name="code">400</int></lst>
</response>

# revert to normal schema post-testing
sudo cp /vagrant/src/ckan/ckan/config/solr/schema.xml /usr/share/solr/solr-4.3.1/example/solr/collection1/conf/schema.xml
sudo service jetty restart
```