### PR TITLE
Stop reraising exceptions caused by notifications.

### DIFF
--- a/ckan/model/modification.py
+++ b/ckan/model/modification.py
@@ -1,5 +1,7 @@
 import logging
 
+from ckan.lib.search import SearchIndexError
+
 import ckan.plugins as plugins
 import domain_object
 import package as _package
@@ -82,6 +84,9 @@ class DomainObjectModificationExtension(plugins.SingletonPlugin):
                 plugins.IDomainObjectModification):
             try:
                 observer.notify(entity, operation)
+            except SearchIndexError, search_error:
+                log.exception(search_error)
+                raise search_error
             except Exception, ex:
                 log.exception(ex)
 
@@ -90,5 +95,8 @@ class DomainObjectModificationExtension(plugins.SingletonPlugin):
                 plugins.IDomainObjectModification):
             try:
                 observer.notify_after_commit(entity, operation)
+            except SearchIndexError, search_error:
+                log.exception(search_error)
+                raise search_error
             except Exception, ex:
                 log.exception(ex)

--- a/ckan/model/modification.py
+++ b/ckan/model/modification.py
@@ -9,6 +9,7 @@ log = logging.getLogger(__name__)
 
 __all__ = ['DomainObjectModificationExtension']
 
+
 class DomainObjectModificationExtension(plugins.SingletonPlugin):
     """
     A domain object level interface to change notifications
@@ -29,7 +30,6 @@ class DomainObjectModificationExtension(plugins.SingletonPlugin):
         for observer in plugins.PluginImplementations(
                 plugins.IDomainObjectModification):
             func(observer)
-
 
     def before_commit(self, session):
         self.notify_observers(session, self.notify)
@@ -60,7 +60,8 @@ class DomainObjectModificationExtension(plugins.SingletonPlugin):
                 for item in plugins.PluginImplementations(plugins.IResourceUrlChange):
                     item.notify(obj)
 
-        changed_pkgs = set(obj for obj in changed if isinstance(obj, _package.Package))
+        changed_pkgs = set(obj for obj in changed
+                           if isinstance(obj, _package.Package))
 
         for obj in new | changed | deleted:
             if not isinstance(obj, _package.Package):
@@ -76,7 +77,6 @@ class DomainObjectModificationExtension(plugins.SingletonPlugin):
         for obj in changed_pkgs:
             method(obj, domain_object.DomainObjectOperation.changed)
 
-
     def notify(self, entity, operation):
         for observer in plugins.PluginImplementations(
                 plugins.IDomainObjectModification):
@@ -84,9 +84,6 @@ class DomainObjectModificationExtension(plugins.SingletonPlugin):
                 observer.notify(entity, operation)
             except Exception, ex:
                 log.exception(ex)
-                # We reraise all exceptions so they are obvious there
-                # is something wrong
-                raise
 
     def notify_after_commit(self, entity, operation):
         for observer in plugins.PluginImplementations(
@@ -95,6 +92,3 @@ class DomainObjectModificationExtension(plugins.SingletonPlugin):
                 observer.notify_after_commit(entity, operation)
             except Exception, ex:
                 log.exception(ex)
-                # We reraise all exceptions so they are obvious there
-                # is something wrong
-                raise


### PR DESCRIPTION
They are secondary errors and should not prevent the change to the dataset occurring. e.g. I am harvesting some data, but because datapusher has an exception, every time the harvester tries to write it has an exception and fails. Admins should look at their logs for these exceptions, and the primary functions should carry on working.