### PR TITLE
Stops Package.get avoiding the cache

### DIFF
--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -76,8 +76,10 @@ class Package(vdm.sqlalchemy.RevisionedObjectMixin,
     @classmethod
     def get(cls, reference):
         '''Returns a package object referenced by its id or name.'''
-        query = meta.Session.query(cls).filter(cls.id==reference)
-        pkg = query.first()
+        if not reference:
+            return None
+
+        pkg = meta.Session.query(cls).get(reference)
         if pkg == None:
             pkg = cls.by_name(reference)
         return pkg


### PR DESCRIPTION
SQLAlchemy has a session cache containing objects that it has retrieved
recently, which are stored in an identity map (pk->object). If you call
session.query(cls).get(pk) the object will be retrieved from the cache
(identity map), if you call session.query(cls).filter() then Sqlalchemy
has to query the database again.

In Package.get() the query to find by id (before looking by name) uses
filter and so will always bypass the session cache. Once upon a time it
used session.query(cls).get(reference), but this was lost in a change
(where eager loading was added, then removed in a later commit).

For a contrived, and probably sub-optimal example ...

for pkg in some_query_that_fetches_packages():
    pkg_dict = logic.get_action('package_show')(context, {'id': pkg.id})

In these cases package_show is issuing another query to the
database, even though the package object is in the session cache
ready for retrieval.

There is more information on how the Session cache works at
http://docs.sqlalchemy.org/en/latest/orm/session_basics.html#is-the-session-a-cache

This should fix #2823 although there are likely other places this could
be done (e.g. group/user)