### PR TITLE
[WIP] Initial implementation of providing async calls via RQ

### DIFF
--- a/bin/travis-install-dependencies
+++ b/bin/travis-install-dependencies
@@ -14,7 +14,7 @@ fi
 
 # Install postgres and solr
 sudo apt-get update -qq
-sudo apt-get install postgresql-$PGVERSION solr-jetty libcommons-fileupload-java:amd64=1.2.2-1
+sudo apt-get install postgresql-$PGVERSION solr-jetty libcommons-fileupload-java:amd64=1.2.2-1 redis-server
 
 if [ $PGVERSION == '8.4' ]
 then

--- a/ckan/lib/queue.py
+++ b/ckan/lib/queue.py
@@ -1,0 +1,107 @@
+from pylons import config
+
+from rq import Queue
+from redis import Redis
+
+from logging import getLogger
+log = getLogger(__name__)
+
+
+queues = None
+
+
+def init_queues():
+    '''
+    Attempt to initialise the three queues on first use. There's no need
+    to create these until we need them (we might not). This will explode
+    if redis is not reachable
+    '''
+    global queues
+
+    connection_url = config.get(u'ckan.queues.url',
+                                u'redis://localhost:6379/0')
+    redis_conn = Redis.from_url(connection_url)
+
+    try:
+        queues = {
+            'low': Queue('low', connection=redis_conn),
+            'medium': Queue('medium', connection=redis_conn),
+            'high': Queue('high', connection=redis_conn)
+        }
+    except Exception, e:
+        log.exception(e)
+
+
+def async(fn, arguments, priority='medium', timeout=30):
+    '''
+    Enqueue a task to be run in the background.
+
+        :param fn: A function to be executed in the background. This
+            should be imported by the caller.
+        :type fn: function
+
+        :param arguments: A list of arguments to be passed to the function,
+            should be empty if there are no arguments.
+        :type arguments: list
+
+        :param priority: The priority of this task, low, medium or high.  By
+            default this is medium.
+        :type priority: string
+
+        :param timeout: How long this should wait before considering
+            the job lost
+        :type: integer
+
+    '''
+    if not queues:
+        init_queues()
+
+    if priority not in queues.keys():
+        raise ValueError("priority is not a valid value")
+
+    job = queues[priority].enqueue_call(func=fn,
+                                        args=arguments, timeout=timeout)
+    log.info("Enqueued task: %r" % job)
+
+
+def clear_tasks(queue_priority):
+    ''' Empties the specified queue and returns the number of items
+       deleted. '''
+    if queues is None:
+        init_queues()
+
+    if queue_priority not in queues.keys():
+        raise ValueError("priority is not a valid value")
+
+    # We have to manually clear the queue unless we use rqinfo on the
+    # command line
+    counter = 0
+    redis_conn = Redis()
+    while True:
+        job_id = redis_conn.lpop("rq:queue:%s" % queue_priority)
+        if job_id is None:
+            break
+        redis_conn.delete("rq:job:" + job_id)
+        log.info("Deleted task: %s" % job_id)
+        counter += 1
+    return counter
+
+
+def task_count(queue_priority=None):
+    '''
+    Returns the number of jobs in the queue specified, which should be low,
+    medium, or high. If no queue is specified, the size of all of the queues is
+    returned.
+    '''
+    if queues is None:
+        init_queues()
+
+    if queue_priority and queue_priority not in queues.keys():
+        raise ValueError("priority is not a valid value")
+
+    size = 0
+    if not queue_priority:
+        size = sum(len(q.job_ids) for q in queues.values())
+    else:
+        size = len(queues.get(queue_priority).job_ids)
+    return size

--- a/ckan/lib/tasks.py
+++ b/ckan/lib/tasks.py
@@ -1,0 +1,53 @@
+from pylons import config
+from ckan.lib.cli import CkanCommand
+from rq import Queue, Connection, Worker
+from redis import Redis
+
+from logging import getLogger
+
+
+class RunTasksCommand(CkanCommand):
+    """Run background tasks
+
+    Creates a worker to listen to one or more queues, and then execute
+    the jobs that it finds there.
+
+    Usage:
+      paster queue               - Listen to high, medium and low queues
+      paster queue -n low        - Listen to only low priorty queue
+      paster queue -n high,low   - Listen to high and low queues
+    """
+
+    summary = __doc__.split('\n')[0]
+    usage = __doc__
+    min_args = 0
+
+    def __init__(self, name):
+        super(RunTasksCommand, self).__init__(name)
+
+        def prep_names(option, opt, value, parser):
+            setattr(parser.values, option.dest, value.split(','))
+
+        self.parser.add_option(u'-n', u'--names', type=u'string',
+                               action=u'callback',
+                               callback=prep_names,
+                               default=['low', 'medium', 'high'],
+                               help=u'specify queue names to watch',)
+
+    def command(self):
+        self._load_config()
+
+        # Can only create a logger *after* loading config.
+        self.log = getLogger(__name__)
+
+        connection_url = config.get(u'ckan.queues.url',
+                                    u'redis://localhost:6379/0')
+        self.log.info(u'Attempting connection to {url}'
+            .format(url=connection_url))
+
+        with Connection(Redis.from_url(connection_url)):
+            self.log.info(u'Listening to queues => %s', self.options.names)
+            qs = [Queue(n) for n in self.options.names]
+            w = Worker(qs)
+            w.work()
+            log.info("Doing work!")

--- a/ckan/pastertemplates/template/bin/travis-build.bash_tmpl
+++ b/ckan/pastertemplates/template/bin/travis-build.bash_tmpl
@@ -5,7 +5,7 @@ echo "This is travis-build.bash..."
 
 echo "Installing the packages that CKAN requires..."
 sudo apt-get update -qq
-sudo apt-get install postgresql-$PGVERSION solr-jetty libcommons-fileupload-java:amd64=1.2.2-1
+sudo apt-get install postgresql-$PGVERSION solr-jetty libcommons-fileupload-java:amd64=1.2.2-1 redis-server
 
 echo "Installing CKAN and its Python dependencies..."
 git clone https://github.com/ckan/ckan

--- a/ckan/tests/lib/test_queue.py
+++ b/ckan/tests/lib/test_queue.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+import logging
+from nose.tools import raises
+
+import ckan.tests.helpers as helpers
+import ckan.lib.queue as queue
+
+log = logging.getLogger(__name__)
+
+
+def fake_function():
+    return 42
+
+
+class TestTasks(object):
+
+    def setup(self):
+        queue.clear_tasks('low')
+        queue.clear_tasks('medium')
+        queue.clear_tasks('high')
+
+    def test_simple_async(self):
+        queue.async(fake_function, [])
+        assert queue.task_count('medium') == 1
+
+    @raises(ValueError)
+    def test_failing_async_bad_priority(self):
+        queue.async(fake_function, [], priority="immediately")
+
+    def test_queue_size(self):
+        queue.async(fake_function, [], priority='low')
+        queue.async(fake_function, [], priority='low')
+        queue.async(fake_function, [], priority='low')
+        assert task.task_count('low') == 3
+        queue.clear_queue('low')
+        assert queue.task_count('low') == 0
+
+    @raises(ValueError)
+    def test_queue_size_invalid(self):
+        assert queue.task_count('immediately') == 0
+
+    def test_queue_size(self):
+        queue.async(fake_function, [], priority='low')
+        queue.async(fake_function, [], priority='medium')
+        queue.async(fake_function, [], priority='high')
+        assert queue.task_count() == 3

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ repoze.who-friendlyform==1.0.8
 repoze.who==2.0
 requests==2.7.0
 routes==1.13
+rq==0.5.6
 simplejson==3.3.1         # via pylons HAND-FIXED FOR NOW #2681
 six==1.10.0               # via pastescript, sqlalchemy-migrate
 solrpy==0.9.5

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ entry_points = {
         'front-end-build = ckan.lib.cli:FrontEndBuildCommand',
         'views = ckan.lib.cli:ViewsCommand',
         'config-tool = ckan.lib.cli:ConfigToolCommand',
+        'queue = ckan.lib.tasks:RunTasksCommand',
     ],
     'console_scripts': [
         'ckan-admin = bin.ckan_admin:Command',


### PR DESCRIPTION
Hi,

I’ve started this PR so that we can have a discussion about approach for solving https://github.com/ckan/ideas-and-roadmap/issues/66 - suspect this will be post 2.5 now.

My initial approach is to provide a function that we (and plugin developers) can call to run a task asynchronously.  This task should be enqueued pretty quickly and return as soon as it can.

Currently that code looks like 

```
from ckan.lib.task import async 
from myckanextention.tasks import my_async_task
async(my_async_task, [arg1, arg2], priority=‘low’)
```

This will then get picked up by rqworker running as a separate process and executed. 

There are lots of outstanding questions:
1. Currently I’ve implemented low, medium and high priority, but rqworker is flexible enough to listen to several, or only one queue, so this can be configured as necessary.  Enough levels? Too many priority levels? 
2. Importing the function you want to call is potentially onerous, should we have core and plugins register the functions they want to call against a name (via the ITask plugin), which can be used rather than the logic layer having to import them - like ITemplateHelpers and IAction? Sort of like `async(‘harvest_run’, [])`. 
3. Should rqworker be allowed to pre-import the CKAN runtime, or should tasks be force to run independently (only communicating via the API)?
4. Is this approach sane? Should we leave it to those who want to use it to do all the work with setup and call rq directly? Should CKAN be providing the entry-point (I obviously think that yes, it should).
5. We should handle the case where someone doesn’t have redis installed (and therefore async tasks fail).  Should this be fatal, i.e. if you try and use async() and redis isn’t installed - it should crash?
