### PR TITLE
Fixed scripts block name

### DIFF
--- a/doc/contributing/frontend/template-blocks.rst
+++ b/doc/contributing/frontend/template-blocks.rst
@@ -213,7 +213,7 @@ scripts
 The scripts block allows you to add additonal scripts to the page. Use the
 ``super()`` function to load the default scripts before/after your own::
 
-  {% block script %}
+  {% block scripts %}
     {{ super() }}
     <script src="/base/js/custom.js"></script>
   {% endblock %}


### PR DESCRIPTION
The proper block is "scripts", rather than "script" and the documentation should be fixed.