### PR TITLE
`q` parameter in followee_list action has no effect

### DIFF
--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -522,7 +522,8 @@ def default_create_activity_schema():
 
 def default_follow_user_schema():
     schema = {'id': [not_missing, not_empty, unicode,
-                     convert_user_name_or_id_to_id]}
+                     convert_user_name_or_id_to_id],
+              'q': [ignore_missing]}
     return schema
 
 

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -2018,3 +2018,46 @@ class TestMembersList():
                                           capacity='member')
 
         eq(len(org_members), 0)
+
+
+class TestFollow(helpers.FunctionalTestBase):
+
+    def test_followee_list(self):
+
+        group1 = factories.Group(title='Finance')
+        group2 = factories.Group(title='Environment')
+        group3 = factories.Group(title='Education')
+
+        user = factories.User()
+
+        context = {'user': user['name']}
+
+        helpers.call_action('follow_group', context, id=group1['id'])
+        helpers.call_action('follow_group', context, id=group2['id'])
+
+        followee_list = helpers.call_action('followee_list', context,
+                                            id=user['name'])
+
+        eq(len(followee_list), 2)
+        eq(sorted([f['display_name'] for f in followee_list]),
+           ['Environment', 'Finance'])
+
+    def test_followee_list_with_q(self):
+
+        group1 = factories.Group(title='Finance')
+        group2 = factories.Group(title='Environment')
+        group3 = factories.Group(title='Education')
+
+        user = factories.User()
+
+        context = {'user': user['name']}
+
+        helpers.call_action('follow_group', context, id=group1['id'])
+        helpers.call_action('follow_group', context, id=group2['id'])
+
+        followee_list = helpers.call_action('followee_list', context,
+                                            id=user['name'],
+                                            q='E')
+
+        eq(len(followee_list), 1)
+        eq(followee_list[0]['display_name'], 'Environment')


### PR DESCRIPTION
The data_dict for `followee_list` was validated using `default_follow_user_schema`, which didn't have validators for `q`, so the data_dict ended up like:

```
{'__extras': {'q': u'Environment}, 'id': u'6cdc2a4c-2814-4a29-98f4-98eb73773984'}
```

Added `q` to the schema and a couple of tests