### PR TITLE
Fix `i18n.extra_*` spelling errors in documentation.

### DIFF
--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -1572,14 +1572,14 @@ Default value: (none)
 
 By default, the locales are searched for in the ``ckan/i18n`` directory. Use this option if you want to use another folder.
 
-.. _ckan.18n.extra_directory:
+.. _ckan.i18n.extra_directory:
 
 ckan.i18n.extra_directory
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Example::
 
-  ckan.18n.extra_directory = /opt/ckan/extra_translations/
+  ckan.i18n.extra_directory = /opt/ckan/extra_translations/
 
 Default value: (none)
 
@@ -1587,14 +1587,14 @@ If you wish to add extra translation strings and have them merged with the
 default ckan translations at runtime you can specify the location of the extra
 translations using this option.
 
-.. _ckan.18n.extra_gettext_domain:
+.. _ckan.i18n.extra_gettext_domain:
 
 ckan.i18n.extra_gettext_domain
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Example::
 
-  ckan.18n.extra_gettext_domain = mydomain
+  ckan.i18n.extra_gettext_domain = mydomain
 
 Default value: (none)
 
@@ -1603,18 +1603,18 @@ example if your translations are stored as
 ``i18n/<locale>/LC_MESSAGES/somedomain.mo`` you would want to set this option
 to ``somedomain``
 
-.. _ckan.18n.extra_locales:
+.. _ckan.i18n.extra_locales:
 
-ckan.18n.extra_locales
-^^^^^^^^^^^^^^^^^^^^^^
+ckan.i18n.extra_locales
+^^^^^^^^^^^^^^^^^^^^^^^
 
 Example::
 
-  ckan.18n.extra_locales = fr es de
+  ckan.i18n.extra_locales = fr es de
 
 Default value: (none)
 
-If you have set an extra i18n directory using ``ckan.18n.extra_directory``, you
+If you have set an extra i18n directory using ``ckan.i18n.extra_directory``, you
 should specify the locales that have been translated in that directory in this
 option.
 


### PR DESCRIPTION
Fix several instances in the "Configuration Options" documentation where `ckan.i18n.extra_*` was misspelled `ckan.18n.extra_*` (missing `i`), including in example source code.


### Features:
- [X] includes updated documentation
- [X] includes user-visible changes