### PR TITLE
ckan.__version__ available as template helper

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@
 Changelog
 ---------
 
+v2.6.0 TBA
+=================
+API changes and deprecations:
+ * Replace `c.__version__` with new helper `h.ckan_version()` (#3103)
+
 v2.5.2 2016-03-31
 =================
 

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -197,7 +197,6 @@ class BaseController(WSGIController):
 
     def __before__(self, action, **params):
         c.__timer = time.time()
-        c.__version__ = ckan.__version__
         app_globals.app_globals._check_uptodate()
 
         self._identify_user()

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -30,8 +30,8 @@ from pylons import config
 from routes import redirect_to as _redirect_to
 from routes import url_for as _routes_default_url_for
 import i18n
-import ckan.exceptions
 
+import ckan.exceptions
 import ckan.lib.fanstatic_resources as fanstatic_resources
 import ckan.model as model
 import ckan.lib.formatters as formatters
@@ -41,6 +41,7 @@ import ckan.logic as logic
 import ckan.lib.uploader as uploader
 import ckan.authz as authz
 import ckan.plugins as p
+import ckan
 
 from ckan.common import _, ungettext, g, c, request, session, json
 
@@ -362,6 +363,12 @@ def full_current_url():
 def lang():
     ''' Return the language code for the current locale eg `en` '''
     return request.environ.get('CKAN_LANG')
+
+
+@core_helper
+def ckan_version():
+    '''Return CKAN version'''
+    return ckan.__version__
 
 
 @core_helper

--- a/ckan/templates/base.html
+++ b/ckan/templates/base.html
@@ -26,7 +26,7 @@
     #}
     {%- block meta -%}
       <meta charset="utf-8" />
-      {% block meta_generator %}<meta name="generator" content="ckan {{ c.__version__ }}" />{% endblock %}
+      {% block meta_generator %}<meta name="generator" content="ckan {{ h.ckan_version() }}" />{% endblock %}
       {% block meta_viewport %}<meta name="viewport" content="width=device-width, initial-scale=1.0">{% endblock %}
     {%- endblock -%}
 


### PR DESCRIPTION
The BaseController in [lib/base.py](https://github.com/ckan/ckan/blob/997b06cf5627660ec7b9b1d8dca2f2463e901d1a/ckan/lib/base.py#L200) adds `__version__` to `c` so it's available to the [base.html](https://github.com/ckan/ckan/blob/997b06cf5627660ec7b9b1d8dca2f2463e901d1a/ckan/templates/base.html#L29) template. 

Instead of having this added to `c`, I suggest removing the line from base.py and add a new template helper, `ckan_version`, that returns `ckan.__version__`, for use in templates.