### PR TITLE
Allow package_owner_org_update action to be called stand-alone

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -197,6 +197,7 @@ def package_create(context, data_dict):
     context_org_update = context.copy()
     context_org_update['ignore_auth'] = True
     context_org_update['defer_commit'] = True
+    context_org_update['add_revision'] = False
     _get_action('package_owner_org_update')(context_org_update,
                                             {'id': pkg.id,
                                              'organization_id': pkg.owner_org})

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -292,6 +292,7 @@ def package_update(context, data_dict):
     context_org_update = context.copy()
     context_org_update['ignore_auth'] = True
     context_org_update['defer_commit'] = True
+    context_org_update['add_revision'] = False
     _get_action('package_owner_org_update')(context_org_update,
                                             {'id': pkg.id,
                                              'organization_id': pkg.owner_org})
@@ -1020,6 +1021,7 @@ def package_owner_org_update(context, data_dict):
     :type id: string
     '''
     model = context['model']
+    user = context['user']
     name_or_id = data_dict.get('id')
     organization_id = data_dict.get('organization_id')
 
@@ -1039,10 +1041,17 @@ def package_owner_org_update(context, data_dict):
         org = None
         pkg.owner_org = None
 
+    if context.get('add_revision', True):
+        rev = model.repo.new_revision()
+        rev.author = user
+        if 'message' in context:
+            rev.message = context['message']
+        else:
+            rev.message = _(u'REST API: Update object %s') % pkg.get("name")
 
     members = model.Session.query(model.Member) \
-            .filter(model.Member.table_id == pkg.id) \
-            .filter(model.Member.capacity == 'organization')
+        .filter(model.Member.table_id == pkg.id) \
+        .filter(model.Member.capacity == 'organization')
 
     need_update = True
     for member_obj in members:

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -858,3 +858,63 @@ class TestUserUpdate(helpers.FunctionalTestBase):
 
         user_obj = model.User.get(user['id'])
         assert user_obj.password != 'pretend-this-is-a-valid-hash'
+
+
+class TestPackageOwnerOrgUpdate(object):
+
+    @classmethod
+    def teardown_class(cls):
+        helpers.reset_db()
+
+    def setup(self):
+        helpers.reset_db()
+
+    def test_package_owner_org_added(self):
+        '''A package without an owner_org can have one added.'''
+        sysadmin = factories.Sysadmin()
+        org = factories.Organization()
+        dataset = factories.Dataset()
+        context = {
+            'user': sysadmin['name'],
+        }
+        assert dataset['owner_org'] is None
+        helpers.call_action('package_owner_org_update',
+                            context=context,
+                            id=dataset['id'],
+                            organization_id=org['id'])
+        dataset_obj = model.Package.get(dataset['id'])
+        assert dataset_obj.owner_org == org['id']
+
+    def test_package_owner_org_changed(self):
+        '''A package with an owner_org can have it changed.'''
+
+        sysadmin = factories.Sysadmin()
+        org_1 = factories.Organization()
+        org_2 = factories.Organization()
+        dataset = factories.Dataset(owner_org=org_1['id'])
+        context = {
+            'user': sysadmin['name'],
+        }
+        assert dataset['owner_org'] == org_1['id']
+        helpers.call_action('package_owner_org_update',
+                            context=context,
+                            id=dataset['id'],
+                            organization_id=org_2['id'])
+        dataset_obj = model.Package.get(dataset['id'])
+        assert dataset_obj.owner_org == org_2['id']
+
+    def test_package_owner_org_removed(self):
+        '''A package with an owner_org can have it removed.'''
+        sysadmin = factories.Sysadmin()
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org=org['id'])
+        context = {
+            'user': sysadmin['name'],
+        }
+        assert dataset['owner_org'] == org['id']
+        helpers.call_action('package_owner_org_update',
+                            context=context,
+                            id=dataset['id'],
+                            organization_id=None)
+        dataset_obj = model.Package.get(dataset['id'])
+        assert dataset_obj.owner_org is None


### PR DESCRIPTION
Fixes #2661 

### Proposed fixes:

When the action `package_owner_org_update` is called alone, it caused an AssertionError in the vdm package:

```<type 'exceptions.AssertionError'>: No revision is currently set for this Session``` 

Changes to package are expected to have a revision, but none is created in `package_owner_org_update`. Note, this action is called by `package_create` and `package_update` to populate the owner org details of a package with no error, because a revision is created in those actions.

This PR ensures a revision is created when `package_owner_org_update` is called outside of a `package_update` and `package_create`.

Perhaps this action was never intended to be called stand-alone?

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport
