### PR TITLE
Change all example uses of domain names to be RFC compliant special-use names

### DIFF
--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -166,11 +166,11 @@ ckan.hide_activity_from_users = %(ckan.site_id)s
 
 ## Email settings
 
-#email_to = you@yourdomain.com
-#error_email_from = paste@localhost
+#email_to = errors@example.com
+#error_email_from = ckan-errors@example.com
 #smtp.server = localhost
 #smtp.starttls = False
-#smtp.user = your_username@gmail.com
+#smtp.user = username@example.com
 #smtp.password = your_password
 #smtp.mail_from =
 

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -1775,7 +1775,7 @@ smtp.server
 
 Example::
 
-  smtp.server = smtp.gmail.com:587
+  smtp.server = smtp.example.com:587
 
 Default value: ``None``
 
@@ -1801,7 +1801,7 @@ smtp.user
 
 Example::
 
-  smtp.user = your_username@gmail.com
+  smtp.user = username@example.com
 
 Default value: ``None``
 
@@ -1827,7 +1827,7 @@ smtp.mail_from
 
 Example::
 
-  smtp.mail_from = you@yourdomain.com
+  smtp.mail_from = ckan@example.com
 
 Default value: ``None``
 
@@ -1841,7 +1841,7 @@ email_to
 
 Example::
 
-  email_to = you@yourdomain.com
+  email_to = errors@example.com
 
 Default value: ``None``
 
@@ -1854,7 +1854,7 @@ error_email_from
 
 Example::
 
-  error_email_from = paste@localhost
+  error_email_from = ckan-errors@example.com
 
 Default value: ``None``
 

--- a/test.ini
+++ b/test.ini
@@ -6,9 +6,9 @@
 [DEFAULT]
 debug = true
 # Uncomment and replace with the address which should receive any error reports
-#email_to = you@yourdomain.com
+#email_to = errors@example.com
 smtp_server = localhost
-error_email_from = paste@localhost
+error_email_from = ckan-errors@example.com
 
 [server:main]
 use = egg:Paste#http


### PR DESCRIPTION
Hi CKAN devs,

We discovered a local installation of your software clogging up our mail queues with undeliverable messages, due apparently to a live domain being used in example configurations and documentation.

This pull request updates all instances we spotted in the sample configuration and documentation where live example domain names are given, and replaces them with "example.com", a domain reserved explicitly for this purpose.

As described in RFC 2606 and RFC 6761, a number of domains such as example.com and example.org are maintained for documentation use, without prior coordination with the IANA.

-Michael