### PR TITLE
Defining 'count' for search_form snippet

### DIFF
--- a/ckan/templates/organization/bulk_process.html
+++ b/ckan/templates/organization/bulk_process.html
@@ -98,7 +98,7 @@
             (_('Name Descending'), 'title_string desc'),
             (_('Last Modified'), 'data_modified desc') ]
           %}
-          {% snippet 'snippets/search_form.html', form_id='organization-datasets-search-form', type='dataset', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, no_title=true, search_class=' ' %}
+          {% snippet 'snippets/search_form.html', form_id='organization-datasets-search-form', type='dataset', query=c.q, count=c.page.item_count, sorting=sorting, sorting_selected=c.sort_by_selected, no_title=true, search_class=' ' %}
         {% endblock %}
 
         {#{% snippet 'snippets/simple_search.html', q=c.q, sort=c.sort_by_selected, placeholder=_('Search datasets...'), extra_sort=[(_('Last Modified'), 'data_modified asc')], input_class='search-normal', form_class='search-aside' %}#}


### PR DESCRIPTION
Fixes #

### Proposed fixes:

Parameter 'count' was not defined as an input for search_form snippet. 
The template bulk_process was getting an UndefinedError from within the snippet. 
I included this parameter and the error was fixed in my case.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply