### PR TITLE
group_list incorrectly including all fields by default

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -372,6 +372,8 @@ def _group_or_org_list(context, data_dict, is_org=False):
     sort = data_dict.get('sort', 'name')
     q = data_dict.get('q')
 
+    all_fields = asbool(data_dict.get('all_fields', None))
+
     # order_by deprecated in ckan 1.8
     # if it is supplied and sort isn't use order_by and raise a warning
     order_by = data_dict.get('order_by', '')
@@ -390,15 +392,7 @@ def _group_or_org_list(context, data_dict, is_org=False):
                                                'package_count', 'title'],
                                total=1)
 
-    all_fields = data_dict.get('all_fields', None)
-    include_extras = all_fields and \
-                     asbool(data_dict.get('include_extras', False))
-
     query = model.Session.query(model.Group)
-    if include_extras:
-        # this does an eager load of the extras, avoiding an sql query every
-        # time group_list_dictize accesses a group's extra.
-        query = query.options(sqlalchemy.orm.joinedload(model.Group._extras))
     query = query.filter(model.Group.state == 'active')
     if groups:
         query = query.filter(model.Group.name.in_(groups))
@@ -421,6 +415,12 @@ def _group_or_org_list(context, data_dict, is_org=False):
     group_list = []
     for group in groups:
         data_dict['id'] = group.id
+
+        for key in ('include_extras', 'include_tags', 'include_users',
+                    'include_groups', 'include_followers'):
+            if key not in data_dict:
+                data_dict[key] = False
+
         group_list.append(logic.get_action(action)(context, data_dict))
 
     group_list = sorted(group_list, key=lambda x: x[sort_info[0][0]],
@@ -1160,6 +1160,12 @@ def _group_or_org_show(context, data_dict, is_org=False):
     include_datasets = asbool(data_dict.get('include_datasets', False))
     packages_field = 'datasets' if include_datasets else 'dataset_count'
 
+    include_tags = asbool(data_dict.get('include_tags', True))
+    include_users = asbool(data_dict.get('include_users', True))
+    include_groups = asbool(data_dict.get('include_groups', True))
+    include_extras = asbool(data_dict.get('include_extras', True))
+    include_followers = asbool(data_dict.get('include_followers', True))
+
     if group is None:
         raise NotFound
     if is_org and not group.is_organization:
@@ -1173,7 +1179,11 @@ def _group_or_org_show(context, data_dict, is_org=False):
         _check_access('group_show', context, data_dict)
 
     group_dict = model_dictize.group_dictize(group, context,
-                                             packages_field=packages_field)
+                                             packages_field=packages_field,
+                                             include_tags=include_tags,
+                                             include_extras=include_extras,
+                                             include_groups=include_groups,
+                                             include_users=include_users,)
 
     if is_org:
         plugin_type = plugins.IOrganizationController
@@ -1192,9 +1202,12 @@ def _group_or_org_show(context, data_dict, is_org=False):
     except AttributeError:
         schema = group_plugin.db_to_form_schema()
 
-    group_dict['num_followers'] = logic.get_action('group_follower_count')(
-        {'model': model, 'session': model.Session},
-        {'id': group_dict['id']})
+    if include_followers:
+        group_dict['num_followers'] = logic.get_action('group_follower_count')(
+            {'model': model, 'session': model.Session},
+            {'id': group_dict['id']})
+    else:
+        group_dict['num_followers'] = 0
 
     if schema is None:
         schema = logic.schema.default_show_group_schema()

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -128,8 +128,6 @@ class TestGroupList(helpers.FunctionalTestBase):
 
         expected_group = dict(group.items()[:])
         for field in ('users', 'tags', 'extras', 'groups'):
-            if field in group_list[0]:
-                del group_list[0][field]
             del expected_group[field]
 
         assert group_list[0] == expected_group


### PR DESCRIPTION
#2214 replaced the `organization/group_list` call to `group_list_dictize` by a `organization/group_show` call for each group. This was bound to be slower as it includes validation, followers, etc but it was made worse by the `include_*` params added in #1840 not being passed to `group_show` and `group_dictize`, effectively running all the extra calls for each group on the CKAN instance. This was part of 2.4.0