### PR TITLE
[#2387] Fix GeoJSON field option in map view

### DIFF
--- a/ckanext/reclineview/plugin.py
+++ b/ckanext/reclineview/plugin.py
@@ -178,7 +178,9 @@ class ReclineMapView(ReclineViewBase):
 
     datastore_fields = []
 
-    datastore_field_types = ['numeric']
+    datastore_field_latlon_types = ['numeric']
+
+    datastore_field_geojson_types = ['text']
 
     def list_map_field_types(self):
         return [t['value'] for t in self.map_field_types]
@@ -213,12 +215,19 @@ class ReclineMapView(ReclineViewBase):
                 }
 
     def setup_template_variables(self, context, data_dict):
-        self.datastore_fields = datastore_fields(data_dict['resource'],
-                                                 self.datastore_field_types)
+        map_latlon_fields = datastore_fields(
+            data_dict['resource'], self.datastore_field_latlon_types)
+        map_geojson_fields = datastore_fields(
+            data_dict['resource'], self.datastore_field_geojson_types)
+
+        self.datastore_fields = map_latlon_fields + map_geojson_fields
+
         vars = ReclineViewBase.setup_template_variables(self, context,
                                                         data_dict)
         vars.update({'map_field_types': self.map_field_types,
-                     'map_fields': self.datastore_fields})
+                     'map_latlon_fields': map_latlon_fields,
+                     'map_geojson_fields': map_geojson_fields
+                     })
         return vars
 
     def form_template(self, context, data_dict):

--- a/ckanext/reclineview/theme/templates/recline_map_form.html
+++ b/ckanext/reclineview/theme/templates/recline_map_form.html
@@ -4,8 +4,8 @@
 {{ form.input('limit', id='field-limit', label=_('Number of rows'), placeholder=_('eg: 100'), value=data.limit, error=errors.limit, classes=['control-medium']) }}
 
 {{ form.select('map_field_type', label=_('Field type'), options=map_field_types, selected=data.map_field_type, error=errors.map_field_type) }}
-{{ form.select('latitude_field', label=_('Latitude field'), options=map_fields, selected=data.latitude_field, error=errors.latitude_field) }}
-{{ form.select('longitude_field', label=_('Longitude field'), options=map_fields, selected=data.longitude_field, error=errors.longitude_field) }}
-{{ form.select('geojson_field', label=_('GeoJSON field'), options=map_fields, selected=data.geojson_field, error=errors.geojson_field) }}
+{{ form.select('latitude_field', label=_('Latitude field'), options=map_latlon_fields, selected=data.latitude_field, error=errors.latitude_field) }}
+{{ form.select('longitude_field', label=_('Longitude field'), options=map_latlon_fields, selected=data.longitude_field, error=errors.longitude_field) }}
+{{ form.select('geojson_field', label=_('GeoJSON field'), options=map_geojson_fields, selected=data.geojson_field, error=errors.geojson_field) }}
 {{ form.checkbox('auto_zoom', label=_('Auto zoom to features'), value=True, checked=data.auto_zoom, error=errors.auto_zoom) }}
 {{ form.checkbox('cluster_markers', label=_('Cluster markers'), value=True, checked=data.cluster_markers, error=errors.cluster_markers) }}


### PR DESCRIPTION
Because the datastore fields were limited to numeric ones (to
accommodate the lat/lon option), it was not possible to select a text
field for the geojson option.

This patch separates the types used on both, while keeping the
validation in place and not mixing types between options.