### PR TITLE
Fix typos in action/create docstrings

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -916,7 +916,7 @@ def user_create(context, data_dict):
     :param openid: (optional)
     :type openid: string
 
-    :returns: the newly created yser
+    :returns: the newly created user
     :rtype: dictionary
 
     '''
@@ -991,7 +991,7 @@ def user_invite(context, data_dict):
         or ``admin``
     :type role: string
 
-    :returns: the newly created yser
+    :returns: the newly created user
     :rtype: dictionary
     '''
     _check_access('user_invite', context, data_dict)


### PR DESCRIPTION
Two small typos in docstrings for ckan/logic/action/create.py