### PR TITLE
Document Unicode filename handling

### DIFF
--- a/ckan/lib/io.py
+++ b/ckan/lib/io.py
@@ -1,0 +1,52 @@
+# encoding: utf-8
+
+u'''
+Utility functions for I/O.
+'''
+
+import sys
+
+
+_FILESYSTEM_ENCODING = unicode(sys.getfilesystemencoding()
+                               or sys.getdefaultencoding())
+
+
+def encode_path(p):
+    u'''
+    Convert a Unicode path string to a byte string.
+
+    Intended to be used for encoding paths that are known to be
+    compatible with the filesystem, for example paths of existing files
+    that were previously decoded using :py:func:`decode_path`. If you're
+    dynamically constructing names for new files using unknown inputs
+    then pass them through :py:func:`ckan.lib.munge.munge_filename`
+    before encoding them.
+
+    Raises a ``UnicodeEncodeError`` if the path cannot be encoded using
+    the filesystem's encoding. That will never happen for paths returned
+    by :py:func:`decode_path`.
+
+    Raises a ``TypeError`` is the input is not a Unicode string.
+    '''
+    if not isinstance(p, unicode):
+        raise TypeError(u'Can only encode unicode, not {}'.format(type(p)))
+    return p.encode(_FILESYSTEM_ENCODING)
+
+
+def decode_path(p):
+    u'''
+    Convert a byte path string to a Unicode string.
+
+    Intended to be used for decoding byte paths to existing files as
+    returned by some of Python's built-in I/O functions.
+
+    Raises a ``UnicodeDecodeError`` if the path cannot be decoded using
+    the filesystem's encoding. Assuming the path was returned by one of
+    Python's I/O functions this means that the environment Python is
+    running in is set up incorrectly.
+
+    Raises a ``TypeError`` if the input is not a byte string.
+    '''
+    if not isinstance(p, str):
+        raise TypeError(u'Can only decode str, not {}'.format(type(p)))
+    return p.decode(_FILESYSTEM_ENCODING)

--- a/ckan/lib/munge.py
+++ b/ckan/lib/munge.py
@@ -9,6 +9,17 @@ import re
 import os.path
 
 from ckan import model
+from ckan.lib.io import decode_path
+
+
+# Maximum length of a filename's extension (including the '.')
+MAX_FILENAME_EXTENSION_LENGTH = 21
+
+# Maximum total length of a filename (including extension)
+MAX_FILENAME_TOTAL_LENGTH = 100
+
+# Minimum total length of a filename (including extension)
+MIN_FILENAME_TOTAL_LENGTH = 3
 
 
 def munge_name(name):
@@ -134,22 +145,27 @@ def munge_filename(filename):
 
     Keeps the filename extension (e.g. .csv).
     Strips off any path on the front.
-    '''
 
-    # just get the filename ignore the path
-    path, filename = os.path.split(filename)
-    # clean up
-    filename = substitute_ascii_equivalents(filename)
+    Returns a Unicode string.
+    '''
+    if not isinstance(filename, unicode):
+        filename = decode_path(filename)
+
+    # Ignore path
+    filename = os.path.split(filename)[1]
+
+    # Clean up
     filename = filename.lower().strip()
-    filename = re.sub(r'[^a-zA-Z0-9_. -]', '', filename).replace(' ', '-')
-    # resize if needed but keep extension
+    filename = substitute_ascii_equivalents(filename)
+    filename = re.sub(ur'[^a-zA-Z0-9_. -]', '', filename).replace(u' ', u'-')
+    filename = re.sub(ur'-+', u'-', filename)
+
+    # Enforce length constraints
     name, ext = os.path.splitext(filename)
-    # limit overly long extensions
-    if len(ext) > 21:
-        ext = ext[:21]
-    # max/min size
-    ext_length = len(ext)
-    name = _munge_to_length(name, max(3 - ext_length, 1), 100 - ext_length)
+    ext = ext[:MAX_FILENAME_EXTENSION_LENGTH]
+    ext_len = len(ext)
+    name = _munge_to_length(name, max(1, MIN_FILENAME_TOTAL_LENGTH - ext_len),
+                            MAX_FILENAME_TOTAL_LENGTH - ext_len)
     filename = name + ext
 
     return filename

--- a/ckan/tests/lib/test_io.py
+++ b/ckan/tests/lib/test_io.py
@@ -1,0 +1,41 @@
+# encoding: utf-8
+
+import io
+import os.path
+import shutil
+import tempfile
+
+from nose.tools import eq_, ok_, raises
+
+import ckan.lib.io as ckan_io
+
+
+class TestDecodeEncodePath(object):
+
+    @raises(TypeError)
+    def test_decode_path_fails_for_unicode(self):
+        ckan_io.decode_path(u'just_a_unicode')
+
+    @raises(TypeError)
+    def test_encode_path_fails_for_str(self):
+        ckan_io.encode_path(b'just_a_str')
+
+    def test_decode_path_returns_unicode(self):
+        ok_(isinstance(ckan_io.decode_path(b'just_a_str'), unicode))
+
+    def test_encode_path_returns_str(self):
+        ok_(isinstance(ckan_io.encode_path(u'just_a_unicode'), str))
+
+    def test_decode_encode_path(self):
+        temp_dir = ckan_io.decode_path(tempfile.mkdtemp())
+        try:
+            filename = u'\xf6\xe4\xfc.txt'
+            path = os.path.join(temp_dir, filename)
+            with io.open(ckan_io.encode_path(path), u'w',
+                         encoding=u'utf-8') as f:
+                f.write(u'foo')
+            # Force str return type
+            filenames = os.listdir(ckan_io.encode_path(temp_dir))
+            eq_(ckan_io.decode_path(filenames[0]), filename)
+        finally:
+            shutil.rmtree(temp_dir)

--- a/ckan/tests/lib/test_munge.py
+++ b/ckan/tests/lib/test_munge.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-from nose.tools import assert_equal
+from nose.tools import assert_equal, ok_
 
 from ckan.lib.munge import (munge_filename_legacy, munge_filename, munge_name,
                             munge_title_to_name, munge_tag)
@@ -57,6 +57,7 @@ class TestMungeFilename(object):
         ('path/to/file.csv', 'file.csv'),
         ('.longextension', '.longextension'),
         ('a.longextension', 'a.longextension'),
+        ('a.now_that_extension_is_too_long', 'a.now_that_extension_i'),
         ('.1', '.1_'),
     ]
 
@@ -65,6 +66,7 @@ class TestMungeFilename(object):
         for org, exp in self.munge_list:
             munge = munge_filename(org)
             assert_equal(munge, exp)
+            ok_(isinstance(munge, unicode))
 
     def test_munge_filename_multiple_pass(self):
         '''Munging filename multiple times produces same result.'''


### PR DESCRIPTION
This is work for #3006.

The PR updates the documentation with information on how to deal with Unicode filenames. It also adds two helper functions (`decode_path` and `encode_path`) for easy handling of byte string filenames.

Since our Unicode documentation has a normative character this PR also is a good time to discuss whether we want to handle Unicode filenames that way.