### PR TITLE
Read both resource proxy constants from config file

### DIFF
--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -151,7 +151,9 @@ ckan.feeds.author_link =
 
 # Resource Proxy settings
 # Preview size limit, default: 1MB
-#ckan.resource_proxy.max_file_size = 1 * 1024 * 1024
+#ckan.resource_proxy.max_file_size = 1048576
+# Size of chunks to read/write.
+#ckan.resource_proxy.chunk_size = 4096
 
 ## Activity Streams Settings
 

--- a/ckanext/resourceproxy/controller.py
+++ b/ckanext/resourceproxy/controller.py
@@ -8,13 +8,12 @@ import pylons.config as config
 import ckan.logic as logic
 import ckan.lib.base as base
 from ckan.common import _
-import ckan.plugins.toolkit as toolkit
+from ckan.plugins.toolkit import asint
 
 log = getLogger(__name__)
 
-MAX_FILE_SIZE = toolkit.asint(
-    config.get('ckan.resource_proxy.max_file_size', 1024 * 1024))
-CHUNK_SIZE = 512
+MAX_FILE_SIZE = asint(config.get('ckan.resource_proxy.max_file_size', 1024**2))
+CHUNK_SIZE = asint(config.get('ckan.resource_proxy.chunk_size', 4096))
 
 
 def proxy_resource(context, data_dict):

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -791,14 +791,30 @@ ckan.resource_proxy.max_file_size
 
 Example::
 
-    ckan.resource_proxy.max_file_size = 1 * 1024 * 1024
+    ckan.resource_proxy.max_file_size = 1048576
 
-Default value:  ``1 * 1024 * 1024`` (1 MB)
+Default value:  ``1048576`` (1 MB)
 
 This sets the upper file size limit for in-line previews.
 Increasing the value allows CKAN to preview larger files (e.g. PDFs) in-line;
 however, a higher value might cause time-outs, or unresponsive browsers for CKAN users
 with lower bandwidth. If left commented out, CKAN will default to 1 MB.
+
+
+.. _ckan.resource_proxy.chunk_size:
+
+ckan.resource_proxy.chunk_size
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+    ckan.resource_proxy.chunk_size = 8192
+
+Default value:  ``4096``
+
+This sets size of the chunk to read and write when proxying.
+Raising this value might save some CPU cycles. It makes no sense to lower it
+below the page size, which is default.
 
 
 Front-End Settings


### PR DESCRIPTION
Hi, using the `1 * 1024 * 1024` value in `ckan.resource_proxy.max_file_size` configuration option has been failing with integer format exception, so I took the liberty to change it to an actual integer. I have also added the second parameter `ckan.resource_proxy.chunk_size`, which originally had a rather small value of `512`. New default is `4096`, which is the PAGESIZE on most platforms.

Please consider merging in.