### PR TITLE
fixes error message when using GET on POST-only actions

### DIFF
--- a/ckan/controllers/api.py
+++ b/ckan/controllers/api.py
@@ -893,7 +893,7 @@ class ApiController(base.BaseController):
             cls.log.debug('Retrieved request body: %r', request.body)
             if not request_data:
                 if not try_url_params:
-                    msg = "Invalid request. Please use POST method"
+                    msg = "Invalid request. Please use POST method" \
                         "for your request"
                     raise ValueError(msg)
                 else:

--- a/ckan/controllers/api.py
+++ b/ckan/controllers/api.py
@@ -893,7 +893,8 @@ class ApiController(base.BaseController):
             cls.log.debug('Retrieved request body: %r', request.body)
             if not request_data:
                 if not try_url_params:
-                    msg = "Invalid request. Please use POST method for your request"
+                    msg = "Invalid request. Please use POST method"
+                        "for your request"
                     raise ValueError(msg)
                 else:
                     request_data = {}

--- a/ckan/controllers/api.py
+++ b/ckan/controllers/api.py
@@ -894,7 +894,7 @@ class ApiController(base.BaseController):
             if not request_data:
                 if not try_url_params:
                     msg = "Invalid request. Please use POST method" \
-                        "for your request"
+                        " for your request"
                     raise ValueError(msg)
                 else:
                     request_data = {}

--- a/ckan/controllers/api.py
+++ b/ckan/controllers/api.py
@@ -893,7 +893,7 @@ class ApiController(base.BaseController):
             cls.log.debug('Retrieved request body: %r', request.body)
             if not request_data:
                 if not try_url_params:
-                    msg = "No request body data"
+                    msg = "Invalid request. Please use POST method for your request"
                     raise ValueError(msg)
                 else:
                     request_data = {}

--- a/ckan/tests/legacy/functional/api/test_api.py
+++ b/ckan/tests/legacy/functional/api/test_api.py
@@ -5,7 +5,7 @@ from ckan.tests.legacy.functional.api.base import *
 import ckan.tests.legacy
 assert_in = ckan.tests.legacy.assert_in
 
-class ApiTestCase(ApiTestCase, ControllerTestCase): 
+class ApiTestCase(ApiTestCase, ControllerTestCase):
 
     def test_get_api(self):
         offset = self.offset('')
@@ -16,7 +16,7 @@ class ApiTestCase(ApiTestCase, ControllerTestCase):
         data = self.data_from_res(res)
         assert 'version' in data, data
         expected_version = self.get_expected_api_version()
-        self.assert_equal(data['version'], expected_version) 
+        self.assert_equal(data['version'], expected_version)
 
 class TestApi3(Api3TestCase, ApiTestCase):
 
@@ -46,7 +46,8 @@ class TestApi3(Api3TestCase, ApiTestCase):
                            params=data_dict,
                            status=[400],
                            expect_errors=True)
-        assert_in('Bad request - JSON Error: No request body data',
+        assert_in('Bad request - JSON Error: Invalid request.'\
+                  ' Please use POST method for your request',
                   res.body)
 
 # Tests for Version 1 of the API.


### PR DESCRIPTION
When request_data is None and try_url_params, it basically means you are calling a POST-only action with GET method, the original error message is not quite clear. I bumped into the error message when I was calling organization_purge in the url bar in my browser, and it took me some time to figure out why, so I think the modification would give users a better idea what exactly went wrong