### PR TITLE
DomainObject.count() doesn't return count

### DIFF
--- a/ckan/model/domain_object.py
+++ b/ckan/model/domain_object.py
@@ -36,7 +36,7 @@ class DomainObject(object):
 
     @classmethod
     def count(cls):
-        cls.Session.query(cls).count()
+        return cls.Session.query(cls).count()
 
     @classmethod
     def by_name(cls, name, autoflush=True):

--- a/ckan/tests/model/test_resource.py
+++ b/ckan/tests/model/test_resource.py
@@ -70,3 +70,12 @@ class TestResource(object):
         length = len(resources)
         assert length == 1, 'Expected 1 resource, but got %d' % length
         assert_equals([resources[0].id], [resource_id])
+
+    def test_resource_count(self):
+        '''Resource.count() should return a count of instances of Resource
+        class'''
+        assert_equals(Resource.count(), 0)
+        factories.Resource()
+        factories.Resource()
+        factories.Resource()
+        assert_equals(Resource.count(), 3)


### PR DESCRIPTION
### CKAN Version if known (or site URL)

master (2.6.0a)

### Please describe the expected behaviour

Calling the class method .count() for classes that inherit from DomainObject should return a count of the number of instances of that class.

### Please describe the actual behaviour

returns None

### What steps can be taken to reproduce the issue? 

Call .count() on a class that inherits from DomainObject