### PR TITLE
Fix pagination style (CSS)

### DIFF
--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -5560,9 +5560,6 @@ a.tag:hover {
 .js .tab-content.active {
   display: block;
 }
-.js .automatic-local-datetime {
-    display: none;
-}
 .box {
   background-color: #FFF;
   border: 1px solid #cccccc;
@@ -5633,11 +5630,6 @@ a.tag:hover {
   font-weight: bold;
   color: #000000;
 }
-.module .pagination {
-  height: 34px;
-  margin-bottom: 0;
-  border-top: 1px solid #dddddd;
-}
 .module-content .pagination {
   margin-left: -25px;
   margin-right: -25px;
@@ -5653,8 +5645,8 @@ a.tag:hover {
   border: 0;
 }
 .module .pagination li a {
-  border-top: none;
-  border-bottom: none;
+  border-top: 1px solid #dddddd;
+  border-bottom: 1px solid #dddddd;
   padding-top: 7px;
   padding-bottom: 7px;
 }
@@ -5663,16 +5655,6 @@ a.tag:hover {
   -webkit-border-radius: 0;
   -moz-border-radius: 0;
   border-radius: 0;
-}
-.module .pagination li:first-child a {
-  border-left-width: 0;
-}
-.module .pagination li:last-child a {
-  border-right-width: 0;
-}
-.module .pagination li.active a {
-  border-left-width: 1px;
-  border-right-width: 1px;
 }
 .module-content-shallow {
   padding: 0;
@@ -8398,8 +8380,14 @@ h4 small {
   padding: 0 10px;
   line-height: 31px;
 }
-.account-masthead .account ul li a span.username {
+.account-masthead .account ul li a span.username,
+.account-masthead .account ul li a span.text {
   margin: 0 2px 0 4px;
+}
+.account-masthead .account ul li a span.text {
+  position: absolute;
+  top: -9999px;
+  left: -9999px;
 }
 .account-masthead .account ul li a:hover {
   color: #d9e7eb;
@@ -8413,7 +8401,7 @@ h4 small {
   vertical-align: 1px;
   margin-left: 3px;
 }
-.account-masthead .account .notifications a span {
+.account-masthead .account .notifications a span.badge {
   font-size: 12px;
   margin-left: 3px;
   padding: 1px 6px;
@@ -8421,12 +8409,14 @@ h4 small {
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
   border-radius: 4px;
+  text-shadow: none;
+  color: #bfd7de;
 }
 .account-masthead .account .notifications a:hover span {
   color: #ffffff;
   background-color: #000f14;
 }
-.account-masthead .account .notifications.notifications-important a span {
+.account-masthead .account .notifications.notifications-important a span.badge {
   color: #ffffff;
   background-color: #c9403a;
 }

--- a/ckan/public/base/less/module.less
+++ b/ckan/public/base/less/module.less
@@ -57,12 +57,6 @@
   color: @layoutBoldColor;
 }
 
-.module .pagination {
-  height: 34px;
-  margin-bottom: 0;
-  border-top: 1px solid @moduleHeadingBorderColor;
-}
-
 .module-content .pagination {
   margin-left: -25px;
   margin-right: -25px;
@@ -76,8 +70,8 @@
 }
 
 .module .pagination li a {
-  border-top: none;
-  border-bottom: none;
+  border-top: 1px solid @moduleHeadingBorderColor;;
+  border-bottom: 1px solid @moduleHeadingBorderColor;;
   padding-top: 7px;
   padding-bottom: 7px;
 }
@@ -85,19 +79,6 @@
 .module .pagination li:first-child a,
 .module .pagination li:last-child a {
   .border-radius(0);
-}
-
-.module .pagination li:first-child a {
-  border-left-width: 0;
-}
-
-.module .pagination li:last-child a {
-  border-right-width: 0;
-}
-
-.module .pagination li.active a {
-  border-left-width: 1px;
-  border-right-width: 1px;
 }
 
 .module-content-shallow {


### PR DESCRIPTION
Fixes #2399

### Proposed fixes:
In issue #2399 it is shown that the pagination laps out of the main div. Removing the `.module .pagination` style fixed that (specifically the `height`).
I also noticed that the pagination is pretty broken overall. Take a look at the screenshots from the primer below:

#### Pagination before (from primer)
<img width="719" alt="screen shot 2016-05-27 at 16 20 22" src="https://cloud.githubusercontent.com/assets/1096357/15610903/0180caac-2428-11e6-821c-fb377f9041a9.png">

#### Pagination after (from primer)
<img width="713" alt="screen shot 2016-05-27 at 16 22 32" src="https://cloud.githubusercontent.com/assets/1096357/15610914/16d42a5c-2428-11e6-8e01-cdbe9461caf7.png">

#### Tags page after 
<img width="876" alt="screen shot 2016-05-27 at 16 22 58" src="https://cloud.githubusercontent.com/assets/1096357/15610920/21635b64-2428-11e6-94f8-3e6859e7182f.png">

Most of this was achieved by deleting css rules that to be honest did not really make sense to me.

Do you think there might be other places where this was a wanted behavior of the pagination? 

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
