### PR TITLE
toolkit: add h, StopOnError, DefaultOrganizationForm

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -40,6 +40,7 @@ class _Helpers(object):
     def __init__(self, helpers):
         self.helpers = helpers
         self._setup()
+        self.no_magic = _HelpersNoMagic(self)
 
     def _setup(self):
         helpers = self.helpers
@@ -97,6 +98,21 @@ class _Helpers(object):
                       '(are you missing an extension?)' % name
                 self.log.critical(msg)
             return self.null_function
+
+
+class _HelpersNoMagic(object):
+    """
+    Access helper.functions as attributes, but raise AttributeError
+    for missing functions instead of returning null_function
+    """
+    def __init__(self, helpers):
+        self._helpers = helpers
+
+    def __getattr__(self, name):
+        fn = getattr(self._helpers, name)
+        if fn is _Helpers.null_function:
+            raise AttributeError("No helper found named '%s'" % name)
+        return fn
 
 
 def load_environment(global_conf, app_conf):

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -74,13 +74,6 @@ class _Helpers(object):
         # logging
         self.log = logging.getLogger('ckan.helpers')
 
-    @classmethod
-    def null_function(cls, *args, **kw):
-        ''' This function is returned if no helper is found. The idea is
-        to try to allow templates to be rendered even if helpers are
-        missing.  Returning the empty string seems to work well.'''
-        return ''
-
     def __getattr__(self, name):
         ''' return the function/object requested '''
         if name in self.functions:
@@ -97,7 +90,14 @@ class _Helpers(object):
                 msg = 'Helper function `%s` could not be found\n ' \
                       '(are you missing an extension?)' % name
                 self.log.critical(msg)
-            return self.null_function
+            return _null_function
+
+
+def _null_function(*args, **kw):
+    ''' This function is returned if no helper is found. The idea is
+    to try to allow templates to be rendered even if helpers are
+    missing.  Returning the empty string seems to work well.'''
+    return ''
 
 
 class _HelpersNoMagic(object):
@@ -110,7 +110,7 @@ class _HelpersNoMagic(object):
 
     def __getattr__(self, name):
         fn = getattr(self._helpers, name)
-        if fn is _Helpers.null_function:
+        if fn is _null_function:
             raise AttributeError("No helper found named '%s'" % name)
         return fn
 

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -39,6 +39,8 @@ class _Toolkit(object):
         'NotAuthorized',        # action not authorized exception
         'UnknownValidator',     # validator not found exception
         'ValidationError',      # model update validation error
+        'StopOnError',          # validation exception to stop further
+                                # validators from being called
         'Invalid',              # validation invalid exception
         'CkanCommand',          # class for providing cli interfaces
         'DefaultDatasetForm',   # base class for IDatasetForm plugins
@@ -180,6 +182,7 @@ For example: ``bar = toolkit.aslist(config.get('ckan.foo.bar', []))``
         t['ObjectNotFound'] = logic.NotFound  # Name change intentional
         t['NotAuthorized'] = logic.NotAuthorized
         t['ValidationError'] = logic.ValidationError
+        t['StopOnError'] = dictization_functions.StopOnError
         t['UnknownValidator'] = logic.UnknownValidator
         t['Invalid'] = logic_validators.Invalid
 

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -20,6 +20,7 @@ class _Toolkit(object):
         '_',                    # i18n translation
         'ungettext',            # i18n translation (plural forms)
         'c',                    # template context
+        'h',                    # template helpers
         'request',              # http request object
         'render',               # template render function
         'render_text',          # Genshi NewTextTemplate render function
@@ -141,6 +142,7 @@ available throughout the template and application code, and are local to the
 current request.
 
 '''
+        t['h'] = pylons.config['pylons.h']
         t['request'] = common.request
         self.docstring_overrides['request'] = '''The Pylons request object.
 

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -45,6 +45,7 @@ class _Toolkit(object):
         'CkanCommand',          # class for providing cli interfaces
         'DefaultDatasetForm',   # base class for IDatasetForm plugins
         'DefaultGroupForm',     # base class for IGroupForm plugins
+        'DefaultOrganizationForm', # base class for IGroupForm plugins for orgs
         'response',             # response object for cookies etc
         'BaseController',       # Allow controllers to be created
         'abort',                # abort actions
@@ -189,6 +190,7 @@ For example: ``bar = toolkit.aslist(config.get('ckan.foo.bar', []))``
         t['CkanCommand'] = cli.CkanCommand
         t['DefaultDatasetForm'] = lib_plugins.DefaultDatasetForm
         t['DefaultGroupForm'] = lib_plugins.DefaultGroupForm
+        t['DefaultOrganizationForm'] = lib_plugins.DefaultOrganizationForm
 
         t['response'] = pylons.response
         self.docstring_overrides['response'] = '''The Pylons response object.

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -142,7 +142,7 @@ available throughout the template and application code, and are local to the
 current request.
 
 '''
-        t['h'] = pylons.config['pylons.h']
+        t['h'] = getattr(pylons.config['pylons.h'], 'no_magic', None)
         t['request'] = common.request
         self.docstring_overrides['request'] = '''The Pylons request object.
 

--- a/ckan/tests/plugins/test_toolkit.py
+++ b/ckan/tests/plugins/test_toolkit.py
@@ -263,8 +263,8 @@ class TestRequiresCkanVersion(object):
 class TestTemplateHelper(object):
     def test_call_helper(self):
         # the null_function would return ''
-        assert_true(tk.h.lang())
+        assert_true(tk.h.icon_url('x'))
 
     def test_attribute_error_on_missing_helper(self):
         assert_raises(AttributeError, getattr,
-            tk.h, 'not_a_real_helper_function')
+                      tk.h, 'not_a_real_helper_function')

--- a/ckan/tests/plugins/test_toolkit.py
+++ b/ckan/tests/plugins/test_toolkit.py
@@ -1,4 +1,4 @@
-from nose.tools import assert_equal, assert_raises
+from nose.tools import assert_equal, assert_raises, assert_true
 
 from ckan.plugins import toolkit as tk
 
@@ -258,3 +258,13 @@ class TestRequiresCkanVersion(object):
         tk.ckan.__version__ = '2'
         assert_raises(tk.CkanVersionException,
                       tk.requires_ckan_version, min_version='3')
+
+
+class TestTemplateHelper(object):
+    def test_call_helper(self):
+        # the null_function would return ''
+        assert_true(tk.h.lang())
+
+    def test_attribute_error_on_missing_helper(self):
+        assert_raises(AttributeError, getattr,
+            tk.h, 'not_a_real_helper_function')


### PR DESCRIPTION
These changes will let me remove all deep ckan imports from ckanext-scheming.

For `h` I've chosen to export the same object that the templates see (with all the same side-effects) I think that's better than just exporting `ckan.lib.helpers` but I would kind of like to have proper AttributeErrors when I mistype a helper name.