### PR TITLE
Fix #3093: Incorrect usage of str.split

### DIFF
--- a/ckan/ckan_nose_plugin.py
+++ b/ckan/ckan_nose_plugin.py
@@ -129,7 +129,7 @@ class CkanNose(Plugin):
 ##
 ##        testname = str(test)
 ##        #if ' ' in testname:
-##        #    testname = testname.split(' ')[1]
+##        #    testname = testname.split()[1]
 ##
 ##        f.write('%s,%s\n' % (testname, str(runtime)))
 ##

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -344,7 +344,7 @@ class BaseController(WSGIController):
             cors_origin_allowed = "*"
         elif config.get('ckan.cors.origin_whitelist') and \
                 request.headers.get('Origin') \
-                in config['ckan.cors.origin_whitelist'].split(" "):
+                in config['ckan.cors.origin_whitelist'].split():
             # set var to the origin to allow it.
             cors_origin_allowed = request.headers.get('Origin')
 

--- a/ckan/lib/datapreview.py
+++ b/ckan/lib/datapreview.py
@@ -175,7 +175,7 @@ def get_default_view_plugins(get_datastore_views=False):
     if config.get('ckan.views.default_views') is None:
         default_view_types = DEFAULT_RESOURCE_VIEW_TYPES
     else:
-        default_view_types = config.get('ckan.views.default_views').split(' ')
+        default_view_types = config.get('ckan.views.default_views').split()
 
     default_view_plugins = []
     for view_type in default_view_types:

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -485,7 +485,7 @@ def are_there_flash_messages():
 def _link_active(kwargs):
     ''' creates classes for the link_to calls '''
     highlight_actions = kwargs.get('highlight_actions',
-                                   kwargs.get('action', '')).split(' ')
+                                   kwargs.get('action', '')).split()
     return (c.controller == kwargs.get('controller')
             and c.action in highlight_actions)
 

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1828,8 +1828,7 @@ def package_search(context, data_dict):
         # instead set it to only retrieve public datasets
         fq = data_dict.get('fq', '')
         if not context.get('ignore_capacity_check', False):
-            fq = ' '.join(p for p in fq.split(' ')
-                          if 'capacity:' not in p)
+            fq = ' '.join(p for p in fq.split() if 'capacity:' not in p)
             data_dict['fq'] = fq + ' capacity:"public"'
 
         # Solr doesn't need 'include_drafts`, so pop it.


### PR DESCRIPTION
This PR fixes multiple locations where `.split()` should have been used instead of `.split(' ')` for splitting strings on whitespace. See #3093 for more information.