### PR TITLE
dataset_purge improvements

### DIFF
--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -110,7 +110,8 @@ def dataset_purge(context, data_dict):
             m.purge()
 
     pkg = model.Package.get(id)
-    model.repo.new_revision()
+    # no new_revision() needed since there are no object_revisions created
+    # during purge
     pkg.purge()
     model.repo.commit_and_remove()
 

--- a/ckan/migration/versions/080_continuity_id_indexes.py
+++ b/ckan/migration/versions/080_continuity_id_indexes.py
@@ -1,0 +1,13 @@
+def upgrade(migrate_engine):
+    migrate_engine.execute(
+        '''
+        CREATE INDEX idx_member_continuity_id
+            ON member_revision (continuity_id);
+        CREATE INDEX idx_package_tag_continuity_id
+            ON package_tag_revision (continuity_id);
+        CREATE INDEX idx_package_continuity_id
+            ON package_revision (continuity_id);
+        CREATE INDEX idx_package_extra_continuity_id
+            ON package_extra_revision (continuity_id);
+        '''
+    )

--- a/ckan/model/domain_object.py
+++ b/ckan/model/domain_object.py
@@ -76,15 +76,12 @@ class DomainObject(object):
         self.Session.remove()
 
     def delete(self):
+        # stateful objects have this method overridden - see
+        # vmd.base.StatefulObjectMixin
         self.Session.delete(self)
 
     def purge(self):
         self.Session().autoflush = False
-        if hasattr(self, '__revisioned__'): # only for versioned objects ...
-            # this actually should auto occur due to cascade relationships but
-            # ...
-            for rev in self.all_revisions:
-                self.Session.delete(rev)
         self.Session.delete(self)
 
     def as_dict(self):

--- a/ckan/tests/logic/action/test_delete.py
+++ b/ckan/tests/logic/action/test_delete.py
@@ -207,6 +207,7 @@ class TestDatasetPurge(object):
             groups=[{'name': 'group1'}],
             owner_org=org['id'],
             extras=[{'key': 'testkey', 'value': 'testvalue'}])
+        factories.Resource(package_id=dataset['id'])
         num_revisions_before = model.Session.query(model.Revision).count()
 
         helpers.call_action('dataset_purge',
@@ -216,6 +217,7 @@ class TestDatasetPurge(object):
 
         # the Package and related objects are gone
         assert_equals(model.Session.query(model.Package).all(), [])
+        assert_equals(model.Session.query(model.Resource).all(), [])
         assert_equals(model.Session.query(model.PackageTag).all(), [])
         # there is no clean-up of the tag object itself, just the PackageTag.
         assert_equals([t.name for t in model.Session.query(model.Tag).all()],
@@ -230,13 +232,14 @@ class TestDatasetPurge(object):
 
         # all the object revisions were purged too
         assert_equals(model.Session.query(model.PackageRevision).all(), [])
+        assert_equals(model.Session.query(model.ResourceRevision).all(), [])
         assert_equals(model.Session.query(model.PackageTagRevision).all(), [])
         assert_equals(model.Session.query(model.PackageExtraRevision).all(),
                       [])
         # Member is not revisioned
 
-        # No Revision objects were purged, in fact 1 is created for the purge
-        assert_equals(num_revisions_after - num_revisions_before, 1)
+        # No Revision objects were purged or created
+        assert_equals(num_revisions_after - num_revisions_before, 0)
 
     def test_missing_id_returns_error(self):
         assert_raises(logic.ValidationError,

--- a/test-core.ini
+++ b/test-core.ini
@@ -127,7 +127,10 @@ level = INFO
 [logger_sqlalchemy]
 handlers =
 qualname = sqlalchemy.engine
-level = WARN
+level = WARNING
+# "level = INFO" logs SQL queries.
+# "level = DEBUG" logs SQL queries and results.
+# "level = WARNING" logs neither.
 
 [handler_console]
 class = StreamHandler


### PR DESCRIPTION
Issue: #1572

* no revision is needed when purging the package. The only thing being created is a Activity, which is not revisioned.
* no need to explicitly delete an object's revision objects. Despite the very old comment, it is clear that this does happen naturally through cascades. This is verified in the test and by reading the SQL produced.
* more indexes to improve speed further.
* Added a resource to the test for fullness.
* Added helpful comments to the test-core.ini to show people how to use it to see generated SQL commands.