### PR TITLE
Exception when viewing Organizations extended with IGroupForm

### DIFF
--- a/ckan/config/routing.py
+++ b/ckan/config/routing.py
@@ -316,7 +316,7 @@ def make_map():
                       'member_delete',
                       'history'
                   ])))
-        m.connect('organization_activity', '/organization/activity/{id}',
+        m.connect('organization_activity', '/organization/activity/{id}/{offset}',
                   action='activity', ckan_icon='time')
         m.connect('organization_read', '/organization/{id}', action='read')
         m.connect('organization_about', '/organization/about/{id}',

--- a/ckan/templates/organization/read_base.html
+++ b/ckan/templates/organization/read_base.html
@@ -15,7 +15,7 @@
 
 {% block content_primary_nav %}
   {{ h.build_nav_icon('organization_read', _('Datasets'), id=c.group_dict.name) }}
-  {{ h.build_nav_icon('organization_activity', _('Activity Stream'), id=c.group_dict.name) }}
+  {{ h.build_nav_icon('organization_activity', _('Activity Stream'), id=c.group_dict.name, offset=0) }}
   {{ h.build_nav_icon('organization_about', _('About'), id=c.group_dict.name) }}
 {% endblock %}
 


### PR DESCRIPTION
Viewing an organization that's been extended with IGroupForm causes an exception:

`Exception: menu item 'organization_activity' need parameter 'offset'`

The default organization_activity route [1] doesn't include an `offset` parameter, but a new route is set up for custom IGroupForm plugins in `lib/plugins.py` [2], which does include the `offset` param. The `group_activity` route includes the offset param, so it being missing from organization is likely an oversight.

Suggest:

1) Add the offset parameter to the organization read_base.html template in the same way it is in the group read_base.html

2) Adding the `{offset}` param to the default organization_activity route.

---

[1] https://github.com/ckan/ckan/blob/ed5fe6e86e520800edcf84d37e5f0c1d8a6ef485/ckan/config/routing.py#L319

[2] https://github.com/ckan/ckan/blob/ed5fe6e86e520800edcf84d37e5f0c1d8a6ef485/ckan/lib/plugins.py#L191