### PR TITLE
Removes all of the code for processing genshi templates

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -37,10 +37,10 @@ All rights reserved.
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, 
+    1. Redistributions of source code must retain the above copyright notice,
        this list of conditions and the following disclaimer.
-    
-    2. Redistributions in binary form must reproduce the above copyright 
+
+    2. Redistributions in binary form must reproduce the above copyright
        notice, this list of conditions and the following disclaimer in the
        documentation and/or other materials provided with the distribution.
 
@@ -59,19 +59,6 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Genshi
-------
-
-Copyright © 2006-2007 Edgewall Software
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-   3. The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
-
-THIS SOFTWARE IS PROVIDED BY THE AUTHOR “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Migrate
 -------

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -9,8 +9,6 @@ import pylons
 from paste.deploy.converters import asbool
 import sqlalchemy
 from pylons import config
-from genshi.template import TemplateLoader
-from genshi.filters.i18n import Translator
 
 import ckan.config.routing as routing
 import ckan.model as model
@@ -138,87 +136,6 @@ def load_environment(global_conf, app_conf):
     # Initialize config with the basic options
     config.init_app(global_conf, app_conf, package='ckan', paths=paths)
 
-    #################################################################
-    #                                                               #
-    #                   HORRIBLE GENSHI HACK                        #
-    #                                                               #
-    #################################################################
-    #                                                               #
-    # Genshi does strange things to get stuff out of the template   #
-    # variables.  This stops it from handling properties in the     #
-    # correct way as it returns the property rather than the actual #
-    # value of the property.                                        #
-    #                                                               #
-    # By overriding lookup_attr() in the LookupBase class we are    #
-    # able to get the required behaviour.  Using @property allows   #
-    # us to move functionality out of templates whilst maintaining  #
-    # backwards compatability.                                      #
-    #                                                               #
-    #################################################################
-
-    '''
-    This code is based on Genshi code
-
-    Copyright © 2006-2012 Edgewall Software
-    All rights reserved.
-
-    Redistribution and use in source and binary forms, with or
-    without modification, are permitted provided that the following
-    conditions are met:
-
-        Redistributions of source code must retain the above copyright
-        notice, this list of conditions and the following disclaimer.
-
-        Redistributions in binary form must reproduce the above
-        copyright notice, this list of conditions and the following
-        disclaimer in the documentation and/or other materials provided
-        with the distribution.
-
-        The name of the author may not be used to endorse or promote
-        products derived from this software without specific prior
-        written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS" AND ANY EXPRESS OR
-    IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-    ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
-    GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
-    IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
-    OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
-    IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-    '''
-    from genshi.template.eval import LookupBase
-
-    @classmethod
-    def genshi_lookup_attr(cls, obj, key):
-        __traceback_hide__ = True
-        try:
-            val = getattr(obj, key)
-        except AttributeError:
-            if hasattr(obj.__class__, key):
-                raise
-            else:
-                try:
-                    val = obj[key]
-                except (KeyError, TypeError):
-                    val = cls.undefined(key, owner=obj)
-        if isinstance(val, property):
-            val = val.fget()
-        return val
-
-    setattr(LookupBase, 'lookup_attr', genshi_lookup_attr)
-    del genshi_lookup_attr
-    del LookupBase
-
-    #################################################################
-    #                                                               #
-    #                       END OF GENSHI HACK                      #
-    #                                                               #
-    #################################################################
-
     # Setup the SQLAlchemy database engine
     # Suppress a couple of sqlalchemy warnings
     msgs = ['^Unicode type received non-unicode bind param value',
@@ -329,20 +246,8 @@ def update_config():
     helpers = _Helpers(h)
     config['pylons.h'] = helpers
 
-    ## redo template setup to use genshi.search_path
-    ## (so remove std template setup)
-    legacy_templates_path = os.path.join(root, 'templates_legacy')
     jinja2_templates_path = os.path.join(root, 'templates')
-    if asbool(config.get('ckan.legacy_templates', 'no')):
-        # We want the new template path for extra snippets like the
-        # dataviewer and also for some testing stuff
-        msg = 'Support for Genshi templates is deprecated and will be removed'\
-            ' in a future release'
-        log.warn(msg)
-
-        template_paths = [legacy_templates_path, jinja2_templates_path]
-    else:
-        template_paths = [jinja2_templates_path, legacy_templates_path]
+    template_paths = [jinja2_templates_path]
 
     extra_template_paths = config.get('extra_template_paths', '')
     if extra_template_paths:
@@ -350,20 +255,10 @@ def update_config():
         template_paths = extra_template_paths.split(',') + template_paths
     config['pylons.app_globals'].template_paths = template_paths
 
-    # Translator (i18n)
-    translator = Translator(pylons.translator)
-
-    def template_loaded(template):
-        translator.setup(template)
-
     # Markdown ignores the logger config, so to get rid of excessive
     # markdown debug messages in the log, set it to the level of the
     # root logger.
     logging.getLogger("MARKDOWN").setLevel(logging.getLogger().level)
-
-    # Create the Genshi TemplateLoader
-    config['pylons.app_globals'].genshi_loader = TemplateLoader(
-        template_paths, auto_reload=True, callback=template_loaded)
 
     # Create Jinja2 environment
     env = jinja_extensions.Environment(

--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -246,10 +246,6 @@ class GroupController(base.BaseController):
 
         context['return_query'] = True
 
-        # c.group_admins is used by CKAN's legacy (Genshi) templates only,
-        # if we drop support for those then we can delete this line.
-        c.group_admins = authz.get_group_or_org_admin_ids(c.group.id)
-
         page = self._get_page_number(request.params)
 
         # most search operations should reset the page counter:

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -87,8 +87,7 @@ def render_jinja2(template_name, extra_vars):
 
 
 def render(template_name, extra_vars=None, cache_key=None, cache_type=None,
-           cache_expire=None, method='xhtml',
-           cache_force=None, renderer=None):
+           cache_expire=None, cache_force=None, renderer=None):
     '''Render a template and return the output.
 
     This is CKAN's main template rendering function.

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -13,8 +13,6 @@ from pylons.controllers.util import redirect_to, redirect
 from pylons.decorators import jsonify
 from pylons.i18n import N_, gettext, ngettext
 from pylons.templating import cached_template, pylons_globals
-from genshi.template import MarkupTemplate
-from genshi.template.text import NewTextTemplate
 from webhelpers.html import literal
 
 import ckan.exceptions
@@ -82,22 +80,6 @@ def render_snippet(template_name, **kw):
     return literal(output)
 
 
-def render_text(template_name, extra_vars=None, cache_force=None):
-    '''Render a Genshi :py:class:`NewTextTemplate`.
-
-    This is just a wrapper function that lets you render a Genshi
-    :py:class:`NewTextTemplate` without having to pass ``method='text'`` or
-    ``loader_class=NewTextTemplate`` (it passes them to
-    :py:func:`~ckan.plugins.toolkit.render` for you).
-
-    '''
-    return render(template_name,
-                  extra_vars=extra_vars,
-                  cache_force=cache_force,
-                  method='text',
-                  loader_class=NewTextTemplate)
-
-
 def render_jinja2(template_name, extra_vars):
     env = config['pylons.app_globals'].jinja_env
     template = env.get_template(template_name)
@@ -105,7 +87,7 @@ def render_jinja2(template_name, extra_vars):
 
 
 def render(template_name, extra_vars=None, cache_key=None, cache_type=None,
-           cache_expire=None, method='xhtml', loader_class=MarkupTemplate,
+           cache_expire=None, method='xhtml',
            cache_force=None, renderer=None):
     '''Render a template and return the output.
 
@@ -144,29 +126,8 @@ def render(template_name, extra_vars=None, cache_key=None, cache_type=None,
                 request.environ['CKAN_DEBUG_INFO'] = []
             request.environ['CKAN_DEBUG_INFO'].append(debug_info)
 
-        # Jinja2 templates
-        if template_type == 'jinja2':
-            # We don't want to have the config in templates it should be
-            # accessed via g (app_globals) as this gives us flexability such
-            # as changing via database settings.
-            del globs['config']
-            # TODO should we raise error if genshi filters??
-            return render_jinja2(template_name, globs)
-
-        # Genshi templates
-        template = globs['app_globals'].genshi_loader.load(
-            template_name.encode('utf-8'), cls=loader_class
-        )
-        stream = template.generate(**globs)
-
-        for item in p.PluginImplementations(p.IGenshiStreamFilter):
-            stream = item.filter(stream)
-
-        if loader_class == NewTextTemplate:
-            return literal(stream.render(method="text", encoding=None))
-
-        return literal(stream.render(method=method, encoding=None,
-                                     strip_whitespace=True))
+        del globs['config']
+        return render_jinja2(template_name, globs)
 
     if 'Pragma' in response.headers:
         del response.headers["Pragma"]
@@ -188,7 +149,7 @@ def render(template_name, extra_vars=None, cache_key=None, cache_type=None,
     # Don't cache if we have set the __no_cache__ param in the query string.
     elif request.params.get('__no_cache__'):
         allow_cache = False
-    # Don't cache if we have extra vars containing data.
+   # Don't cache if we have extra vars containing data.
     elif extra_vars:
         for k, v in extra_vars.iteritems():
             allow_cache = False
@@ -212,8 +173,7 @@ def render(template_name, extra_vars=None, cache_key=None, cache_type=None,
 
     # Render Time :)
     try:
-        return cached_template(template_name, render_template,
-                               loader_class=loader_class)
+        return cached_template(template_name, render_template)
     except ckan.exceptions.CkanUrlException, e:
         raise ckan.exceptions.CkanUrlException(
             '\nAn Exception has been raised for template %s\n%s' %

--- a/ckan/lib/extract.py
+++ b/ckan/lib/extract.py
@@ -1,5 +1,4 @@
 import re
-from genshi.filters.i18n import extract as extract_genshi
 from jinja2.ext import babel_extract as extract_jinja2
 import lib.jinja_extensions
 
@@ -33,19 +32,8 @@ def jinja2_cleaner(fileobj, *args, **kw):
 
 
 def extract_ckan(fileobj, *args, **kw):
-    ''' Determine the type of file (Genshi or Jinja2) and then call the
-    correct extractor function.
-
-    Basically we just look for genshi.edgewall.org which all genshi XML
-    templates should contain. '''
-
     source = fileobj.read()
-    if re.search('genshi\.edgewall\.org', source):
-        # genshi
-        output = extract_genshi(fileobj, *args, **kw)
-    else:
-        # jinja2
-        output = jinja2_cleaner(fileobj, *args, **kw)
+    output = jinja2_cleaner(fileobj, *args, **kw)
     # we've eaten the file so we need to get back to the start
     fileobj.seek(0)
     return output

--- a/ckan/lib/render.py
+++ b/ckan/lib/render.py
@@ -21,22 +21,6 @@ def find_template(template_name):
             return os.path.join(path, template_name)
 
 def template_type(template_path):
-    ''' returns best guess for template type
-    returns 'jinja2', 'genshi', 'genshi-text' '''
-    if template_path.endswith('.txt'):
-        return 'genshi-text'
-    try:
-        f = open(template_path, 'r')
-    except IOError:
-        # do the import here due to circular import hell functions like
-        # abort should be in a none circular importing file but that
-        # refactor has not yet happened
-        import ckan.lib.base as base
-        base.abort(404)
-    source = f.read()
-    f.close()
-    if re.search('genshi\.edgewall\.org', source):
-        return 'genshi'
     return 'jinja2'
 
 class TemplateNotFound(Exception):

--- a/ckan/plugins/core.py
+++ b/ckan/plugins/core.py
@@ -152,10 +152,6 @@ def load(*plugins):
         for observer_plugin in observers:
             observer_plugin.after_load(service)
 
-        if interfaces.IGenshiStreamFilter in service.__interfaces__:
-            log.warn("Plugin '%s' is using deprecated interface "
-                     'IGenshiStreamFilter' % plugin)
-
         _PLUGINS.append(plugin)
         _PLUGINS_CLASS.append(service.__class__)
 

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -4,7 +4,7 @@ extend CKAN.
 '''
 __all__ = [
     'Interface',
-    'IGenshiStreamFilter', 'IRoutes',
+    'IRoutes',
     'IMapper', 'ISession',
     'IMiddleware',
     'IAuthFunctions',
@@ -58,23 +58,6 @@ class IMiddleware(Interface):
         '''Return an app configured with this error log middleware
         '''
         return app
-
-
-class IGenshiStreamFilter(Interface):
-    '''
-    Hook into template rendering.
-    See ckan.lib.base.py:render
-    '''
-
-    def filter(self, stream):
-        """
-        Return a filtered Genshi stream.
-        Called when any page is rendered.
-
-        :param stream: Genshi stream of the current output document
-        :returns: filtered Genshi stream
-        """
-        return stream
 
 
 class IRoutes(Interface):
@@ -1227,7 +1210,7 @@ class IGroupForm(Interface):
 
         The group controller is the controller, that is used to handle requests
         of the group type(s) of this plugin.
-        
+
         If this method is not provided, the default group controller is used
         (`group`).
         """

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -22,7 +22,6 @@ class _Toolkit(object):
         'c',                    # template context
         'request',              # http request object
         'render',               # template render function
-        'render_text',          # Genshi NewTextTemplate render function
         'render_snippet',       # snippet render function
         'asbool',               # converts an object to a boolean
         'asint',                # converts an object to an integer
@@ -147,7 +146,6 @@ request body variables, cookies, the request URL, etc.
 
 '''
         t['render'] = base.render
-        t['render_text'] = base.render_text
         t['asbool'] = converters.asbool
         self.docstring_overrides['asbool'] = '''Convert a string from the
 config file into a boolean.

--- a/ckan/tests/legacy/functional/test_package.py
+++ b/ckan/tests/legacy/functional/test_package.py
@@ -1,7 +1,6 @@
 import datetime
 
 from pylons import config, c
-from genshi.core import escape as genshi_escape
 from difflib import unified_diff
 from nose.tools import assert_equal
 
@@ -143,8 +142,8 @@ class TestPackageForm(TestPackageBase):
         for num, (key, value, deleted) in enumerate(sorted(extras)):
             key_in_html_body = self.escape_for_html_body(key)
             value_in_html_body = self.escape_for_html_body(value)
-            key_escaped = genshi_escape(key)
-            value_escaped = genshi_escape(value)
+            key_escaped = key
+            value_escaped = value
             self.check_tag(main_res, 'extras__%s__key' % num, key_in_html_body)
             self.check_tag(main_res, 'extras__%s__value' % num, value_escaped)
             if deleted:

--- a/ckan/tests/legacy/misc/test_format_text.py
+++ b/ckan/tests/legacy/misc/test_format_text.py
@@ -146,6 +146,5 @@ class TestFormatText:
   [msn]:    http://search.msn.com/    "MSN Search"'''
         exp = '''<p>I get 10 times more traffic from <a href="http://google.com/" title="Google">Google</a> than from
 <a href="http://search.yahoo.com/" title="Yahoo Search">Yahoo</a> or <a href="http://search.msn.com/" title="MSN Search">MSN</a>.</p>'''
-        # NB when this is put into Genshi, it will close the tag for you.
         out = h.render_markdown(instr)
         assert exp in out, '\nGot: %s\nWanted: %s' % (out, exp)

--- a/ckan/tests/legacy/pylons_controller.py
+++ b/ckan/tests/legacy/pylons_controller.py
@@ -5,12 +5,12 @@ Based on answer at:
 http://groups.google.com/group/pylons-discuss/browse_thread/thread/5f8d8f59fd459a77
 '''
 
-from unittest import TestCase 
-from paste.registry import Registry 
-import pylons 
+from unittest import TestCase
+from paste.registry import Registry
+import pylons
 from pylons.util import AttribSafeContextObj
 import ckan.lib.app_globals as app_globals
-from pylons.controllers.util import Request, Response 
+from pylons.controllers.util import Request, Response
 from routes.util import URLGenerator
 
 from ckan.config.routing import make_map
@@ -25,12 +25,12 @@ class TestPylonsSession(dict):
 
 
 class PylonsTestCase(object):
-    """A basic test case which allows access to pylons.c and pylons.request. 
+    """A basic test case which allows access to pylons.c and pylons.request.
     """
     @classmethod
     def setup_class(cls):
-        cls.registry=Registry() 
-        cls.registry.prepare() 
+        cls.registry=Registry()
+        cls.registry.prepare()
 
         cls.context_obj=AttribSafeContextObj()
         cls.registry.register(pylons.c, cls.context_obj)
@@ -38,14 +38,11 @@ class PylonsTestCase(object):
         cls.app_globals_obj = app_globals.app_globals
         cls.registry.register(pylons.g, cls.app_globals_obj)
 
-        cls.request_obj=Request(dict(HTTP_HOST="nohost", REQUEST_METHOD="GET")) 
-        cls.registry.register(pylons.request, cls.request_obj) 
+        cls.request_obj=Request(dict(HTTP_HOST="nohost", REQUEST_METHOD="GET"))
+        cls.registry.register(pylons.request, cls.request_obj)
 
-        cls.translator_obj=MockTranslator() 
-        cls.registry.register(pylons.translator, cls.translator_obj) 
-
-        cls.buffet = pylons.templating.Buffet('genshi', template_root='ckan.templates')
-        cls.registry.register(pylons.buffet, cls.buffet)
+        cls.translator_obj=MockTranslator()
+        cls.registry.register(pylons.translator, cls.translator_obj)
 
         cls.registry.register(pylons.response, Response())
         mapper = make_map()

--- a/ckanext/test_tag_vocab_plugin.py
+++ b/ckanext/test_tag_vocab_plugin.py
@@ -3,8 +3,6 @@ Currently this is used in tests/functional/test_tag_vocab.py'''
 
 
 from pylons import request, tmpl_context as c
-from genshi.input import HTML
-from genshi.filters import Transformer
 from ckan.logic import get_action
 from ckan.logic.converters import convert_to_tags, convert_from_tags, free_tags_only
 from ckan.logic.schema import default_create_package_schema, default_update_package_schema, default_show_package_schema
@@ -15,7 +13,6 @@ TEST_VOCAB_NAME = 'test-vocab'
 
 class MockVocabTagsPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IDatasetForm, inherit=True)
-    plugins.implements(plugins.IGenshiStreamFilter)
 
     def is_fallback(self):
         return False
@@ -67,26 +64,3 @@ class MockVocabTagsPlugin(plugins.SingletonPlugin):
             'vocab_tags_selected': [convert_from_tags(TEST_VOCAB_NAME), ignore_missing],
         })
         return schema
-
-    def filter(self, stream):
-        routes = request.environ.get('pylons.routes_dict')
-        if routes.get('controller') == 'package' \
-            and routes.get('action') == 'read':
-                # add vocab tags to the bottom of the page
-                tags = c.pkg_dict.get('vocab_tags_selected', [])
-                for tag in tags:
-                    stream = stream | Transformer('body')\
-                        .append(HTML('<p>%s</p>' % tag))
-        if routes.get('controller') == 'package' \
-            and routes.get('action') == 'edit':
-                # add vocabs tag select box to edit page
-                html = '<select id="vocab_tags" name="vocab_tags" size="60" multiple="multiple">'
-                selected_tags = c.pkg_dict.get('vocab_tags_selected', [])
-                for tag in c.vocab_tags:
-                    if tag in selected_tags:
-                        html += '<option selected="selected" value="%s">%s</option>' % (tag, tag)
-                    else:
-                        html += '<option value="%s">%s</option>' % (tag, tag)
-                html += '</select>'
-                stream = stream | Transformer('fieldset[@id="basic-information"]').append(HTML(html))
-        return stream

--- a/doc/maintaining/apps-ideas.rst
+++ b/doc/maintaining/apps-ideas.rst
@@ -2,6 +2,8 @@
 Apps & Ideas
 ============
 
-Since 1.7 CKAN has a feature called Apps & Ideas which allows users to provide information on apps, ideas, visualizations, articles etc that are related to a specific dataset. Once created these items will be shown against the dataset but also shown on the apps dashboard which will allow users to filter the results based on popularity, or type, or the data when the items were created.
+The old "Apps & Ideas" functionality to allow users to provide information on apps, ideas, visualizations, articles etc that are related to a specific dataset has been moved to a separate extension: `ckanext-showcase`_.
 
-This feature is enabled by default but can be disabled using the :ref:`ckan.dataset.show_apps_ideas` setting to hide the tab on the dataset pages.
+.. _ckanext-showcase: https://github.com/ckan/ckanext-showcase
+
+

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -765,21 +765,6 @@ Format as a space-separated list of the plugin names. The plugin name is the key
         they're given in the config file, regardless of which Python modules
         they're implemented in.
 
-.. _ckan.datastore.enabled:
-
-ckan.datastore.enabled
-^^^^^^^^^^^^^^^^^^^^^^
-
-Example::
-
-  ckan.datastore.enabled = True
-
-Default value: ``False``
-
-Controls if the Data API link will appear in Dataset's Resource page.
-
-.. note:: This setting only applies to the legacy templates.
-
 .. _ckanext.stats.cache_enabled:
 
 ckanext.stats.cache_enabled
@@ -963,7 +948,7 @@ Default value: ``False``
 
 This controls if the legacy genshi templates are used.
 
-.. note:: This is only for legacy code, and shouldn't be used anymore.
+.. note:: This is option is **deprecated** and has no effect any more.
 
 .. _ckan.datasets_per_page:
 
@@ -992,21 +977,6 @@ Default value:  (empty)
 This sets a space-separated list of extra field key values which will not be shown on the dataset read page.
 
 .. warning::  While this is useful to e.g. create internal notes, it is not a security measure. The keys will still be available via the API and in revision diffs.
-
-.. _ckan.dataset.show_apps_ideas:
-
-ckan.dataset.show_apps_ideas
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-ckan.dataset.show_apps_ideas::
-
- ckan.dataset.show_apps_ideas = false
-
-Default value:  true
-
-When set to false, or no, this setting will hide the 'Apps, Ideas, etc' tab on the package read page. If the value is not set, or is set to true or yes, then the tab will shown.
-
-.. note::  This only applies to the legacy Genshi-based templates
 
 .. _ckan.dumps_url:
 

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -1273,7 +1273,7 @@ Example::
 
  extra_template_paths = /home/okfn/brazil_ckan_config/templates
 
-To customise the display of CKAN you can supply replacements for the Genshi template files. Use this option to specify where CKAN should look for additional templates, before reverting to the ``ckan/templates`` folder. You can supply more than one folder, separating the paths with a comma (,).
+Use this option to specify where CKAN should look for additional templates, before reverting to the ``ckan/templates`` folder. You can supply more than one folder, separating the paths with a comma (,).
 
 For more information on theming, see :doc:`/theming/index`.
 
@@ -1613,7 +1613,7 @@ Example::
 
 Default value: (none)
 
-If you wish to add extra translation strings and have them merged with the 
+If you wish to add extra translation strings and have them merged with the
 default ckan translations at runtime you can specify the location of the extra
 translations using this option.
 

--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,6 @@ Jinja2==2.6  # newer version causes problem in CkanInternationalizationExtension
 Pylons==0.9.7
 Beaker==1.7.0 # need to pin this because of https://github.com/bbangert/beaker/commit/fc511ceda4305fcf54919b3f081fed7790e2fef3
 bleach==1.4.2
-Genshi==0.6
 WebTest==1.4.3  # need to pin this so that Pylons does not install a newer version that conflicts with WebOb==1.0.8
 fanstatic==0.12
 Markdown==2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ bleach==1.4.2
 decorator==4.0.4          # via pylons, sqlalchemy-migrate
 fanstatic==0.12
 formencode==1.3.0         # via pylons
-Genshi==0.6
 Jinja2==2.6
 mako==1.0.2               # via pylons
 Markdown==2.4

--- a/test-core.ini
+++ b/test-core.ini
@@ -86,8 +86,6 @@ ckan.locale_default = en
 ckan.locale_order = en pt_BR ja it cs_CZ ca es fr el sv sr sr@latin no sk fi ru de pl nl bg ko_KR hu sa sl lv
 ckan.locales_filtered_out =
 
-ckan.datastore.enabled = 1
-
 ckanext.stats.cache_enabled = 0
 
 ckan.datasets_per_page = 20


### PR DESCRIPTION
As genshi was deprecated 2.5 years ago, it's about time we removed it.
This PR removes genshi.

This should fix #2833 