### PR TITLE
[2939] & [1651] How to solr-jetty JSP support

### DIFF
--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -295,6 +295,20 @@ installed, we need to install and configure Solr.
 
         JAVA_HOME=/usr/lib/jvm/java-6-openjdk-i386/
 
+   .. note::
+
+    If you get the message ``HTTP ERROR 500... JSP support not configured.``
+    then you will need to install a solr-jetty bug fix. You do this by::
+
+        cd /tmp
+        wget https://launchpad.net/~vshn/+archive/ubuntu/solr/+files/solr-jetty-jsp-fix_1.0.2_all.deb
+        sudo dpkg -i solr-jetty-jsp-fix_1.0.2_all.deb
+        sudo service solr restart
+
+    You should now see a welcome page from Solr if you open
+    http://localhost:8983/solr/ in your web browser (replace localhost with
+    your server address if needed).
+
 #. Replace the default ``schema.xml`` file with a symlink to the CKAN schema
    file included in the sources.
 


### PR DESCRIPTION
Fixes #2939 & #1651 
### Proposed fixes:

Many beginning CKAN run into issues with solr-jetty (Ubuntu 14.04). The following documentation addition provides a recipe to fix the JSP support error.
### Features:
- [ ] includes tests covering changes **Not applicable**
- [x] includes updated documentation
- [x] includes user-visible changes **As above**
- [ ] includes API changes  **Not applicable**
- [ ] includes bugfix for possible backport  **Not applicable**

Please [X] all the boxes above that apply

There are still issues with solr-jetty. The documentation additions here
provide a recipe to handle/fix the 'HTTP ERROR 500... JSP support not
configured' error.
