### PR TITLE
Fix #2926: Only include snippet HTML comment in debug mode.

### DIFF
--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -75,8 +75,9 @@ def render_snippet(template_name, **kw):
     cache_force = kw.pop('cache_force', None)
     output = render(template_name, extra_vars=kw, cache_force=cache_force,
                     renderer='snippet')
-    output = '\n<!-- Snippet %s start -->\n%s\n<!-- Snippet %s end -->\n' % (
-        template_name, output, template_name)
+    if config.get('debug'):
+        output = ('\n<!-- Snippet %s start -->\n%s\n<!-- Snippet %s end -->\n'
+                  % (template_name, output, template_name))
     return literal(output)
 
 

--- a/ckan/tests/controllers/test_admin.py
+++ b/ckan/tests/controllers/test_admin.py
@@ -223,6 +223,7 @@ class TestConfig(helpers.FunctionalTestBase):
         style_tag = reset_intro_response_html.select('head style')
         assert_equal(len(style_tag), 0)
 
+    @helpers.change_config('debug', True)
     def test_homepage_style(self):
         '''Select a homepage style'''
         app = self._get_test_app()
@@ -255,6 +256,7 @@ class TestConfig(helpers.FunctionalTestBase):
 class TestTrashView(helpers.FunctionalTestBase):
     '''View tests for permanently deleting datasets with Admin Trash.'''
 
+    @helpers.change_config('debug', True)
     def test_trash_view_anon_user(self):
         '''An anon user shouldn't be able to access trash view.'''
         app = self._get_test_app()

--- a/ckan/tests/lib/test_base.py
+++ b/ckan/tests/lib/test_base.py
@@ -3,6 +3,21 @@ from nose import tools as nose_tools
 import ckan.tests.helpers as helpers
 
 
+class TestRenderSnippet(helpers.FunctionalTestBase):
+    """
+    Test ``ckan.lib.base.render_snippet``.
+    """
+    @helpers.change_config('debug', True)
+    def test_comment_present_if_debug_true(self):
+        response = self._get_test_app().get('/')
+        assert '<!-- Snippet ' in response
+
+    @helpers.change_config('debug', False)
+    def test_comment_absent_if_debug_false(self):
+        response = self._get_test_app().get('/')
+        assert '<!-- Snippet ' not in response
+
+
 class TestCORS(helpers.FunctionalTestBase):
 
     def test_options(self):


### PR DESCRIPTION
This fixes #2926.

Previously, the `{% snippet %}` Jinja-directive always surrounded the snippet's content with HTML comments. Now this is only done if the `debug` configuration variable is true.