### PR TITLE
[#2394] Fix user log out on username change

### DIFF
--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -35,6 +35,15 @@ DataError = dictization_functions.DataError
 unflatten = dictization_functions.unflatten
 
 
+def set_repoze_user(user_id):
+    '''Set the repoze.who cookie to match a given user_id'''
+    if 'repoze.who.plugins' in request.environ:
+        rememberer = request.environ['repoze.who.plugins']['friendlyform']
+        identity = {'repoze.who.userid': user_id}
+        response.headerlist += rememberer.remember(request.environ,
+                                                   identity)
+
+
 class UserController(base.BaseController):
     def __before__(self, action, **env):
         base.BaseController.__before__(self, action, **env)
@@ -245,10 +254,7 @@ class UserController(base.BaseController):
             return self.new(data_dict, errors, error_summary)
         if not c.user:
             # log the user in programatically
-            rememberer = request.environ['repoze.who.plugins']['friendlyform']
-            identity = {'repoze.who.userid': data_dict['name']}
-            response.headerlist += rememberer.remember(request.environ,
-                                                       identity)
+            set_repoze_user(data_dict['name'])
             h.redirect_to(controller='user', action='me', __ckan_no_root=True)
         else:
             # #1799 User has managed to register whilst logged in - warn user
@@ -321,6 +327,12 @@ class UserController(base.BaseController):
 
     def _save_edit(self, id, context):
         try:
+            if id in (c.userobj.id, c.userobj.name):
+                current_user = True
+            else:
+                current_user = False
+            old_username = c.userobj.name
+
             data_dict = logic.clean_dict(unflatten(
                 logic.tuplize_dict(logic.parse_params(request.params))))
             context['message'] = data_dict.get('log_message', '')
@@ -343,6 +355,11 @@ class UserController(base.BaseController):
 
             user = get_action('user_update')(context, data_dict)
             h.flash_success(_('Profile updated'))
+
+            if current_user and data_dict['name'] != old_username:
+                # Changing currently logged in user's name.
+                # Update repoze.who cookie to match
+                set_repoze_user(data_dict['name'])
             h.redirect_to(controller='user', action='read', id=user['name'])
         except NotAuthorized:
             abort(403, _('Unauthorized to edit user %s') % id)

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -289,6 +289,100 @@ class TestUserEdit(helpers.FunctionalTestBase):
         response = submit_and_follow(app, form, env, 'save')
         assert_true('Profile updated' in response)
 
+    def test_edit_user_logged_in_username_change(self):
+
+        user_pass = 'pass'
+        user = factories.User(password=user_pass)
+        app = self._get_test_app()
+
+        # Have to do an actual login as this test relys on repoze cookie handling.
+        # get the form
+        response = app.get('/user/login')
+        # ...it's the second one
+        login_form = response.forms[1]
+        # fill it in
+        login_form['login'] = user['name']
+        login_form['password'] = user_pass
+        # submit it
+        login_form.submit()
+
+        # Now the cookie is set, run the test
+        response = app.get(
+            url=url_for(controller='user', action='edit'),
+        )
+        # existing values in the form
+        form = response.forms['user-edit-form']
+
+        # new values
+        form['name'] = 'new-name'
+        response = submit_and_follow(app, form, name='save')
+        response = helpers.webtest_maybe_follow(response)
+
+        expected_url = url_for(controller='user', action='read', id='new-name')
+        assert response.request.path == expected_url
+
+    def test_edit_user_logged_in_username_change_by_name(self):
+        user_pass = 'pass'
+        user = factories.User(password=user_pass)
+        app = self._get_test_app()
+
+        # Have to do an actual login as this test relys on repoze cookie handling.
+        # get the form
+        response = app.get('/user/login')
+        # ...it's the second one
+        login_form = response.forms[1]
+        # fill it in
+        login_form['login'] = user['name']
+        login_form['password'] = user_pass
+        # submit it
+        login_form.submit()
+
+        # Now the cookie is set, run the test
+        response = app.get(
+            url=url_for(controller='user', action='edit', id=user['name']),
+        )
+        # existing values in the form
+        form = response.forms['user-edit-form']
+
+        # new values
+        form['name'] = 'new-name'
+        response = submit_and_follow(app, form, name='save')
+        response = helpers.webtest_maybe_follow(response)
+
+        expected_url = url_for(controller='user', action='read', id='new-name')
+        assert response.request.path == expected_url
+
+    def test_edit_user_logged_in_username_change_by_id(self):
+        user_pass = 'pass'
+        user = factories.User(password=user_pass)
+        app = self._get_test_app()
+
+        # Have to do an actual login as this test relys on repoze cookie handling.
+        # get the form
+        response = app.get('/user/login')
+        # ...it's the second one
+        login_form = response.forms[1]
+        # fill it in
+        login_form['login'] = user['name']
+        login_form['password'] = user_pass
+        # submit it
+        login_form.submit()
+
+        # Now the cookie is set, run the test
+        response = app.get(
+            url=url_for(controller='user', action='edit', id=user['id']),
+        )
+        # existing values in the form
+        form = response.forms['user-edit-form']
+
+        # new values
+        form['name'] = 'new-name'
+        response = submit_and_follow(app, form, name='save')
+        response = helpers.webtest_maybe_follow(response)
+
+        expected_url = url_for(controller='user', action='read', id='new-name')
+        assert response.request.path == expected_url
+
     def test_perform_reset_for_key_change(self):
         password = 'password'
         params = {'password1': password, 'password2': password}

--- a/ckan/tests/helpers.py
+++ b/ckan/tests/helpers.py
@@ -188,6 +188,8 @@ class FunctionalTestBase(object):
     def setup(self):
         '''Reset the database and clear the search indexes.'''
         reset_db()
+        if hasattr(self, '_test_app'):
+            self._test_app.reset()
         search.clear_all()
 
     @classmethod


### PR DESCRIPTION
Fixes #2394  

### Proposed fixes:
Adjusts repoze cookie when the currently logged in username is changed, by abstracting code out from create user.
Includes a fix to unit test running which didn't reset the TestApp's cookies on each test.

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
