### PR TITLE
[#2946] "Unsupported" warning banner shown for old docs

### DIFF
--- a/ckan/__init__.py
+++ b/ckan/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.1.0a'
+__version__ = '2.6.0a'
 
 __description__ = 'CKAN Software'
 __long_description__ = \

--- a/ckan/__init__.py
+++ b/ckan/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.6.0a'
+__version__ = '2.1.0a'
 
 __description__ = 'CKAN Software'
 __long_description__ = \

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,6 +9,8 @@ polib==1.0.3
 mock==1.0.1
 factory-boy==2.1.1
 coveralls
-sphinx-rtd-theme==0.1.9
+# sphinx-rtd-theme - we need commit eeff564 which missed the 0.1.9 release
+# (which is the latest at time of writing)
+-e git://github.com/snide/sphinx_rtd_theme.git@eeff5645dc4eeb7a5c4910d39c17131961045dce#egg=sphinx_rtd_theme
 beautifulsoup4==4.3.2
 pip-tools==1.1.2

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,0 +1,8 @@
+{% extends "!layout.html" %}
+{% block extrabody %} 
+{% if status_of_this_version=='unsupported' %}
+  <div style="background-color: #FFBABA; color: #6A0E0E; position: fixed; min-width: 768px; top: 0; width: 100%; padding: 8px 20px 8px; font-size: 14px; line-height: 1.6; text-align: center; z-index: 300">
+    WARNING: This document is for an old version of CKAN that is no longer supported
+  </div>
+{% endif %}
+{% endblock %}

--- a/doc/contributing/release-process.rst
+++ b/doc/contributing/release-process.rst
@@ -393,6 +393,13 @@ a release.
    b. If it is the latest stable release, set it to be the Default Version and
       check it is displayed on http://docs.ckan.org.
 
+#. Rebuild the docs of 3 versions ago, so that it gets the 'not supported' banner.
+
+   Go to the
+   `Read the Docs build page <https://readthedocs.org/projects/ckan/builds/>`_,
+   from the drop-down select the version that is the 4th oldest (excluding
+   "latest") and then click 'Build'.
+
 #. Write a CKAN blog post and announce it to ckan-announce & ckan-dev & twitter.
 
    CKAN blog here: <http://ckan.org/wp-admin>`_


### PR DESCRIPTION
Fixes #2946

Shows "Unsupported" banner over docs older than the latest 3 point releases. e.g. currently docs for 2.5.2, 2.4.3 and 2.3.4 would show as normal, but 2.2.3, 2.1.5 etc would show as "unsupported".

![banner](https://cloud.githubusercontent.com/assets/307612/14492585/3b029652-0178-11e6-9e6c-ecc8297ce2d0.png)

It's a bit annoying that it clips some of the page content, but that requires CSS changes to the sphinx template. I think it is good enough.

To test this:
```
pip install -r dev-requirements.txt
vim ckan/__init__.py # and set the version temporarily to 2.1.0
python setup.py build_sphinx
# open ckan/build/sphinx/html/api/index.html
```