### PR TITLE
Allow Sysadmins to create users with the form

### DIFF
--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -166,7 +166,7 @@ class UserController(base.BaseController):
         if context['save'] and not data:
             return self._save_new(context)
 
-        if c.user and not data:
+        if c.user and not data and not authz.is_sysadmin(c.user):
             # #1799 Don't offer the registration form if already logged in
             return render('user/logout_first.html')
 


### PR DESCRIPTION
(Even if create_user_from_web is false).

I've come across several workflows where people wanted a centralised administrator to be the **only** person able to create accounts. This change allows that. Everything else works perfectly. I can offer more detail later on - I'm just in a rush at the moment.

Cheers,
Carl