### PR TITLE
2604 file upload ux

### DIFF
--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -6893,25 +6893,34 @@ textarea {
   -moz-box-shadow: none;
   box-shadow: none;
 }
-.js .image-upload #field-image-url {
-  padding-right: 29px;
+.js .image-upload #field-image-url,
+.js .data-upload #field-image-url,
+.js .image-upload #field-data-url,
+.js .data-upload #field-data-url {
+  padding-right: 90px;
 }
-.js .image-upload #field-image-upload {
+.js .image-upload #field-image-upload,
+.js .data-upload #field-image-upload,
+.js .image-upload #field-data-upload,
+.js .data-upload #field-data-upload {
   cursor: pointer;
   position: absolute;
   z-index: 1;
   opacity: 0;
   filter: alpha(opacity=0);
 }
-.js .image-upload .controls {
+.js .image-upload .controls,
+.js .data-upload .controls {
   position: relative;
 }
-.js .image-upload .btn {
+.js .image-upload .btn,
+.js .data-upload .btn {
   position: relative;
   top: 0;
   margin-right: 10px;
 }
-.js .image-upload .btn.hover {
+.js .image-upload .btn.hover,
+.js .data-upload .btn.hover {
   color: #333333;
   text-decoration: none;
   background-position: 0 -15px;
@@ -6920,18 +6929,31 @@ textarea {
   -o-transition: background-position 0.1s linear;
   transition: background-position 0.1s linear;
 }
-.js .image-upload .btn-remove-url {
+.js .image-upload .btn-remove-url,
+.js .data-upload .btn-remove-url,
+.js .image-upload .btn-remove-data,
+.js .data-upload .btn-remove-data {
   position: absolute;
   margin-right: 0;
   top: 4px;
   right: 5px;
-  padding: 0 4px;
   -webkit-border-radius: 100px;
   -moz-border-radius: 100px;
   border-radius: 100px;
 }
-.js .image-upload .btn-remove-url .icon-remove {
+.js .image-upload .btn-remove-url .icon-remove,
+.js .data-upload .btn-remove-url .icon-remove,
+.js .image-upload .btn-remove-data .icon-remove,
+.js .data-upload .btn-remove-data .icon-remove {
   margin-right: 0;
+}
+.js .image-upload .btn-remove-url,
+.js .data-upload .btn-remove-url {
+  padding: 0 4px;
+}
+.js .image-upload .btn-remove-data,
+.js .data-upload .btn-remove-data {
+  padding: 0 12px;
 }
 .add-member-form .control-label {
   width: 100%;

--- a/ckan/public/base/javascript/modules/data-upload.js
+++ b/ckan/public/base/javascript/modules/data-upload.js
@@ -1,0 +1,202 @@
+/**
+ * Data-upload module
+ *
+ * This module provides the user experience for adding data to a resource
+ *
+ * Based on image-upload.js
+ *
+ * Author: Jared Smith @ Highway Three Solutions
+ */
+this.ckan.module('data-upload', function($, _) {
+  return {
+    is_url: false,
+    is_upload: false,
+    field_url: '',
+    field_upload: '',
+    field_clear: '',
+    options: {
+      i18n: {
+        upload: _('Upload'),
+        url: _('Link'),
+        remove: _('Remove'),
+        label: _('Data'),
+        label_for_url: _('URL'),
+        label_for_upload: _('File'),
+        upload_tooltip: _('Upload a file on your computer'),
+        url_tooltip: _('Link to a URL on the internet (you can also link to an API)')
+      }
+    },
+
+    initialize: function () {
+      $.proxyAll(this, /_on/);
+      var options = this.options;
+
+      // firstly setup the fields
+      var field_upload = 'input[name="' + options.field_upload + '"]';
+      var field_url    = 'input[name="' + options.field_url    + '"]';
+      var field_clear  = 'input[name="' + options.field_clear  + '"]';
+
+      this.input               = $(field_upload, this.el);
+      this.field_data          = this.input.parents('.control-group');
+      this.field_url           = $(field_url, this.el).parents('.control-group');
+      this.field_url_input     = $('input', this.field_url);
+      this.label_data_location = $('label[for="field-data-url"]');
+
+      // Is there a clear checkbox on the form already?
+      var checkbox = $(field_clear, this.el);
+      if (checkbox.length > 0) {
+        checkbox.parents('.control-group').remove();
+      }
+
+      // Adds the hidden clear input to the form
+      this.field_clear = $('<input type="hidden" name="clear_upload">')
+        .appendTo(this.el);
+
+      // Button to set the field to be a URL
+      this.button_url = $('<a href="javascript:;" class="btn"><i class="icon-globe"></i> '+this.i18n('url')+'</a>')
+        .prop('title', this.i18n('url_tooltip'))
+        .on('click', this._onFromWeb)
+        .insertAfter(this.input);
+
+      // Button to attach local file to the form
+      this.button_upload = $('<a href="javascript:;" class="btn"><i class="icon-cloud-upload"></i>'+this.i18n('upload')+'</a>')
+        .prop('title', this.i18n('upload_tooltip'))
+        .insertAfter(this.input);
+
+      // Button for resetting the form when there is a URL set
+      $('<a href="javascript:;" class="btn btn-danger btn-remove-data">Remove</a>')
+        .prop('title', this.i18n('remove'))
+        .on('click', this._onRemove)
+        .insertBefore(this.field_url_input);
+
+      // Update the main label
+      $('label[for="field-data-upload"]').text(this.i18n('label'));
+
+      // Setup the file input
+      this.input
+        .on('mouseover', this._onInputMouseOver)
+        .on('mouseout', this._onInputMouseOut)
+        .on('change', this._onInputChange)
+        .prop('title', this.i18n('upload_tooltip'))
+        .css('width', this.button_upload.outerWidth());
+
+      // Fields storage. Used in this.changeState
+      this.fields = $('<i />')
+        .add(this.button_upload)
+        .add(this.button_url)
+        .add(this.input)
+        .add(this.field_url)
+        .add(this.field_data);
+
+      if (options.is_url) {
+        this._showOnlyFieldUrl();
+
+        this.label_data_location.text(this.i18n('label_for_url'));
+      }
+      else if (options.is_upload) {
+        this._showOnlyFieldUrl();
+
+        this.field_url_input.prop('readonly', true);
+        // If the data is an uploaded file, the filename will display rather than whole url of the site
+        var filename = this._fileNameFromUpload(this.field_url_input.val());
+        this.field_url_input.val(filename);
+
+        this.label_data_location.text(this.i18n('label_for_upload'));
+      }
+      else {
+        this._showOnlyButtons();
+      }
+    },
+
+    /* Quick way of getting just the filename in the uri of the resource data
+     *
+     * Returns String.
+     */
+    _fileNameFromUpload: function(url) {
+      url = url.substring(0, (url.indexOf("#") == -1) ? url.length : url.indexOf("#"));
+      url = url.substring(0, (url.indexOf("?") == -1) ? url.length : url.indexOf("?"));
+      url = url.substring(url.lastIndexOf("/") + 1, url.length);
+
+      return url;
+    },
+
+    /* Event listener for when someone sets the field to URL mode
+     *
+     * Returns nothing.
+     */
+    _onFromWeb: function() {
+      this._showOnlyFieldUrl();
+      this.field_url_input.focus();
+
+      if (this.options.is_upload) {
+        this.field_clear.val('true');
+
+        this.label_data_location.text(this.i18n('label_for_url'));
+      }
+    },
+
+    /* Event listener for resetting the field back to the blank state
+     *
+     * Returns nothing.
+     */
+    _onRemove: function() {
+      this._showOnlyButtons();
+      this.field_url_input.val('');
+      this.field_url_input.prop('readonly', false);
+      this.field_clear.val('true');
+    },
+
+    /* Event listener for when someone chooses a file to upload
+     *
+     * Returns nothing.
+     */
+    _onInputChange: function() {
+      var file_name = this.input.val().split(/^C:\\fakepath\\/).pop();
+      this.field_url_input.val(file_name);
+      this.field_url_input.prop('readonly', true);
+      this.field_clear.val('');
+
+      this.label_data_location.text(this.i18n('label_for_upload'));
+
+      this._showOnlyFieldUrl();
+    },
+
+    /* Show only the buttons, hiding all others
+     *
+     * Returns nothing.
+     */
+    _showOnlyButtons: function() {
+      this.fields.hide();
+      this.button_upload
+        .add(this.field_data)
+        .add(this.button_url)
+        .add(this.input)
+        .show();
+    },
+
+    /* Show only the URL field, hiding all others
+     *
+     * Returns nothing.
+     */
+    _showOnlyFieldUrl: function() {
+      this.fields.hide();
+      this.field_url.show();
+    },
+
+    /* Event listener for when a user mouseovers the hidden file input
+     *
+     * Returns nothing.
+     */
+    _onInputMouseOver: function() {
+      this.button_upload.addClass('hover');
+    },
+
+    /* Event listener for when a user mouseouts the hidden file input
+     *
+     * Returns nothing.
+     */
+    _onInputMouseOut: function() {
+      this.button_upload.removeClass('hover');
+    }
+  };
+});

--- a/ckan/public/base/javascript/resource.config
+++ b/ckan/public/base/javascript/resource.config
@@ -43,6 +43,7 @@ ckan =
     modules/table-toggle-more.js
     modules/dataset-visibility.js
     modules/media-grid.js
+    modules/data-upload.js
     modules/image-upload.js
 
 main =

--- a/ckan/public/base/less/forms.less
+++ b/ckan/public/base/less/forms.less
@@ -734,11 +734,12 @@ textarea {
   }
 }
 
-.js .image-upload {
-  #field-image-url {
-    padding-right: 29px;
+.js .image-upload,
+.js .data-upload {
+  #field-image-url, #field-data-url {
+    padding-right: 90px;
   }
-  #field-image-upload {
+  #field-image-upload, #field-data-upload {
     cursor: pointer;
     position: absolute;
     z-index: 1;
@@ -758,16 +759,21 @@ textarea {
       .transition(background-position .1s linear);
     }
   }
-  .btn-remove-url {
+  .btn-remove-url, .btn-remove-data {
     position: absolute;
     margin-right: 0;
     top: 4px;
     right: 5px;
-    padding: 0 4px;
     .border-radius(100px);
     .icon-remove {
       margin-right: 0;
     }
+  }
+  .btn-remove-url {
+    padding: 0 4px;
+  }
+  .btn-remove-data {
+    padding: 0 12px;
   }
 }
 .add-member-form .control-label {

--- a/ckan/templates/macros/form.html
+++ b/ckan/templates/macros/form.html
@@ -118,7 +118,7 @@ Examples:
 {% macro markdown(name, id='', label='', value='', placeholder='', error="", classes=[], attrs={}, is_required=false) %}
   {% set classes = (classes|list) %}
   {% do classes.append('control-full') %}
-  {% set markdown_tooltip = "<pre><p>__Bold text__ or _italic text_</p><p># title<br>## secondary title<br>### etc</p><p>* list<br>* of<br>* items</p><p>http://auto.link.ed/</p></pre><p><b><a href='http://daringfireball.net/projects/markdown/syntax' target='_blank'>Full markdown syntax</a></b></p><p class='muted'><b>Please note:</b> HTML tags are stripped out for security reasons</p>" %} 
+  {% set markdown_tooltip = "<pre><p>__Bold text__ or _italic text_</p><p># title<br>## secondary title<br>### etc</p><p>* list<br>* of<br>* items</p><p>http://auto.link.ed/</p></pre><p><b><a href='http://daringfireball.net/projects/markdown/syntax' target='_blank'>Full markdown syntax</a></b></p><p class='muted'><b>Please note:</b> HTML tags are stripped out for security reasons</p>" %}
 
   {%- set extra_html = caller() if caller -%}
   {% call input_block(id or name, label or name, error, classes, control_classes=["editor"], extra_html=extra_html, is_required=is_required) %}
@@ -427,4 +427,28 @@ Example
 
   {% if is_upload_enabled %}</div>{% endif %}
 
+{% endmacro %}
+
+{#
+For uploading or linking data to a resource.
+Based on the image_upload macro, but re-purposed for data upload specifically.
+
+Example
+  {% import 'macros/form.html' as form %}
+  {{ form.data_upload(data, errors, field_url='url', field_upload='upload', is_url=data.url and not is_upload, is_upload=is_upload) }}
+
+#}
+{% macro data_upload(data, errors, field_url='', field_upload='', field_clear='clear_upload',
+                     is_url=false, is_upload=false) %}
+  {% set upload_label = _('File') %}
+  {% set url_label = _('URL') %}
+
+  <div class="data-upload" data-module="data-upload" data-module-is_url="{{ 'true' if is_url else 'false' }}" data-module-is_upload="{{ 'true' if is_upload else 'false' }}" data-module-field_url="{{ field_url }}" data-module-field_upload="{{ field_upload }}" data-module-field_clear="{{ field_clear }}"
+  >
+    {{ input(field_url, label=url_label, id='field-data-url', placeholder=data.url, value=data.get(field_url), error=errors.get(field_url), classes=['control-full']) }}
+
+    {{ input(field_upload, label=upload_label, id='field-data-upload', type='file', placeholder='', value='', error='', classes=['control-full']) }}
+
+    {{ checkbox(field_clear, label=_('Clear Upload'), id='field-clear-upload', value='true', error='', classes=['control-full']) }}
+  </div>
 {% endmacro %}

--- a/ckan/templates/package/snippets/resource_form.html
+++ b/ckan/templates/package/snippets/resource_form.html
@@ -19,9 +19,8 @@
   {% block basic_fields %}
     {% block basic_fields_url %}
       {% set is_upload = (data.url_type == 'upload') %}
-      {{ form.image_upload(data, errors, field_url='url', field_upload='upload', field_clear='clear_upload',
-         is_upload_enabled=h.uploads_enabled(), is_url=data.url and not is_upload, is_upload=is_upload,
-         upload_label=_('File'), url_label=_('URL')) }}
+      
+      {{ form.data_upload(data, errors, field_url='url', field_upload='upload', is_url=data.url and not is_upload, is_upload=is_upload) }}
     {% endblock %}
 
     {% block basic_fields_name %}


### PR DESCRIPTION
Fixes #2604 

### Proposed fixes:

I've changed the label from 'File' to 'Data' when there's no file/link.

When uploading a file from a local machine to a resource, the label will
change to 'File'. When adding a link to a resource, the label will
change to 'URL'.

When editing a resource, if the data is an upload, the data field will
only display the filename, rather than the url. The label for an upload
will also display as 'File'.

The remove data icon now uses text 'Remove' instead of an icon.

<img width="956" alt="screen shot 2016-05-25 at 4 14 44 pm" src="https://cloud.githubusercontent.com/assets/5874122/15559066/ec3a942e-2293-11e6-8172-c87cb2a7666e.png">
<img width="950" alt="screen shot 2016-05-25 at 4 14 34 pm" src="https://cloud.githubusercontent.com/assets/5874122/15559067/ec3ad33a-2293-11e6-9993-644e2e7551d4.png">
<img width="955" alt="screen shot 2016-05-25 at 4 13 29 pm" src="https://cloud.githubusercontent.com/assets/5874122/15559068/ec3dec6e-2293-11e6-81e2-884837a22786.png">

---
In a separate commit, I've included the updated main.css file

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
