### PR TITLE
Fix broken link to Google's Python style guide

### DIFF
--- a/doc/contributing/python.rst
+++ b/doc/contributing/python.rst
@@ -9,7 +9,7 @@ For Python code style follow `PEP 8`_ plus the guidelines below.
 Some good links about Python code style:
 
 - `Guide to Python <http://docs.python-guide.org/en/latest/writing/style/>`_ from Hitchhiker's
-- `Google Python Style Guide <http://google-styleguide.googlecode.com/svn/trunk/pyguide.html>`_
+- `Google Python Style Guide <https://google.github.io/styleguide/pyguide.html>`_
 
 .. seealso::
 


### PR DESCRIPTION
Fixes #3137 3137

### Proposed fixes

repairs broken link to Google Python Style Guide



### Features:

- [X] includes updated documentation
