### PR TITLE
Resource proxy fails if HEAD responds with 403

### DIFF
--- a/ckanext/resourceproxy/controller.py
+++ b/ckanext/resourceproxy/controller.py
@@ -40,9 +40,10 @@ def proxy_resource(context, data_dict):
         # first we try a HEAD request which may not be supported
         did_get = False
         r = requests.head(url)
-        # 405 would be the appropriate response here, but 400 with
-        # the invalid method mentioned in the text is also possible (#2412)
-        if r.status_code in (400, 405):
+        # Servers can refuse HEAD requests. 405 is the appropriate response,
+        # but 400 with the invalid method mentioned in the text, or a 403
+        # (forbidden) status is also possible (#2412, #2530)
+        if r.status_code in (400, 403, 405):
             r = requests.get(url, stream=True)
             did_get = True
         r.raise_for_status()


### PR DESCRIPTION
Similar to #2412. Some servers[1] respond with a 403 to the initial HEAD request made by the resource_proxy extension[2], so don't attempt the GET request of the file.

[1]e.g. https://barnet.gov.uk/dam/jcr:7e9d19d0-071a-4209-9955-68485a5c937a/CSG_Overview_v0.2.pdf
[2]https://github.com/ckan/ckan/blob/530440944e9ccf844159004e987d50e5ccbab13b/ckanext/resourceproxy/controller.py#L42-L48