### PR TITLE
Remove `e.message` deprecation warning when running tests

### DIFF
--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -174,7 +174,9 @@ class TestLogout(helpers.FunctionalTestBase):
 
     @helpers.change_config('ckan.root_path', '/my/prefix')
     def test_non_root_user_logout_url_redirect(self):
-        '''_logout url redirects to logged out page.
+        '''
+        _logout url redirects to logged out page with `ckan.root_path`
+        prefixed.
 
         Note: this doesn't test the actual logout of a logged in user, just
         the associated redirect.
@@ -183,10 +185,8 @@ class TestLogout(helpers.FunctionalTestBase):
 
         logout_url = url_for(controller='user', action='logout')
         logout_response = app.get(logout_url, status=302)
-        try:
-            final_response = helpers.webtest_maybe_follow(logout_response)
-        except Exception as e:
-            assert_true('/my/prefix/user/logout' in e.message)
+        assert_equal(logout_response.status_int, 302)
+        assert_true('/my/prefix/user/logout' in logout_response.location)
 
 
 class TestUser(helpers.FunctionalTestBase):


### PR DESCRIPTION
There's a deprecation warning when running tests: 

> DeprecationWarning: BaseException.message has been deprecated as of Python 2.6
  assert_true('/my/prefix/user/logout' in e.message)

Which leads to this test in [test_user.py](https://github.com/ckan/ckan/blob/811d8889bf6a49d5eb2f1a833fa26a0d45eec4f2/ckan/tests/controllers/test_user.py#L175).

We shouldn't need to follow the redirect to assert that a redirect is returned. Following the redirect returns a 404 in any case, because the test instance isn't mounted at `root_path`, and testing the resulting exception is a bit weird.

This PR removes the attempt to follow the redirect and instead tests that the appropriate url is the basis for the redirect when requesting a logout.
