### PR TITLE
Remove tag validators

### DIFF
--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -28,8 +28,6 @@ from ckan.logic.validators import (
     package_name_validator,
     package_version_validator,
     group_name_validator,
-    tag_length_validator,
-    tag_name_validator,
     tag_string_convert,
     duplicate_extras_key,
     ignore_not_package_admin,
@@ -111,9 +109,7 @@ def default_tags_schema():
     schema = {
         'name': [not_missing,
                  not_empty,
-                 unicode,
-                 tag_length_validator,
-                 tag_name_validator,
+                 unicode
                  ],
         'vocabulary_id': [ignore_missing, unicode, vocabulary_id_exists],
         'revision_timestamp': [ignore],

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -408,26 +408,6 @@ def group_name_validator(key, data, errors, context):
     if result:
         errors[key].append(_('Group name already exists in database'))
 
-def tag_length_validator(value, context):
-
-    if len(value) < MIN_TAG_LENGTH:
-        raise Invalid(
-            _('Tag "%s" length is less than minimum %s') % (value, MIN_TAG_LENGTH)
-        )
-    if len(value) > MAX_TAG_LENGTH:
-        raise Invalid(
-            _('Tag "%s" length is more than maximum %i') % (value, MAX_TAG_LENGTH)
-        )
-    return value
-
-def tag_name_validator(value, context):
-
-    tagname_match = re.compile('[\w \-.]*$', re.UNICODE)
-    if not tagname_match.match(value):
-        raise Invalid(_('Tag "%s" must be alphanumeric '
-                        'characters or symbols: -_.') % (value))
-    return value
-
 def tag_not_uppercase(value, context):
 
     tagname_uppercase = re.compile('[A-Z]')
@@ -451,10 +431,6 @@ def tag_string_convert(key, data, errors, context):
 
     for num, tag in zip(count(current_index+1), tags):
         data[('tags', num, 'name')] = tag
-
-    for tag in tags:
-        tag_length_validator(tag, context)
-        tag_name_validator(tag, context)
 
 def ignore_not_admin(key, data, errors, context):
     # Deprecated in favour of ignore_not_package_admin


### PR DESCRIPTION
Fixes #2780 

### Proposed fixes:
Removes `tag_name_validator` and `tag_length_validator` as per @amercader's context in #2780