### PR TITLE
add an errors block to resource_form

### DIFF
--- a/ckan/templates/package/snippets/resource_form.html
+++ b/ckan/templates/package/snippets/resource_form.html
@@ -12,7 +12,7 @@
     {% endif %}
   {% endblock %}
 
-  {{ form.errors(error_summary) }}
+  {% block errors %}{{ form.errors(error_summary) }}{% endblock %}
 
   <input name="id" value="{{ data.id }}" type="hidden"/>
 


### PR DESCRIPTION
Bring resource_form in line with package_form: allow the errors at the top of the form to be overridden. I need this for scheming's custom errors with the correct field labels for each field.