### PR TITLE
Also notify observers of packages involved in PackageRelationship

### DIFF
--- a/ckan/model/modification.py
+++ b/ckan/model/modification.py
@@ -4,6 +4,7 @@ import ckan.plugins as plugins
 import domain_object
 import package as _package
 import resource
+import package_relationship
 
 log = logging.getLogger(__name__)
 
@@ -63,6 +64,9 @@ class DomainObjectModificationExtension(plugins.SingletonPlugin):
         changed_pkgs = set(obj for obj in changed if isinstance(obj, _package.Package))
 
         for obj in new | changed | deleted:
+            if isinstance(obj, package_relationship.PackageRelationship):
+                changed_pkgs.add(obj.subject)
+                changed_pkgs.add(obj.object)
             if not isinstance(obj, _package.Package):
                 try:
                     related_packages = obj.related_packages()


### PR DESCRIPTION
When relations exist between packages (via PackageRelationship) the related packages are not being included in the notification of what is changing. A consequence is that when viewing the details of a package, the related packages are not shown.
 
This pull request fixes this issue by including the related packages in the list of changed objects.