### PR TITLE
Allow Sysadmins to create users with the form (and test)

### DIFF
--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -166,7 +166,8 @@ class UserController(base.BaseController):
         '''GET to display a form for registering a new user.
            or POST the form data to actually do the user registration.
         '''
-        context = {'model': model, 'session': model.Session,
+        context = {'model': model,
+                   'session': model.Session,
                    'user': c.user,
                    'auth_user_obj': c.userobj,
                    'schema': self._new_form_to_db_schema(),
@@ -264,7 +265,14 @@ class UserController(base.BaseController):
             h.flash_success(_('User "%s" is now registered but you are still '
                             'logged in as "%s" from before') %
                             (data_dict['name'], c.user))
-            return render('user/logout_first.html')
+            if authz.is_sysadmin(c.user):
+                # the sysadmin created a new user. We redirect him to the
+                # activity page for the newly created user
+                h.redirect_to(controller='user',
+                              action='activity',
+                              id=data_dict['name'])
+            else:
+                return render('user/logout_first.html')
 
     def edit(self, id=None, data=None, errors=None, error_summary=None):
         context = {'save': 'save' in request.params,

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -180,7 +180,7 @@ class UserController(base.BaseController):
         if context['save'] and not data:
             return self._save_new(context)
 
-        if c.user and not data:
+        if c.user and not data and not authz.is_sysadmin(c.user):
             # #1799 Don't offer the registration form if already logged in
             return render('user/logout_first.html')
 

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -59,6 +59,37 @@ class TestRegisterUser(helpers.FunctionalTestBase):
         response = form.submit('save')
         assert_true('The passwords you entered do not match' in response)
 
+    def test_create_user_as_sysadmin(self):
+        admin_pass = 'pass'
+        sysadmin = factories.Sysadmin(password=admin_pass)
+        app = self._get_test_app()
+
+        # Have to do an actual login as this test relies on repoze
+        #  cookie handling.
+
+        # get the form
+        response = app.get('/user/login')
+        # ...it's the second one
+        login_form = response.forms[1]
+        # fill it in
+        login_form['login'] = sysadmin['name']
+        login_form['password'] = admin_pass
+        # submit it
+        login_form.submit('save')
+
+        response = app.get(
+            url=url_for(controller='user', action='register'),
+        )
+        assert "user-register-form" in response.forms
+        form = response.forms['user-register-form']
+        form['name'] = 'newestuser'
+        form['fullname'] = 'Newest User'
+        form['email'] = 'test@test.com'
+        form['password1'] = 'testpassword'
+        form['password2'] = 'testpassword'
+        response2 = form.submit('save')
+        assert '/user/activity' in response2.location
+
 
 class TestLoginView(helpers.FunctionalTestBase):
     def test_registered_user_login(self):
@@ -223,16 +254,6 @@ class TestUserEdit(helpers.FunctionalTestBase):
             url_for(controller='user', action='edit', id=username),
             status=403
         )
-
-    def test_create_user_as_sysadmin(self):
-        sysadmin = factories.Sysadmin()
-        app = self._get_test_app()
-        env = {'REMOTE_USER': sysadmin['name'].encode('ascii')}
-        response = app.get(
-            url=url_for(controller='user', action='register'),
-            extra_environ=env,
-        )
-        assert "user-register-form" in response.forms
 
     def test_edit_user(self):
         user = factories.User(password='pass')

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -224,6 +224,16 @@ class TestUserEdit(helpers.FunctionalTestBase):
             status=403
         )
 
+    def test_create_user_as_sysadmin(self):
+        sysadmin = factories.Sysadmin()
+        app = self._get_test_app()
+        env = {'REMOTE_USER': sysadmin['name'].encode('ascii')}
+        response = app.get(
+            url=url_for(controller='user', action='register'),
+            extra_environ=env,
+        )
+        assert "user-register-form" in response.forms
+
     def test_edit_user(self):
         user = factories.User(password='pass')
         app = self._get_test_app()


### PR DESCRIPTION
Fixes #2863

### Proposed fixes:
Takes the changes from #2863 and adds a test for them.

Additionally the sysadmin is redirected to the newly created user's activity feed now as proposed by @wardi. This is also checked in the test.


### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport