### PR TITLE
[#2873] Use `resource.url` as raw_resource_url

### DIFF
--- a/ckan/templates/package/snippets/resource_view.html
+++ b/ckan/templates/package/snippets/resource_view.html
@@ -28,7 +28,7 @@
           </p>
           <p id="data-view-error" class="collapse"></p>
           <p>
-            <a href="{{ raw_resource_url }}" class="btn btn-large resource-url-analytics" target="_blank">
+            <a href="{{ resource.url }}" class="btn btn-large resource-url-analytics" target="_blank">
               <i class="icon-large icon-download"></i>
               {{ _('Download resource') }}
             </a>


### PR DESCRIPTION
`resource_view` template uses raw_resouce_url in order to create
download link if resource can't be displayed, but this variable is not
passed into snippet. To make that simpler, use resource.url property
for download button.