### PR TITLE
Bulk operations don't update the package_revision table

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -1093,6 +1093,7 @@ def _bulk_update_dataset(context, data_dict, update_dict):
     model.Session.query(model.package_revision_table) \
         .filter(model.PackageRevision.id.in_(datasets)) \
         .filter(model.PackageRevision.owner_org == org_id) \
+        .filter(model.PackageRevision.current is True) \
         .update(update_dict, synchronize_session=False)
 
     model.Session.commit()

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -1084,16 +1084,15 @@ def _bulk_update_dataset(context, data_dict, update_dict):
     org_id = data_dict.get('org_id')
 
     model = context['model']
-
     model.Session.query(model.package_table) \
         .filter(model.Package.id.in_(datasets)) \
         .filter(model.Package.owner_org == org_id) \
         .update(update_dict, synchronize_session=False)
 
     # revisions
-    model.Session.query(model.package_table) \
-        .filter(model.Package.id.in_(datasets)) \
-        .filter(model.Package.owner_org == org_id) \
+    model.Session.query(model.package_revision_table) \
+        .filter(model.PackageRevision.id.in_(datasets)) \
+        .filter(model.PackageRevision.owner_org == org_id) \
         .update(update_dict, synchronize_session=False)
 
     model.Session.commit()

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -14,7 +14,7 @@ import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
 from ckan import model
 
-assert_equals = nose.tools.assert_equals
+assert_equals = eq_ = nose.tools.assert_equals
 assert_raises = nose.tools.assert_raises
 
 
@@ -918,3 +918,99 @@ class TestPackageOwnerOrgUpdate(object):
                             organization_id=None)
         dataset_obj = model.Package.get(dataset['id'])
         assert dataset_obj.owner_org is None
+
+
+class TestBulkOperations(object):
+
+    @classmethod
+    def teardown_class(cls):
+        helpers.reset_db()
+
+    def setup(self):
+        helpers.reset_db()
+
+    def test_bulk_make_private(self):
+
+        org = factories.Organization()
+
+        dataset1 = factories.Dataset(owner_org=org['id'])
+        dataset2 = factories.Dataset(owner_org=org['id'])
+
+        helpers.call_action('bulk_update_private', {},
+                            datasets=[dataset1['id'], dataset2['id']],
+                            org_id=org['id'])
+
+        # Check search index
+        datasets = helpers.call_action('package_search', {},
+                                       q='owner_org:{0}'.format(org['id']))
+
+        for dataset in datasets['results']:
+            eq_(dataset['private'], True)
+
+        # Check DB
+        datasets = model.Session.query(model.Package) \
+            .filter(model.Package.owner_org == org['id']).all()
+        for dataset in datasets:
+            eq_(dataset.private, True)
+
+        revisions = model.Session.query(model.PackageRevision) \
+            .filter(model.PackageRevision.owner_org == org['id']).all()
+        for revision in revisions:
+            eq_(revision.private, True)
+
+    def test_bulk_make_public(self):
+
+        org = factories.Organization()
+
+        dataset1 = factories.Dataset(owner_org=org['id'], private=True)
+        dataset2 = factories.Dataset(owner_org=org['id'], private=True)
+
+        helpers.call_action('bulk_update_public', {},
+                            datasets=[dataset1['id'], dataset2['id']],
+                            org_id=org['id'])
+
+        # Check search index
+        datasets = helpers.call_action('package_search', {},
+                                       q='owner_org:{0}'.format(org['id']))
+
+        for dataset in datasets['results']:
+            eq_(dataset['private'], False)
+
+        # Check DB
+        datasets = model.Session.query(model.Package) \
+            .filter(model.Package.owner_org == org['id']).all()
+        for dataset in datasets:
+            eq_(dataset.private, False)
+
+        revisions = model.Session.query(model.PackageRevision) \
+            .filter(model.PackageRevision.owner_org == org['id']).all()
+        for revision in revisions:
+            eq_(revision.private, False)
+
+    def test_bulk_delete(self):
+
+        org = factories.Organization()
+
+        dataset1 = factories.Dataset(owner_org=org['id'])
+        dataset2 = factories.Dataset(owner_org=org['id'])
+
+        helpers.call_action('bulk_update_delete', {},
+                            datasets=[dataset1['id'], dataset2['id']],
+                            org_id=org['id'])
+
+        # Check search index
+        datasets = helpers.call_action('package_search', {},
+                                       q='owner_org:{0}'.format(org['id']))
+
+        eq_(datasets['results'], [])
+
+        # Check DB
+        datasets = model.Session.query(model.Package) \
+            .filter(model.Package.owner_org == org['id']).all()
+        for dataset in datasets:
+            eq_(dataset.state, 'deleted')
+
+        revisions = model.Session.query(model.PackageRevision) \
+            .filter(model.PackageRevision.owner_org == org['id']).all()
+        for revision in revisions:
+            eq_(revision.state, 'deleted')

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -954,7 +954,9 @@ class TestBulkOperations(object):
             eq_(dataset.private, True)
 
         revisions = model.Session.query(model.PackageRevision) \
-            .filter(model.PackageRevision.owner_org == org['id']).all()
+            .filter(model.PackageRevision.owner_org == org['id']) \
+            .filter(model.PackageRevision.current is True) \
+            .all()
         for revision in revisions:
             eq_(revision.private, True)
 
@@ -983,7 +985,9 @@ class TestBulkOperations(object):
             eq_(dataset.private, False)
 
         revisions = model.Session.query(model.PackageRevision) \
-            .filter(model.PackageRevision.owner_org == org['id']).all()
+            .filter(model.PackageRevision.owner_org == org['id']) \
+            .filter(model.PackageRevision.current is True) \
+            .all()
         for revision in revisions:
             eq_(revision.private, False)
 
@@ -1011,6 +1015,8 @@ class TestBulkOperations(object):
             eq_(dataset.state, 'deleted')
 
         revisions = model.Session.query(model.PackageRevision) \
-            .filter(model.PackageRevision.owner_org == org['id']).all()
+            .filter(model.PackageRevision.owner_org == org['id']) \
+            .filter(model.PackageRevision.current is True) \
+            .all()
         for revision in revisions:
             eq_(revision.state, 'deleted')


### PR DESCRIPTION
`bulk_update_private`, `bulk_update_public` and ``bulk_update_delete` change the `package` table and the search index but not the revision table, which causes the changes to not be reflected everywhere.

This fixes the model query and adds a bunch of tests.