### PR TITLE
Show 404 when user has no permission for deleted package

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -361,10 +361,8 @@ class PackageController(base.BaseController):
         try:
             c.pkg_dict = get_action('package_show')(context, data_dict)
             c.pkg = context['package']
-        except NotFound:
+        except (NotFound, NotAuthorized):
             abort(404, _('Dataset not found'))
-        except NotAuthorized:
-            abort(401, _('Unauthorized to read package %s') % id)
 
         # used by disqus plugin
         c.current_package_id = c.pkg.id

--- a/ckan/tests/legacy/functional/test_package.py
+++ b/ckan/tests/legacy/functional/test_package.py
@@ -683,7 +683,7 @@ class TestNonActivePackages(TestPackageBase):
 
     def test_read(self):
         offset = url_for(controller='package', action='read', id=self.non_active_name)
-        res = self.app.get(offset, status=[302, 401])
+        res = self.app.get(offset, status=[404])
 
 
     def test_read_as_admin(self):


### PR DESCRIPTION
When a user currently has no permissions to view it, a deleted package
will send them to the login page and log them out.

This PR will instead, when the user has no permission, send a 404.  

~~I am not 100% happy with this solution (catch the notauthorized and check state) and think it may be better for check_access to throw NotFound when it is a deleted object (although this will probably still end up catching the exception from the auth check).~~

Should fix #2805