### PR TITLE
Fixing unqualified exception use in helpers

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2028,7 +2028,7 @@ def get_organization(org=None, include_datasets=False):
         return {}
     try:
         return logic.get_action('organization_show')({}, {'id': org, 'include_datasets': include_datasets})
-    except (NotFound, ValidationError, NotAuthorized):
+    except (logic.NotFound, logic.ValidationError, logic.NotAuthorized):
         return {}
 
 


### PR DESCRIPTION
The function get_organization used unqualified exception types in the except block.
This commit fixes it.