### PR TITLE
Fix - better exception for when bad smtp settings.

### DIFF
--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 import smtplib
+import socket
 import logging
 import uuid
 from time import time
@@ -56,7 +57,13 @@ def _mail_recipient(recipient_name, recipient_email,
             config.get('smtp.starttls'))
         smtp_user = config.get('smtp.user')
         smtp_password = config.get('smtp.password')
-    smtp_connection.connect(smtp_server)
+
+    try:
+        smtp_connection.connect(smtp_server)
+    except socket.error, e:
+        log.exception(e)
+        raise MailerException('SMTP server could not be connected to: "%s" %s'
+                              % (smtp_server, e))
     try:
         # Identify ourselves and prompt the server for supported features.
         smtp_connection.ehlo()

--- a/ckan/tests/lib/test_mailer.py
+++ b/ckan/tests/lib/test_mailer.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-from nose.tools import assert_equal, assert_raises, assert_in
+from nose.tools import assert_equal, assert_raises, assert_in, assert_raises
 from email.mime.text import MIMEText
 from email.parser import Parser
 from email.header import decode_header
@@ -223,3 +223,13 @@ class TestMailer(MailerBase):
         body = self.get_email_body(msg[3])
         assert_in(org['title'], body)
         assert_in(h.roles_translated()[role], body)
+
+    @helpers.change_config('smtp.test_server', '999.999.999.999')
+    def test_bad_smtp_host(self):
+        test_email = {'recipient_name': 'Bob',
+                      'recipient_email': 'b@example.com',
+                      'subject': 'Meeting',
+                      'body': 'The meeting is cancelled.',
+                      'headers': {'header1': 'value1'}}
+        assert_raises(mailer.MailerException,
+                      mailer.mail_recipient, **test_email)


### PR DESCRIPTION
Improve error message when smtp server is not configured correctly. Before this, they just see an uncaught socket exception merely saying: "[Errno 111] Connection refused" when an email tries to be sent.

This was seen on by a user of the issues extension: https://github.com/ckan/ckanext-issues/issues/63#issuecomment-234525736