### PR TITLE
Better stacktrace for broken SOLR

### DIFF
--- a/ckan/model/modification.py
+++ b/ckan/model/modification.py
@@ -88,7 +88,7 @@ class DomainObjectModificationExtension(plugins.SingletonPlugin):
                 log.exception(search_error)
                 # Reraise, since it's pretty crucial to ckan if it can't index
                 # a dataset
-                raise search_error
+                raise
             except Exception, ex:
                 log.exception(ex)
                 # Don't reraise other exceptions since they are generally of
@@ -103,7 +103,7 @@ class DomainObjectModificationExtension(plugins.SingletonPlugin):
                 log.exception(search_error)
                 # Reraise, since it's pretty crucial to ckan if it can't index
                 # a dataset
-                raise search_error
+                raise
             except Exception, ex:
                 log.exception(ex)
                 # Don't reraise other exceptions since they are generally of


### PR DESCRIPTION
### Proposed fixes:
* The benefit of "raise" on its own is that the original stacktrace is made available, rather than creating a new stacktrace with "raise search_error". So its easier to debug.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
