### PR TITLE
Tidy-up BaseController pagination code

### DIFF
--- a/ckan/controllers/feed.py
+++ b/ckan/controllers/feed.py
@@ -310,7 +310,7 @@ class FeedController(base.BaseController):
                 search_params[param] = value
                 fq += ' %s:"%s"' % (param, value)
 
-        page = self._get_page_number(request.params)
+        page = h.get_page_number(request.params)
 
         limit = ITEMS_LIMIT
         data_dict = {
@@ -455,7 +455,7 @@ class FeedController(base.BaseController):
         Returns the constructed search-query dict, and the valid URL
         query parameters.
         """
-        page = self._get_page_number(request.params)
+        page = h.get_page_number(request.params)
 
         limit = ITEMS_LIMIT
         data_dict = {

--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -150,7 +150,7 @@ class GroupController(base.BaseController):
     def index(self):
         group_type = self._guess_group_type()
 
-        page = self._get_page_number(request.params) or 1
+        page = h.get_page_number(request.params) or 1
         items_per_page = 21
 
         context = {'model': model, 'session': model.Session,
@@ -247,7 +247,7 @@ class GroupController(base.BaseController):
 
         context['return_query'] = True
 
-        page = self._get_page_number(request.params)
+        page = h.get_page_number(request.params)
 
         # most search operations should reset the page counter:
         params_nopage = [(k, v) for k, v in request.params.items()

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -146,7 +146,7 @@ class PackageController(base.BaseController):
         # unicode format (decoded from utf8)
         q = c.q = request.params.get('q', u'')
         c.query_error = False
-        page = self._get_page_number(request.params)
+        page = h.get_page_number(request.params)
 
         limit = g.datasets_per_page
 

--- a/ckan/controllers/revision.py
+++ b/ckan/controllers/revision.py
@@ -124,7 +124,7 @@ class RevisionController(base.BaseController):
             query = model.Session.query(model.Revision)
             c.page = h.Page(
                 collection=query,
-                page=self._get_page_number(request.params),
+                page=h.get_page_number(request.params),
                 url=h.pager_url,
                 items_per_page=20
             )

--- a/ckan/controllers/tag.py
+++ b/ckan/controllers/tag.py
@@ -36,7 +36,7 @@ class TagController(base.BaseController):
         data_dict = {'all_fields': True}
 
         if c.q:
-            page = self._get_page_number(request.params)
+            page = h.get_page_number(request.params)
             data_dict['q'] = c.q
             data_dict['limit'] = LIMIT
             data_dict['offset'] = (page - 1) * LIMIT

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -97,7 +97,7 @@ class UserController(base.BaseController):
                        handler_name)
 
     def index(self):
-        page = self._get_page_number(request.params)
+        page = h.get_page_number(request.params)
         c.q = request.params.get('q', '')
         c.order_by = request.params.get('order_by', 'name')
 

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -377,24 +377,6 @@ class BaseController(WSGIController):
         user = query.filter_by(apikey=apikey).first()
         return user
 
-    def _get_page_number(self, params, key='page', default=1):
-        """
-        Returns the page number from the provided params after
-        verifies that it is an integer.
-
-        If it fails it will abort the request with a 400 error
-        """
-        p = params.get(key, default)
-
-        try:
-            p = int(p)
-            if p < 1:
-                raise ValueError("Negative number not allowed")
-        except ValueError, e:
-            abort(400, ('"page" parameter must be a positive integer'))
-
-        return p
-
 
 # Include the '_' function in the public names
 __all__ = [__name for __name in locals().keys() if not __name.startswith('_')

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -34,8 +34,6 @@ from ckan.common import json, _, ungettext, c, g, request, response
 
 log = logging.getLogger(__name__)
 
-PAGINATE_ITEMS_PER_PAGE = 50
-
 APIKEY_HEADER_NAME_KEY = 'apikey_header_name'
 APIKEY_HEADER_NAME_DEFAULT = 'X-CKAN-API-Key'
 

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -37,8 +37,6 @@ log = logging.getLogger(__name__)
 APIKEY_HEADER_NAME_KEY = 'apikey_header_name'
 APIKEY_HEADER_NAME_DEFAULT = 'X-CKAN-API-Key'
 
-ALLOWED_FIELDSET_PARAMS = ['package_form', 'restrict']
-
 
 def abort(status_code=None, detail='', headers=None, comment=None):
     '''Abort the current request immediately by returning an HTTP exception.

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1097,7 +1097,8 @@ def get_page_number(params, key='page', default=1):
             raise ValueError("Negative number not allowed")
     except ValueError:
         import ckan.lib.base as base
-        base.abort(400, ('"{key}" parameter must be a positive integer'))
+        base.abort(400, ('"{key}" parameter must be a positive integer'
+                   .format(key=key)))
 
     return p
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1082,6 +1082,27 @@ class Page(paginate.Page):
 
 
 @core_helper
+def get_page_number(params, key='page', default=1):
+    '''
+    Return the page number from the provided params after verifying that it is
+    an positive integer.
+
+    If it fails it will abort the request with a 400 error.
+    '''
+    p = params.get(key, default)
+
+    try:
+        p = int(p)
+        if p < 1:
+            raise ValueError("Negative number not allowed")
+    except ValueError:
+        import ckan.lib.base as base
+        base.abort(400, ('"page" parameter must be a positive integer'))
+
+    return p
+
+
+@core_helper
 def get_display_timezone():
     ''' Returns a pytz timezone for the display_timezone setting in the
     configuration file or UTC if not specified.

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1097,7 +1097,7 @@ def get_page_number(params, key='page', default=1):
             raise ValueError("Negative number not allowed")
     except ValueError:
         import ckan.lib.base as base
-        base.abort(400, ('"page" parameter must be a positive integer'))
+        base.abort(400, ('"{key}" parameter must be a positive integer'))
 
     return p
 

--- a/ckan/tests/controllers/test_feed.py
+++ b/ckan/tests/controllers/test_feed.py
@@ -2,7 +2,6 @@
 
 from routes import url_for
 
-from ckan import model
 import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
 
@@ -15,7 +14,7 @@ class TestFeedNew(helpers.FunctionalTestBase):
                          id=group['name']) + '?page=0'
         app = self._get_test_app()
         res = app.get(offset, status=400)
-        assert '"page" parameter must be a positive integer' in res, res
+        assert '"{key}" parameter must be a positive integer' in res, res
 
     def test_atom_feed_page_negative_gives_error(self):
         group = factories.Group()
@@ -23,7 +22,7 @@ class TestFeedNew(helpers.FunctionalTestBase):
                          id=group['name']) + '?page=-2'
         app = self._get_test_app()
         res = app.get(offset, status=400)
-        assert '"page" parameter must be a positive integer' in res, res
+        assert '"{key}" parameter must be a positive integer' in res, res
 
     def test_atom_feed_page_not_int_gives_error(self):
         group = factories.Group()
@@ -31,4 +30,4 @@ class TestFeedNew(helpers.FunctionalTestBase):
                          id=group['name']) + '?page=abc'
         app = self._get_test_app()
         res = app.get(offset, status=400)
-        assert '"page" parameter must be a positive integer' in res, res
+        assert '"{key}" parameter must be a positive integer' in res, res

--- a/ckan/tests/controllers/test_feed.py
+++ b/ckan/tests/controllers/test_feed.py
@@ -14,7 +14,7 @@ class TestFeedNew(helpers.FunctionalTestBase):
                          id=group['name']) + '?page=0'
         app = self._get_test_app()
         res = app.get(offset, status=400)
-        assert '"{key}" parameter must be a positive integer' in res, res
+        assert '"page" parameter must be a positive integer' in res, res
 
     def test_atom_feed_page_negative_gives_error(self):
         group = factories.Group()
@@ -22,7 +22,7 @@ class TestFeedNew(helpers.FunctionalTestBase):
                          id=group['name']) + '?page=-2'
         app = self._get_test_app()
         res = app.get(offset, status=400)
-        assert '"{key}" parameter must be a positive integer' in res, res
+        assert '"page" parameter must be a positive integer' in res, res
 
     def test_atom_feed_page_not_int_gives_error(self):
         group = factories.Group()
@@ -30,4 +30,4 @@ class TestFeedNew(helpers.FunctionalTestBase):
                          id=group['name']) + '?page=abc'
         app = self._get_test_app()
         res = app.get(offset, status=400)
-        assert '"{key}" parameter must be a positive integer' in res, res
+        assert '"page" parameter must be a positive integer' in res, res


### PR DESCRIPTION
In the past, the BaseController used to deal with a lot of pagination logic used by subclassing controllers. Most of this has since been moved to the controllers themselves that make use of a Page helper in `lib/helpers.py`. There's still a `_get_page_number` method on the BaseController that gets and validates a page number from the request params. This can also be moved to the helpers module, providing for better reuse by controller classes and, as part of the Flask migration, by flask views.

There are tests in [tests/controllers/test_feed.py](https://github.com/ckan/ckan/blob/9f59e91113a7e129bd4ce801f3fae5835d0baef4/ckan/tests/controllers/test_feed.py) that provide coverage for this method.