### PR TITLE
Allow filtering on group type when listing orgs

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -834,7 +834,7 @@ def organization_create(context, data_dict):
 
     '''
     # wrapper for creating organizations
-    data_dict['type'] = 'organization'
+    data_dict.setdefault('type', 'organization')
     _check_access('organization_create', context, data_dict)
     return _group_or_org_create(context, data_dict, is_org=True)
 

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -383,8 +383,8 @@ def _group_or_org_list(context, data_dict, is_org=False):
         ))
 
     query = query.filter(model.Group.is_organization == is_org)
-    if not is_org:
-        query = query.filter(model.Group.type == group_type)
+    query = query.filter(model.Group.type == group_type)
+
     if sort_info:
         sort_field = sort_info[0][0]
         sort_direction = sort_info[0][1]
@@ -520,7 +520,7 @@ def organization_list(context, data_dict):
     '''
     _check_access('organization_list', context, data_dict)
     data_dict['groups'] = data_dict.pop('organizations', [])
-    data_dict['type'] = 'organization'
+    data_dict.setdefault('type', 'organization')
     return _group_or_org_list(context, data_dict, is_org=True)
 
 

--- a/ckan/tests/factories.py
+++ b/ckan/tests/factories.py
@@ -278,7 +278,6 @@ class Organization(factory.Factory):
 
     # These are the default params that will be used to create new
     # organizations.
-    type = 'organization'
     is_organization = True
 
     title = 'Test Organization'
@@ -298,6 +297,8 @@ class Organization(factory.Factory):
             assert False, "Positional args aren't supported, use keyword args."
 
         context = {'user': _get_action_user_name(kwargs)}
+
+        kwargs.setdefault('type', 'organization')
 
         group_dict = helpers.call_action('organization_create',
                                          context=context,

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -653,6 +653,27 @@ class TestOrganizationCreate(helpers.FunctionalTestBase):
         for k in created.keys():
             assert created[k] == shown[k], k
 
+    def test_create_organization_custom_type(self):
+        custom_org_type = 'some-custom-type'
+        user = factories.User()
+        context = {
+            'user': user['name'],
+            'ignore_auth': True,
+        }
+
+        org = helpers.call_action(
+            'organization_create',
+            context=context,
+            name='test-organization',
+            type=custom_org_type
+        )
+
+        assert len(org['users']) == 1
+        assert org['display_name'] == u'test-organization'
+        assert org['package_count'] == 0
+        assert org['is_organization']
+        assert org['type'] == custom_org_type
+
 
 class TestUserCreate(helpers.FunctionalTestBase):
 

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -427,6 +427,21 @@ class TestOrganizationList(helpers.FunctionalTestBase):
         assert (sorted(org_list) ==
                 sorted([g['name'] for g in [org1, org2]]))
 
+    def test_organization_list_return_custom_organization_type(self):
+        '''
+        Getting the org_list with a type defined should only return
+        orgs of that type.
+        '''
+        org1 = factories.Organization()
+        org2 = factories.Organization(type="custom_org")
+        factories.Group(type="custom")
+        factories.Group(type="custom")
+
+        org_list = helpers.call_action('organization_list', type='custom_org')
+
+        assert (sorted(org_list) ==
+                sorted([g['name'] for g in [org2]])), '{}'.format(org_list)
+
 
 class TestOrganizationShow(helpers.FunctionalTestBase):
 


### PR DESCRIPTION
Updating actions so organizations can have a group type that is not 'organization'.
This allows you to use IGroupForm to implement custom organization types.

The documentation already implies this is possible (and it is mostly, this fixes some actions which had organization hardcoded, regardless of what is passed in)

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
