### PR TITLE
Uncaught email exceptions on user invite

### DIFF
--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -97,6 +97,30 @@ class TestUserInvite(object):
 
         assert_equals(invited_user.name.split('-')[0], 'maria')
 
+    @helpers.change_config('smtp.server', 'email.example.com')
+    def test_smtp_error_returns_error_message(self):
+
+        sysadmin = factories.Sysadmin()
+        group = factories.Group()
+
+        context = {
+            'user': sysadmin['name']
+        }
+        params = {
+            'email': 'example-invited-user@example.com',
+            'group_id': group['id'],
+            'role': 'editor'
+        }
+
+        assert_raises(logic.ValidationError, helpers.call_action,
+                      'user_invite', context, **params)
+
+        # Check that the pending user was deleted
+        user = model.Session.query(model.User).filter(
+            model.User.name.like('example-invited-user%')).all()
+
+        assert_equals(user[0].state, 'deleted')
+
     def _invite_user_to_group(self, email='user@email.com',
                               group=None, role='member'):
         user = factories.User()


### PR DESCRIPTION
When inviting a user to a group or an organization, either via the UI or the `user_invite` API call if there was a problem sending the invite email the exception is not caught, resulting in a 500 error. Common exceptions include `[Errno 111] Connection refused` and `MailerException: SMTPAuthenticationError(435, '4.7.8 Error: authentication failed:')`.

I think we should delete the pending user (which is already created at this point).

Error returned:

![5mdnzcw](https://cloud.githubusercontent.com/assets/200230/15708279/adf3095a-27f5-11e6-8740-4424139aea71.png)
