### PR TITLE
Add missing routes to IGroupForm

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -380,10 +380,6 @@ class GroupController(base.BaseController):
         group_type = self._ensure_controller_matches_group_type(
             id.split('@')[0])
 
-        if group_type != 'organization':
-            # FIXME: better error
-            raise Exception('Must be an organization')
-
         # check we are org admin
 
         context = {'model': model, 'session': model.Session,
@@ -400,6 +396,10 @@ class GroupController(base.BaseController):
             c.group = context['group']
         except (NotFound, NotAuthorized):
             abort(404, _('Group not found'))
+
+        if not c.group_dict['is_organization']:
+            # FIXME: better error
+            raise Exception('Must be an organization')
 
         #use different form names so that ie7 can be detected
         form_names = set(["bulk_action.public", "bulk_action.delete",
@@ -443,9 +443,7 @@ class GroupController(base.BaseController):
             get_action(action_functions[action])(context, data_dict)
         except NotAuthorized:
             abort(403, _('Not authorized to perform bulk update'))
-        base.redirect(h.url_for(controller='organization',
-                                action='bulk_process',
-                                id=id))
+        self._redirect_to_this_controller(action='bulk_process', id=id)
 
     def new(self, data=None, errors=None, error_summary=None):
         if data and 'type' in data:

--- a/ckan/lib/plugins.py
+++ b/ckan/lib/plugins.py
@@ -178,7 +178,7 @@ def register_group_plugins(map):
                         '/%s/{action}/{id}' % group_type,
                         controller=group_controller,
                         requirements=dict(action='|'.join(
-                            ['edit', 'authz', 'history', 'member_new',
+                            ['edit', 'authz', 'delete', 'history', 'member_new',
                              'member_delete', 'followers', 'follow',
                              'unfollow', 'admins', 'activity'])))
             map.connect('%s_edit' % group_type, '/%s/edit/{id}' % group_type,
@@ -193,6 +193,13 @@ def register_group_plugins(map):
                         '/%s/activity/{id}/{offset}' % group_type,
                         controller=group_controller,
                         action='activity', ckan_icon='time'),
+            map.connect('%s_about' % group_type, '/%s/about/{id}' % group_type,
+                        controller=group_controller,
+                        action='about', ckan_icon='info-sign')
+            map.connect('%s_bulk_process' % group_type,
+                        '/%s/bulk_process/{id}' % group_type,
+                        controller=group_controller,
+                        action='bulk_process', ckan_icon='sitemap')
 
             if group_type in _group_plugins:
                 raise ValueError("An existing IGroupForm is "
@@ -201,12 +208,16 @@ def register_group_plugins(map):
             _group_plugins[group_type] = plugin
             _group_controllers[group_type] = group_controller
 
+            controller_obj = None
+            # If using one of the default controllers, tell it that it is allowed
+            # to handle other group_types.
+            # Import them here to avoid circular imports.
             if group_controller == 'group':
-                # Tell the default group controller that it is allowed to
-                # handle other group_types.
-                # Import it here to avoid circular imports.
-                from ckan.controllers.group import GroupController
-                GroupController.add_group_type(group_type)
+                from ckan.controllers.group import GroupController as controller_obj
+            elif group_controller == 'organization':
+                from ckan.controllers.organization import OrganizationController as controller_obj
+            if controller_obj is not None:
+                controller_obj.add_group_type(group_type)
 
     # Setup the fallback behaviour if one hasn't been defined.
     if _default_group_plugin is None:

--- a/ckanext/example_igroupform/plugin.py
+++ b/ckanext/example_igroupform/plugin.py
@@ -61,3 +61,29 @@ class ExampleIGroupFormPlugin_DefaultGroupType(plugins.SingletonPlugin,
 
     def group_form(self):
         return 'example_igroup_form/group_form.html'
+
+
+class ExampleIGroupFormOrganizationPlugin(plugins.SingletonPlugin,
+                                          tk.DefaultOrganizationForm):
+    '''An example IGroupForm Organization CKAN plugin with custom group_type.
+
+    Doesn't do much yet.
+    '''
+    plugins.implements(plugins.IGroupForm, inherit=False)
+    plugins.implements(plugins.IConfigurer)
+
+    # IConfigurer
+
+    def update_config(self, config_):
+        tk.add_template_directory(config_, 'templates')
+
+    # IGroupForm
+
+    def group_types(self):
+        return (group_type,)
+
+    def is_fallback(self):
+        False
+
+    def group_controller(self):
+        return 'organization'

--- a/ckanext/example_igroupform/tests/test_controllers.py
+++ b/ckanext/example_igroupform/tests/test_controllers.py
@@ -24,6 +24,97 @@ def _get_group_new_page(app, group_type):
     return env, response
 
 
+class TestGroupController(helpers.FunctionalTestBase):
+    @classmethod
+    def setup_class(cls):
+        super(TestGroupController, cls).setup_class()
+        plugins.load('example_igroupform')
+
+    @classmethod
+    def teardown_class(cls):
+        plugins.unload('example_igroupform')
+        super(TestGroupController, cls).teardown_class()
+
+    def test_about(self):
+        app = self._get_test_app()
+        user = factories.User()
+        group = factories.Group(user=user, type=custom_group_type)
+        group_name = group['name']
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        url = url_for('%s_about' % custom_group_type,
+                      id=group_name)
+        response = app.get(url=url, extra_environ=env)
+        response.mustcontain(group_name)
+
+    def test_bulk_process(self):
+        app = self._get_test_app()
+        user = factories.User()
+        group = factories.Group(user=user, type=custom_group_type)
+        group_name = group['name']
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        url = url_for('%s_bulk_process' % custom_group_type,
+                      id=group_name)
+        try:
+            response = app.get(url=url, extra_environ=env)
+        except Exception as e:
+            assert (e.args == ('Must be an organization', ))
+        else:
+            raise Exception("Response should have raised an exception")
+
+    def test_delete(self):
+        app = self._get_test_app()
+        user = factories.User()
+        group = factories.Group(user=user, type=custom_group_type)
+        group_name = group['name']
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        url = url_for('%s_action' % custom_group_type, action='delete',
+                      id=group_name)
+        response = app.get(url=url, extra_environ=env)
+
+
+class TestOrganizationController(helpers.FunctionalTestBase):
+    @classmethod
+    def setup_class(cls):
+        super(TestOrganizationController, cls).setup_class()
+        plugins.load('example_igroupform_organization')
+
+    @classmethod
+    def teardown_class(cls):
+        plugins.unload('example_igroupform_organization')
+        super(TestOrganizationController, cls).teardown_class()
+
+    def test_about(self):
+        app = self._get_test_app()
+        user = factories.User()
+        group = factories.Organization(user=user, type=custom_group_type)
+        group_name = group['name']
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        url = url_for('%s_about' % custom_group_type,
+                      id=group_name)
+        response = app.get(url=url, extra_environ=env)
+        response.mustcontain(group_name)
+
+    def test_bulk_process(self):
+        app = self._get_test_app()
+        user = factories.User()
+        group = factories.Organization(user=user, type=custom_group_type)
+        group_name = group['name']
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        url = url_for('%s_bulk_process' % custom_group_type,
+                      id=group_name)
+        response = app.get(url=url, extra_environ=env)
+
+    def test_delete(self):
+        app = self._get_test_app()
+        user = factories.User()
+        group = factories.Organization(user=user, type=custom_group_type)
+        group_name = group['name']
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        url = url_for('%s_action' % custom_group_type, action='delete',
+                      id=group_name)
+        response = app.get(url=url, extra_environ=env)
+
+
 class TestGroupControllerNew(helpers.FunctionalTestBase):
     @classmethod
     def setup_class(cls):

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ entry_points = {
         'example_idatasetform_v4 = ckanext.example_idatasetform.plugin_v4:ExampleIDatasetFormPlugin',
         'example_igroupform = ckanext.example_igroupform.plugin:ExampleIGroupFormPlugin',
         'example_igroupform_default_group_type = ckanext.example_igroupform.plugin:ExampleIGroupFormPlugin_DefaultGroupType',
+        'example_igroupform_organization = ckanext.example_igroupform.plugin:ExampleIGroupFormOrganizationPlugin',
         'example_iauthfunctions_v1 = ckanext.example_iauthfunctions.plugin_v1:ExampleIAuthFunctionsPlugin',
         'example_iauthfunctions_v2 = ckanext.example_iauthfunctions.plugin_v2:ExampleIAuthFunctionsPlugin',
         'example_iauthfunctions_v3 = ckanext.example_iauthfunctions.plugin_v3:ExampleIAuthFunctionsPlugin',


### PR DESCRIPTION
IGroupForm is missing two routes:
_about
_bulk_process

This adds them (and adds a new example plugin with some tests around IGroupForm's with organizations)


### Features:

- [x] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport


