### PR TITLE
[WIP] Fix encoding of setup.py for non-ascii names

### DIFF
--- a/ckan/pastertemplates/__init__.py
+++ b/ckan/pastertemplates/__init__.py
@@ -51,6 +51,9 @@ class CkanextTemplate(Template):
     def check_vars(self, vars, cmd):
         vars = Template.check_vars(self, vars, cmd)
 
+        reload(sys)
+        sys.setdefaultencoding('utf-8')
+
         if not vars['project'].startswith('ckanext-'):
             print "\nError: Project name must start with 'ckanext-'"
             sys.exit(1)
@@ -63,7 +66,7 @@ class CkanextTemplate(Template):
         keywords = [keyword for keyword in keywords
                     if keyword not in ('ckan', 'CKAN')]
         keywords.insert(0, 'CKAN')
-        vars['keywords'] = ' '.join(keywords)
+        vars['keywords'] = u' '.join(keywords)
 
         # For an extension named ckanext-example we want a plugin class
         # named ExamplePlugin.

--- a/ckan/pastertemplates/__init__.py
+++ b/ckan/pastertemplates/__init__.py
@@ -51,6 +51,8 @@ class CkanextTemplate(Template):
     def check_vars(self, vars, cmd):
         vars = Template.check_vars(self, vars, cmd)
 
+        # workaround for a paster issue https://github.com/ckan/ckan/issues/2636
+        # this is only used from a short-lived paster command
         reload(sys)
         sys.setdefaultencoding('utf-8')
 

--- a/ckan/pastertemplates/template/setup.py_tmpl
+++ b/ckan/pastertemplates/template/setup.py_tmpl
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from setuptools import setup, find_packages  # Always prefer setuptools over distutils
 from codecs import open  # To use a consistent encoding
 from os import path


### PR DESCRIPTION
Sets the default-encoding so that what the user enters is utf8 and
this stops the paster templates for exploding.  Also sets the encoding
on the setup.py template so that it can be run if it has utf8 chars in it

This should fix #2636