### PR TITLE
Add a submit_all command to datapusher.

### DIFF
--- a/ckanext/datapusher/cli.py
+++ b/ckanext/datapusher/cli.py
@@ -14,6 +14,9 @@ class DatapusherCommand(cli.CkanCommand):
                     ignoring if their files haven't changed.
         submit <pkgname> - Submits all resources from the package
                          identified by pkgname (either the short name or ID).
+        submit_all  - Submit every package to the datastore.
+                      This is useful if you're setting up datastore
+                      for a ckan that already has datasets.
     '''
 
     summary = __doc__.split('\n')[0]
@@ -24,7 +27,12 @@ class DatapusherCommand(cli.CkanCommand):
             self._confirm_or_abort()
 
             self._load_config()
-            self._submit_all()
+            self._resubmit_all()
+        elif self.args and self.args[0] == 'submit_all':
+            self._confirm_or_abort()
+
+            self._load_config()
+            self._submit_all_packages()
         elif self.args and self.args[0] == 'submit':
             self._confirm_or_abort()
 
@@ -49,9 +57,17 @@ class DatapusherCommand(cli.CkanCommand):
             print "Aborting..."
             sys.exit(0)
 
-    def _submit_all(self):
+    def _resubmit_all(self):
         resources_ids = datastore_db.get_all_resources_ids_in_datastore()
         self._submit(resource_ids)
+
+    def _submit_all_packages(self):
+        # submit every package
+        # for each package in the package list, submit each resource w/ _submit_package
+        import ckan.model as model
+        package_list = p.toolkit.get_action('package_list')
+        for p_id in package_list({'model': model, 'ignore_auth': True}, {}):
+            self._submit_package(p_id)
 
     def _submit_package(self, pkg_id):
         import ckan.model as model

--- a/ckanext/datapusher/cli.py
+++ b/ckanext/datapusher/cli.py
@@ -63,7 +63,8 @@ class DatapusherCommand(cli.CkanCommand):
 
     def _submit_all_packages(self):
         # submit every package
-        # for each package in the package list, submit each resource w/ _submit_package
+        # for each package in the package list,
+        #   submit each resource w/ _submit_package
         import ckan.model as model
         package_list = p.toolkit.get_action('package_list')
         for p_id in package_list({'model': model, 'ignore_auth': True}, {}):


### PR DESCRIPTION
### Proposed fixes:
This allows you to add every resource of every package to the datastore.
this is useful if you're setting up datastore for a a ckan that's
already got datasets. Also renames the existing submit_all function to resubmit_all, because
it would not act on resources that had not already been submitted to
datastore.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport