### PR TITLE
Update Jinja2 version

### DIFF
--- a/ckan/lib/jinja_extensions.py
+++ b/ckan/lib/jinja_extensions.py
@@ -62,7 +62,10 @@ class CkanInternationalizationExtension(ext.InternationalizationExtension):
 
     def parse(self, parser):
         node = ext.InternationalizationExtension.parse(self, parser)
-        args = getattr(node.nodes[0], 'args', None)
+        if isinstance(node, list):
+            args = getattr(node[1].nodes[0], 'args', None)
+        else:
+            args = getattr(node.nodes[0], 'args', None)
         if args:
             for arg in args:
                 if isinstance(arg, nodes.Const):

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -1569,3 +1569,17 @@ class TestPackageFollow(helpers.FunctionalTestBase):
         followers_response = app.get(followers_url, extra_environ=env,
                                      status=200)
         assert_true(user_one['display_name'] in followers_response)
+
+
+class TestDatasetRead(helpers.FunctionalTestBase):
+
+    def test_dataset_read(self):
+        app = self._get_test_app()
+
+        dataset = factories.Dataset()
+
+        url = url_for(controller='package',
+                      action='read',
+                      id=dataset['id'])
+        response = app.get(url)
+        assert_in(dataset['title'], response)

--- a/requirements.in
+++ b/requirements.in
@@ -2,8 +2,7 @@
 # Use pip-compile to create a requirements.txt file from this
 
 Babel>=0.9.6,<1.0.0  # newer versions cause problems with when switching languages
-Jinja2==2.6  # newer version causes problem in CkanInternationalizationExtension.parse
-			 # when creating a new dataset
+Jinja2==2.8
 Pylons==0.9.7
 Beaker==1.7.0 # need to pin this because of https://github.com/bbangert/beaker/commit/fc511ceda4305fcf54919b3f081fed7790e2fef3
 bleach==1.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Flask==0.10.1
 FormEncode==1.3.0
 html5lib==0.9999999       # via bleach
 itsdangerous==0.24        # via flask
-Jinja2==2.6
+Jinja2==2.8
 Mako==1.0.3
 Markdown==2.4
 MarkupSafe==0.23


### PR DESCRIPTION
Again, we are using a quite old version from 2011 (!)

The main issue is an [API change](https://github.com/pallets/jinja/commit/79c8475f80257be4999a20d1432ff6a8e3f38815#diff-fc43b0d0748bc433885163912839f823L297) on Jinja2 Internationalization extension that makes our own `CkanInternationalizationExtension` crash when rendering eg resource_list.html.

There don't seem to be other major changes on the Jinja2 [changelog](https://github.com/pallets/jinja/blob/master/CHANGES) but will wait for the tests.