### PR TITLE
[#3012] Persist datastore_active on resource updates

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -80,6 +80,11 @@ def resource_update(context, data_dict):
         log.error('Could not find resource %s after all', id)
         raise NotFound(_('Resource was not found.'))
 
+    # Persist the datastore_active extra if already present and not provided
+    if ('datastore_active' in resource.extras and
+            'datastore_active' not in data_dict):
+        data_dict['datastore_active'] = resource.extras['datastore_active']
+
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.before_update(context, pkg_dict['resources'][n], data_dict)
 

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -723,6 +723,77 @@ class TestResourceUpdate(object):
         assert_equals(res_returned['anotherfield'], 'second')
         assert 'newfield' not in res_returned
 
+    def test_datastore_active_is_persisted_if_true_and_not_provided(self):
+        dataset = factories.Dataset()
+        resource = factories.Resource(package=dataset,
+                                      url='http://example.com',
+                                      datastore_active=True)
+
+        res_returned = helpers.call_action('resource_update',
+                                           id=resource['id'],
+                                           url='http://example.com',
+                                           name='Test')
+
+        assert_equals(res_returned['datastore_active'], True)
+
+    def test_datastore_active_is_persisted_if_false_and_not_provided(self):
+        dataset = factories.Dataset()
+        resource = factories.Resource(package=dataset,
+                                      url='http://example.com',
+                                      datastore_active=False)
+
+        res_returned = helpers.call_action('resource_update',
+                                           id=resource['id'],
+                                           url='http://example.com',
+                                           name='Test')
+
+        assert_equals(res_returned['datastore_active'], False)
+
+    def test_datastore_active_is_updated_if_false_and_provided(self):
+        dataset = factories.Dataset()
+        resource = factories.Resource(package=dataset,
+                                      url='http://example.com',
+                                      datastore_active=False)
+
+        res_returned = helpers.call_action('resource_update',
+                                           id=resource['id'],
+                                           url='http://example.com',
+                                           name='Test',
+                                           datastore_active=True)
+
+        assert_equals(res_returned['datastore_active'], True)
+
+    def test_datastore_active_is_updated_if_true_and_provided(self):
+        dataset = factories.Dataset()
+        resource = factories.Resource(package=dataset,
+                                      url='http://example.com',
+                                      datastore_active=True)
+
+        res_returned = helpers.call_action('resource_update',
+                                           id=resource['id'],
+                                           url='http://example.com',
+                                           name='Test',
+                                           datastore_active=False)
+
+        assert_equals(res_returned['datastore_active'], False)
+
+    def test_datastore_active_not_present_if_not_provided_and_not_datastore_plugin_enabled(self):
+
+        assert not p.plugin_loaded('datastore')
+
+        dataset = factories.Dataset()
+        resource = factories.Resource(package=dataset,
+                                      url='http://example.com',
+                                      )
+
+        res_returned = helpers.call_action('resource_update',
+                                           id=resource['id'],
+                                           url='http://example.com',
+                                           name='Test',
+                                           )
+
+        assert 'datastore_active' not in res_returned
+
 
 class TestConfigOptionUpdate(object):
 


### PR DESCRIPTION
Fixes #3012

As datastore_active is stored as an extra, if it's not provided in the
incoming data_dict on resource_update it will get dropped. This happens
most noticeably when udpating via the frontend, causing the green Data
API button to disappear.