### PR TITLE
Coveralls - exclude libraries

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,0 @@
-[run]
-omit = */migration/*, /tests/*
-source =
-    ckan
-    ckanext
-include =
-    ckan/*
-    ckanext/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,8 @@
 [run]
 omit = */migration/*, /tests/*
-source = ckan, ckanext
+source =
+    ckan
+    ckanext
+include =
+    ckan/*
+    ckanext/*

--- a/bin/travis-run-tests
+++ b/bin/travis-run-tests
@@ -16,7 +16,7 @@ MOCHA_ERROR=$?
 killall paster
 
 # And finally, run the nosetests
-nosetests --ckan --reset-db --with-pylons=test-core.ini --nologcapture --with-coverage ckan ckanext
+nosetests --ckan --reset-db --with-pylons=test-core.ini --nologcapture --with-coverage --cover-package=ckan --cover-package=ckanext ckan ckanext
 # Did an error occur?
 NOSE_ERROR=$?
 


### PR DESCRIPTION
In the travis log it shows the coverage across ckan, ckan, but also all the python modules it calls too. There seems no point showing the coverage of sqlalchemy, requests etc, and including them in the stats, so let's remove them.

e.g.

> sqlalchemy/orm/query.py                                                     1088    358    67%   127-136, 152-155, 167, 172, 192-195, 198-213, 237-238, 257, 310-316, 320, 326-332, 348, 354, 367, 369, 376, 378, 384, 386, 397, 406, 418, 444, 477, 480, 540, 554, 566, 577, 580, 636, 659, 691-696, 724-725, 788, 795, 813, 839, 868, 896-913, 920-925, 933, 981-987, 993-996, 1024, 1050, 1062, 1065, 1071-1079, 1100, 1113-1115, 1129, 1158, 1189, 1203, 1205, 1293-1295, 1297-1298, 1305, 1318, 1337-1351, 1391, 1401, 1412, 1423, 1434, 1445, 1695, 1711, 1779-1791, 1798, 1806, 1820-1823, 1827, 1848, 1855, 1873-1877, 1879, 1883, 1918, 1924, 1929-1941, 1956-1957, 1963, 1978, 2002-2003, 2019-2021, 2026-2027, 2047, 2189, 2195, 2199, 2204, 2216-2219, 2256, 2282-2285, 2313, 2332, 2370, 2395, 2397-2398, 2411, 2479-2483, 2509, 2524-2525, 2553, 2767-2768, 2783-2789, 2794, 2804-2864, 2893, 2896, 2899, 2916-2919, 2924, 2931-2946, 2958, 2964-2966, 3007-3024, 3040-3043, 3045-3048, 3061, 3067, 3079, 3087, 3130, 3152-3156, 3159, 3202-3207, 3237-3239, 3242, 3246, 3251-3253, 3265-3267, 3272-3289, 3295-3300, 3305, 3309-3314, 3317-3323, 3326-3327, 3330-3331, 3334-3341, 3366, 3371-3372, 3375, 3384-3385, 3428-3433, 3449-3455, 3466, 3480, 3495, 3555, 3558-3562