### PR TITLE
updated requirements for requests and six

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,9 +31,9 @@ pyutilib.component.core==4.5.3
 repoze.lru==0.6
 repoze.who==2.0
 repoze.who-friendlyform==1.0.8
-requests==2.3.0
+requests==2.7.0
 simplejson==3.3.1
-six==1.7.3
+six==1.9.0
 solrpy==0.9.5
 sqlalchemy-migrate==0.9.1
 sqlparse==0.1.11


### PR DESCRIPTION
Addressing #2470 

This accommodates for extensions using the flickrapi, which requires higher versions of requests and six than ckan master provides.