### PR TITLE
resource_edit incorrectly setting action to new instead of edit.

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -644,7 +644,7 @@ class PackageController(base.BaseController):
         errors = errors or {}
         error_summary = error_summary or {}
         vars = {'data': data, 'errors': errors,
-                'error_summary': error_summary, 'action': 'new',
+                'error_summary': error_summary, 'action': 'edit',
                 'resource_form_snippet': self._resource_form(package_type),
                 'dataset_type': package_type}
         return render('package/resource_edit.html', extra_vars=vars)


### PR DESCRIPTION
resource_edit incorrectly setting `action='new'` instead of `action='edit'`. This value being set properly is required for our extension to behave properly when setting field defaults (we only want to set a default value if action='new').