### PR TITLE
[#2799] Fix authz.auth_is_anon_user() when couldn't get the user's IP

### DIFF
--- a/ckan/authz.py
+++ b/ckan/authz.py
@@ -430,12 +430,15 @@ def auth_is_anon_user(context):
 
         See ckan/lib/base.py:232 for pylons context object logic
     '''
+    is_ip = lambda x: re.match('\d+\.\d+\.\d+\.\d+', x)
+    is_unknown_ip = lambda x: x == 'Unknown IP Address'
+
     context_user = context.get('user')
     # FIXME: our current pattern is to set context['user'] to
     # the IP address in our controller code. Detect and
     # ignore that case for now. Stop putting the IP address
     # in context['user'] in a future ckan version.
-    if context_user and '.' in context_user:
+    if context_user and (is_ip(context_user) or is_unknown_ip(context_user)):
         context_user = None
     is_anon_user = not bool(context_user)
 

--- a/ckan/tests/test_authz.py
+++ b/ckan/tests/test_authz.py
@@ -6,6 +6,8 @@ from ckan.tests import helpers
 
 
 assert_equals = nose.tools.assert_equals
+assert_true = nose.tools.assert_true
+assert_false = nose.tools.assert_false
 
 
 class TestCheckConfigPermission(object):
@@ -64,3 +66,31 @@ class TestCheckConfigPermission(object):
         assert_equals(sorted(auth.check_config_permission(
             'roles_that_cascade_to_sub_groups')),
             sorted(['admin', 'editor']))
+
+    def test_auth_is_anon_user_is_false_if_user_is_truthy(self):
+        context = {
+            'user': 'some-user'
+        }
+        assert_false(auth.auth_is_anon_user(context))
+
+    def test_auth_is_anon_user_is_true_if_user_wasnt_passed(self):
+        context = {}
+        assert_true(auth.auth_is_anon_user(context))
+
+    def test_auth_is_anon_user_is_true_if_user_is_falsy(self):
+        context = {
+            'user': '',
+        }
+        assert_true(auth.auth_is_anon_user(context))
+
+    def test_auth_is_anon_user_is_true_if_user_is_an_IP(self):
+        context = {
+            'user': '0.0.0.0',
+        }
+        assert_true(auth.auth_is_anon_user(context))
+
+    def test_auth_is_anon_user_is_true_if_user_is_Unknown_IP_Address(self):
+        context = {
+            'user': 'Unknown IP Address',
+        }
+        assert_true(auth.auth_is_anon_user(context))


### PR DESCRIPTION
Also improve the method for checking if the username is an IP.