### PR TITLE
Prevent unicode error on error controller

### DIFF
--- a/ckan/controllers/error.py
+++ b/ckan/controllers/error.py
@@ -31,6 +31,10 @@ class ErrorController(BaseController):
         # Bypass error template for API operations.
         if original_request and original_request.path.startswith('/api'):
             return original_response.body
+        # If the charset has been lost on the middleware stack, use the
+        # default one (utf-8)
+        if not original_response.charset and original_response.default_charset:
+            original_response.charset = original_response.default_charset
         # Otherwise, decorate original response with error template.
         c.content = literal(original_response.unicode_body) or \
             cgi.escape(request.GET.get('message', ''))


### PR DESCRIPTION
When using custom middlewares like the sentry one (https://github.com/okfn/ckanext-sentry), sometimes the response when an exception happens loses its encoding, which causes this exception on top of the original one (full stacktrace below):

```
  File "/home/adria/dev/pyenvs/ni/src/ckan/ckan/controllers/error.py", line 35, in document
    c.content = literal(original_response.unicode_body) or \
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/webob/response.py", line 339, in _unicode_body__get
    "You cannot access Response.unicode_body unless charset is set")
AttributeError: You cannot access Response.unicode_body unless charset is set
```

I spent ages going down the middleware rabbit hole and digging into the raven (the library the powers sentry) source code but couldn't find at what point we were losing the `original_response.charset`. 

I think that in any case it's safe to use the default one (utf-8) if the encoding is missing. An alternative would be to display `original_response.body` if the encoding is missing, but that might cause other unicode issues.


```
  File "/home/adria/dev/pyenvs/ni/src/ckan/ckan/config/middleware.py", line 228, in __call__
    return self.app(environ, start_response)
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/paste/registry.py", line 379, in __call__
    app_iter = self.application(environ, start_response)
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/repoze/who/middleware.py", line 87, in __call__
    app_iter = app(environ, wrapper.wrap_start_response)
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/pylons/middleware.py", line 214, in __call__
    self.app, new_environ, catch_exc_info=True)
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/pylons/util.py", line 97, in call_wsgi_application
    output.extend(app_iter)
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/raven-5.8.1-py2.7.egg/raven/middleware.py", line 35, in __call__
    iterable = self.application(environ, start_response)
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/webob/dec.py", line 147, in __call__
    resp = self.call_func(req, *args, **self.kwargs)
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/webob/dec.py", line 208, in call_func
    return self.func(req, *args, **kwargs)
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/fanstatic/publisher.py", line 234, in __call__
    return request.get_response(self.app)
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/webob/request.py", line 1053, in get_response
    application, catch_exc_info=False)
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/webob/request.py", line 1022, in call_application
    app_iter = application(self.environ, start_response)
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/webob/dec.py", line 147, in __call__
    resp = self.call_func(req, *args, **self.kwargs)
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/webob/dec.py", line 208, in call_func
    return self.func(req, *args, **kwargs)
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/fanstatic/injector.py", line 54, in __call__
    response = request.get_response(self.app)
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/webob/request.py", line 1053, in get_response
    application, catch_exc_info=False)
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/webob/request.py", line 1022, in call_application
    app_iter = application(self.environ, start_response)
  File "/home/adria/dev/pyenvs/ni/src/ckan/ckan/config/middleware.py", line 389, in inner
    result = application(environ, start_response)
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/beaker/middleware.py", line 73, in __call__
    return self.app(environ, start_response)
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/beaker/middleware.py", line 155, in __call__
    return self.wrap_app(environ, session_start_response)
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/routes/middleware.py", line 131, in __call__
    response = self.app(environ, start_response)
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/pylons/wsgiapp.py", line 125, in __call__
    response = self.dispatch(controller, environ, start_response)
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/pylons/wsgiapp.py", line 324, in dispatch
    return controller(environ, start_response)
  File "/home/adria/dev/pyenvs/ni/src/ckan/ckan/lib/base.py", line 338, in __call__
    res = WSGIController.__call__(self, environ, start_response)
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/pylons/controllers/core.py", line 221, in __call__
    response = self._dispatch_call()
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/pylons/controllers/core.py", line 172, in _dispatch_call
    response = self._inspect_call(func)
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/pylons/controllers/core.py", line 107, in _inspect_call
    result = self._perform_call(func, args)
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/pylons/controllers/core.py", line 60, in _perform_call
    return func(**args)
  File "/home/adria/dev/pyenvs/ni/src/ckan/ckan/controllers/error.py", line 35, in document
    c.content = literal(original_response.unicode_body) or \
  File "/home/adria/dev/pyenvs/ni/local/lib/python2.7/site-packages/webob/response.py", line 339, in _unicode_body__get
    "You cannot access Response.unicode_body unless charset is set")
AttributeError: You cannot access Response.unicode_body unless charset is set
```