### PR TITLE
search-index rebuild: Don't crash when crashing.

### DIFF
--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -192,8 +192,8 @@ def rebuild(package_id=None, only_missing=False, force=False, refresh=False, def
                     defer_commit
                 )
             except Exception, e:
-                log.error('Error while indexing dataset %s: %s' %
-                          (pkg_id, str(e)))
+                log.error(u'Error while indexing dataset %s: %s' %
+                          (pkg_id, repr(e)))
                 if force:
                     log.error(text_traceback())
                     continue


### PR DESCRIPTION
If an error occurs (especially when importing data using paster) that
contains a unicode string (such as a multilingual package name), the
try...catch will also crash when attempting to print it, resulting in
some very confusing stack traces that bury the real stack trace.