### PR TITLE
Non-default Celery backends cause exception with "paster db init"

### DIFF
--- a/ckan/model/__init__.py
+++ b/ckan/model/__init__.py
@@ -217,13 +217,18 @@ class Repository(vdm.sqlalchemy.Repository):
                 try:
                     import ckan.lib.celery_app as celery_app
                     import celery.db.session as celery_session
-                    ## This creates the database tables it is a slight
-                    ## hack to celery.
+                    import celery.backends.database
+                    ## This creates the database tables (if using that backend)
+                    ## It is a slight hack to celery
                     backend = celery_app.celery.backend
-                    celery_result_session = backend.ResultSession()
-                    engine = celery_result_session.bind
-                    celery_session.ResultModelBase.metadata.create_all(engine)
+                    if isinstance(backend,
+                                  celery.backends.database.DatabaseBackend):
+                        celery_result_session = backend.ResultSession()
+                        engine = celery_result_session.bind
+                        celery_session.ResultModelBase.metadata.\
+                            create_all(engine)
                 except ImportError:
+                    # use of celery is optional
                     pass
 
                 self.init_configuration_data()


### PR DESCRIPTION
e.g. in our ckan.ini we specify redis have this celery config:
```
[app:celery]
BROKER_BACKEND = redis
BROKER_HOST = redis://localhost/1
CELERY_RESULT_BACKEND = redis
REDIS_HOST = 127.0.0.1
REDIS_PORT = 6379
REDIS_DB = 0
REDIS_CONNECT_RETRY = True
```
and when you run "paster db init" it gives exception:
```
  File "/src/ckan/ckan/lib/cli.py", line 154, in command
    model.repo.init_db()
  File "/src/ckan/ckan/model/__init__.py", line 218, in init_db
    celery_result_session = backend.ResultSession()
AttributeError: 'RedisBackend' object has no attribute 'ResultSession'
```
You can work round it by commenting out the configuration for this alternative backend when you run paster db init. But it is annoying to do that on automatic deployment etc.

Celery in ckan has pretty awful, and we may not agree with it being there. But DGU uses it and this fix would be helpfully merged, meanwhile the wider celery thing can be debated.