### PR TITLE
Add and test PEP 263 source file encoding specifications.

### DIFF
--- a/ckan/__init__.py
+++ b/ckan/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 __version__ = '2.6.0a'
 
 __description__ = 'CKAN Software'

--- a/ckan/authz.py
+++ b/ckan/authz.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import sys
 import re
 from logging import getLogger

--- a/ckan/ckan_nose_plugin.py
+++ b/ckan/ckan_nose_plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.plugins import Plugin
 from inspect import isclass
 import hashlib

--- a/ckan/common.py
+++ b/ckan/common.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # This file contains commonly used parts of external libraries. The idea is
 # to help in removing helpers from being used as a dependency by many files
 # but at the same time making it easy to change for example the json lib

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+# encoding: utf-8
+
 """Pylons environment configuration"""
 import os
 import logging

--- a/ckan/config/install.py
+++ b/ckan/config/install.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import re
 
 from pylons.util import PylonsInstaller

--- a/ckan/config/middleware.py
+++ b/ckan/config/middleware.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """Pylons middleware initialization"""
 import urllib
 import urllib2

--- a/ckan/config/routing.py
+++ b/ckan/config/routing.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """Routes configuration
 
 The more specific and detailed routes should be defined first so they

--- a/ckan/controllers/admin.py
+++ b/ckan/controllers/admin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from pylons import config
 
 import ckan.lib.base as base

--- a/ckan/controllers/api.py
+++ b/ckan/controllers/api.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import os.path
 import logging
 import cgi

--- a/ckan/controllers/error.py
+++ b/ckan/controllers/error.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import cgi
 
 from paste.urlparser import PkgResourcesParser

--- a/ckan/controllers/feed.py
+++ b/ckan/controllers/feed.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """
 The feed controller produces Atom feeds of datasets.
 

--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import logging
 import datetime
 from urllib import urlencode

--- a/ckan/controllers/home.py
+++ b/ckan/controllers/home.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from pylons import config, cache
 import sqlalchemy.exc
 

--- a/ckan/controllers/organization.py
+++ b/ckan/controllers/organization.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import re
 
 import ckan.controllers.group as group

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import logging
 from urllib import urlencode
 import datetime

--- a/ckan/controllers/partyline.py
+++ b/ckan/controllers/partyline.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from pylons.controllers import WSGIController
 from pylons import config
 

--- a/ckan/controllers/revision.py
+++ b/ckan/controllers/revision.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from datetime import datetime, timedelta
 
 from pylons.i18n import get_lang

--- a/ckan/controllers/storage.py
+++ b/ckan/controllers/storage.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''
 
 Note: This is the old file store controller for CKAN < 2.2.

--- a/ckan/controllers/template.py
+++ b/ckan/controllers/template.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.lib.base as base
 import ckan.lib.render
 

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import logging
 from urllib import quote
 

--- a/ckan/controllers/util.py
+++ b/ckan/controllers/util.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import re
 
 import ckan.lib.base as base

--- a/ckan/exceptions.py
+++ b/ckan/exceptions.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+# encoding: utf-8
+
+
 class CkanException(Exception):
     pass
 

--- a/ckan/i18n/__init__.py
+++ b/ckan/i18n/__init__.py
@@ -1,1 +1,3 @@
+# encoding: utf-8
+
 # Need some content here to avoid the packaging stripping it out

--- a/ckan/i18n/check_po_files.py
+++ b/ckan/i18n/check_po_files.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# encoding: utf-8
+
 '''Script for checking for common translation mistakes in po files, see:
 
     paster check-po-files --help

--- a/ckan/lib/activity_streams.py
+++ b/ckan/lib/activity_streams.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import re
 
 from webhelpers.html import literal

--- a/ckan/lib/activity_streams_session_extension.py
+++ b/ckan/lib/activity_streams_session_extension.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from pylons import config
 from sqlalchemy.orm.session import SessionExtension
 from paste.deploy.converters import asbool

--- a/ckan/lib/alphabet_paginate.py
+++ b/ckan/lib/alphabet_paginate.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''
 Based on webhelpers.paginator, but:
  * each page is for items beginning with a particular letter

--- a/ckan/lib/app_globals.py
+++ b/ckan/lib/app_globals.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 ''' The application's Globals object '''
 
 import logging

--- a/ckan/lib/auth_tkt.py
+++ b/ckan/lib/auth_tkt.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import math
 import os
 

--- a/ckan/lib/authenticator.py
+++ b/ckan/lib/authenticator.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import logging
 
 from zope.interface import implements

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """The base Controller API
 
 Provides the BaseController class for subclassing.

--- a/ckan/lib/captcha.py
+++ b/ckan/lib/captcha.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from pylons import config
 
 import urllib

--- a/ckan/lib/celery_app.py
+++ b/ckan/lib/celery_app.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ConfigParser
 import os
 import logging

--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import collections
 import csv
 import multiprocessing as mp

--- a/ckan/lib/config_tool.py
+++ b/ckan/lib/config_tool.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import re
 
 INSERT_NEW_SECTIONS_BEFORE_SECTION = 'app:main'

--- a/ckan/lib/create_test_data.py
+++ b/ckan/lib/create_test_data.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import logging
 from collections import defaultdict
 import datetime

--- a/ckan/lib/datapreview.py
+++ b/ckan/lib/datapreview.py
@@ -1,4 +1,4 @@
-# coding=UTF-8
+# encoding: utf-8
 
 """Data previewer functions
 

--- a/ckan/lib/dictization/__init__.py
+++ b/ckan/lib/dictization/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 from sqlalchemy.orm import class_mapper
 import sqlalchemy

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''
 These dictize functions generally take a domain object (such as Package) and
 convert it to a dictionary, including related objects (e.g. for Package it

--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 import uuid
 import logging

--- a/ckan/lib/email_notifications.py
+++ b/ckan/lib/email_notifications.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''
 Code for generating email notifications for users (e.g. email notifications for
 new activities in your dashboard activity stream) and emailing them to the

--- a/ckan/lib/extract.py
+++ b/ckan/lib/extract.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import re
 from jinja2.ext import babel_extract as extract_jinja2
 import lib.jinja_extensions

--- a/ckan/lib/fanstatic_extensions.py
+++ b/ckan/lib/fanstatic_extensions.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import fanstatic.core as core
 
 

--- a/ckan/lib/fanstatic_resources.py
+++ b/ckan/lib/fanstatic_resources.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import os.path
 import sys
 import logging

--- a/ckan/lib/formatters.py
+++ b/ckan/lib/formatters.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 import pytz
 from babel import numbers

--- a/ckan/lib/hash.py
+++ b/ckan/lib/hash.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import hmac
 import hashlib
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1,4 +1,4 @@
-# coding=UTF-8
+# encoding: utf-8
 
 '''Helper functions
 

--- a/ckan/lib/i18n.py
+++ b/ckan/lib/i18n.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import os
 
 from babel import Locale, localedata

--- a/ckan/lib/jinja_extensions.py
+++ b/ckan/lib/jinja_extensions.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import re
 from os import path
 import logging

--- a/ckan/lib/jsonp.py
+++ b/ckan/lib/jsonp.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import decorator
 
 from ckan.common import json, request, response

--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import smtplib
 import logging
 import uuid

--- a/ckan/lib/maintain.py
+++ b/ckan/lib/maintain.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 ''' This module contains code that helps in maintaining the Ckan codebase. '''
 
 import inspect

--- a/ckan/lib/munge.py
+++ b/ckan/lib/munge.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Note these functions are similar to, but separate from name/title mungers
 # found in the ckanext importer. That one needs to be stable to prevent
 # packages changing name on reimport, but these ones can be changed and

--- a/ckan/lib/navl/__init__.py
+++ b/ckan/lib/navl/__init__.py
@@ -1,1 +1,3 @@
+# encoding: utf-8
+
 __license__ = 'MIT'

--- a/ckan/lib/navl/dictization_functions.py
+++ b/ckan/lib/navl/dictization_functions.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import copy
 import formencode as fe
 import inspect

--- a/ckan/lib/navl/validators.py
+++ b/ckan/lib/navl/validators.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.lib.navl.dictization_functions as df
 
 from ckan.common import _

--- a/ckan/lib/plugins.py
+++ b/ckan/lib/plugins.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import logging
 import os
 import sys

--- a/ckan/lib/render.py
+++ b/ckan/lib/render.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import os
 import re
 import logging

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import logging
 import sys
 import cgitb

--- a/ckan/lib/search/common.py
+++ b/ckan/lib/search/common.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 import logging
 import re

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import socket
 import string
 import logging

--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import re
 import logging
 

--- a/ckan/lib/search/sql.py
+++ b/ckan/lib/search/sql.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import or_
 from ckan.lib.search.query import SearchQuery
 import ckan.model as model

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import os
 import cgi
 import pylons

--- a/ckan/lib/util.py
+++ b/ckan/lib/util.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''Shared utility functions for any Python code to use.
 
 Unlike :py:mod:`ckan.lib.helpers`, the functions in this module are not

--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import functools
 import logging
 import re

--- a/ckan/logic/action/__init__.py
+++ b/ckan/logic/action/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from copy import deepcopy
 import re
 

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''API functions for adding data to CKAN.'''
 
 import logging

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''API functions for deleting data from CKAN.'''
 
 import sqlalchemy as sqla

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''API functions for searching for and getting data from CKAN.'''
 
 import uuid

--- a/ckan/logic/action/patch.py
+++ b/ckan/logic/action/patch.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''API functions for partial updates of existing data in CKAN'''
 
 import ckan.logic.action.update as _update

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''API functions for updating existing data in CKAN.'''
 
 import logging

--- a/ckan/logic/auth/__init__.py
+++ b/ckan/logic/auth/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''
 Helper functions to be used in the auth check functions
 '''

--- a/ckan/logic/auth/create.py
+++ b/ckan/logic/auth/create.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.logic as logic
 import ckan.authz as authz
 import ckan.logic.auth as logic_auth

--- a/ckan/logic/auth/delete.py
+++ b/ckan/logic/auth/delete.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.logic as logic
 import ckan.authz as authz
 from ckan.logic.auth import get_group_object

--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.logic as logic
 import ckan.authz as authz
 from ckan.lib.base import _

--- a/ckan/logic/auth/patch.py
+++ b/ckan/logic/auth/patch.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from ckan import logic
 import ckan.logic.auth.update as _update
 

--- a/ckan/logic/auth/update.py
+++ b/ckan/logic/auth/update.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.logic as logic
 import ckan.authz as authz
 import ckan.logic.auth as logic_auth

--- a/ckan/logic/converters.py
+++ b/ckan/logic/converters.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import json
 
 import ckan.model as model

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from formencode.validators import OneOf
 
 import ckan.model

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import collections
 import datetime
 from itertools import count

--- a/ckan/migration/manage.py
+++ b/ckan/migration/manage.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# encoding: utf-8
+
 from migrate.versioning.shell import main
 
 main(repository='ckan/migration')

--- a/ckan/migration/versions/001_add_existing_tables.py
+++ b/ckan/migration/versions/001_add_existing_tables.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 

--- a/ckan/migration/versions/002_add_author_and_maintainer.py
+++ b/ckan/migration/versions/002_add_author_and_maintainer.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import migrate.changeset

--- a/ckan/migration/versions/003_add_user_object.py
+++ b/ckan/migration/versions/003_add_user_object.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import uuid

--- a/ckan/migration/versions/004_add_group_object.py
+++ b/ckan/migration/versions/004_add_group_object.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import uuid

--- a/ckan/migration/versions/005_add_authorization_tables.py
+++ b/ckan/migration/versions/005_add_authorization_tables.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import uuid

--- a/ckan/migration/versions/006_add_ratings.py
+++ b/ckan/migration/versions/006_add_ratings.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import uuid

--- a/ckan/migration/versions/007_add_system_roles.py
+++ b/ckan/migration/versions/007_add_system_roles.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import uuid

--- a/ckan/migration/versions/008_update_vdm_ids.py
+++ b/ckan/migration/versions/008_update_vdm_ids.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 import sqlalchemy.schema
 import uuid

--- a/ckan/migration/versions/009_add_creation_timestamps.py
+++ b/ckan/migration/versions/009_add_creation_timestamps.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from datetime import datetime
 
 from sqlalchemy import *

--- a/ckan/migration/versions/010_add_user_about.py
+++ b/ckan/migration/versions/010_add_user_about.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import migrate.changeset

--- a/ckan/migration/versions/011_add_package_search_vector.py
+++ b/ckan/migration/versions/011_add_package_search_vector.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import migrate.changeset

--- a/ckan/migration/versions/012_add_resources.py
+++ b/ckan/migration/versions/012_add_resources.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import migrate.changeset

--- a/ckan/migration/versions/013_add_hash.py
+++ b/ckan/migration/versions/013_add_hash.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import migrate.changeset

--- a/ckan/migration/versions/014_hash_2.py
+++ b/ckan/migration/versions/014_hash_2.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import migrate.changeset

--- a/ckan/migration/versions/015_remove_state_object.py
+++ b/ckan/migration/versions/015_remove_state_object.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 import sqlalchemy.sql as sql
 

--- a/ckan/migration/versions/016_uuids_everywhere.py
+++ b/ckan/migration/versions/016_uuids_everywhere.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 import sqlalchemy.schema
 import uuid

--- a/ckan/migration/versions/017_add_pkg_relationships.py
+++ b/ckan/migration/versions/017_add_pkg_relationships.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import uuid

--- a/ckan/migration/versions/018_adjust_licenses.py
+++ b/ckan/migration/versions/018_adjust_licenses.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import uuid

--- a/ckan/migration/versions/019_pkg_relationships_state.py
+++ b/ckan/migration/versions/019_pkg_relationships_state.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import migrate.changeset

--- a/ckan/migration/versions/020_add_changeset.py
+++ b/ckan/migration/versions/020_add_changeset.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import datetime

--- a/ckan/migration/versions/022_add_group_extras.py
+++ b/ckan/migration/versions/022_add_group_extras.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import migrate.changeset

--- a/ckan/migration/versions/023_add_harvesting.py
+++ b/ckan/migration/versions/023_add_harvesting.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import datetime

--- a/ckan/migration/versions/024_add_harvested_document.py
+++ b/ckan/migration/versions/024_add_harvested_document.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import datetime

--- a/ckan/migration/versions/025_add_authorization_groups.py
+++ b/ckan/migration/versions/025_add_authorization_groups.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 from datetime import datetime

--- a/ckan/migration/versions/026_authorization_group_user_pk.py
+++ b/ckan/migration/versions/026_authorization_group_user_pk.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 from datetime import datetime

--- a/ckan/migration/versions/027_adjust_harvester.py
+++ b/ckan/migration/versions/027_adjust_harvester.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import warnings
 
 from sqlalchemy import exc as sa_exc

--- a/ckan/migration/versions/028_drop_harvest_source_status.py
+++ b/ckan/migration/versions/028_drop_harvest_source_status.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import migrate.changeset

--- a/ckan/migration/versions/029_version_groups.py
+++ b/ckan/migration/versions/029_version_groups.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import uuid
 
 from sqlalchemy import *

--- a/ckan/migration/versions/030_additional_user_attributes.py
+++ b/ckan/migration/versions/030_additional_user_attributes.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from sqlalchemy import types
 from migrate import *

--- a/ckan/migration/versions/031_move_openid_to_new_field.py
+++ b/ckan/migration/versions/031_move_openid_to_new_field.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from sqlalchemy import types
 from migrate import *

--- a/ckan/migration/versions/032_add_extra_info_field_to_resources.py
+++ b/ckan/migration/versions/032_add_extra_info_field_to_resources.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from sqlalchemy import types
 from migrate import *

--- a/ckan/migration/versions/033_auth_group_user_id_add_conditional.py
+++ b/ckan/migration/versions/033_auth_group_user_id_add_conditional.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import datetime

--- a/ckan/migration/versions/034_resource_group_table.py
+++ b/ckan/migration/versions/034_resource_group_table.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import datetime

--- a/ckan/migration/versions/035_harvesting_doc_versioning.py
+++ b/ckan/migration/versions/035_harvesting_doc_versioning.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import datetime

--- a/ckan/migration/versions/036_lockdown_roles.py
+++ b/ckan/migration/versions/036_lockdown_roles.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import datetime

--- a/ckan/migration/versions/037_role_anon_editor.py
+++ b/ckan/migration/versions/037_role_anon_editor.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from sqlalchemy.sql import select, and_
 from migrate import *

--- a/ckan/migration/versions/038_delete_migration_tables.py
+++ b/ckan/migration/versions/038_delete_migration_tables.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from migrate import *
 
 def upgrade(migrate_engine):

--- a/ckan/migration/versions/039_add_expired_id_and_dates.py
+++ b/ckan/migration/versions/039_add_expired_id_and_dates.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from migrate import *
 import uuid
 import datetime

--- a/ckan/migration/versions/040_reset_key_on_user.py
+++ b/ckan/migration/versions/040_reset_key_on_user.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 

--- a/ckan/migration/versions/041_resource_new_fields.py
+++ b/ckan/migration/versions/041_resource_new_fields.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from migrate import *
 
 def upgrade(migrate_engine):

--- a/ckan/migration/versions/042_user_revision_indexes.py
+++ b/ckan/migration/versions/042_user_revision_indexes.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from migrate import *
 
 def upgrade(migrate_engine):

--- a/ckan/migration/versions/043_drop_postgres_search.py
+++ b/ckan/migration/versions/043_drop_postgres_search.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import migrate.changeset

--- a/ckan/migration/versions/044_add_task_status.py
+++ b/ckan/migration/versions/044_add_task_status.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 

--- a/ckan/migration/versions/045_user_name_unique.py
+++ b/ckan/migration/versions/045_user_name_unique.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import warnings
 
 from sqlalchemy import exc as sa_exc

--- a/ckan/migration/versions/046_drop_changesets.py
+++ b/ckan/migration/versions/046_drop_changesets.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 import migrate.changeset

--- a/ckan/migration/versions/047_rename_package_group_member.py
+++ b/ckan/migration/versions/047_rename_package_group_member.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from migrate import *
 
 def upgrade(migrate_engine):

--- a/ckan/migration/versions/048_add_activity_streams_tables.py
+++ b/ckan/migration/versions/048_add_activity_streams_tables.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 

--- a/ckan/migration/versions/049_add_group_approval_status.py
+++ b/ckan/migration/versions/049_add_group_approval_status.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from migrate import *
 
 def upgrade(migrate_engine):

--- a/ckan/migration/versions/050_term_translation_table.py
+++ b/ckan/migration/versions/050_term_translation_table.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 

--- a/ckan/migration/versions/051_add_tag_vocabulary.py
+++ b/ckan/migration/versions/051_add_tag_vocabulary.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 

--- a/ckan/migration/versions/052_update_member_capacities.py
+++ b/ckan/migration/versions/052_update_member_capacities.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from migrate import *
 
 def upgrade(migrate_engine):

--- a/ckan/migration/versions/053_add_group_logo.py
+++ b/ckan/migration/versions/053_add_group_logo.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 

--- a/ckan/migration/versions/054_add_resource_created_date.py
+++ b/ckan/migration/versions/054_add_resource_created_date.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 def upgrade(migrate_engine):
     migrate_engine.execute('''
         ALTER TABLE resource

--- a/ckan/migration/versions/055_update_user_and_activity_detail.py
+++ b/ckan/migration/versions/055_update_user_and_activity_detail.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 def upgrade(migrate_engine):
     migrate_engine.execute('''
         ALTER TABLE activity_detail

--- a/ckan/migration/versions/056_add_related_table.py
+++ b/ckan/migration/versions/056_add_related_table.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 

--- a/ckan/migration/versions/057_tracking.py
+++ b/ckan/migration/versions/057_tracking.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 

--- a/ckan/migration/versions/058_add_follower_tables.py
+++ b/ckan/migration/versions/058_add_follower_tables.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 

--- a/ckan/migration/versions/059_add_related_count_and_flag.py
+++ b/ckan/migration/versions/059_add_related_count_and_flag.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 

--- a/ckan/migration/versions/060_add_system_info_table.py
+++ b/ckan/migration/versions/060_add_system_info_table.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 

--- a/ckan/migration/versions/061_add_follower__group_table.py
+++ b/ckan/migration/versions/061_add_follower__group_table.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 

--- a/ckan/migration/versions/062_add_dashboard_table.py
+++ b/ckan/migration/versions/062_add_dashboard_table.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 

--- a/ckan/migration/versions/063_org_changes.py
+++ b/ckan/migration/versions/063_org_changes.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from migrate import *
 
 def upgrade(migrate_engine):

--- a/ckan/migration/versions/064_add_email_last_sent_column.py
+++ b/ckan/migration/versions/064_add_email_last_sent_column.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 

--- a/ckan/migration/versions/065_add_email_notifications_preference.py
+++ b/ckan/migration/versions/065_add_email_notifications_preference.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import *
 from migrate import *
 

--- a/ckan/migration/versions/066_default_package_type.py
+++ b/ckan/migration/versions/066_default_package_type.py
@@ -1,3 +1,6 @@
+# encoding: utf-8
+
+
 def upgrade(migrate_engine):
 
     update_statement = '''

--- a/ckan/migration/versions/067_turn_extras_to_strings.py
+++ b/ckan/migration/versions/067_turn_extras_to_strings.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import json
 
 def upgrade(migrate_engine):

--- a/ckan/migration/versions/068_add_package_extras_index.py
+++ b/ckan/migration/versions/068_add_package_extras_index.py
@@ -1,3 +1,6 @@
+# encoding: utf-8
+
+
 def upgrade(migrate_engine):
     migrate_engine.execute(
         '''

--- a/ckan/migration/versions/069_resource_url_and_metadata_modified.py
+++ b/ckan/migration/versions/069_resource_url_and_metadata_modified.py
@@ -1,3 +1,6 @@
+# encoding: utf-8
+
+
 def upgrade(migrate_engine):
 
     update_schema = '''

--- a/ckan/migration/versions/070_add_activity_and_resource_indexes.py
+++ b/ckan/migration/versions/070_add_activity_and_resource_indexes.py
@@ -1,3 +1,6 @@
+# encoding: utf-8
+
+
 def upgrade(migrate_engine):
     migrate_engine.execute(
         '''

--- a/ckan/migration/versions/071_add_state_column_to_user_table.py
+++ b/ckan/migration/versions/071_add_state_column_to_user_table.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.model
 
 

--- a/ckan/migration/versions/072_add_resource_view.py
+++ b/ckan/migration/versions/072_add_resource_view.py
@@ -1,3 +1,6 @@
+# encoding: utf-8
+
+
 def upgrade(migrate_engine):
     migrate_engine.execute('''
         BEGIN;

--- a/ckan/migration/versions/073_update_resource_view_resource_id_constraint.py
+++ b/ckan/migration/versions/073_update_resource_view_resource_id_constraint.py
@@ -1,3 +1,6 @@
+# encoding: utf-8
+
+
 def upgrade(migrate_engine):
     migrate_engine.execute('''
         BEGIN;

--- a/ckan/migration/versions/074_remove_resource_groups.py
+++ b/ckan/migration/versions/074_remove_resource_groups.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.model
 
 

--- a/ckan/migration/versions/075_rename_view_plugins.py
+++ b/ckan/migration/versions/075_rename_view_plugins.py
@@ -1,3 +1,6 @@
+# encoding: utf-8
+
+
 def upgrade(migrate_engine):
     migrate_engine.execute(
         '''

--- a/ckan/migration/versions/076_rename_view_plugins_2.py
+++ b/ckan/migration/versions/076_rename_view_plugins_2.py
@@ -1,3 +1,6 @@
+# encoding: utf-8
+
+
 def upgrade(migrate_engine):
     migrate_engine.execute(
         '''

--- a/ckan/migration/versions/077_add_revisions_to_system_info.py
+++ b/ckan/migration/versions/077_add_revisions_to_system_info.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import vdm.sqlalchemy
 
 

--- a/ckan/migration/versions/078_remove_old_authz_model.py
+++ b/ckan/migration/versions/078_remove_old_authz_model.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.model
 
 

--- a/ckan/migration/versions/079_resource_revision_index.py
+++ b/ckan/migration/versions/079_resource_revision_index.py
@@ -1,3 +1,6 @@
+# encoding: utf-8
+
+
 def upgrade(migrate_engine):
     migrate_engine.execute(
         '''

--- a/ckan/migration/versions/080_continuity_id_indexes.py
+++ b/ckan/migration/versions/080_continuity_id_indexes.py
@@ -1,3 +1,6 @@
+# encoding: utf-8
+
+
 def upgrade(migrate_engine):
     migrate_engine.execute(
         '''

--- a/ckan/migration/versions/081_set_datastore_active.py
+++ b/ckan/migration/versions/081_set_datastore_active.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import json
 from sqlalchemy import create_engine
 from sqlalchemy.sql import text

--- a/ckan/migration/versions/082_create_index_creator_user_id.py
+++ b/ckan/migration/versions/082_create_index_creator_user_id.py
@@ -1,3 +1,6 @@
+# encoding: utf-8
+
+
 def upgrade(migrate_engine):
     migrate_engine.execute(
         '''

--- a/ckan/migration/versions/083_remove_related_items.py
+++ b/ckan/migration/versions/083_remove_related_items.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 
 WARNING = """
 

--- a/ckan/migration/versions/084_add_metadata_created.py
+++ b/ckan/migration/versions/084_add_metadata_created.py
@@ -1,3 +1,6 @@
+# encoding: utf-8
+
+
 def upgrade(migrate_engine):
     migrate_engine.execute('''
         ALTER TABLE package_revision

--- a/ckan/model/__init__.py
+++ b/ckan/model/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from __future__ import with_statement   # necessary for python 2.5 support
 import warnings
 import logging

--- a/ckan/model/activity.py
+++ b/ckan/model/activity.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 
 from sqlalchemy import (

--- a/ckan/model/core.py
+++ b/ckan/model/core.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 
 from sqlalchemy import Column, DateTime, Text, Boolean

--- a/ckan/model/dashboard.py
+++ b/ckan/model/dashboard.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 import sqlalchemy
 import meta

--- a/ckan/model/domain_object.py
+++ b/ckan/model/domain_object.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 
 import sqlalchemy as sa

--- a/ckan/model/extension.py
+++ b/ckan/model/extension.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """
 Provides bridges between the model and plugin PluginImplementationss
 """

--- a/ckan/model/follower.py
+++ b/ckan/model/follower.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import meta
 import datetime
 import sqlalchemy

--- a/ckan/model/group.py
+++ b/ckan/model/group.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 
 from sqlalchemy import orm, types, Column, Table, ForeignKey, or_, and_

--- a/ckan/model/group_extra.py
+++ b/ckan/model/group_extra.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import vdm.sqlalchemy
 import vdm.sqlalchemy.stateful
 from sqlalchemy import orm, types, Column, Table, ForeignKey

--- a/ckan/model/license.py
+++ b/ckan/model/license.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 import urllib2
 import re

--- a/ckan/model/meta.py
+++ b/ckan/model/meta.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 
 from paste.deploy.converters import asbool

--- a/ckan/model/misc.py
+++ b/ckan/model/misc.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """
 Contains miscelaneous set of DB-related functions
 """

--- a/ckan/model/modification.py
+++ b/ckan/model/modification.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import logging
 
 from ckan.lib.search import SearchIndexError

--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 from calendar import timegm
 import logging

--- a/ckan/model/package_extra.py
+++ b/ckan/model/package_extra.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import vdm.sqlalchemy
 import vdm.sqlalchemy.stateful
 from sqlalchemy import orm, types, Column, Table, ForeignKey

--- a/ckan/model/package_relationship.py
+++ b/ckan/model/package_relationship.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import vdm.sqlalchemy
 from sqlalchemy import orm, types, Column, Table, ForeignKey
 

--- a/ckan/model/rating.py
+++ b/ckan/model/rating.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 
 from sqlalchemy import orm, types, Column, Table, ForeignKey

--- a/ckan/model/resource.py
+++ b/ckan/model/resource.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 
 from sqlalchemy.util import OrderedDict

--- a/ckan/model/resource_view.py
+++ b/ckan/model/resource_view.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import sqlalchemy as sa
 
 import meta

--- a/ckan/model/system_info.py
+++ b/ckan/model/system_info.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''
 The system_info table and SystemInfo mapped class store runtime-editable
 configuration options.

--- a/ckan/model/tag.py
+++ b/ckan/model/tag.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import vdm.sqlalchemy
 from sqlalchemy.orm import relation
 from sqlalchemy import types, Column, Table, ForeignKey, and_, UniqueConstraint

--- a/ckan/model/task_status.py
+++ b/ckan/model/task_status.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from datetime import datetime
 from sqlalchemy import types, Column, Table, UniqueConstraint
 

--- a/ckan/model/term_translation.py
+++ b/ckan/model/term_translation.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import Column, Table
 from sqlalchemy.types import UnicodeText
 import meta

--- a/ckan/model/tracking.py
+++ b/ckan/model/tracking.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import types, Column, Table
 
 import meta

--- a/ckan/model/types.py
+++ b/ckan/model/types.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 ## IMPORTS FIXED
 import datetime
 import copy

--- a/ckan/model/user.py
+++ b/ckan/model/user.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 import re
 import os

--- a/ckan/model/vocabulary.py
+++ b/ckan/model/vocabulary.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import types, Column, Table
 
 import meta

--- a/ckan/pastertemplates/__init__.py
+++ b/ckan/pastertemplates/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """A Paste template for creating new CKAN extensions.
 
 Usage::

--- a/ckan/pastertemplates/template/ckanext/__init__.py
+++ b/ckan/pastertemplates/template/ckanext/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # this is a namespace package
 try:
     import pkg_resources

--- a/ckan/plugins/__init__.py
+++ b/ckan/plugins/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from ckan.plugins.core import *
 from ckan.plugins.interfaces import *
 

--- a/ckan/plugins/core.py
+++ b/ckan/plugins/core.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''
 Provides plugin services to the CKAN
 '''

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''A collection of interfaces that CKAN plugins can implement to customize and
 extend CKAN.
 

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import sys
 
 

--- a/ckan/plugins/toolkit_sphinx_extension.py
+++ b/ckan/plugins/toolkit_sphinx_extension.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''A Sphinx extension to automatically document CKAN's crazy plugins toolkit,
 autodoc-style.
 

--- a/ckan/templates/revision/__init__.py
+++ b/ckan/templates/revision/__init__.py
@@ -1,1 +1,3 @@
+# encoding: utf-8
+
 # empty file needed for pylons to find templates in this directory

--- a/ckan/tests/config/test_environment.py
+++ b/ckan/tests/config/test_environment.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import os
 from nose import tools as nosetools
 

--- a/ckan/tests/config/test_middleware.py
+++ b/ckan/tests/config/test_middleware.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import mock
 import wsgiref
 from nose.tools import assert_equals, assert_not_equals, eq_

--- a/ckan/tests/controllers/__init__.py
+++ b/ckan/tests/controllers/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''
 Controller tests probably shouldn't use mocking.
 

--- a/ckan/tests/controllers/test_admin.py
+++ b/ckan/tests/controllers/test_admin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_true, assert_equal
 
 from bs4 import BeautifulSoup

--- a/ckan/tests/controllers/test_api.py
+++ b/ckan/tests/controllers/test_api.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''
 NB Don't test logic functions here. This is just for the mechanics of the API
 controller itself.

--- a/ckan/tests/controllers/test_feed.py
+++ b/ckan/tests/controllers/test_feed.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from routes import url_for
 
 from ckan import model

--- a/ckan/tests/controllers/test_group.py
+++ b/ckan/tests/controllers/test_group.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from bs4 import BeautifulSoup
 from nose.tools import assert_equal, assert_true
 

--- a/ckan/tests/controllers/test_home.py
+++ b/ckan/tests/controllers/test_home.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+# encoding: utf-8
+
 from nose.tools import eq_
 from ckan.lib.helpers import url_for
 from bs4 import BeautifulSoup

--- a/ckan/tests/controllers/test_organization.py
+++ b/ckan/tests/controllers/test_organization.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from bs4 import BeautifulSoup
 from nose.tools import assert_equal, assert_true
 from routes import url_for

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from bs4 import BeautifulSoup
 from nose.tools import (
     assert_equal,

--- a/ckan/tests/controllers/test_tags.py
+++ b/ckan/tests/controllers/test_tags.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import math
 import string
 

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from bs4 import BeautifulSoup
 from nose.tools import assert_true, assert_false, assert_equal
 

--- a/ckan/tests/controllers/test_util.py
+++ b/ckan/tests/controllers/test_util.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_equal
 from pylons.test import pylonsapp
 import paste.fixture

--- a/ckan/tests/factories.py
+++ b/ckan/tests/factories.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''This is a collection of factory classes for building CKAN users, datasets,
 etc.
 

--- a/ckan/tests/helpers.py
+++ b/ckan/tests/helpers.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''This is a collection of helper functions for use in tests.
 
 We want to avoid sharing test helper functions between test modules as

--- a/ckan/tests/i18n/test_check_po_files.py
+++ b/ckan/tests/i18n/test_check_po_files.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+# encoding: utf-8
+
 import nose
 
 from ckan.i18n.check_po_files import (check_po_file,

--- a/ckan/tests/legacy/__init__.py
+++ b/ckan/tests/legacy/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """Pylons application test package
 
 When the test runner finds and executes tests within this directory,

--- a/ckan/tests/legacy/ckantestplugins.py
+++ b/ckan/tests/legacy/ckantestplugins.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from collections import defaultdict
 
 import ckan.plugins as p

--- a/ckan/tests/legacy/functional/api/__init__.py
+++ b/ckan/tests/legacy/functional/api/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_equal
 import copy
 

--- a/ckan/tests/legacy/functional/api/base.py
+++ b/ckan/tests/legacy/functional/api/base.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import re
 try:
     from cStringIO import StringIO

--- a/ckan/tests/legacy/functional/api/model/test_group.py
+++ b/ckan/tests/legacy/functional/api/model/test_group.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import copy
 
 from ckan import model

--- a/ckan/tests/legacy/functional/api/model/test_licenses.py
+++ b/ckan/tests/legacy/functional/api/model/test_licenses.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_equal 
 
 from ckan import model

--- a/ckan/tests/legacy/functional/api/model/test_package.py
+++ b/ckan/tests/legacy/functional/api/model/test_package.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import copy
 
 from nose.tools import assert_equal, assert_raises

--- a/ckan/tests/legacy/functional/api/model/test_ratings.py
+++ b/ckan/tests/legacy/functional/api/model/test_ratings.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_equal 
 from nose.plugins.skip import SkipTest
 

--- a/ckan/tests/legacy/functional/api/model/test_relationships.py
+++ b/ckan/tests/legacy/functional/api/model/test_relationships.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_equal 
 from nose.plugins.skip import SkipTest
 

--- a/ckan/tests/legacy/functional/api/model/test_revisions.py
+++ b/ckan/tests/legacy/functional/api/model/test_revisions.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_equal 
 
 from ckan import model

--- a/ckan/tests/legacy/functional/api/model/test_tag.py
+++ b/ckan/tests/legacy/functional/api/model/test_tag.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import copy
 
 from nose.tools import assert_equal

--- a/ckan/tests/legacy/functional/api/model/test_vocabulary.py
+++ b/ckan/tests/legacy/functional/api/model/test_vocabulary.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan
 import pylons.test
 import paste.fixture

--- a/ckan/tests/legacy/functional/api/test_activity.py
+++ b/ckan/tests/legacy/functional/api/test_activity.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''Functional tests for the public activity streams API.
 
 This module tests the contents of the various public activity streams:

--- a/ckan/tests/legacy/functional/api/test_api.py
+++ b/ckan/tests/legacy/functional/api/test_api.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import json
 
 from ckan.tests.legacy.functional.api.base import *

--- a/ckan/tests/legacy/functional/api/test_dashboard.py
+++ b/ckan/tests/legacy/functional/api/test_dashboard.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''Test for the dashboard API.
 
 This module tests the various functions of the user dashboard, such as the

--- a/ckan/tests/legacy/functional/api/test_email_notifications.py
+++ b/ckan/tests/legacy/functional/api/test_email_notifications.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import time
 
 import ckan.model as model

--- a/ckan/tests/legacy/functional/api/test_follow.py
+++ b/ckan/tests/legacy/functional/api/test_follow.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''Test for the follower API.
 
 This module tests following, unfollowing, getting a list of what you're

--- a/ckan/tests/legacy/functional/api/test_misc.py
+++ b/ckan/tests/legacy/functional/api/test_misc.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from paste.deploy.converters import asbool
 from ckan.tests.legacy.functional.api.base import *
 from ckan.lib.create_test_data import CreateTestData

--- a/ckan/tests/legacy/functional/api/test_package_search.py
+++ b/ckan/tests/legacy/functional/api/test_package_search.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_raises
 from nose.plugins.skip import SkipTest
 

--- a/ckan/tests/legacy/functional/api/test_resource.py
+++ b/ckan/tests/legacy/functional/api/test_resource.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from ckan.tests.legacy.functional.api.base import ApiTestCase, CreateTestData
 from ckan.tests.legacy import TestController as ControllerTestCase
 from ckan import model

--- a/ckan/tests/legacy/functional/api/test_resource_search.py
+++ b/ckan/tests/legacy/functional/api/test_resource_search.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from ckan.tests.legacy.functional.api.base import *
 from ckan.tests.legacy import TestController as ControllerTestCase
 

--- a/ckan/tests/legacy/functional/api/test_user.py
+++ b/ckan/tests/legacy/functional/api/test_user.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import paste
 from pylons import config
 from nose.tools import assert_equal

--- a/ckan/tests/legacy/functional/api/test_util.py
+++ b/ckan/tests/legacy/functional/api/test_util.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_equal
 
 from ckan import model, __version__

--- a/ckan/tests/legacy/functional/base.py
+++ b/ckan/tests/legacy/functional/base.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from ckan.tests.legacy.html_check import HtmlCheckMethods
 from ckan.tests.legacy import TestController as ControllerTestCase
 

--- a/ckan/tests/legacy/functional/test_activity.py
+++ b/ckan/tests/legacy/functional/test_activity.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from pylons import config
 from pylons.test import pylonsapp
 from paste.deploy.converters import asbool

--- a/ckan/tests/legacy/functional/test_admin.py
+++ b/ckan/tests/legacy/functional/test_admin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.model as model
 from ckan.tests.legacy import url_for, CreateTestData, WsgiAppCase
 

--- a/ckan/tests/legacy/functional/test_error.py
+++ b/ckan/tests/legacy/functional/test_error.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from base import FunctionalTestCase
 
 class TestError(FunctionalTestCase):

--- a/ckan/tests/legacy/functional/test_group.py
+++ b/ckan/tests/legacy/functional/test_group.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import mock
 
 import ckan.model as model

--- a/ckan/tests/legacy/functional/test_package.py
+++ b/ckan/tests/legacy/functional/test_package.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 
 from pylons import config, c

--- a/ckan/tests/legacy/functional/test_pagination.py
+++ b/ckan/tests/legacy/functional/test_pagination.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import re
 
 from nose.tools import assert_equal

--- a/ckan/tests/legacy/functional/test_preview_interface.py
+++ b/ckan/tests/legacy/functional/test_preview_interface.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# encoding: utf-8
 
 import ckan.lib.helpers as h
 import ckan.logic as l

--- a/ckan/tests/legacy/functional/test_revision.py
+++ b/ckan/tests/legacy/functional/test_revision.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from ckan.tests.legacy import TestController, CreateTestData, url_for
 import ckan.model as model
 

--- a/ckan/tests/legacy/functional/test_tag.py
+++ b/ckan/tests/legacy/functional/test_tag.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import json
 
 from ckan.tests.legacy import *

--- a/ckan/tests/legacy/functional/test_tracking.py
+++ b/ckan/tests/legacy/functional/test_tracking.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''Functional tests for CKAN's builtin page view tracking feature.'''
 
 import tempfile

--- a/ckan/tests/legacy/functional/test_user.py
+++ b/ckan/tests/legacy/functional/test_user.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from routes import url_for
 from nose.tools import assert_equal
 from pylons import config

--- a/ckan/tests/legacy/html_check.py
+++ b/ckan/tests/legacy/html_check.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import re
 import sgmllib
 

--- a/ckan/tests/legacy/lib/__init__.py
+++ b/ckan/tests/legacy/lib/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_equal
 
 from ckan import model

--- a/ckan/tests/legacy/lib/test_alphabet_pagination.py
+++ b/ckan/tests/legacy/lib/test_alphabet_pagination.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import re
 
 from nose.tools import assert_equal, assert_true, assert_in

--- a/ckan/tests/legacy/lib/test_authenticator.py
+++ b/ckan/tests/legacy/lib/test_authenticator.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan
 
 import ckan.lib.create_test_data as ctd

--- a/ckan/tests/legacy/lib/test_cli.py
+++ b/ckan/tests/legacy/lib/test_cli.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import os
 import csv
 

--- a/ckan/tests/legacy/lib/test_dictization.py
+++ b/ckan/tests/legacy/lib/test_dictization.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from ckan.tests.legacy import assert_equal, assert_not_in, assert_in
 from pprint import pprint, pformat
 from difflib import unified_diff

--- a/ckan/tests/legacy/lib/test_dictization_schema.py
+++ b/ckan/tests/legacy/lib/test_dictization_schema.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from pprint import pprint, pformat
 
 from ckan.lib.create_test_data import CreateTestData

--- a/ckan/tests/legacy/lib/test_email_notifications.py
+++ b/ckan/tests/legacy/lib/test_email_notifications.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''Tests for the ckan.lib.email_notifications module.
 
 Note that email_notifications is used by an action function, so most of the

--- a/ckan/tests/legacy/lib/test_hash.py
+++ b/ckan/tests/legacy/lib/test_hash.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_equals
 
 from ckan.lib.hash import get_message_hash, get_redirect

--- a/ckan/tests/legacy/lib/test_helpers.py
+++ b/ckan/tests/legacy/lib/test_helpers.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+# encoding: utf-8
+
 import datetime
 from nose.tools import assert_equal, assert_raises
 

--- a/ckan/tests/legacy/lib/test_i18n.py
+++ b/ckan/tests/legacy/lib/test_i18n.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_equal, assert_raises
 from pylons import config, session
 import pylons

--- a/ckan/tests/legacy/lib/test_navl.py
+++ b/ckan/tests/legacy/lib/test_navl.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from ckan.lib.navl.dictization_functions import (flatten_schema,
                                    get_all_key_combinations,
                                    make_full_schema,

--- a/ckan/tests/legacy/lib/test_resource_search.py
+++ b/ckan/tests/legacy/lib/test_resource_search.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from webob.multidict import UnicodeMultiDict, MultiDict
 from nose.tools import assert_raises, assert_equal
 

--- a/ckan/tests/legacy/lib/test_simple_search.py
+++ b/ckan/tests/legacy/lib/test_simple_search.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_equal
 
 from ckan import model

--- a/ckan/tests/legacy/lib/test_solr_package_search.py
+++ b/ckan/tests/legacy/lib/test_solr_package_search.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_equal, assert_raises
 
 from ckan import model

--- a/ckan/tests/legacy/lib/test_solr_package_search_synchronous_update.py
+++ b/ckan/tests/legacy/lib/test_solr_package_search_synchronous_update.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from ckan import model
 import ckan.lib.search as search
 

--- a/ckan/tests/legacy/lib/test_solr_schema_version.py
+++ b/ckan/tests/legacy/lib/test_solr_schema_version.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import os
 from ckan.tests.legacy import TestController
 

--- a/ckan/tests/legacy/lib/test_solr_search_index.py
+++ b/ckan/tests/legacy/lib/test_solr_search_index.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import pysolr
 from pylons import config
 from ckan import model

--- a/ckan/tests/legacy/lib/test_tag_search.py
+++ b/ckan/tests/legacy/lib/test_tag_search.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_raises
 from ckan.tests.legacy import *
 from ckan.tests.legacy import is_search_supported

--- a/ckan/tests/legacy/logic/test_action.py
+++ b/ckan/tests/legacy/logic/test_action.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import re
 import json
 import urllib

--- a/ckan/tests/legacy/logic/test_auth.py
+++ b/ckan/tests/legacy/logic/test_auth.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import paste
 from pylons import config
 import ckan.config.middleware

--- a/ckan/tests/legacy/logic/test_init.py
+++ b/ckan/tests/legacy/logic/test_init.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import nose.tools as tools
 
 import ckan.model as model

--- a/ckan/tests/legacy/logic/test_member.py
+++ b/ckan/tests/legacy/logic/test_member.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_raises
 import ckan.model as model
 import ckan.logic as logic

--- a/ckan/tests/legacy/logic/test_tag.py
+++ b/ckan/tests/legacy/logic/test_tag.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import json
 from nose.tools import assert_equal
 import ckan.lib.search as search

--- a/ckan/tests/legacy/logic/test_tag_vocab.py
+++ b/ckan/tests/legacy/logic/test_tag_vocab.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.model as model
 import ckan.logic as logic
 import ckan.logic.converters as converters

--- a/ckan/tests/legacy/logic/test_validators.py
+++ b/ckan/tests/legacy/logic/test_validators.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_equal
 
 from ckan import model

--- a/ckan/tests/legacy/misc/test_format_text.py
+++ b/ckan/tests/legacy/misc/test_format_text.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.lib.helpers as h
 
 class TestFormatText:

--- a/ckan/tests/legacy/misc/test_mock_mail_server.py
+++ b/ckan/tests/legacy/misc/test_mock_mail_server.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import time
 from nose.tools import assert_equal
 from pylons import config

--- a/ckan/tests/legacy/misc/test_sync.py
+++ b/ckan/tests/legacy/misc/test_sync.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import os
 import subprocess
 import urllib2

--- a/ckan/tests/legacy/mock_mail_server.py
+++ b/ckan/tests/legacy/mock_mail_server.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import threading
 import asyncore
 import socket

--- a/ckan/tests/legacy/mock_plugin.py
+++ b/ckan/tests/legacy/mock_plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from ckan.plugins import Plugin, SingletonPlugin
 
 class _MockPlugin(object):

--- a/ckan/tests/legacy/models/test_activity.py
+++ b/ckan/tests/legacy/models/test_activity.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.model as model
 
 Activity = model.Activity

--- a/ckan/tests/legacy/models/test_extras.py
+++ b/ckan/tests/legacy/models/test_extras.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from ckan.tests.legacy import *
 
 import ckan.model as model

--- a/ckan/tests/legacy/models/test_follower.py
+++ b/ckan/tests/legacy/models/test_follower.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.model as model
 import ckan.lib.create_test_data as ctd
 

--- a/ckan/tests/legacy/models/test_group.py
+++ b/ckan/tests/legacy/models/test_group.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from ckan.tests.legacy import assert_equal, assert_in, assert_not_in, CreateTestData
 
 import ckan.model as model

--- a/ckan/tests/legacy/models/test_misc.py
+++ b/ckan/tests/legacy/models/test_misc.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_equal
 
 from ckan.tests.legacy import *

--- a/ckan/tests/legacy/models/test_package.py
+++ b/ckan/tests/legacy/models/test_package.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_equal
 
 from ckan.tests.legacy import *

--- a/ckan/tests/legacy/models/test_package_relationships.py
+++ b/ckan/tests/legacy/models/test_package_relationships.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from ckan.tests.legacy import *
 import ckan.model as model
 from ckan.lib.create_test_data import CreateTestData

--- a/ckan/tests/legacy/models/test_purge_revision.py
+++ b/ckan/tests/legacy/models/test_purge_revision.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from ckan.tests.legacy import *
 
 import ckan.model as model

--- a/ckan/tests/legacy/models/test_resource.py
+++ b/ckan/tests/legacy/models/test_resource.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from sqlalchemy import MetaData, __version__ as sqav
 from nose.tools import assert_equal, raises
 

--- a/ckan/tests/legacy/models/test_revision.py
+++ b/ckan/tests/legacy/models/test_revision.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 
 from nose.tools import assert_equal

--- a/ckan/tests/legacy/models/test_user.py
+++ b/ckan/tests/legacy/models/test_user.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_equal
 
 from ckan.tests.legacy import *

--- a/ckan/tests/legacy/pylons_controller.py
+++ b/ckan/tests/legacy/pylons_controller.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''For unit testing that does not use paste fixture web requests, but needs
 pylons set up for access to c, g or the template engine.
 

--- a/ckan/tests/legacy/schema/test_schema.py
+++ b/ckan/tests/legacy/schema/test_schema.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_equal
 
 import ckan

--- a/ckan/tests/legacy/test_coding_standards.py
+++ b/ckan/tests/legacy/test_coding_standards.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''
 The aim of these tests is to check and improve the coding standards in ckan.
 Common issues are tested for here and tests fail if they are discovered in

--- a/ckan/tests/legacy/test_plugins.py
+++ b/ckan/tests/legacy/test_plugins.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """
 Tests for plugin loading via PCA
 """

--- a/ckan/tests/legacy/test_versions.py
+++ b/ckan/tests/legacy/test_versions.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import subprocess
 
 class TestVersions(object):

--- a/ckan/tests/lib/__init__.py
+++ b/ckan/tests/lib/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''**All lib functions should have tests**.
 
 .. todo::

--- a/ckan/tests/lib/dictization/test_model_dictize.py
+++ b/ckan/tests/lib/dictization/test_model_dictize.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 import copy
 

--- a/ckan/tests/lib/navl/test_dictization_functions.py
+++ b/ckan/tests/lib/navl/test_dictization_functions.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import nose
 from ckan.lib.navl.dictization_functions import validate
 

--- a/ckan/tests/lib/navl/test_validators.py
+++ b/ckan/tests/lib/navl/test_validators.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+# encoding: utf-8
+
 '''Unit tests for ckan/lib/navl/validators.py.
 
 '''

--- a/ckan/tests/lib/search/test_index.py
+++ b/ckan/tests/lib/search/test_index.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 import hashlib
 import json

--- a/ckan/tests/lib/test_app_globals.py
+++ b/ckan/tests/lib/test_app_globals.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from ckan.lib.app_globals import app_globals as g
 
 

--- a/ckan/tests/lib/test_auth_tkt.py
+++ b/ckan/tests/lib/test_auth_tkt.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose import tools as nose_tools
 
 from ckan.tests import helpers

--- a/ckan/tests/lib/test_base.py
+++ b/ckan/tests/lib/test_base.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose import tools as nose_tools
 
 import ckan.tests.helpers as helpers

--- a/ckan/tests/lib/test_cli.py
+++ b/ckan/tests/lib/test_cli.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# encoding: utf-8
 
 import logging
 

--- a/ckan/tests/lib/test_config_tool.py
+++ b/ckan/tests/lib/test_config_tool.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from ckan.lib import config_tool
 
 

--- a/ckan/tests/lib/test_datapreview.py
+++ b/ckan/tests/lib/test_datapreview.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+# encoding: utf-8
+
 import nose
 from pylons import config
 

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import nose
 import pytz
 import tzlocal

--- a/ckan/tests/lib/test_mailer.py
+++ b/ckan/tests/lib/test_mailer.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_equal, assert_raises
 from pylons import config
 from email.mime.text import MIMEText

--- a/ckan/tests/lib/test_munge.py
+++ b/ckan/tests/lib/test_munge.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_equal
 
 from ckan.lib.munge import (munge_filename_legacy, munge_filename, munge_name,

--- a/ckan/tests/logic/action/__init__.py
+++ b/ckan/tests/logic/action/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''**All action functions should have tests.**
 
 Most action function tests will be high-level tests that both test the code in

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''Unit tests for ckan/logic/auth/create.py.
 
 '''

--- a/ckan/tests/logic/action/test_delete.py
+++ b/ckan/tests/logic/action/test_delete.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import nose.tools
 
 import ckan.tests.helpers as helpers

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import nose.tools
 
 import ckan.logic as logic

--- a/ckan/tests/logic/action/test_patch.py
+++ b/ckan/tests/logic/action/test_patch.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''Unit tests for ckan/logic/action/patch.py.'''
 import datetime
 

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''Unit tests for ckan/logic/action/update.py.'''
 import datetime
 

--- a/ckan/tests/logic/auth/__init__.py
+++ b/ckan/tests/logic/auth/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''**All auth functions should have tests.**
 
 Most auth function tests should be unit tests that test the auth function in

--- a/ckan/tests/logic/auth/test_create.py
+++ b/ckan/tests/logic/auth/test_create.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''Unit tests for ckan/logic/auth/create.py.
 
 '''

--- a/ckan/tests/logic/auth/test_delete.py
+++ b/ckan/tests/logic/auth/test_delete.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 
 '''Unit tests for ckan/logic/auth/delete.py.
 

--- a/ckan/tests/logic/auth/test_get.py
+++ b/ckan/tests/logic/auth/test_get.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''Unit tests for ckan/logic/auth/get.py.
 
 '''

--- a/ckan/tests/logic/auth/test_init.py
+++ b/ckan/tests/logic/auth/test_init.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import nose
 
 import ckan.model as core_model

--- a/ckan/tests/logic/auth/test_update.py
+++ b/ckan/tests/logic/auth/test_update.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''Unit tests for ckan/logic/auth/update.py.
 
 '''

--- a/ckan/tests/logic/test_conversion.py
+++ b/ckan/tests/logic/test_conversion.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''Functional tests for converters in ckan/logic/converters.py.
 
 '''

--- a/ckan/tests/logic/test_converters.py
+++ b/ckan/tests/logic/test_converters.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+# encoding: utf-8
+
 '''Unit tests for ckan/logic/converters.py.
 
 '''

--- a/ckan/tests/logic/test_schema.py
+++ b/ckan/tests/logic/test_schema.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''
 
 We *don't* write tests for the schemas defined in :py:mod:`ckan.logic.schema`.

--- a/ckan/tests/logic/test_validators.py
+++ b/ckan/tests/logic/test_validators.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+# encoding: utf-8
+
 '''Unit tests for ckan/logic/validators.py.
 
 '''

--- a/ckan/tests/migration/__init__.py
+++ b/ckan/tests/migration/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''**All migration scripts should have tests.**
 
 .. todo::

--- a/ckan/tests/model/__init__.py
+++ b/ckan/tests/model/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''**All model methods should have tests**.
 
 .. todo::

--- a/ckan/tests/model/test_license.py
+++ b/ckan/tests/model/test_license.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import os
 
 from nose.tools import assert_equal

--- a/ckan/tests/model/test_resource.py
+++ b/ckan/tests/model/test_resource.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import nose.tools
 
 import ckan.model as model

--- a/ckan/tests/model/test_resource_view.py
+++ b/ckan/tests/model/test_resource_view.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import nose.tools
 
 import ckan.model as model

--- a/ckan/tests/model/test_system_info.py
+++ b/ckan/tests/model/test_system_info.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import nose.tools
 
 import ckan.tests.helpers as helpers

--- a/ckan/tests/model/test_user.py
+++ b/ckan/tests/model/test_user.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import os
 import hashlib
 import unittest

--- a/ckan/tests/plugins/__init__.py
+++ b/ckan/tests/plugins/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''The plugin interfaces in :mod:`ckan.plugins.interfaces` are not directly
 testable because they don't contain any code, *but*:
 

--- a/ckan/tests/plugins/test_toolkit.py
+++ b/ckan/tests/plugins/test_toolkit.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_equal, assert_raises, assert_true, raises
 
 from ckan.plugins import toolkit as tk

--- a/ckan/tests/test_authz.py
+++ b/ckan/tests/test_authz.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import nose
 
 from ckan import authz as auth

--- a/ckan/tests/test_factories.py
+++ b/ckan/tests/test_factories.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import nose.tools
 
 import ckan.plugins as p

--- a/ckan/websetup.py
+++ b/ckan/websetup.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """Setup the ckan application"""
 import logging
 

--- a/ckanext/__init__.py
+++ b/ckanext/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # this is a namespace package
 try:
     import pkg_resources

--- a/ckanext/datapusher/cli.py
+++ b/ckanext/datapusher/cli.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import sys
 
 import ckan.lib.cli as cli

--- a/ckanext/datapusher/helpers.py
+++ b/ckanext/datapusher/helpers.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins.toolkit as toolkit
 
 

--- a/ckanext/datapusher/interfaces.py
+++ b/ckanext/datapusher/interfaces.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from ckan.plugins.interfaces import Interface
 
 

--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import logging
 import json
 import urlparse

--- a/ckanext/datapusher/logic/auth.py
+++ b/ckanext/datapusher/logic/auth.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckanext.datastore.logic.auth as auth
 
 

--- a/ckanext/datapusher/logic/schema.py
+++ b/ckanext/datapusher/logic/schema.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins as p
 import ckanext.datastore.logic.schema as dsschema
 

--- a/ckanext/datapusher/plugin.py
+++ b/ckanext/datapusher/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import logging
 
 import ckan.plugins as p

--- a/ckanext/datapusher/tests/test.py
+++ b/ckanext/datapusher/tests/test.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import json
 import httpretty
 import httpretty.core

--- a/ckanext/datapusher/tests/test_action.py
+++ b/ckanext/datapusher/tests/test_action.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 
 from nose.tools import eq_

--- a/ckanext/datapusher/tests/test_default_views.py
+++ b/ckanext/datapusher/tests/test_default_views.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 import nose
 

--- a/ckanext/datapusher/tests/test_interfaces.py
+++ b/ckanext/datapusher/tests/test_interfaces.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import json
 import httpretty
 import nose

--- a/ckanext/datastore/commands.py
+++ b/ckanext/datastore/commands.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from __future__ import print_function
 import argparse
 import os

--- a/ckanext/datastore/controller.py
+++ b/ckanext/datastore/controller.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import StringIO
 import unicodecsv as csv
 

--- a/ckanext/datastore/db.py
+++ b/ckanext/datastore/db.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import json
 import datetime
 import os

--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import logging
 import json
 

--- a/ckanext/datastore/interfaces.py
+++ b/ckanext/datastore/interfaces.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins.interfaces as interfaces
 
 

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import logging
 
 import pylons

--- a/ckanext/datastore/logic/auth.py
+++ b/ckanext/datastore/logic/auth.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins as p
 
 

--- a/ckanext/datastore/logic/schema.py
+++ b/ckanext/datastore/logic/schema.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import json
 
 import ckan.plugins as p

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import sys
 import logging
 import re

--- a/ckanext/datastore/tests/helpers.py
+++ b/ckanext/datastore/tests/helpers.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.model as model
 import ckan.lib.cli as cli
 

--- a/ckanext/datastore/tests/sample_datastore_plugin.py
+++ b/ckanext/datastore/tests/sample_datastore_plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins as p
 
 import ckanext.datastore.interfaces as interfaces

--- a/ckanext/datastore/tests/test_configure.py
+++ b/ckanext/datastore/tests/test_configure.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import unittest
 import nose.tools
 import pyutilib.component.core

--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import json
 import nose
 import sys

--- a/ckanext/datastore/tests/test_db.py
+++ b/ckanext/datastore/tests/test_db.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import mock
 import nose
 

--- a/ckanext/datastore/tests/test_delete.py
+++ b/ckanext/datastore/tests/test_delete.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import json
 import nose
 

--- a/ckanext/datastore/tests/test_disable.py
+++ b/ckanext/datastore/tests/test_disable.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import nose
 
 import pylons.config as config

--- a/ckanext/datastore/tests/test_dump.py
+++ b/ckanext/datastore/tests/test_dump.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import json
 
 import nose

--- a/ckanext/datastore/tests/test_helpers.py
+++ b/ckanext/datastore/tests/test_helpers.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# encoding: utf-8
 
 import pylons
 import sqlalchemy.orm as orm

--- a/ckanext/datastore/tests/test_info.py
+++ b/ckanext/datastore/tests/test_info.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import json
 import nose
 import pprint

--- a/ckanext/datastore/tests/test_interface.py
+++ b/ckanext/datastore/tests/test_interface.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import nose
 
 import ckan.plugins as p

--- a/ckanext/datastore/tests/test_plugin.py
+++ b/ckanext/datastore/tests/test_plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import nose
 import mock
 

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import json
 import nose
 import pprint

--- a/ckanext/datastore/tests/test_unit.py
+++ b/ckanext/datastore/tests/test_unit.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import unittest
 import pylons
 import nose

--- a/ckanext/datastore/tests/test_upsert.py
+++ b/ckanext/datastore/tests/test_upsert.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+# encoding: utf-8
+
 import json
 import nose
 import datetime

--- a/ckanext/example_iauthfunctions/plugin_v1.py
+++ b/ckanext/example_iauthfunctions/plugin_v1.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins as plugins
 
 

--- a/ckanext/example_iauthfunctions/plugin_v2.py
+++ b/ckanext/example_iauthfunctions/plugin_v2.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins as plugins
 
 

--- a/ckanext/example_iauthfunctions/plugin_v3.py
+++ b/ckanext/example_iauthfunctions/plugin_v3.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 

--- a/ckanext/example_iauthfunctions/plugin_v4.py
+++ b/ckanext/example_iauthfunctions/plugin_v4.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 

--- a/ckanext/example_iauthfunctions/plugin_v5_custom_config_setting.py
+++ b/ckanext/example_iauthfunctions/plugin_v5_custom_config_setting.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import pylons.config as config
 
 import ckan.plugins as plugins

--- a/ckanext/example_iauthfunctions/tests/test_example_iauthfunctions.py
+++ b/ckanext/example_iauthfunctions/tests/test_example_iauthfunctions.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''Tests for the ckanext.example_iauthfunctions extension.
 
 '''

--- a/ckanext/example_iconfigurer/controller.py
+++ b/ckanext/example_iconfigurer/controller.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.lib.base as base
 import ckan.lib.helpers as helpers
 

--- a/ckanext/example_iconfigurer/plugin.py
+++ b/ckanext/example_iconfigurer/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from routes.mapper import SubMapper
 
 import ckan.plugins as plugins

--- a/ckanext/example_iconfigurer/plugin_v1.py
+++ b/ckanext/example_iconfigurer/plugin_v1.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 

--- a/ckanext/example_iconfigurer/plugin_v2.py
+++ b/ckanext/example_iconfigurer/plugin_v2.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 

--- a/ckanext/example_iconfigurer/tests/test_example_iconfigurer.py
+++ b/ckanext/example_iconfigurer/tests/test_example_iconfigurer.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose import tools as nosetools
 
 import ckan.tests.helpers as helpers

--- a/ckanext/example_iconfigurer/tests/test_iconfigurer_toolkit.py
+++ b/ckanext/example_iconfigurer/tests/test_iconfigurer_toolkit.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose import tools as nosetools
 
 import ckan.tests.helpers as helpers

--- a/ckanext/example_iconfigurer/tests/test_iconfigurer_update_config.py
+++ b/ckanext/example_iconfigurer/tests/test_iconfigurer_update_config.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import nose.tools
 
 from pylons import config

--- a/ckanext/example_idatasetform/plugin.py
+++ b/ckanext/example_idatasetform/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import logging
 
 import ckan.plugins as plugins

--- a/ckanext/example_idatasetform/plugin_v1.py
+++ b/ckanext/example_idatasetform/plugin_v1.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins as p
 import ckan.plugins.toolkit as tk
 

--- a/ckanext/example_idatasetform/plugin_v2.py
+++ b/ckanext/example_idatasetform/plugin_v2.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins as p
 import ckan.plugins.toolkit as tk
 

--- a/ckanext/example_idatasetform/plugin_v3.py
+++ b/ckanext/example_idatasetform/plugin_v3.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''Example IDatasetFormPlugin'''
 import ckan.plugins as p
 import ckan.plugins.toolkit as tk

--- a/ckanext/example_idatasetform/plugin_v4.py
+++ b/ckanext/example_idatasetform/plugin_v4.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins as p
 import ckan.plugins.toolkit as tk
 

--- a/ckanext/example_idatasetform/tests/test_controllers.py
+++ b/ckanext/example_idatasetform/tests/test_controllers.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_equal
 from routes import url_for
 

--- a/ckanext/example_idatasetform/tests/test_example_idatasetform.py
+++ b/ckanext/example_idatasetform/tests/test_example_idatasetform.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import nose.tools as nt
 
 import pylons.config as config

--- a/ckanext/example_igroupform/plugin.py
+++ b/ckanext/example_igroupform/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as tk
 

--- a/ckanext/example_igroupform/tests/test_controllers.py
+++ b/ckanext/example_igroupform/tests/test_controllers.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_equal
 from routes import url_for
 

--- a/ckanext/example_iresourcecontroller/plugin.py
+++ b/ckanext/example_iresourcecontroller/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from collections import defaultdict
 import ckan.plugins as plugins
 

--- a/ckanext/example_iresourcecontroller/tests/test_example_iresourcecontroller.py
+++ b/ckanext/example_iresourcecontroller/tests/test_example_iresourcecontroller.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''Tests for the ckanext.example_iauthfunctions extension.
 
 '''

--- a/ckanext/example_itemplatehelpers/plugin.py
+++ b/ckanext/example_itemplatehelpers/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins as plugins
 
 # Our custom template helper function.

--- a/ckanext/example_itranslation/plugin.py
+++ b/ckanext/example_itranslation/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from ckan import plugins
 from ckan.plugins import toolkit
 from ckan.lib.plugins import DefaultTranslation

--- a/ckanext/example_itranslation/plugin_v1.py
+++ b/ckanext/example_itranslation/plugin_v1.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from ckan import plugins
 from ckan.plugins import toolkit
 

--- a/ckanext/example_itranslation/tests/test_plugin.py
+++ b/ckanext/example_itranslation/tests/test_plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from ckan import plugins
 from ckan.tests import helpers
 

--- a/ckanext/example_iuploader/plugin.py
+++ b/ckanext/example_iuploader/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import os
 
 from ckan import plugins

--- a/ckanext/example_iuploader/test/test_plugin.py
+++ b/ckanext/example_iuploader/test/test_plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import __builtin__ as builtins
 
 import paste.fileapp

--- a/ckanext/example_ivalidators/plugin.py
+++ b/ckanext/example_ivalidators/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from ckan.plugins.toolkit import Invalid
 from ckan import plugins
 

--- a/ckanext/example_ivalidators/tests/test_ivalidators.py
+++ b/ckanext/example_ivalidators/tests/test_ivalidators.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from nose.tools import assert_equals, assert_raises
 import pylons.config as config
 

--- a/ckanext/example_theme/custom_config_setting/plugin.py
+++ b/ckanext/example_theme/custom_config_setting/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import pylons.config as config
 
 import ckan.plugins as plugins

--- a/ckanext/example_theme/custom_emails/plugin.py
+++ b/ckanext/example_theme/custom_emails/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 

--- a/ckanext/example_theme/custom_emails/tests.py
+++ b/ckanext/example_theme/custom_emails/tests.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import os
 from pylons import config
 from ckan import plugins

--- a/ckanext/example_theme/v01_empty_extension/plugin.py
+++ b/ckanext/example_theme/v01_empty_extension/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins as plugins
 
 

--- a/ckanext/example_theme/v02_empty_template/plugin.py
+++ b/ckanext/example_theme/v02_empty_template/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 '''plugin.py
 
 '''

--- a/ckanext/example_theme/v08_custom_helper_function/plugin.py
+++ b/ckanext/example_theme/v08_custom_helper_function/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 

--- a/ckanext/example_theme/v12_extra_public_dir/plugin.py
+++ b/ckanext/example_theme/v12_extra_public_dir/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 

--- a/ckanext/example_theme/v15_fanstatic/plugin.py
+++ b/ckanext/example_theme/v15_fanstatic/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 

--- a/ckanext/example_theme/v16_initialize_a_javascript_module/plugin.py
+++ b/ckanext/example_theme/v16_initialize_a_javascript_module/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 

--- a/ckanext/imageview/plugin.py
+++ b/ckanext/imageview/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import logging
 import ckan.plugins as p
 

--- a/ckanext/imageview/tests/test_view.py
+++ b/ckanext/imageview/tests/test_view.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from routes import url_for
 
 import ckan.plugins as p

--- a/ckanext/multilingual/plugin.py
+++ b/ckanext/multilingual/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan
 from ckan.plugins import SingletonPlugin, implements, IPackageController
 from ckan.plugins import IGroupController, IOrganizationController, ITagController, IResourceController

--- a/ckanext/multilingual/tests/test_multilingual_plugin.py
+++ b/ckanext/multilingual/tests/test_multilingual_plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins
 import ckanext.multilingual.plugin as mulilingual_plugin
 import ckan.lib.helpers

--- a/ckanext/reclineview/plugin.py
+++ b/ckanext/reclineview/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from logging import getLogger
 
 from ckan.common import json

--- a/ckanext/reclineview/tests/test_view.py
+++ b/ckanext/reclineview/tests/test_view.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import paste.fixture
 import pylons.config as config
 

--- a/ckanext/resourceproxy/controller.py
+++ b/ckanext/resourceproxy/controller.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from logging import getLogger
 import urlparse
 

--- a/ckanext/resourceproxy/plugin.py
+++ b/ckanext/resourceproxy/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from logging import getLogger
 
 import ckan.lib.helpers as h

--- a/ckanext/resourceproxy/tests/test_proxy.py
+++ b/ckanext/resourceproxy/tests/test_proxy.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import sys
 import requests
 import unittest

--- a/ckanext/stats/__init__.py
+++ b/ckanext/stats/__init__.py
@@ -1,1 +1,3 @@
+# encoding: utf-8
+
 __import__('pkg_resources').declare_namespace(__name__)

--- a/ckanext/stats/controller.py
+++ b/ckanext/stats/controller.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import ckan.plugins as p
 from ckan.lib.base import BaseController
 import stats as stats_lib

--- a/ckanext/stats/plugin.py
+++ b/ckanext/stats/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from logging import getLogger
 
 import ckan.plugins as p

--- a/ckanext/stats/public/__init__.py
+++ b/ckanext/stats/public/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # this is a namespace package
 try:
     import pkg_resources

--- a/ckanext/stats/public/ckanext/__init__.py
+++ b/ckanext/stats/public/ckanext/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # this is a namespace package
 try:
     import pkg_resources

--- a/ckanext/stats/public/ckanext/stats/__init__.py
+++ b/ckanext/stats/public/ckanext/stats/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # this is a namespace package
 try:
     import pkg_resources

--- a/ckanext/stats/stats.py
+++ b/ckanext/stats/stats.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 
 from pylons import config

--- a/ckanext/stats/tests/__init__.py
+++ b/ckanext/stats/tests/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import paste.fixture
 from pylons import config
 from ckan.config.middleware import make_app

--- a/ckanext/stats/tests/test_stats_lib.py
+++ b/ckanext/stats/tests/test_stats_lib.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import datetime
 from nose.tools import assert_equal
 

--- a/ckanext/stats/tests/test_stats_plugin.py
+++ b/ckanext/stats/tests/test_stats_plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import os
 
 from ckan.tests.legacy import url_for

--- a/ckanext/test_tag_vocab_plugin.py
+++ b/ckanext/test_tag_vocab_plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 ''' THIS PLUGIN IS FOR TESTING PURPOSES ONLY.
 Currently this is used in tests/functional/test_tag_vocab.py'''
 

--- a/ckanext/textview/plugin.py
+++ b/ckanext/textview/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import logging
 
 from ckan.common import json

--- a/ckanext/textview/tests/test_view.py
+++ b/ckanext/textview/tests/test_view.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import paste.fixture
 import pylons.config as config
 import urlparse

--- a/ckanext/webpageview/plugin.py
+++ b/ckanext/webpageview/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import logging
 import ckan.plugins as p
 

--- a/ckanext/webpageview/tests/test_view.py
+++ b/ckanext/webpageview/tests/test_view.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from routes import url_for
 
 import ckan.plugins as p

--- a/profile_tests.py
+++ b/profile_tests.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Runs all the tests and save a speed profile to ckan.tests.profile
 import nose
 import cProfile

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Avoid problem releasing to pypi from vagrant
 import os
 if os.environ.get('USER', '') == 'vagrant':


### PR DESCRIPTION
This is work for #3006. It was originally submitted via #3049 but has been put into this separate PR to ease reviewing.

This PR adds PEP 263 encoding specifications to all Python source files. It also adds a test which checks that every Python source file does have an encoding specification.