### PR TITLE
CKAN 2.5 tests and source install fail due to unpinned html5lib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ bleach==1.4.2
 decorator==4.0.4          # via pylons, sqlalchemy-migrate
 fanstatic==0.12
 formencode==1.3.0         # via pylons
+html5lib==0.9999999       # via bleach
 Genshi==0.6
 Jinja2==2.6
 mako==1.0.2               # via pylons


### PR DESCRIPTION
html5lib in 2.5 was not pinned in requirements.txt for some reason. This backports the version pinned on master at the moment