### PR TITLE
2478 licenses more specific

### DIFF
--- a/ckan/config/licenses_default.json
+++ b/ckan/config/licenses_default.json
@@ -1,0 +1,266 @@
+[
+{"comment": "These are the default CKAN licenses. To configure your own, create a new file and refer to it using the ckan.licenses_file configuration option.    These particular licenses are agreed by CKAN core team as the best start-point for a government or community data portal. They are both a) well-known - to discourage license proliferation and b) open - to encourage maximizing reuse. Furthermore, these are listed as 'Recommended conformant licenses' at http://opendefinition.org/licenses/. Each license's JSON is copied from: http://licenses.opendefinition.org/licenses/groups/all.json"
+},
+{
+
+    "domain_content": true,
+    "domain_data": true,
+    "domain_software": true,
+    "family": "",
+    "id": "CC0-1.0",
+    "maintainer": "Creative Commons",
+    "od_conformance": "approved",
+    "osd_conformance": "not reviewed",
+    "status": "active",
+    "title": "Creative Commons Zero 1.0",
+    "url": "https://creativecommons.org/publicdomain/zero/1.0/"
+
+},
+{
+
+    "domain_content": true,
+    "domain_data": true,
+    "domain_software": false,
+    "family": "",
+    "id": "CC-BY-4.0",
+    "maintainer": "Creative Commons",
+    "od_conformance": "approved",
+    "osd_conformance": "not reviewed",
+    "status": "active",
+    "title": "Creative Commons Attribution 4.0",
+    "url": "https://creativecommons.org/licenses/by/4.0/"
+
+},
+{
+
+    "domain_content": true,
+    "domain_data": true,
+    "domain_software": false,
+    "family": "",
+    "id": "CC-BY-SA-4.0",
+    "maintainer": "Creative Commons",
+    "od_conformance": "approved",
+    "osd_conformance": "not reviewed",
+    "status": "active",
+    "title": "Creative Commons Attribution Share-Alike 4.0",
+    "url": "https://creativecommons.org/licenses/by-sa/4.0/"
+
+},
+
+{"comment": "We allow people to say the license is not specified to stop them selecting another (incorrect one) just to get the dataset accepted."},
+
+{
+
+    "domain_content": false,
+    "domain_data": false,
+    "domain_software": false,
+    "family": "",
+    "id": "notspecified",
+    "is_generic": true,
+    "maintainer": "",
+    "od_conformance": "not reviewed",
+    "osd_conformance": "not reviewed",
+    "status": "active",
+    "title": "License not specified",
+    "url": ""
+
+},
+
+{"comment": "Below are default licenses from earlier CKAN versions. They are included in case an old dataset specifies one of them. They are excluded from the drop-down for editing datasets (using config option 'ckan.licenses_offered_exclusions') because they are considered too generic / underspecified to be helpful (e.g. lack of licence version numbers). However they need listing here, because otherwise any existing dataset which specifies one of them would not be able to display the license title and URL, being left with just the id (e.g. 'odc-pddl')."},
+
+                {
+                    "domain_content": false,
+                    "domain_data": true,
+                    "domain_software": false,
+                    "family": "",
+                    "id": "odc-pddl",
+                    "is_generic": false,
+                    "od_conformance": "approved",
+                    "osd_conformance": "not reviewed",
+                    "maintainer": "",
+                    "status": "active",
+                    "title": "Open Data Commons Public Domain Dedication and Licence (PDDL)",
+                    "url": "http://www.opendefinition.org/licenses/odc-pddl"
+                },
+                {
+                    "domain_content": false,
+                    "domain_data": true,
+                    "domain_software": false,
+                    "family": "",
+                    "id": "odc-odbl",
+                    "is_generic": false,
+                    "od_conformance": "approved",
+                    "osd_conformance": "not reviewed",
+                    "maintainer": "",
+                    "status": "active",
+                    "title": "Open Data Commons Open Database License (ODbL)",
+                    "url": "http://www.opendefinition.org/licenses/odc-odbl"
+                },
+                {
+                    "domain_content": false,
+                    "domain_data": true,
+                    "domain_software": false,
+                    "family": "",
+                    "id": "odc-by",
+                    "is_generic": false,
+                    "od_conformance": "approved",
+                    "osd_conformance": "not reviewed",
+                    "maintainer": "",
+                    "status": "active",
+                    "title": "Open Data Commons Attribution License",
+                    "url": "http://www.opendefinition.org/licenses/odc-by"
+                },
+                {
+                    "domain_content": true,
+                    "domain_data": true,
+                    "domain_software": false,
+                    "family": "",
+                    "id": "cc-zero",
+                    "is_generic": false,
+                    "od_conformance": "approved",
+                    "osd_conformance": "not reviewed",
+                    "maintainer": "",
+                    "status": "active",
+                    "title": "Creative Commons CCZero",
+                    "url": "http://www.opendefinition.org/licenses/cc-zero"
+                },
+                {
+                    "domain_content": true,
+                    "domain_data": false,
+                    "domain_software": false,
+                    "family": "",
+                    "id": "cc-by",
+                    "is_generic": false,
+                    "od_conformance": "approved",
+                    "osd_conformance": "not reviewed",
+                    "maintainer": "",
+                    "status": "active",
+                    "title": "Creative Commons Attribution",
+                    "url": "http://www.opendefinition.org/licenses/cc-by"
+                },
+                {
+                    "domain_content": true,
+                    "domain_data": false,
+                    "domain_software": false,
+                    "family": "",
+                    "id": "cc-by-sa",
+                    "is_generic": false,
+                    "od_conformance": "approved",
+                    "osd_conformance": "not reviewed",
+                    "maintainer": "",
+                    "status": "active",
+                    "title": "Creative Commons Attribution Share-Alike",
+                    "url": "http://www.opendefinition.org/licenses/cc-by-sa"
+                },
+                {
+                    "domain_content": true,
+                    "domain_data": false,
+                    "domain_software": false,
+                    "family": "",
+                    "id": "gfdl",
+                    "is_generic": false,
+                    "od_conformance": "approved",
+                    "osd_conformance": "not reviewed",
+                    "maintainer": "",
+                    "status": "active",
+                    "title": "GNU Free Documentation License",
+                    "url": "http://www.opendefinition.org/licenses/gfdl"
+                },
+                {
+                    "domain_content": true,
+                    "domain_data": false,
+                    "domain_software": false,
+                    "family": "",
+                    "id": "other-open",
+                    "is_generic": true,
+                    "od_conformance": "approved",
+                    "osd_conformance": "not reviewed",
+                    "maintainer": "",
+                    "status": "active",
+                    "title": "Other (Open)",
+                    "url": ""
+                },
+                {
+                    "domain_content": true,
+                    "domain_data": false,
+                    "domain_software": false,
+                    "family": "",
+                    "id": "other-pd",
+                    "is_generic": true,
+                    "od_conformance": "approved",
+                    "osd_conformance": "not reviewed",
+                    "maintainer": "",
+                    "status": "active",
+                    "title": "Other (Public Domain)",
+                    "url": ""
+                },
+                {
+                    "domain_content": true,
+                    "domain_data": false,
+                    "domain_software": false,
+                    "family": "",
+                    "id": "other-at",
+                    "is_generic": true,
+                    "od_conformance": "approved",
+                    "osd_conformance": "not reviewed",
+                    "maintainer": "",
+                    "status": "active",
+                    "title": "Other (Attribution)",
+                    "url": ""
+                },
+                {
+                    "domain_content": true,
+                    "domain_data": false,
+                    "domain_software": false,
+                    "family": "",
+                    "id": "uk-ogl",
+                    "od_conformance": "approved",
+                    "osd_conformance": "not reviewed",
+                    "maintainer": "",
+                    "status": "active",
+                    "title": "UK Open Government Licence (OGL)",
+                    "url": "http://reference.data.gov.uk/id/open-government-licence"
+                },
+                {
+                    "domain_content": false,
+                    "domain_data": false,
+                    "domain_software": false,
+                    "family": "",
+                    "id": "cc-nc",
+                    "od_conformance": "not reviewed",
+                    "osd_conformance": "not reviewed",
+                    "maintainer": "",
+                    "status": "active",
+                    "title": "Creative Commons Non-Commercial (Any)",
+                    "url": "http://creativecommons.org/licenses/by-nc/2.0/"
+                },
+                {
+                    "domain_content": false,
+                    "domain_data": false,
+                    "domain_software": false,
+                    "family": "",
+                    "id": "other-nc",
+                    "is_generic": true,
+                    "od_conformance": "not reviewed",
+                    "osd_conformance": "not reviewed",
+                    "maintainer": "",
+                    "status": "active",
+                    "title": "Other (Non-Commercial)",
+                    "url": ""
+                },
+                {
+                    "domain_content": false,
+                    "domain_data": false,
+                    "domain_software": false,
+                    "family": "",
+                    "id": "other-closed",
+                    "is_generic": true,
+                    "od_conformance": "not reviewed",
+                    "osd_conformance": "not reviewed",
+                    "maintainer": "",
+                    "status": "active",
+                    "title": "Other (Not Open)",
+                    "url": ""
+                }
+]
+

--- a/ckan/lib/extract.py
+++ b/ckan/lib/extract.py
@@ -1,4 +1,6 @@
 import re
+import json
+
 from genshi.filters.i18n import extract as extract_genshi
 from jinja2.ext import babel_extract as extract_jinja2
 import lib.jinja_extensions
@@ -49,3 +51,20 @@ def extract_ckan(fileobj, *args, **kw):
     # we've eaten the file so we need to get back to the start
     fileobj.seek(0)
     return output
+
+
+def extract_licenses(fileobj, keywords, comment_tags, options):
+    ''' Extract the translatable strings from a licenses JSON file.
+
+    :return: an iterator over ``(lineno, funcname, message, comments)``
+                 tuples
+    '''
+    licenses_json = fileobj.read()
+    licenses = json.loads(licenses_json)
+    licenses_list = licenses.keys() if isinstance(licenses, dict) \
+        else licenses
+    for i, license in enumerate(licenses_list):
+        if license.keys() == ['comment']:
+            continue
+        yield (i, 'gettext', license['title'],
+               ['License title (%s)' % license['id']])

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2032,6 +2032,49 @@ def get_organization(org=None, include_datasets=False):
     except (NotFound, ValidationError, NotAuthorized):
         return {}
 
+
+def license_options(existing_license_id=None):
+    '''Returns [(l.title, l.id), ...] for the licenses configured to be
+    offered. Always includes the existing_license_id, if supplied.
+    '''
+    register = model.Package.get_license_register()
+    all_license_ids = register.keys()
+
+    def check_license_ids(license_ids):
+        for license_id in license_ids:
+            assert license_id in all_license_ids, \
+                'License "%s" not in the register: %s' % (license_id,
+                                                          all_license_ids)
+    if config.get('ckan.licenses_offered'):
+        license_ids = config.get('ckan.licenses_offered').split()
+        check_license_ids(license_ids)
+        # use the ordering specified in the config
+    else:
+        if config.get('ckan.licenses_offered_exclusions'):
+            exclude_ids = config.get('ckan.licenses_offered_exclusions')\
+                .split()
+            check_license_ids(exclude_ids)
+        else:
+            # default is to exclude these ones from older CKAN versions
+            exclude_ids = (
+                'odc-pddl', 'odc-odbl', 'odc-by', 'cc-zero', 'cc-by',
+                'cc-by-sa', 'gfdl', 'other-open', 'other-pd', 'other-at',
+                'uk-ogl', 'cc-nc', 'other-nc', 'other-closed')
+        sorted_licenses = sorted(register.values(), key=lambda x: x.title)
+        # put notspecified at the end
+        notspecified = register.get('notspecified')
+        if notspecified and notspecified in sorted_licenses:
+            sorted_licenses.remove(notspecified)
+            sorted_licenses.append(notspecified)
+        license_ids = [license.id for license in sorted_licenses
+                       if license.id not in exclude_ids]
+    if existing_license_id and existing_license_id not in license_ids:
+        license_ids.insert(0, existing_license_id)
+    return [
+        (license_id,
+         register[license_id].title if license_id in register else license_id)
+        for license_id in license_ids]
+
 # these are the functions that will end up in `h` template helpers
 __allowed_functions__ = [
     # functions defined in ckan.lib.helpers
@@ -2150,4 +2193,5 @@ __allowed_functions__ = [
     'urlencode',
     'check_config_permission',
     'view_resource_url',
+    'license_options',
 ]

--- a/ckan/lib/plugins.py
+++ b/ckan/lib/plugins.py
@@ -270,9 +270,10 @@ class DefaultDatasetForm(object):
         c.groups_available = authz_fn(context, data_dict)
 
         c.licenses = [('', '')] + base.model.Package.get_license_options()
+        maintain.deprecate_context_item('licenses', 'Use `h.license_options` instead')
         # CS: bad_spelling ignore 2 lines
         c.licences = c.licenses
-        maintain.deprecate_context_item('licences', 'Use `c.licenses` instead')
+        maintain.deprecate_context_item('licences', 'Use `h.license_options` instead')
         c.is_sysadmin = ckan.authz.is_sysadmin(c.user)
 
         if c.pkg:

--- a/ckan/model/license.py
+++ b/ckan/model/license.py
@@ -1,11 +1,12 @@
 import datetime
 import urllib2
 import re
+import os
 
 from pylons import config
 from paste.deploy.converters import asbool
 
-from ckan.common import _, json
+from ckan.common import json
 import ckan.lib.maintain as maintain
 
 log = __import__('logging').getLogger(__name__)
@@ -82,30 +83,35 @@ class LicenseRegister(object):
     """Dictionary-like interface to a group of licenses."""
 
     def __init__(self):
-        group_url = config.get('licenses_group_url', None)
-        if group_url:
-            self.load_licenses(group_url)
+        filepath = config.get('ckan.licenses_file')
+        url = config.get('ckan.licenses_url') or \
+            config.get('licenses_group_url')
+        if filepath:
+            self.load_licenses_from_file(filepath)
+        elif url:
+            self.load_licenses_from_url(url)
         else:
-            default_license_list = [
-                LicenseNotSpecified(),
-                LicenseOpenDataCommonsPDDL(),
-                LicenseOpenDataCommonsOpenDatabase(),
-                LicenseOpenDataAttribution(),
-                LicenseCreativeCommonsZero(),
-                LicenseCreativeCommonsAttribution(),
-                LicenseCreativeCommonsAttributionShareAlike(),
-                LicenseGNUFreeDocument(),
-                LicenseOtherOpen(),
-                LicenseOtherPublicDomain(),
-                LicenseOtherAttribution(),
-                LicenseOpenGovernment(),
-                LicenseCreativeCommonsNonCommercial(),
-                LicenseOtherNonCommercial(),
-                LicenseOtherClosed(),
-                ]
-            self._create_license_list(default_license_list)
+            default_filepath = os.path.abspath(
+                os.path.join(os.path.dirname(__file__),
+                             '..', 'config',
+                             'licenses_default.json'))
+            self.load_licenses_from_file(default_filepath)
 
-    def load_licenses(self, license_url):
+    def load_licenses_from_file(self, filepath):
+        try:
+            with open(filepath, 'rb') as f:
+                content = f.read()
+        except IOError, inst:
+            msg = "Couldn't open license file %r: %s" % (filepath, inst)
+            raise Exception(msg)
+        try:
+            license_data = json.loads(content)
+        except ValueError, inst:
+            msg = "Couldn't read JSON in license file %r: %s" % (filepath, inst)
+            raise Exception(msg)
+        self._create_license_list(license_data, filepath)
+
+    def load_licenses_from_url(self, license_url):
         try:
             response = urllib2.urlopen(license_url)
             response_body = response.read()
@@ -119,13 +125,16 @@ class LicenseRegister(object):
             raise Exception(inst)
         self._create_license_list(license_data, license_url)
 
-    def _create_license_list(self, license_data, license_url=''):
+    def _create_license_list(self, license_data, location=''):
         if isinstance(license_data, dict):
-            self.licenses = [License(entity) for entity in license_data.values()]
+            self.licenses = [License(entity)
+                             for entity in license_data.values()
+                             if entity.keys() != ['comment']]
         elif isinstance(license_data, list):
-            self.licenses = [License(entity) for entity in license_data]
+            self.licenses = [License(entity) for entity in license_data
+                             if entity.keys() != ['comment']]
         else:
-            msg = "Licenses at %s must be dictionary or list" % license_url
+            msg = "Licenses at %s must be a list or dictionary" % location
             raise ValueError(msg)
 
     def __getitem__(self, key, default=Exception):
@@ -155,195 +164,3 @@ class LicenseRegister(object):
     def __len__(self):
         return len(self.licenses)
 
-
-class DefaultLicense(dict):
-    ''' The license was a dict but this did not allow translation of the
-    title.  This is a slightly changed dict that allows us to have the title
-    as a property and so translated. '''
-
-    domain_content = False
-    domain_data = False
-    domain_software = False
-    family = ''
-    is_generic = False
-    od_conformance = 'not reviewed'
-    osd_conformance = 'not reviewed'
-    maintainer = ''
-    status = 'active'
-    url = ''
-    title = ''
-    id = ''
-
-    keys = ['domain_content',
-            'id',
-            'domain_data',
-            'domain_software',
-            'family',
-            'is_generic',
-            'od_conformance',
-            'osd_conformance',
-            'maintainer',
-            'status',
-            'url',
-            'title']
-
-    def __getitem__(self, key):
-        ''' behave like a dict but get from attributes '''
-        if key in self.keys:
-            value = getattr(self, key)
-            if isinstance(value, str):
-                return unicode(value)
-            else:
-                return value
-        else:
-            raise KeyError()
-
-    def copy(self):
-        ''' create a dict of the license used by the licenses api '''
-        out = {}
-        for key in self.keys:
-            out[key] = unicode(getattr(self, key))
-        return out
-
-class LicenseNotSpecified(DefaultLicense):
-    id = "notspecified"
-    is_generic = True
-
-    @property
-    def title(self):
-        return _("License not specified")
-
-class LicenseOpenDataCommonsPDDL(DefaultLicense):
-    domain_data = True
-    id = "odc-pddl"
-    od_conformance = 'approved'
-    url = "http://www.opendefinition.org/licenses/odc-pddl"
-
-    @property
-    def title(self):
-        return _("Open Data Commons Public Domain Dedication and License (PDDL)")
-
-class LicenseOpenDataCommonsOpenDatabase(DefaultLicense):
-    domain_data = True
-    id = "odc-odbl"
-    od_conformance = 'approved'
-    url = "http://www.opendefinition.org/licenses/odc-odbl"
-
-    @property
-    def title(self):
-        return _("Open Data Commons Open Database License (ODbL)")
-
-class LicenseOpenDataAttribution(DefaultLicense):
-    domain_data = True
-    id = "odc-by"
-    od_conformance = 'approved'
-    url = "http://www.opendefinition.org/licenses/odc-by"
-
-    @property
-    def title(self):
-        return _("Open Data Commons Attribution License")
-
-class LicenseCreativeCommonsZero(DefaultLicense):
-    domain_content = True
-    domain_data = True
-    id = "cc-zero"
-    od_conformance = 'approved'
-    url = "http://www.opendefinition.org/licenses/cc-zero"
-
-    @property
-    def title(self):
-        return _("Creative Commons CCZero")
-
-class LicenseCreativeCommonsAttribution(DefaultLicense):
-    id = "cc-by"
-    od_conformance = 'approved'
-    url = "http://www.opendefinition.org/licenses/cc-by"
-
-    @property
-    def title(self):
-        return _("Creative Commons Attribution")
-
-class LicenseCreativeCommonsAttributionShareAlike(DefaultLicense):
-    domain_content = True
-    id = "cc-by-sa"
-    od_conformance = 'approved'
-    url = "http://www.opendefinition.org/licenses/cc-by-sa"
-
-    @property
-    def title(self):
-        return _("Creative Commons Attribution Share-Alike")
-
-class LicenseGNUFreeDocument(DefaultLicense):
-    domain_content = True
-    id = "gfdl"
-    od_conformance = 'approved'
-    url = "http://www.opendefinition.org/licenses/gfdl"
-    @property
-    def title(self):
-        return _("GNU Free Documentation License")
-
-class LicenseOtherOpen(DefaultLicense):
-    domain_content = True
-    id = "other-open"
-    is_generic = True
-    od_conformance = 'approved'
-
-    @property
-    def title(self):
-        return _("Other (Open)")
-
-class LicenseOtherPublicDomain(DefaultLicense):
-    domain_content = True
-    id = "other-pd"
-    is_generic = True
-    od_conformance = 'approved'
-
-    @property
-    def title(self):
-        return _("Other (Public Domain)")
-
-class LicenseOtherAttribution(DefaultLicense):
-    domain_content = True
-    id = "other-at"
-    is_generic = True
-    od_conformance = 'approved'
-
-    @property
-    def title(self):
-        return _("Other (Attribution)")
-
-class LicenseOpenGovernment(DefaultLicense):
-    domain_content = True
-    id = "uk-ogl"
-    od_conformance = 'approved'
-    # CS: bad_spelling ignore
-    url = "http://reference.data.gov.uk/id/open-government-licence"
-
-    @property
-    def title(self):
-        # CS: bad_spelling ignore
-        return _("UK Open Government Licence (OGL)")
-
-class LicenseCreativeCommonsNonCommercial(DefaultLicense):
-    id = "cc-nc"
-    url = "http://creativecommons.org/licenses/by-nc/2.0/"
-
-    @property
-    def title(self):
-        return _("Creative Commons Non-Commercial (Any)")
-
-class LicenseOtherNonCommercial(DefaultLicense):
-    id = "other-nc"
-    is_generic = True
-
-    @property
-    def title(self):
-        return _("Other (Non-Commercial)")
-
-class LicenseOtherClosed(DefaultLicense):
-    id = "other-closed"
-    is_generic = True
-
-    @property
-    def title(self):
-        return _("Other (Not Open)")

--- a/ckan/model/license.py
+++ b/ckan/model/license.py
@@ -62,13 +62,7 @@ class License(object):
                 self.osd_conformance == 'approved'
         return self._isopen
 
-    @maintain.deprecated("License.as_dict() is deprecated and will be "
-                         "removed in a future version of CKAN. Instead, "
-                         "please use attribute access.")
     def as_dict(self):
-        '''NB This method is deprecated and will be removed in a future version
-        of CKAN. Instead, please use attribute access.
-        '''
         data = self._data.copy()
         if 'date_created' in data:
             value = data['date_created']

--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -336,7 +336,12 @@ class Package(vdm.sqlalchemy.RevisionedObjectMixin,
         return cls._license_register
 
     @classmethod
+    @maintain.deprecated('get_license_options is deprecated - use '
+                         'h.license_options() instead.')
     def get_license_options(cls):
+        '''DEPRECATED in 2.4 - does not take account of config options to
+        select licenses for the form options. Use h.license_options() instead.
+        '''
         register = cls.get_license_register()
         return [(l.title, l.id) for l in register.values()]
 

--- a/ckan/public/base/less/forms.less
+++ b/ckan/public/base/less/forms.less
@@ -170,11 +170,11 @@ textarea {
 
 @media (min-width: 980px) {
   .form-horizontal .info-block {
-    padding: 6px 0 6px 25px;
+    padding: 0px 0 6px 25px;
   }
   .form-horizontal .info-inline {
     float: right;
-    width: 265px;
+    width: 200px;
     margin-top: 0;
     padding-bottom: 0;
   }

--- a/ckan/templates/package/snippets/package_basic_fields.html
+++ b/ckan/templates/package/snippets/package_basic_fields.html
@@ -29,17 +29,18 @@
   {% set error = errors.license_id %}
   <label class="control-label" for="field-license">{{ _("License") }}</label>
   <div class="controls">
-    <select id="field-license" name="license_id" data-module="autocomplete">
-      {% for license_desc, license_id in licenses|sort if license_desc  %}
-        <option value="{{ license_id }}" {% if data.get('license_id', 'notspecified') == license_id %}selected="selected"{% endif %}>{{ license_desc }}</option>
+    <select id="field-license" name="license_id" class="input-xlarge" data-module="autocomplete">
+      {% set existing_license_id = data.get('license_id', 'notspecified') %}
+      {% for license_id, license_desc in h.license_options(existing_license_id) %}
+        <option value="{{ license_id }}" {% if existing_license_id == license_id %}selected="selected"{% endif %}>{{ license_desc }}</option>
       {% endfor %}
     </select>
     {% if error %}<span class="error-block">{{ error }}</span>{% endif %}
     <span class="info-block info-inline">
       <i class="icon-info-sign"></i>
       {% trans %}
-        License definitions and additional information can be found
-        at <a href="http://opendefinition.org/licenses/">opendefinition.org</a>
+        License information can be found at
+        <a href="http://opendefinition.org/licenses/" target="_blank">opendefinition.org</a>
       {% endtrans %}
     </span>
   </div>
@@ -68,7 +69,7 @@
     <div class="control-group">
       <label for="field-organizations" class="control-label">{{ _('Organization') }}</label>
       <div class="controls">
-        <select id="field-organizations" name="owner_org" data-module="autocomplete">
+        <select id="field-organizations" name="owner_org" class="input-xlarge" data-module="autocomplete">
           {% if h.check_config_permission('create_unowned_dataset') %}
              <option value="" {% if not selected_org and data.id %} selected="selected" {% endif %}>{{ _('No organization') }}</option>
           {% endif %}
@@ -87,7 +88,7 @@
       <div class="control-group">
         <label for="field-private" class="control-label">{{ _('Visibility') }}</label>
         <div class="controls">
-          <select id="field-private" name="private">
+          <select id="field-private" name="private" class="input-small">
             {% for option in [('True', _('Private')), ('False', _('Public'))] %}
             <option value="{{ option[0] }}" {% if option[0] == data.private|trim %}selected="selected"{% endif %}>{{ option[1] }}</option>
             {% endfor %}

--- a/ckan/templates/package/snippets/package_basic_fields.html
+++ b/ckan/templates/package/snippets/package_basic_fields.html
@@ -30,7 +30,7 @@
   <label class="control-label" for="field-license">{{ _("License") }}</label>
   <div class="controls">
     <select id="field-license" name="license_id" class="input-xlarge" data-module="autocomplete">
-      {% set existing_license_id = data.get('license_id', 'notspecified') %}
+      {% set existing_license_id = data.get('license_id') %}
       {% for license_id, license_desc in h.license_options(existing_license_id) %}
         <option value="{{ license_id }}" {% if existing_license_id == license_id %}selected="selected"{% endif %}>{{ license_desc }}</option>
       {% endfor %}

--- a/ckan/tests/model/test_license.py
+++ b/ckan/tests/model/test_license.py
@@ -13,7 +13,7 @@ class TestLicenseRegister(object):
         helpers.reset_db()
 
     def test_default_register_has_basic_properties_of_a_license(self):
-        config['licenses_group_url'] = None
+        config['ckan.licenses_url'] = None
         reg = LicenseRegister()
 
         license = reg['cc-by']
@@ -26,7 +26,7 @@ class TestLicenseRegister(object):
         this_dir = os.path.dirname(os.path.realpath(__file__))
         # v1 is used by CKAN so far
         register_filepath = '%s/licenses.v1' % this_dir
-        config['licenses_group_url'] = 'file:///%s' % register_filepath
+        config['ckan.licenses_url'] = 'file:///%s' % register_filepath
         reg = LicenseRegister()
 
         license = reg['cc-by']
@@ -39,7 +39,7 @@ class TestLicenseRegister(object):
         this_dir = os.path.dirname(os.path.realpath(__file__))
         # v2 is used by http://licenses.opendefinition.org in recent times
         register_filepath = '%s/licenses.v2' % this_dir
-        config['licenses_group_url'] = 'file:///%s' % register_filepath
+        config['ckan.licenses_url'] = 'file:///%s' % register_filepath
         reg = LicenseRegister()
 
         license = reg['CC-BY-4.0']

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -1598,12 +1598,12 @@ Default value: /path/to/ckan/model/licenses-default.json
 
 Note, ckan.licenses_url is a rename of the deprecated 'licenses_group_url'.
 
-.. _ckan.licenses_offered
+.. _ckan.licenses_offered:
 
 ckan.licenses_offered
 ^^^^^^^^^^^^^^^^^^^^^
 
-A list of licenses that are offered to the user, selected from the licenses list. By specifying a subset of licenses using this option, you are effectively 'deprecating' the other licenses. Deprecating is preferable to deleting the old license, else any datasets with the old license will not show the licence title, URL or openness. In addition, this option allows you to specify a particular ordering of the licenses in the drop-down list (otherwise they are in alphabetical order).
+A list of licenses that are offered to the user, selected from the licenses list. By specifying a subset of licenses using this option, you are effectively 'deprecating' the other licenses. Deprecating is preferable to deleting the old license, else any datasets with the old license will not show the license title, URL or openness. In addition, this option allows you to specify a particular ordering of the licenses in the drop-down list (otherwise they are in alphabetical order).
 
 Expressed as the license IDs in a space-separated list.
 
@@ -1611,12 +1611,12 @@ Examples::
 
  ckan.licenses_offered = cc0 cc-by
 
-.. _ckan.licenses_offered_exclusions
+.. _ckan.licenses_offered_exclusions:
 
 ckan.licenses_offered_exclusions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A list of licenses that are not offered to the user in the dataset create/edit form. This can be used to 'deprecate' licenses when newer versions are added. Deprecating is preferable to deleting the old license, else any datasets with the old license will not show the licence title, URL or openness.
+A list of licenses that are not offered to the user in the dataset create/edit form. This can be used to 'deprecate' licenses when newer versions are added. Deprecating is preferable to deleting the old license, else any datasets with the old license will not show the license title, URL or openness.
 
 Expressed as the license IDs in a space-separated list. This option is ignored if you also specify ckan.licenses_offered.
 

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -1576,27 +1576,55 @@ interface, see :doc:`form-integration`.
 
 The ``<NAME>`` string is replaced with the name of the dataset that was edited.
 
+.. _ckan.licenses_file:
+.. _ckan.licenses_url:
 .. _licenses_group_url:
 
-licenses_group_url
-^^^^^^^^^^^^^^^^^^
+ckan.licenses_file & ckan.licenses_url
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A url pointing to a JSON file containing a list of license objects. This list
-determines the licenses offered by the system to users, for example when
-creating or editing a dataset.
+This allows you to specify that licenses that this CKAN has in its license list, from which can be displayed against datasets, or offered when creating or editing datasets. Specify a filepath or URL of a JSON file containing a list of the license objects.
 
-This is entirely optional - by default, the system will use an internal cached
-version of the CKAN list of licenses available from the
-http://licenses.opendefinition.org/licenses/groups/ckan.json.
+The default list of licenses is in: `ckan/model/licenses-default.json`
 
-More details about the license objects - including the license format and some
-example license lists - can be found at the `Open Licenses Service
-<http://licenses.opendefinition.org/>`_.
+When defining licenses JSON, it's best to take the JSON for each license from the `Open Definition Licenses Service <http://licenses.opendefinition.org/>`_. When adding any additional licenses, the important keys to include are: `id`, `title`, `od_conformance` and `url`. The `od_conformance` field determines whether it is 'open' according to the Open Definition, which populates a dataset's `isopen` property, used by CKAN to display the "Open Data" icon and is used by extensions such as ckanext-qa and third-party services.
 
 Examples::
 
- licenses_group_url = file:///path/to/my/local/json-list-of-licenses.json
- licenses_group_url = http://licenses.opendefinition.org/licenses/groups/od.json
+ ckan.licenses_file = /etc/ckan/json-list-of-licenses.json
+ ckan.licenses_url = http://licenses.opendefinition.org/licenses/groups/od.json
+
+Default value: /path/to/ckan/model/licenses-default.json
+
+Note, ckan.licenses_url is a rename of the deprecated 'licenses_group_url'.
+
+.. _ckan.licenses_offered
+
+ckan.licenses_offered
+^^^^^^^^^^^^^^^^^^^^^
+
+A list of licenses that are offered to the user, selected from the licenses list. By specifying a subset of licenses using this option, you are effectively 'deprecating' the other licenses. Deprecating is preferable to deleting the old license, else any datasets with the old license will not show the licence title, URL or openness. In addition, this option allows you to specify a particular ordering of the licenses in the drop-down list (otherwise they are in alphabetical order).
+
+Expressed as the license IDs in a space-separated list.
+
+Examples::
+
+ ckan.licenses_offered = cc0 cc-by
+
+.. _ckan.licenses_offered_exclusions
+
+ckan.licenses_offered_exclusions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A list of licenses that are not offered to the user in the dataset create/edit form. This can be used to 'deprecate' licenses when newer versions are added. Deprecating is preferable to deleting the old license, else any datasets with the old license will not show the licence title, URL or openness.
+
+Expressed as the license IDs in a space-separated list. This option is ignored if you also specify ckan.licenses_offered.
+
+Example::
+
+ ckan.licenses_offered_exclusions = uk-ogl-1
+
+Default value: odc-pddl odc-odbl odc-by cc-zero cc-by cc-by-sa gfdl other-open other-pd other-at uk-ogl cc-nc other-nc other-closed
 
 .. _email-settings:
 

--- a/setup.py
+++ b/setup.py
@@ -149,6 +149,7 @@ entry_points = {
     ],
     'babel.extractors': [
         'ckan = ckan.lib.extract:extract_ckan',
+        'licenses = ckan.lib.extract:extract_licenses',
     ],
 }
 
@@ -186,10 +187,8 @@ setup(
             ('templates/**.txt', 'genshi', {
                 'template_class': 'genshi.template:TextTemplate'
             }),
-            ('templates_legacy/**.txt', 'genshi', {
-                'template_class': 'genshi.template:TextTemplate'
-            }),
             ('public/**', 'ignore', None),
+            ('config/licenses_default.json', 'licenses', None),
         ],
         'ckanext': [
             ('**.py', 'python', None),


### PR DESCRIPTION
Issue: #2478 

Default licenses are now more specific. Plus config options for a necessary 'license deprecation' mechanism.
- The default licences is now three well-known open CC licences with version numbers.
- License options offered is now a subset of all of them, to allow deprecation of licenses. Config options added, plus logic in helper.
- Default licenses now in a JSON file for simple customization by copying it. Added extractor to ensure titles are translated.
- Simplified configuring a file with licences in - no more weird file:/// to work out.
- Form CSS marginally improved with a bigger select box for the long license names. Adjusted some other sizings in sympathy.
