### PR TITLE
Build Status badge in README should point to CircleCI, not Travis

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ CKAN: The Open Source Data Portal Software
     :target: https://stackoverflow.com/questions/tagged/ckan
     :alt: Support on StackOverflow
 
-.. image:: https://circleci.com/gh/ckan/ckan.svg?style=svg
+.. image:: https://circleci.com/gh/ckan/ckan.svg?style=shield
     :target: https://circleci.com/gh/ckan/ckan
     :alt: Build Status
 

--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@ CKAN: The Open Source Data Portal Software
     :target: https://stackoverflow.com/questions/tagged/ckan
     :alt: Support on StackOverflow
 
-.. image:: https://secure.travis-ci.org/ckan/ckan.png?branch=master
-    :target: http://travis-ci.org/ckan/ckan
+.. image:: https://circleci.com/gh/ckan/ckan.svg?style=svg
+    :target: https://circleci.com/gh/ckan/ckan
     :alt: Build Status
 
 .. image:: https://coveralls.io/repos/github/ckan/ckan/badge.svg?branch=master


### PR DESCRIPTION
We now use CircleCI for continuous integration, rather than Travis. We should change the Build Status badge in the README to point to the appropriate ckan project on CircleCI.
