### PR TITLE
[#2981] Preserve sort order in groups on pagination

### DIFF
--- a/ckan/templates/group/index.html
+++ b/ckan/templates/group/index.html
@@ -34,7 +34,7 @@
     {% endif %}
   {% endblock %}
   {% block page_pagination %}
-    {{ c.page.pager() }}
+    {{ c.page.pager(q=c.q or '', sort=c.sort_by_selected or '') }}
   {% endblock %}
 {% endblock %}
 

--- a/ckan/tests/controllers/test_group.py
+++ b/ckan/tests/controllers/test_group.py
@@ -23,17 +23,34 @@ class TestGroupController(helpers.FunctionalTestBase):
                                    action='bulk_process', id='does-not-exist')
         app.get(url=bulk_process_url, status=404)
 
-    def test_page_thru_list_of_orgs(self):
-        orgs = [factories.Organization() for i in range(35)]
+    def test_page_thru_list_of_orgs_preserves_sort_order(self):
+        orgs = [factories.Organization() for _ in range(35)]
         app = self._get_test_app()
-        org_url = url_for(controller='organization', action='index')
+        org_url = url_for(controller='organization',
+                          action='index',
+                          sort='name desc')
         response = app.get(url=org_url)
-        assert orgs[0]['name'] in response
-        assert orgs[-1]['name'] not in response
+        assert orgs[-1]['name'] in response
+        assert orgs[0]['name'] not in response
 
         response2 = response.click('2')
-        assert orgs[0]['name'] not in response2
-        assert orgs[-1]['name'] in response2
+        assert orgs[-1]['name'] not in response2
+        assert orgs[0]['name'] in response2
+
+    def test_page_thru_list_of_groups_preserves_sort_order(self):
+        groups = [factories.Group() for _ in range(35)]
+        app = self._get_test_app()
+        group_url = url_for(controller='group',
+                            action='index',
+                            sort='title desc')
+
+        response = app.get(url=group_url)
+        assert groups[-1]['title'] in response
+        assert groups[0]['title'] not in response
+
+        response2 = response.click(r'^2$')
+        assert groups[-1]['title'] not in response2
+        assert groups[0]['title'] in response2
 
 
 def _get_group_new_page(app):

--- a/ckan/tests/legacy/functional/test_pagination.py
+++ b/ckan/tests/legacy/functional/test_pagination.py
@@ -100,12 +100,12 @@ class TestPaginationGroup(TestController):
 
     def test_group_index(self):
         res = self.app.get(url_for(controller='group', action='index'))
-        assert 'href="/group?page=2"' in res, res
+        assert 'href="/group?sort=&amp;q=&amp;page=2"' in res, res
         grp_numbers = scrape_search_results(res, 'group')
         assert_equal(['00', '01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20'], grp_numbers)
 
         res = self.app.get(url_for(controller='group', action='index', page=2))
-        assert 'href="/group?page=1"' in res
+        assert 'href="/group?sort=&amp;q=&amp;page=1"' in res
         grp_numbers = scrape_search_results(res, 'group')
         assert_equal(['21'], grp_numbers)
 


### PR DESCRIPTION
Fixes #2981

### Proposed fixes:
- Uses the same code that was introduced in #2153 for organizations
- Changes the tests to sort descending so that they actually make sure
  that the sort order is not changed
  - I did this because when I removed the sorting from the templates the tests would still pass. This is because they did not set the sort order to descending so they were just testing the old behavior but not actually the new one which should be preserving the order. This way we can make sure that is actually happening


### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

