### PR TITLE
fixed navbar.less for latest lessc version

### DIFF
--- a/ckan/public/base/vendor/bootstrap/less/navbar.less
+++ b/ckan/public/base/vendor/bootstrap/less/navbar.less
@@ -192,11 +192,12 @@
 }
 
 // Reset container width
-// Required here as we reset the width earlier on and the grid mixins don't override early enough
+// Required here as we reset the width earlier on and the grid mixins dont override early enough
 .navbar-static-top .container,
 .navbar-fixed-top .container,
 .navbar-fixed-bottom .container {
-  #grid > .core > .span(@gridColumns);
+    width: (@gridColumnWidth * @gridColumns) + (@gridGutterWidth * (@gridColumns - 1));
+// #grid > .core > .span(@gridColumns);
 }
 
 // Fixed to top


### PR DESCRIPTION
If the current version of less.js (2.5.1) compiles navbar.less (called from bin/less), the following error occurs:

```
An error occurred running the less command:
Command failed: NameError: #grid > .core > .span is undefined in /home/vonwalha/ckan/lib/default/src/ckan/ckan/public/base/vendor/bootstrap/less/navbar.less on line 199, column 3:
198 .navbar-fixed-bottom .container {
199   #grid > .core > .span(@gridColumns);
200 }
```
This results in an empty main.css.

Apparently this is due to an incompatibility between less.js versions. The fix was taken from
http://stackoverflow.com/questions/26628309/less-v2-does-not-compile-twitters-bootstrap-2-x