### PR TITLE
Changed the date formatter to display the timezone abbreviation instead of full name

### DIFF
--- a/ckan/lib/formatters.py
+++ b/ckan/lib/formatters.py
@@ -137,7 +137,7 @@ def localised_nice_date(datetime_, show_date=False, with_hours=False):
         'day': datetime_.day,
         'year': datetime_.year,
         'month': _MONTH_FUNCTIONS[datetime_.month - 1](),
-        'timezone': datetime_.tzinfo.zone,
+        'timezone': datetime_.tzname(),
     }
 
     if with_hours:


### PR DESCRIPTION
Displays `February 3, 20016 (EST)` instead of `February 3, 20016 (America/Toronto)` or `February 3, 20016 (America/New York)`