### PR TITLE
include '.sql' migrations (Fixes #3045)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,4 +17,6 @@ include ckanext/datastore/set_permissions.sql
 prune .git
 include CHANGELOG.txt
 include ckan/migration/migrate.cfg
+include ckan/migration/README
+recursive-include ckan/migration/versions *.sql
 recursive-include ckan_deb *

--- a/setup.py
+++ b/setup.py
@@ -177,14 +177,6 @@ setup(
     zip_safe=False,
     packages=find_packages(exclude=['ez_setup']),
     namespace_packages=['ckanext', 'ckanext.stats'],
-    include_package_data=True,
-    package_data={'ckan': [
-        'i18n/*/LC_MESSAGES/*.mo',
-        'migration/migrate.cfg',
-        'migration/README',
-        'migration/tests/test_dumps/*',
-        'migration/versions/*',
-    ]},
     message_extractors={
         'ckan': [
             ('**.py', 'python', None),


### PR DESCRIPTION
Fixes #3045 

### Proposed fixes:

install all migrations, include the migrations for 021 which are .sql files.

remove dead code from setup.py (the code in there made no
difference to the tarball produced by sdist.)

update MANIFEST.in to achieve what the stuff in setup.py
was trying to do.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X ] includes bugfix for possible backport

Please [X] all the boxes above that apply