### PR TITLE
Fixing issue with proper deletion/creation of extra fields for organizations

### DIFF
--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -420,6 +420,10 @@ def group_dict_save(group_dict, context, prevent_packages_update=False):
         for key in new_extras:
             group.extras[key] = extras[key]
 
+    #necessary to wipe extras completely
+    if extras == {}:
+        group.extras = {}
+
     # We will get a list of packages that we have either added or
     # removed from the group, and trigger a re-index.
     package_ids = pkgs_edited['removed']

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -507,6 +507,16 @@ def _group_or_org_update(context, data_dict, is_org=False):
     session = context['session']
     id = _get_or_bust(data_dict, 'id')
 
+    #Wipe out empty and "deleted" extras
+    _extras = []
+    for _extra in data_dict['extras']:
+        deleted = _extra.get('deleted', None)
+        if _extra['value'] == '' or _extra['key'] == '' or deleted == 'on':
+            pass
+        else:
+            _extras.append(_extra)
+    data_dict['extras'] = _extras
+
     group = model.Group.get(id)
     context["group"] = group
     if group is None:

--- a/ckan/templates/macros/form.html
+++ b/ckan/templates/macros/form.html
@@ -118,7 +118,7 @@ Examples:
 {% macro markdown(name, id='', label='', value='', placeholder='', error="", classes=[], attrs={}, is_required=false) %}
   {% set classes = (classes|list) %}
   {% do classes.append('control-full') %}
-  {% set markdown_tooltip = "<pre><p>__Bold text__ or _italic text_</p><p># title<br>## secondary title<br>### etc</p><p>* list<br>* of<br>* items</p><p>http://auto.link.ed/</p></pre><p><b><a href='http://daringfireball.net/projects/markdown/syntax' target='_blank'>Full markdown syntax</a></b></p><p class='muted'><b>Please note:</b> HTML tags are stripped out for security reasons</p>" %} 
+  {% set markdown_tooltip = "<pre><p>__Bold text__ or _italic text_</p><p># title<br>## secondary title<br>### etc</p><p>* list<br>* of<br>* items</p><p>http://auto.link.ed/</p></pre><p><b><a href='http://daringfireball.net/projects/markdown/syntax' target='_blank'>Full markdown syntax</a></b></p><p class='muted'><b>Please note:</b> HTML tags are stripped out for security reasons</p>" %}
 
   {%- set extra_html = caller() if caller -%}
   {% call input_block(id or name, label or name, error, classes, control_classes=["editor"], extra_html=extra_html, is_required=is_required) %}
@@ -236,6 +236,37 @@ Examples:
         </label>
       {% endif %}
     </div>
+  {% endcall %}
+{% endmacro %}
+
+{% macro custom_org(names=(), id="", label="", values=(), placeholders=(), error="", classes=[], attrs={}, is_required=false, key_values=()) %}
+  {%- set classes = (classes|list) -%}
+  {%- set label_id = (id or names[0]) ~ "-key" -%}
+  {%- set extra_html = caller() if caller -%}
+  {%- do classes.append('control-custom') -%}
+
+  {% call input_block(label_id, label or name, error, classes, control_classes=["editor"], extra_html=extra_html, is_required=is_required) %}
+    <div class="input-prepend" {{ attributes(attrs) }}>
+      <label for="{{ label_id }}" class="add-on">Key</label><input id="{{ id or names[0] }}-key" type="text" name="{{ names[0] }}" value="{{ values[0] | empty_and_escape }}" placeholder="{{ placeholders[0] }}" />
+      <label for="{{ id or names[1] }}-value" class="add-on">Value</label><input id="{{ id or names[1] }}-value" type="text" name="{{ names[1] }}" value="{{ values[1] | empty_and_escape }}" placeholder="{{ placeholders[1] }}" />
+      {% if values[0] or values[1] or error %}
+        <label class="checkbox" for="{{ id or names[2] }}-remove">
+          <input type="checkbox" id="{{ id or names[2] }}-remove" name="{{ names[2] }}"{% if values[2] %} checked{% endif %} style="display:none;" /> <span id="{{ id or names[2] }}-remove-button" class="btn btn-default btn-primary" onclick="organization_remove_custom(event)">{{ _('Remove') }}</span>
+        </label>
+      {% endif %}
+    </div>
+    <script type="text/javascript">
+      function organization_remove_custom(event) {
+        var removeButtonId = event.target.id;
+        var baseId = removeButtonId.split('-');
+        baseId.splice(-2,2)
+        baseId = baseId.join('-');
+        var keyField = document.getElementById(baseId + '-key');
+        keyField.value = '';
+        var valueField = document.getElementById(baseId + '-value');
+        valueField.value = '';
+      }
+    </script>
   {% endcall %}
 {% endmacro %}
 

--- a/ckan/templates/organization/snippets/organization_form.html
+++ b/ckan/templates/organization/snippets/organization_form.html
@@ -29,7 +29,7 @@
   {% block custom_fields %}
     {% for extra in data.extras %}
       {% set prefix = 'extras__%d__' % loop.index0 %}
-      {{ form.custom(
+      {{ form.custom_org(
         names=(prefix ~ 'key', prefix ~ 'value', prefix ~ 'deleted'),
         id='field-extras-%d' % loop.index,
         label=_('Custom Field'),


### PR DESCRIPTION
https://github.com/ckan/ckan/issues/1868

Remove button now puts empty strings to key/value fields
Extras with empty fields are delete from data_dict
Remove button is rendered with additional macros not to break any existing code