### PR TITLE
Reset URL fields if resource upload fails

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -682,6 +682,9 @@ class PackageController(base.BaseController):
                 else:
                     get_action('resource_create')(context, data)
             except ValidationError, e:
+                if data.get('url_type') == 'upload':
+                    data.pop('url')
+                    data.pop('url_type')
                 errors = e.error_dict
                 error_summary = e.error_summary
                 return self.new_resource(id, data, errors, error_summary)


### PR DESCRIPTION
Fixes #2650 
### Proposed fixes:

Reset URL fields if resource upload fails.

While this means a user has to reselect the file to upload, without introducing either AJAXyness, or some cache of previously failed uploads (and an associated cleanup job) this is the simplest solution.
### Features:
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
