### PR TITLE
option for disabling related items

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1158,6 +1158,8 @@ def related_item_link(related_item_dict):
                   id=related_item_dict['id'])
     return link_to(text, url)
 
+def related_enabled():
+    return asbool(config.get('ckan.related_enabled', True))
 
 def tag_link(tag):
     url = url_for(controller='tag', action='read', id=tag['name'])
@@ -2090,6 +2092,7 @@ __allowed_functions__ = [
     'resource_display_name',
     'resource_link',
     'related_item_link',
+    'related_enabled',
     'tag_link',
     'group_link',
     'dump_json',

--- a/ckan/templates/package/read_base.html
+++ b/ckan/templates/package/read_base.html
@@ -24,7 +24,9 @@
   {{ h.build_nav_icon('dataset_read', _('Dataset'), id=pkg.name) }}
   {{ h.build_nav_icon('dataset_groups', _('Groups'), id=pkg.name) }}
   {{ h.build_nav_icon('dataset_activity', _('Activity Stream'), id=pkg.name) }}
-  {{ h.build_nav_icon('related_list', _('Related'), id=pkg.name) }}
+  {% if h.related_enabled() %}
+    {{ h.build_nav_icon('related_list', _('Related'), id=pkg.name) }}
+  {% endif %}
 {% endblock %}
 
 {% block primary_content_inner %}

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -964,6 +964,20 @@ When set to false, or no, this setting will hide the 'Apps, Ideas, etc' tab on t
 
 .. note::  This only applies to the legacy Genshi-based templates
 
+.. _ckan.related_enabled:
+
+ckan.related_enabled
+^^^^^^^^^^^^^^^^^^^^
+
+ckan.related_enabled::
+
+ ckan.related_enabled = true
+
+Default value: true
+
+When set to false, disables the Related tab on the dataset page, effectively
+hiding the Related Items feature.
+
 .. _ckan.dumps_url:
 
 ckan.dumps_url


### PR DESCRIPTION
Now that we have [ckanext-showcase](https://github.com/ckan/ckanext-showcase), I wanted to have a simple way of disabling (or rather, hiding) the related items feature. This PR hides it when a config variable is set, otherwise it doesn't touch the related items by default.

Related to https://github.com/ckan/ckanext-showcase/pull/16