### PR TITLE
group_list performance issues: timeouts on homepage

### DIFF
--- a/ckan/controllers/home.py
+++ b/ckan/controllers/home.py
@@ -74,17 +74,8 @@ class HomeController(base.BaseController):
                 'license': _('Licenses'),
             }
 
-            data_dict = {'sort': 'package_count desc', 'all_fields': 1}
-            # only give the terms to group dictize that are returned in the
-            # facets as full results take a lot longer
-            if 'groups' in c.search_facets:
-                data_dict['groups'] = [
-                    item['name'] for item in c.search_facets['groups']['items']
-                ]
-            c.groups = logic.get_action('group_list')(context, data_dict)
         except search.SearchError:
             c.package_count = 0
-            c.groups = []
 
         if c.userobj is not None:
             msg = None
@@ -111,74 +102,6 @@ class HomeController(base.BaseController):
             if msg:
                 h.flash_notice(msg, allow_html=True)
 
-        # START OF DIRTINESS
-        def get_group(id):
-            def _get_group_type(id):
-                """
-                Given the id of a group it determines the type of a group given
-                a valid id/name for the group.
-                """
-                group = model.Group.get(id)
-                if not group:
-                    return None
-                return group.type
-
-            def db_to_form_schema(group_type=None):
-                from ckan.lib.plugins import lookup_group_plugin
-                return lookup_group_plugin(group_type).db_to_form_schema()
-
-            group_type = _get_group_type(id.split('@')[0])
-            context = {'model': model, 'session': model.Session,
-                       'ignore_auth': True,
-                       'user': c.user or c.author,
-                       'auth_user_obj': c.userobj,
-                       'schema': db_to_form_schema(group_type=group_type),
-                       'limits': {'packages': 2},
-                       'for_view': True}
-            data_dict = {'id': id, 'include_datasets': True}
-
-            try:
-                group_dict = logic.get_action('group_show')(context, data_dict)
-            except logic.NotFound:
-                return None
-
-            return {'group_dict': group_dict}
-
-        global dirty_cached_group_stuff
-        if not dirty_cached_group_stuff:
-            groups_data = []
-            groups = config.get('ckan.featured_groups', '').split()
-
-            for group_name in groups:
-                group = get_group(group_name)
-                if group:
-                    groups_data.append(group)
-                if len(groups_data) == 2:
-                    break
-
-            # c.groups is from the solr query above
-            if len(groups_data) < 2 and len(c.groups) > 0:
-                group = get_group(c.groups[0]['name'])
-                if group:
-                    groups_data.append(group)
-            if len(groups_data) < 2 and len(c.groups) > 1:
-                group = get_group(c.groups[1]['name'])
-                if group:
-                    groups_data.append(group)
-            # We get all the packages or at least too many so
-            # limit it to just 2
-            for group in groups_data:
-                group['group_dict']['packages'] = \
-                    group['group_dict']['packages'][:2]
-            #now add blanks so we have two
-            while len(groups_data) < 2:
-                groups_data.append({'group_dict': {}})
-            # cache for later use
-            dirty_cached_group_stuff = groups_data
-
-        c.group_package_stuff = dirty_cached_group_stuff
-
-        # END OF DIRTINESS
         return base.render('home/index.html', cache_force=True)
 
     def license(self):

--- a/ckan/controllers/home.py
+++ b/ckan/controllers/home.py
@@ -12,9 +12,6 @@ from ckan.common import _, g, c
 
 CACHE_PARAMETERS = ['__cache', '__no_cache__']
 
-# horrible hack
-dirty_cached_group_stuff = None
-
 
 class HomeController(base.BaseController):
     repo = model.repo

--- a/ckan/tests/controllers/test_group.py
+++ b/ckan/tests/controllers/test_group.py
@@ -254,3 +254,46 @@ class TestGroupFollow(helpers.FunctionalTestBase):
         followers_response = app.get(followers_url, extra_environ=env,
                                      status=200)
         assert_true(user_one['display_name'] in followers_response)
+
+
+class TestGroupIndex(helpers.FunctionalTestBase):
+
+    def test_group_index(self):
+        app = self._get_test_app()
+
+        for i in xrange(1, 25):
+            _i = '0' + str(i) if i < 10 else i
+            factories.Group(
+                name='test-group-{0}'.format(_i),
+                title='Test Group {0}'.format(_i))
+
+        url = url_for(controller='group',
+                      action='index')
+        response = app.get(url)
+
+        for i in xrange(1, 21):
+            _i = '0' + str(i) if i < 10 else i
+            assert_in('Test Group {0}'.format(_i), response)
+
+        assert 'Test Group 22' not in response
+
+        url = url_for(controller='group',
+                      action='index',
+                      page=1)
+        response = app.get(url)
+
+        for i in xrange(1, 21):
+            _i = '0' + str(i) if i < 10 else i
+            assert_in('Test Group {0}'.format(_i), response)
+
+        assert 'Test Group 22' not in response
+
+        url = url_for(controller='group',
+                      action='index',
+                      page=2)
+        response = app.get(url)
+
+        for i in xrange(22, 25):
+            assert_in('Test Group {0}'.format(i), response)
+
+        assert 'Test Group 21' not in response

--- a/ckan/tests/controllers/test_group.py
+++ b/ckan/tests/controllers/test_group.py
@@ -261,7 +261,7 @@ class TestGroupIndex(helpers.FunctionalTestBase):
     def test_group_index(self):
         app = self._get_test_app()
 
-        for i in xrange(1, 25):
+        for i in xrange(1, 26):
             _i = '0' + str(i) if i < 10 else i
             factories.Group(
                 name='test-group-{0}'.format(_i),
@@ -271,7 +271,7 @@ class TestGroupIndex(helpers.FunctionalTestBase):
                       action='index')
         response = app.get(url)
 
-        for i in xrange(1, 21):
+        for i in xrange(1, 22):
             _i = '0' + str(i) if i < 10 else i
             assert_in('Test Group {0}'.format(_i), response)
 
@@ -282,7 +282,7 @@ class TestGroupIndex(helpers.FunctionalTestBase):
                       page=1)
         response = app.get(url)
 
-        for i in xrange(1, 21):
+        for i in xrange(1, 22):
             _i = '0' + str(i) if i < 10 else i
             assert_in('Test Group {0}'.format(_i), response)
 
@@ -293,7 +293,7 @@ class TestGroupIndex(helpers.FunctionalTestBase):
                       page=2)
         response = app.get(url)
 
-        for i in xrange(22, 25):
+        for i in xrange(22, 26):
             assert_in('Test Group {0}'.format(i), response)
 
         assert 'Test Group 21' not in response

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -8,6 +8,7 @@ import ckan.logic.schema as schema
 
 
 eq = nose.tools.eq_
+assert_raises = nose.tools.assert_raises
 
 
 class TestPackageShow(helpers.FunctionalTestBase):
@@ -178,6 +179,49 @@ class TestGroupList(helpers.FunctionalTestBase):
         expected_parent_group = dict(parent_group.items()[:])
 
         eq([g['name'] for g in child_group_returned['groups']], [expected_parent_group['name']])
+
+    def test_group_list_limit(self):
+
+        group1 = factories.Group()
+        group2 = factories.Group()
+        group3 = factories.Group()
+
+        group_list = helpers.call_action('group_list', limit=1)
+
+        eq(len(group_list), 1)
+        eq(group_list[0], group1['name'])
+
+    def test_group_list_offset(self):
+
+        group1 = factories.Group()
+        group2 = factories.Group()
+        group3 = factories.Group()
+
+        group_list = helpers.call_action('group_list', offset=2)
+
+        eq(len(group_list), 1)
+        eq(group_list[0], group3['name'])
+
+    def test_group_list_limit_and_offset(self):
+
+        group1 = factories.Group()
+        group2 = factories.Group()
+        group3 = factories.Group()
+
+        group_list = helpers.call_action('group_list', offset=1, limit=1)
+
+        eq(len(group_list), 1)
+        eq(group_list[0], group2['name'])
+
+    def test_group_list_wrong_limit(self):
+
+        assert_raises(logic.ValidationError, helpers.call_action, 'group_list',
+                      limit='a')
+
+    def test_group_list_wrong_offset(self):
+
+        assert_raises(logic.ValidationError, helpers.call_action, 'group_list',
+                      offset='-2')
 
 
 class TestGroupShow(helpers.FunctionalTestBase):

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -128,8 +128,6 @@ class TestGroupList(helpers.FunctionalTestBase):
 
         expected_group = dict(group.items()[:])
         for field in ('users', 'tags', 'extras', 'groups'):
-            if field in group_list[0]:
-                del group_list[0][field]
             del expected_group[field]
 
         assert group_list[0] == expected_group
@@ -148,6 +146,17 @@ class TestGroupList(helpers.FunctionalTestBase):
 
         eq(group_list[0]['extras'], group['extras'])
         eq(group_list[0]['extras'][0]['key'], 'key1')
+
+    def test_group_list_users_returned(self):
+        user = factories.User()
+        group = factories.Group(users=[{'name': user['name'],
+                                        'capacity': 'admin'}])
+
+        group_list = helpers.call_action('group_list', all_fields=True,
+                                         include_users=True)
+
+        eq(group_list[0]['users'], group['users'])
+        eq(group_list[0]['users'][0]['name'], group['users'][0]['name'])
 
     # NB there is no test_group_list_tags_returned because tags are not in the
     # group_create schema (yet)


### PR DESCRIPTION
Problems:

1. `group_list` / `organization_list` are calling `group_show` / `orgsanization_show` for all items even when you are just requesting ids/names (the default behaviour)

2. The widgets on the homepage and their associated helpers are calling `group_list` / `organization_list` when they only need to show 1 of each.

This basically means timeouts on the homepage and pages that call `group_list` or `organization_list` on instances that have many groups / orgs (like demo.ckan.org).

demo.ckan.org was running 2.2.x and worked fine, so something along the way went wrong.

