### PR TITLE
Param use_default_schema does not work on package_search

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1713,6 +1713,10 @@ def package_search(context, data_dict):
         sysadmin will be returned all draft datasets. Optional, the default is
         ``False``.
     :type include_drafts: boolean
+    :param use_default_schema: use default package schema instead of
+        a custom schema defined with an IDatasetForm plugin (default: False)
+    :type use_default_schema: bool
+
 
     The following advanced Solr parameters are supported as well. Note that
     some of these are only available on particular Solr versions. See Solr's
@@ -1752,9 +1756,6 @@ def package_search(context, data_dict):
         "count", "display_name" and "name" entries.  The display_name is a
         form of the name that can be used in titles.
     :type search_facets: nested dict of dicts.
-    :param use_default_schema: use default package schema instead of
-        a custom schema defined with an IDatasetForm plugin (default: False)
-    :type use_default_schema: bool
 
     An example result: ::
 
@@ -1816,7 +1817,11 @@ def package_search(context, data_dict):
 
     results = []
     if not abort:
-        data_source = 'data_dict' if data_dict.get('use_default_schema') else 'validated_data_dict'
+        if asbool(data_dict.get('use_default_schema')):
+            data_source = 'data_dict'
+        else:
+            data_source = 'validated_data_dict'
+        data_dict.pop('use_default_schema', None)
         # return a list of package ids
         data_dict['fl'] = 'id {0}'.format(data_source)
 


### PR DESCRIPTION
#1327 made both `package_search` and `package_show` return the validated data_dict instead of the default one. In both cases passing `use_default_schema=True` should allow to retrieve the unvalidated data_dict, but on `package_search` is returning an exception:

```
    response = fn(context, data)
  File "/home/adria/dev/pyenvs/flask/src/ckan/ckan/logic/__init__.py", line 416, in wrapped
    result = _action(context, data_dict, **kw)
  File "/home/adria/dev/pyenvs/flask/src/ckan/ckan/logic/action/get.py", line 1852, in package_search
    query.run(data_dict)
  File "/home/adria/dev/pyenvs/flask/src/ckan/ckan/lib/search/query.py", line 306, in run
    raise SearchQueryError("Invalid search parameters: %s" % invalid_params)
SearchQueryError: Invalid search parameters: ['use_default_schema']
```

That's because the param is not removed before being sent to Solr