### PR TITLE
Set ckan.locale_default as language for FormEncode

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -8,6 +8,7 @@ import pytz
 
 import sqlalchemy
 from pylons import config
+import formencode
 
 import ckan.config.routing as routing
 import ckan.model as model
@@ -198,6 +199,12 @@ def update_config():
         # must be first for them to override defaults
         template_paths = extra_template_paths.split(',') + template_paths
     config['pylons.app_globals'].template_paths = template_paths
+
+    # Set the default language for validation messages from formencode
+    # to what is set as the default locale in the config
+    default_lang = config.get('ckan.locale_default', 'en')
+    formencode.api.set_stdtranslation(domain="FormEncode",
+                                      languages=[default_lang])
 
     # Markdown ignores the logger config, so to get rid of excessive
     # markdown debug messages in the log, set it to the level of the

--- a/ckan/lib/navl/dictization_functions.py
+++ b/ckan/lib/navl/dictization_functions.py
@@ -6,8 +6,6 @@ from pylons import config
 
 from ckan.common import _
 
-default_lang = config.get('ckan.locale_default', 'en')
-fe.api.set_stdtranslation(domain="FormEncode", languages=default_lang)
 
 class Missing(object):
     def __unicode__(self):

--- a/ckan/lib/navl/dictization_functions.py
+++ b/ckan/lib/navl/dictization_functions.py
@@ -6,6 +6,9 @@ from pylons import config
 
 from ckan.common import _
 
+default_lang = config.get('ckan.locale_default', 'en')
+fe.api.set_stdtranslation(domain="FormEncode", languages=default_lang)
+
 class Missing(object):
     def __unicode__(self):
         raise Invalid(_('Missing value'))

--- a/ckan/tests/lib/test_navl.py
+++ b/ckan/tests/lib/test_navl.py
@@ -1,0 +1,30 @@
+import nose
+import pylons
+
+from ckan.tests import helpers
+from ckan.config import environment
+
+eq_ = nose.tools.eq_
+
+
+class TestFormencdoeLanguage(object):
+    @helpers.change_config('ckan.locale_default', 'de')
+    def test_formencode_uses_locale_default(self):
+        environment.update_config()
+        from ckan.lib.navl.dictization_functions import validate
+        from ckan.lib.navl.validators import not_empty
+        from formencode import validators
+        schema = {
+            "name": [not_empty, unicode],
+            "email": [validators.Email],
+            "email2": [validators.Email],
+        }
+
+        data = {
+            "name": "fred",
+            "email": "32",
+            "email2": "david@david.com",
+        }
+
+        converted_data, errors = validate(data, schema)
+        eq_({'email': [u'Eine E-Mail-Adresse muss genau ein @-Zeichen enthalten']}, errors)


### PR DESCRIPTION
Fixes #3060

### Proposed fixes:
The locale for FormEncode which does the validation is now set on top of the `dictization_functions.py` file. It is taken from the ckan config file instead of the system `LANG`

- If this is not done FormEncode takes the system `LANG` for its
  validation messages which might lead to unexpected behaviour.
- This also leads to the tests passing on machines where the LANG is
  set to something other then `en`
- More information can be found at
  http://www.formencode.org/en/latest/Validator.html#localization-of-error-messages-i18n


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport