### PR TITLE
Don't use cached values when rendering notes.

### DIFF
--- a/ckan/lib/plugins.py
+++ b/ckan/lib/plugins.py
@@ -261,8 +261,6 @@ class DefaultDatasetForm(object):
         return ckan.logic.schema.default_show_package_schema()
 
     def setup_template_variables(self, context, data_dict):
-        from ckan.lib.helpers import render_markdown
-
         authz_fn = logic.get_action('group_list_authz')
         c.groups_authz = authz_fn(context, data_dict)
         data_dict.update({'available_only': True})
@@ -276,8 +274,8 @@ class DefaultDatasetForm(object):
         c.is_sysadmin = ckan.authz.is_sysadmin(c.user)
 
         if c.pkg:
+            # Used by the disqus plugin
             c.related_count = c.pkg.related_count
-            c.pkg_notes_formatted = render_markdown(c.pkg.notes)
 
         if context.get('revision_id') or context.get('revision_date'):
             if context.get('revision_id'):

--- a/ckan/templates/package/read.html
+++ b/ckan/templates/package/read.html
@@ -23,9 +23,9 @@
       {% endblock %}
     </h1>
     {% block package_notes %}
-      {% if c.pkg_notes_formatted %}
+      {% if pkg.notes %}
         <div class="notes embedded-content">
-          {{ c.pkg_notes_formatted }}
+          {{ h.render_markdown(pkg.notes) }}
         </div>
       {% endif %}
     {% endblock %}


### PR DESCRIPTION
Currently, a cached field with the rendered markdown is used in the
package/read template.

This value is set very early in the process (and also results in
rendering markdown when it is not needed).

Since it is set so early, it bypasses all of the hooks designed to allow
these values to be manipulated, such as `before_view`. This breaks
extension on core fields that depend on being able to modify these
fields, like the multi-lingual support extension ckanext-fluent.