### PR TITLE
[#2856] Create DataPusher task timestamps using UTC

### DIFF
--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -74,7 +74,7 @@ def datapusher_submit(context, data_dict):
         'entity_id': res_id,
         'entity_type': 'resource',
         'task_type': 'datapusher',
-        'last_updated': str(datetime.datetime.now()),
+        'last_updated': str(datetime.datetime.utcnow()),
         'state': 'submitting',
         'key': 'datapusher',
         'value': '{}',
@@ -119,7 +119,7 @@ def datapusher_submit(context, data_dict):
                  'details': str(e)}
         task['error'] = json.dumps(error)
         task['state'] = 'error'
-        task['last_updated'] = str(datetime.datetime.now()),
+        task['last_updated'] = str(datetime.datetime.utcnow()),
         p.toolkit.get_action('task_status_update')(context, task)
         raise p.toolkit.ValidationError(error)
 
@@ -134,7 +134,7 @@ def datapusher_submit(context, data_dict):
                  'status_code': r.status_code}
         task['error'] = json.dumps(error)
         task['state'] = 'error'
-        task['last_updated'] = str(datetime.datetime.now()),
+        task['last_updated'] = str(datetime.datetime.utcnow()),
         p.toolkit.get_action('task_status_update')(context, task)
         raise p.toolkit.ValidationError(error)
 
@@ -143,7 +143,7 @@ def datapusher_submit(context, data_dict):
 
     task['value'] = value
     task['state'] = 'pending'
-    task['last_updated'] = str(datetime.datetime.now()),
+    task['last_updated'] = str(datetime.datetime.utcnow()),
     p.toolkit.get_action('task_status_update')(context, task)
 
     return True
@@ -175,7 +175,7 @@ def datapusher_hook(context, data_dict):
     })
 
     task['state'] = status
-    task['last_updated'] = str(datetime.datetime.now())
+    task['last_updated'] = str(datetime.datetime.utcnow())
 
     resubmit = False
 

--- a/ckanext/datapusher/tests/test_action.py
+++ b/ckanext/datapusher/tests/test_action.py
@@ -30,7 +30,7 @@ class TestDataPusherAction(object):
             'entity_id': resource_id,
             'entity_type': 'resource',
             'task_type': 'datapusher',
-            'last_updated': str(datetime.datetime.now()),
+            'last_updated': str(datetime.datetime.utcnow()),
             'state': 'pending',
             'key': 'datapusher',
             'value': '{}',
@@ -163,13 +163,14 @@ class TestDataPusherAction(object):
                                    **self._pending_task(resource['id']))
 
         # Update the resource, set a new last_modified (changes on file upload)
-        helpers.call_action('resource_update', {},
-                            id=resource['id'],
-                            package_id=dataset['id'],
-                            url='http://example.com/file.csv',
-                            format='CSV',
-                            last_modified=datetime.datetime.now().isoformat()
-                            )
+        helpers.call_action(
+            'resource_update', {},
+            id=resource['id'],
+            package_id=dataset['id'],
+            url='http://example.com/file.csv',
+            format='CSV',
+            last_modified=datetime.datetime.utcnow().isoformat()
+        )
         # Not called
         eq_(len(mock_datapusher_submit.mock_calls), 1)
 


### PR DESCRIPTION
When an upload to the DataPusher finishes we check `resource['last_modified']` (in UTC) against `task['last_updated']` to check whether it changed during the previous upload and resubmit it.
As `task['last_updated']` was created using `datetime.now()` this could lead to infinite upload loops.

Discussion is here:

https://github.com/ckan/ckan/issues/2856#issuecomment-220383735