### PR TITLE
package_search include_private flag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,10 @@ v2.6.0 TBA
 API changes and deprecations:
  * Replace `c.__version__` with new helper `h.ckan_version()` (#3103)
 
+Major:
+ * Private datasets are now included in the default dataset search results (#3191)
+ * package_search API action now has an include_private parameter (#3191)
+
 v2.5.2 2016-03-31
 =================
 

--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -294,13 +294,12 @@ class GroupController(base.BaseController):
                     else:
                         search_extras[param] = value
 
-            fq = 'capacity:"public"'
+            include_private = False
             user_member_of_orgs = [org['id'] for org
                                    in h.organizations_available('read')]
 
             if (c.group and c.group.id in user_member_of_orgs):
-                fq = ''
-                context['ignore_capacity_check'] = True
+                include_private = True
 
             facets = OrderedDict()
 
@@ -327,7 +326,8 @@ class GroupController(base.BaseController):
 
             data_dict = {
                 'q': q,
-                'fq': fq,
+                'fq': '',
+                'include_private': include_private,
                 'facet.field': facets.keys(),
                 'rows': limit,
                 'sort': sort_by,

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -264,7 +264,9 @@ class PackageController(base.BaseController):
                 'rows': limit,
                 'start': (page - 1) * limit,
                 'sort': sort_by,
-                'extras': search_extras
+                'extras': search_extras,
+                'include_private': asbool(config.get(
+                    'ckan.search.default_include_private', True)),
             }
 
             query = get_action('package_search')(context, data_dict)

--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -2367,6 +2367,7 @@ Not used when using the `-d` option.''')
             'q': '',
             'fq': '',
             'fq_list': [],
+            'include_private': True,
             'rows': n,
             'start': n * (page - 1),
         }
@@ -2390,8 +2391,7 @@ Not used when using the `-d` option.''')
             search_data_dict['q'] = '*:*'
 
         query = p.toolkit.get_action('package_search')(
-            {'ignore_capacity_check': True},
-            search_data_dict)
+            {}, search_data_dict)
 
         return query
 

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -386,7 +386,7 @@ def group_dictize(group, context,
                     authz.has_user_permission_for_group_or_org(
                         group_.id, context.get('user'), 'read'))
                 if is_group_member:
-                    context['ignore_capacity_check'] = True
+                    q['include_private'] = True
 
             if not just_the_count:
                 # Is there a packages limit in the context?

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1711,6 +1711,10 @@ def package_search(context, data_dict):
         sysadmin will be returned all draft datasets. Optional, the default is
         ``False``.
     :type include_drafts: boolean
+    :param include_private: if ``True``, private datasets will be included in
+        the results. Only private datasets from the user's organizations will
+        be returned and sysadmins will be returned all private datasets.
+        Optional, the default is ``False``.
     :param use_default_schema: use default package schema instead of
         a custom schema defined with an IDatasetForm plugin (default: False)
     :type use_default_schema: bool

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1836,7 +1836,7 @@ def package_search(context, data_dict):
             capacity_fq = None
         elif include_private and user:
             orgs = logic.get_action('organization_list_for_user')(
-                {'user': user}, {'permission': 'member'})
+                {'user': user}, {'permission': 'read'})
             if orgs:
                 capacity_fq = '({0} OR owner_org:({1}))'.format(
                     capacity_fq,

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -1586,7 +1586,6 @@ class TestSearch(helpers.FunctionalTestBase):
         assert_equal([n.string for n in ds_titles], ['A private dataset'])
 
 
-
 class TestPackageFollow(helpers.FunctionalTestBase):
 
     def test_package_follow(self):

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -418,12 +418,6 @@ class TestPackageNew(helpers.FunctionalTestBase):
 
 
 class TestPackageEdit(helpers.FunctionalTestBase):
-    @classmethod
-    def setup_class(cls):
-        super(cls, cls).setup_class()
-        helpers.reset_db()
-        search.clear_all()
-
     def test_organization_admin_can_edit(self):
         user = factories.User()
         organization = factories.Organization(
@@ -563,14 +557,6 @@ class TestPackageEdit(helpers.FunctionalTestBase):
 
 
 class TestPackageRead(helpers.FunctionalTestBase):
-    @classmethod
-    def setup_class(cls):
-        super(cls, cls).setup_class()
-        helpers.reset_db()
-
-    def setup(self):
-        model.repo.rebuild_db()
-
     def test_read(self):
         dataset = factories.Dataset()
         app = helpers._get_test_app()
@@ -1018,9 +1004,6 @@ class TestResourceView(helpers.FunctionalTestBase):
 
         helpers.reset_db()
 
-    def setup(self):
-        model.repo.rebuild_db()
-
     @classmethod
     def teardown_class(cls):
         p.unload('image_view')
@@ -1062,15 +1045,6 @@ class TestResourceView(helpers.FunctionalTestBase):
 
 
 class TestResourceRead(helpers.FunctionalTestBase):
-    @classmethod
-    def setup_class(cls):
-        super(TestResourceRead, cls).setup_class()
-        helpers.reset_db()
-        search.clear_all()
-
-    def setup(self):
-        model.repo.rebuild_db()
-
     def test_existing_resource_with_not_associated_dataset(self):
 
         dataset = factories.Dataset()
@@ -1329,11 +1303,6 @@ class TestResourceDelete(helpers.FunctionalTestBase):
 
 
 class TestSearch(helpers.FunctionalTestBase):
-    @classmethod
-    def setup_class(cls):
-        super(cls, cls).setup_class()
-        helpers.reset_db()
-
     def test_search_basic(self):
         dataset1 = factories.Dataset()
 

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -1210,6 +1210,33 @@ class TestPackageSearch(helpers.FunctionalTestBase):
 
         eq([r['name'] for r in results], [private_dataset['name']])
 
+    def test_package_search_private_with_include_private_wont_show_other_orgs_private(self):
+        user = factories.User()
+        user2 = factories.User()
+        org = factories.Organization(user=user)
+        org2 = factories.Organization(user=user2)
+        private_dataset = factories.Dataset(user=user2, private=True, owner_org=org2['name'])
+
+        results = helpers.call_action(
+            'package_search',
+            include_private=True,
+            context={'user': user['name']})['results']
+
+        eq([r['name'] for r in results], [])
+
+    def test_package_search_private_with_include_private_syadmin(self):
+        user = factories.User()
+        sysadmin = factories.Sysadmin()
+        org = factories.Organization(user=user)
+        private_dataset = factories.Dataset(user=user, private=True, owner_org=org['name'])
+
+        results = helpers.call_action(
+            'package_search',
+            include_private=True,
+            context={'user': sysadmin['name']})['results']
+
+        eq([r['name'] for r in results], [private_dataset['name']])
+
     def test_package_works_without_user_in_context(self):
         '''
         package_search() should work even if user isn't in the context (e.g.

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -1199,7 +1199,6 @@ class TestPackageSearch(helpers.FunctionalTestBase):
         '''
         user = factories.User()
         org = factories.Organization(user=user)
-        factories.Dataset(user=user)
         factories.Dataset(user=user, state='deleted')
         factories.Dataset(user=user, state='draft')
         private_dataset = factories.Dataset(user=user, private=True, owner_org=org['name'])
@@ -1209,8 +1208,7 @@ class TestPackageSearch(helpers.FunctionalTestBase):
             include_private=True,
             context={'user': user['name']})['results']
 
-        eq(len(results), 1)
-        eq(results[0]['name'], private_dataset['name'])
+        eq([r['name'] for r in results], [private_dataset['name']])
 
     def test_package_works_without_user_in_context(self):
         '''

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -1192,10 +1192,10 @@ class TestPackageSearch(helpers.FunctionalTestBase):
         nose.tools.assert_true(dataset['name'] not in names)
         nose.tools.assert_true(draft_dataset['name'] in names)
 
-    def test_package_search_private_with_ignore_capacity_check(self):
+    def test_package_search_private_with_include_private(self):
         '''
         package_search() can return private datasets when
-        `ignore_capacity_check` present in context.
+        `include_private=True`
         '''
         user = factories.User()
         org = factories.Organization(user=user)
@@ -1204,9 +1204,10 @@ class TestPackageSearch(helpers.FunctionalTestBase):
         factories.Dataset(user=user, state='draft')
         private_dataset = factories.Dataset(user=user, private=True, owner_org=org['name'])
 
-        fq = '+capacity:"private"'
-        results = helpers.call_action('package_search', fq=fq,
-                                      context={'ignore_capacity_check': True})['results']
+        results = helpers.call_action(
+            'package_search',
+            include_private=True,
+            context={'user': user['name']})['results']
 
         eq(len(results), 1)
         eq(results[0]['name'], private_dataset['name'])

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -655,6 +655,21 @@ Default value:  ``false``
 Controls whether the default search page (``/dataset``) should show only
 standard datasets or also custom dataset types.
 
+.. _ckan.search.default_include_private:
+
+ckan.search.default_include_private
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+ ckan.search.defalt_include_private = false
+
+Default value:  ``true``
+
+Controls whether the default search page (``/dataset``) should include
+private datasets visible to the current user or only public datasets
+visible to everyone.
+
 .. _search.facets.limit:
 
 search.facets.limit


### PR DESCRIPTION
Proposed fix for #3176 

Stop using a context variable in package_show to return private datasets (only works from inside ckan), instead allow users to pass `include_private=True` to have all datasets they have permission to see returned.

This is essentially what is already allowed when users browse to the organzation search page *unless* there's a customised package_show auth function. In that case we might be exposing more information than was available earlier (users can get the whole dataset metadata not just what's seen in search results). We'll have to change the way permissions on datasets are defined to fix that issue, see: #3192 for next steps.