### PR TITLE
Fix exception seen on the occasion that SOLR returns a mangled result during package_search

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1856,7 +1856,7 @@ def package_search(context, data_dict):
 
         for package in query.results:
             # get the package object
-            package, package_dict = package['id'], package.get(data_source)
+            package_dict = package.get(data_source)
             ## use data in search index if there
             if package_dict:
                 # the package_dict still needs translating when being viewed


### PR DESCRIPTION
Fixes the exception when it does log.error a few lines later than this change.

Only affects CKAN 2.5.1.

For more info, see this comment:
https://github.com/ckan/ckan/commit/34e1e3f05f52b9ec5b2c2ff79af9822e6d01dd0a#commitcomment-15781370