### PR TITLE
FunctionalTestCase changes

### DIFF
--- a/ckan/tests/controllers/test_feed.py
+++ b/ckan/tests/controllers/test_feed.py
@@ -11,22 +11,19 @@ class TestFeedNew(helpers.FunctionalTestBase):
         group = factories.Group()
         offset = url_for(controller='feed', action='group',
                          id=group['name']) + '?page=0'
-        app = self._get_test_app()
-        res = app.get(offset, status=400)
+        res = self.app.get(offset, status=400)
         assert '"page" parameter must be a positive integer' in res, res
 
     def test_atom_feed_page_negative_gives_error(self):
         group = factories.Group()
         offset = url_for(controller='feed', action='group',
                          id=group['name']) + '?page=-2'
-        app = self._get_test_app()
-        res = app.get(offset, status=400)
+        res = self.app.get(offset, status=400)
         assert '"page" parameter must be a positive integer' in res, res
 
     def test_atom_feed_page_not_int_gives_error(self):
         group = factories.Group()
         offset = url_for(controller='feed', action='group',
                          id=group['name']) + '?page=abc'
-        app = self._get_test_app()
-        res = app.get(offset, status=400)
+        res = self.app.get(offset, status=400)
         assert '"page" parameter must be a positive integer' in res, res

--- a/ckan/tests/helpers.py
+++ b/ckan/tests/helpers.py
@@ -179,7 +179,7 @@ class FunctionalTestBase(object):
         # Make a copy of the Pylons config, so we can restore it in teardown.
         cls._original_config = dict(config)
         cls._apply_config_changes(config)
-        cls._get_test_app()
+        cls.app = cls._get_test_app()
 
     @classmethod
     def _apply_config_changes(cls, cfg):


### PR DESCRIPTION
**TL;DR**: Should our functional reuse the same app within the same test class or recreate it on each test? If the former, can we make it a bit easier to reference the test app?
## 

Our new functional tests (ie those that require an actual app instance to make requests) are generally written like this:

``` python
import ckan.tests.helpers as helpers
import ckan.tests.factories as factories


class TestFeedNew(helpers.FunctionalTestBase):

    def test_atom_feed_page_zero_gives_error(self):
        group = factories.Group()
        offset = url_for(controller='feed', action='group',
                         id=group['name']) + '?page=0'
        app = self._get_test_app()
        res = app.get(offset, status=400)
        assert '"page" parameter must be a positive integer' in res, res
```

We essentially call `app = self._get_test_app()` on each test and use it on that context.

But the [`FunctionalTestBase._get_test_app()`](https://github.com/ckan/ckan/blob/05375b57cb80f80f4510f47964eb457bb85758b1/ckan/tests/helpers.py#L170) method actually caches the reference to the app, so every time we call `self._get_test_app()` on each test the same one is reused.

This seems reasonable to me (as long as we are only sharing it inside one particular Test class) but then there's this comment on the method made by @wardi:

```
        # FIXME: remove this method and switch to using helpers.get_test_app
        # in each test once the old functional tests are fixed or removed
```

@wardi do you remember the context for this?

Using `helpers.get_test_app()` on each test would mean recreating the app on every single test, which seems a bit overkill to me. Also if called directly we would miss the logic around configuration that is done on `setup_class`.

Unless there is a reason for using individual calls for `helpers.get_test_app()` I'd like to propose some backwards compatible changes to make things easier going forward. First of all just add a proper reference to `self.app` available to all tests from the class. This is a one line change that allows tests to be written like this:

``` python
import ckan.tests.helpers as helpers
import ckan.tests.factories as factories


class TestFeedNew(helpers.FunctionalTestBase):

    def test_atom_feed_page_zero_gives_error(self):
        group = factories.Group()
        offset = url_for(controller='feed', action='group',
                         id=group['name']) + '?page=0'
        res = self.app.get(offset, status=400)
        assert '"page" parameter must be a positive integer' in res, res 
```

Going forward though this will make things much easier when testing Flask stuff, particularly when needing to provide a `test_request_context` (eg when calling the [common url_for](https://github.com/ckan/ckan/compare/poc-flask-views...poc-flask-views.common-url_for) for both Pylons and Flask (WIP)), as we will need an easy reference to the actual Flask app object (not the WebTest one):

``` python
from ckan.lib.helpers import url_for

from ckan import model
import ckan.tests.helpers as helpers
import ckan.tests.factories as factories


class TestFeedNew(helpers.FunctionalTestBase):

    def test_atom_feed_page_zero_gives_error(self):
        group = factories.Group()
        with self.flask_app.test_request_context():
            offset = url_for(controller='feed', action='group',
                             id=group['name']) + '?page=0'
        res = self.app.get(offset, status=400)
        assert '"page" parameter must be a positive integer' in res, res 

```
