### PR TITLE
Fixes repr(DictizationError) returning ""

### DIFF
--- a/ckan/lib/navl/dictization_functions.py
+++ b/ckan/lib/navl/dictization_functions.py
@@ -37,6 +37,9 @@ class DictizationError(Exception):
             return repr(self.error)
         return ''
 
+    def __unicode__(self):
+        return unicode(str(self))
+
 class Invalid(DictizationError):
     '''Exception raised by some validator, converter and dictization functions
     when the given value is invalid.


### PR DESCRIPTION
I came across this when debugging. When you print a DictizationError (e.g. during package_update) it shows as blank, when it has a string inside.
