### PR TITLE
delete organizations causes 500 errror

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -625,9 +625,9 @@ class GroupController(base.BaseController):
         try:
             if request.method == 'POST':
                 self._action('group_delete')(context, {'id': id})
-                if self.group_type == 'organization':
+                if group_type == 'organization':
                     h.flash_notice(_('Organization has been deleted.'))
-                elif self.group_type == 'group':
+                elif group_type == 'group':
                     h.flash_notice(_('Group has been deleted.'))
                 else:
                     h.flash_notice(_('%s has been deleted.')

--- a/ckan/templates/organization/confirm_delete.html
+++ b/ckan/templates/organization/confirm_delete.html
@@ -10,7 +10,7 @@
       {% block form %}
         <p>{{ _('Are you sure you want to delete organization - {name}?').format(name=c.group_dict.name) }}</p>
         <p class="form-actions">
-          <form action="{% url_for controller='organization', action='delete', id=c.group_dict.name %}" method="post">
+          <form id="organization-confirm-delete-form" action="{% url_for controller='organization', action='delete', id=c.group_dict.name %}" method="post">
             <button class="btn" type="submit" name="cancel" >{{ _('Cancel') }}</button>
             <button class="btn btn-primary" type="submit" name="delete" >{{ _('Confirm Delete') }}</button>
           </form>

--- a/ckan/tests/controllers/test_organization.py
+++ b/ckan/tests/controllers/test_organization.py
@@ -1,0 +1,67 @@
+from nose.tools import assert_equal
+from routes import url_for
+
+from ckan.tests import factories, helpers
+from ckan.tests.helpers import submit_and_follow
+
+
+class TestOrganizationDelete(helpers.FunctionalTestBase):
+    def setup(self):
+        super(TestOrganizationDelete, self).setup()
+        self.app = helpers._get_test_app()
+        self.user = factories.User()
+        self.user_env = {'REMOTE_USER': self.user['name'].encode('ascii')}
+        self.organization = factories.Organization(user=self.user)
+
+    def test_owner_delete(self):
+        response = self.app.get(url=url_for(controller='organization',
+                                            action='delete',
+                                            id=self.organization['id']),
+                                status=200,
+                                extra_environ=self.user_env)
+
+        form = response.forms['organization-confirm-delete-form']
+        response = submit_and_follow(self.app, form, name='delete',
+                                     extra_environ=self.user_env)
+        organization = helpers.call_action('organization_show',
+                                           id=self.organization['id'])
+        assert_equal(organization['state'], 'deleted')
+
+    def test_sysadmin_delete(self):
+        sysadmin = factories.Sysadmin()
+        extra_environ = {'REMOTE_USER': sysadmin['name'].encode('ascii')}
+        response = self.app.get(url=url_for(controller='organization',
+                                            action='delete',
+                                            id=self.organization['id']),
+                                status=200,
+                                extra_environ=extra_environ)
+
+        form = response.forms['organization-confirm-delete-form']
+        response = submit_and_follow(self.app, form, name='delete',
+                                     extra_environ=self.user_env)
+        organization = helpers.call_action('organization_show',
+                                           id=self.organization['id'])
+        assert_equal(organization['state'], 'deleted')
+
+    def test_non_authorized_user_trying_to_delete_fails(self):
+        user = factories.User()
+        extra_environ = {'REMOTE_USER': user['name'].encode('ascii')}
+        self.app.get(url=url_for(controller='organization',
+                                 action='delete',
+                                 id=self.organization['id']),
+                     status=401,
+                     extra_environ=extra_environ)
+
+        organization = helpers.call_action('organization_show',
+                                           id=self.organization['id'])
+        assert_equal(organization['state'], 'active')
+
+    def test_anon_user_trying_to_delete_fails(self):
+        self.app.get(url=url_for(controller='organization',
+                                 action='delete',
+                                 id=self.organization['id']),
+                     status=302)  # redirects to login form
+
+        organization = helpers.call_action('organization_show',
+                                           id=self.organization['id'])
+        assert_equal(organization['state'], 'active')


### PR DESCRIPTION
current on master and release-v2.4.0

didn't update the delete controller for groups when group_types were changed in https://github.com/ckan/ckan/pull/2354 . self.group_type is now self.group_types and is a list of the group types. this fixes the check in the controller.

split from the organization tests so there is less to review