### PR TITLE
Slow page rendering when using lots of snippets

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1578,40 +1578,6 @@ def debug_inspect(arg):
 
 
 @core_helper
-def debug_full_info_as_list(debug_info):
-    ''' This dumps the template variables for debugging purposes only. '''
-    out = []
-    ignored_keys = ['c', 'app_globals', 'g', 'h', 'request', 'tmpl_context',
-                    'actions', 'translator', 'session', 'N_', 'ungettext',
-                    'config', 'response', '_']
-    ignored_context_keys = ['__class__', '__context', '__delattr__',
-                            '__dict__',
-                            '__doc__', '__format__', '__getattr__',
-                            '__getattribute__', '__hash__', '__init__',
-                            '__module__', '__new__', '__reduce__',
-                            '__reduce_ex__', '__repr__', '__setattr__',
-                            '__sizeof__', '__str__', '__subclasshook__',
-                            '__weakref__', 'action', 'environ', 'pylons',
-                            'start_response']
-    debug_vars = debug_info['vars']
-    for key in debug_vars.keys():
-        if key not in ignored_keys:
-            data = pprint.pformat(debug_vars.get(key))
-            data = data.decode('utf-8')
-            out.append((key, data))
-
-    if 'tmpl_context' in debug_vars:
-        for key in debug_info['c_vars']:
-
-            if key not in ignored_context_keys:
-                data = pprint.pformat(getattr(debug_vars['tmpl_context'], key))
-                data = data.decode('utf-8')
-                out.append(('c.%s' % key, data))
-
-    return out
-
-
-@core_helper
 def popular(type_, number, min=1, title=None):
     ''' display a popular icon. '''
     if type_ == 'views':

--- a/ckan/templates/snippets/debug.html
+++ b/ckan/templates/snippets/debug.html
@@ -11,21 +11,6 @@
 <b>Template path</b>: {{ info.template_path }}
 <b>Template type</b>: {{ info.template_type }}
 <b>Renderer</b>: {{ info.renderer }}
-{% set debug_info = h.debug_full_info_as_list(info) %}
-{% if debug_info %}
-<a class="toggle-debug-vars" style="color:#333"><b>Variables (toggle)</b></a>
-<p style="display:block;white-space:normal;">
-{%- for value in debug_info %}{{ value.0 }}   {% endfor %}
-</p><p style="display:none;">
-{% for value in debug_info -%}
-  <b>{{ value.0 }}</b>: {{ value.1 }}
-{% endfor -%}
-</p>
-{%- else -%}
-<p>{ no variables passed to template}</p>
-{%- endif -%}
-<hr/>
-{%- endfor %}
 </div>
   <script>
     (function () {
@@ -70,17 +55,6 @@
           toggleElement(debug);
           return false;
         };
-      })();
-
-      (function toggleVariables() {
-        var buttons = getElementsByClassName('toggle-debug-vars');
-        for (var i = 0; i < buttons.length; i++) {
-          buttons[i].onclick = function () {
-            var vars = nextElementSibling(this);
-            toggleElement(vars);
-            toggleElement(nextElementSibling(vars));
-          };
-        }
       })();
     })();
   </script>

--- a/ckan/templates/snippets/debug.html
+++ b/ckan/templates/snippets/debug.html
@@ -11,6 +11,8 @@
 <b>Template path</b>: {{ info.template_path }}
 <b>Template type</b>: {{ info.template_type }}
 <b>Renderer</b>: {{ info.renderer }}
+<hr/>
+{%- endfor %}
 </div>
   <script>
     (function () {


### PR DESCRIPTION
update the the debug snippet to not render all variables passed to every snippet.

This is especially painful when passing a complete package data_dict through to scheming display snippets. The complete dictionary is rendered as HTML on every single snippet rendered, adding massively to the size of the page rendered. 