### PR TITLE
Pin third party requs in requirements.txt, not setup.py

### DIFF
--- a/doc/extensions/best-practices.rst
+++ b/doc/extensions/best-practices.rst
@@ -56,3 +56,23 @@ Internationalize user-visible strings
 
 All user-visible strings should be internationalized, see
 :doc:`/contributing/string-i18n`.
+
+
+---------------------------------------------
+Add third party libraries to requirements.txt
+---------------------------------------------
+
+If your extension requires third party libraries, rather than 
+adding them to ``setup.py``, they should be added
+to ``requirements.txt``, which can be installed with::
+
+  pip install -r requirements.txt
+  
+To prevent accidental breakage of your extension through backwards-incompatible 
+behaviour of newer versions of your dependencies, their versions should be pinned, 
+such as::
+
+  requests==2.7.0
+  
+On the flip side, be mindful that this could also create version conflicts with
+requirements of considerably newer or older extensions.


### PR DESCRIPTION
Add a section to Docs >  Extensions > Best practices about third party requirements as advocated by @davidread in https://github.com/ckan/ckan/issues/2470