### PR TITLE
Pad object names from factories with zeros

### DIFF
--- a/ckan/tests/factories.py
+++ b/ckan/tests/factories.py
@@ -109,7 +109,7 @@ class User(factory.Factory):
     about = 'Just another test user.'
 
     # Generate a different user name param for each user that gets created.
-    name = factory.Sequence(lambda n: 'test_user_{n}'.format(n=n))
+    name = factory.Sequence(lambda n: 'test_user_{0:02d}'.format(n))
 
     # Compute the email param for each user based on the values of the other
     # params above.
@@ -138,7 +138,7 @@ class Resource(factory.Factory):
 
     FACTORY_FOR = ckan.model.Resource
 
-    name = factory.Sequence(lambda n: 'test_resource_{n}'.format(n=n))
+    name = factory.Sequence(lambda n: 'test_resource_{0:02d}'.format(n))
     description = 'Just another test resource.'
     format = 'res_format'
     url = 'http://link.to.some.data'
@@ -182,7 +182,7 @@ class ResourceView(factory.Factory):
 
     FACTORY_FOR = ckan.model.ResourceView
 
-    title = factory.Sequence(lambda n: 'test_resource_view_{n}'.format(n=n))
+    title = factory.Sequence(lambda n: 'test_resource_view_{0:02d}'.format(n))
     description = 'Just another test resource view.'
     view_type = 'image_view'
     resource_id = factory.LazyAttribute(lambda _: Resource()['id'])
@@ -212,7 +212,7 @@ class Sysadmin(factory.Factory):
     password = 'pass'
     about = 'Just another test sysadmin.'
 
-    name = factory.Sequence(lambda n: 'test_sysadmin_{n}'.format(n=n))
+    name = factory.Sequence(lambda n: 'test_sysadmin_{0:02d}'.format(n))
 
     email = factory.LazyAttribute(_generate_email)
     sysadmin = True
@@ -316,7 +316,7 @@ class Dataset(factory.Factory):
     notes = 'Just another test dataset.'
 
     # Generate a different group name param for each user that gets created.
-    name = factory.Sequence(lambda n: 'test_dataset_{n}'.format(n=n))
+    name = factory.Sequence(lambda n: 'test_dataset_{0:02d}'.format(n))
 
     @classmethod
     def _build(cls, target_class, *args, **kwargs):
@@ -343,7 +343,7 @@ class MockUser(factory.Factory):
     fullname = 'Mr. Mock User'
     password = 'pass'
     about = 'Just another mock user.'
-    name = factory.Sequence(lambda n: 'mock_user_{n}'.format(n=n))
+    name = factory.Sequence(lambda n: 'mock_user_{0:02d}'.format(n))
     email = factory.LazyAttribute(_generate_email)
     reset_key = factory.LazyAttribute(_generate_reset_key)
     id = factory.LazyAttribute(_generate_user_id)
@@ -368,7 +368,7 @@ class SystemInfo(factory.Factory):
 
     FACTORY_FOR = ckan.model.SystemInfo
 
-    key = factory.Sequence(lambda n: 'test_config_{n}'.format(n=n))
+    key = factory.Sequence(lambda n: 'test_config_{0:02d}'.format(n))
     value = _generate_random_string()
 
     @classmethod
@@ -408,7 +408,7 @@ class Vocabulary(factory.Factory):
     '''A factory class for creating tag vocabularies.'''
 
     FACTORY_FOR = ckan.model.Vocabulary
-    name = factory.Sequence(lambda n: 'test_vocabulary_{n}'.format(n=n))
+    name = factory.Sequence(lambda n: 'test_vocabulary_{0:02d}'.format(n))
 
     @classmethod
     def _build(cls, target_class, *args, **kwargs):

--- a/ckan/tests/factories.py
+++ b/ckan/tests/factories.py
@@ -245,7 +245,7 @@ class Group(factory.Factory):
 
     FACTORY_FOR = ckan.model.Group
 
-    name = factory.Sequence(lambda n: 'test_group_{n}'.format(n=n))
+    name = factory.Sequence(lambda n: 'test_group_{0:02d}'.format(n))
     title = factory.LazyAttribute(_generate_group_title)
     description = 'A test description for this test group.'
 
@@ -285,7 +285,7 @@ class Organization(factory.Factory):
     image_url = 'http://placekitten.com/g/200/100'
 
     # Generate a different group name param for each user that gets created.
-    name = factory.Sequence(lambda n: 'test_org_{n}'.format(n=n))
+    name = factory.Sequence(lambda n: 'test_org_{0:02d}'.format(n))
 
     @classmethod
     def _build(cls, target_class, *args, **kwargs):


### PR DESCRIPTION
Fixes #

### Proposed fixes:
The test in ckan/tests/controllers/test_group.py would sometimes fail when run in an unfortunate order (note: never on circle.ci as that splits up the test in way where this does not happen). The `test_page_thru_list_of_orgs_preserves_sort_order` and `test_page_thru_list_of_groups_preserves_sort_order` would fail because some organizations had already been created by other tests and the numbering would start a 5 instead of 1. And because the sorting was done via strings (so `Group 5` came after `Group 31` the test would fail. By always padding them with zeros (so it is `Group 05` now). this should not happen anymore and make the tests more stable.

This does not include any new tests and only changes code in the test folder. Since the test are still passing this should be save to merge.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

