### PR TITLE
Add a before_edit method to the IPackageController

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1076,6 +1076,10 @@ def package_show(context, data_dict):
     if context.get('for_view'):
         for item in plugins.PluginImplementations(plugins.IPackageController):
             package_dict = item.before_view(package_dict)
+    elif context.get('for_edit'):
+        for item in plugins.PluginImplementations(plugins.IPackageController):
+            package_dict = item.before_edit(package_dict)
+
 
     for item in plugins.PluginImplementations(plugins.IPackageController):
         item.read(pkg)

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -591,6 +591,13 @@ class IPackageController(Interface):
         '''
         return pkg_dict
 
+    def before_edit(self, pkg_dict):
+        '''
+             Extensions will recieve this before the dataset gets
+             displayed. The dictionary passed will be the one that gets
+             sent to the template.
+        '''
+        return pkg_dict
 
 class IResourceController(Interface):
     """


### PR DESCRIPTION
The reason why we need this is that we use Fluent on datasets titles. For the view pages, we use the `before_view` method to resolve the fluent fields to the current UI language but we can't on the edit page which cause fluent field to be rendered as dictionaries.