### PR TITLE
[#1372] Make resource name default to file name

### DIFF
--- a/ckan/public/base/test/index.html
+++ b/ckan/public/base/test/index.html
@@ -46,6 +46,7 @@
     <script src="../javascript/modules/autocomplete.js"></script>
     <script src="../javascript/modules/resource-form.js"></script>
     <script src="../javascript/modules/resource-upload-field.js"></script>
+    <script src="../javascript/modules/image-upload.js"></script>
     <script src="../javascript/modules/confirm-action.js"></script>
     <script src="../javascript/modules/custom-fields.js"></script>
 
@@ -59,6 +60,7 @@
     <script src="./spec/view-filters.spec.js"></script>
     <script src="./spec/modules/resource-form.spec.js"></script>
     <script src="./spec/modules/resource-upload-field.spec.js"></script>
+    <script src="./spec/modules/image-upload.spec.js"></script>
     <script src="./spec/modules/confirm-action.spec.js"></script>
     <script src="./spec/modules/basic-form.spec.js"></script>
     <script src="./spec/modules/autocomplete.spec.js"></script>

--- a/ckan/public/base/test/spec/modules/image-upload.spec.js
+++ b/ckan/public/base/test/spec/modules/image-upload.spec.js
@@ -1,0 +1,65 @@
+/*globals describe beforeEach afterEach it assert sinon ckan jQuery */
+describe('ckan.modules.ImageUploadModule()', function () {
+  var ImageUploadModule = ckan.module.registry['image-upload'];
+
+  beforeEach(function () {
+    this.el = document.createElement('div');
+    this.sandbox = ckan.sandbox();
+    this.module = new ImageUploadModule(this.el, {}, this.sandbox);
+    this.module.el.html([
+      '<div class="control-group"><input name="image_url" /></div>',
+      '<input name="image_upload" />',
+    ]);
+    this.module.initialize();
+    this.module.field_name = jQuery('<input>', {type: 'text'})
+  });
+
+  afterEach(function () {
+    this.module.teardown();
+  });
+
+  describe('._onFromWeb()', function () {
+
+    it('should change name when url changed', function () {
+      this.module.field_url_input.val('http://example.com/some_image.png');
+      this.module._onFromWebBlur();
+      assert.equal(this.module.field_name.val(), 'some_image.png');
+
+      this.module.field_url_input.val('http://example.com/undefined_file');
+      this.module._onFromWebBlur();
+      assert.equal(this.module.field_name.val(), 'undefined_file');
+    });
+
+    it('should ignore url changes if name was manualy changed', function () {
+      this.module.field_url_input.val('http://example.com/some_image.png');
+      this.module._onFromWebBlur();
+      assert.equal(this.module.field_name.val(), 'some_image.png');
+
+      this.module._onModifyName();
+
+      this.module.field_url_input.val('http://example.com/undefined_file');
+      this.module._onFromWebBlur();
+      assert.equal(this.module.field_name.val(), 'some_image.png');
+    });
+
+    it('should ignore url changes if name was filled before', function () {
+      this.module._nameIsDirty = true;
+      this.module.field_name.val('prefilled');
+
+      this.module.field_url_input.val('http://example.com/some_image.png');
+      this.module._onFromWebBlur();
+      assert.equal(this.module.field_name.val(), 'prefilled');
+
+      this.module.field_url_input.val('http://example.com/second_some_image.png');
+      this.module._onFromWebBlur();
+      assert.equal(this.module.field_name.val(), 'prefilled');
+
+      this.module._onModifyName()
+
+      this.module.field_url_input.val('http://example.com/undefined_file');
+      this.module._onFromWebBlur();
+      assert.equal(this.module.field_name.val(), 'prefilled');
+    });
+  });
+
+});


### PR DESCRIPTION
Currently user have to manually add resource name after or before
uploading/linking resource

After this change name will be automatically filled when resource
uploaded or added link to resource, but only if name has not been
previously modified by user and was empty from the very begining.
i.e. this won't work for resource update