### PR TITLE
Disable forced reindexing on group/organization.

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -585,8 +585,6 @@ class GroupController(base.BaseController):
             data_dict['id'] = id
             context['allow_partial_update'] = True
             group = self._action('group_update')(context, data_dict)
-            if id != group['name']:
-                self._force_reindex(group)
 
             h.redirect_to('%s_read' % group['type'], id=group['name'])
         except NotAuthorized:


### PR DESCRIPTION
Basically reverting commit dbe25d8b8d7fa.

Currently, if a group or organization changes, all datasets belonging to that group/organization are reindexed _in the webserver process_. If you have many datasets in your group/organization, this effectively never finishes and blocks indefinitely.

When a proper background queue worker is available, this should be enabled and utilize the queue. For now, it would be best to let sysadmins know they should be scheduling nightly/periodic reindexes.
