### PR TITLE
Wrong format autodetected for TSVs prevents DataPusher from being called

### DIFF
--- a/ckan/config/resource_formats.json
+++ b/ckan/config/resource_formats.json
@@ -18,7 +18,7 @@
   ["MDB", "Access Database", "application/x-msaccess", []],
   ["NetCDF", "NetCDF File", "application/netcdf", []],
   ["ArcGIS Map Service", "ArcGIS Map Service", "ArcGIS Map Service", ["arcgis map service"]],
-  ["TSV", "Tab Separated Values File", "text/tsv", []],
+  ["TSV", "Tab Separated Values File", "text/tsv", ["text/tab-separated-values"]],
   ["WFS", "Web Feature Service", null, []],
   ["ArcGIS Online Map", "ArcGIS Online Map", "ArcGIS Online Map", ["web map application"]],
   ["Perl", "Perl Script", "text/x-perl", []],

--- a/ckan/config/resource_formats.json
+++ b/ckan/config/resource_formats.json
@@ -18,7 +18,7 @@
   ["MDB", "Access Database", "application/x-msaccess", []],
   ["NetCDF", "NetCDF File", "application/netcdf", []],
   ["ArcGIS Map Service", "ArcGIS Map Service", "ArcGIS Map Service", ["arcgis map service"]],
-  ["TSV", "Tab Separated Values File", "text/tsv", ["text/tab-separated-values"]],
+  ["TSV", "Tab Separated Values File", "text/tab-separated-values", ["text/tsv"]],
   ["WFS", "Web Feature Service", null, []],
   ["ArcGIS Online Map", "ArcGIS Online Map", "ArcGIS Online Map", ["web map application"]],
   ["Perl", "Perl Script", "text/x-perl", []],

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -118,3 +118,5 @@ class TestResourceFormat(object):
         eq_(h.unified_resource_format('tsv'), 'TSV')
 
         eq_(h.unified_resource_format('text/tab-separated-values'), 'TSV')
+
+        eq_(h.unified_resource_format('text/tsv'), 'TSV')

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -109,3 +109,12 @@ class TestLicenseOptions(object):
         eq_(dict(licenses)['some-old-license'], 'some-old-license')
         # and it is first on the list
         eq_(licenses[0][0], 'some-old-license')
+
+
+class TestResourceFormat(object):
+
+    def test_autodetect_tsv(self):
+
+        eq_(h.unified_resource_format('tsv'), 'TSV')
+
+        eq_(h.unified_resource_format('text/tab-separated-values'), 'TSV')


### PR DESCRIPTION
When you upload or link to a TSV file (eg http://example.com/test.tsv) and don't specify a resource format, the format that you end up with is `text/tab-separated-values`. This is not recognized by the DataPusher and the resource is not uploaded to the DataStore.

This value is returned by `mimetypes.guess_type()` on the [`if_empty_guess_fomat`](https://github.com/ckan/ckan/blob/master/ckan/logic/validators.py#L770) validator. The [`clean_format`](https://github.com/ckan/ckan/blob/master/ckan/logic/validators.py#L781) validator should transform this to `TSV` but it doesn't because the miemtype is missing in the alternative representations for this format in [resource_formats.json](https://github.com/ckan/ckan/blob/master/ckan/config/resource_formats.json#L21).

This patch adds this alternative representation.