### PR TITLE
[#3089] move RootPathMiddleware up the WSGI stack so it doesn't impact…

### DIFF
--- a/ckan/config/middleware.py
+++ b/ckan/config/middleware.py
@@ -88,6 +88,8 @@ def make_pylons_stack(conf, full_stack=True, static_files=True, **app_conf):
     for plugin in PluginImplementations(IMiddleware):
         app = plugin.make_middleware(app, config)
 
+    app = RootPathMiddleware(app, config)
+
     # Routing/Session/Cache Middleware
     app = RoutesMiddleware(app, config['routes.map'])
     # we want to be able to retrieve the routes middleware to be able to update
@@ -199,8 +201,6 @@ def make_pylons_stack(conf, full_stack=True, static_files=True, **app_conf):
     # Tracking
     if asbool(config.get('ckan.tracking_enabled', 'false')):
         app = TrackingMiddleware(app, config)
-
-    app = RootPathMiddleware(app, config)
 
     return app
 


### PR DESCRIPTION
… other middleware. Fixes #3089 

This PR moves the RootPathMiddleware up the WSGI stack so it doesn't impact other middleware including repoze.who plugins, which is the cause of #3089.

I figured this should only change the environment for CKAN and CKAN plugins so I've moved it up above routes.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

