### PR TITLE
avert sqlalchemy warning on IN clause operating on empty set

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1895,9 +1895,11 @@ def package_search(context, data_dict):
     for field_name in ('groups', 'organization'):
         group_names.extend(facets.get(field_name, {}).keys())
 
-    groups = session.query(model.Group.name, model.Group.title) \
-                    .filter(model.Group.name.in_(group_names)) \
-                    .all()
+    groups = (session.query(model.Group.name, model.Group.title)
+                     .filter(model.Group.name.in_(group_names))
+                     .all()
+              if group_names else [])
+
     group_titles_by_name = dict(groups)
 
     # Transform facets into a more useful data structure.

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -192,6 +192,7 @@ Create a directory to contain the site's config files:
 
     sudo mkdir -p |config_dir|
     sudo chown -R \`whoami\` |config_parent_dir|/
+    sudo chown -R \`whoami\` ~/ckan/etc
 
 Create the CKAN config file:
 


### PR DESCRIPTION
Fixes #2740 

### Proposed fixes:
On package search, only look for matching groups in database if there are any to match, averting sqlalchemy warning 'The IN-predicate on ... was invoked with an empty sequence. This results in a contradiction, which nonethless can be expensive to evaluate.  Consider alternative strategies for improved performance.'


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply

