### PR TITLE
An IUploader interface for extensions

### DIFF
--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -16,11 +16,11 @@ _max_resource_size = None
 _max_image_size = None
 
 
-def get_uploader(data_dict):
-    '''Queries IUploader plugins and returns an uploader instance.'''
+def get_resource_uploader(data_dict):
+    '''Query IUploader plugins and return a resource uploader instance.'''
     upload = None
     for plugin in plugins.PluginImplementations(plugins.IUploader):
-        upload = plugin.get_uploader(data_dict)
+        upload = plugin.get_resource_uploader(data_dict)
 
     # default uploader
     if upload is None:
@@ -33,7 +33,7 @@ def get_storage_path():
     '''Function to cache storage path'''
     global _storage_path
 
-    #None means it has not been set. False means not in config.
+    # None means it has not been set. False means not in config.
     if _storage_path is None:
         storage_path = config.get('ckan.storage_path')
         ofs_impl = config.get('ofs.impl')
@@ -89,7 +89,7 @@ class Upload(object):
         try:
             os.makedirs(self.storage_path)
         except OSError, e:
-            ## errno 17 is file already exists
+            # errno 17 is file already exists
             if e.errno != 17:
                 raise
         self.object_type = object_type
@@ -121,7 +121,7 @@ class Upload(object):
             data_dict[url_field] = self.filename
             self.upload_file = self.upload_field_storage.file
             self.tmp_filepath = self.filepath + '~'
-        ### keep the file if there has been no change
+        # keep the file if there has been no change
         elif self.old_filename and not self.old_filename.startswith('http'):
             if not self.clear:
                 data_dict[url_field] = self.old_filename
@@ -159,7 +159,7 @@ class Upload(object):
                 and not self.old_filename.startswith('http')):
             try:
                 os.remove(self.old_filepath)
-            except OSError, e:
+            except OSError:
                 pass
 
 
@@ -173,7 +173,7 @@ class ResourceUpload(object):
         try:
             os.makedirs(self.storage_path)
         except OSError, e:
-            ## errno 17 is file already exists
+            # errno 17 is file already exists
             if e.errno != 17:
                 raise
         self.filename = None
@@ -227,7 +227,7 @@ class ResourceUpload(object):
             try:
                 os.makedirs(directory)
             except OSError, e:
-                ## errno 17 is file already exists
+                # errno 17 is file already exists
                 if e.errno != 17:
                     raise
             tmp_filepath = filepath + '~'
@@ -236,7 +236,7 @@ class ResourceUpload(object):
             current_size = 0
             while True:
                 current_size = current_size + 1
-                #MB chunks
+                # MB chunks
                 data = self.upload_file.read(2 ** 20)
                 if not data:
                     break

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -2,10 +2,11 @@ import os
 import cgi
 import pylons
 import datetime
-import ckan.lib.munge as munge
 import logging
-import ckan.logic as logic
 
+import ckan.lib.munge as munge
+import ckan.logic as logic
+import ckan.plugins as plugins
 
 config = pylons.config
 log = logging.getLogger(__name__)
@@ -13,6 +14,19 @@ log = logging.getLogger(__name__)
 _storage_path = None
 _max_resource_size = None
 _max_image_size = None
+
+
+def get_uploader(data_dict):
+    '''Queries IUploader plugins and returns an uploader instance.'''
+    upload = None
+    for plugin in plugins.PluginImplementations(plugins.IUploader):
+        upload = plugin.get_uploader(data_dict)
+
+    # default uploader
+    if upload is None:
+        upload = ResourceUpload(data_dict)
+
+    return upload
 
 
 def get_storage_path():

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -16,6 +16,20 @@ _max_resource_size = None
 _max_image_size = None
 
 
+def get_uploader(upload_to, old_filename=None):
+    '''Query IUploader plugins and return an uploader instance for general
+    files.'''
+    upload = None
+    for plugin in plugins.PluginImplementations(plugins.IUploader):
+        upload = plugin.get_uploader(upload_to, old_filename)
+
+    # default uploader
+    if upload is None:
+        upload = Upload(upload_to, old_filename)
+
+    return upload
+
+
 def get_resource_uploader(data_dict):
     '''Query IUploader plugins and return a resource uploader instance.'''
     upload = None

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -684,7 +684,7 @@ def _group_or_org_create(context, data_dict, is_org=False):
     session = context['session']
     data_dict['is_organization'] = is_org
 
-    upload = uploader.Upload('group')
+    upload = uploader.get_uploader('group')
     upload.update_data_dict(data_dict, 'image_url',
                             'image_upload', 'clear_upload')
     # get the schema
@@ -766,6 +766,7 @@ def _group_or_org_create(context, data_dict, is_org=False):
     logic.get_action('activity_create')(activity_create_context, activity_dict)
 
     upload.upload(uploader.get_max_image_size())
+
     if not context.get('defer_commit'):
         model.repo.commit()
     context["group"] = group

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -295,13 +295,7 @@ def resource_create(context, data_dict):
     if not 'resources' in pkg_dict:
         pkg_dict['resources'] = []
 
-    upload = None
-    for plugin in plugins.PluginImplementations(plugins.IUploader):
-        upload = plugin.get_uploader(data_dict)
-
-    # default uploader
-    if upload is None:
-        upload = uploader.ResourceUpload(data_dict)
+    upload = uploader.get_uploader(data_dict)
 
     pkg_dict['resources'].append(data_dict)
 

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -295,7 +295,13 @@ def resource_create(context, data_dict):
     if not 'resources' in pkg_dict:
         pkg_dict['resources'] = []
 
-    upload = uploader.ResourceUpload(data_dict)
+    upload = None
+    for plugin in plugins.PluginImplementations(plugins.IUploader):
+        upload = plugin.get_uploader(data_dict)
+
+    # default uploader
+    if upload is None:
+        upload = uploader.ResourceUpload(data_dict)
 
     pkg_dict['resources'].append(data_dict)
 

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -295,7 +295,7 @@ def resource_create(context, data_dict):
     if not 'resources' in pkg_dict:
         pkg_dict['resources'] = []
 
-    upload = uploader.get_uploader(data_dict)
+    upload = uploader.get_resource_uploader(data_dict)
 
     pkg_dict['resources'].append(data_dict)
 

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -148,13 +148,7 @@ def resource_update(context, data_dict):
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.before_update(context, pkg_dict['resources'][n], data_dict)
 
-    upload = None
-    for plugin in plugins.PluginImplementations(plugins.IUploader):
-        upload = plugin.get_uploader(data_dict)
-
-    # default uploader
-    if upload is None:
-        upload = uploader.ResourceUpload(data_dict)
+    upload = uploader.get_uploader(data_dict)
 
     pkg_dict['resources'][n] = data_dict
 

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -148,7 +148,13 @@ def resource_update(context, data_dict):
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.before_update(context, pkg_dict['resources'][n], data_dict)
 
-    upload = uploader.ResourceUpload(data_dict)
+    upload = None
+    for plugin in plugins.PluginImplementations(plugins.IUploader):
+        upload = plugin.get_uploader(data_dict)
+
+    # default uploader
+    if upload is None:
+        upload = uploader.ResourceUpload(data_dict)
 
     pkg_dict['resources'][n] = data_dict
 

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -148,7 +148,7 @@ def resource_update(context, data_dict):
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.before_update(context, pkg_dict['resources'][n], data_dict)
 
-    upload = uploader.get_uploader(data_dict)
+    upload = uploader.get_resource_uploader(data_dict)
 
     pkg_dict['resources'][n] = data_dict
 

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -499,6 +499,7 @@ def package_relationship_update(context, data_dict):
     context['relationship'] = entity
     return _update_package_relationship(entity, comment, context)
 
+
 def _group_or_org_update(context, data_dict, is_org=False):
     model = context['model']
     user = context['user']
@@ -515,15 +516,15 @@ def _group_or_org_update(context, data_dict, is_org=False):
     # get the schema
     group_plugin = lib_plugins.lookup_group_plugin(group.type)
     try:
-        schema = group_plugin.form_to_db_schema_options({'type':'update',
-                                               'api':'api_version' in context,
+        schema = group_plugin.form_to_db_schema_options({'type': 'update',
+                                               'api': 'api_version' in context,
                                                'context': context})
     except AttributeError:
         schema = group_plugin.form_to_db_schema()
 
-    upload = uploader.Upload('group', group.image_url)
+    upload = uploader.get_uploader('group', group.image_url)
     upload.update_data_dict(data_dict, 'image_url',
-                           'image_upload', 'clear_upload')
+                            'image_upload', 'clear_upload')
 
     if is_org:
         _check_access('organization_update', context, data_dict)
@@ -609,11 +610,12 @@ def _group_or_org_update(context, data_dict, is_org=False):
         # in the group.
 
     upload.upload(uploader.get_max_image_size())
+
     if not context.get('defer_commit'):
         model.repo.commit()
 
-
     return model_dictize.group_dictize(group, context)
+
 
 def group_update(context, data_dict):
     '''Update a group.

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -22,6 +22,7 @@ __all__ = [
     'ITemplateHelpers',
     'IFacets',
     'IAuthenticator',
+    'IUploader'
 ]
 
 from inspect import isclass
@@ -1458,3 +1459,13 @@ class IAuthenticator(Interface):
         '''called on abort.  This allows aborts due to authorization issues
         to be overriden'''
         return (status_code, detail, headers, comment)
+
+
+class IUploader(Interface):
+    '''
+    Extensions can implement this interface can provide a custom uploader to
+    be used by resource_create and resource_update actions.
+    '''
+
+    def get_uploader(self):
+        '''Return an alternative uploader object for resource files.'''

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1438,11 +1438,10 @@ class IAuthenticator(Interface):
     Allows custom authentication methods to be integrated into CKAN.
     Currently it is experimental and the interface may change.'''
 
-
     def identify(self):
         '''called to identify the user.
 
-        If the user is identfied then it should set
+        If the user is identified then it should set
         c.user: The id of the user
         c.userobj: The actual user object (this may be removed as a
         requirement in a later release so that access to the model is not
@@ -1463,12 +1462,81 @@ class IAuthenticator(Interface):
 
 class IUploader(Interface):
     '''
-    Extensions can implement this interface can provide a custom uploader to
-    be used by resource_create and resource_update actions.
+    Extensions implementing this interface can provide custom uploaders to
+    upload resources and group images.
     '''
 
     def get_uploader(self):
-        '''Return an uploader object used to upload general files.'''
+        '''Return an uploader object to upload general files that must
+        implement the following methods:
+
+        ``__init__(upload_to, old_filename=None)``
+
+        Set up the uploader.
+
+        :param upload_to: name of the subdirectory within the storage
+            directory to upload the file
+        :type upload_to: string
+
+        :param old_filename: name of an existing image asset, so the extension
+            can replace it if necessary
+        :type old_filename: string
+
+        ``update_data_dict(data_dict, url_field, file_field, clear_field)``
+
+        Allow the data_dict to be manipulated before it reaches any
+        validators.
+
+        :param data_dict: data_dict to be updated
+        :type data_dict: dictionary
+
+        :param url_field: name of the field where the upload is going to be
+        :type url_field: string
+
+        :param file_field: name of the key where the FieldStorage is kept (i.e
+            the field where the file data actually is).
+        :type file_field: string
+
+        :param clear_field: name of a boolean field which requests the upload
+            to be deleted.
+        :type clear_field: string
+
+        ``upload(max_size)``
+
+        Perform the actual upload.
+
+        :param max_size: upload size can be limited by this value in MBs.
+        :type max_size: int
+
+        '''
 
     def get_resource_uploader(self):
-        '''Return an uploader object used to upload resource files.'''
+        '''Return an uploader object used to upload resource files that must
+        implement the following methods:
+
+        ``__init__(resource)``
+
+        Set up the resource uploader.
+
+        :param resource: resource dict
+        :type resource: dictionary
+
+        ``upload(id, max_size)``
+
+        Perform the actual upload.
+
+        :param id: resource id, can be used to create filepath
+        :type id: string
+
+        :param max_size: upload size can be limited by this value in MBs.
+        :type max_size: int
+
+        ``get_path(id)``
+
+        Required by the ``resource_download`` action to determine the path to
+        the file.
+
+        :param id: resource id
+        :type id: string
+
+        '''

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1467,6 +1467,8 @@ class IUploader(Interface):
     be used by resource_create and resource_update actions.
     '''
 
+    def get_uploader(self):
+        '''Return an uploader object used to upload general files.'''
+
     def get_resource_uploader(self):
-        '''Return an alternative resource uploader object for resource
-        files.'''
+        '''Return an uploader object used to upload resource files.'''

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1467,5 +1467,6 @@ class IUploader(Interface):
     be used by resource_create and resource_update actions.
     '''
 
-    def get_uploader(self):
-        '''Return an alternative uploader object for resource files.'''
+    def get_resource_uploader(self):
+        '''Return an alternative resource uploader object for resource
+        files.'''


### PR DESCRIPTION
A way to override the default `lib.uploader.ResourceUploader` class from extensions, enabling other file storage solutions, e.g. integration with cloud providers.