### PR TITLE
[#2555] Add old postgres versions deprecation notice.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,10 @@ Changes and deprecations
   introduces both ``python-markdown`` and ``bleach`` as dependencies, as ``bleach``
   is used to clean any HTML provided to the markdown processor.
 
+* Note: This is the last version of CKAN to support Postgresql 8.x, 9.0 and 9.1. The
+  next minor version of CKAN will require Postgresql 9.2 or later.
+
+
 v2.4.1 2015-09-02
 =================
 


### PR DESCRIPTION
Issue #2555 - Whilst we won't get in the postgres upgrade instructions, we can at least warn people officially about the intent, which might help them avoid installing one of the old versions.

Or maybe this note should go elsewhere in the docs instead?