### PR TITLE
Fix for ckanext-showcase

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1863,7 +1863,7 @@ def package_search(context, data_dict):
 
     model = context['model']
     session = context['session']
-    user = context['user']
+    user = context.get('user')
 
     _check_access('package_search', context, data_dict)
 

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -1122,6 +1122,13 @@ class TestPackageSearch(helpers.FunctionalTestBase):
         eq(len(results), 1)
         eq(results[0]['name'], private_dataset['name'])
 
+    def test_package_works_without_user_in_context(self):
+        '''
+        package_search() should work even if user isn't in the context (e.g.
+        ckanext-showcase tests.
+        '''
+        logic.get_action('package_search')({}, dict(q='anything'))
+
 
 class TestBadLimitQueryParameters(helpers.FunctionalTestBase):
     '''test class for #1258 non-int query parameters cause 500 errors


### PR DESCRIPTION
Cope with the fact that user is optional in the context (judging by the prevelance of similar lines throughout).

Fix needed for: https://github.com/ckan/ckanext-showcase/issues/15