### PR TITLE
Docs say extensions should import ungettext from ckan.plugins.toolkit. Doesn't have ungettext.

### DIFF
--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -18,6 +18,7 @@ class _Toolkit(object):
     contents = [
         ## Imported functions/objects ##
         '_',                    # i18n translation
+        'ungettext',            # i18n translation (plural forms)
         'c',                    # template context
         'request',              # http request object
         'render',               # template render function
@@ -110,6 +111,19 @@ Everywhere in your code where you want strings to be internationalized
 ``_()`` function, eg.::
 
     msg = toolkit._("Hello")
+
+'''
+        t['ungettext'] = common.ungettext
+        self.docstring_overrides['ungettext'] = '''The Pylons ``ungettext``
+        function.
+
+Mark a string for translation that has pural forms in the format
+``ungettext(singular, plural, n)``. Returns the localized unicode string of
+the pluralized value.
+
+Mark a string to be localized as follows::
+
+    msg = toolkit.ungettext("Mouse", "Mice", len(mouses))
 
 '''
         t['c'] = common.c


### PR DESCRIPTION
:disappointed: 

http://docs.ckan.org/en/latest/contributing/string-i18n.html#internationalizing-strings-in-python-code

This pull request adds ungettext to toolkit.