### PR TITLE
#2373: Do not validate packages or resources from database to views

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -344,7 +344,7 @@ class PackageController(base.BaseController):
     def read(self, id):
         context = {'model': model, 'session': model.Session,
                    'user': c.user, 'for_view': True,
-                   'auth_user_obj': c.userobj}
+                   'auth_user_obj': c.userobj, 'validate': False}
         data_dict = {'id': id, 'include_tracking': True}
 
         # interpret @<revision_id> or @<date> suffix
@@ -1060,7 +1060,8 @@ class PackageController(base.BaseController):
         context = {'model': model, 'session': model.Session,
                    'user': c.user,
                    'auth_user_obj': c.userobj,
-                   'for_view': True}
+                   'for_view': True,
+                   'validate': False}
 
         try:
             c.package = get_action('package_show')(context, {'id': id})


### PR DESCRIPTION
Fixes #2373 

### Proposed fixes:

Package read and resource read expect unvalidated dicts for templates. This context change skips validation and hence solves this problem with certain extensions for example scheming and fluent since these produce dicts instead of just strings if validated.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply

