### PR TITLE
[#3128] Render resource view descriptions as Markdown.

### DIFF
--- a/ckan/templates/package/snippets/resource_view.html
+++ b/ckan/templates/package/snippets/resource_view.html
@@ -10,7 +10,7 @@
       <i class="icon-code"></i>
       {{ _("Embed") }}
     </a>
-    <p class="desc">{{ resource_view['description'] }}</p>
+    <p class="desc">{{ h.render_markdown(resource_view['description']) }}</p>
     <div class="m-top ckanext-datapreview">
       {% if not to_preview and h.resource_view_is_filterable(resource_view) %}
         {% snippet 'package/snippets/resource_view_filters.html', resource=resource %}

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -1050,6 +1050,17 @@ class TestResourceView(helpers.FunctionalTestBase):
         app = self._get_test_app()
         app.get(url, status=404)
 
+    def test_resource_view_description_is_rendered_as_markdown(self):
+        resource_view = factories.ResourceView(description="Some **Markdown**")
+        url = url_for(controller='package',
+                      action='resource_read',
+                      id=resource_view['package_id'],
+                      resource_id=resource_view['resource_id'],
+                      view_id=resource_view['id'])
+        app = self._get_test_app()
+        response = app.get(url)
+        response.mustcontain('Some <strong>Markdown</strong>')
+
 
 class TestResourceRead(helpers.FunctionalTestBase):
     @classmethod


### PR DESCRIPTION
Fixes #3128. Includes a test.

Previously, CKAN rendered resource view descriptions as plain text, in contrast to the help text given in the resource view edit form which says that Markdown is supported.