### PR TITLE
Packages (and package count) added back to templates

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1921,7 +1921,8 @@ def featured_group_org(items, get_action, list_action, count):
         context = {'ignore_auth': True,
                    'limits': {'packages': 2},
                    'for_view': True}
-        data_dict = {'id': id}
+        data_dict = {'id': id,
+                     'include_datasets': True}
 
         try:
             out = logic.get_action(get_action)(context, data_dict)

--- a/ckan/templates/group/snippets/info.html
+++ b/ckan/templates/group/snippets/info.html
@@ -34,7 +34,7 @@
         </dl>
         <dl>
           <dt>{{ _('Datasets') }}</dt>
-          <dd>{{ h.SI_number_span(group.packages|length) }}</dd>
+          <dd>{{ h.SI_number_span(group.package_count) }}</dd>
         </dl>
       </div>
       {% endblock %}

--- a/ckan/templates/organization/snippets/organization_item.html
+++ b/ckan/templates/organization/snippets/organization_item.html
@@ -27,8 +27,8 @@ Example:
     {% endif %}
   {% endblock %}
   {% block datasets %}
-    {% if organization.packages %}
-      <strong class="count">{{ ungettext('{num} Dataset', '{num} Datasets', organization.packages).format(num=organization.packages) }}</strong>
+    {% if organization.package_count %}
+      <strong class="count">{{ ungettext('{num} Dataset', '{num} Datasets', organization.package_count).format(num=organization.package_count) }}</strong>
     {% else %}
       <span class="count">{{ _('0 Datasets') }}</span>
     {% endif %}


### PR DESCRIPTION
#2206 excludes packages from `organization_show` and `group_show` by default. There are a couple places in the templates where we need a package count or to include package again. Fixes #2557.