### PR TITLE
Dataset permission labels

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -294,13 +294,12 @@ class GroupController(base.BaseController):
                     else:
                         search_extras[param] = value
 
-            fq = 'capacity:"public"'
+            include_private = False
             user_member_of_orgs = [org['id'] for org
                                    in h.organizations_available('read')]
 
             if (c.group and c.group.id in user_member_of_orgs):
-                fq = ''
-                context['ignore_capacity_check'] = True
+                include_private = True
 
             facets = OrderedDict()
 
@@ -327,7 +326,8 @@ class GroupController(base.BaseController):
 
             data_dict = {
                 'q': q,
-                'fq': fq,
+                'fq': '',
+                'include_private': include_private,
                 'facet.field': facets.keys(),
                 'rows': limit,
                 'sort': sort_by,

--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -2367,6 +2367,7 @@ Not used when using the `-d` option.''')
             'q': '',
             'fq': '',
             'fq_list': [],
+            'include_private': True,
             'rows': n,
             'start': n * (page - 1),
         }
@@ -2390,8 +2391,7 @@ Not used when using the `-d` option.''')
             search_data_dict['q'] = '*:*'
 
         query = p.toolkit.get_action('package_search')(
-            {'ignore_capacity_check': True},
-            search_data_dict)
+            {}, search_data_dict)
 
         return query
 

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -386,7 +386,7 @@ def group_dictize(group, context,
                     authz.has_user_permission_for_group_or_org(
                         group_.id, context.get('user'), 'read'))
                 if is_group_member:
-                    context['ignore_capacity_check'] = True
+                    q['include_private'] = True
 
             if not just_the_count:
                 # Is there a packages limit in the context?

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -1192,10 +1192,10 @@ class TestPackageSearch(helpers.FunctionalTestBase):
         nose.tools.assert_true(dataset['name'] not in names)
         nose.tools.assert_true(draft_dataset['name'] in names)
 
-    def test_package_search_private_with_ignore_capacity_check(self):
+    def test_package_search_private_with_include_private(self):
         '''
         package_search() can return private datasets when
-        `ignore_capacity_check` present in context.
+        `include_private=True`
         '''
         user = factories.User()
         org = factories.Organization(user=user)
@@ -1204,9 +1204,10 @@ class TestPackageSearch(helpers.FunctionalTestBase):
         factories.Dataset(user=user, state='draft')
         private_dataset = factories.Dataset(user=user, private=True, owner_org=org['name'])
 
-        fq = '+capacity:"private"'
-        results = helpers.call_action('package_search', fq=fq,
-                                      context={'ignore_capacity_check': True})['results']
+        results = helpers.call_action(
+            'package_search',
+            include_private=True,
+            context={'user': user['name']})['results']
 
         eq(len(results), 1)
         eq(results[0]['name'], private_dataset['name'])


### PR DESCRIPTION
This is a suggested change to the dataset view permissions.

At the moment we return only public datasets from `package_search` #3176 and `package_list`. Private datasets are visible from the front end on the organization page if you're a member of the organization (unless the controller has been overridden). If you know the dataset names or ids with `package_show` (unless the package_show auth function has been overridden).

Users might never find out about datasets they have permission to view e.g. if they only use the API, if they don't know the correct org to search or if search controller is overridden. Users might see datasets listed in an organization search page that they are prevented from viewing if the package_show auth function doesn't match logic in search controller.

Let's deprecate customizing the package_show auth function and replace it with permission labels in the search index.

We implement our current permissions by adding `permission_labels = [pkg.owner_org]` to the search index for private datasets, and `permission_labels = ['public']` for public datasets. For non-sysadmins `package_search` will call a new plugin interface to get a list of permission labels for the search. By default that interface will return `'public'` and the UUID of organizations the current user is a member of.

CKAN plugins would be able to implement that new interface and override before_index to set their own permission labels. This scheme should cover many types of permission business logic, including full 1:1 user permissions for viewing datasets.