### PR TITLE
resource_id_exists defined twice in validators.py

### DIFF
--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -264,15 +264,6 @@ def activity_type_exists(activity_type):
     else:
         raise Invalid('%s: %s' % (_('Not found'), _('Activity type')))
 
-def resource_id_exists(value, context):
-
-    model = context['model']
-    session = context['session']
-
-    result = session.query(model.Resource).get(value)
-    if not result:
-        raise Invalid('%s: %s' % (_('Not found'), _('Resource')))
-    return value
 
 # A dictionary mapping activity_type values from activity dicts to functions
 # for validating the object_id values from those same activity dicts.


### PR DESCRIPTION
`resource_id_exists` validator is unnecessarily defined twice in ckan.logic.validators.py

### CKAN Version if known (or site URL)

master (2.6.0a)
