### PR TITLE
Use 403 when actions are forbidden, not 401 

### DIFF
--- a/ckan/config/middleware.py
+++ b/ckan/config/middleware.py
@@ -108,12 +108,12 @@ def make_app(conf, full_stack=True, static_files=True, **app_conf):
         # Handle Python exceptions
         app = ErrorHandler(app, conf, **config['pylons.errorware'])
 
-        # Display error documents for 401, 403, 404 status codes (and
+        # Display error documents for 400, 403, 404 status codes (and
         # 500 when debug is disabled)
         if asbool(config['debug']):
-            app = StatusCodeRedirect(app, [400, 404])
+            app = StatusCodeRedirect(app, [400, 403, 404])
         else:
-            app = StatusCodeRedirect(app, [400, 404, 500])
+            app = StatusCodeRedirect(app, [400, 403, 404, 500])
 
     # Initialize repoze.who
     who_parser = WhoConfig(conf['here'])

--- a/ckan/controllers/admin.py
+++ b/ckan/controllers/admin.py
@@ -28,7 +28,7 @@ class AdminController(base.BaseController):
         try:
             logic.check_access('sysadmin', context, {})
         except logic.NotAuthorized:
-            base.abort(401, _('Need to be system administrator to administer'))
+            base.abort(403, _('Need to be system administrator to administer'))
         c.revision_change_state_allowed = True
 
     def _get_config_form_items(self):

--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -160,7 +160,7 @@ class GroupController(base.BaseController):
         try:
             self._check_access('site_read', context)
         except NotAuthorized:
-            abort(401, _('Not authorized to see this page'))
+            abort(403, _('Not authorized to see this page'))
 
         # pass user info to context as needed to view private datasets of
         # orgs correctly
@@ -218,10 +218,8 @@ class GroupController(base.BaseController):
             data_dict['include_datasets'] = False
             c.group_dict = self._action('group_show')(context, data_dict)
             c.group = context['group']
-        except NotFound:
+        except (NotFound, NotAuthorized):
             abort(404, _('Group not found'))
-        except NotAuthorized:
-            abort(401, _('Unauthorized to read group %s') % id)
 
         self._read(id, limit, group_type)
         return render(self._read_template(c.group_dict['type']),
@@ -400,10 +398,8 @@ class GroupController(base.BaseController):
             data_dict['include_datasets'] = False
             c.group_dict = self._action('group_show')(context, data_dict)
             c.group = context['group']
-        except NotFound:
+        except (NotFound, NotAuthorized):
             abort(404, _('Group not found'))
-        except NotAuthorized:
-            abort(401, _('Unauthorized to read group %s') % id)
 
         #use different form names so that ie7 can be detected
         form_names = set(["bulk_action.public", "bulk_action.delete",
@@ -446,7 +442,7 @@ class GroupController(base.BaseController):
         try:
             get_action(action_functions[action])(context, data_dict)
         except NotAuthorized:
-            abort(401, _('Not authorized to perform bulk update'))
+            abort(403, _('Not authorized to perform bulk update'))
         base.redirect(h.url_for(controller='organization',
                                 action='bulk_process',
                                 id=id))
@@ -466,7 +462,7 @@ class GroupController(base.BaseController):
         try:
             self._check_access('group_create', context)
         except NotAuthorized:
-            abort(401, _('Unauthorized to create a group'))
+            abort(403, _('Unauthorized to create a group'))
 
         if context['save'] and not data:
             return self._save_new(context, group_type)
@@ -508,10 +504,8 @@ class GroupController(base.BaseController):
             c.grouptitle = old_data.get('title')
             c.groupname = old_data.get('name')
             data = data or old_data
-        except NotFound:
+        except (NotFound, NotAuthorized):
             abort(404, _('Group not found'))
-        except NotAuthorized:
-            abort(401, _('Unauthorized to read group %s') % '')
 
         group = context.get("group")
         c.group = group
@@ -520,7 +514,7 @@ class GroupController(base.BaseController):
         try:
             self._check_access('group_update', context)
         except NotAuthorized:
-            abort(401, _('User %r not authorized to edit %s') % (c.user, id))
+            abort(403, _('User %r not authorized to edit %s') % (c.user, id))
 
         errors = errors or {}
         vars = {'data': data, 'errors': errors,
@@ -553,9 +547,7 @@ class GroupController(base.BaseController):
 
             # Redirect to the appropriate _read route for the type of group
             h.redirect_to(group['type'] + '_read', id=group['name'])
-        except NotAuthorized:
-            abort(401, _('Unauthorized to read group %s') % '')
-        except NotFound, e:
+        except (NotFound, NotAuthorized), e:
             abort(404, _('Group not found'))
         except dict_fns.DataError:
             abort(400, _(u'Integrity Error'))
@@ -585,9 +577,7 @@ class GroupController(base.BaseController):
                 self._force_reindex(group)
 
             h.redirect_to('%s_read' % group['type'], id=group['name'])
-        except NotAuthorized:
-            abort(401, _('Unauthorized to read group %s') % id)
-        except NotFound, e:
+        except (NotFound, NotAuthorized), e:
             abort(404, _('Group not found'))
         except dict_fns.DataError:
             abort(400, _(u'Integrity Error'))
@@ -615,7 +605,7 @@ class GroupController(base.BaseController):
         except NotAuthorized:
             c.authz_editable = False
         if not c.authz_editable:
-            abort(401,
+            abort(403,
                   _('User %r not authorized to edit %s authorizations') %
                    (c.user, id))
 
@@ -636,7 +626,7 @@ class GroupController(base.BaseController):
         try:
             self._check_access('group_delete', context, {'id': id})
         except NotAuthorized:
-            abort(401, _('Unauthorized to delete group %s') % '')
+            abort(403, _('Unauthorized to delete group %s') % '')
 
         try:
             if request.method == 'POST':
@@ -651,7 +641,7 @@ class GroupController(base.BaseController):
                 self._redirect_to_this_controller(action='index')
             c.group_dict = self._action('group_show')(context, {'id': id})
         except NotAuthorized:
-            abort(401, _('Unauthorized to delete group %s') % '')
+            abort(403, _('Unauthorized to delete group %s') % '')
         except NotFound:
             abort(404, _('Group not found'))
         return self._render_template('group/confirm_delete.html', group_type)
@@ -669,9 +659,7 @@ class GroupController(base.BaseController):
             data_dict = {'id': id}
             data_dict['include_datasets'] = False
             c.group_dict = self._action('group_show')(context, data_dict)
-        except NotAuthorized:
-            abort(401, _('Unauthorized to delete group %s') % '')
-        except NotFound:
+        except (NotFound, NotAuthorized):
             abort(404, _('Group not found'))
         return self._render_template('group/members.html', group_type)
 
@@ -722,7 +710,7 @@ class GroupController(base.BaseController):
                 else:
                     c.user_role = 'member'
         except NotAuthorized:
-            abort(401, _('Unauthorized to add member to group %s') % '')
+            abort(403, _('Unauthorized to add member to group %s') % '')
         except NotFound:
             abort(404, _('Group not found'))
         except ValidationError, e:
@@ -741,7 +729,7 @@ class GroupController(base.BaseController):
         try:
             self._check_access('group_member_delete', context, {'id': id})
         except NotAuthorized:
-            abort(401, _('Unauthorized to delete group %s members') % '')
+            abort(403, _('Unauthorized to delete group %s members') % '')
 
         try:
             user_id = request.params.get('user')
@@ -754,7 +742,7 @@ class GroupController(base.BaseController):
             c.user_id = user_id
             c.group_id = id
         except NotAuthorized:
-            abort(401, _('Unauthorized to delete group %s') % '')
+            abort(403, _('Unauthorized to delete group %s members') % '')
         except NotFound:
             abort(404, _('Group not found'))
         return self._render_template('group/confirm_delete_member.html',
@@ -788,10 +776,8 @@ class GroupController(base.BaseController):
             #TODO: remove
             # Still necessary for the authz check in group/layout.html
             c.group = context['group']
-        except NotFound:
+        except (NotFound, NotAuthorized):
             abort(404, _('Group not found'))
-        except NotAuthorized:
-            abort(401, _('User %r not authorized to edit %r') % (c.user, id))
 
         format = request.params.get('format', '')
         if format == 'atom':
@@ -847,12 +833,8 @@ class GroupController(base.BaseController):
                    'user': c.user, 'for_view': True}
         try:
             c.group_dict = self._get_group_dict(id)
-        except NotFound:
+        except (NotFound, NotAuthorized):
             abort(404, _('Group not found'))
-        except NotAuthorized:
-            abort(401,
-                  _('Unauthorized to read group {group_id}').format(
-                      group_id=id))
 
         # Add the group's activity stream (already rendered to HTML) to the
         # template context for the group/read.html template to retrieve later.
@@ -912,7 +894,7 @@ class GroupController(base.BaseController):
             c.followers = \
                 get_action('group_follower_list')(context, {'id': id})
         except NotAuthorized:
-            abort(401, _('Unauthorized to view followers %s') % '')
+            abort(403, _('Unauthorized to view followers %s') % '')
         return render('group/followers.html',
                       extra_vars={'group_type': group_type})
 
@@ -943,7 +925,5 @@ class GroupController(base.BaseController):
         try:
             return self._action('group_show')(
                 context, {'id': id, 'include_datasets': False})
-        except NotFound:
+        except (NotFound, NotAuthorized):
             abort(404, _('Group not found'))
-        except NotAuthorized:
-            abort(401, _('Unauthorized to read group %s') % id)

--- a/ckan/controllers/home.py
+++ b/ckan/controllers/home.py
@@ -23,7 +23,7 @@ class HomeController(base.BaseController):
                        'auth_user_obj': c.userobj}
             logic.check_access('site_read', context)
         except logic.NotAuthorized:
-            base.abort(401, _('Not authorized to see this page'))
+            base.abort(403, _('Not authorized to see this page'))
         except (sqlalchemy.exc.ProgrammingError,
                 sqlalchemy.exc.OperationalError), e:
             # postgres and sqlite errors for missing tables

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -139,7 +139,7 @@ class PackageController(base.BaseController):
                        'auth_user_obj': c.userobj}
             check_access('site_read', context)
         except NotAuthorized:
-            abort(401, _('Not authorized to see this page'))
+            abort(403, _('Not authorized to see this page'))
 
         # unicode format (decoded from utf8)
         q = c.q = request.params.get('q', u'')
@@ -316,15 +316,13 @@ class PackageController(base.BaseController):
         except NotFound:
             abort(404, _('Dataset not found'))
         except NotAuthorized:
-            abort(401, _('User %r not authorized to edit %s') % (c.user, id))
+            abort(403, _('User %r not authorized to edit %s') % (c.user, id))
         # check if package exists
         try:
             c.pkg_dict = get_action('package_show')(context, data_dict)
             c.pkg = context['package']
-        except NotFound:
+        except (NotFound, NotAuthorized):
             abort(404, _('Dataset not found'))
-        except NotAuthorized:
-            abort(401, _('Unauthorized to read package %s') % id)
 
         package_type = c.pkg_dict['type'] or 'dataset'
         self._setup_template_variables(context, {'id': id},
@@ -423,7 +421,7 @@ class PackageController(base.BaseController):
             c.pkg = context['package']
 
         except NotAuthorized:
-            abort(401, _('Unauthorized to read package %s') % '')
+            abort(403, _('Unauthorized to read package %s') % '')
         except NotFound:
             abort(404, _('Dataset not found'))
 
@@ -491,7 +489,7 @@ class PackageController(base.BaseController):
         try:
             check_access('package_create', context)
         except NotAuthorized:
-            abort(401, _('Unauthorized to create a package'))
+            abort(403, _('Unauthorized to create a package'))
 
         if context['save'] and not data:
             return self._save_new(context, package_type=package_type)
@@ -561,7 +559,7 @@ class PackageController(base.BaseController):
                 return self.resource_edit(id, resource_id, data,
                                           errors, error_summary)
             except NotAuthorized:
-                abort(401, _('Unauthorized to edit this resource'))
+                abort(403, _('Unauthorized to edit this resource'))
             redirect(h.url_for(controller='package', action='resource_read',
                                id=id, resource_id=resource_id))
 
@@ -638,7 +636,7 @@ class PackageController(base.BaseController):
                 try:
                     data_dict = get_action('package_show')(context, {'id': id})
                 except NotAuthorized:
-                    abort(401, _('Unauthorized to update dataset'))
+                    abort(403, _('Unauthorized to update dataset'))
                 except NotFound:
                     abort(404, _('The dataset {id} could not be found.'
                                  ).format(id=id))
@@ -675,7 +673,7 @@ class PackageController(base.BaseController):
                 error_summary = e.error_summary
                 return self.new_resource(id, data, errors, error_summary)
             except NotAuthorized:
-                abort(401, _('Unauthorized to create a resource'))
+                abort(403, _('Unauthorized to create a resource'))
             except NotFound:
                 abort(404, _('The dataset {id} could not be found.'
                              ).format(id=id))
@@ -711,7 +709,7 @@ class PackageController(base.BaseController):
             check_access(
                 'resource_create', context, {"package_id": pkg_dict["id"]})
         except NotAuthorized:
-            abort(401, _('Unauthorized to create a resource for this package'))
+            abort(403, _('Unauthorized to create a resource for this package'))
 
         package_type = pkg_dict['type'] or 'dataset'
 
@@ -747,9 +745,7 @@ class PackageController(base.BaseController):
             if data:
                 old_data.update(data)
             data = old_data
-        except NotAuthorized:
-            abort(401, _('Unauthorized to read package %s') % '')
-        except NotFound:
+        except (NotFound, NotAuthorized):
             abort(404, _('Dataset not found'))
         # are we doing a multiphase add?
         if data.get('state', '').startswith('draft'):
@@ -764,7 +760,7 @@ class PackageController(base.BaseController):
         try:
             check_access('package_update', context)
         except NotAuthorized:
-            abort(401, _('User %r not authorized to edit %s') % (c.user, id))
+            abort(403, _('User %r not authorized to edit %s') % (c.user, id))
         # convert tags if not supplied in data
         if data and not data.get('tag_string'):
             data['tag_string'] = ', '.join(h.dict_list_reduce(
@@ -797,9 +793,7 @@ class PackageController(base.BaseController):
                    'revision_id': revision}
         try:
             data = get_action('package_show')(context, {'id': id})
-        except NotAuthorized:
-            abort(401, _('Unauthorized to read package %s') % '')
-        except NotFound:
+        except (NotFound, NotAuthorized):
             abort(404, _('Dataset not found'))
 
         data.pop('tags')
@@ -816,7 +810,7 @@ class PackageController(base.BaseController):
             pkg_revisions = get_action('package_revision_list')(
                 context, data_dict)
         except NotAuthorized:
-            abort(401, _('Unauthorized to read package %s') % '')
+            abort(403, _('Unauthorized to read package %s') % '')
         except NotFound:
             abort(404, _('Dataset not found'))
 
@@ -917,7 +911,7 @@ class PackageController(base.BaseController):
             self._form_save_redirect(pkg_dict['name'], 'new',
                                      package_type=package_type)
         except NotAuthorized:
-            abort(401, _('Unauthorized to read package %s') % '')
+            abort(403, _('Unauthorized to read package %s') % '')
         except NotFound, e:
             abort(404, _('Dataset not found'))
         except dict_fns.DataError:
@@ -965,7 +959,7 @@ class PackageController(base.BaseController):
             self._form_save_redirect(pkg['name'], 'edit',
                                      package_type=package_type)
         except NotAuthorized:
-            abort(401, _('Unauthorized to read package %s') % id)
+            abort(403, _('Unauthorized to read package %s') % id)
         except NotFound, e:
             abort(404, _('Dataset not found'))
         except dict_fns.DataError:
@@ -1017,7 +1011,7 @@ class PackageController(base.BaseController):
             c.pkg_dict = get_action('package_show')(context, {'id': id})
             dataset_type = c.pkg_dict['type'] or 'dataset'
         except NotAuthorized:
-            abort(401, _('Unauthorized to delete package %s') % '')
+            abort(403, _('Unauthorized to delete package %s') % '')
         except NotFound:
             abort(404, _('Dataset not found'))
         return render('package/confirm_delete.html',
@@ -1035,7 +1029,7 @@ class PackageController(base.BaseController):
         try:
             check_access('package_delete', context, {'id': id})
         except NotAuthorized:
-            abort(401, _('Unauthorized to delete package %s') % '')
+            abort(403, _('Unauthorized to delete package %s') % '')
 
         try:
             if request.method == 'POST':
@@ -1046,7 +1040,7 @@ class PackageController(base.BaseController):
                 context, {'id': resource_id})
             c.pkg_id = id
         except NotAuthorized:
-            abort(401, _('Unauthorized to delete resource %s') % '')
+            abort(403, _('Unauthorized to delete resource %s') % '')
         except NotFound:
             abort(404, _('Resource not found'))
         return render('package/confirm_delete_resource.html',
@@ -1060,10 +1054,8 @@ class PackageController(base.BaseController):
 
         try:
             c.package = get_action('package_show')(context, {'id': id})
-        except NotFound:
+        except (NotFound, NotAuthorized):
             abort(404, _('Dataset not found'))
-        except NotAuthorized:
-            abort(401, _('Unauthorized to read dataset %s') % id)
 
         for resource in c.package.get('resources', []):
             if resource['id'] == resource_id:
@@ -1136,10 +1128,8 @@ class PackageController(base.BaseController):
         try:
             rsc = get_action('resource_show')(context, {'id': resource_id})
             get_action('package_show')(context, {'id': id})
-        except NotFound:
+        except (NotFound, NotAuthorized):
             abort(404, _('Resource not found'))
-        except NotAuthorized:
-            abort(401, _('Unauthorized to read resource %s') % id)
 
         if rsc.get('url_type') == 'upload':
             upload = uploader.ResourceUpload(rsc)
@@ -1215,7 +1205,7 @@ class PackageController(base.BaseController):
         except NotFound:
             abort(404, _('Dataset not found'))
         except NotAuthorized:
-            abort(401, _('Unauthorized to read package %s') % id)
+            abort(403, _('Unauthorized to read package %s') % id)
 
         return render('package/followers.html',
                       {'dataset_type': dataset_type})
@@ -1228,10 +1218,8 @@ class PackageController(base.BaseController):
         try:
             c.pkg_dict = get_action('package_show')(context, data_dict)
             dataset_type = c.pkg_dict['type'] or 'dataset'
-        except NotFound:
+        except (NotFound, NotAuthorized):
             abort(404, _('Dataset not found'))
-        except NotAuthorized:
-            abort(401, _('Unauthorized to read dataset %s') % id)
 
         if request.method == 'POST':
             new_group = request.POST.get('group_added')
@@ -1297,7 +1285,7 @@ class PackageController(base.BaseController):
         except NotFound:
             abort(404, _('Dataset not found'))
         except NotAuthorized:
-            abort(401, _('Unauthorized to read dataset %s') % id)
+            abort(403, _('Unauthorized to read dataset %s') % id)
 
         return render('package/activity.html',
                       {'dataset_type': dataset_type})
@@ -1324,10 +1312,8 @@ class PackageController(base.BaseController):
                 raise NotFound
             dataset_type = c.package['type'] or 'dataset'
 
-        except NotFound:
+        except (NotFound, NotAuthorized):
             abort(404, _('Resource not found'))
-        except NotAuthorized:
-            abort(401, _('Unauthorized to read resource %s') % id)
 
         # Construct the recline state
         state_version = int(request.params.get('state_version', '1'))
@@ -1390,15 +1376,13 @@ class PackageController(base.BaseController):
         try:
             check_access('package_update', context, data_dict)
         except NotAuthorized:
-            abort(401, _('User %r not authorized to edit %s') % (c.user, id))
+            abort(403, _('User %r not authorized to edit %s') % (c.user, id))
         # check if package exists
         try:
             c.pkg_dict = get_action('package_show')(context, data_dict)
             c.pkg = context['package']
-        except NotFound:
+        except (NotFound, NotAuthorized):
             abort(404, _('Dataset not found'))
-        except NotAuthorized:
-            abort(401, _('Unauthorized to read dataset %s') % id)
 
         try:
             c.resource = get_action('resource_show')(context,
@@ -1409,7 +1393,7 @@ class PackageController(base.BaseController):
         except NotFound:
             abort(404, _('Resource not found'))
         except NotAuthorized:
-            abort(401, _('Unauthorized to read resource %s') % id)
+            abort(403, _('Unauthorized to read resource %s') % id)
 
         self._setup_template_variables(context, {'id': id},
                                        package_type=package_type)
@@ -1426,23 +1410,19 @@ class PackageController(base.BaseController):
         try:
             check_access('resource_update', context, {'id': resource_id})
         except NotAuthorized, e:
-            abort(401, _('User %r not authorized to edit %s') % (c.user, id))
+            abort(403, _('User %r not authorized to edit %s') % (c.user, id))
 
         # get resource and package data
         try:
             c.pkg_dict = get_action('package_show')(context, {'id': id})
             c.pkg = context['package']
-        except NotFound:
+        except (NotFound, NotAuthorized):
             abort(404, _('Dataset not found'))
-        except NotAuthorized:
-            abort(401, _('Unauthorized to read dataset %s') % id)
         try:
             c.resource = get_action('resource_show')(context,
                                                      {'id': resource_id})
-        except NotFound:
+        except (NotFound, NotAuthorized):
             abort(404, _('Resource not found'))
-        except NotAuthorized:
-            abort(401, _('Unauthorized to read resource %s') % id)
 
         data = {}
         errors = {}
@@ -1477,7 +1457,7 @@ class PackageController(base.BaseController):
             except NotAuthorized:
                 ## This should never happen unless the user maliciously changed
                 ## the resource_id in the url.
-                abort(401, _('Unauthorized to edit resource'))
+                abort(403, _('Unauthorized to edit resource'))
             else:
                 if not to_preview:
                     redirect(h.url_for(controller='package',
@@ -1494,10 +1474,8 @@ class PackageController(base.BaseController):
                 ## might as well preview when loading good existing view
                 if not errors:
                     to_preview = True
-            except NotFound:
+            except (NotFound, NotAuthorized):
                 abort(404, _('View not found'))
-            except NotAuthorized:
-                abort(401, _('Unauthorized to view View %s') % view_id)
 
         view_type = view_type or request.GET.get('view_type')
         data['view_type'] = view_type
@@ -1545,18 +1523,14 @@ class PackageController(base.BaseController):
 
         try:
             package = get_action('package_show')(context, {'id': id})
-        except NotFound:
+        except (NotFound, NotAuthorized):
             abort(404, _('Dataset not found'))
-        except NotAuthorized:
-            abort(401, _('Unauthorized to read dataset %s') % id)
 
         try:
             resource = get_action('resource_show')(
                 context, {'id': resource_id})
-        except NotFound:
+        except (NotFound, NotAuthorized):
             abort(404, _('Resource not found'))
-        except NotAuthorized:
-            abort(401, _('Unauthorized to read resource %s') % resource_id)
 
         view = None
         if request.params.get('resource_view', ''):
@@ -1568,11 +1542,8 @@ class PackageController(base.BaseController):
             try:
                 view = get_action('resource_view_show')(
                     context, {'id': view_id})
-            except NotFound:
+            except (NotFound, NotAuthorized):
                 abort(404, _('Resource view not found'))
-            except NotAuthorized:
-                abort(401,
-                      _('Unauthorized to read resource view %s') % view_id)
 
         if not view or not isinstance(view, dict):
             abort(404, _('Resource view not supplied'))
@@ -1609,10 +1580,8 @@ class PackageController(base.BaseController):
             preview_plugin.setup_template_variables(context, data_dict)
             c.resource_json = json.dumps(c.resource)
             dataset_type = c.package['type'] or 'dataset'
-        except NotFound:
+        except (NotFound, NotAuthorized):
             abort(404, _('Resource not found'))
-        except NotAuthorized:
-            abort(401, _('Unauthorized to read resource %s') % id)
         else:
             return render(preview_plugin.preview_template(context, data_dict),
                           extra_vars={'dataset_type': dataset_type})

--- a/ckan/controllers/revision.py
+++ b/ckan/controllers/revision.py
@@ -28,7 +28,7 @@ class RevisionController(base.BaseController):
         try:
             logic.check_access('site_read', context)
         except logic.NotAuthorized:
-            base.abort(401, _('Not authorized to see this page'))
+            base.abort(403, _('Not authorized to see this page'))
 
     def index(self):
         return self.list()
@@ -179,7 +179,7 @@ class RevisionController(base.BaseController):
         if action in ['delete', 'undelete']:
             # this should be at a lower level (e.g. logic layer)
             if not c.revision_change_state_allowed:
-                base.abort(401)
+                base.abort(403)
             if action == 'delete':
                 revision.state = model.State.DELETED
             elif action == 'undelete':

--- a/ckan/controllers/tag.py
+++ b/ckan/controllers/tag.py
@@ -20,7 +20,7 @@ class TagController(base.BaseController):
                        'auth_user_obj': c.userobj}
             logic.check_access('site_read', context)
         except logic.NotAuthorized:
-            base.abort(401, _('Not authorized to see this page'))
+            base.abort(403, _('Not authorized to see this page'))
 
     def index(self):
         c.q = request.params.get('q', '')

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -43,7 +43,7 @@ class UserController(base.BaseController):
             check_access('site_read', context)
         except NotAuthorized:
             if c.action not in ('login', 'request_reset', 'perform_reset',):
-                abort(401, _('Not authorized to see this page'))
+                abort(403, _('Not authorized to see this page'))
 
     ## hooks for subclasses
     new_user_form = 'user/new_user_form.html'
@@ -70,7 +70,7 @@ class UserController(base.BaseController):
         except NotFound:
             abort(404, _('User not found'))
         except NotAuthorized:
-            abort(401, _('Not authorized to see this page'))
+            abort(403, _('Not authorized to see this page'))
 
         c.user_dict = user_dict
         c.is_myself = user_dict['name'] == c.user
@@ -99,7 +99,7 @@ class UserController(base.BaseController):
         try:
             check_access('user_list', context, data_dict)
         except NotAuthorized:
-            abort(401, _('Not authorized to see this page'))
+            abort(403, _('Not authorized to see this page'))
 
         users_list = get_action('user_list')(context, data_dict)
 
@@ -144,7 +144,7 @@ class UserController(base.BaseController):
         try:
             check_access('user_create', context)
         except NotAuthorized:
-            abort(401, _('Unauthorized to register as a user.'))
+            abort(403, _('Unauthorized to register as a user.'))
 
         return self.new(data, errors, error_summary)
 
@@ -161,7 +161,7 @@ class UserController(base.BaseController):
         try:
             check_access('user_create', context)
         except NotAuthorized:
-            abort(401, _('Unauthorized to create a user'))
+            abort(403, _('Unauthorized to create a user'))
 
         if context['save'] and not data:
             return self._save_new(context)
@@ -193,7 +193,7 @@ class UserController(base.BaseController):
             h.redirect_to(user_index)
         except NotAuthorized:
             msg = _('Unauthorized to delete user with id "{user_id}".')
-            abort(401, msg.format(user_id=id))
+            abort(403, msg.format(user_id=id))
 
     def generate_apikey(self, id):
         '''Cycle the API key of a user'''
@@ -212,7 +212,7 @@ class UserController(base.BaseController):
         try:
             result = get_action('user_generate_apikey')(context, data_dict)
         except NotAuthorized:
-            abort(401, _('Unauthorized to edit user %s') % '')
+            abort(403, _('Unauthorized to edit user %s') % '')
         except NotFound:
             abort(404, _('User not found'))
 
@@ -227,7 +227,7 @@ class UserController(base.BaseController):
             captcha.check_recaptcha(request)
             user = get_action('user_create')(context, data_dict)
         except NotAuthorized:
-            abort(401, _('Unauthorized to create user %s') % '')
+            abort(403, _('Unauthorized to create user %s') % '')
         except NotFound, e:
             abort(404, _('User not found'))
         except DataError:
@@ -271,7 +271,7 @@ class UserController(base.BaseController):
         try:
             check_access('user_update', context, data_dict)
         except NotAuthorized:
-            abort(401, _('Unauthorized to edit a user.'))
+            abort(403, _('Unauthorized to edit a user.'))
 
         if (context['save']) and not data:
             return self._save_edit(id, context)
@@ -290,7 +290,7 @@ class UserController(base.BaseController):
             data = data or old_data
 
         except NotAuthorized:
-            abort(401, _('Unauthorized to edit user %s') % '')
+            abort(403, _('Unauthorized to edit user %s') % '')
         except NotFound:
             abort(404, _('User not found'))
 
@@ -298,7 +298,7 @@ class UserController(base.BaseController):
 
         if not (authz.is_sysadmin(c.user)
                 or c.user == user_obj.name):
-            abort(401, _('User %s not authorized to edit %s') %
+            abort(403, _('User %s not authorized to edit %s') %
                   (str(c.user), id))
 
         errors = errors or {}
@@ -339,7 +339,7 @@ class UserController(base.BaseController):
             h.flash_success(_('Profile updated'))
             h.redirect_to(controller='user', action='read', id=user['name'])
         except NotAuthorized:
-            abort(401, _('Unauthorized to edit user %s') % id)
+            abort(403, _('Unauthorized to edit user %s') % id)
         except NotFound, e:
             abort(404, _('User not found'))
         except DataError:
@@ -425,7 +425,7 @@ class UserController(base.BaseController):
         try:
             check_access('request_reset', context)
         except NotAuthorized:
-            abort(401, _('Unauthorized to request reset password.'))
+            abort(403, _('Unauthorized to request reset password.'))
 
         if request.method == 'POST':
             id = request.params.get('user')
@@ -480,7 +480,7 @@ class UserController(base.BaseController):
         try:
             check_access('user_reset', context)
         except NotAuthorized:
-            abort(401, _('Unauthorized to reset password.'))
+            abort(403, _('Unauthorized to reset password.'))
 
         try:
             data_dict = {'id': id}
@@ -544,7 +544,7 @@ class UserController(base.BaseController):
         try:
             c.followers = f(context, {'id': c.user_dict['id']})
         except NotAuthorized:
-            abort(401, _('Unauthorized to view followers %s') % '')
+            abort(403, _('Unauthorized to view followers %s') % '')
         return render('user/followers.html')
 
     def activity(self, id, offset=0):
@@ -558,7 +558,7 @@ class UserController(base.BaseController):
         try:
             check_access('user_show', context, data_dict)
         except NotAuthorized:
-            abort(401, _('Not authorized to see this page'))
+            abort(403, _('Not authorized to see this page'))
 
         self._setup_template_variables(context, data_dict)
 
@@ -600,11 +600,8 @@ class UserController(base.BaseController):
                 abort(404, _('Follow item not found'))
             try:
                 followee = action_function(context, data_dict)
-            except NotFound:
+            except (NotFound, NotAuthorized):
                 abort(404, _('{0} not found').format(filter_type))
-            except NotAuthorized:
-                abort(401, _('Unauthorized to read {0} {1}').format(
-                    filter_type, id))
 
             if followee is not None:
                 return {

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -49,7 +49,7 @@ def abort(status_code=None, detail='', headers=None, comment=None):
     abort response, and showing flash messages in the web interface.
 
     '''
-    if status_code == 401:
+    if status_code == 403:
         # Allow IAuthenticator plugins to alter the abort
         for item in p.PluginImplementations(p.IAuthenticator):
             result = item.abort(status_code, detail, headers, comment)

--- a/ckan/tests/controllers/test_admin.py
+++ b/ckan/tests/controllers/test_admin.py
@@ -260,13 +260,7 @@ class TestTrashView(helpers.FunctionalTestBase):
         app = self._get_test_app()
 
         trash_url = url_for(controller='admin', action='trash')
-        trash_response = app.get(trash_url, status=302)
-        # redirects to login page with flash message
-        trash_response = trash_response.follow()
-        assert_true('Need to be system administrator to administer'
-                    in trash_response)
-        assert_true('<!-- Snippet user/snippets/login_form.html start -->'
-                    in trash_response)
+        trash_response = app.get(trash_url, status=403)
 
     def test_trash_view_normal_user(self):
         '''A normal logged in user shouldn't be able to access trash view.'''
@@ -275,7 +269,7 @@ class TestTrashView(helpers.FunctionalTestBase):
 
         env = {'REMOTE_USER': user['name'].encode('ascii')}
         trash_url = url_for(controller='admin', action='trash')
-        trash_response = app.get(trash_url, extra_environ=env, status=401)
+        trash_response = app.get(trash_url, extra_environ=env, status=403)
         assert_true('Need to be system administrator to administer'
                     in trash_response)
 

--- a/ckan/tests/controllers/test_group.py
+++ b/ckan/tests/controllers/test_group.py
@@ -50,7 +50,7 @@ class TestGroupControllerNew(helpers.FunctionalTestBase):
     def test_not_logged_in(self):
         app = self._get_test_app()
         app.get(url=url_for(controller='group', action='new'),
-                status=302)
+                status=403)
 
     def test_form_renders(self):
         app = self._get_test_app()
@@ -110,7 +110,7 @@ class TestGroupControllerEdit(helpers.FunctionalTestBase):
     def test_not_logged_in(self):
         app = self._get_test_app()
         app.get(url=url_for(controller='group', action='new'),
-                status=302)
+                status=403)
 
     def test_group_doesnt_exist(self):
         app = self._get_test_app()
@@ -214,7 +214,7 @@ class TestGroupDelete(helpers.FunctionalTestBase):
         self.app.get(url=url_for(controller='group',
                                  action='delete',
                                  id=self.group['id']),
-                     status=401,
+                     status=403,
                      extra_environ=extra_environ)
 
         group = helpers.call_action('group_show',
@@ -225,7 +225,7 @@ class TestGroupDelete(helpers.FunctionalTestBase):
         self.app.get(url=url_for(controller='group',
                                  action='delete',
                                  id=self.group['id']),
-                     status=302)  # redirects to login form
+                     status=403)
 
         group = helpers.call_action('group_show',
                                     id=self.group['id'])

--- a/ckan/tests/controllers/test_organization.py
+++ b/ckan/tests/controllers/test_organization.py
@@ -17,7 +17,7 @@ class TestOrganizationNew(helpers.FunctionalTestBase):
 
     def test_not_logged_in(self):
         self.app.get(url=url_for(controller='group', action='new'),
-                     status=302)
+                     status=403)
 
     def test_name_required(self):
         response = self.app.get(url=self.organization_new_url,
@@ -173,7 +173,7 @@ class TestOrganizationDelete(helpers.FunctionalTestBase):
         self.app.get(url=url_for(controller='organization',
                                  action='delete',
                                  id=self.organization['id']),
-                     status=401,
+                     status=403,
                      extra_environ=extra_environ)
 
         organization = helpers.call_action('organization_show',
@@ -184,7 +184,7 @@ class TestOrganizationDelete(helpers.FunctionalTestBase):
         self.app.get(url=url_for(controller='organization',
                                  action='delete',
                                  id=self.organization['id']),
-                     status=302)  # redirects to login form
+                     status=403)
 
         organization = helpers.call_action('organization_show',
                                            id=self.organization['id'])

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -429,8 +429,8 @@ class TestPackageDelete(helpers.FunctionalTestBase):
         app = helpers._get_test_app()
         response = app.post(
             url_for(controller='package', action='delete', id=dataset['name']),
+            status=403,
         )
-        assert_equal(403, response.status_int)
         response.mustcontain('Unauthorized to delete package')
 
         deleted = helpers.call_action('package_show', id=dataset['id'])
@@ -477,7 +477,10 @@ class TestPackageDelete(helpers.FunctionalTestBase):
 
         form = response.forms['confirm-dataset-delete-form']
         response = form.submit('cancel')
-        response = helpers.webtest_maybe_follow(response)
+        response = helpers.webtest_maybe_follow(
+            response,
+            extra_environ=env,
+        )
         assert_equal(200, response.status_int)
 
 
@@ -648,8 +651,8 @@ class TestResourceDelete(helpers.FunctionalTestBase):
         response = app.post(
             url_for(controller='package', action='resource_delete',
                     id=dataset['name'], resource_id=resource['id']),
+            status=403,
         )
-        assert_equal(403, response.status_int)
         response.mustcontain('Unauthorized to delete package')
 
     def test_logged_in_users_cannot_delete_resources_they_do_not_own(self):

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -430,8 +430,7 @@ class TestPackageDelete(helpers.FunctionalTestBase):
         response = app.post(
             url_for(controller='package', action='delete', id=dataset['name']),
         )
-        response = response.follow()
-        assert_equal(200, response.status_int)
+        assert_equal(403, response.status_int)
         response.mustcontain('Unauthorized to delete package')
 
         deleted = helpers.call_action('package_show', id=dataset['id'])
@@ -452,7 +451,7 @@ class TestPackageDelete(helpers.FunctionalTestBase):
             extra_environ=env,
             expect_errors=True
         )
-        assert_equal(401, response.status_int)
+        assert_equal(403, response.status_int)
         response.mustcontain('Unauthorized to delete package')
 
     def test_confirm_cancel_delete(self):
@@ -650,8 +649,7 @@ class TestResourceDelete(helpers.FunctionalTestBase):
             url_for(controller='package', action='resource_delete',
                     id=dataset['name'], resource_id=resource['id']),
         )
-        response = response.follow()
-        assert_equal(200, response.status_int)
+        assert_equal(403, response.status_int)
         response.mustcontain('Unauthorized to delete package')
 
     def test_logged_in_users_cannot_delete_resources_they_do_not_own(self):
@@ -673,7 +671,7 @@ class TestResourceDelete(helpers.FunctionalTestBase):
             extra_environ=env,
             expect_errors=True
         )
-        assert_equal(401, response.status_int)
+        assert_equal(403, response.status_int)
         response.mustcontain('Unauthorized to delete package')
 
     def test_sysadmins_can_delete_any_resource(self):

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -194,8 +194,6 @@ class TestUserEdit(helpers.FunctionalTestBase):
             url_for(controller='user', action='edit', id='unknown_person'),
             status=403
         )
-        response = response.follow()
-        assert_true('Login' in response)
 
     def test_user_edit_not_logged_in(self):
         '''Attempt to read edit user for an existing, not-logged in user

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -192,7 +192,7 @@ class TestUserEdit(helpers.FunctionalTestBase):
         app = self._get_test_app()
         response = app.get(
             url_for(controller='user', action='edit', id='unknown_person'),
-            status=302  # redirect to login page
+            status=403
         )
         response = response.follow()
         assert_true('Login' in response)
@@ -205,10 +205,8 @@ class TestUserEdit(helpers.FunctionalTestBase):
         username = user['name']
         response = app.get(
             url_for(controller='user', action='edit', id=username),
-            status=302
+            status=403
         )
-        response = response.follow()
-        assert_true('Login' in response)
 
     def test_edit_user(self):
         user = factories.User(password='pass')

--- a/ckan/tests/legacy/functional/test_admin.py
+++ b/ckan/tests/legacy/functional/test_admin.py
@@ -14,10 +14,9 @@ class TestAdminController(WsgiAppCase):
     #test that only sysadmins can access the /ckan-admin page
     def test_index(self):
         url = url_for('ckanadmin', action='index')
-        # redirect as not authorized
-        response = self.app.get(url, status=[302])
+        response = self.app.get(url, status=[403])
         # random username
-        response = self.app.get(url, status=[401],
+        response = self.app.get(url, status=[403],
                 extra_environ={'REMOTE_USER': 'my-random-user-name'})
         # now test real access
         username = u'testsysadmin'.encode('utf8')

--- a/ckan/tests/legacy/functional/test_package.py
+++ b/ckan/tests/legacy/functional/test_package.py
@@ -763,10 +763,10 @@ class TestResourceListing(TestPackageBase):
          self.app.get('/dataset/resources/crimeandpunishment', extra_environ=self.extra_environ_tester, status=200)
 
     def test_resource_listing_premissions_non_auth_user(self):
-        # non auth user 401
-         self.app.get('/dataset/resources/crimeandpunishment', extra_environ=self.extra_environ_someone_else, status=[302,401])
+        # non auth user 403
+         self.app.get('/dataset/resources/crimeandpunishment', extra_environ=self.extra_environ_someone_else, status=[403])
 
     def test_resource_listing_premissions_not_logged_in(self):
-        # not logged in 401
-         self.app.get('/dataset/resources/crimeandpunishment', status=[302,401])
+        # not logged in 403
+         self.app.get('/dataset/resources/crimeandpunishment', status=[403])
 

--- a/ckan/tests/legacy/functional/test_package.py
+++ b/ckan/tests/legacy/functional/test_package.py
@@ -511,7 +511,7 @@ class TestEdit(TestPackageForm):
             self.res = self.app.get(self.offset, extra_environ=self.extra_environ_admin)
             fv = self.res.forms['dataset-edit']
             fv['title'] = u'New Title'
-            res = fv.submit('save')
+            res = fv.submit('save', extra_environ=self.extra_environ_admin)
 
             # check relationship still exists
             rels = model.Package.by_name(self.editpkg_name).get_relationships()

--- a/ckan/tests/legacy/functional/test_user.py
+++ b/ckan/tests/legacy/functional/test_user.py
@@ -65,7 +65,7 @@ class TestUserController(FunctionalTestCase, HtmlCheckMethods, PylonsTestCase, S
         url = url_for(controller='user', action='delete', id=user.id)
         extra_environ = {'REMOTE_USER': 'an_unauthorized_user'}
 
-        self.app.get(url, status=401, extra_environ=extra_environ)
+        self.app.get(url, status=403, extra_environ=extra_environ)
 
     def test_user_read_without_id(self):
         offset = '/user/'
@@ -160,7 +160,7 @@ class TestUserController(FunctionalTestCase, HtmlCheckMethods, PylonsTestCase, S
                          action='perform_reset',
                          id=user.id,
                          key=user.reset_key)
-        res = self.app.post(offset, params=params, status=302)
+        res = self.app.post(offset, params=params, status=403)
 
         user = model.User.get(user.id)
         assert user.is_deleted(), user

--- a/ckanext/datapusher/plugin.py
+++ b/ckanext/datapusher/plugin.py
@@ -53,10 +53,8 @@ class ResourceDataController(base.BaseController):
             toolkit.c.resource = p.toolkit.get_action('resource_show')(
                 None, {'id': resource_id}
             )
-        except logic.NotFound:
+        except (logic.NotFound, logic.NotAuthorized):
             base.abort(404, _('Resource not found'))
-        except logic.NotAuthorized:
-            base.abort(401, _('Unauthorized to edit this resource'))
 
         try:
             datapusher_status = p.toolkit.get_action('datapusher_status')(
@@ -65,7 +63,7 @@ class ResourceDataController(base.BaseController):
         except logic.NotFound:
             datapusher_status = {}
         except logic.NotAuthorized:
-            base.abort(401, _('Not authorized to see this page'))
+            base.abort(403, _('Not authorized to see this page'))
 
         return base.render('package/resource_data.html',
                            extra_vars={'status': datapusher_status})


### PR DESCRIPTION
401 is for when a user can't authenticate. All our current 401 errors are causing users to be logged out by repoze (which is reasonable). Instead we want to say "yes, I know who you are, you just aren't allowed to access this page"