### PR TITLE
Datastore doc improvement

### DIFF
--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -134,13 +134,12 @@ superuser using::
 
 Then you can use this connection to set the permissions::
 
-    sudo ckan datastore set-permissions |
-    sudo -u postgres psql --set ON_ERROR_STOP=1
+    sudo ckan datastore set-permissions | sudo -u postgres psql --set ON_ERROR_STOP=1
 
 .. note::
    If you performed a source install, you will need to replace all references to
    ``sudo ckan ...`` with ``paster --plugin=ckan ...`` and provide the path to
-   the config file, e.g. ``paster --plugin=ckan datastore set-permissions postgres -c /etc/ckan/default/development.ini``
+   the config file, e.g. ``paster --plugin=ckan datastore set-permissions -c /etc/ckan/default/development.ini``
 
 If your database server is not local, but you can access it over SSH, you can
 pipe the permissions script over SSH::


### PR DESCRIPTION
* Removed confusing line-break after the pipe
* Removed 'postgres' keyword - it was removed in the syntax of recent versions of ckan.