### PR TITLE
Catch validation error in actvity lists

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -825,10 +825,15 @@ class GroupController(base.BaseController):
         except (NotFound, NotAuthorized):
             abort(404, _('Group not found'))
 
-        # Add the group's activity stream (already rendered to HTML) to the
-        # template context for the group/read.html template to retrieve later.
-        c.group_activity_stream = self._action('group_activity_list_html')(
-            context, {'id': c.group_dict['id'], 'offset': offset})
+        try:
+            # Add the group's activity stream (already rendered to HTML) to the
+            # template context for the group/read.html
+            # template to retrieve later.
+            c.group_activity_stream = self._action('group_activity_list_html')(
+                context, {'id': c.group_dict['id'], 'offset': offset})
+
+        except ValidationError as error:
+            base.abort(400)
 
         return render(self._activity_template(group_type),
                       extra_vars={'group_type': group_type})

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -585,8 +585,11 @@ class UserController(base.BaseController):
 
         self._setup_template_variables(context, data_dict)
 
-        c.user_activity_stream = get_action('user_activity_list_html')(
-            context, {'id': c.user_dict['id'], 'offset': offset})
+        try:
+            c.user_activity_stream = get_action('user_activity_list_html')(
+                context, {'id': c.user_dict['id'], 'offset': offset})
+        except ValidationError:
+            base.abort(400)
 
         return render('user/activity_stream.html')
 


### PR DESCRIPTION
Fixes #2859

### Proposed fixes:
As there was no progress in issue #2859 for some time now I decided to implement the change that @amercader proposed. 

The controllers now catch the `ValidationError`s and abort with a 400 code. We could also add a more detailed description for the user but I am not sure if it is necessary.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport