### PR TITLE
Do not create default views on update

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -317,14 +317,14 @@ def resource_create(context, data_dict):
     resource = updated_pkg_dict['resources'][-1]
 
     ##  Add the default views to the new resource
-    create_datastore_views = paste.deploy.converters.asbool(
-        data_dict.get('create_datastore_views', False))
-    ckan.lib.datapreview.add_views_to_resource(context,
-                                               resource,
-                                               None,
-                                               view_types=[],
-                                               create_datastore_views=
-                                               create_datastore_views)
+    logic.get_action('resource_create_default_resource_views')(
+        {'model': context['model'],
+         'user': context['user'],
+         'ignore_auth': True
+         },
+        {'resource': resource,
+         'package': updated_pkg_dict
+         })
 
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.after_create(context, resource)

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -316,6 +316,16 @@ def resource_create(context, data_dict):
     updated_pkg_dict = _get_action('package_show')(context, {'id': package_id})
     resource = updated_pkg_dict['resources'][-1]
 
+    ##  Add the default views to the new resource
+    create_datastore_views = paste.deploy.converters.asbool(
+        data_dict.get('create_datastore_views', False))
+    ckan.lib.datapreview.add_views_to_resource(context,
+                                               resource,
+                                               None,
+                                               view_types=[],
+                                               create_datastore_views=
+                                               create_datastore_views)
+
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.after_create(context, resource)
 

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -307,13 +307,6 @@ def package_update(context, data_dict):
 
         item.after_update(context, data)
 
-    # Create default views for resources if necessary
-    if data.get('resources'):
-        logic.get_action('package_create_default_resource_views')(
-            {'model': context['model'], 'user': context['user'],
-             'ignore_auth': True},
-            {'package': data})
-
     if not context.get('defer_commit'):
         model.repo.commit()
 

--- a/ckan/tests/lib/test_datapreview.py
+++ b/ckan/tests/lib/test_datapreview.py
@@ -271,7 +271,6 @@ class TestViewsCreation(object):
             eq_(len(views_list), 1)
             eq_(views_list[0]['view_type'], 'image_view')
 
-
     def test_default_views_created_on_resource_create(self):
 
         dataset_dict = factories.Dataset(

--- a/ckan/tests/lib/test_datapreview.py
+++ b/ckan/tests/lib/test_datapreview.py
@@ -271,49 +271,6 @@ class TestViewsCreation(object):
             eq_(len(views_list), 1)
             eq_(views_list[0]['view_type'], 'image_view')
 
-    def test_default_views_created_on_package_update(self):
-
-        dataset_dict = factories.Dataset(
-            resources=[{
-                'url': 'http://not.for.viewing',
-                'format': 'xxx',
-            }]
-        )
-
-        resource_id = dataset_dict['resources'][0]['id']
-
-        views_list = helpers.call_action('resource_view_list', id=resource_id)
-
-        eq_(len(views_list), 0)
-
-        updated_data_dict = {
-            'id': dataset_dict['id'],
-            'resources': [
-                {
-                    'url': 'http://not.for.viewing',
-                    'format': 'xxx',
-                },
-                {
-                    'url': 'http://some.image.png',
-                    'format': 'png',
-                },
-
-
-            ]
-        }
-
-        dataset_dict = helpers.call_action('package_update', **updated_data_dict)
-
-        for resource in dataset_dict['resources']:
-            resource_id = resource['id'] if resource['format'] == 'PNG' else None
-
-        assert resource_id
-
-        updated_views_list = helpers.call_action('resource_view_list', id=resource_id)
-        eq_(len(updated_views_list), 1)
-        eq_(updated_views_list[0]['view_type'], 'image_view')
-
-        pass
 
     def test_default_views_created_on_resource_create(self):
 
@@ -333,35 +290,6 @@ class TestViewsCreation(object):
         new_resource_dict = helpers.call_action('resource_create', **resource_dict)
 
         views_list = helpers.call_action('resource_view_list', id=new_resource_dict['id'])
-
-        eq_(len(views_list), 1)
-        eq_(views_list[0]['view_type'], 'image_view')
-
-    def test_default_views_created_on_resource_update(self):
-
-        dataset_dict = factories.Dataset(
-            resources=[{
-                'url': 'http://not.for.viewing',
-                'format': 'xxx',
-            }]
-        )
-
-        resource_id = dataset_dict['resources'][0]['id']
-
-        views_list = helpers.call_action('resource_view_list', id=resource_id)
-
-        eq_(len(views_list), 0)
-
-        resource_dict = {
-            'id': resource_id,
-            'package_id': dataset_dict['id'],
-            'url': 'http://some.image.png',
-            'format': 'png',
-        }
-
-        updated_resource_dict = helpers.call_action('resource_update', **resource_dict)
-
-        views_list = helpers.call_action('resource_view_list', id=updated_resource_dict['id'])
 
         eq_(len(views_list), 1)
         eq_(views_list[0]['view_type'], 'image_view')

--- a/ckanext/reclineview/plugin.py
+++ b/ckanext/reclineview/plugin.py
@@ -90,7 +90,7 @@ class ReclineView(ReclineViewBase):
         resource = data_dict['resource']
 
         if (resource.get('datastore_active') or
-                resource.get('url') == '_datastore_only_resource'):
+                '_datastore_only_resource' in resource.get('url', '')):
             return True
         resource_format = resource.get('format', None)
         if resource_format:

--- a/ckanext/reclineview/plugin.py
+++ b/ckanext/reclineview/plugin.py
@@ -62,7 +62,7 @@ class ReclineViewBase(p.SingletonPlugin):
     def can_view(self, data_dict):
         resource = data_dict['resource']
         return (resource.get('datastore_active') or
-                resource.get('url') == '_datastore_only_resource')
+                '_datastore_only_resource' in resource.get('url', ''))
 
     def setup_template_variables(self, context, data_dict):
         return {'resource_json': json.dumps(data_dict['resource']),

--- a/ckanext/reclineview/tests/test_view.py
+++ b/ckanext/reclineview/tests/test_view.py
@@ -107,7 +107,7 @@ class TestReclineViewDatastoreOnly(helpers.FunctionalTestBase):
     def test_create_datastore_only_view(self):
         dataset = factories.Dataset()
         data = {
-            'resource': {'package_id': dataset['id'], 'format': 'csv'},
+            'resource': {'package_id': dataset['id']},
             'fields': [{'id': 'a'}, {'id': 'b'}],
             'records': [{'a': 1, 'b': 'xyz'}, {'a': 2, 'b': 'zzz'}]
         }

--- a/ckanext/reclineview/tests/test_view.py
+++ b/ckanext/reclineview/tests/test_view.py
@@ -107,7 +107,7 @@ class TestReclineViewDatastoreOnly(helpers.FunctionalTestBase):
     def test_create_datastore_only_view(self):
         dataset = factories.Dataset()
         data = {
-            'resource': {'package_id': dataset['id']},
+            'resource': {'package_id': dataset['id'], 'format': 'csv'},
             'fields': [{'id': 'a'}, {'id': 'b'}],
             'records': [{'a': 1, 'b': 'xyz'}, {'a': 2, 'b': 'zzz'}]
         }


### PR DESCRIPTION
Fixes #3011

### Proposed fixes:
With this change the views are created on `resource_create` but not on `package_update` The tests that made sure that views were created on update were removed. The `test_datepreview.py` file contains a `test_default_views_created_on_resource_create` test that assures that the default views are created when a new resource is created.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport