### PR TITLE
Package_search does not return more than a 1000 rows

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1768,7 +1768,8 @@ def package_search(context, data_dict):
         documentation, this is a comma-separated string of field names and
         sort-orderings.
     :type sort: string
-    :param rows: the number of matching rows to return.
+    :param rows: the number of matching rows to return. There is a hard limit
+        of 1000 datasets per query.
     :type rows: int
     :param start: the offset in the complete result for where the set of
         returned datasets should begin.


### PR DESCRIPTION
Package_search allows to define the amount of results through the rows parameter, but apparently values more than a 1000 don't have effect. At least in our instance at https://www.opendata.fi/en and data.gov.uk.

If this is by design, it should at least be documented since it is used in quite many extensions for example: 
https://github.com/ckan/ckanapi-exporter/blob/master/ckanapi_exporter/exporter.py#L18

which returns only 1000 results.