### PR TITLE
retrieve the title of a package in a selected language rather than in …

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -420,7 +420,8 @@ class PackageController(base.BaseController):
                 h.redirect_to(controller='revision', action='diff', **params)
 
         context = {'model': model, 'session': model.Session,
-                   'user': c.user, 'auth_user_obj': c.userobj}
+                   'user': c.user, 'auth_user_obj': c.userobj,
+                   'for_view': True}
         data_dict = {'id': id}
         try:
             c.pkg_dict = get_action('package_show')(context, data_dict)
@@ -747,7 +748,9 @@ class PackageController(base.BaseController):
         if context['save'] and not data:
             return self._save_edit(id, context, package_type=package_type)
         try:
-            c.pkg_dict = get_action('package_show')(context, {'id': id})
+            c.pkg_dict = get_action('package_show')(dict(context,
+                                                         for_view=True),
+                                                    {'id': id})
             context['for_edit'] = True
             old_data = get_action('package_show')(context, {'id': id})
             # old data is from the database and data is passed from the


### PR DESCRIPTION
Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply

…the form of a dictionary when a multi-language plugin is used. With our release-v2.4-ndm branch using the multi-language plugin, the UI front displays the title of a dataset as a dictionary in the page of package edit or history. The page of package read displays the title correctly in the selected language. In this update, the multi-language plugin in "package_show" is enabled by setting the context['for_view'] as true for the cases of package edit and history. 
We have tested the update in our release-v2.5-ndm branch. The title is displayed correctly. We are propagating the change to the master branch now. At the UI front, we do not see any change. 
There are other functions, for example, new resource, follow/unfollow, followers, groups, calling the package_show without setting the context['for_view'] field. Since the package edit function calls package_show with context['for_edit'], should we differentiate the edit function with others in the package_show instead of adding context['for_view'] in lots of places? For instance, the multi-language plugin is called in the case that context['for_edit'] is false.