### PR TITLE
Update helpers.py

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1880,6 +1880,8 @@ def format_resource_items(items):
                 value = formatters.localised_number(float(value))
             elif re.search(reg_ex_int, value):
                 value = formatters.localised_number(int(value))
+        elif isinstance(value, bool):
+            continue
         elif ((isinstance(value, int) or isinstance(value, float))
                 and value not in (True, False)):
             value = formatters.localised_number(value)


### PR DESCRIPTION
Fixes #
### Proposed fixes:
### Features:
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply

Quick fix on a nasty bug (which only really had effect after I pip install --upgrade Babel actually, I don't really understand why). 
As Python considers that boolean values are instances of Int (because before boolean types were introduced they were actuel integers) a test should be done on the specific boolean type BEFORE it is tested against integer type, to avoid sending a boolean value like 'True' to a decimal formatter. I don't know which formatter to use instead, so I just "continue" here, without using any localized representation of boolean values.
