### PR TITLE
Return 403 Response when user is not authorized to list organizations

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -159,6 +159,7 @@ class GroupController(base.BaseController):
         sort_by = c.sort_by_selected = request.params.get('sort')
         try:
             self._check_access('site_read', context)
+            self._check_access('group_list', context)
         except NotAuthorized:
             abort(403, _('Not authorized to see this page'))
 

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -519,13 +519,10 @@ def organization_list(context, data_dict):
     :rtype: list of strings
 
     '''
-    try:
-        _check_access('organization_list', context, data_dict)
-        data_dict['groups'] = data_dict.pop('organizations', [])
-        data_dict.setdefault('type', 'organization')
-        return _group_or_org_list(context, data_dict, is_org=True)
-    except logic.NotAuthorized:
-        base.abort(403, _('You are not authorized to see a list of organizations'))
+    _check_access('organization_list', context, data_dict)
+    data_dict['groups'] = data_dict.pop('organizations', [])
+    data_dict.setdefault('type', 'organization')
+    return _group_or_org_list(context, data_dict, is_org=True)
 
 
 def group_list_authz(context, data_dict):

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -26,7 +26,6 @@ import ckan.lib.datapreview as datapreview
 import ckan.authz as authz
 
 from ckan.common import _
-from ckan.lib import base
 
 log = logging.getLogger('ckan.logic')
 

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -26,6 +26,7 @@ import ckan.lib.datapreview as datapreview
 import ckan.authz as authz
 
 from ckan.common import _
+from ckan.lib import base
 
 log = logging.getLogger('ckan.logic')
 
@@ -518,10 +519,13 @@ def organization_list(context, data_dict):
     :rtype: list of strings
 
     '''
-    _check_access('organization_list', context, data_dict)
-    data_dict['groups'] = data_dict.pop('organizations', [])
-    data_dict.setdefault('type', 'organization')
-    return _group_or_org_list(context, data_dict, is_org=True)
+    try:
+        _check_access('organization_list', context, data_dict)
+        data_dict['groups'] = data_dict.pop('organizations', [])
+        data_dict.setdefault('type', 'organization')
+        return _group_or_org_list(context, data_dict, is_org=True)
+    except logic.NotAuthorized:
+        base.abort(403, _('You are not authorized to see a list of organizations'))
 
 
 def group_list_authz(context, data_dict):

--- a/ckan/tests/controllers/test_organization.py
+++ b/ckan/tests/controllers/test_organization.py
@@ -1,6 +1,7 @@
 from bs4 import BeautifulSoup
 from nose.tools import assert_equal, assert_true
 from routes import url_for
+from mock import patch
 
 from ckan.tests import factories, helpers
 from ckan.tests.helpers import webtest_submit, submit_and_follow, assert_in
@@ -70,10 +71,11 @@ class TestOrganizationList(helpers.FunctionalTestBase):
         self.organization_list_url = url_for(controller='organization',
                                              action='index')
 
+    @patch('ckan.logic.auth.get.organization_list', return_value={'success': False})
     def test_error_message_shown_when_no_organization_list_permission(self, mock_check_access):
         response = self.app.get(url=self.organization_list_url,
-                                extra_environ=self.user_env)
-        assert response.status_int == 403
+                                extra_environ=self.user_env,
+                                status=403)
 
 
 class TestOrganizationRead(helpers.FunctionalTestBase):

--- a/ckan/tests/controllers/test_organization.py
+++ b/ckan/tests/controllers/test_organization.py
@@ -61,6 +61,21 @@ class TestOrganizationNew(helpers.FunctionalTestBase):
         assert_equal(group['description'], 'Sciencey datasets')
 
 
+class TestOrganizationList(helpers.FunctionalTestBase):
+    def setup(self):
+        super(TestOrganizationList, self).setup()
+        self.app = helpers._get_test_app()
+        self.user = factories.User()
+        self.user_env = {'REMOTE_USER': self.user['name'].encode('ascii')}
+        self.organization_list_url = url_for(controller='organization',
+                                             action='index')
+
+    def test_error_message_shown_when_no_organization_list_permission(self, mock_check_access):
+        response = self.app.get(url=self.organization_list_url,
+                                extra_environ=self.user_env)
+        assert response.status_int == 403
+
+
 class TestOrganizationRead(helpers.FunctionalTestBase):
     def setup(self):
         super(TestOrganizationRead, self).setup()


### PR DESCRIPTION
Fixes #2990 

### Proposed fixes:
When a user tries to access `/organization` now but does not have permission for `organization_list` a 403 response is returned instead of the backend breaking because of an uncaught exception of type `NotAuthorized`

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
