### PR TITLE
Remove `site_url_nice` from app_globals

### DIFF
--- a/ckan/lib/app_globals.py
+++ b/ckan/lib/app_globals.py
@@ -169,13 +169,9 @@ def reset():
     for key in schema.keys():
         get_config_value(key)
 
-    # cusom styling
+    # custom styling
     main_css = get_config_value('ckan.main_css', '/base/css/main.css')
     set_main_css(main_css)
-    # site_url_nice
-    site_url_nice = app_globals.site_url.replace('http://', '')
-    site_url_nice = site_url_nice.replace('www.', '')
-    app_globals.site_url_nice = site_url_nice
 
     if app_globals.site_logo:
         app_globals.header_class = 'header-image'


### PR DESCRIPTION
### CKAN Version if known (or site URL)

Master, in the file: https://github.com/ckan/ckan/blob/b4a9a5b205919042586a1b9ae33d7f9aba24e537/ckan/lib/app_globals.py#L175-L178

Just a desire to remove unused code. 

Running `git log -p -S site_url_nice` on the repository shows this was added to app_globals so a message in a base template could echo a user-friendly url. The template made use of it for one day before the message was changed to output the site title instead. It's not used anywhere else in the codebase. Perhaps an extension is using it, but I doubt it. This sort of thing should be a template helper instead anyway.