### PR TITLE
Remove references to old session data

### DIFF
--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -267,15 +267,13 @@ class BaseController(WSGIController):
             c.user = c.user.decode('utf8')
             c.userobj = model.User.by_name(c.user)
             if c.userobj is None or not c.userobj.is_active():
+
                 # This occurs when a user that was still logged in is deleted,
-                # or when you are logged in, clean db
-                # and then restart (or when you change your username)
-                # There is no user object, so even though repoze thinks you
-                # are logged in and your cookie has ckan_display_name, we
-                # need to force user to logout and login again to get the
-                # User object.
-                session['lang'] = request.environ.get('CKAN_LANG')
-                session.save()
+                # or when you are logged in, clean db and then restart (or
+                # when you change your username) There is no user object, so
+                # even though repoze thinks you are logged in and your cookie
+                # has ckan_display_name, we need to force user to logout and
+                # login again to get the User object.
 
                 ev = request.environ
                 if 'repoze.who.plugins' in ev:

--- a/ckan/tests/legacy/lib/test_i18n.py
+++ b/ckan/tests/legacy/lib/test_i18n.py
@@ -1,4 +1,4 @@
-from nose.tools import assert_equal, assert_raises
+from nose.tools import assert_equal
 from pylons import config, session
 import pylons
 
@@ -11,8 +11,10 @@ class TestI18n(PylonsTestCase):
 
     def handle_request(self, session_language=None, languages_header=[]):
         session['locale'] = session_language
+
         class FakePylons:
             translator = None
+
         class FakeRequest:
             # Populated from the HTTP_ACCEPT_LANGUAGE header normally
             languages = languages_header
@@ -21,44 +23,16 @@ class TestI18n(PylonsTestCase):
         request = FakeRequest()
         real_pylons_request = pylons.request
         try:
-            pylons.request = request # for set_lang to work
+            pylons.request = request  # for set_lang to work
+
             class FakeTmplContext:
-                language = None # gets filled in by handle_request
+                language = None  # gets filled in by handle_request
             tmpl_context = FakeTmplContext()
             ckan.lib.i18n.handle_request(request, tmpl_context)
-            return tmpl_context.language # the language that got set
+            return tmpl_context.language  # the language that got set
         finally:
             pylons.request = real_pylons_request
 
     def test_handle_request__default(self):
         assert_equal(self.handle_request(),
                      config['ckan.locale_default'])
-
-## Session no longer used to set languages so test no longer relevant
-## see #1653
-
-##    def test_handle_request__session(self):
-##        assert_equal(self.handle_request(session_language='fr'),
-##                     'fr')
-
-## Browser lang detection disabled - see #1452
-
-##    def test_handle_request__header(self):
-##        assert_equal(self.handle_request(languages_header=['de']),
-##                     'de')
-
-##    def test_handle_request__header_negotiate(self):
-##        # Language so is not an option, so reverts to next one
-##        assert_equal(self.handle_request(languages_header=['so_KE', 'de']),
-##                     'de')
-
-##    def test_handle_request__header_but_defaults(self):
-##        # Language so is not an option, so reverts to default
-##        assert_equal(self.handle_request(languages_header=['so_KE']),
-##                     'en')
-
-##    def test_handle_request__header_territory(self):
-##        # Request for specific version of German ends up simply as de.
-##        assert_equal(self.handle_request(languages_header=['fr_CA', 'en']),
-##                     'fr')
-

--- a/ckan/tests/legacy/test_coding_standards.py
+++ b/ckan/tests/legacy/test_coding_standards.py
@@ -565,7 +565,6 @@ class TestPep8(object):
         'ckan/tests/legacy/lib/test_email_notifications.py',
         'ckan/tests/legacy/lib/test_hash.py',
         'ckan/tests/legacy/lib/test_helpers.py',
-        'ckan/tests/legacy/lib/test_i18n.py',
         'ckan/tests/legacy/lib/test_mailer.py',
         'ckan/tests/legacy/lib/test_munge.py',
         'ckan/tests/legacy/lib/test_navl.py',


### PR DESCRIPTION
Locale is persisted by i18n middleware in the url, and no longer in the session. This PR just removes a couple of stray references to the old session code.