### PR TITLE
IGroupForm: new groups (of type 'group') use group_form

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -127,8 +127,6 @@ class GroupController(base.BaseController):
             idx = -2
 
         gt = parts[idx]
-        if gt == 'group':
-            gt = None
 
         return gt
 

--- a/ckan/lib/plugins.py
+++ b/ckan/lib/plugins.py
@@ -439,7 +439,7 @@ class DefaultGroupForm(object):
         into a format suitable for the form (optional)'''
 
     def db_to_form_schema_options(self, options):
-        '''This allows the selectino of different schemas for different
+        '''This allows the selection of different schemas for different
         purposes.  It is optional and if not available, ``db_to_form_schema``
         should be used.
         If a context is provided, and it contains a schema, it will be

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1171,7 +1171,7 @@ class IGroupForm(Interface):
 
     The behaviour of the plugin is determined by 5 method hooks:
 
-     - package_form(self)
+     - group_form(self)
      - form_to_db_schema(self)
      - db_to_form_schema(self)
      - check_data_dict(self, data_dict)
@@ -1220,7 +1220,7 @@ class IGroupForm(Interface):
 
     ##### End of control methods
 
-    ##### Hooks for customising the PackageController's behaviour        #####
+    ##### Hooks for customising the GroupController's behaviour          #####
     ##### TODO: flesh out the docstrings a little more.                  #####
     def new_template(self):
         """
@@ -1254,7 +1254,7 @@ class IGroupForm(Interface):
         rendered for the edit page
         """
 
-    def package_form(self):
+    def group_form(self):
         """
         Returns a string representing the location of the template to be
         rendered.  e.g. "group/new_group_form.html".

--- a/ckanext/example_igroupform/plugin.py
+++ b/ckanext/example_igroupform/plugin.py
@@ -13,11 +13,17 @@ group_type_utf8 = group_type.encode('utf8')
 
 class ExampleIGroupFormPlugin(plugins.SingletonPlugin,
                               tk.DefaultGroupForm):
-    '''An example IGroupForm CKAN plugin.
+    '''An example IGroupForm CKAN plugin with custom group_type.
 
     Doesn't do much yet.
     '''
     plugins.implements(plugins.IGroupForm, inherit=False)
+    plugins.implements(plugins.IConfigurer)
+
+    # IConfigurer
+
+    def update_config(self, config_):
+        tk.add_template_directory(config_, 'templates')
 
     # IGroupForm
 
@@ -26,3 +32,32 @@ class ExampleIGroupFormPlugin(plugins.SingletonPlugin,
 
     def is_fallback(self):
         False
+
+    def group_form(self):
+        return 'example_igroup_form/group_form.html'
+
+
+class ExampleIGroupFormPlugin_DefaultGroupType(plugins.SingletonPlugin,
+                                               tk.DefaultGroupForm):
+    '''An example IGroupForm CKAN plugin for default group_type.
+
+    Doesn't do much yet.
+    '''
+    plugins.implements(plugins.IGroupForm, inherit=False)
+    plugins.implements(plugins.IConfigurer)
+
+    # IConfigurer
+
+    def update_config(self, config_):
+        tk.add_template_directory(config_, 'templates')
+
+    # IGroupForm
+
+    def group_types(self):
+        return ('group',)
+
+    def is_fallback(self):
+        False
+
+    def group_form(self):
+        return 'example_igroup_form/group_form.html'

--- a/ckanext/example_igroupform/templates/example_igroup_form/group_form.html
+++ b/ckanext/example_igroupform/templates/example_igroup_form/group_form.html
@@ -1,0 +1,7 @@
+{% extends "group/new_group_form.html" %}
+
+{# Add some custom text so we know the form was rendered. #}
+{% block error_summary %}
+    {{ super() }}
+    My Custom Group Form!
+{% endblock %}

--- a/ckanext/example_igroupform/tests/test_controllers.py
+++ b/ckanext/example_igroupform/tests/test_controllers.py
@@ -10,10 +10,11 @@ assert_in = helpers.assert_in
 webtest_submit = helpers.webtest_submit
 submit_and_follow = helpers.submit_and_follow
 
-group_type = u'grup'
+custom_group_type = u'grup'
+group_type = u'group'
 
 
-def _get_group_new_page(app):
+def _get_group_new_page(app, group_type):
     user = factories.User()
     env = {'REMOTE_USER': user['name'].encode('ascii')}
     response = app.get(
@@ -36,7 +37,43 @@ class TestGroupControllerNew(helpers.FunctionalTestBase):
 
     def test_save(self):
         app = self._get_test_app()
-        env, response = _get_group_new_page(app)
+        env, response = _get_group_new_page(app, custom_group_type)
+        form = response.forms['group-edit']
+        form['name'] = u'saved'
+
+        response = submit_and_follow(app, form, env, 'save')
+        # check correct redirect
+        assert_equal(response.req.url,
+                     'http://localhost/%s/saved' % custom_group_type)
+        # check saved ok
+        group = model.Group.by_name(u'saved')
+        assert_equal(group.title, u'')
+        assert_equal(group.type, custom_group_type)
+        assert_equal(group.state, 'active')
+
+    def test_custom_group_form(self):
+        '''Our custom group form is being used for new groups.'''
+        app = self._get_test_app()
+        env, response = _get_group_new_page(app, custom_group_type)
+
+        assert_in('My Custom Group Form!', response,
+                  msg="Custom group form not being used.")
+
+
+class TestGroupControllerNew_DefaultGroupType(helpers.FunctionalTestBase):
+    @classmethod
+    def setup_class(cls):
+        super(TestGroupControllerNew_DefaultGroupType, cls).setup_class()
+        plugins.load('example_igroupform_default_group_type')
+
+    @classmethod
+    def teardown_class(cls):
+        plugins.unload('example_igroupform_default_group_type')
+        super(TestGroupControllerNew_DefaultGroupType, cls).teardown_class()
+
+    def test_save(self):
+        app = self._get_test_app()
+        env, response = _get_group_new_page(app, group_type)
         form = response.forms['group-edit']
         form['name'] = u'saved'
 
@@ -50,8 +87,16 @@ class TestGroupControllerNew(helpers.FunctionalTestBase):
         assert_equal(group.type, group_type)
         assert_equal(group.state, 'active')
 
+    def test_custom_group_form(self):
+        '''Our custom group form is being used for new groups.'''
+        app = self._get_test_app()
+        env, response = _get_group_new_page(app, group_type)
 
-def _get_group_edit_page(app, group_name=None):
+        assert_in('My Custom Group Form!', response,
+                  msg="Custom group form not being used.")
+
+
+def _get_group_edit_page(app, group_type, group_name=None):
     user = factories.User()
     if group_name is None:
         group = factories.Group(user=user, type=group_type)
@@ -78,6 +123,47 @@ class TestGroupControllerEdit(helpers.FunctionalTestBase):
         app = self._get_test_app()
         user = factories.User()
         env = {'REMOTE_USER': user['name'].encode('ascii')}
+        url = url_for('%s_edit' % custom_group_type,
+                      id='doesnt_exist')
+        app.get(url=url, extra_environ=env,
+                status=404)
+
+    def test_save(self):
+        app = self._get_test_app()
+        env, response, group_name = \
+            _get_group_edit_page(app, custom_group_type)
+        form = response.forms['group-edit']
+
+        response = submit_and_follow(app, form, env, 'save')
+        group = model.Group.by_name(group_name)
+        assert_equal(group.state, 'active')
+        assert_equal(group.type, custom_group_type)
+
+    def test_custom_group_form(self):
+        '''Our custom group form is being used to edit groups.'''
+        app = self._get_test_app()
+        env, response, group_name = \
+            _get_group_edit_page(app, custom_group_type)
+
+        assert_in('My Custom Group Form!', response,
+                  msg="Custom group form not being used.")
+
+
+class TestGroupControllerEdit_DefaultGroupType(helpers.FunctionalTestBase):
+    @classmethod
+    def setup_class(cls):
+        super(TestGroupControllerEdit_DefaultGroupType, cls).setup_class()
+        plugins.load('example_igroupform_default_group_type')
+
+    @classmethod
+    def teardown_class(cls):
+        plugins.unload('example_igroupform_default_group_type')
+        super(TestGroupControllerEdit_DefaultGroupType, cls).teardown_class()
+
+    def test_group_doesnt_exist(self):
+        app = self._get_test_app()
+        user = factories.User()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
         url = url_for('%s_edit' % group_type,
                       id='doesnt_exist')
         app.get(url=url, extra_environ=env,
@@ -85,10 +171,18 @@ class TestGroupControllerEdit(helpers.FunctionalTestBase):
 
     def test_save(self):
         app = self._get_test_app()
-        env, response, group_name = _get_group_edit_page(app)
+        env, response, group_name = _get_group_edit_page(app, group_type)
         form = response.forms['group-edit']
 
         response = submit_and_follow(app, form, env, 'save')
         group = model.Group.by_name(group_name)
         assert_equal(group.state, 'active')
         assert_equal(group.type, group_type)
+
+    def test_custom_group_form(self):
+        '''Our custom group form is being used to edit groups.'''
+        app = self._get_test_app()
+        env, response, group_name = _get_group_edit_page(app, group_type)
+
+        assert_in('My Custom Group Form!', response,
+                  msg="Custom group form not being used.")

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ entry_points = {
         'example_idatasetform_v3 = ckanext.example_idatasetform.plugin_v3:ExampleIDatasetFormPlugin',
         'example_idatasetform_v4 = ckanext.example_idatasetform.plugin_v4:ExampleIDatasetFormPlugin',
         'example_igroupform = ckanext.example_igroupform.plugin:ExampleIGroupFormPlugin',
+        'example_igroupform_default_group_type = ckanext.example_igroupform.plugin:ExampleIGroupFormPlugin_DefaultGroupType',
         'example_iauthfunctions_v1 = ckanext.example_iauthfunctions.plugin_v1:ExampleIAuthFunctionsPlugin',
         'example_iauthfunctions_v2 = ckanext.example_iauthfunctions.plugin_v2:ExampleIAuthFunctionsPlugin',
         'example_iauthfunctions_v3 = ckanext.example_iauthfunctions.plugin_v3:ExampleIAuthFunctionsPlugin',


### PR DESCRIPTION
Extensions can implement IGroupForm's `group_form` method to define the form template to use for new and editing forms. This isn't working for new forms because the group controller method `_guess_group_types` returns `None` for the default group type [1].

This commit allows `_guess_group_types` to return 'group' for the default group type and adds some tests to ExampleIGroupForm extension tests.

[1] https://github.com/ckan/ckan/blob/9026c30f5d7024623f1512c926acdcc0c46a0490/ckan/controllers/group.py#L131