### PR TITLE
Expose config and translator via toolkit.

### DIFF
--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -20,6 +20,8 @@ class _Toolkit(object):
         '_',                    # i18n translation
         'ungettext',            # i18n translation (plural forms)
         'c',                    # template context
+        'config',               # The pylons configuration
+        'translator',           # Pylons translator, often used in plugins when create commands
         'request',              # http request object
         'render',               # template render function
         'render_text',          # Genshi NewTextTemplate render function
@@ -138,6 +140,20 @@ available throughout the template and application code, and are local to the
 current request.
 
 '''
+        t['config'] = pylons.config
+        self.docstring_overrides['config'] = '''The Pylons configuration object.
+
+The configuration object containing information about this request as well as
+options loaded from the .ini file.
+'''
+
+        t['translator'] = pylons.translator
+        self.docstring_overrides['translator'] = '''The Pylons translator object.
+
+Often used in extensions within commands or migrations for setting up the
+CKAN i18n translator.
+'''
+
         t['request'] = common.request
         self.docstring_overrides['request'] = '''The Pylons request object.
 

--- a/ckan/tests/lib/test_toolkit.py
+++ b/ckan/tests/lib/test_toolkit.py
@@ -1,0 +1,20 @@
+import ckan.tests.helpers as helpers
+
+from nose.tools import assert_equals, assert_not_equals
+import ckan.plugins.toolkit as t
+from pylons import config
+from pylons import translator
+
+
+class TestToolkit(helpers.FunctionalTestBase):
+
+    def test_config_is_in_toolkit(self):
+        assert sorted(t.config.keys()) == sorted(config.keys())
+
+    def test_config_values_are_accurate(self):
+        for k, v in t.config.iteritems():
+            assert config[k] == v
+
+    def test_translator(self):
+        assert translator.gettext("Test") == \
+            t.translator.gettext("Test")


### PR DESCRIPTION
To avoid importing of pylons in extensions, we should include the most
commonly imported pylons modules in the plugin toolkit.

This PR does that in order to fix #2776