### PR TITLE
Purge dataset relationships

### DIFF
--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -117,6 +117,8 @@ def dataset_purge(context, data_dict):
     :type id: string
 
     '''
+    from sqlalchemy import or_
+
     model = context['model']
     id = _get_or_bust(data_dict, 'id')
 
@@ -133,6 +135,11 @@ def dataset_purge(context, data_dict):
     if members.count() > 0:
         for m in members.all():
             m.purge()
+
+    for r in model.Session.query(model.PackageRelationship).filter(
+            or_(model.PackageRelationship.subject_package_id == pkg.id,
+                model.PackageRelationship.object_package_id == pkg.id)).all():
+        r.purge()
 
     pkg = model.Package.get(id)
     # no new_revision() needed since there are no object_revisions created

--- a/ckan/tests/logic/action/test_delete.py
+++ b/ckan/tests/logic/action/test_delete.py
@@ -451,6 +451,30 @@ class TestDatasetPurge(object):
         # No Revision objects were purged or created
         assert_equals(num_revisions_after - num_revisions_before, 0)
 
+    def test_purged_dataset_removed_from_relationships(self):
+        child = factories.Dataset()
+        parent = factories.Dataset()
+        grandparent = factories.Dataset()
+
+        helpers.call_action('package_relationship_create',
+                            subject=child['id'],
+                            type='child_of',
+                            object=parent['id'])
+
+        helpers.call_action('package_relationship_create',
+                            subject=parent['id'],
+                            type='child_of',
+                            object=grandparent['id'])
+
+        assert_equals(len(
+            model.Session.query(model.PackageRelationship).all()), 2)
+
+        helpers.call_action('dataset_purge',
+                            context={'ignore_auth': True},
+                            id=parent['name'])
+
+        assert_equals(model.Session.query(model.PackageRelationship).all(), [])
+
     def test_missing_id_returns_error(self):
         assert_raises(logic.ValidationError,
                       helpers.call_action, 'dataset_purge')


### PR DESCRIPTION
Contributes to #2186

### Proposed fixes:
dataset_purge was not purging a dataset's relationships


### Features:

- [X ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X ] includes bugfix for possible backport

Please [X] all the boxes above that apply

