### PR TITLE
Converts more models to use sqlalchemy cache.

### DIFF
--- a/ckan/model/group.py
+++ b/ckan/model/group.py
@@ -80,8 +80,10 @@ class Member(vdm.sqlalchemy.RevisionedObjectMixin,
     @classmethod
     def get(cls, reference):
         '''Returns a group object referenced by its id or name.'''
-        query = meta.Session.query(cls).filter(cls.id == reference)
-        member = query.first()
+        if not reference:
+            return None
+
+        member = meta.Session.query(cls).get(reference)
         if member is None:
             member = cls.by_name(reference)
         return member

--- a/ckan/model/resource.py
+++ b/ckan/model/resource.py
@@ -111,8 +111,10 @@ class Resource(vdm.sqlalchemy.RevisionedObjectMixin,
     @classmethod
     def get(cls, reference):
         '''Returns a resource object referenced by its name or id.'''
-        query = meta.Session.query(Resource).filter(Resource.id == reference)
-        resource = query.first()
+        if not reference:
+            return None
+
+        resource = meta.Session.query(cls).get(reference)
         if resource is None:
             resource = cls.by_name(reference)
         return resource

--- a/ckan/model/resource_view.py
+++ b/ckan/model/resource_view.py
@@ -24,8 +24,12 @@ class ResourceView(domain_object.DomainObject):
     @classmethod
     def get(cls, reference):
         '''Returns a ResourceView object referenced by its id.'''
-        query = meta.Session.query(cls).filter(cls.id == reference)
-        return query.first()
+        if not reference:
+            return None
+
+        view = meta.Session.query(cls).get(reference)
+
+        return view
 
     @classmethod
     def get_columns(cls):

--- a/ckan/model/task_status.py
+++ b/ckan/model/task_status.py
@@ -24,7 +24,10 @@ class TaskStatus(domain_object.DomainObject):
     @classmethod
     def get(cls, reference):
         '''Returns a task status object referenced by its id.'''
-        query = meta.Session.query(cls).filter(cls.id==reference)
-        return query.first()
+        if not reference:
+            return None
+
+        task = meta.Session.query(cls).get(reference)
+        return task
 
 meta.mapper(TaskStatus, task_status_table)


### PR DESCRIPTION
In a similar vein to #2824 this PR will have more model objects use the
session cache in .get() where an ID (PK) is provided.

Related to #2823 

Bonus 3s tests speedup :)