### PR TITLE
make resource urls optional

### DIFF
--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -113,7 +113,7 @@ def resource_dictize(res, context):
                                     resource_id=res.id,
                                     filename=cleaned_name,
                                     qualified=True)
-    elif not urlparse.urlsplit(url).scheme and not context.get('for_edit'):
+    elif resource['url'] and not urlparse.urlsplit(url).scheme and not context.get('for_edit'):
         resource['url'] = u'http://' + url.lstrip('/')
     return resource
 

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -280,7 +280,8 @@ def resource_create(context, data_dict):
     user = context['user']
 
     package_id = _get_or_bust(data_dict, 'package_id')
-    _get_or_bust(data_dict, 'url')
+    if not data_dict.get('url'):
+        data_dict['url'] = ''
 
     pkg_dict = _get_action('package_show')(
         dict(context, return_type='dict'),

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -58,6 +58,8 @@ def resource_update(context, data_dict):
     model = context['model']
     user = context['user']
     id = _get_or_bust(data_dict, "id")
+    if not data_dict.get('url'):
+        data_dict['url'] = ''
 
     resource = model.Resource.get(id)
     context["resource"] = resource

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -79,7 +79,7 @@ def default_resource_schema():
         'id': [ignore_empty, unicode],
         'revision_id': [ignore_missing, unicode],
         'package_id': [ignore],
-        'url': [not_empty, unicode, remove_whitespace],
+        'url': [ignore_missing, unicode, remove_whitespace],
         'description': [ignore_missing, unicode],
         'format': [if_empty_guess_format, ignore_missing, clean_format, unicode],
         'hash': [ignore_missing, unicode],

--- a/ckan/tests/legacy/lib/test_dictization_schema.py
+++ b/ckan/tests/legacy/lib/test_dictization_schema.py
@@ -113,19 +113,9 @@ class TestBasicDictize:
 
         assert errors == {
             'name': [u'That URL is already in use.'],
-            'resources': [{}, {'url': [u'Missing value']}]
         }, pformat(errors)
 
         data["id"] = package_id
-
-        converted_data, errors = validate(data,
-                                          default_update_package_schema(),
-                                          self.context)
-
-        assert errors == {
-            'resources': [{}, {'url': [u'Missing value']}]
-        }, pformat(errors)
-
         data['name'] = '????jfaiofjioafjij'
 
         converted_data, errors = validate(data,
@@ -134,7 +124,6 @@ class TestBasicDictize:
         assert errors == {
             'name': [u'Must be purely lowercase alphanumeric (ascii) '
                      'characters and these symbols: -_'],
-            'resources': [{}, {'url': [u'Missing value']}]
         }, pformat(errors)
 
     def test_2_group_schema(self):

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -403,15 +403,14 @@ class TestResourceCreate(object):
         assert_raises(logic.ValidationError, helpers.call_action,
                       'resource_create', **data_dict)
 
-    def test_it_requires_url(self):
+    def test_doesnt_require_url(self):
         user = factories.User()
         dataset = factories.Dataset(user=user)
         data_dict = {
             'package_id': dataset['id']
         }
 
-        assert_raises(logic.ValidationError, helpers.call_action,
-                      'resource_create', **data_dict)
+        helpers.call_action('resource_create', **data_dict)
 
 
 class TestMemberCreate(object):

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -409,11 +409,10 @@ class TestResourceCreate(object):
         data_dict = {
             'package_id': dataset['id']
         }
-
         new_resouce = helpers.call_action('resource_create', **data_dict)
 
-        data_dict={
-             'id':new_resouce['id']
+        data_dict = {
+            'id': new_resouce['id']
         }
         stored_resource = helpers.call_action('resource_show', **data_dict)
 

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -410,7 +410,14 @@ class TestResourceCreate(object):
             'package_id': dataset['id']
         }
 
-        helpers.call_action('resource_create', **data_dict)
+        new_resouce = helpers.call_action('resource_create', **data_dict)
+
+        data_dict={
+             'id':new_resouce['id']
+        }
+        stored_resource = helpers.call_action('resource_show', **data_dict)
+
+        assert not stored_resource['url']
 
 
 class TestMemberCreate(object):


### PR DESCRIPTION
When uploading a file or when creating a datastore resource, CKAN requires a dummy value entered in to the url field simply to pass validation.

Some users may want to create resources that aren't accessible publicly yet, again requiring some kind of dummy value to be entered.
