### PR TITLE
Use old style Travis builds

### DIFF
--- a/ckan/pastertemplates/template/+dot+travis.yml_tmpl
+++ b/ckan/pastertemplates/template/+dot+travis.yml_tmpl
@@ -1,4 +1,5 @@
 language: python
+sudo: required
 python:
     - "2.6"
     - "2.7"


### PR DESCRIPTION
Travis has migrated to the new [container infrastructure](http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/) for every new build. We cannot use this because we use some commands with `sudo`.

I've modified the `.travis.yml` template so that new extension build on the old infrastructure.