### PR TITLE
Checks for duplicate column names

### DIFF
--- a/ckanext/datastore/db.py
+++ b/ckanext/datastore/db.py
@@ -316,6 +316,13 @@ def create_table(context, data_dict):
                 })
             field['type'] = _guess_type(records[0][field['id']])
 
+    # Check for duplicate fields
+    unique_fields = set([f['id'] for f in supplied_fields])
+    if not len(unique_fields) == len(supplied_fields):
+        raise ValidationError({
+            'field': ['Duplicate column names are not supported']
+        })
+
     if records:
         # check record for sanity
         if not isinstance(records[0], dict):

--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -1,7 +1,7 @@
 import json
 import nose
 import sys
-from nose.tools import assert_equal
+from nose.tools import assert_equal, raises
 
 import pylons
 from pylons import config
@@ -137,6 +137,21 @@ class TestDatastoreCreateNewTests(object):
         result = helpers.call_action('datastore_create', **data)
         current_index_names = self._get_index_names(resource['id'])
         assert_equal(previous_index_names, current_index_names)
+
+    @raises(p.toolkit.ValidationError)
+    def test_create_duplicate_fields(self):
+        package = factories.Dataset()
+        data = {
+            'resource': {
+                'book': 'crime',
+                'author': ['tolstoy', 'dostoevsky'],
+                'package_id': package['id']
+            },
+            'fields': [{'id': 'book', 'type': 'text'},
+                       {'id': 'book', 'type': 'text'}],
+        }
+        result = helpers.call_action('datastore_create', **data)
+
 
     def _has_index_on_field(self, resource_id, field):
         sql = u"""


### PR DESCRIPTION
In an attempt to fix #2574 this PR now checks for duplicate column names in the data sent to datastore_create. This will now raise a ValidationError instead of a more generic SQLAlchemy Exception

