### PR TITLE
SQL 'execute' audit

### DIFF
--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -505,9 +505,9 @@ class TestDatastoreCreate(tests.WsgiAppCase):
 
             assert results == results_alias
 
-            sql = (u"select * from _table_metadata "
-                "where alias_of='{0}' and name='{1}'").format(resource.id, alias)
-            results = c.execute(sql)
+            sql = u"select * from _table_metadata " \
+                  "where alias_of=%s and name=%s"
+            results = c.execute(sql, resource.id, alias)
             assert results.rowcount == 1
         self.Session.remove()
 
@@ -617,13 +617,13 @@ class TestDatastoreCreate(tests.WsgiAppCase):
         # new aliases should replace old aliases
         c = self.Session.connection()
         for alias in aliases:
-            sql = (u"select * from _table_metadata "
-                "where alias_of='{0}' and name='{1}'").format(resource.id, alias)
-            results = c.execute(sql)
+            sql = u"select * from _table_metadata " \
+                   "where alias_of=%s and name=%s"
+            results = c.execute(sql, resource.id, alias)
             assert results.rowcount == 0
 
         sql = (u"select * from _table_metadata "
-            "where alias_of='{0}' and name='{1}'").format(resource.id, 'another_alias')
+               "where alias_of='{0}' and name='{1}'").format(resource.id, 'another_alias')
         results = c.execute(sql)
         assert results.rowcount == 1
         self.Session.remove()

--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -617,14 +617,14 @@ class TestDatastoreCreate(tests.WsgiAppCase):
         # new aliases should replace old aliases
         c = self.Session.connection()
         for alias in aliases:
-            sql = u"select * from _table_metadata " \
-                   "where alias_of=%s and name=%s"
+            sql = "select * from _table_metadata " \
+                  "where alias_of=%s and name=%s"
             results = c.execute(sql, resource.id, alias)
             assert results.rowcount == 0
 
-        sql = (u"select * from _table_metadata "
-               "where alias_of='{0}' and name='{1}'").format(resource.id, 'another_alias')
-        results = c.execute(sql)
+        sql = "select * from _table_metadata " \
+              "where alias_of=%s and name=%s"
+        results = c.execute(sql, resource.id, 'another_alias')
         assert results.rowcount == 1
         self.Session.remove()
 


### PR DESCRIPTION
I grepped for all SQL execute statements and where possible I changed them so params are passed to execute, rather than substituted into the string beforehand (for security reasons). Pleased to see there are only a couple of very minor things that could be improved.