### PR TITLE
make context['user'] always username or None

### DIFF
--- a/ckan/authz.py
+++ b/ckan/authz.py
@@ -431,12 +431,6 @@ def auth_is_anon_user(context):
         See ckan/lib/base.py:232 for pylons context object logic
     '''
     context_user = context.get('user')
-    # FIXME: our current pattern is to set context['user'] to
-    # the IP address in our controller code. Detect and
-    # ignore that case for now. Stop putting the IP address
-    # in context['user'] in a future ckan version.
-    if context_user and '.' in context_user:
-        context_user = None
     is_anon_user = not bool(context_user)
 
     return is_anon_user

--- a/ckan/controllers/api.py
+++ b/ckan/controllers/api.py
@@ -52,7 +52,7 @@ class ApiController(base.BaseController):
 
         self._identify_user()
         try:
-            context = {'model': model, 'user': c.user or c.author,
+            context = {'model': model, 'user': c.user,
                        'auth_user_obj': c.userobj}
             logic.check_access('site_read', context)
         except NotAuthorized:
@@ -622,7 +622,7 @@ class ApiController(base.BaseController):
         c.q = request.params.get('q', '')
 
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'auth_user_obj': c.userobj}
+                   'user': c.user, 'auth_user_obj': c.userobj}
 
         tag_names = get_action('tag_list')(context, {})
         results = []
@@ -657,7 +657,7 @@ class ApiController(base.BaseController):
         user_list = []
         if q:
             context = {'model': model, 'session': model.Session,
-                       'user': c.user or c.author, 'auth_user_obj': c.userobj}
+                       'user': c.user, 'auth_user_obj': c.userobj}
 
             data_dict = {'q': q, 'limit': limit}
 
@@ -734,7 +734,7 @@ class ApiController(base.BaseController):
         package_dicts = []
         if q:
             context = {'model': model, 'session': model.Session,
-                       'user': c.user or c.author, 'auth_user_obj': c.userobj}
+                       'user': c.user, 'auth_user_obj': c.userobj}
 
             data_dict = {'q': q, 'limit': limit}
 
@@ -751,7 +751,7 @@ class ApiController(base.BaseController):
         tag_names = []
         if q:
             context = {'model': model, 'session': model.Session,
-                       'user': c.user or c.author, 'auth_user_obj': c.userobj}
+                       'user': c.user, 'auth_user_obj': c.userobj}
 
             data_dict = {'q': q, 'limit': limit}
 
@@ -770,7 +770,7 @@ class ApiController(base.BaseController):
         formats = []
         if q:
             context = {'model': model, 'session': model.Session,
-                       'user': c.user or c.author, 'auth_user_obj': c.userobj}
+                       'user': c.user, 'auth_user_obj': c.userobj}
             data_dict = {'q': q, 'limit': limit}
             formats = get_action('format_autocomplete')(context, data_dict)
 

--- a/ckan/controllers/feed.py
+++ b/ckan/controllers/feed.py
@@ -46,7 +46,7 @@ def _package_search(data_dict):
      * unless overridden, sets a default item limit
     """
     context = {'model': model, 'session': model.Session,
-               'user': c.user or c.author, 'auth_user_obj': c.userobj}
+               'user': c.user, 'auth_user_obj': c.userobj}
 
     if 'sort' not in data_dict or not data_dict['sort']:
         data_dict['sort'] = 'metadata_modified desc'
@@ -217,7 +217,7 @@ class FeedController(base.BaseController):
     def group(self, id):
         try:
             context = {'model': model, 'session': model.Session,
-                       'user': c.user or c.author, 'auth_user_obj': c.userobj}
+                       'user': c.user, 'auth_user_obj': c.userobj}
             group_dict = logic.get_action('group_show')(context, {'id': id})
         except logic.NotFound:
             base.abort(404, _('Group not found'))
@@ -227,7 +227,7 @@ class FeedController(base.BaseController):
     def organization(self, id):
         try:
             context = {'model': model, 'session': model.Session,
-                       'user': c.user or c.author, 'auth_user_obj': c.userobj}
+                       'user': c.user, 'auth_user_obj': c.userobj}
             group_dict = logic.get_action('organization_show')(context,
                                                                {'id': id})
         except logic.NotFound:

--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -152,7 +152,7 @@ class GroupController(base.BaseController):
         items_per_page = 21
 
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'for_view': True,
+                   'user': c.user, 'for_view': True,
                    'with_private': False}
 
         q = c.q = request.params.get('q', '')
@@ -204,7 +204,7 @@ class GroupController(base.BaseController):
             id.split('@')[0])
 
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author,
+                   'user': c.user,
                    'schema': self._db_to_form_schema(group_type=group_type),
                    'for_view': True}
         data_dict = {'id': id}
@@ -230,7 +230,7 @@ class GroupController(base.BaseController):
     def _read(self, id, limit, group_type):
         ''' This is common code used by both read and bulk_process'''
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author,
+                   'user': c.user,
                    'schema': self._db_to_form_schema(group_type=group_type),
                    'for_view': True, 'extras_as_string': True}
 
@@ -393,7 +393,7 @@ class GroupController(base.BaseController):
         # check we are org admin
 
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author,
+                   'user': c.user,
                    'schema': self._db_to_form_schema(group_type=group_type),
                    'for_view': True, 'extras_as_string': True}
         data_dict = {'id': id}
@@ -464,7 +464,7 @@ class GroupController(base.BaseController):
             data['type'] = group_type
 
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author,
+                   'user': c.user,
                    'save': 'save' in request.params,
                    'parent': request.params.get('parent', None)}
         try:
@@ -496,7 +496,7 @@ class GroupController(base.BaseController):
             id.split('@')[0])
 
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author,
+                   'user': c.user,
                    'save': 'save' in request.params,
                    'for_edit': True,
                    'parent': request.params.get('parent', None)
@@ -612,7 +612,7 @@ class GroupController(base.BaseController):
 
         try:
             context = \
-                {'model': model, 'user': c.user or c.author, 'group': group}
+                {'model': model, 'user': c.user, 'group': group}
             self._check_access('group_edit_permissions', context)
             c.authz_editable = True
             c.group = context['group']
@@ -635,7 +635,7 @@ class GroupController(base.BaseController):
             self._redirect_to_this_controller(action='edit', id=id)
 
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author}
+                   'user': c.user}
 
         try:
             self._check_access('group_delete', context, {'id': id})
@@ -664,7 +664,7 @@ class GroupController(base.BaseController):
         group_type = self._ensure_controller_matches_group_type(id)
 
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author}
+                   'user': c.user}
 
         try:
             c.members = self._action('member_list')(
@@ -683,7 +683,7 @@ class GroupController(base.BaseController):
         group_type = self._ensure_controller_matches_group_type(id)
 
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author}
+                   'user': c.user}
 
         #self._check_access('group_delete', context, {'id': id})
         try:
@@ -740,7 +740,7 @@ class GroupController(base.BaseController):
             self._redirect_to_this_controller(action='members', id=id)
 
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author}
+                   'user': c.user}
 
         try:
             self._check_access('group_member_delete', context, {'id': id})
@@ -782,7 +782,7 @@ class GroupController(base.BaseController):
                 h.redirect_to(controller='revision', action='diff', **params)
 
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author,
+                   'user': c.user,
                    'schema': self._db_to_form_schema()}
         data_dict = {'id': id}
         try:
@@ -848,7 +848,7 @@ class GroupController(base.BaseController):
 
         group_type = self._ensure_controller_matches_group_type(id)
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'for_view': True}
+                   'user': c.user, 'for_view': True}
         try:
             c.group_dict = self._get_group_dict(id)
         except NotFound:
@@ -871,7 +871,7 @@ class GroupController(base.BaseController):
         self._ensure_controller_matches_group_type(id)
         context = {'model': model,
                    'session': model.Session,
-                   'user': c.user or c.author}
+                   'user': c.user}
         data_dict = {'id': id}
         try:
             get_action('follow_group')(context, data_dict)
@@ -891,7 +891,7 @@ class GroupController(base.BaseController):
         self._ensure_controller_matches_group_type(id)
         context = {'model': model,
                    'session': model.Session,
-                   'user': c.user or c.author}
+                   'user': c.user}
         data_dict = {'id': id}
         try:
             get_action('unfollow_group')(context, data_dict)
@@ -910,7 +910,7 @@ class GroupController(base.BaseController):
     def followers(self, id):
         group_type = self._ensure_controller_matches_group_type(id)
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author}
+                   'user': c.user}
         c.group_dict = self._get_group_dict(id)
         try:
             c.followers = \
@@ -930,7 +930,7 @@ class GroupController(base.BaseController):
     def about(self, id):
         group_type = self._ensure_controller_matches_group_type(id)
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author}
+                   'user': c.user}
         c.group_dict = self._get_group_dict(id)
         group_type = c.group_dict['type']
         self._setup_template_variables(context, {'id': id},
@@ -942,7 +942,7 @@ class GroupController(base.BaseController):
         ''' returns the result of group_show action or aborts if there is a
         problem '''
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author,
+                   'user': c.user,
                    'for_view': True}
         try:
             return self._action('group_show')(

--- a/ckan/controllers/home.py
+++ b/ckan/controllers/home.py
@@ -19,7 +19,7 @@ class HomeController(base.BaseController):
     def __before__(self, action, **env):
         try:
             base.BaseController.__before__(self, action, **env)
-            context = {'model': model, 'user': c.user or c.author,
+            context = {'model': model, 'user': c.user,
                        'auth_user_obj': c.userobj}
             logic.check_access('site_read', context)
         except logic.NotAuthorized:
@@ -41,7 +41,7 @@ class HomeController(base.BaseController):
         try:
             # package search
             context = {'model': model, 'session': model.Session,
-                       'user': c.user or c.author, 'auth_user_obj': c.userobj}
+                       'user': c.user, 'auth_user_obj': c.userobj}
             data_dict = {
                 'q': '*:*',
                 'facet.field': g.facets,

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -135,7 +135,7 @@ class PackageController(base.BaseController):
         package_type = self._guess_package_type()
 
         try:
-            context = {'model': model, 'user': c.user or c.author,
+            context = {'model': model, 'user': c.user,
                        'auth_user_obj': c.userobj}
             check_access('site_read', context)
         except NotAuthorized:
@@ -220,7 +220,7 @@ class PackageController(base.BaseController):
                         search_extras[param] = value
 
             context = {'model': model, 'session': model.Session,
-                       'user': c.user or c.author, 'for_view': True,
+                       'user': c.user, 'for_view': True,
                        'auth_user_obj': c.userobj}
 
             if package_type and package_type != 'dataset':
@@ -307,7 +307,7 @@ class PackageController(base.BaseController):
 
     def resources(self, id):
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'for_view': True,
+                   'user': c.user, 'for_view': True,
                    'auth_user_obj': c.userobj}
         data_dict = {'id': id, 'include_tracking': True}
 
@@ -335,7 +335,7 @@ class PackageController(base.BaseController):
 
     def read(self, id):
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'for_view': True,
+                   'user': c.user, 'for_view': True,
                    'auth_user_obj': c.userobj}
         data_dict = {'id': id, 'include_tracking': True}
 
@@ -415,7 +415,7 @@ class PackageController(base.BaseController):
                 h.redirect_to(controller='revision', action='diff', **params)
 
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'auth_user_obj': c.userobj}
+                   'user': c.user, 'auth_user_obj': c.userobj}
         data_dict = {'id': id}
         try:
             c.pkg_dict = get_action('package_show')(context, data_dict)
@@ -487,7 +487,7 @@ class PackageController(base.BaseController):
             package_type = self._guess_package_type(True)
 
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'auth_user_obj': c.userobj,
+                   'user': c.user, 'auth_user_obj': c.userobj,
                    'save': 'save' in request.params}
 
         # Package needs to have a organization group in the call to
@@ -558,7 +558,7 @@ class PackageController(base.BaseController):
 
             context = {'model': model, 'session': model.Session,
                        'api_version': 3, 'for_edit': True,
-                       'user': c.user or c.author, 'auth_user_obj': c.userobj}
+                       'user': c.user, 'auth_user_obj': c.userobj}
 
             data['package_id'] = id
             try:
@@ -579,7 +579,7 @@ class PackageController(base.BaseController):
 
         context = {'model': model, 'session': model.Session,
                    'api_version': 3, 'for_edit': True,
-                   'user': c.user or c.author, 'auth_user_obj': c.userobj}
+                   'user': c.user, 'auth_user_obj': c.userobj}
         pkg_dict = get_action('package_show')(context, {'id': id})
         if pkg_dict['state'].startswith('draft'):
             # dataset has not yet been fully created
@@ -631,7 +631,7 @@ class PackageController(base.BaseController):
             del data['id']
 
             context = {'model': model, 'session': model.Session,
-                       'user': c.user or c.author, 'auth_user_obj': c.userobj}
+                       'user': c.user, 'auth_user_obj': c.userobj}
 
             # see if we have any data that we are trying to save
             data_provided = False
@@ -714,7 +714,7 @@ class PackageController(base.BaseController):
 
         # get resources for sidebar
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'auth_user_obj': c.userobj}
+                   'user': c.user, 'auth_user_obj': c.userobj}
         try:
             pkg_dict = get_action('package_show')(context, {'id': id})
         except NotFound:
@@ -745,7 +745,7 @@ class PackageController(base.BaseController):
     def edit(self, id, data=None, errors=None, error_summary=None):
         package_type = self._get_package_type(id)
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'auth_user_obj': c.userobj,
+                   'user': c.user, 'auth_user_obj': c.userobj,
                    'save': 'save' in request.params}
 
         if context['save'] and not data:
@@ -814,7 +814,7 @@ class PackageController(base.BaseController):
 
     def read_ajax(self, id, revision=None):
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'auth_user_obj': c.userobj,
+                   'user': c.user, 'auth_user_obj': c.userobj,
                    'revision_id': revision}
         try:
             data = get_action('package_show')(context, {'id': id})
@@ -831,7 +831,7 @@ class PackageController(base.BaseController):
     def history_ajax(self, id):
 
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'auth_user_obj': c.userobj}
+                   'user': c.user, 'auth_user_obj': c.userobj}
         data_dict = {'id': id}
         try:
             pkg_revisions = get_action('package_revision_list')(
@@ -1028,7 +1028,7 @@ class PackageController(base.BaseController):
             h.redirect_to(controller='package', action='edit', id=id)
 
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'auth_user_obj': c.userobj}
+                   'user': c.user, 'auth_user_obj': c.userobj}
 
         try:
             if request.method == 'POST':
@@ -1051,7 +1051,7 @@ class PackageController(base.BaseController):
                           resource_id=resource_id, id=id)
 
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'auth_user_obj': c.userobj}
+                   'user': c.user, 'auth_user_obj': c.userobj}
 
         try:
             check_access('package_delete', context, {'id': id})
@@ -1075,7 +1075,7 @@ class PackageController(base.BaseController):
 
     def resource_read(self, id, resource_id):
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author,
+                   'user': c.user,
                    'auth_user_obj': c.userobj,
                    'for_view': True}
 
@@ -1154,7 +1154,7 @@ class PackageController(base.BaseController):
         stored or downloading an uploaded file directly.
         """
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'auth_user_obj': c.userobj}
+                   'user': c.user, 'auth_user_obj': c.userobj}
 
         try:
             rsc = get_action('resource_show')(context, {'id': resource_id})
@@ -1187,7 +1187,7 @@ class PackageController(base.BaseController):
         '''Start following this dataset.'''
         context = {'model': model,
                    'session': model.Session,
-                   'user': c.user or c.author, 'auth_user_obj': c.userobj}
+                   'user': c.user, 'auth_user_obj': c.userobj}
         data_dict = {'id': id}
         try:
             get_action('follow_dataset')(context, data_dict)
@@ -1206,7 +1206,7 @@ class PackageController(base.BaseController):
         '''Stop following this dataset.'''
         context = {'model': model,
                    'session': model.Session,
-                   'user': c.user or c.author, 'auth_user_obj': c.userobj}
+                   'user': c.user, 'auth_user_obj': c.userobj}
         data_dict = {'id': id}
         try:
             get_action('unfollow_dataset')(context, data_dict)
@@ -1224,7 +1224,7 @@ class PackageController(base.BaseController):
 
     def followers(self, id=None):
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'for_view': True,
+                   'user': c.user, 'for_view': True,
                    'auth_user_obj': c.userobj}
 
         data_dict = {'id': id}
@@ -1246,7 +1246,7 @@ class PackageController(base.BaseController):
 
     def groups(self, id):
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'for_view': True,
+                   'user': c.user, 'for_view': True,
                    'auth_user_obj': c.userobj, 'use_cache': False}
         data_dict = {'id': id}
         try:
@@ -1308,7 +1308,7 @@ class PackageController(base.BaseController):
         '''Render this package's public activity stream page.'''
 
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'for_view': True,
+                   'user': c.user, 'for_view': True,
                    'auth_user_obj': c.userobj}
         data_dict = {'id': id}
         try:
@@ -1335,7 +1335,7 @@ class PackageController(base.BaseController):
         querystring (as well as accepting them via routes).
         """
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'auth_user_obj': c.userobj}
+                   'user': c.user, 'auth_user_obj': c.userobj}
 
         try:
             c.resource = get_action('resource_show')(context,
@@ -1408,7 +1408,7 @@ class PackageController(base.BaseController):
     def resource_views(self, id, resource_id):
         package_type = self._get_package_type(id.split('@')[0])
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'for_view': True,
+                   'user': c.user, 'for_view': True,
                    'auth_user_obj': c.userobj}
         data_dict = {'id': id}
 
@@ -1444,7 +1444,7 @@ class PackageController(base.BaseController):
     def edit_view(self, id, resource_id, view_id=None):
         package_type = self._get_package_type(id.split('@')[0])
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'for_view': True,
+                   'user': c.user, 'for_view': True,
                    'auth_user_obj': c.userobj}
 
         # update resource should tell us early if the user has privilages.
@@ -1565,7 +1565,7 @@ class PackageController(base.BaseController):
         '''
         context = {'model': model,
                    'session': model.Session,
-                   'user': c.user or c.author,
+                   'user': c.user,
                    'auth_user_obj': c.userobj}
 
         try:
@@ -1615,7 +1615,7 @@ class PackageController(base.BaseController):
         context = {
             'model': model,
             'session': model.Session,
-            'user': c.user or c.author,
+            'user': c.user,
             'auth_user_obj': c.userobj
         }
 

--- a/ckan/controllers/revision.py
+++ b/ckan/controllers/revision.py
@@ -15,7 +15,7 @@ class RevisionController(base.BaseController):
     def __before__(self, action, **env):
         base.BaseController.__before__(self, action, **env)
 
-        context = {'model': model, 'user': c.user or c.author,
+        context = {'model': model, 'user': c.user,
                    'auth_user_obj': c.userobj}
         if c.user:
             try:

--- a/ckan/controllers/tag.py
+++ b/ckan/controllers/tag.py
@@ -16,7 +16,7 @@ class TagController(base.BaseController):
     def __before__(self, action, **env):
         base.BaseController.__before__(self, action, **env)
         try:
-            context = {'model': model, 'user': c.user or c.author,
+            context = {'model': model, 'user': c.user,
                        'auth_user_obj': c.userobj}
             logic.check_access('site_read', context)
         except logic.NotAuthorized:
@@ -26,7 +26,7 @@ class TagController(base.BaseController):
         c.q = request.params.get('q', '')
 
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'auth_user_obj': c.userobj,
+                   'user': c.user, 'auth_user_obj': c.userobj,
                    'for_view': True}
 
         data_dict = {'all_fields': True}
@@ -60,7 +60,7 @@ class TagController(base.BaseController):
 
     def read(self, id):
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'auth_user_obj': c.userobj,
+                   'user': c.user, 'auth_user_obj': c.userobj,
                    'for_view': True}
 
         data_dict = {'id': id}

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -38,7 +38,7 @@ class UserController(base.BaseController):
     def __before__(self, action, **env):
         base.BaseController.__before__(self, action, **env)
         try:
-            context = {'model': model, 'user': c.user or c.author,
+            context = {'model': model, 'user': c.user,
                        'auth_user_obj': c.userobj}
             check_access('site_read', context)
         except NotAuthorized:
@@ -91,7 +91,7 @@ class UserController(base.BaseController):
         c.q = request.params.get('q', '')
         c.order_by = request.params.get('order_by', 'name')
 
-        context = {'return_query': True, 'user': c.user or c.author,
+        context = {'return_query': True, 'user': c.user,
                    'auth_user_obj': c.userobj}
 
         data_dict = {'q': c.q,
@@ -114,7 +114,7 @@ class UserController(base.BaseController):
 
     def read(self, id=None):
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'auth_user_obj': c.userobj,
+                   'user': c.user, 'auth_user_obj': c.userobj,
                    'for_view': True}
         data_dict = {'id': id,
                      'user_obj': c.userobj,
@@ -155,7 +155,7 @@ class UserController(base.BaseController):
            or POST the form data to actually do the user registration.
         '''
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author,
+                   'user': c.user,
                    'auth_user_obj': c.userobj,
                    'schema': self._new_form_to_db_schema(),
                    'save': 'save' in request.params}
@@ -308,7 +308,7 @@ class UserController(base.BaseController):
 
         self._setup_template_variables({'model': model,
                                         'session': model.Session,
-                                        'user': c.user or c.author},
+                                        'user': c.user},
                                        data_dict)
 
         c.is_myself = True
@@ -537,7 +537,7 @@ class UserController(base.BaseController):
         raise ValueError(_('You must provide a password'))
 
     def followers(self, id=None):
-        context = {'for_view': True, 'user': c.user or c.author,
+        context = {'for_view': True, 'user': c.user,
                    'auth_user_obj': c.userobj}
         data_dict = {'id': id, 'user_obj': c.userobj,
                      'include_num_followers': True}
@@ -553,7 +553,7 @@ class UserController(base.BaseController):
         '''Render this user's public activity stream page.'''
 
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'auth_user_obj': c.userobj,
+                   'user': c.user, 'auth_user_obj': c.userobj,
                    'for_view': True}
         data_dict = {'id': id, 'user_obj': c.userobj,
                      'include_num_followers': True}
@@ -583,7 +583,7 @@ class UserController(base.BaseController):
         if (filter_type and filter_id):
             context = {
                 'model': model, 'session': model.Session,
-                'user': c.user or c.author, 'auth_user_obj': c.userobj,
+                'user': c.user, 'auth_user_obj': c.userobj,
                 'for_view': True
             }
             data_dict = {'id': filter_id, 'include_num_followers': True}
@@ -627,7 +627,7 @@ class UserController(base.BaseController):
 
     def dashboard(self, id=None, offset=0):
         context = {'model': model, 'session': model.Session,
-                   'user': c.user or c.author, 'auth_user_obj': c.userobj,
+                   'user': c.user, 'auth_user_obj': c.userobj,
                    'for_view': True}
         data_dict = {'id': id, 'user_obj': c.userobj, 'offset': offset}
         self._setup_template_variables(context, data_dict)
@@ -651,21 +651,21 @@ class UserController(base.BaseController):
         return render('user/dashboard.html')
 
     def dashboard_datasets(self):
-        context = {'for_view': True, 'user': c.user or c.author,
+        context = {'for_view': True, 'user': c.user,
                    'auth_user_obj': c.userobj}
         data_dict = {'user_obj': c.userobj, 'include_datasets': True}
         self._setup_template_variables(context, data_dict)
         return render('user/dashboard_datasets.html')
 
     def dashboard_organizations(self):
-        context = {'for_view': True, 'user': c.user or c.author,
+        context = {'for_view': True, 'user': c.user,
                    'auth_user_obj': c.userobj}
         data_dict = {'user_obj': c.userobj}
         self._setup_template_variables(context, data_dict)
         return render('user/dashboard_organizations.html')
 
     def dashboard_groups(self):
-        context = {'for_view': True, 'user': c.user or c.author,
+        context = {'for_view': True, 'user': c.user,
                    'auth_user_obj': c.userobj}
         data_dict = {'user_obj': c.userobj}
         self._setup_template_variables(context, data_dict)
@@ -675,7 +675,7 @@ class UserController(base.BaseController):
         '''Start following this user.'''
         context = {'model': model,
                    'session': model.Session,
-                   'user': c.user or c.author,
+                   'user': c.user,
                    'auth_user_obj': c.userobj}
         data_dict = {'id': id, 'include_num_followers': True}
         try:
@@ -695,7 +695,7 @@ class UserController(base.BaseController):
         '''Stop following this user.'''
         context = {'model': model,
                    'session': model.Session,
-                   'user': c.user or c.author,
+                   'user': c.user,
                    'auth_user_obj': c.userobj}
         data_dict = {'id': id, 'include_num_followers': True}
         try:

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -819,7 +819,7 @@ def sorted_extras(package_extras, auto_clean=False, subs=None, exclude=None):
 
 def check_access(action, data_dict=None):
     context = {'model': model,
-               'user': c.user or c.author}
+               'user': c.user}
     if not data_dict:
         data_dict = {}
     try:

--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -211,7 +211,7 @@ def _prepopulate_context(context):
     context.setdefault('model', model)
     context.setdefault('session', model.Session)
     try:
-        context.setdefault('user', c.user or c.author)
+        context.setdefault('user', c.user)
     except TypeError:
         # c not registered
         pass
@@ -322,7 +322,7 @@ def get_action(action):
     As the context parameter passed to an action function is commonly::
 
         context = {'model': ckan.model, 'session': ckan.model.Session,
-                   'user': pylons.c.user or pylons.c.author}
+                   'user': pylons.c.user}
 
     an action function returned by ``get_action()`` will automatically add
     these parameters to the context if they are not defined.  This is

--- a/ckanext/resourceproxy/controller.py
+++ b/ckanext/resourceproxy/controller.py
@@ -85,5 +85,5 @@ class ProxyController(base.BaseController):
     def proxy_resource(self, resource_id):
         data_dict = {'resource_id': resource_id}
         context = {'model': base.model, 'session': base.model.Session,
-                   'user': base.c.user or base.c.author}
+                   'user': base.c.user}
         return proxy_resource(context, data_dict)


### PR DESCRIPTION
This removes the need to detect IP addresses and other non-username strings in `context['user']`. This is important because this value is used to determine authorization to perform actions.