### PR TITLE
[WIP/RFC] Add group type to search facets.

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1885,17 +1885,17 @@ def package_search(context, data_dict):
         'sort': data_dict['sort']
     }
 
-    # create a lookup table of group name to title for all the groups and
+    # create a lookup table of group name to title and type for all the groups and
     # organizations in the current search's facets.
     group_names = []
     for field_name in ('groups', 'organization'):
         group_names.extend(facets.get(field_name, {}).keys())
 
-    groups = (session.query(model.Group.name, model.Group.title)
+    groups = (session.query(model.Group.name, model.Group.title, model.Group.type)
                     .filter(model.Group.name.in_(group_names))
                     .all()
               if group_names else [])
-    group_titles_by_name = dict(groups)
+    group_details_by_name = dict((group[0], group[1:]) for group in groups)
 
     # Transform facets into a more useful data structure.
     restructured_facets = {}
@@ -1908,9 +1908,10 @@ def package_search(context, data_dict):
             new_facet_dict = {}
             new_facet_dict['name'] = key_
             if key in ('groups', 'organization'):
-                display_name = group_titles_by_name.get(key_, key_)
+                display_name, group_type = group_details_by_name.get(key_, key_)
                 display_name = display_name if display_name and display_name.strip() else key_
                 new_facet_dict['display_name'] = display_name
+                new_facet_dict['type'] = group_type
             elif key == 'license_id':
                 license = model.Package.get_license_register().get(key_)
                 if license:


### PR DESCRIPTION
This is somewhat of a Request For Comment / WIP.

I'm looking at separating search facets by group type. This appears to be the easiest way, and shouldn't much if any overhead. I can't see an easy way to do the split on the results page unfortunately, but perhaps adding this info to the facet won't be frowned on, even if it's only so the info can be available for extensions / helpers / templates.

Currently I'm doing the display of the group type facets in an extension, manually splitting the organizations facet returned by solr based on the type this PR adds, but it requires hardcoding the group types (by overriding `dataset_facets`, `before_search` and the `get_facet_items_dict` helper)
