### PR TITLE
A resource is allowed to have null value in its url. We don't set res…

### DIFF
--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -113,7 +113,7 @@ def resource_dictize(res, context):
                                     resource_id=res.id,
                                     filename=cleaned_name,
                                     qualified=True)
-    elif not urlparse.urlsplit(url).scheme and not context.get('for_edit'):
+    elif resource['url'] and not urlparse.urlsplit(url).scheme and not context.get('for_edit'):
         resource['url'] = u'http://' + url.lstrip('/')
     return resource
 


### PR DESCRIPTION
Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply

…ource['url'] as 'http://' after the resource is retrieved from the database. In this way, the value of resource['url'] is kept as null at front end. We have tested the update with the others in the same branch using the default web UI front. For a resuouce with an empty url, in the Resource Page , the line for URL and the Go to resource Button are not displayed. In the Package page, the Go to resource button is not included in the Explore pop up menu. There is no extra log message shown up in the console.