### PR TITLE
*_member_create don't raise validation errors

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -1372,6 +1372,9 @@ def _group_or_org_member_create(context, data_dict, is_org=False):
 
     schema = ckan.logic.schema.member_schema()
     data, errors = _validate(data_dict, schema, context)
+    if errors:
+        model.Session.rollback()
+        raise ValidationError(errors)
 
     username = _get_or_bust(data_dict, 'username')
     role = data_dict.get('role')

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -532,9 +532,9 @@ def default_follow_dataset_schema():
 
 def member_schema():
     schema = {
-        'id': [group_id_exists, unicode],
-        'username': [user_name_exists, unicode],
-        'role': [role_exists, unicode],
+        'id': [not_missing, not_empty, group_id_exists, unicode],
+        'username': [not_missing, user_name_exists, unicode],
+        'role': [not_missing, role_exists, unicode],
     }
     return schema
 

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -534,7 +534,7 @@ def default_follow_dataset_schema():
 
 def member_schema():
     schema = {
-        'id': [not_missing, not_empty, group_id_or_name_exists, unicode],
+        'id': [not_missing, group_id_or_name_exists, unicode],
         'username': [not_missing, user_id_or_name_exists, unicode],
         'role': [not_missing, role_exists, unicode],
     }

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -55,8 +55,10 @@ from ckan.logic.validators import (
     resource_id_exists,
     tag_not_in_vocabulary,
     group_id_exists,
+    group_id_or_name_exists,
     owner_org_validator,
     user_name_exists,
+    user_id_or_name_exists,
     role_exists,
     datasets_with_no_organization_cannot_be_private,
     list_of_strings,
@@ -532,8 +534,8 @@ def default_follow_dataset_schema():
 
 def member_schema():
     schema = {
-        'id': [not_missing, not_empty, group_id_exists, unicode],
-        'username': [not_missing, user_name_exists, unicode],
+        'id': [not_missing, not_empty, group_id_or_name_exists, unicode],
+        'username': [not_missing, user_id_or_name_exists, unicode],
         'role': [not_missing, role_exists, unicode],
     }
     return schema

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -151,7 +151,7 @@ class TestResourceViewCreate(object):
 
     @classmethod
     def teardown_class(cls):
-
+        p.unload('image_view')
         helpers.reset_db()
 
     def setup(self):

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -151,7 +151,6 @@ class TestResourceViewCreate(object):
 
     @classmethod
     def teardown_class(cls):
-        p.unload('image_view')
 
         helpers.reset_db()
 
@@ -484,6 +483,48 @@ class TestMemberCreate(object):
         assert_equals(new_membership['table_name'], 'user')
         assert_equals(new_membership['table_id'], user['id'])
         assert_equals(new_membership['capacity'], 'member')
+
+    def test_group_member_creation_raises_validation_error_if_id_missing(self):
+
+        assert_raises(logic.ValidationError,
+                      helpers.call_action, 'group_member_create',
+                      username='someuser',
+                      role='member',)
+
+    def test_group_member_creation_raises_validation_error_if_username_missing(self):
+
+        assert_raises(logic.ValidationError,
+                      helpers.call_action, 'group_member_create',
+                      id='someid',
+                      role='member',)
+
+    def test_group_member_creation_raises_validation_error_if_role_missing(self):
+
+        assert_raises(logic.ValidationError,
+                      helpers.call_action, 'group_member_create',
+                      id='someid',
+                      username='someuser',)
+
+    def test_org_member_creation_raises_validation_error_if_id_missing(self):
+
+        assert_raises(logic.ValidationError,
+                      helpers.call_action, 'organization_member_create',
+                      username='someuser',
+                      role='member',)
+
+    def test_org_member_creation_raises_validation_error_if_username_missing(self):
+
+        assert_raises(logic.ValidationError,
+                      helpers.call_action, 'organization_member_create',
+                      id='someid',
+                      role='member',)
+
+    def test_org_member_creation_raises_validation_error_if_role_missing(self):
+
+        assert_raises(logic.ValidationError,
+                      helpers.call_action, 'organization_member_create',
+                      id='someid',
+                      username='someuser',)
 
 
 class TestDatasetCreate(helpers.FunctionalTestBase):


### PR DESCRIPTION
`organization_member_create` and `group_member_create` don't raise validation errors if one of the parameters is missing (`id`, `username` or `role`, all mandatory).

This leads to confusing failures when submitting eg a key with an extra space (`"username "`):

```
(ProgrammingError) can't adapt type 'Missing' 'SELECT "user".password AS user_password, "user".id AS user_id, "user".name AS user_name, "user".openid AS user_openid, "user".fullname AS user_fullname, "user".email AS user_email, "user".apikey AS user_apikey, "user".created AS user_created, "user".reset_key AS user_reset_key, "user".about AS user_about, "user".activity_streams_email_notifications AS user_activity_streams_email_notifications, "user".sysadmin AS user_sysadmin, "user".state AS user_state \\nFROM "user" \\nWHERE "user".name = %(name_1)s ORDER BY "user".name \\n LIMIT %(param_1)s' {'name_1': <ckan.lib.navl.dictization_functions.Missing object at 0x7fb32056be10>, 'param_1': 1}
```
