### PR TITLE
Move code path for group into explicit else

### DIFF
--- a/ckan/controllers/feed.py
+++ b/ckan/controllers/feed.py
@@ -188,22 +188,24 @@ class FeedController(base.BaseController):
                                   action=group_type,
                                   id=obj_dict['name'])
 
-        guid = _create_atom_id(u'/feeds/group/%s.atom' %
-                               obj_dict['name'])
-        alternate_url = self._alternate_url(params, groups=obj_dict['name'])
-        desc = u'Recently created or updated datasets on %s by group: "%s"' %\
-            (g.site_title, obj_dict['title'])
-        title = u'%s - Group: "%s"' %\
-            (g.site_title, obj_dict['title'])
-
         if is_org:
             guid = _create_atom_id(u'/feeds/organization/%s.atom' %
                                    obj_dict['name'])
             alternate_url = self._alternate_url(params,
                                                 organization=obj_dict['name'])
-            desc = u'Recently created or  updated datasets on %s '\
+            desc = u'Recently created or updated datasets on %s '\
                 'by organization: "%s"' % (g.site_title, obj_dict['title'])
             title = u'%s - Organization: "%s"' %\
+                (g.site_title, obj_dict['title'])
+
+        else:  # is organization
+            guid = _create_atom_id(u'/feeds/group/%s.atom' %
+                                   obj_dict['name'])
+            alternate_url = self._alternate_url(params,
+                                                groups=obj_dict['name'])
+            desc = u'Recently created or updated datasets on %s '\
+                'by group: "%s"' % (g.site_title, obj_dict['title'])
+            title = u'%s - Group: "%s"' %\
                 (g.site_title, obj_dict['title'])
 
         return self.output_feed(results,

--- a/ckan/controllers/feed.py
+++ b/ckan/controllers/feed.py
@@ -198,7 +198,7 @@ class FeedController(base.BaseController):
             title = u'%s - Organization: "%s"' %\
                 (g.site_title, obj_dict['title'])
 
-        else:  # is organization
+        else:  # is group
             guid = _create_atom_id(u'/feeds/group/%s.atom' %
                                    obj_dict['name'])
             alternate_url = self._alternate_url(params,


### PR DESCRIPTION
Fixes  -
### Proposed fixes:
When going over `ckan/controllers/feed.py` I noticed a small part of the code where readability could be easily improved. This might also make the code *slightly* faster since if `is_org` is `True` we save four assingments that would later be overwritten.

Here are my comments from the commit message:
- the functionality in the code remains the same
- The branch for the case that `is_org` is False was just moved into
  an explicit `else` for better readibility
- The code in the else branch was also slightly reindented to be more
  simliar to the if branch

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport


