### PR TITLE
[#2697] Make sure package_autocomplete uses LIKE with wildcards

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1608,7 +1608,7 @@ def package_autocomplete(context, data_dict):
     limit = data_dict.get('limit', 10)
     q = data_dict['q']
 
-    like_q = u"%s%%" % q
+    like_q = u"%%%s%%" % q
 
     query = model.Session.query(model.Package)
     query = query.filter(model.Package.state == 'active')


### PR DESCRIPTION
The current implementation uses 'q%' to search for packages starting
with a certain search term. This commit changes this to use the
following format: '%q%', thus search for the term anywhere in the title
and name field.