### PR TITLE
Deal with a bad "sort" param better

### DIFF
--- a/bin/travis-run-tests
+++ b/bin/travis-run-tests
@@ -16,7 +16,7 @@ MOCHA_ERROR=$?
 killall paster
 
 # And finally, run the nosetests
-nosetests --ckan --reset-db --with-pylons=test-core.ini --nologcapture --with-coverage --cover-package=ckan --cover-package=ckanext ckan ckanext
+nosetests --ckan --reset-db --with-pylons=test-core.ini --with-coverage --cover-package=ckan --cover-package=ckanext ckan ckanext
 # Did an error occur?
 NOSE_ERROR=$?
 

--- a/bin/travis-run-tests
+++ b/bin/travis-run-tests
@@ -16,11 +16,11 @@ MOCHA_ERROR=$?
 killall paster
 
 # And finally, run the nosetests
-nosetests --ckan --reset-db --with-pylons=test-core.ini --with-coverage --cover-package=ckan --cover-package=ckanext ckan ckanext
+nosetests --ckan --reset-db --with-pylons=test-core.ini --nologcapture --with-coverage --cover-package=ckan --cover-package=ckanext ckan ckanext
 # Did an error occur?
 NOSE_ERROR=$?
 
-[ "0" -ne "$MOCHA_ERROR" ] && echo MOCKA tests have failed
+[ "0" -ne "$MOCHA_ERROR" ] && echo MOCHA tests have failed
 [ "0" -ne "$NOSE_ERROR" ] && echo NOSE tests have failed
 
 # If an error occurred in our tests make sure travis knows

--- a/bin/travis-run-tests
+++ b/bin/travis-run-tests
@@ -16,7 +16,7 @@ MOCHA_ERROR=$?
 killall paster
 
 # And finally, run the nosetests
-nosetests --ckan --reset-db --with-pylons=test-core.ini --with-coverage --cover-package=ckan --cover-package=ckanext ckan ckanext
+nosetests --ckan --reset-db --with-pylons=test-core.ini --nologcapture --with-coverage --cover-package=ckan --cover-package=ckanext ckan ckanext
 # Did an error occur?
 NOSE_ERROR=$?
 

--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -362,7 +362,7 @@ class PackageSearchQuery(SearchQuery):
             error_msg = e.reason
             try:
                 error_msg = json.loads(e.body)['error']['msg']
-                if error_msg.startswith("Can't determine a Sort Order") or
+                if error_msg.startswith("Can't determine a Sort Order") or \
                         error_msg.startswith('Unknown sort order'):
                     raise SearchQueryError('Invalid "sort" parameter')
             except ValueError:

--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -361,6 +361,7 @@ class PackageSearchQuery(SearchQuery):
             solr_response = conn.raw_query(**query)
         except SolrException, e:
             error_msg = e.reason
+            print 'SOLR ERROR', e.body
             try:
                 error_msg = json.loads(e.body)['error']['msg']
                 if error_msg.startswith("Can't determine a Sort Order"):

--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -360,8 +360,15 @@ class PackageSearchQuery(SearchQuery):
         try:
             solr_response = conn.raw_query(**query)
         except SolrException, e:
+            error_msg = e.reason
+            try:
+                error_msg = json.loads(e.body)['error']['msg']
+                if error_msg.startswith("Can't determine a Sort Order"):
+                    raise SearchQueryError('Invalid "sort" parameter')
+            except ValueError:
+                pass
             raise SearchError('SOLR returned an error running query: %r Error: %r' %
-                              (query, e.reason))
+                              (query, error_msg))
         try:
             data = json.loads(solr_response)
             response = data['response']

--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -362,7 +362,9 @@ class PackageSearchQuery(SearchQuery):
             # Error with the sort parameter.  You see slightly different
             # error messages depending on whether the SOLR JSON comes back
             # or Jetty gets in the way converting it to HTML - not sure why
+            #
             if "Can't determine a Sort Order" in e.body or \
+                    "Can't determine Sort Order" in e.body or \
                     'Unknown sort order' in e.body:
                 raise SearchQueryError('Invalid "sort" parameter')
             raise SearchError(

--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -354,17 +354,16 @@ class PackageSearchQuery(SearchQuery):
             query['mm'] = query.get('mm', '2<-1 5<80%')
             query['qf'] = query.get('qf', QUERY_FIELDS)
 
-
         conn = make_connection()
         log.debug('Package query: %r' % query)
         try:
             solr_response = conn.raw_query(**query)
         except SolrException, e:
             error_msg = e.reason
-            print 'SOLR ERROR', e.body
             try:
                 error_msg = json.loads(e.body)['error']['msg']
-                if error_msg.startswith("Can't determine a Sort Order"):
+                if error_msg.startswith("Can't determine a Sort Order") or
+                        error_msg.startswith('Unknown sort order'):
                     raise SearchQueryError('Invalid "sort" parameter')
             except ValueError:
                 pass

--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -360,12 +360,16 @@ class PackageSearchQuery(SearchQuery):
             solr_response = conn.raw_query(**query)
         except SolrException, e:
             error_msg = e.reason
+            print 'Exception %r' % repr(e)
+            print 'Exception %r' % repr(e.body)
             try:
                 error_msg = json.loads(e.body)['error']['msg']
                 if error_msg.startswith("Can't determine a Sort Order") or \
                         error_msg.startswith('Unknown sort order'):
                     raise SearchQueryError('Invalid "sort" parameter')
+                print 'Msg: %r' % error_msg
             except ValueError:
+                print 'Cannot parse %r' % repr(e)
                 pass
             raise SearchError('SOLR returned an error running query: %r Error: %r' %
                               (query, error_msg))

--- a/ckan/templates/snippets/search_form.html
+++ b/ckan/templates/snippets/search_form.html
@@ -45,8 +45,10 @@
   {% endblock %}
 
   {% block search_title %}
-    {% if not no_title %}
+    {% if not error %}
       <h2>{% snippet 'snippets/search_result_text.html', query=query, count=count, type=type %}</h2>
+    {% else %}
+      <h2>Error</h2>
     {% endif %}
   {% endblock %}
 
@@ -74,7 +76,7 @@
 
 </form>
 
-{% if show_empty and count == 0 %}
+{% if show_empty and count == 0 and not error %}
   {% trans %}
     <p class="extra">Please try another search.</p>
   {% endtrans %}
@@ -82,6 +84,6 @@
 
 {% if error %}
   {% trans %}
-    <p><strong>There was an error while searching.</strong> Please try again.</p>
+    <p id="search-error"><strong>There was an error while searching.</strong> Please try again.</p>
   {% endtrans %}
 {% endif %}

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -758,7 +758,13 @@ class TestSearch(helpers.FunctionalTestBase):
         offset = url_for(controller='package', action='search') + \
             '?sort=gvgyr_fgevat+nfp'
         app = self._get_test_app()
-        app.get(offset, status=400)
+        response = app.get(offset, status=[200, 400])
+        if response.status == 200:
+            import sys
+            sys.stdout.write(response.body)
+            raise Exception("Solr returned an unknown error message. "
+                            "Please check the error handling "
+                            "in ckan/lib/search/query.py:run")
 
     def test_search_solr_syntax_error(self):
         factories.Dataset()


### PR DESCRIPTION
When spiders mangle the "sort" search params, I'm fed up of reading the log.error messages.

Also the 'error' page CKAN shows (e.g. a connection error) should not say there were "no results" http://demo.ckan.org/dataset?q=--integrate