### PR TITLE
avert sqlalchemy warning on package search if no group names to match

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1895,9 +1895,10 @@ def package_search(context, data_dict):
     for field_name in ('groups', 'organization'):
         group_names.extend(facets.get(field_name, {}).keys())
 
-    groups = session.query(model.Group.name, model.Group.title) \
-                    .filter(model.Group.name.in_(group_names)) \
+    groups = (session.query(model.Group.name, model.Group.title)
+                    .filter(model.Group.name.in_(group_names))
                     .all()
+              if group_names else [])
     group_titles_by_name = dict(groups)
 
     # Transform facets into a more useful data structure.


### PR DESCRIPTION
Fixes #2740

### Proposed fixes:
On package search, only look for matching groups in database if there are any to match, averting sqlalchemy warning 'The IN-predicate on ... was invoked with an empty sequence. This results in a contradiction, which nonethless can be expensive to evaluate. Consider alternative strategies for improved performance.'


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport



