### PR TITLE
Specify encoding in new files

### DIFF
--- a/ckan/tests/lib/test_navl.py
+++ b/ckan/tests/lib/test_navl.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import nose
 import pylons
 

--- a/ckanext/example_iauthfunctions/plugin_v6_parent_auth_functions.py
+++ b/ckanext/example_iauthfunctions/plugin_v6_parent_auth_functions.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import pylons.config as config
 
 import ckan.plugins as plugins


### PR DESCRIPTION
The last big merge broke the build because some of the new files did not specify `# encoding: utf-8` on top of the file as now required by the new tests.

This PR adds those lines and fixes the build.

