### PR TITLE
Some tests for the validators *_exists.

### DIFF
--- a/ckan/tests/logic/test_validators.py
+++ b/ckan/tests/logic/test_validators.py
@@ -19,6 +19,8 @@ import ckan.tests.factories as factories
 import ckan.tests.lib.navl.test_validators as t
 import ckan.lib.navl.dictization_functions as df
 import ckan.logic.validators as validators
+import ckan.tests.factories as factories
+import ckan.tests.helpers as helpers
 import ckan.model as model
 
 assert_equals = nose.tools.assert_equals
@@ -523,6 +525,71 @@ class TestBoolValidator(object):
 
     def test_string_false(self):
         assert_equals(validators.boolean_validator('f', None), False)
+
+
+class TestExistsValidator(helpers.FunctionalTestBase):
+
+    def _make_context(self):
+        return {
+            'model': model,
+            'session': model.Session
+        }
+
+    @nose.tools.raises(df.Invalid)
+    def test_package_name_exists_empty(self):
+        ctx = self._make_context()
+        v = validators.package_name_exists('', ctx)
+
+    def test_package_name_exists(self):
+        name = 'pne_validation_test'
+        dataset = factories.Dataset(name=name)
+        ctx = self._make_context()
+        v = validators.package_name_exists(name, ctx)
+        assert v == name
+
+    @nose.tools.raises(df.Invalid)
+    def test_resource_id_exists_empty(self):
+        ctx = self._make_context()
+        v = validators.resource_id_exists('', ctx)
+
+    def test_resource_id_exists(self):
+        resource = factories.Resource()
+        ctx = self._make_context()
+        v = validators.resource_id_exists(resource['id'], ctx)
+        assert v == resource['id']
+
+    @nose.tools.raises(df.Invalid)
+    def test_user_id_or_name_exists_empty(self):
+        ctx = self._make_context()
+        v = validators.user_id_or_name_exists('', ctx)
+
+    def test_user_id_or_name_exists(self):
+        user = factories.User(name='username')
+        ctx = self._make_context()
+        v = validators.user_id_or_name_exists(user['id'], ctx)
+        assert v == user['id']
+        v = validators.user_id_or_name_exists(user['name'], ctx)
+        assert v == user['name']
+
+    @nose.tools.raises(df.Invalid)
+    def test_group_id_or_name_exists_empty(self):
+        ctx = self._make_context()
+        v = validators.user_id_or_name_exists('', ctx)
+
+    def test_group_id_or_name_exists(self):
+        group = factories.Group()
+        ctx = self._make_context()
+        v = validators.group_id_or_name_exists(group['id'], ctx)
+        assert v == group['id']
+
+        v = validators.group_id_or_name_exists(group['name'], ctx)
+        assert v == group['name']
+
+    @nose.tools.raises(df.Invalid)
+    def test_role_exists_empty(self):
+        ctx = self._make_context()
+        v = validators.role_exists('', ctx)
+
 
 #TODO: Need to test when you are not providing owner_org and the validator
 #      queries for the dataset with package_show


### PR DESCRIPTION
Coverage
(https://coveralls.io/builds/3602797/source?filename=ckan%2Flogic%2Fvalidators.py)
suggests these tests weren't covered, so these test the success and fail
cases for group_exists, package_exists etc.