### PR TITLE
include recursive chown ~/ckan/etc/ in doc on step #4 (Create a CKAN …

### DIFF
--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -192,6 +192,7 @@ Create a directory to contain the site's config files:
 
     sudo mkdir -p |config_dir|
     sudo chown -R \`whoami\` |config_parent_dir|/
+    sudo chown -R \`whoami\` ~/ckan/etc
 
 Create the CKAN config file:
 


### PR DESCRIPTION
Fixes #2987 
### Proposed fixes:
Add instruction
    sudo chown -R \`whoami\` ~/ckan/etc
into step 4 (Create a CKAN config file)

### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

