### PR TITLE
Quieten activity logs

### DIFF
--- a/ckan/lib/activity_streams_session_extension.py
+++ b/ckan/lib/activity_streams_session_extension.py
@@ -4,6 +4,8 @@ from paste.deploy.converters import asbool
 import logging
 
 logger = logging.getLogger(__name__)
+# Suppress noisy debug log normally. Enable it only if working on this feature.
+logger.setLevel(logging.WARN)
 
 
 def activity_stream_item(obj, activity_type, revision, user_id):

--- a/ckan/lib/activity_streams_session_extension.py
+++ b/ckan/lib/activity_streams_session_extension.py
@@ -3,9 +3,7 @@ from sqlalchemy.orm.session import SessionExtension
 from paste.deploy.converters import asbool
 import logging
 
-logger = logging.getLogger(__name__)
-# Suppress noisy debug log normally. Enable it only if working on this feature.
-logger.setLevel(logging.WARN)
+log = logging.getLogger(__name__)
 
 
 def activity_stream_item(obj, activity_type, revision, user_id):
@@ -13,19 +11,17 @@ def activity_stream_item(obj, activity_type, revision, user_id):
     if callable(method):
         return method(activity_type, revision, user_id)
     else:
-        logger.debug("Object did not have a suitable "
-            "activity_stream_item() method, it must not be a package.")
+        # Object did not have a suitable activity_stream_item() method; it must
+        # not be a package
         return None
 
 
 def activity_stream_detail(obj, activity_id, activity_type):
-    method = getattr(obj, "activity_stream_detail",
-            None)
+    method = getattr(obj, "activity_stream_detail", None)
     if callable(method):
         return method(activity_id, activity_type)
     else:
-        logger.debug("Object did not have a suitable  "
-            "activity_stream_detail() method.")
+        # Object did not have a suitable activity_stream_detail() method
         return None
 
 
@@ -53,8 +49,7 @@ class DatasetActivitySessionExtension(SessionExtension):
             object_cache = session._object_cache
             revision = session.revision
         except AttributeError:
-            logger.debug('session had no _object_cache or no revision,'
-                    ' skipping this commit', exc_info=True)
+            # session had no _object_cache or no revision; skipping this commit
             return
 
         if revision.user:
@@ -64,7 +59,6 @@ class DatasetActivitySessionExtension(SessionExtension):
             # revision.author is their IP address. Just log them as 'not logged
             # in' rather than logging their IP address.
             user_id = 'not logged in'
-        logger.debug('user_id: %s' % user_id)
 
         # The top-level objects that we will append to the activity table. The
         # keys here are package IDs, and the values are model.activity:Activity
@@ -79,16 +73,13 @@ class DatasetActivitySessionExtension(SessionExtension):
 
         # Log new packages first to prevent them from getting incorrectly
         # logged as changed packages.
-        logger.debug("Looking for new packages...")
+        # Looking for new packages...
         for obj in object_cache['new']:
-            logger.debug("Looking at object %s" % obj)
             activity = activity_stream_item(obj, 'new', revision, user_id)
             if activity is None:
                 continue
-            # If the object returns an activity stream item we know that the
+            # The object returns an activity stream item, so we know that the
             # object is a package.
-            logger.debug("Looks like this object is a package")
-            logger.debug("activity: %s" % activity)
 
             # Don't create activities for private datasets.
             if obj.private:
@@ -98,36 +89,31 @@ class DatasetActivitySessionExtension(SessionExtension):
 
             activity_detail = activity_stream_detail(obj, activity.id, "new")
             if activity_detail is not None:
-                logger.debug("activity_detail: %s" % activity_detail)
                 activity_details[activity.id] = [activity_detail]
 
         # Now process other objects.
-        logger.debug("Looking for other objects...")
         for activity_type in ('new', 'changed', 'deleted'):
             objects = object_cache[activity_type]
             for obj in objects:
-                logger.debug("Looking at %s object %s" % (activity_type, obj))
 
-                if not hasattr(obj,"id"):
-                    logger.debug("Object has no id, skipping...")
+                if not hasattr(obj, "id"):
+                    # Object has no id; skipping
                     continue
 
-
                 if activity_type == "new" and obj.id in activities:
-                    logger.debug("This object was already logged as a new "
-                            "package")
+                    # This object was already logged as a new package
                     continue
 
                 try:
                     related_packages = obj.related_packages()
-                    logger.debug("related_packages: %s" % related_packages)
                 except (AttributeError, TypeError):
-                    logger.debug("Object did not have a suitable "
-                            "related_packages() method, skipping it.")
+                    # Object did not have a suitable related_packages() method;
+                    # skipping it
                     continue
 
                 for package in related_packages:
-                    if package is None: continue
+                    if package is None:
+                        continue
 
                     # Don't create activities for private datasets.
                     if package.private:
@@ -136,34 +122,29 @@ class DatasetActivitySessionExtension(SessionExtension):
                     if package.id in activities:
                         activity = activities[package.id]
                     else:
-                        activity = activity_stream_item(package, "changed",
-                                revision, user_id)
-                        if activity is None: continue
-                    logger.debug("activity: %s" % activity)
+                        activity = activity_stream_item(
+                            package, "changed", revision, user_id)
+                        if activity is None:
+                            continue
 
-                    activity_detail = activity_stream_detail(obj, activity.id,
-                            activity_type)
-                    logger.debug("activity_detail: %s" % activity_detail)
+                    activity_detail = activity_stream_detail(
+                        obj, activity.id, activity_type)
                     if activity_detail is not None:
                         if not package.id in activities:
                             activities[package.id] = activity
                         if activity_details.has_key(activity.id):
                             activity_details[activity.id].append(
-                                    activity_detail)
+                                activity_detail)
                         else:
-                            activity_details[activity.id] =  [activity_detail]
+                            activity_details[activity.id] = [activity_detail]
 
         for key, activity in activities.items():
-            logger.debug("Emitting activity: %s %s"
-                    % (activity.id, activity.activity_type))
+            # Emitting activity
             session.add(activity)
 
         for key, activity_detail_list in activity_details.items():
             for activity_detail_obj in activity_detail_list:
-                logger.debug("Emitting activity detail: %s %s %s"
-                        % (activity_detail_obj.activity_id,
-                            activity_detail_obj.activity_type,
-                            activity_detail_obj.object_type))
+                # Emitting activity detail
                 session.add(activity_detail_obj)
 
         session.flush()

--- a/ckan/tests/legacy/functional/api/test_dashboard.py
+++ b/ckan/tests/legacy/functional/api/test_dashboard.py
@@ -30,6 +30,7 @@ class TestDashboard(object):
 
     @classmethod
     def setup_class(cls):
+        ckan.lib.search.clear_all()
         CreateTestData.create()
         cls.app = paste.fixture.TestApp(pylons.test.pylonsapp)
         joeadmin = ckan.model.User.get('joeadmin')

--- a/ckan/tests/legacy/functional/test_group.py
+++ b/ckan/tests/legacy/functional/test_group.py
@@ -17,10 +17,6 @@ class TestGroup(FunctionalTestCase):
         model.Session.remove()
         CreateTestData.create()
 
-        # reduce extraneous logging
-        from ckan.lib import activity_streams_session_extension
-        activity_streams_session_extension.logger.level = 100
-
     @classmethod
     def teardown_class(self):
         model.repo.rebuild_db()

--- a/ckan/tests/lib/test_munge.py
+++ b/ckan/tests/lib/test_munge.py
@@ -1,4 +1,4 @@
-from nose.tools import assert_equal
+from nose import tools as nose_tools
 
 from ckan.lib.munge import (munge_filename_legacy, munge_filename, munge_name,
                             munge_title_to_name, munge_tag)
@@ -27,15 +27,15 @@ class TestMungeFilenameLegacy(object):
         '''Munge a list of filenames gives expected results.'''
         for org, exp in self.munge_list:
             munge = munge_filename_legacy(org)
-            assert_equal(munge, exp)
+            nose_tools.assert_equal(munge, exp)
 
     def test_munge_filename_multiple_pass(self):
         '''Munging filename multiple times produces same result.'''
         for org, exp in self.munge_list:
             first_munge = munge_filename_legacy(org)
-            assert_equal(first_munge, exp)
+            nose_tools.assert_equal(first_munge, exp)
             second_munge = munge_filename_legacy(first_munge)
-            assert_equal(second_munge, exp)
+            nose_tools.assert_equal(second_munge, exp)
 
 
 class TestMungeFilename(object):
@@ -61,15 +61,15 @@ class TestMungeFilename(object):
         '''Munge a list of filenames gives expected results.'''
         for org, exp in self.munge_list:
             munge = munge_filename(org)
-            assert_equal(munge, exp)
+            nose_tools.assert_equal(munge, exp)
 
     def test_munge_filename_multiple_pass(self):
         '''Munging filename multiple times produces same result.'''
         for org, exp in self.munge_list:
             first_munge = munge_filename(org)
-            assert_equal(first_munge, exp)
+            nose_tools.assert_equal(first_munge, exp)
             second_munge = munge_filename(first_munge)
-            assert_equal(second_munge, exp)
+            nose_tools.assert_equal(second_munge, exp)
 
 
 class TestMungeName(object):
@@ -88,15 +88,15 @@ class TestMungeName(object):
         '''Munge a list of names gives expected results.'''
         for org, exp in self.munge_list:
             munge = munge_name(org)
-            assert_equal(munge, exp)
+            nose_tools.assert_equal(munge, exp)
 
     def test_munge_name_multiple_pass(self):
         '''Munging name multiple times produces same result.'''
         for org, exp in self.munge_list:
             first_munge = munge_name(org)
-            assert_equal(first_munge, exp)
+            nose_tools.assert_equal(first_munge, exp)
             second_munge = munge_name(first_munge)
-            assert_equal(second_munge, exp)
+            nose_tools.assert_equal(second_munge, exp)
 
 
 class TestMungeTitleToName(object):
@@ -118,7 +118,7 @@ class TestMungeTitleToName(object):
         '''Munge a list of names gives expected results.'''
         for org, exp in self.munge_list:
             munge = munge_title_to_name(org)
-            assert_equal(munge, exp)
+            nose_tools.assert_equal(munge, exp)
 
 
 class TestMungeTag:
@@ -136,12 +136,12 @@ class TestMungeTag:
         '''Munge a list of tags gives expected results.'''
         for org, exp in self.munge_list:
             munge = munge_tag(org)
-            assert_equal(munge, exp)
+            nose_tools.assert_equal(munge, exp)
 
     def test_munge_tag_multiple_pass(self):
         '''Munge a list of tags muliple times gives expected results.'''
         for org, exp in self.munge_list:
             first_munge = munge_tag(org)
-            assert_equal(first_munge, exp)
+            nose_tools.assert_equal(first_munge, exp)
             second_munge = munge_tag(first_munge)
-            assert_equal(second_munge, exp)
+            nose_tools.assert_equal(second_munge, exp)

--- a/ckan/tests/lib/test_munge.py
+++ b/ckan/tests/lib/test_munge.py
@@ -1,4 +1,4 @@
-from nose import tools as nose_tools
+from nose.tools import assert_equal
 
 from ckan.lib.munge import (munge_filename_legacy, munge_filename, munge_name,
                             munge_title_to_name, munge_tag)
@@ -27,15 +27,15 @@ class TestMungeFilenameLegacy(object):
         '''Munge a list of filenames gives expected results.'''
         for org, exp in self.munge_list:
             munge = munge_filename_legacy(org)
-            nose_tools.assert_equal(munge, exp)
+            assert_equal(munge, exp)
 
     def test_munge_filename_multiple_pass(self):
         '''Munging filename multiple times produces same result.'''
         for org, exp in self.munge_list:
             first_munge = munge_filename_legacy(org)
-            nose_tools.assert_equal(first_munge, exp)
+            assert_equal(first_munge, exp)
             second_munge = munge_filename_legacy(first_munge)
-            nose_tools.assert_equal(second_munge, exp)
+            assert_equal(second_munge, exp)
 
 
 class TestMungeFilename(object):
@@ -61,15 +61,15 @@ class TestMungeFilename(object):
         '''Munge a list of filenames gives expected results.'''
         for org, exp in self.munge_list:
             munge = munge_filename(org)
-            nose_tools.assert_equal(munge, exp)
+            assert_equal(munge, exp)
 
     def test_munge_filename_multiple_pass(self):
         '''Munging filename multiple times produces same result.'''
         for org, exp in self.munge_list:
             first_munge = munge_filename(org)
-            nose_tools.assert_equal(first_munge, exp)
+            assert_equal(first_munge, exp)
             second_munge = munge_filename(first_munge)
-            nose_tools.assert_equal(second_munge, exp)
+            assert_equal(second_munge, exp)
 
 
 class TestMungeName(object):
@@ -88,15 +88,15 @@ class TestMungeName(object):
         '''Munge a list of names gives expected results.'''
         for org, exp in self.munge_list:
             munge = munge_name(org)
-            nose_tools.assert_equal(munge, exp)
+            assert_equal(munge, exp)
 
     def test_munge_name_multiple_pass(self):
         '''Munging name multiple times produces same result.'''
         for org, exp in self.munge_list:
             first_munge = munge_name(org)
-            nose_tools.assert_equal(first_munge, exp)
+            assert_equal(first_munge, exp)
             second_munge = munge_name(first_munge)
-            nose_tools.assert_equal(second_munge, exp)
+            assert_equal(second_munge, exp)
 
 
 class TestMungeTitleToName(object):
@@ -118,7 +118,7 @@ class TestMungeTitleToName(object):
         '''Munge a list of names gives expected results.'''
         for org, exp in self.munge_list:
             munge = munge_title_to_name(org)
-            nose_tools.assert_equal(munge, exp)
+            assert_equal(munge, exp)
 
 
 class TestMungeTag:
@@ -136,12 +136,12 @@ class TestMungeTag:
         '''Munge a list of tags gives expected results.'''
         for org, exp in self.munge_list:
             munge = munge_tag(org)
-            nose_tools.assert_equal(munge, exp)
+            assert_equal(munge, exp)
 
     def test_munge_tag_multiple_pass(self):
         '''Munge a list of tags muliple times gives expected results.'''
         for org, exp in self.munge_list:
             first_munge = munge_tag(org)
-            nose_tools.assert_equal(first_munge, exp)
+            assert_equal(first_munge, exp)
             second_munge = munge_tag(first_munge)
-            nose_tools.assert_equal(second_munge, exp)
+            assert_equal(second_munge, exp)


### PR DESCRIPTION
This logging clouds out other much more useful debug logging.

When working on this feature you can enable the logging again easily, temporarily.