### PR TITLE
Raise HelperError exception when calling non-existing helper

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -54,8 +54,8 @@ class HelperAttributeDict(dict):
 
     def __getitem__(self, key):
         try:
-            value = super(HelperAttributeDict, self).__getitem__(self, key)
-        except AttributeError:
+            value = super(HelperAttributeDict, self).__getitem__(key)
+        except KeyError:
             raise ckan.exceptions.HelperError(
                 'Helper \'{key}\' has not been defined.'.format(
                     key=key

--- a/ckan/templates/tests/broken_helper_as_attribute.html
+++ b/ckan/templates/tests/broken_helper_as_attribute.html
@@ -1,0 +1,5 @@
+{% extends 'page.html' %}
+
+{% block page %}
+    {{ h.not_here() }}
+{% endblock %}

--- a/ckan/templates/tests/broken_helper_as_item.html
+++ b/ckan/templates/tests/broken_helper_as_item.html
@@ -1,0 +1,5 @@
+{% extends 'page.html' %}
+
+{% block page %}
+    {{ h['not_here']() }}
+{% endblock %}

--- a/ckan/templates/tests/helper_as_attribute.html
+++ b/ckan/templates/tests/helper_as_attribute.html
@@ -1,0 +1,5 @@
+{% extends 'page.html' %}
+
+{% block page %}
+    My lang is: {{ h.lang() }}
+{% endblock %}

--- a/ckan/templates/tests/helper_as_item.html
+++ b/ckan/templates/tests/helper_as_item.html
@@ -1,0 +1,5 @@
+{% extends 'page.html' %}
+
+{% block page %}
+    My lang is: {{ h['lang']() }}
+{% endblock %}

--- a/ckan/tests/plugins/test_toolkit.py
+++ b/ckan/tests/plugins/test_toolkit.py
@@ -1,4 +1,4 @@
-from nose.tools import assert_equal, assert_raises, assert_true
+from nose.tools import assert_equal, assert_raises, assert_true, raises
 
 from ckan.plugins import toolkit as tk
 
@@ -260,11 +260,21 @@ class TestRequiresCkanVersion(object):
                       tk.requires_ckan_version, min_version='3')
 
 
-class TestTemplateHelper(object):
+class TestToolkitHelper(object):
     def test_call_helper(self):
         # the null_function would return ''
         assert_true(tk.h.icon_url('x'))
 
-    def test_attribute_error_on_missing_helper(self):
+    def test_tk_helper_attribute_error_on_missing_helper(self):
         assert_raises(AttributeError, getattr,
                       tk.h, 'not_a_real_helper_function')
+
+    @raises(AttributeError)
+    def test_tk_helper_as_attribute_missing_helper(self):
+        '''Directly attempt access to module function'''
+        tk.h.nothere()
+
+    @raises(tk.HelperError)
+    def test_tk_helper_as_item_missing_helper(self):
+        '''Directly attempt access as item'''
+        tk.h['nothere']()

--- a/setup.py
+++ b/setup.py
@@ -158,6 +158,7 @@ entry_points = {
         'test_datastore_view = ckan.tests.lib.test_datapreview:MockDatastoreBasedResourceView',
         'test_datapusher_plugin = ckanext.datapusher.tests.test_interfaces:FakeDataPusherPlugin',
         'test_routing_plugin = ckan.tests.config.test_middleware:MockRoutingPlugin',
+        'test_helpers_plugin = ckan.tests.lib.test_helpers:TestHelpersPlugin',
     ],
     'babel.extractors': [
         'ckan = ckan.lib.extract:extract_ckan',


### PR DESCRIPTION
Fixes #3041 

### Proposed fixes:

Fixes super call to `HelperAttributeDict.__getitem__` by removing the `self` parameter, and catches the correct `KeyError` exception.

### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
