### PR TITLE
Name field in error message

### DIFF
--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -823,7 +823,8 @@ def extra_key_not_in_root_schema(key, data, errors, context):
 
     for schema_key in context.get('schema_keys', []):
         if schema_key == data[key]:
-            raise Invalid(_('There is a schema field with the same name'))
+            error_message = _('There is a schema field with the same name')
+            raise Invalid(error_message + ":field_name=" + schema_key)
 
 
 def empty_if_not_sysadmin(key, data, errors, context):

--- a/ckan/tests/logic/test_conversion.py
+++ b/ckan/tests/logic/test_conversion.py
@@ -149,4 +149,4 @@ class TestConvertToExtras(object):
 
         assert 'extras' in errors
         eq_(errors['extras'],
-            [{'key': [u'There is a schema field with the same name']}])
+            [{'key': [u'There is a schema field with the same name:field_name=custom_text']}])


### PR DESCRIPTION
To avoid quests which field is the one already present the name of the field is attached to the error message.

Please also merge this back into the 2.3 branch.