### PR TITLE
[#2952] Fix issue when password contain special characters that need escaping

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -255,36 +255,43 @@ class ManageDb(CkanCommand):
             raise AssertionError('Expected postgres database - not %r' % self.db_details.get('db_type'))
         pg_cmd = command
         pg_cmd += ' -U %(db_user)s' % self.db_details
+        env = {}
         if self.db_details.get('db_pass') not in (None, ''):
-            pg_cmd = 'export PGPASSWORD=%(db_pass)s && ' % self.db_details + pg_cmd
+            env = {'PGPASSWORD': self.db_details.get('db_pass')}
         if self.db_details.get('db_host') not in (None, ''):
             pg_cmd += ' -h %(db_host)s' % self.db_details
         if self.db_details.get('db_port') not in (None, ''):
             pg_cmd += ' -p %(db_port)s' % self.db_details
-        return pg_cmd
+        return pg_cmd, env
 
     def _get_psql_cmd(self):
-        psql_cmd = self._get_postgres_cmd('psql')
+        psql_cmd, env = self._get_postgres_cmd('psql')
         psql_cmd += ' -d %(db_name)s' % self.db_details
-        return psql_cmd
+        return psql_cmd, env
 
     def _postgres_dump(self, filepath):
-        pg_dump_cmd = self._get_postgres_cmd('pg_dump')
+        pg_dump_cmd, env = self._get_postgres_cmd('pg_dump')
         pg_dump_cmd += ' %(db_name)s' % self.db_details
-        pg_dump_cmd += ' > %s' % filepath
-        self._run_cmd(pg_dump_cmd)
+        self._run_cmd(pg_dump_cmd, env, filepath)
         print 'Dumped database to: %s' % filepath
 
     def _postgres_load(self, filepath):
         import ckan.model as model
         assert not model.repo.are_tables_created(), "Tables already found. You need to 'db clean' before a load."
-        pg_cmd = self._get_psql_cmd() + ' -f %s' % filepath
+        pg_cmd, env = self._get_psql_cmd() + ' -f %s' % filepath
         self._run_cmd(pg_cmd)
         print 'Loaded CKAN database: %s' % filepath
 
-    def _run_cmd(self, command_line):
+    def _run_cmd(self, command_line, env={}, out_file=None):
         import subprocess
-        retcode = subprocess.call(command_line, shell=True)
+        import os
+        full_env = os.environ.copy()
+        full_env.update(env)
+        if out_file:
+            with open(out_file, 'w') as outf:
+                retcode = subprocess.call(command_line.split(' '), env=full_env, stdout=outf)
+        else:
+            retcode = subprocess.call(command_line.split(' '), env=full_env)
         if retcode != 0:
             raise SystemError('Command exited with errorcode: %i' % retcode)
 


### PR DESCRIPTION
Fixes #2952

### Proposed fixes:
- Changed the method `_run_cmd()` to instead of run the cmd with `shell=True` that needs scaping, runed with `shell=False` (default) so [`subprocess.call`](https://docs.python.org/2/library/subprocess.html#using-the-subprocess-module) takes care of scaping what is needed.
- instead of passing the password to pg_dump and load in the command passed as environmental variable.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply

