### PR TITLE
Adds metadata_created as a proper DB field.

### DIFF
--- a/ckan/migration/versions/082_add_metadata_created.py
+++ b/ckan/migration/versions/082_add_metadata_created.py
@@ -1,0 +1,15 @@
+def upgrade(migrate_engine):
+    migrate_engine.execute('''
+        ALTER TABLE package_revision
+            ADD COLUMN metadata_created timestamp without time zone;
+        ALTER TABLE package
+            ADD COLUMN metadata_created timestamp without time zone
+            DEFAULT now();
+
+        UPDATE package SET metadata_created=
+            (SELECT revision_timestamp
+             FROM package_revision
+             WHERE id=package.id
+             ORDER BY revision_timestamp ASC
+             LIMIT 1);
+    ''')

--- a/ckan/migration/versions/082_add_metadata_created.py
+++ b/ckan/migration/versions/082_add_metadata_created.py
@@ -3,8 +3,7 @@ def upgrade(migrate_engine):
         ALTER TABLE package_revision
             ADD COLUMN metadata_created timestamp without time zone;
         ALTER TABLE package
-            ADD COLUMN metadata_created timestamp without time zone
-            DEFAULT now();
+            ADD COLUMN metadata_created timestamp without time zone;
 
         UPDATE package SET metadata_created=
             (SELECT revision_timestamp

--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -47,6 +47,7 @@ package_table = Table('package', meta.metadata,
         Column('type', types.UnicodeText, default=u'dataset'),
         Column('owner_org', types.UnicodeText),
         Column('creator_user_id', types.UnicodeText),
+        Column('metadata_created', types.DateTime, default=datetime.datetime.utcnow),
         Column('metadata_modified', types.DateTime, default=datetime.datetime.utcnow),
         Column('private', types.Boolean, default=False),
 )
@@ -480,16 +481,6 @@ class Package(vdm.sqlalchemy.RevisionedObjectMixin,
             groupcaps = zip( groups,caps )
             groups = [g[0] for g in groupcaps if g[1] == capacity]
         return groups
-
-    @property
-    def metadata_created(self):
-        import ckan.model as model
-        q = meta.Session.query(model.PackageRevision.revision_timestamp)\
-            .filter(model.PackageRevision.id == self.id)\
-            .order_by(model.PackageRevision.revision_timestamp.asc())
-        ts = q.first()
-        if ts:
-            return ts[0]
 
     @staticmethod
     def get_fields(core_only=False, fields_to_ignore=None):


### PR DESCRIPTION
Currently the metadata_created is calculated on each access by querying
the package_revision table and finding the oldest revision (it is a property 
function).  There's little advantage to this over setting the field to be a 
column on the package table and defaulting to now().  This means it can 
be overwritten by those components, like harvesting, that require the ability 
to do so- without meddling with revisions.

This should fix #2735