### PR TITLE
Fix #2953: Strange facet item order.

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -670,7 +670,8 @@ def get_facet_items_dict(facet, limit=None, exclude_active=False):
             facets.append(dict(active=False, **facet_item))
         elif not exclude_active:
             facets.append(dict(active=True, **facet_item))
-    facets = sorted(facets, key=lambda item: item['count'], reverse=True)
+    # Sort descendingly by count and ascendingly by case-sensitive display name
+    facets.sort(key=lambda it: (-it['count'], it['display_name'].lower()))
     if c.search_facets_limits and limit is None:
         limit = c.search_facets_limits.get(facet)
     # zero treated as infinite for hysterical raisins


### PR DESCRIPTION
Fixes #2953:

Previously, facet items (e.g. tags) were first sorted descendingly by
number of matching datasets and then descendingly by case-sensitive
display name. The latter is unexpected and makes browsing the facets
unnecessarily difficult.

With this PR, facets are first sorted descendingly by dataset count
(as before) and then ascendingly by case-insensitive display name.