### PR TITLE
2551 Allow a good orthograph for the word 'record' when there is only one result.

### DIFF
--- a/ckanext/reclineview/theme/public/widget.recordcount.js
+++ b/ckanext/reclineview/theme/public/widget.recordcount.js
@@ -9,7 +9,7 @@ this.recline.View = this.recline.View || {};
 my.RecordCount = Backbone.View.extend({
   className: 'recline-record-count',
   template: ' \
-    <span class="count">{{recordCount}}</span> records \
+    <span class="count">{{recordCount}}</span> {{record}} \
   ',
 
   initialize: function() {
@@ -21,6 +21,11 @@ my.RecordCount = Backbone.View.extend({
   render: function() {
     var tmplData = this.model.toTemplateJSON();
     tmplData.recordCount = tmplData.recordCount || 'Unknown number of';
+	if (tmplData.recordCount==1) {
+      tmplData.record = 'record';
+    } else {
+      tmplData.record = 'records';
+    }
     var templated = Mustache.render(this.template, tmplData);
     this.$el.html(templated);
   }


### PR DESCRIPTION
Fix issue #2551 

It would be great if 'record' and 'Unknown number of' were translatable in widget.recordCount.js .
