### PR TITLE
Remove extra `/` in feed ids.

### DIFF
--- a/ckan/controllers/feed.py
+++ b/ckan/controllers/feed.py
@@ -146,6 +146,7 @@ def _create_atom_id(resource_path, authority_name=None, date_string=None):
         # this still results in an invalid feed.
         site_url = config.get('ckan.site_url', '')
         return '/'.join([site_url, resource_path])
+        return urlparse.urljoin(site_url, resource_path)
 
     tagging_entity = ','.join([authority_name, date_string])
     return ':'.join(['tag', tagging_entity, resource_path])

--- a/ckan/tests/controllers/test_feed.py
+++ b/ckan/tests/controllers/test_feed.py
@@ -30,3 +30,8 @@ class TestFeedNew(helpers.FunctionalTestBase):
         app = self._get_test_app()
         res = app.get(offset, status=400)
         assert '"page" parameter must be a positive integer' in res, res
+
+    def test_atom_feed_page_creates_proper_ids(self):
+        from ckan.controllers.feed import _create_atom_id
+        atom_id = _create_atom_id('/dataset/123', authority_name='the_authority')
+        assert atom_id == 'http://test.ckan.net/dataset/123'


### PR DESCRIPTION
Fixes #3017

### Proposed fixes:
The `resource_path` that is passed to the `_create_atom_id` function seems to always start with a `/`.  I did not want to manually strip that though because at some point the value passed here might be different. Fortunately the `urlparse.urljoin` function removes duplicate slashes when joining urls so this should work

The test I added most certainly is not in the correct file (the other three are all touching the api while this is testing a private function) but I did not know where to put it.

Feedback on this is most welcome.

PS: I also marked that this is touching the api. Judging from the docstring the specification seems to be very strict about identifiers never changing. If we merge this change though the `ids` in the feed *will* change though (because they do not have the duplicate slash anymore). Not sure how to handle this.

### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport
