### PR TITLE
Add git into package install

### DIFF
--- a/doc/maintaining/installing/install-from-package.rst
+++ b/doc/maintaining/installing/install-from-package.rst
@@ -27,9 +27,9 @@ CKAN:
 
     sudo apt-get update
 
-#. Install the Ubuntu packages that CKAN requires::
+#. Install the Ubuntu packages that CKAN requires (and 'git', to enable you to install CKAN extensions)::
 
-    sudo apt-get install -y nginx apache2 libapache2-mod-wsgi libpq5
+    sudo apt-get install -y nginx apache2 libapache2-mod-wsgi libpq5 git-core
 
 #. Download the CKAN package:
 


### PR DESCRIPTION
Git is added so that it is the same as the source install in this respect. You need git to install nearly all extensions. (Discussed in https://github.com/ckan/ckanext-harvest/issues/260 )