### PR TITLE
Update trading name of Open Knowledge Foundation

### DIFF
--- a/ckan/templates/footer.html
+++ b/ckan/templates/footer.html
@@ -13,7 +13,7 @@
             {% block footer_links_ckan %}
               {% set api_url = 'http://docs.ckan.org/en/{0}/api/'.format(g.ckan_doc_version) %}
               <li><a href="{{ api_url }}">{{ _('CKAN API') }}</a></li>
-              <li><a href="http://www.okfn.org/">{{ _('Open Knowledge Foundation') }}</a></li>
+              <li><a href="http://www.okfn.org/">{{ _('Open Knowledge International') }}</a></li>
               <li><a href="http://www.opendefinition.org/okd/"><img src="{{ h.url_for_static('/base/images/od_80x15_blue.png') }}"></a></li>
             {% endblock %}
           </ul>


### PR DESCRIPTION
Open Knowledge Foundation now trades as Open Knowledge International. This PR reflects this change.

