### PR TITLE
Explicitly create a ckan core for tests

### DIFF
--- a/bin/solr_init/create_core.sh
+++ b/bin/solr_init/create_core.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
+SOLR_HOME=${SOLR_HOME:-/opt/solr}
+SOLR_URL=${SOLR_HOST:-http://localhost:8983}
+SOLR_CORE=${SOLR_CORE:-ckan}
+SOLR_SCHEMA=${SOLR_SCHEMA:-$HOME/ckan/ckan/config/solr/schema.xml}
 
-INSTANCE_DIR=$SOLR_HOME/example/solr/$CKAN_SOLR_CORE
-cp -R $SOLR_HOME/example/solr/collection1 $SOLR_HOME/example/solr/$CKAN_SOLR_CORE
-cp $CKAN_SOLR_SCHEMA $SOLR_HOME/example/solr/$CKAN_SOLR_CORE/conf
+INSTANCE_DIR=$SOLR_HOME/example/solr/$SOLR_CORE
+cp -R $SOLR_HOME/example/solr/collection1 $SOLR_HOME/example/solr/$SOLR_CORE
+cp $SOLR_SCHEMA $SOLR_HOME/example/solr/$SOLR_CORE/conf
 
-curl "http://localhost:8983/solr/admin/cores?action=CREATE&name=$CKAN_SOLR_CORE&instanceDir=$INSTANCE_DIR"
+curl "$SOLR_URL/solr/admin/cores?action=CREATE&name=$SOLR_CORE&instanceDir=$INSTANCE_DIR"

--- a/bin/solr_init/create_core.sh
+++ b/bin/solr_init/create_core.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+INSTANCE_DIR=$SOLR_HOME/example/solr/$CKAN_SOLR_CORE
+cp -R $SOLR_HOME/example/solr/collection1 $SOLR_HOME/example/solr/$CKAN_SOLR_CORE
+cp $CKAN_SOLR_SCHEMA $SOLR_HOME/example/solr/$CKAN_SOLR_CORE/conf
+
+curl "http://localhost:8983/solr/admin/cores?action=CREATE&name=$CKAN_SOLR_CORE&instanceDir=$INSTANCE_DIR"

--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,9 @@ machine:
         CKAN_DATASTORE_POSTGRES_WRITE_USER: ckan_default
         CKAN_DATASTORE_POSTGRES_READ_USER: datastore_default
         CKAN_DATASTORE_POSTGRES_READ_PWD: pass
+        CKAN_SOLR_CORE: ckan
+        CKAN_SOLR_SCHEMA: $HOME/ckan/ckan/config/solr/schema.xml
+        SOLR_HOME: $HOME/solr
 
 dependencies:
     override:
@@ -26,10 +29,11 @@ database:
         - sed -i -e 's/.*datastore.read_url.*/ckan.datastore.read_url = postgresql:\/\/datastore_default:pass@\/datastore_test/' test-core.ini
         - paster datastore -c test-core.ini set-permissions | sudo -u postgres psql
 
-        - cp -R /opt/solr-4.3.1 $HOME/solr
-        - cp ckan/config/solr/schema.xml $HOME/solr/example/solr/collection1/conf
-        - cd $HOME/solr/example; java -jar start.jar >> $HOME/solr.log:
+        - cp -R /opt/solr-4.3.1 $SOLR_HOME
+        - cd $SOLR_HOME/example; java -jar start.jar >> $HOME/solr.log:
             background: true
+        - sleep 5
+        - ./bin/solr_init/create_core.sh
 
         - paster db init -c test-core.ini
 

--- a/circle.yml
+++ b/circle.yml
@@ -9,8 +9,6 @@ machine:
         CKAN_DATASTORE_POSTGRES_WRITE_USER: ckan_default
         CKAN_DATASTORE_POSTGRES_READ_USER: datastore_default
         CKAN_DATASTORE_POSTGRES_READ_PWD: pass
-        CKAN_SOLR_CORE: ckan
-        CKAN_SOLR_SCHEMA: $HOME/ckan/ckan/config/solr/schema.xml
         SOLR_HOME: $HOME/solr
 
 dependencies:

--- a/test-core.ini
+++ b/test-core.ini
@@ -29,7 +29,7 @@ ckan.datapusher.url = http://datapusher.ckan.org/
 ckan.datapusher.formats = csv xls xlsx tsv application/csv application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
 
 ## Solr support
-solr_url = http://127.0.0.1:8983/solr
+solr_url = http://127.0.0.1:8983/solr/ckan
 
 ckan.auth.user_create_organizations = true
 ckan.auth.user_create_groups = true


### PR DESCRIPTION
This will make it easier in the future to upgrade to a newer version of Solr, where there is no default core.