### PR TITLE
Search index rebuild takes a while; let's give it a progress counter

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -402,14 +402,14 @@ class SearchIndexCommand(CkanCommand):
     '''Creates a search index for all datasets
 
     Usage:
-      search-index [-i] [-o] [-r] [-e] rebuild [dataset_name]  - reindex dataset_name if given, if not then rebuild
-                                                                 full search index (all datasets)
-      search-index rebuild_fast                                - reindex using multiprocessing using all cores.
-                                                                 This acts in the same way as rubuild -r [EXPERIMENTAL]
-      search-index check                                       - checks for datasets not indexed
-      search-index show DATASET_NAME                           - shows index of a dataset
-      search-index clear [dataset_name]                        - clears the search index for the provided dataset or
-                                                                 for the whole ckan instance
+      search-index [-i] [-o] [-r] [-e] [-q] rebuild [dataset_name]  - reindex dataset_name if given, if not then rebuild
+                                                                    full search index (all datasets)
+      search-index rebuild_fast                                     - reindex using multiprocessing using all cores.
+                                                                    This acts in the same way as rubuild -r [EXPERIMENTAL]
+      search-index check                                            - checks for datasets not indexed
+      search-index show DATASET_NAME                                - shows index of a dataset
+      search-index clear [dataset_name]                             - clears the search index for the provided dataset or
+                                                                    for the whole ckan instance
     '''
 
     summary = __doc__.split('\n')[0]
@@ -431,6 +431,10 @@ class SearchIndexCommand(CkanCommand):
         self.parser.add_option('-r', '--refresh', dest='refresh',
                                action='store_true', default=False,
                                help='Refresh current index (does not clear the existing one)')
+
+        self.parser.add_option('-q', '--quiet', dest='quiet',
+                               action='store_true', default=False,
+                               help='Do not output index rebuild progress')
 
         self.parser.add_option('-e', '--commit-each', dest='commit_each',
                                action='store_true', default=False, help=
@@ -474,7 +478,8 @@ Default is false.''')
             rebuild(only_missing=self.options.only_missing,
                     force=self.options.force,
                     refresh=self.options.refresh,
-                    defer_commit=(not self.options.commit_each))
+                    defer_commit=(not self.options.commit_each),
+                    quiet=self.options.quiet)
 
         if not self.options.commit_each:
             commit()

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -135,7 +135,8 @@ class SynchronousSearchPlugin(p.SingletonPlugin):
             log.warn("Discarded Sync. indexing for: %s" % entity)
 
 
-def rebuild(package_id=None, only_missing=False, force=False, refresh=False, defer_commit=False, package_ids=None):
+def rebuild(package_id=None, only_missing=False, force=False, refresh=False,
+            defer_commit=False, package_ids=None, quiet=False):
     '''
         Rebuilds the search index.
 
@@ -185,10 +186,12 @@ def rebuild(package_id=None, only_missing=False, force=False, refresh=False, def
 
         total_packages = len(package_ids)
         for counter, pkg_id in enumerate(package_ids):
-            sys.stdout.write(
-                "\rIndexing dataset {0}/{1}".format(counter, total_packages)
-            )
-            sys.stdout.flush()
+            if not quiet:
+                sys.stdout.write(
+                    "\rIndexing dataset {0}/{1}".format(
+                        counter +1, total_packages)
+                )
+                sys.stdout.flush()
             try:
                 package_index.update_dict(
                     logic.get_action('package_show')(context,

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -183,7 +183,12 @@ def rebuild(package_id=None, only_missing=False, force=False, refresh=False, def
             if not refresh:
                 package_index.clear()
 
-        for pkg_id in package_ids:
+        total_packages = len(package_ids)
+        for counter, pkg_id in enumerate(package_ids):
+            sys.stdout.write(
+                "\rIndexing dataset {0}/{1}".format(counter, total_packages)
+            )
+            sys.stdout.flush()
             try:
                 package_index.update_dict(
                     logic.get_action('package_show')(context,


### PR DESCRIPTION
Search index rebuild can take an hour or two when you have many thousands of datasets. This PR shows a simple counter, so that the user can get a little bit of feedback on the progress, and know that the rebuild isn't stuck somewhere.