### PR TITLE
Clarify that site_url doesn't set the site's mount path

### DIFF
--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -270,10 +270,14 @@ Example::
 
 Default value:  (an explicit value is mandatory)
 
-The URL of your CKAN site. Many CKAN features that need an absolute URL to your
+Set this to the URL of your CKAN site. Many CKAN features that need an absolute URL to your
 site use this setting.
 
 .. important:: It is mandatory to complete this setting
+
+.. note:: If you want to mount CKAN at a path other than /, then this setting
+  should reflect that, but the URL you mount it at is determined by your
+  apache config (your WSGIScriptAlias path) (or equivalent for other servers).
 
 .. warning::
 


### PR DESCRIPTION
In response to:
http://stackoverflow.com/questions/32495459/install-ckan-in-a-sub-directory