### PR TITLE
Do not crash when indexing fails on a dataset with unicode.

### DIFF
--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -192,8 +192,8 @@ def rebuild(package_id=None, only_missing=False, force=False, refresh=False, def
                     defer_commit
                 )
             except Exception, e:
-                log.error('Error while indexing dataset %s: %s' %
-                          (pkg_id, str(e)))
+                log.error(u'Error while indexing dataset %s: %s' %
+                          (pkg_id, repr(e)))
                 if force:
                     log.error(text_traceback())
                     continue


### PR DESCRIPTION
If an exception is raised while indexing, and that dataset contains unicode, a second exception will be raised trampling the first.