### PR TITLE
Deprecate h.url, make it use h.url_for internally

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1037,7 +1037,7 @@ def pager_url(page, partial=None, **kwargs):
     if routes_dict.get('id'):
         kwargs['id'] = routes_dict['id']
     kwargs['page'] = page
-    return url(**kwargs)
+    return url_for(**kwargs)
 
 
 class Page(paginate.Page):

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -142,13 +142,13 @@ def redirect_to(*args, **kw):
     return _redirect_to(url_for(*args, **kw))
 
 
+@maintain.deprecated('h.url is deprecated please use h.url_for')
 @core_helper
 def url(*args, **kw):
-    '''Create url adding i18n information if selected
-    wrapper for pylons.url'''
-    locale = kw.pop('locale', None)
-    my_url = _pylons_default_url(*args, **kw)
-    return _local_url(my_url, locale=locale, **kw)
+    '''
+    Deprecated: please use `url_for` instead
+    '''
+    return url_for(*args, **kw)
 
 
 @core_helper

--- a/ckan/templates/base.html
+++ b/ckan/templates/base.html
@@ -86,7 +86,7 @@
   </head>
 
   {# Allows custom attributes to be added to the <body> tag #}
-  <body{% block bodytag %} data-site-root="{{ h.url('/', locale='default', qualified=true) }}" data-locale-root="{{ h.url('/', qualified=true) }}" {% endblock %}>
+  <body{% block bodytag %} data-site-root="{{ h.url_for('/', locale='default', qualified=true) }}" data-locale-root="{{ h.url_for('/', qualified=true) }}" {% endblock %}>
 
     {#
     The page block allows you to add content to the page. Most of the time it is

--- a/ckan/templates/group/snippets/feeds.html
+++ b/ckan/templates/group/snippets/feeds.html
@@ -1,4 +1,4 @@
-{%- set dataset_feed = h.url(controller='feed', action='group', id=c.group_dict.name) -%}
-{%- set history_feed = h.url(controller='revision', action='list', format='atom', days=1) -%}
+{%- set dataset_feed = h.url_for(controller='feed', action='group', id=c.group_dict.name) -%}
+{%- set history_feed = h.url_for(controller='revision', action='list', format='atom', days=1) -%}
 <link rel="alternate" type="application/atom+xml" title="{{ g.site_title }} - {{ _('Datasets in group: {group}').format(group=c.group_dict.display_name) }}" href="{{ dataset_feed }}" />
 <link rel="alternate" type="application/atom+xml" title="{{ g.site_title }} - {{ _('Recent Revision History') }}" href="{{ history_feed }}" />

--- a/ckan/templates/header.html
+++ b/ckan/templates/header.html
@@ -82,10 +82,10 @@
 
       {% block header_logo %}
         {% if g.site_logo %}
-          <a class="logo" href="{{ h.url('home') }}"><img src="{{ h.url_for_static_or_external(g.site_logo) }}" alt="{{ g.site_title }}" title="{{ g.site_title }}" /></a>
+          <a class="logo" href="{{ h.url_for('home') }}"><img src="{{ h.url_for_static_or_external(g.site_logo) }}" alt="{{ g.site_title }}" title="{{ g.site_title }}" /></a>
         {% else %}
           <h1>
-            <a href="{{ h.url('home') }}">{{ g.site_title }}</a>
+            <a href="{{ h.url_for('home') }}">{{ g.site_title }}</a>
           </h1>
           {% if g.site_description %}<h2>{{ g.site_description }}</h2>{% endif %}
         {% endif %}

--- a/ckan/templates/organization/snippets/feeds.html
+++ b/ckan/templates/organization/snippets/feeds.html
@@ -1,4 +1,4 @@
-{%- set dataset_feed = h.url(controller='feed', action='organization', id=c.group_dict.name) -%}
-{%- set history_feed = h.url(controller='revision', action='list', format='atom', days=1) -%}
+{%- set dataset_feed = h.url_for(controller='feed', action='organization', id=c.group_dict.name) -%}
+{%- set history_feed = h.url_for(controller='revision', action='list', format='atom', days=1) -%}
 <link rel="alternate" type="application/atom+xml" title="{{ g.site_title }} - {{ _('Datasets in organization: {group}').format(group=c.group_dict.display_name) }}" href="{{ dataset_feed }}" />
 <link rel="alternate" type="application/atom+xml" title="{{ g.site_title }} - {{ _('Recent Revision History') }}" href="{{ history_feed }}" />

--- a/ckan/templates/package/read_base.html
+++ b/ckan/templates/package/read_base.html
@@ -27,7 +27,7 @@
         <div class="module info alert alert-info">
           <p class="module-content">
             {% set timestamp = h.render_datetime(c.revision_date, with_hours=True) %}
-            {% set url = h.url(controller='package', action='read', id=pkg.name) %}
+            {% set url = h.url_for(controller='package', action='read', id=pkg.name) %}
 
             {% trans timestamp=timestamp, url=url %}This is an old revision of this dataset, as edited at {{ timestamp }}. It may differ significantly from the <a href="{{ url }}">current revision</a>.{% endtrans %}
           </p>

--- a/ckan/templates/package/snippets/resource_view.html
+++ b/ckan/templates/package/snippets/resource_view.html
@@ -6,7 +6,7 @@
        href="#embed-{{ resource_view['id'] }}"
        data-module="resource-view-embed"
        data-module-id="{{ resource_view['id'] }}"
-       data-module-url="{{ h.url('resource_view', id=package['name'], resource_id=resource['id'], view_id=resource_view['id'], qualified=True) }}">
+       data-module-url="{{ h.url_for('resource_view', id=package['name'], resource_id=resource['id'], view_id=resource_view['id'], qualified=True) }}">
       <i class="icon-code"></i>
       {{ _("Embed") }}
     </a>
@@ -37,20 +37,20 @@
         {% if not to_preview %}
           {% set current_filters = request.str_GET.get('filters') %}
           {% if current_filters %}
-            {% set src = h.url(qualified=true, controller='package',
+            {% set src = h.url_for(qualified=true, controller='package',
                                action='resource_view', id=package['name'],
                                resource_id=resource['id'],
                                view_id=resource_view['id'],
                                filters=current_filters)  %}
           {% else %}
-            {% set src = h.url(qualified=true, controller='package',
+            {% set src = h.url_for(qualified=true, controller='package',
                                action='resource_view', id=package['name'],
                                resource_id=resource['id'],
                                view_id=resource_view['id'])  %}
           {% endif %}
         {% else %}
           {# When previewing we need to stick the whole resource_view as a param as there is no other way to pass to information on to the iframe #}
-          {% set src = h.url(qualified=true, controller='package', action='resource_view', id=package['name'], resource_id=resource['id']) + '?' + h.urlencode({'resource_view': h.dump_json(resource_view)}) %}
+          {% set src = h.url_for(qualified=true, controller='package', action='resource_view', id=package['name'], resource_id=resource['id']) + '?' + h.urlencode({'resource_view': h.dump_json(resource_view)}) %}
         {% endif %}
         <iframe src="{{ src }}" frameborder="0" width="100%" data-module="data-viewer">
           <p>{{ _('Your browser does not support iframes.') }}</p>

--- a/ckan/templates/snippets/home_breadcrumb_item.html
+++ b/ckan/templates/snippets/home_breadcrumb_item.html
@@ -1,2 +1,2 @@
 {# Used to insert the home icon into a breadcrumb #}
-<li class="home"><a href="{{ h.url('home') }}"><i class="icon-home"></i><span> {{ _('Home') }}</span></a></li>
+<li class="home"><a href="{{ h.url_for('home') }}"><i class="icon-home"></i><span> {{ _('Home') }}</span></a></li>

--- a/ckan/tests/legacy/functional/test_pagination.py
+++ b/ckan/tests/legacy/functional/test_pagination.py
@@ -100,12 +100,12 @@ class TestPaginationGroup(TestController):
 
     def test_group_index(self):
         res = self.app.get(url_for(controller='group', action='index'))
-        assert 'href="/group?sort=&amp;q=&amp;page=2"' in res, res
+        assert 'href="/group?q=&amp;sort=&amp;page=2"' in res, res
         grp_numbers = scrape_search_results(res, 'group')
         assert_equal(['00', '01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20'], grp_numbers)
 
         res = self.app.get(url_for(controller='group', action='index', page=2))
-        assert 'href="/group?sort=&amp;q=&amp;page=1"' in res
+        assert 'href="/group?q=&amp;sort=&amp;page=1"' in res
         grp_numbers = scrape_search_results(res, 'group')
         assert_equal(['21'], grp_numbers)
 


### PR DESCRIPTION
`h.url` does not do anything that `h.url_for` already does, has the same signature and is used is only a handful of places.

For the [ongoing work](https://github.com/ckan/ckan/tree/poc-flask-views.common-url_for) on Flask/Pylons url_for I'm keen on simplifying the helpers dealing with urls. 