### PR TITLE
[#2746] Simplify test for empty or missing value in markdown_extract

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -866,7 +866,7 @@ def markdown_extract(text, extract_length=190):
     ''' return the plain text representation of markdown encoded text.  That
     is the texted without any html tags.  If extract_length is 0 then it
     will not be truncated.'''
-    if (text is None) or (text.strip() == ''):
+    if not text:
         return ''
     plain = RE_MD_HTML_TAGS.sub('', markdown(text))
     if not extract_length or len(plain) < extract_length:


### PR DESCRIPTION
I recently encountered a case where the markdown_extract function was failing because of the empty value that was being passed in the notes field (we customizing heavily with scheming). The problem could be traced to this line:

```python
if (text is None) or (text.strip() == ''):
```

This can be avoided by simplifying this test to:

```python
if not text:
```