### PR TITLE
Overwrite path to solr core for Travis in paster templates

### DIFF
--- a/ckan/pastertemplates/template/bin/travis-build.bash_tmpl
+++ b/ckan/pastertemplates/template/bin/travis-build.bash_tmpl
@@ -22,6 +22,11 @@ echo "Creating the PostgreSQL user and database..."
 sudo -u postgres psql -c "CREATE USER ckan_default WITH PASSWORD 'pass';"
 sudo -u postgres psql -c 'CREATE DATABASE ckan_test WITH OWNER ckan_default;'
 
+echo "SOLR config..."
+# Solr is multicore for tests on ckan master, but it's easier to run tests on
+# Travis single-core. See https://github.com/ckan/ckan/issues/2972
+sed -i -e 's/solr_url.*/solr_url = http:\/\/127.0.0.1:8983\/solr/' ckan/test-core.ini
+
 echo "Initialising the database..."
 cd ckan
 paster db init -c test-core.ini


### PR DESCRIPTION
Fixes #2972

### Proposed fixes:

The paster templates for setting up an extension provide a simple Travis script. Travis expects a simple single-core solr setup. However, the solr_url setting has been changed in master to work with a multi-core setup in Solr. This PR uses suggestions made in #2972 to overwrite the solr_url in test-core.ini during the Travis build.
