### PR TITLE
[#2736] Fix bad merge in check_po_files.py (Fixes master failures)

### DIFF
--- a/ckan/i18n/check_po_files.py
+++ b/ckan/i18n/check_po_files.py
@@ -66,7 +66,7 @@ class CheckPoFiles(paste.script.command.Command):
             if errors:
                 for msgid, msgstr in errors:
                     print 'Format specifiers don\'t match:'
-                    print u'    {0} -> {1}'.format(entry.msgid, entry.msgstr).encode('latin7', 'ignore')
+                    print u'    {0} -> {1}'.format(msgid, msgstr)
 
 
 def check_po_file(path):


### PR DESCRIPTION
`entity` is no longer used after #2613. Also removes the encoding bit as
it doesn't display the characters properly.

And it fixes a PEP8 breakage on master.