### PR TITLE
package-search: improving performance on fetching facet display name (2nd try)

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1968,7 +1968,7 @@ def package_search(context, data_dict):
 
     #Querying just for the columns we're interested in: name and title
     groups = session.query(model.Group.name, model.Group.title).filter(model.Group.name.in_(group_keys)).all()
-    group_display_names = {g.name: g.title for g in groups}
+    group_display_names = dict((g.name, g.title) for g in groups)
 
     # Transform facets into a more useful data structure.
     restructured_facets = {}

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1944,7 +1944,7 @@ def package_search(context, data_dict):
                         package_dict = item.before_view(package_dict)
                 results.append(package_dict)
             else:
-                results.append(model_dictize.package_dictize(pkg, context))
+                log.error('No package_dict is coming from solr for package with id {}'.format(package))
 
         count = query.count
         facets = query.facets


### PR DESCRIPTION
In our CKAN project, [HDX](https://data.hdx.rwlabs.org), we show all facets ( as opposed to just the popular ones ) on the search page. We have 241 groups and 110 orgs so the time spent for fetching the `display_name` for the orgs and groups can be significant. Therefore, instead of fetching the title for each org and group I've changed the code to do only one db query and to fetch only the needed columns.

## On HDX
On my laptop ( i5, 16GB RAM, SSD ) I get the following time with the **unchanged pacakge_search()** function:
  * `2015-10-18 20:07:16,683 INFO  [ckan.lib.base]  /dataset render time 2.159 seconds`

**After the change**:
  * `2015-10-18 20:05:28,595 INFO  [ckan.lib.base]  /dataset render time 0.930 seconds`

## On "Core" CKAN
I get the following time with the **unchanged pacakge_search()** function:
  * on /dataset `2015-10-18 20:44:50,578 INFO  [ckan.lib.base]  /dataset render time 0.347 seconds`
  * on /dataset?_organization_limit=0&_groups_limit=0 `2015-10-18 20:47:28,893 INFO  [ckan.lib.base]  /dataset render time 0.417 seconds`

**And after the change**:
  * on /dataset `2015-10-18 20:40:33,138 INFO  [ckan.lib.base]  /dataset render time 0.205 seconds`
  * /dataset?_organization_limit=0&_groups_limit=0 `2015-10-18 20:43:14,784 INFO  [ckan.lib.base]  /dataset render time 0.221 seconds`

In debug mode ( pydevd ), the differences are much higher: around 3 seconds on HDX and 1 second on core ckan


Also I removed a reference to the **pkg** variable that is no longer used since "trusting solr".