### PR TITLE
resource view tests

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -582,7 +582,6 @@ class PackageController(base.BaseController):
 
     def resource_edit(self, id, resource_id, data=None, errors=None,
                       error_summary=None):
-
         if request.method == 'POST' and not data:
             data = data or clean_dict(dict_fns.unflatten(tuplize_dict(parse_params(
                 request.POST))))
@@ -610,21 +609,39 @@ class PackageController(base.BaseController):
             redirect(h.url_for(controller='package', action='resource_read',
                                id=id, resource_id=resource_id))
 
-        context = {'model': model, 'session': model.Session,
-                   'api_version': 3, 'for_edit': True,
-                   'user': c.user or c.author, 'auth_user_obj': c.userobj}
-        pkg_dict = get_action('package_show')(context, {'id': id})
+        try:
+            context = {
+                'model': model,
+                'session': model.Session,
+                'api_version': 3,
+                'for_edit': True,
+                'user': c.user or c.author,
+                'auth_user_obj': c.userobj
+            }
+            pkg_dict = get_action('package_show')(context, {'id': id})
+        except NotAuthorized:
+            abort(401, _('Unauthorized to edit this resource'))
+        except NotFound:
+            abort(404, _('Dataset not found'))
+
         if pkg_dict['state'].startswith('draft'):
             # dataset has not yet been fully created
-            resource_dict = get_action('resource_show')(context, {'id': resource_id})
-            fields = ['url', 'resource_type', 'format', 'name', 'description', 'id']
+            resource_dict = get_action('resource_show')(
+                context,
+                {'id': resource_id}
+            )
+            fields = ['url', 'resource_type', 'format', 'name',
+                      'description', 'id']
             data = {}
             for field in fields:
                 data[field] = resource_dict[field]
             return self.new_resource(id, data=data)
         # resource is fully created
         try:
-            resource_dict = get_action('resource_show')(context, {'id': resource_id})
+            resource_dict = get_action('resource_show')(
+                context,
+                {'id': resource_id}
+            )
         except NotFound:
             abort(404, _('Resource not found'))
         c.pkg_dict = pkg_dict

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -1450,12 +1450,12 @@ class PackageController(base.BaseController):
             check_access('package_update', context, data_dict)
         except NotAuthorized:
             abort(401, _('User %r not authorized to edit %s') % (c.user, id))
-        # check if package exists
+        except NotFound:
+            abort(404, _('Dataset not found'))
+
         try:
             c.pkg_dict = get_action('package_show')(context, data_dict)
             c.pkg = context['package']
-        except NotFound:
-            abort(404, _('Dataset not found'))
         except NotAuthorized:
             abort(401, _('Unauthorized to read dataset %s') % id)
 
@@ -1486,6 +1486,8 @@ class PackageController(base.BaseController):
             check_access('resource_update', context, {'id': resource_id})
         except NotAuthorized, e:
             abort(401, _('User %r not authorized to edit %s') % (c.user, id))
+        except NotFound:
+            abort(404, _('Resource not found'))
 
         # get resource and package data
         try:

--- a/ckan/templates/package/edit_view.html
+++ b/ckan/templates/package/edit_view.html
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block form %}
-  <form class="dataset-form dataset-resource-form form-horizontal" method="post" data-module="basic-form resource-form">
+  <form id="resource-view-edit" class="dataset-form dataset-resource-form form-horizontal" method="post" data-module="basic-form resource-form">
     {% include 'package/snippets/view_form.html' %}
     <div class="form-actions">
       <button class="btn btn-danger pull-left" name="delete" value="Delete"> {{ _('Delete') }} </button>

--- a/ckan/templates/package/new_view.html
+++ b/ckan/templates/package/new_view.html
@@ -22,7 +22,7 @@
     </p>
   {% endif %}
 
-  <form class="dataset-form dataset-resource-form form-horizontal" method="post" data-module="basic-form resource-form">
+  <form id="resource-view-edit" class="dataset-form dataset-resource-form form-horizontal" method="post" data-module="basic-form resource-form">
     {% include 'package/snippets/view_form.html' %}
     <div class="form-actions">
         <button class="btn {% if not h.resource_view_display_preview(data) %}hide{%endif%}" name="preview" value="True" type="submit">{{ _('Preview') }}</button>

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -5,14 +5,15 @@ from nose.tools import (
     assert_true,
 )
 
-
 from routes import url_for
 
 import ckan.model as model
 import ckan.plugins as p
+from ckan.lib import search
 
 import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
+from ckan.tests.helpers import assert_in
 
 
 webtest_submit = helpers.webtest_submit
@@ -29,7 +30,7 @@ def _get_package_new_page(app):
     return env, response
 
 
-class TestPackageControllerNew(helpers.FunctionalTestBase):
+class TestPackageNew(helpers.FunctionalTestBase):
     def test_form_renders(self):
         app = self._get_test_app()
         env, response = _get_package_new_page(app)
@@ -112,6 +113,30 @@ class TestPackageControllerNew(helpers.FunctionalTestBase):
         assert_equal(pkg.resources[1].url, u'http://example.com/resource1')
         assert_equal(pkg.state, 'active')
 
+    def test_resource_uploads(self):
+        app = self._get_test_app()
+        env, response = _get_package_new_page(app)
+        form = response.forms['dataset-edit']
+        form['name'] = u'complete-package-with-two-resources'
+
+        response = submit_and_follow(app, form, env, 'save')
+        form = response.forms['resource-edit']
+        form['upload'] = ('README.rst', b'data')
+
+        response = submit_and_follow(app, form, env, 'save', 'go-metadata')
+        pkg = model.Package.by_name(u'complete-package-with-two-resources')
+        assert_equal(pkg.resources[0].url_type, u'upload')
+        assert_equal(pkg.state, 'active')
+        response = app.get(
+            url_for(
+                controller='package',
+                action='resource_download',
+                id=pkg.id,
+                resource_id=pkg.resources[0].id
+            ),
+        )
+        assert_equal('data', response.body)
+
     def test_previous_button_works(self):
         app = self._get_test_app()
         env, response = _get_package_new_page(app)
@@ -162,8 +187,10 @@ class TestPackageControllerNew(helpers.FunctionalTestBase):
         '''
         user = factories.User()
         # user is admin of org.
-        org = factories.Organization(name="my-org",
-                                     users=[{'name': user['id'], 'capacity': 'admin'}])
+        org = factories.Organization(
+            name="my-org",
+            users=[{'name': user['id'], 'capacity': 'admin'}]
+        )
 
         app = self._get_test_app()
         env = {'REMOTE_USER': user['name'].encode('ascii')}
@@ -334,6 +361,172 @@ class TestPackageControllerNew(helpers.FunctionalTestBase):
         # The organization id is in the response in a value attribute
         assert 'value="{0}"'.format(org['id']) in pkg_edit_response
 
+    def test_unauthed_user_creating_dataset(self):
+        app = self._get_test_app()
+
+        # provide REMOTE_ADDR to idenfity as remote user, see
+        # BaseController._identify_user() for details
+        response = app.post(url=url_for(controller='package', action='new'),
+                            extra_environ={'REMOTE_ADDR': '127.0.0.1'})
+        response = response.follow()
+        assert_in('Unauthorized to create a package', response.body)
+
+
+class TestPackageEdit(helpers.FunctionalTestBase):
+    @classmethod
+    def setup_class(cls):
+        super(cls, cls).setup_class()
+        helpers.reset_db()
+        search.clear()
+
+    def test_organization_admin_can_edit(self):
+        user = factories.User()
+        organization = factories.Organization(
+            users=[{'name': user['id'], 'capacity': 'admin'}]
+        )
+        dataset = factories.Dataset(owner_org=organization['id'])
+        app = helpers._get_test_app()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        response = app.get(
+            url_for(controller='package',
+                    action='edit',
+                    id=dataset['name']),
+            extra_environ=env,
+        )
+        form = response.forms['dataset-edit']
+        form['notes'] = u'edited description'
+        submit_and_follow(app, form, env, 'save')
+
+        result = helpers.call_action('package_show', id=dataset['id'])
+        assert_equal(u'edited description', result['notes'])
+
+    def test_organization_editor_can_edit(self):
+        user = factories.User()
+        organization = factories.Organization(
+            users=[{'name': user['id'], 'capacity': 'editor'}]
+        )
+        dataset = factories.Dataset(owner_org=organization['id'])
+        app = helpers._get_test_app()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        response = app.get(
+            url_for(controller='package',
+                    action='edit',
+                    id=dataset['name']),
+            extra_environ=env,
+        )
+        form = response.forms['dataset-edit']
+        form['notes'] = u'edited description'
+        submit_and_follow(app, form, env, 'save')
+
+        result = helpers.call_action('package_show', id=dataset['id'])
+        assert_equal(u'edited description', result['notes'])
+
+    def test_organization_member_cannot_edit(self):
+        user = factories.User()
+        organization = factories.Organization(
+            users=[{'name': user['id'], 'capacity': 'member'}]
+        )
+        dataset = factories.Dataset(owner_org=organization['id'])
+        app = helpers._get_test_app()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        response = app.get(
+            url_for(controller='package',
+                    action='edit',
+                    id=dataset['name']),
+            extra_environ=env,
+            expect_errors=True
+        )
+        assert_equal(401, response.status_int)
+
+    def test_user_not_in_organization_cannot_edit(self):
+        user = factories.User()
+        organization = factories.Organization()
+        dataset = factories.Dataset(owner_org=organization['id'])
+        app = helpers._get_test_app()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        response = app.get(
+            url_for(controller='package',
+                    action='edit',
+                    id=dataset['name']),
+            extra_environ=env,
+            expect_errors=True
+        )
+        assert_equal(401, response.status_int)
+
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        response = app.get(
+            url_for(controller='package',
+                    action='post',
+                    id=dataset['name']),
+            {'notes': 'edited description'},
+            extra_environ=env,
+        )
+        response = response.follow()
+        assert_in('not authorized to edit {0}'.format(dataset['name']),
+                  response.body)
+
+    def test_anonymous_user_cannot_edit(self):
+        organization = factories.Organization()
+        dataset = factories.Dataset(owner_org=organization['id'])
+        app = helpers._get_test_app()
+        response = app.get(
+            url_for(controller='package',
+                    action='edit',
+                    id=dataset['name']),
+        )
+        # anonymous users get redirected to the login page
+        response = response.follow()
+        assert_in('not authorized to edit {0}'.format(dataset['name']),
+                  response.body)
+
+        response = app.post(
+            url_for(controller='package',
+                    action='edit',
+                    id=dataset['name']),
+            {'notes': 'edited description'},
+            expect_errors=True,
+
+        )
+        response = response.follow()
+        assert_in('not authorized to edit {0}'.format(dataset['name']),
+                  response.body)
+
+    def test_validation_errors_for_dataset_name_appear(self):
+        '''fill out a bad dataset set name and make sure errors appear'''
+        user = factories.User()
+        organization = factories.Organization(
+            users=[{'name': user['id'], 'capacity': 'admin'}]
+        )
+        dataset = factories.Dataset(owner_org=organization['id'])
+        app = helpers._get_test_app()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        response = app.get(
+            url_for(controller='package',
+                    action='edit',
+                    id=dataset['name']),
+            extra_environ=env,
+        )
+        form = response.forms['dataset-edit']
+        form['name'] = u'this is not a valid name'
+        response = webtest_submit(form, 'save', status=200, extra_environ=env)
+        assert_in('The form contains invalid entries', response.body)
+
+        assert_in('Name: Must be purely lowercase alphanumeric (ascii) '
+                  'characters and these symbols: -_', response.body)
+
+    def test_edit_a_dataset_that_does_not_exist_404s(self):
+        user = factories.User()
+        app = helpers._get_test_app()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        response = app.get(
+            url_for(controller='package',
+                    action='edit',
+                    id='does-not-exist'),
+            extra_environ=env,
+            expect_errors=True
+        )
+        assert_equal(404, response.status_int)
+
 
 class TestPackageRead(helpers.FunctionalTestBase):
     @classmethod
@@ -351,6 +544,71 @@ class TestPackageRead(helpers.FunctionalTestBase):
                                    id=dataset['name']))
         response.mustcontain('Test Dataset')
         response.mustcontain('Just another test dataset')
+
+    def test_organization_members_can_read_private_datasets(self):
+        members = {
+            'member': factories.User(),
+            'editor': factories.User(),
+            'admin': factories.User(),
+            'sysadmin': factories.Sysadmin()
+        }
+        organization = factories.Organization(
+            users=[
+                {'name': members['member']['id'], 'capacity': 'member'},
+                {'name': members['editor']['id'], 'capacity': 'editor'},
+                {'name': members['admin']['id'], 'capacity': 'admin'},
+            ]
+        )
+        dataset = factories.Dataset(
+            owner_org=organization['id'],
+            private=True,
+        )
+        app = helpers._get_test_app()
+
+        for user, user_dict in members.items():
+            response = app.get(
+                url_for(
+                    controller='package',
+                    action='read',
+                    id=dataset['name']
+                ),
+                extra_environ={
+                    'REMOTE_USER': user_dict['name'].encode('ascii'),
+                },
+            )
+            assert_in('Test Dataset', response.body)
+            assert_in('Just another test dataset', response.body)
+
+    def test_anonymous_users_cannot_read_private_datasets(self):
+        organization = factories.Organization()
+        dataset = factories.Dataset(
+            owner_org=organization['id'],
+            private=True,
+        )
+        app = helpers._get_test_app()
+        response = app.get(
+            url_for(controller='package', action='read', id=dataset['name']),
+        )
+        # get redirected if you are not logged in
+        response = response.follow()
+        assert_in('Unauthorized to read package {0}'.format(dataset['name']),
+                  response.body)
+
+    def test_user_not_in_organization_cannot_read_private_datasets(self):
+        user = factories.User()
+        organization = factories.Organization()
+        dataset = factories.Dataset(
+            owner_org=organization['id'],
+            private=True,
+        )
+        app = helpers._get_test_app()
+        response = app.get(
+            url_for(controller='package', action='read', id=dataset['name']),
+            extra_environ={'REMOTE_USER': user['name'].encode('ascii')},
+            expect_errors=True
+        )
+        assert_equal(401, response.status_int)
+        assert_in('Unauthorized to read package', response.body)
 
     def test_read_rdf(self):
         dataset1 = factories.Dataset()
@@ -485,7 +743,252 @@ class TestPackageDelete(helpers.FunctionalTestBase):
         assert_equal(200, response.status_int)
 
 
-class TestResourceRead(helpers.FunctionalTestBase):
+class TestResourceNew(helpers.FunctionalTestBase):
+    def test_manage_dataset_resource_listing_page(self):
+        user = factories.User()
+        organization = factories.Organization(user=user)
+        dataset = factories.Dataset(owner_org=organization['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        app = helpers._get_test_app()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        response = app.get(
+            url_for(
+                controller='package',
+                action='resources',
+                id=dataset['name'],
+            ),
+            extra_environ=env
+        )
+        assert_in(resource['name'], response)
+        assert_in(resource['description'], response)
+        assert_in(resource['format'], response)
+
+    def test_unauth_user_cannot_view_manage_dataset_resource_listing_page(self):
+        user = factories.User()
+        organization = factories.Organization(user=user)
+        dataset = factories.Dataset(owner_org=organization['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+        app = helpers._get_test_app()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        response = app.get(
+            url_for(
+                controller='package',
+                action='resources',
+                id=dataset['name'],
+            ),
+            extra_environ=env
+        )
+        assert_in(resource['name'], response)
+        assert_in(resource['description'], response)
+        assert_in(resource['format'], response)
+
+    def test_404_on_manage_dataset_resource_listing_page_that_does_not_exist(self):
+        user = factories.User()
+        app = helpers._get_test_app()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        response = app.get(
+            url_for(
+                controller='package',
+                action='resources',
+                id='does-not-exist'
+            ),
+            extra_environ=env,
+            expect_errors=True
+        )
+        assert_equal(404, response.status_int)
+
+    def test_add_new_resource_with_link_and_download(self):
+        user = factories.User()
+        dataset = factories.Dataset()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        app = helpers._get_test_app()
+
+        response = app.get(
+            url_for(
+                controller='package',
+                action='new_resource',
+                id=dataset['id'],
+            ),
+            extra_environ=env
+        )
+
+        form = response.forms['resource-edit']
+        form['url'] = u'http://test.com/'
+        response = submit_and_follow(app, form, env, 'save',
+                                     'go-dataset-complete')
+
+        result = helpers.call_action('package_show', id=dataset['id'])
+        response = app.get(
+            url_for(
+                controller='package',
+                action='resource_download',
+                id=dataset['id'],
+                resource_id=result['resources'][0]['id']
+            ),
+            extra_environ=env,
+        )
+        assert_equal(302, response.status_int)
+
+    def test_editor_can_add_new_resource(self):
+        user = factories.User()
+        organization = factories.Organization(
+            users=[{'name': user['id'], 'capacity': 'editor'}]
+        )
+        dataset = factories.Dataset(
+            owner_org=organization['id'],
+        )
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        app = helpers._get_test_app()
+
+        response = app.get(
+            url_for(
+                controller='package',
+                action='new_resource',
+                id=dataset['id'],
+            ),
+            extra_environ=env
+        )
+
+        form = response.forms['resource-edit']
+        form['name'] = u'test resource'
+        form['url'] = u'http://test.com/'
+        response = submit_and_follow(app, form, env, 'save',
+                                     'go-dataset-complete')
+
+        result = helpers.call_action('package_show', id=dataset['id'])
+        assert_equal(1, len(result['resources']))
+        assert_equal(u'test resource', result['resources'][0]['name'])
+
+    def test_admin_can_add_new_resource(self):
+        user = factories.User()
+        organization = factories.Organization(
+            users=[{'name': user['id'], 'capacity': 'admin'}]
+        )
+        dataset = factories.Dataset(
+            owner_org=organization['id'],
+        )
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        app = helpers._get_test_app()
+
+        response = app.get(
+            url_for(
+                controller='package',
+                action='new_resource',
+                id=dataset['id'],
+            ),
+            extra_environ=env
+        )
+
+        form = response.forms['resource-edit']
+        form['name'] = u'test resource'
+        form['url'] = u'http://test.com/'
+        response = submit_and_follow(app, form, env, 'save',
+                                     'go-dataset-complete')
+
+        result = helpers.call_action('package_show', id=dataset['id'])
+        assert_equal(1, len(result['resources']))
+        assert_equal(u'test resource', result['resources'][0]['name'])
+
+    def test_member_cannot_add_new_resource(self):
+        user = factories.User()
+        organization = factories.Organization(
+            users=[{'name': user['id'], 'capacity': 'member'}]
+        )
+        dataset = factories.Dataset(
+            owner_org=organization['id'],
+        )
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        app = helpers._get_test_app()
+
+        response = app.get(
+            url_for(
+                controller='package',
+                action='new_resource',
+                id=dataset['id'],
+            ),
+            extra_environ=env,
+            expect_errors=True,
+        )
+        assert_equal(401, response.status_int)
+
+        response = app.post(
+            url_for(
+                controller='package',
+                action='new_resource',
+                id=dataset['id'],
+            ),
+            {'name': 'test', 'url': 'test', 'save': 'save', 'id': ''},
+            extra_environ=env,
+            expect_errors=True,
+        )
+        assert_equal(401, response.status_int)
+
+    def test_non_organization_users_cannot_add_new_resource(self):
+        '''on an owned dataset'''
+        user = factories.User()
+        organization = factories.Organization()
+        dataset = factories.Dataset(
+            owner_org=organization['id'],
+        )
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        app = helpers._get_test_app()
+
+        response = app.get(
+            url_for(
+                controller='package',
+                action='new_resource',
+                id=dataset['id'],
+            ),
+            extra_environ=env,
+            expect_errors=True,
+        )
+        assert_equal(401, response.status_int)
+
+        response = app.post(
+            url_for(
+                controller='package',
+                action='new_resource',
+                id=dataset['id'],
+            ),
+            {'name': 'test', 'url': 'test', 'save': 'save', 'id': ''},
+            extra_environ=env,
+            expect_errors=True,
+        )
+        assert_equal(401, response.status_int)
+
+    def test_anonymous_users_cannot_add_new_resource(self):
+        organization = factories.Organization()
+        dataset = factories.Dataset(
+            owner_org=organization['id'],
+        )
+        app = helpers._get_test_app()
+
+        response = app.get(
+            url_for(
+                controller='package',
+                action='new_resource',
+                id=dataset['id'],
+            ),
+        )
+        assert_equal(302, response.status_int)
+        response = response.follow()
+        assert_in('Unauthorized to create a resource', response)
+
+        response = app.post(
+            url_for(
+                controller='package',
+                action='new_resource',
+                id=dataset['id'],
+            ),
+            {'name': 'test', 'url': 'test', 'save': 'save', 'id': ''},
+            expect_errors=True,
+        )
+        assert_equal(302, response.status_int)
+        response = response.follow()
+        assert_in('Unauthorized to create a resource', response)
+
+
+class TestResourceView(helpers.FunctionalTestBase):
     @classmethod
     def setup_class(cls):
         super(cls, cls).setup_class()
@@ -495,12 +998,12 @@ class TestResourceRead(helpers.FunctionalTestBase):
 
         helpers.reset_db()
 
+    def setup(self):
+        model.repo.rebuild_db()
+
     @classmethod
     def teardown_class(cls):
         p.unload('image_view')
-
-    def setup(self):
-        model.repo.rebuild_db()
 
     def test_existent_resource_view_page_returns_ok_code(self):
         resource_view = factories.ResourceView()
@@ -526,18 +1029,16 @@ class TestResourceRead(helpers.FunctionalTestBase):
         app = self._get_test_app()
         app.get(url, status=404)
 
-    def test_existing_resource_with_associated_dataset(self):
 
-        dataset = factories.Dataset()
-        resource = factories.Resource(package_id=dataset['id'])
+class TestResourceRead(helpers.FunctionalTestBase):
+    @classmethod
+    def setup_class(cls):
+        super(TestResourceRead, cls).setup_class()
+        helpers.reset_db()
+        search.clear()
 
-        url = url_for(controller='package',
-                      action='resource_read',
-                      id=dataset['id'],
-                      resource_id=resource['id'])
-
-        app = self._get_test_app()
-        app.get(url, status=200)
+    def setup(self):
+        model.repo.rebuild_db()
 
     def test_existing_resource_with_not_associated_dataset(self):
 
@@ -600,6 +1101,82 @@ class TestResourceRead(helpers.FunctionalTestBase):
 
         app = self._get_test_app()
         app.get(url, status=200, extra_environ=env)
+
+    def test_user_not_in_organization_cannot_read_private_dataset(self):
+        user = factories.User()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        organization = factories.Organization()
+        dataset = factories.Dataset(
+            owner_org=organization['id'],
+            private=True,
+        )
+        resource = factories.Resource(package_id=dataset['id'])
+
+        url = url_for(controller='package',
+                      action='resource_read',
+                      id=dataset['id'],
+                      resource_id=resource['id'])
+
+        app = self._get_test_app()
+        response = app.get(url,
+                           status=200,
+                           extra_environ=env,
+                           expect_errors=True)
+        assert_equal(401, response.status_int)
+        assert_in('Unauthorized to read dataset', response.body)
+
+    def test_organization_members_can_read_resources_in_private_datasets(self):
+        members = {
+            'member': factories.User(),
+            'editor': factories.User(),
+            'admin': factories.User(),
+            'sysadmin': factories.Sysadmin()
+        }
+        organization = factories.Organization(
+            users=[
+                {'name': members['member']['id'], 'capacity': 'member'},
+                {'name': members['editor']['id'], 'capacity': 'editor'},
+                {'name': members['admin']['id'], 'capacity': 'admin'},
+            ]
+        )
+        dataset = factories.Dataset(
+            owner_org=organization['id'],
+            private=True,
+        )
+        resource = factories.Resource(package_id=dataset['id'])
+
+        app = helpers._get_test_app()
+
+        for user, user_dict in members.items():
+            response = app.get(
+                url_for(
+                    controller='package',
+                    action='resource_read',
+                    id=dataset['name'],
+                    resource_id=resource['id'],
+                ),
+                extra_environ={
+                    'REMOTE_USER': user_dict['name'].encode('ascii'),
+                },
+            )
+            assert_in('Just another test resource', response.body)
+
+    def test_anonymous_users_cannot_read_private_datasets(self):
+        organization = factories.Organization()
+        dataset = factories.Dataset(
+            owner_org=organization['id'],
+            private=True,
+        )
+        app = helpers._get_test_app()
+        response = app.get(
+            url_for(controller='package', action='read', id=dataset['name']),
+        )
+        # get redirected if you are not logged in
+        response = response.follow()
+        assert_in(
+            'Unauthorized to read package {0}'.format(dataset['name']),
+            response.body
+        )
 
 
 class TestResourceDelete(helpers.FunctionalTestBase):


### PR DESCRIPTION
https://github.com/joetsoi/ckan/commit/3b0a88c5474f9819f112a53bd4fbc503ca44e301 changes to resource view controller are needed here to catch the 404 errors instead of 500ing if you give the id for a dataset that doesn't exist
