### PR TITLE
Do not crash on AttributeError in dict_list_reduce helper function

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -868,7 +868,11 @@ def dict_list_reduce(list_, key, unique=True):
     values for the key with unique values if requested. '''
     new_list = []
     for item in list_:
-        value = item.get(key)
+        try:
+            value = item.get(key)
+        except AttributeError:
+            # item might not be a dict.
+            continue
         if not value or (unique and value in new_list):
             continue
         new_list.append(value)


### PR DESCRIPTION
I got the following error on a freshly installed CKAN 2.4.1 (source install) after adding a few datasets on a request to the home page.

```
[...]
File '/usr/local/src/ckan/ckan/templates/snippets/package_item.html', line 66 in block "resources_inner"
  {% for resource in h.dict_list_reduce(package.resources, 'format') %}
File '/usr/local/src/ckan/ckan/lib/helpers.py', line 872 in dict_list_reduce
  value = item.get(key)
AttributeError: 'int' object has no attribute 'get'
```

Not sure why this occurs... Looking closer, I saw `0` and `1` integers values as `item` (`key` was `'format'`).
