### PR TITLE
[#2760] change old password label if user is sysadmin

### DIFF
--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -315,6 +315,10 @@ class UserController(base.BaseController):
         c.is_myself = True
         c.show_email_notifications = asbool(
             config.get('ckan.activity_streams_email_notifications'))
+        if authz.is_sysadmin(c.user):
+            vars['oldpassword_label'] = 'Sysadmin password'
+        else:
+            vars['oldpassword_label'] = 'Old password'
         c.form = render(self.edit_user_form, extra_vars=vars)
 
         return render('user/edit.html')

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -315,10 +315,6 @@ class UserController(base.BaseController):
         c.is_myself = True
         c.show_email_notifications = asbool(
             config.get('ckan.activity_streams_email_notifications'))
-        if authz.is_sysadmin(c.user):
-            vars['oldpassword_label'] = 'Sysadmin password'
-        else:
-            vars['oldpassword_label'] = 'Old password'
         c.form = render(self.edit_user_form, extra_vars=vars)
 
         return render('user/edit.html')

--- a/ckan/templates/user/edit_user_form.html
+++ b/ckan/templates/user/edit_user_form.html
@@ -24,7 +24,7 @@
 
   <fieldset>
     <legend>{{ _('Change password') }}</legend>
-    {{ form.input('old_password', type='password', label=_('Sysadmin password') if c.is_sysadmin else _('Old password'), id='field-password', value=data.oldpassword, error=errors.oldpassword, classes=['control-medium'], attrs={'autocomplete': 'off'} ) }}
+    {{ form.input('old_password', type='password', label=_('Sysadmin Password') if c.is_sysadmin else _('Old Password'), id='field-password', value=data.oldpassword, error=errors.oldpassword, classes=['control-medium'], attrs={'autocomplete': 'off'} ) }}
 
     {{ form.input('password1', type='password', label=_('Password'), id='field-password', value=data.password1, error=errors.password1, classes=['control-medium'], attrs={'autocomplete': 'off'} ) }}
 

--- a/ckan/templates/user/edit_user_form.html
+++ b/ckan/templates/user/edit_user_form.html
@@ -24,7 +24,7 @@
 
   <fieldset>
     <legend>{{ _('Change password') }}</legend>
-    {{ form.input('old_password', type='password', label=_(oldpassword_label), id='field-password', value=data.oldpassword, error=errors.oldpassword, classes=['control-medium'], attrs={'autocomplete': 'off'} ) }}
+    {{ form.input('old_password', type='password', label=_('Sysadmin password') if c.is_sysadmin else _('Old password'), id='field-password', value=data.oldpassword, error=errors.oldpassword, classes=['control-medium'], attrs={'autocomplete': 'off'} ) }}
 
     {{ form.input('password1', type='password', label=_('Password'), id='field-password', value=data.password1, error=errors.password1, classes=['control-medium'], attrs={'autocomplete': 'off'} ) }}
 

--- a/ckan/templates/user/edit_user_form.html
+++ b/ckan/templates/user/edit_user_form.html
@@ -24,7 +24,15 @@
 
   <fieldset>
     <legend>{{ _('Change password') }}</legend>
-    {{ form.input('old_password', type='password', label=_('Sysadmin Password') if c.is_sysadmin else _('Old Password'), id='field-password', value=data.oldpassword, error=errors.oldpassword, classes=['control-medium'], attrs={'autocomplete': 'off'} ) }}
+    {{ form.input('old_password',
+                  type='password',
+                  label=_('Sysadmin Password') if c.is_sysadmin else _('Old Password'),
+                  id='field-password',
+                  value=data.oldpassword,
+                  error=errors.oldpassword,
+                  classes=['control-medium'],
+                  attrs={'autocomplete': 'off'}
+                  ) }}
 
     {{ form.input('password1', type='password', label=_('Password'), id='field-password', value=data.password1, error=errors.password1, classes=['control-medium'], attrs={'autocomplete': 'off'} ) }}
 

--- a/ckan/templates/user/edit_user_form.html
+++ b/ckan/templates/user/edit_user_form.html
@@ -24,7 +24,7 @@
 
   <fieldset>
     <legend>{{ _('Change password') }}</legend>
-    {{ form.input('old_password', type='password', label=_('Old Password'), id='field-password', value=data.oldpassword, error=errors.oldpassword, classes=['control-medium'], attrs={'autocomplete': 'off'} ) }}
+    {{ form.input('old_password', type='password', label=_(oldpassword_label), id='field-password', value=data.oldpassword, error=errors.oldpassword, classes=['control-medium'], attrs={'autocomplete': 'off'} ) }}
 
     {{ form.input('password1', type='password', label=_('Password'), id='field-password', value=data.password1, error=errors.password1, classes=['control-medium'], attrs={'autocomplete': 'off'} ) }}
 


### PR DESCRIPTION
Fixes #2760

### Proposed fixes:
The label on the edit user page now reads `Sysadmin password` if the user is a sysadmin or `Old password` if the user is not. This should clarify the situation in which the sysadmin wants to change another user's password. 

I am not sure if this is your standard way to change labels programatically. I am open for pointers on how to do it in a more fitting way.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

