### PR TITLE
CircleCi - deleted --allow-all-external

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,6 +15,7 @@ machine:
         version: 0.10.33
 
 dependencies:
+
     pre:
         - "[ -e ~/.local/bin/circleci-matrix ]
            || mkdir -p ~/.local/bin
@@ -22,8 +23,8 @@ dependencies:
            && chmod +x ~/.local/bin/circleci-matrix"
 
     override:
-        - pip install -r requirements.txt --allow-all-external
-        - pip install -r dev-requirements.txt --allow-all-external
+        - pip install -r requirements.txt
+        - pip install -r dev-requirements.txt
         - python setup.py develop
 
     post:
@@ -38,6 +39,7 @@ dependencies:
         - ~/nvm/v0.10.33/bin/phantomjs
 
 database:
+
     post:
         - sudo -E -u postgres ./bin/postgres_init/1_create_ckan_db.sh
         - sudo -E -u postgres ./bin/postgres_init/2_create_ckan_datastore_db.sh
@@ -53,6 +55,7 @@ database:
         - paster db init -c test-core.ini
 
 test:
+
     override:
         - circleci-matrix:
             parallel: true


### PR DESCRIPTION
DEPRECATION: --allow-all-external has been deprecated and will be removed in the future. Due to changes in the repository protocol, it no longer has any effect.

