### PR TITLE
Display warning when creating dataset without organizations

### DIFF
--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -29,7 +29,7 @@ def owner_org_validator(key, data, errors, context):
 
     if value is missing or value is None:
         if not authz.check_config_permission('create_unowned_dataset'):
-            raise Invalid(_('A organization must be supplied'))
+            raise Invalid(_('An organization must be provided'))
         data.pop(key, None)
         raise df.StopOnError
 
@@ -38,7 +38,7 @@ def owner_org_validator(key, data, errors, context):
     user = model.User.get(user)
     if value == '':
         if not authz.check_config_permission('create_unowned_dataset'):
-            raise Invalid(_('A organization must be supplied'))
+            raise Invalid(_('An organization must be provided'))
         return
 
     group = model.Group.get(value)

--- a/ckan/templates/package/new.html
+++ b/ckan/templates/package/new.html
@@ -1,23 +1,10 @@
-{% extends "package/base_form_page.html" %}
+{% if not h.organizations_available('create_dataset')
+        and not h.check_config_permission('ckan.auth.create_unowned_dataset') %}
 
-{% block subtitle %}{{ _('Create Dataset') }}{% endblock %}
+    {% include "package/snippets/cannot_create_package.html" %}
 
+{% else %}
+    {% extends "package/base_form_page.html" %}
 
-{% if not h.organizations_available('create_dataset') %}
-
-{% block primary_content %}
-  <section class="module">
-    {% block page_header %}{% endblock %}
-    <div class="module-content">
-      {% block primary_content_inner %}
-        <p>{{ _('Before you can create a dataset you need to create an organization first.') }}</p>
-
-          <a class='btn btn-primary' href="{{ h.url_for(controller='organization', action='new') }}">
-            {{ _('Create a new organization') }}
-          </a>
-      {% endblock %}
-    </div>
-  </section>
-{% endblock %}
-
+    {% block subtitle %}{{ _('Create Dataset') }}{% endblock %}
 {% endif  %}

--- a/ckan/templates/package/new.html
+++ b/ckan/templates/package/new.html
@@ -1,3 +1,23 @@
 {% extends "package/base_form_page.html" %}
 
 {% block subtitle %}{{ _('Create Dataset') }}{% endblock %}
+
+
+{% if not h.organizations_available('create_dataset') %}
+
+{% block primary_content %}
+  <section class="module">
+    {% block page_header %}{% endblock %}
+    <div class="module-content">
+      {% block primary_content_inner %}
+        <p>{{ _('Before you can create a dataset you need to create an organization first.') }}</p>
+
+          <a class='btn btn-primary' href="{{ h.url_for(controller='organization', action='new') }}">
+            {{ _('Create a new organization') }}
+          </a>
+      {% endblock %}
+    </div>
+  </section>
+{% endblock %}
+
+{% endif  %}

--- a/ckan/templates/package/snippets/cannot_create_package.html
+++ b/ckan/templates/package/snippets/cannot_create_package.html
@@ -1,0 +1,27 @@
+{% extends "package/base_form_page.html" %}
+
+{% block primary_content %}
+
+{% block page_header %}{% endblock %}
+    <section class="module">
+        <div class="module-content">
+          {% block primary_content_inner %}
+              {%  if h.check_access('organization_create') %}
+                <div class="alert alert-warning">{{ _('Before you can create a dataset you need to create an organization.') }}</div>
+
+                  <a class='btn btn-primary' href="{{ h.url_for(controller='organization', action='new') }}">
+                    {{ _('Create a new organization') }}
+                  </a>
+
+              {% else %}
+                   <div class="alert alert-danger">
+                      <p> {{ _('There are no organizations to which you can assign this dataset.') }} </p>
+                      <p>{{ _('Ask a system administrator to create an organization before you can continue.') }}</p>
+                   </div>
+
+              {% endif %}
+
+            {% endblock %}
+        </div>
+    </section>
+{% endblock %}

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -8,6 +8,7 @@ from nose.tools import (
     assert_true,
 )
 
+from mock import patch
 from routes import url_for
 
 import ckan.model as model
@@ -39,6 +40,43 @@ class TestPackageNew(helpers.FunctionalTestBase):
         app = self._get_test_app()
         env, response = _get_package_new_page(app)
         assert_true('dataset-edit' in response.forms)
+
+    @helpers.change_config('ckan.auth.create_unowned_dataset', 'false')
+    def test_needs_organization_but_no_organizations_has_button(self,):
+        ''' Scenario: The settings say every dataset needs an organization
+        but there are no organizations. If the user is allowed to create an
+        organization they should be prompted to do so when they try to create
+        a new dataset'''
+        app = self._get_test_app()
+        sysadmin = factories.Sysadmin()
+
+        env = {'REMOTE_USER': sysadmin['name'].encode('ascii')}
+        response = app.get(
+            url=url_for(controller='package', action='new'),
+            extra_environ=env
+        )
+        assert 'dataset-edit' not in response.forms
+        assert url_for(controller='organization', action='new') in response
+
+    @patch('ckan.logic.auth.create.organization_create',
+           return_value={'success': False})
+    @helpers.change_config('ckan.auth.create_unowned_dataset', 'false')
+    def test_needs_organization_but_no_organizations_no_button(self, *args):
+        ''' Scenario: The settings say every dataset needs an organization
+        but there are no organizations. If the user is not allowed to create an
+        organization they should be told to ask the admin but no link should be
+        presented'''
+        app = self._get_test_app()
+        sysadmin = factories.Sysadmin()
+
+        env = {'REMOTE_USER': sysadmin['name'].encode('ascii')}
+        response = app.get(
+            url=url_for(controller='package', action='new'),
+            extra_environ=env
+        )
+        assert 'dataset-edit' not in response.forms
+        assert url_for(controller='organization', action='new') not in response
+        assert 'Ask a system administrator' in response
 
     def test_name_required(self):
         app = self._get_test_app()

--- a/ckan/tests/helpers.py
+++ b/ckan/tests/helpers.py
@@ -328,6 +328,53 @@ def change_config(key, value):
     return decorator
 
 
+def mock_auth(auth_function_path):
+    '''
+    Decorator to easily mock a CKAN auth method in the context of a test
+     function
+
+    It adds a mock object for the provided auth_function_path as a parameter to
+     the test function.
+
+    Essentially it makes sure that `ckan.authz.clear_auth_functions_cache` is
+     called before and after to make sure that the auth functions pick up
+     the newly changed values.
+
+    Usage::
+
+        @helpers.mock_auth('ckan.logic.auth.create.package_create')
+        def test_mock_package_create(self, mock_package_create):
+            from ckan import logic
+            mock_package_create.return_value = {'success': True}
+
+            # package_create is mocked
+            eq_(logic.check_access('package_create', {}), True)
+
+            assert mock_package_create.called
+
+    :param action_name: the full path to the auth function to be mocked,
+        e.g. ``ckan.logic.auth.create.package_create``
+    :type action_name: string
+
+    '''
+    from ckan.authz import clear_auth_functions_cache
+
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+
+            try:
+                with mock.patch(auth_function_path) as mocked_auth:
+                    clear_auth_functions_cache()
+                    new_args = args + tuple([mocked_auth])
+                    return_value = func(*new_args, **kwargs)
+            finally:
+                clear_auth_functions_cache()
+            return return_value
+
+        return nose.tools.make_decorator(func)(wrapper)
+    return decorator
+
+
 def mock_action(action_name):
     '''
     Decorator to easily mock a CKAN action in the context of a test function


### PR DESCRIPTION
Fixes #3046, #2767

### Proposed fixes:
As discussed in #3046 already this now checks if there are organizations to which the dataset can be added or not. If there are non it checks if the user is allowed to create on or not and depending on the answer provides them with a link.

The tests are failing right now unfortunately. When either one of them is commented out they both pass but the first one fails when run together. Any idea what this could be? Also I feel bad for having to introduce `patch` in those tests again, maybe there is a better way to do it?


### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport