### PR TITLE
[#1749] Remove the last usage of "h.get_action"

### DIFF
--- a/ckanext/example_theme/v18_snippet_api/templates/ajax_snippets/example_theme_popover.html
+++ b/ckanext/example_theme/v18_snippet_api/templates/ajax_snippets/example_theme_popover.html
@@ -10,7 +10,7 @@
     <dl>
 
       <dt>{{ _('Followers') }}</dt>
-      <dd>{{ h.get_action('dataset_follower_count', {'id': id}) }}</dd>
+      <dd>{{ h.follow_count('dataset', id) }}</dd>
 
       <dt>{{ _('Resources') }}</dt>
       <dd>{{ num_resources }}</dd>


### PR DESCRIPTION
This removes the last usage of `h.get_action()` I could find in the code. #2384 previously removed another one.

I believe #1749 can be closed if this PR is accepted and merged.