### PR TITLE
[WIP] Auth fixes for datastore_search and datastore_search_sql 

### DIFF
--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -399,7 +399,7 @@ def datastore_search(context, data_dict):
         raise p.toolkit.ValidationError(errors)
 
     res_id = data_dict['resource_id']
-    data_dict['connection_url'] = pylons.config['ckan.datastore.write_url']
+    data_dict['connection_url'] = pylons.config['ckan.datastore.read_url']
 
     resources_sql = sqlalchemy.text(u'''SELECT alias_of FROM "_table_metadata"
                                         WHERE name = :id''')


### PR DESCRIPTION
This PR removes the use of the write_url in the datastore_search action, as the permissions are already checked later on against the auth.datastore_search function (which delegates to resource_show).

Looks like the non-removal of write_url in the action method was an accidental oversight.

Tests (including the privacy tests for TestDatastoreSearch.test_search_private_dataset) continue to pass.

Should fix tickets #2564 and #2562 