### PR TITLE
Improve JavaScript i18n documentation.

### DIFF
--- a/doc/contributing/frontend/index.rst
+++ b/doc/contributing/frontend/index.rst
@@ -185,9 +185,8 @@ Modules
 Modules are the core of the CKAN website, every component that is
 interactive on the page should be a module. These are then initialized
 by including a ``data-module`` attribute on an element on the page. For
-example:
+example::
 
-::
     <select name="format" data-module="autocomplete"></select>
 
 The idea is to create small isolated components that can easily be
@@ -331,39 +330,7 @@ useful in the future.
 Internationalization
 ====================
 
-All strings within modules should be internationalized. Strings can be
-set in the ``options.i18n`` object and there is a ``.i18n()`` helper for
-retrieving them.
-
-::
-
-    ckan.module('language-picker', function (jQuery, _) {
-      return {
-        options: {
-          i18n: {
-            hello_1: _('Hello'),
-            hello_2: _('Hello %(name)s'),
-            apples: function (params) {
-              var n = params.num;
-              return _('I have %(num)d apple').isPlural(n, 'I have %(num)d apples');
-            }
-          }
-        },
-        initialize: function () {
-          // Standard example
-          this.i18n('hello_1'); // "Hello"
-
-          // String interpolation example
-          var name = 'Dave';
-          this.i18n('hello_2', {name: name}); // "Hello Dave"
-
-          // Plural example
-          var total = 1;
-          this.i18n('apples', {num: total}); // "I have 1 apple"
-          this.i18n('apples', {num: 3});     // "I have 3 apples"
-        }
-      }
-    });
+See :ref:`javascript_i18n`.
 
 
 jQuery plugins

--- a/doc/contributing/frontend/javascript-module-tutorial.rst
+++ b/doc/contributing/frontend/javascript-module-tutorial.rst
@@ -106,34 +106,30 @@ functionality elsewhere.
       this.sandbox.client.favoriteDataset(this.button.val());
     }
 
-Notifications and Internationalisation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Internationalisation
+~~~~~~~~~~~~~~~~~~~~
+See :ref:`javascript_i18n`.
+
+
+Notifications
+~~~~~~~~~~~~~
 
 This submits the dataset to the API but ideally we want to tell the user
 what we're doing.
 
-::
+.. code-block:: javascript
 
-    options: {
-      i18n: {
-        loading: _('Favouriting dataset'),
-        done: _('Favourited dataset %(id)s')
-      }
-    },
     favorite: function () {
-      // i18n gets a translation key from the options object.
-      this.button.text(this.i18n('loading'));
+      this.button.text('Loading');
 
       // The client on the sandbox should always be used to talk to the api.
       var request = this.sandbox.client.favoriteDataset(this.button.val())
       request.done(jQuery.proxy(this._onSuccess, this));
     },
     _onSuccess: function () {
-      // We can perform interpolation on messages.
-      var message = this.i18n('done', {id: this.button.val()});
-
       // Notify allows global messages to be displayed to the user.
-      this.sandbox.notify(message, 'success');
+      this.sandbox.notify('Done', 'success');
     }
 
 Options

--- a/doc/extensions/translating-extensions.rst
+++ b/doc/extensions/translating-extensions.rst
@@ -163,3 +163,13 @@ implement the ``ITranslation`` interface yourself.
    ~ckan.plugins.interfaces.ITranslation.i18n_directory
    ~ckan.plugins.interfaces.ITranslation.i18n_locales
    ~ckan.plugins.interfaces.ITranslation.i18n_domain
+
+----------
+JavaScript
+----------
+Extensions currently `cannot provide their own translations for JavaScript
+strings <https://github.com/ckan/ideas-and-roadmap/issues/176>`_.
+
+However, they can re-use existing JavaScript translations from CKAN. See
+:ref:`javascript_i18n` for details.
+

--- a/doc/theming/javascript-module-objects-and-methods.rst
+++ b/doc/theming/javascript-module-objects-and-methods.rst
@@ -23,6 +23,8 @@ module to use, including:
   document traversal and manipulation, event handling, and animation. See
   `jQuery's own docs <http://jquery.com/>`_ for details.
 
+.. _this_sandbox:
+
 * :js:data:`this.sandbox`, an object containing useful functions for all
   modules to use, including:
 

--- a/doc/theming/javascript.rst
+++ b/doc/theming/javascript.rst
@@ -1,3 +1,5 @@
+.. _javascript_modules:
+
 =============================
 Customizing CKAN's JavaScript
 =============================
@@ -521,10 +523,7 @@ clicked it turns green:
 Internationalization
 --------------------
 
-.. todo::
-
-   Show how to Internationalize a JavaScript module.
-
+See :ref:`javascript_i18n`.
 
 --------------------------
 Testing JavaScript modules


### PR DESCRIPTION
Reorganizes the existing documentation in a single place that is linked to from related topics. Also adds more details, for example regarding `paster trans js`.