### PR TITLE
Handle special characters in column names to fix recline view

### DIFF
--- a/ckanext/reclineview/theme/public/vendor/recline/recline.js
+++ b/ckanext/reclineview/theme/public/vendor/recline/recline.js
@@ -3222,7 +3222,12 @@ my.SlickGrid = Backbone.View.extend({
     }
 
     function sanitizeFieldName(name) {
-      var sanitized = $(name).text();
+      var sanitized;
+      try{
+        sanitized = $(name).text();
+      } catch(e) {
+        sanitized = '';
+      }
       return (name !== sanitized && sanitized !== '') ? sanitized : name;
     }
 


### PR DESCRIPTION
Some special characters/unicode characters are causing recline view
sanitization for HTML to fail with a JS error:
```
"bootstrap.js:3 Uncaught Error: Syntax error, unrecognized expression:"
```

Fixes #2490 by catching JS exceptions