### PR TITLE
member_list returns deleted datasets and users

### DIFF
--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -37,10 +37,22 @@ def user_delete(context, data_dict):
     user_id = _get_or_bust(data_dict, 'id')
     user = model.User.get(user_id)
 
+    # New revision, needed by the member table
+    rev = model.repo.new_revision()
+    rev.author = context['user']
+    rev.message = _(u' Delete User: {0}').format(user.name)
+
     if user is None:
         raise NotFound('User "{id}" was not found.'.format(id=user_id))
 
     user.delete()
+
+    user_memberships = model.Session.query(model.Member).filter(
+        model.Member.table_id == user_id).all()
+
+    for membership in user_memberships:
+        membership.delete()
+
     model.repo.commit()
 
 
@@ -65,7 +77,7 @@ def package_delete(context, data_dict):
     if entity is None:
         raise NotFound
 
-    _check_access('package_delete',context, data_dict)
+    _check_access('package_delete', context, data_dict)
 
     rev = model.repo.new_revision()
     rev.author = user
@@ -77,6 +89,14 @@ def package_delete(context, data_dict):
         item.after_delete(context, data_dict)
 
     entity.delete()
+
+    dataset_memberships = model.Session.query(model.Member).filter(
+        model.Member.table_id == id).filter(
+        model.Member.state == 'active').all()
+
+    for membership in dataset_memberships:
+        membership.delete()
+
     model.repo.commit()
 
 

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -128,7 +128,7 @@ class TestGroupList(helpers.FunctionalTestBase):
 
         eq(group_list, ['bb', 'aa'])
 
-    def assert_equals_expected(self, expected_dict, result_dict):
+    def eq_expected(self, expected_dict, result_dict):
         superfluous_keys = set(result_dict) - set(expected_dict)
         assert not superfluous_keys, 'Did not expect key: %s' % \
             ' '.join(('%s=%s' % (k, result_dict[k]) for k in superfluous_keys))
@@ -1903,3 +1903,116 @@ class TestRevisionList(helpers.FunctionalTestBase):
         revs = helpers.call_action('revision_list', since_id='1',
                                    sort='time_asc')
         eq(revs, ['2', '3'])
+
+
+class TestMembersList():
+
+    def setup(self):
+        helpers.reset_db()
+
+    def test_dataset_delete_marks_membership_of_group_as_deleted(self):
+        sysadmin = factories.Sysadmin()
+        group = factories.Group()
+        dataset = factories.Dataset(groups=[{'name': group['name']}])
+        context = {'user': sysadmin['name']}
+
+        group_members = helpers.call_action('member_list', context,
+                                            id=group['id'],
+                                            object_type='package')
+
+        eq(len(group_members), 1)
+        eq(group_members[0][0], dataset['id'])
+        eq(group_members[0][1], 'package')
+
+        helpers.call_action('package_delete', context, id=dataset['id'])
+
+        group_members = helpers.call_action('member_list', context,
+                                            id=group['id'],
+                                            object_type='package')
+
+        eq(len(group_members), 0)
+
+    def test_dataset_delete_marks_membership_of_org_as_deleted(self):
+        sysadmin = factories.Sysadmin()
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org=org['id'])
+        context = {'user': sysadmin['name']}
+
+        org_members = helpers.call_action('member_list', context,
+                                          id=org['id'],
+                                          object_type='package')
+
+        eq(len(org_members), 1)
+        eq(org_members[0][0], dataset['id'])
+        eq(org_members[0][1], 'package')
+
+        helpers.call_action('package_delete', context, id=dataset['id'])
+
+        org_members = helpers.call_action('member_list', context,
+                                          id=org['id'],
+                                          object_type='package')
+
+        eq(len(org_members), 0)
+
+    def test_user_delete_marks_membership_of_group_as_deleted(self):
+        sysadmin = factories.Sysadmin()
+        group = factories.Group()
+        user = factories.User()
+        context = {'user': sysadmin['name']}
+
+        member_dict = {
+            'username': user['id'],
+            'id': group['id'],
+            'role': 'member'
+        }
+        helpers.call_action('group_member_create', context, **member_dict)
+
+        group_members = helpers.call_action('member_list', context,
+                                            id=group['id'],
+                                            object_type='user',
+                                            capacity='member')
+
+        eq(len(group_members), 1)
+        eq(group_members[0][0], user['id'])
+        eq(group_members[0][1], 'user')
+
+        helpers.call_action('user_delete', context, id=user['id'])
+
+        group_members = helpers.call_action('member_list', context,
+                                            id=group['id'],
+                                            object_type='user',
+                                            capacity='member')
+
+        eq(len(group_members), 0)
+
+    def test_user_delete_marks_membership_of_org_as_deleted(self):
+        sysadmin = factories.Sysadmin()
+        org = factories.Organization()
+        user = factories.User()
+        context = {'user': sysadmin['name']}
+
+        member_dict = {
+            'username': user['id'],
+            'id': org['id'],
+            'role': 'member'
+        }
+        helpers.call_action('organization_member_create', context,
+                            **member_dict)
+
+        org_members = helpers.call_action('member_list', context,
+                                          id=org['id'],
+                                          object_type='user',
+                                          capacity='member')
+
+        eq(len(org_members), 1)
+        eq(org_members[0][0], user['id'])
+        eq(org_members[0][1], 'user')
+
+        helpers.call_action('user_delete', context, id=user['id'])
+
+        org_members = helpers.call_action('member_list', context,
+                                          id=org['id'],
+                                          object_type='user',
+                                          capacity='member')
+
+        eq(len(org_members), 0)


### PR DESCRIPTION
Visiting a Group or Org Members page will show deleted users.
Also calling `member_list` on a Group or Org will return deleted datasets (although this is not used on the frontend).

This is because the members table is stateful, ie it has a `state=active/deleted` field which is not updated when deleting a dataset or user.

This PR sets the state of all user/dataset memberships to `deleted` and adds some tests