### PR TITLE
Allow url schemes to be configured in config

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -244,8 +244,11 @@ def is_url(*args, **kw):
     except ValueError:
         return False
 
-    valid_schemes = ('http', 'https', 'ftp')
-    return url.scheme in valid_schemes
+    default_valid_schemes = ('http', 'https', 'ftp')
+
+    valid_schemes = config.get('ckan.valid_url_schemes', '').lower().split()
+
+    return url.scheme in (valid_schemes or default_valid_schemes)
 
 
 def _add_i18n_to_url(url_to_amend, **kw):

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -392,6 +392,16 @@ Default value: ``False``
 
 This controls if CKAN will track the site usage. For more info, read :ref:`tracking`.
 
+ckan.valid_url_schemes
+^^^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+  ckan.valid_url_schemes = http https ftp sftp
+
+Default value: ``http https ftp``
+
+Controls what uri schemes are rendered as links.
 
 .. _config-authorization:
 


### PR DESCRIPTION
Hi,

I have a use-case for my organization where I want to enable additional URL schemes for linked data sources (such as `sftp`.) This PR adds a new configuration option for `ckan.valid_url_schemes` that allows you to specify additional schemes.

Thanks!