### PR TITLE
[#3151] Extractable plural translations in JavaScript

### DIFF
--- a/ckan/public/base/javascript/i18n.js
+++ b/ckan/public/base/javascript/i18n.js
@@ -1,3 +1,47 @@
+'use strict';
+
+/*
+ * CKAN JavaScript i18n functionality.
+ *
+ * Adds an `i18n` attribute to the CKAN object (`this.ckan`).
+ *
+ * Singular strings can be translated using `i18n._`:
+ *
+ *     ckan.i18n._('Hello, world!')
+ *
+ * The function will return the translated string in the currently selected
+ * language. Often, a translateable string contains dynamic parts, for example
+ * a username. These can be included via named `%`-placeholders:
+ *
+ *     ckan.i18n._('Hello, %(name)s!', {name: 'Jessica'})
+ *
+ * After translation the placeholders are replaced using the values passed in
+ * the second argument.
+ *
+ * Plural strings can be translated using `i18n.ngettext`:
+ *
+ *     ckan.i18n.ngettext('%(num)d item was deleted',
+ *                        '%(num)d items were deleted',
+ *                        num_items)
+ *
+ * Here, the first two arguments contain the singular and plural translation
+ * strings. The third argument contains the number which is used to decide
+ * whether the singular form or the plural form is to be used. The `num`
+ * placeholder is special in plural forms and will be replaced with the value
+ * of the third argument.
+ *
+ * As before your strings can contain additional placeholders, and you pass
+ * their values using another argument:
+ *
+ *     ckan.i18n.ngettext('%(name)s deleted %(num)d item',
+ *                        '%(name)s deleted %(num)d items',
+ *                        num_items,
+ *                        {name: 'Thomas'})
+ *
+ * Note that inside a CKAN JS module you can also use the shortcuts `this._`
+ * and `this.ngettext`.
+ */
+
 this.ckan = this.ckan || {};
 
 (function (ckan, jQuery, Jed) {
@@ -10,15 +54,26 @@ this.ckan = this.ckan || {};
     }
   };
 
-  ckan.i18n = new Jed({
+  var jed = new Jed({
     domain: 'ckan',
     locale_data: {
       ckan: domain
     }
   });
 
-  ckan.i18n.translate = jQuery.proxy(ckan.i18n.translate, ckan.i18n);
+  ckan.i18n = {};
 
+  /*
+   * Expose JED translation interface [DEPRECATED].
+   *
+   * Using the JED functions directly is deprecated and only kept for
+   * backwards-compatibility. Use `_` and `ngettext` instead.
+   */
+  ckan.i18n.translate = jQuery.proxy(jed.translate, jed);
+
+  /*
+   * Internal function to load a translation.
+   */
   ckan.i18n.load = function (data) {
     if (data && data['']) {
       // Extend our default domain data with the new keys.
@@ -26,11 +81,21 @@ this.ckan = this.ckan || {};
     }
   };
 
+  ckan.i18n._ = function (string, values) {
+    return jed.sprintf(jed.gettext(string), values || {});
+  };
+
+  ckan.i18n.ngettext = function(singular, plural, num, values) {
+    values = values || {};
+    values['num'] = num;
+    return jed.sprintf(jed.ngettext(singular, plural, num), values);
+  };
+
   ckan.sandbox.extend({
-    /* An alias for ckan.i18n */
+    /* An alias for ckan.i18n [DEPRECATED] */
     i18n: ckan.i18n,
 
-    /* An alias for ckan.l18n.translate() */
+    /* An alias for ckan.l18n.translate() [DEPRECATED] */
     translate: ckan.i18n.translate
   });
 })(this.ckan, this.jQuery, this.Jed);

--- a/ckan/public/base/javascript/modules/activity-stream.js
+++ b/ckan/public/base/javascript/modules/activity-stream.js
@@ -7,7 +7,7 @@
  * - id: what's the id of the context?
  * - offset: what's the current offset?
  */	
-this.ckan.module('activity-stream', function($, _) {
+this.ckan.module('activity-stream', function($) {
 	return {
 		/* options object can be extended using data-module-* attributes */
 		options : {
@@ -15,10 +15,7 @@ this.ckan.module('activity-stream', function($, _) {
 			id: null,
 			context: null,
 			offset: null,
-			loading: false,
-			i18n: {
-				loading: _('Loading...')
-			}
+			loading: false
 		},
 
 		/* Initialises the module setting up elements and event listeners.
@@ -97,7 +94,7 @@ this.ckan.module('activity-stream', function($, _) {
 			var options = this.options;
 			if (!options.loading) {
 				options.loading = true;
-				$('.load-more a', this.el).html(this.i18n('loading')).addClass('disabled');
+				$('.load-more a', this.el).html(this._('Loading...')).addClass('disabled');
 				this.sandbox.client.call('GET', options.context+'_activity_list_html', '?id='+options.id+'&offset='+options.offset, this._onActivitiesLoaded);
 			}
 		},

--- a/ckan/public/base/javascript/modules/api-info.js
+++ b/ckan/public/base/javascript/modules/api-info.js
@@ -8,18 +8,14 @@
  *   <a data-module="api-info" data-module-template="http://example.com/path/to/template">API</a>
  *
  */
-this.ckan.module('api-info', function (jQuery, _) {
+this.ckan.module('api-info', function (jQuery) {
   return {
 
     /* holds the loaded lightbox */
     modal: null,
 
     options: {
-      template: null,
-      i18n: {
-        noTemplate: _('There is no API data to load for this resource'),
-        loadError: _('Failed to load data API information')
-      }
+      template: null
     },
 
     /* Sets up the API info module.
@@ -97,7 +93,7 @@ this.ckan.module('api-info', function (jQuery, _) {
      */
     loadTemplate: function () {
       if (!this.options.template) {
-        this.sandbox.notify(this.i18n('noTemplate'));
+        this.sandbox.notify(this._('There is no API data to load for this resource'));
         return jQuery.Deferred().reject().promise();
       }
 
@@ -125,7 +121,7 @@ this.ckan.module('api-info', function (jQuery, _) {
     /* error handler when the template fails to load */
     _onTemplateError: function () {
       this.loading(false);
-      this.sandbox.notify(this.i18n('loadError'));
+      this.sandbox.notify(this._('Failed to load data API information'));
     }
   };
 });

--- a/ckan/public/base/javascript/modules/autocomplete.js
+++ b/ckan/public/base/javascript/modules/autocomplete.js
@@ -15,7 +15,7 @@
  *   // <input name="tags" data-module="autocomplete" data-module-source="http://" />
  *
  */
-this.ckan.module('autocomplete', function (jQuery, _) {
+this.ckan.module('autocomplete', function (jQuery) {
   return {
     /* Options for the module */
     options: {
@@ -26,15 +26,7 @@ this.ckan.module('autocomplete', function (jQuery, _) {
       source: null,
       interval: 1000,
       dropdownClass: '',
-      containerClass: '',
-      i18n: {
-        noMatches: _('No matches found'),
-        emptySearch: _('Start typing…'),
-        inputTooShort: function (data) {
-          return _('Input is too short, must be at least one character')
-          .ifPlural(data.min, 'Input is too short, must be at least %(min)d characters');
-        }
-      }
+      containerClass: ''
     },
 
     /* Sets up the module, binding methods, creating elements etc. Called
@@ -200,7 +192,7 @@ this.ckan.module('autocomplete', function (jQuery, _) {
      * Returns a text string.
      */
     formatNoMatches: function (term) {
-      return !term ? this.i18n('emptySearch') : this.i18n('noMatches');
+      return !term ? this._('Start typing…') : this._('No matches found');
     },
 
     /* Formatter used by the select2 plugin that returns a string when the
@@ -209,7 +201,11 @@ this.ckan.module('autocomplete', function (jQuery, _) {
      * Returns a string.
      */
     formatInputTooShort: function (term, min) {
-      return this.i18n('inputTooShort', {min: min});
+      return this.ngettext(
+        'Input is too short, must be at least one character',
+        'Input is too short, must be at least %(num)d characters',
+        min
+      );
     },
 
     /* Takes a string and converts it into an object used by the select2 plugin.

--- a/ckan/public/base/javascript/modules/basic-form.js
+++ b/ckan/public/base/javascript/modules/basic-form.js
@@ -1,7 +1,7 @@
-this.ckan.module('basic-form', function (jQuery, _) {
+this.ckan.module('basic-form', function (jQuery) {
   return {
     initialize: function () {
-      var message = _('There are unsaved modifications to this form').fetch();
+      var message = this._('There are unsaved modifications to this form');
       this.el.incompleteFormWarning(message);
       // Internet Explorer 7 fix for forms with <button type="submit">
       if ($('html').hasClass('ie7')) {

--- a/ckan/public/base/javascript/modules/confirm-action.js
+++ b/ckan/public/base/javascript/modules/confirm-action.js
@@ -1,14 +1,27 @@
-this.ckan.module('confirm-action', function (jQuery, _) {
+this.ckan.module('confirm-action', function (jQuery) {
   return {
     /* An object of module options */
     options: {
-      /* Locale options can be overidden with data-module-i18n attribute */
+      /* Content can be overriden by setting data-module-content to a
+       * *translated* string inside the template, e.g.
+       *
+       *     <a href="..."
+       *        data-module="confirm-action"
+       *        data-module-content="{{ _('Are you sure?') }}">
+       *    {{ _('Delete') }}
+       *    </a>
+       */
+      content: '',
+
+      /* This is part of the old i18n system and is kept for backwards-
+       * compatibility for templates which set the content via the
+       * `i18n.content` attribute instead of via the `content` attribute
+       * as described above.
+       */
       i18n: {
-        heading: _('Please Confirm Action'),
-        content: _('Are you sure you want to perform this action?'),
-        confirm: _('Confirm'),
-        cancel: _('Cancel')
+        content: '',
       },
+
       template: [
         '<div class="modal">',
         '<div class="modal-header">',
@@ -81,10 +94,13 @@ this.ckan.module('confirm-action', function (jQuery, _) {
         element.on('click', '.btn-cancel', this._onConfirmCancel);
         element.modal({show: false});
 
-        element.find('h3').text(this.i18n('heading'));
-        element.find('.modal-body').text(this.i18n('content'));
-        element.find('.btn-primary').text(this.i18n('confirm'));
-        element.find('.btn-cancel').text(this.i18n('cancel'));
+        element.find('h3').text(this._('Please Confirm Action'));
+        var content = this.options.content ||
+                      this.options.i18n.content || /* Backwards-compatibility */
+                      this._('Are you sure you want to perform this action?');
+        element.find('.modal-body').text(content);
+        element.find('.btn-primary').text(this._('Confirm'));
+        element.find('.btn-cancel').text(this._('Cancel'));
       }
       return this.modal;
     },

--- a/ckan/public/base/javascript/modules/custom-fields.js
+++ b/ckan/public/base/javascript/modules/custom-fields.js
@@ -4,7 +4,7 @@
  *
  * See the snippets/custom_form_fields.html for an example.
  */
-this.ckan.module('custom-fields', function (jQuery, _) {
+this.ckan.module('custom-fields', function (jQuery) {
   return {
     options: {
       /* The selector used for each custom field wrapper */

--- a/ckan/public/base/javascript/modules/dashboard.js
+++ b/ckan/public/base/javascript/modules/dashboard.js
@@ -7,7 +7,7 @@
  *   <div data-module="dashboard"></div>
  *
  */
-this.ckan.module('dashboard', function ($, _) {
+this.ckan.module('dashboard', function ($) {
   return {
     button: null,
     popover: null,

--- a/ckan/public/base/javascript/modules/dataset-visibility.js
+++ b/ckan/public/base/javascript/modules/dataset-visibility.js
@@ -2,7 +2,7 @@
  * When no organization is selected in the org dropdown then set visibility to
  * public always and disable dropdown
  */
-this.ckan.module('dataset-visibility', function ($, _) {
+this.ckan.module('dataset-visibility', function ($) {
   return {
     currentValue: false,
     options: {

--- a/ckan/public/base/javascript/modules/follow.js
+++ b/ckan/public/base/javascript/modules/follow.js
@@ -11,18 +11,14 @@
  *   <a data-module="follow" data-module-action="follow" data-module-type="user" data-module-id="{user_id}">Follow User</a>
  *
  */
-this.ckan.module('follow', function($, _) {
+this.ckan.module('follow', function($) {
 	return {
 		/* options object can be extended using data-module-* attributes */
 		options : {
 			action: null,
 			type: null,
 			id: null,
-			loading: false,
-			i18n: {
-				follow: _('Follow'),
-				unfollow: _('Unfollow')
-			}
+			loading: false
 		},
 
 		/* Initialises the module setting up elements and event listeners.
@@ -70,10 +66,10 @@ this.ckan.module('follow', function($, _) {
 			this.el.removeClass('disabled');
 			if (options.action == 'follow') {
 				options.action = 'unfollow';
-				this.el.html('<i class="icon-remove-sign"></i> ' + this.i18n('unfollow')).removeClass('btn-success').addClass('btn-danger');
+				this.el.html('<i class="icon-remove-sign"></i> ' + this._('Unfollow')).removeClass('btn-success').addClass('btn-danger');
 			} else {
 				options.action = 'follow';
-				this.el.html('<i class="icon-plus-sign"></i> ' + this.i18n('follow')).removeClass('btn-danger').addClass('btn-success');
+				this.el.html('<i class="icon-plus-sign"></i> ' + this._('Follow')).removeClass('btn-danger').addClass('btn-success');
 			}
 			sandbox.publish('follow-' + options.action + '-' + options.id);
 		}

--- a/ckan/public/base/javascript/modules/image-upload.js
+++ b/ckan/public/base/javascript/modules/image-upload.js
@@ -1,7 +1,7 @@
 /* Image Upload
  *
  */
-this.ckan.module('image-upload', function($, _) {
+this.ckan.module('image-upload', function($) {
   return {
     /* options object can be extended using data-module-* attributes */
     options: {
@@ -11,17 +11,7 @@ this.ckan.module('image-upload', function($, _) {
       field_url: 'image_url',
       field_clear: 'clear_upload',
       field_name: 'name',
-      upload_label: '',
-      i18n: {
-        upload: _('Upload'),
-        url: _('Link'),
-        remove: _('Remove'),
-        upload_label: _('Image'),
-        label_for_url: _('URL'),
-        label_for_upload: _('File'),
-        upload_tooltip: _('Upload a file on your computer'),
-        url_tooltip: _('Link to a URL on the internet (you can also link to an API)')
-      }
+      upload_label: ''
     },
 
     /* Should be changed to true if user modifies resource's name
@@ -65,30 +55,36 @@ this.ckan.module('image-upload', function($, _) {
         .appendTo(this.el);
 
       // Button to set the field to be a URL
-      this.button_url = $('<a href="javascript:;" class="btn"><i class="icon-globe"></i>'+this.i18n('url')+'</a>')
-        .prop('title', this.i18n('url_tooltip'))
+      this.button_url = $('<a href="javascript:;" class="btn">' +
+                          '<i class="icon-globe"></i>' +
+                          this._('Link') + '</a>')
+        .prop('title', this._('Link to a URL on the internet (you can also link to an API)'))
         .on('click', this._onFromWeb)
         .insertAfter(this.input);
 
       // Button to attach local file to the form
-      this.button_upload = $('<a href="javascript:;" class="btn"><i class="icon-cloud-upload"></i>'+this.i18n('upload')+'</a>')
+      this.button_upload = $('<a href="javascript:;" class="btn">' +
+                             '<i class="icon-cloud-upload"></i>' +
+                             this._('Upload') + '</a>')
         .insertAfter(this.input);
 
       // Button for resetting the form when there is a URL set
-      $('<a href="javascript:;" class="btn btn-danger btn-remove-url">'+this.i18n('remove')+'</a>')
-        .prop('title', this.i18n('remove'))
+      var removeText = this._('Remove');
+      $('<a href="javascript:;" class="btn btn-danger btn-remove-url">'
+        + removeText + '</a>')
+        .prop('title', removeText)
         .on('click', this._onRemove)
         .insertBefore(this.field_url_input);
 
       // Update the main label (this is displayed when no data/image has been uploaded/linked)
-      $('label[for="field-image-upload"]').text(options.upload_label || this.i18n('upload_label'));
+      $('label[for="field-image-upload"]').text(options.upload_label || this._('Image'));
 
       // Setup the file input
       this.input
         .on('mouseover', this._onInputMouseOver)
         .on('mouseout', this._onInputMouseOut)
         .on('change', this._onInputChange)
-        .prop('title', this.i18n('upload_tooltip'))
+        .prop('title', this._('Upload a file on your computer'))
         .css('width', this.button_upload.outerWidth());
 
       // Fields storage. Used in this.changeState
@@ -111,7 +107,7 @@ this.ckan.module('image-upload', function($, _) {
       if (options.is_url) {
         this._showOnlyFieldUrl();
 
-        this._updateUrlLabel(this.i18n('label_for_url'));
+        this._updateUrlLabel(this._('URL'));
       } else if (options.is_upload) {
         this._showOnlyFieldUrl();
 
@@ -120,7 +116,7 @@ this.ckan.module('image-upload', function($, _) {
         var filename = this._fileNameFromUpload(this.field_url_input.val());
         this.field_url_input.val(filename);
 
-        this._updateUrlLabel(this.i18n('label_for_upload'));
+        this._updateUrlLabel(this._('File'));
       } else {
         this._showOnlyButtons();
       }
@@ -174,7 +170,7 @@ this.ckan.module('image-upload', function($, _) {
         this.field_clear.val('true');
       }
 
-      this._updateUrlLabel(this.i18n('label_for_url'));
+      this._updateUrlLabel(this._('URL'));
     },
 
     /* Event listener for resetting the field back to the blank state
@@ -205,7 +201,7 @@ this.ckan.module('image-upload', function($, _) {
 
       this._autoName(file_name);
 
-      this._updateUrlLabel(this.i18n('label_for_upload'));
+      this._updateUrlLabel(this._('File'));
     },
 
     /* Show only the buttons, hiding all others

--- a/ckan/public/base/javascript/modules/media-grid.js
+++ b/ckan/public/base/javascript/modules/media-grid.js
@@ -1,8 +1,8 @@
 /* Media Grid
  * Super simple plugin that waits for all the images to be loaded in the media
  * grid and then applies the jQuery.masonry to then
- */ 
-this.ckan.module('media-grid', function ($, _) {
+ */
+this.ckan.module('media-grid', function ($) {
   return {
     initialize: function () {
       var wrapper = this.el;

--- a/ckan/public/base/javascript/modules/popover-context.js
+++ b/ckan/public/base/javascript/modules/popover-context.js
@@ -31,7 +31,7 @@ window.popover_context = {
 	}
 };
 
-this.ckan.module('popover-context', function($, _) {
+this.ckan.module('popover-context', function($) {
 	return {
 
 		/* options object can be extended using data-module-* attributes */
@@ -40,10 +40,7 @@ this.ckan.module('popover-context', function($, _) {
 			loading: false,
 			error: false,
 			authed: false,
-			throbber: '<img src="{SITE_ROOT}/base/images/loading-spinner.gif">',
-			i18n: {
-				loading: _('Loading...')
-			}
+			throbber: '<img src="{SITE_ROOT}/base/images/loading-spinner.gif">'
 		},
 
 		/* Initialises the module setting up elements and event listeners.
@@ -62,7 +59,7 @@ this.ckan.module('popover-context', function($, _) {
 				this.el.popover({
 					animation: false,
 					html: true,
-					content: this.options.throbber.replace('{SITE_ROOT}', ckan.SITE_ROOT) + this.i18n('loading'),
+					content: this.options.throbber.replace('{SITE_ROOT}', ckan.SITE_ROOT) + this._('Loading...'),
 					placement: 'bottom'
 				});
 				this.el.on('mouseover', this._onMouseOver);

--- a/ckan/public/base/javascript/modules/resource-form.js
+++ b/ckan/public/base/javascript/modules/resource-form.js
@@ -1,7 +1,7 @@
 /* Module for the resource form. Handles validation and updating the form
  * with external data such as from a file upload.
  */
-this.ckan.module('resource-form', function (jQuery, _) {
+this.ckan.module('resource-form', function (jQuery) {
   return {
     /* Called by the ckan core if a corresponding element is found on the page.
      * Handles setting up event listeners, adding elements to the page etc.

--- a/ckan/public/base/javascript/modules/resource-reorder.js
+++ b/ckan/public/base/javascript/modules/resource-reorder.js
@@ -1,15 +1,10 @@
 /* Module for reordering resources
  */
-this.ckan.module('resource-reorder', function($, _) {
+this.ckan.module('resource-reorder', function($) {
   return {
     options: {
       id: false,
-      i18n: {
-        label: _('Reorder resources'),
-        save: _('Save order'),
-        saving: _('Saving...'),
-        cancel: _('Cancel')
-      }
+      labelText: 'Reorder resources'
     },
     template: {
       title: '<h1></h1>',
@@ -43,23 +38,25 @@ this.ckan.module('resource-reorder', function($, _) {
     initialize: function() {
       jQuery.proxyAll(this, /_on/);
 
+      var labelText = this._(this.labelText);
+
       this.html_title = $(this.template.title)
-        .text(this.i18n('label'))
+        .text(labelText)
         .insertBefore(this.el)
         .hide();
       var button = $(this.template.button)
         .on('click', this._onHandleStartReorder)
         .appendTo('.page_primary_action');
-      $('span', button).text(this.i18n('label'));
+      $('span', button).text(labelText);
 
       this.html_form_actions = $(this.template.form_actions)
         .hide()
         .insertAfter(this.el);
       $('.save', this.html_form_actions)
-        .text(this.i18n('save'))
+        .text(this._('Save order'))
         .on('click', this._onHandleSave);
       $('.cancel', this.html_form_actions)
-        .text(this.i18n('cancel'))
+        .text(this._('Cancel'))
         .on('click', this._onHandleCancel);
 
       this.html_handles = $(this.template.handle)
@@ -69,7 +66,7 @@ this.ckan.module('resource-reorder', function($, _) {
       this.html_saving = $(this.template.saving)
         .hide()
         .insertBefore($('.save', this.html_form_actions));
-      $('span', this.html_saving).text(this.i18n('saving'));
+      $('span', this.html_saving).text(this._('Saving...'));
 
       this.cache = this.el.html();
 

--- a/ckan/public/base/javascript/modules/resource-upload-field.js
+++ b/ckan/public/base/javascript/modules/resource-upload-field.js
@@ -12,7 +12,7 @@
  *           template: Optional template can be provided.
  *
  */
-this.ckan.module('resource-upload-field', function (jQuery, _, i18n) {
+this.ckan.module('resource-upload-field', function (jQuery) {
   return {
     /* Default options for the module */
     options: {
@@ -20,15 +20,6 @@ this.ckan.module('resource-upload-field', function (jQuery, _, i18n) {
         method: 'POST',
         file: 'file',
         params: []
-      },
-      i18n: {
-        label: _('Upload a file'),
-        errorTitle: _('An Error Occurred'),
-        uploadSuccess: _('Resource uploaded'),
-        uploadError: _('Unable to upload file'),
-        authError: _('Unable to authenticate upload'),
-        metadataError: _('Unable to get data for uploaded file'),
-        uploadingWarning: _('You are uploading a file. Are you sure you want to navigate away and stop this upload?')
       },
       template: [
         '<span class="resource-upload-field">',
@@ -63,7 +54,7 @@ this.ckan.module('resource-upload-field', function (jQuery, _, i18n) {
     setupFileUpload: function () {
       var options = this.options;
 
-      this.upload.find('label').text(this.i18n('label'));
+      this.upload.find('label').text(this._('Upload a file'));
       this.upload.find('input[type=file]').fileupload({
         type: options.form.method,
         paramName: options.form.file,
@@ -150,7 +141,7 @@ this.ckan.module('resource-upload-field', function (jQuery, _, i18n) {
      * Returns nothing.
      */
     notify: function (message, type) {
-      var title = this.i18n('errorTitle');
+      var title = this._('An Error Occurred');
       this.sandbox.notify(title, message, type);
     },
 
@@ -207,7 +198,7 @@ this.ckan.module('resource-upload-field', function (jQuery, _, i18n) {
      * a file.
      */
     _onUploadFail: function () {
-      this.sandbox.notify(this.i18n('uploadError'));
+      this.sandbox.notify(this._('Unable to upload file'));
     },
 
     /* Callback called when jQuery file upload plugin sends a file */
@@ -258,7 +249,7 @@ this.ckan.module('resource-upload-field', function (jQuery, _, i18n) {
 
     /* Called when the request for auth credentials fails. */
     _onAuthError: function (event, data) {
-      this.sandbox.notify(this.i18n('authError'));
+      this.sandbox.notify(this._('Unable to authenticate upload'));
       this._onUploadComplete();
     },
 
@@ -266,19 +257,20 @@ this.ckan.module('resource-upload-field', function (jQuery, _, i18n) {
     _onMetadataSuccess: function (data, response) {
       var resource = this.sandbox.client.convertStorageMetadataToResource(response);
 
-      this.sandbox.notify(this.i18n('uploadSuccess'), '', 'success');
+      this.sandbox.notify(this._('Resource uploaded'), '', 'success');
       this.sandbox.publish('resource:uploaded', resource);
     },
 
     /* Called when the request for file metadata fails */
     _onMetadataError: function () {
-      this.sandbox.notify(this.i18n('metadataError'));
+      this.sandbox.notify(this._('Unable to get data for uploaded file'));
       this._onUploadComplete();
     },
 
     /* Called before the window unloads whilst uploading */
     _onWindowBeforeUnload: function(event) {
-      var message = this.i18n('uploadingWarning');
+      var message = this._('You are uploading a file. Are you sure you ' +
+                           'want to navigate away and stop this upload?');
       if (event.originalEvent.returnValue) {
         event.originalEvent.returnValue = message;
       }

--- a/ckan/public/base/javascript/modules/resource-view-embed.js
+++ b/ckan/public/base/javascript/modules/resource-view-embed.js
@@ -1,4 +1,4 @@
-this.ckan.module('resource-view-embed', function ($, _) {
+this.ckan.module('resource-view-embed', function ($) {
   var modal;
   var self;
 

--- a/ckan/public/base/javascript/modules/resource-view-filters.js
+++ b/ckan/public/base/javascript/modules/resource-view-filters.js
@@ -1,4 +1,4 @@
-this.ckan.module('resource-view-filters', function (jQuery, _) {
+this.ckan.module('resource-view-filters', function (jQuery) {
   'use strict';
 
   function initialize() {

--- a/ckan/public/base/javascript/modules/resource-view-reorder.js
+++ b/ckan/public/base/javascript/modules/resource-view-reorder.js
@@ -1,15 +1,10 @@
-/* Module for reordering resources
+/* Module for reordering resource views
  */
-this.ckan.module('resource-view-reorder', function($, _) {
+this.ckan.module('resource-view-reorder', function($) {
   return {
     options: {
       id: false,
-      i18n: {
-        label: _('Reorder resource view'),
-        save: _('Save order'),
-        saving: _('Saving...'),
-        cancel: _('Cancel')
-      }
+      labelText: 'Reorder resource view'
     },
     template: {
       title: '<h1></h1>',
@@ -38,29 +33,30 @@ this.ckan.module('resource-view-reorder', function($, _) {
     initialize: function() {
       jQuery.proxyAll(this, /_on/);
 
+      var labelText = this._(this.labelText);
       this.html_title = $(this.template.title)
-        .text(this.i18n('label'))
+        .text(labelText)
         .insertBefore(this.el)
         .hide();
       var button = $(this.template.button)
         .on('click', this._onHandleStartReorder)
         .appendTo('.page_primary_action');
-      $('span', button).text(this.i18n('label'));
+      $('span', button).text(labelText);
 
       this.html_form_actions = $(this.template.form_actions)
         .hide()
         .insertAfter(this.el);
       $('.save', this.html_form_actions)
-        .text(this.i18n('save'))
+        .text(this._('Save order'))
         .on('click', this._onHandleSave);
       $('.cancel', this.html_form_actions)
-        .text(this.i18n('cancel'))
+        .text(this._('Cancel'))
         .on('click', this._onHandleCancel);
 
       this.html_saving = $(this.template.saving)
         .hide()
         .insertBefore($('.save', this.html_form_actions));
-      $('span', this.html_saving).text(this.i18n('saving'));
+      $('span', this.html_saving).text(this._('Saving...'));
 
       this.cache = this.el.html();
 

--- a/ckan/public/base/javascript/modules/slug-preview.js
+++ b/ckan/public/base/javascript/modules/slug-preview.js
@@ -26,15 +26,11 @@ this.ckan.module('slug-preview-target', {
   }
 });
 
-this.ckan.module('slug-preview-slug', function (jQuery, _) {
+this.ckan.module('slug-preview-slug', function (jQuery) {
   return {
     options: {
       prefix: '',
-      placeholder: '<slug>',
-      i18n: {
-        url:  _('URL'),
-        edit: _('Edit')
-      }
+      placeholder: '<slug>'
     },
 
     initialize: function () {
@@ -57,8 +53,8 @@ this.ckan.module('slug-preview-slug', function (jQuery, _) {
           prefix: options.prefix,
           placeholder: options.placeholder,
           i18n: {
-            'URL': this.i18n('url'),
-            'Edit': this.i18n('edit')
+            'URL': this._('URL'),
+            'Edit': this._('Edit')
           }
         });
 

--- a/ckan/public/base/javascript/modules/table-selectable-rows.js
+++ b/ckan/public/base/javascript/modules/table-selectable-rows.js
@@ -7,7 +7,7 @@
  *   <table data-module="table-selectable-rows">...</table>
  *
  */
-this.ckan.module('table-selectable-rows', function($, _) {
+this.ckan.module('table-selectable-rows', function($) {
 	return {
 
 		// Store for jQuery object for the select all checkbox

--- a/ckan/public/base/javascript/modules/table-toggle-more.js
+++ b/ckan/public/base/javascript/modules/table-toggle-more.js
@@ -1,15 +1,10 @@
 /* Table toggle more
  * When a table has more things to it that need to be hidden and then shown more
  */
-this.ckan.module('table-toggle-more', function($, _) {
+this.ckan.module('table-toggle-more', function($) {
   return {
     /* options object can be extended using data-module-* attributes */
-    options: {
-      i18n: {
-        show_more: _('Show more'),
-        show_less: _('Hide')
-      }
-    },
+    options: {},
 
     /* Initialises the module setting up elements and event listeners.
      *
@@ -27,8 +22,8 @@ this.ckan.module('table-toggle-more', function($, _) {
           '<tr class="toggle-show toggle-show-more">',
           '<td colspan="'+cols+'">',
           '<small>',
-          '<a href="#" class="show-more">'+this.i18n('show_more')+'</a>',
-          '<a href="#" class="show-less">'+this.i18n('show_less')+'</a>',
+          '<a href="#" class="show-more">' + this._('Show more') + '</a>',
+          '<a href="#" class="show-less">' + this._('Hide') + '</a>',
           '</small>',
           '</td>',
           '</tr>'

--- a/ckan/public/base/test/index.html
+++ b/ckan/public/base/test/index.html
@@ -52,6 +52,7 @@
 
     <!-- Suite -->
     <script src="./spec/ckan.spec.js"></script>
+    <script src="./spec/i18n.spec.js"></script>
     <script src="./spec/module.spec.js"></script>
     <script src="./spec/sandbox.spec.js"></script>
     <script src="./spec/client.spec.js"></script>
@@ -134,6 +135,26 @@
       afterEach(function () {
         this.fixture.empty();
       });
+
+
+      // Add dummy translations for testing i18n
+      ckan.i18n.load({
+        '': {
+          "domain": "ckan",
+          "lang": "en",
+          "plural_forms": "nplurals=2; plural=(n != 1);"
+        },
+        'foo': [null, 'FOO'],
+        'hello %(name)s!': [null, 'HELLO %(name)s!'],
+        'bar': ['bars', 'BAR', 'BARS'],
+        '%(color)s shirt': [
+          '%(color)s shirts',
+          '%(color)s SHIRT',
+          '%(color)s SHIRTS'
+        ],
+        '%(num)d item': ['%(num)d items', '%(num)d ITEM', '%(num)d ITEMS']
+      });
+
 
       if (window.mochaPhantomJS) {
         mochaPhantomJS.run();

--- a/ckan/public/base/test/spec/i18n.spec.js
+++ b/ckan/public/base/test/spec/i18n.spec.js
@@ -1,0 +1,116 @@
+describe('ckan.i18n', function () {
+  describe('ckan.i18n.translate', function () {
+    it('should work while being deprecated', function () {
+      var x = ckan.i18n.translate('foo');
+      assert.deepProperty(x, 'fetch');
+      assert.equal(x.fetch(), 'FOO');
+      assert.deepProperty(x, 'ifPlural');
+    });
+  });
+
+  describe('._(string, [values])', function () {
+    it('should return the translated string', function () {
+      assert.equal(ckan.i18n._('foo'), 'FOO');
+    });
+
+    it('should return the key when no translation exists', function () {
+      assert.equal(ckan.i18n._('no translation'), 'no translation');
+    });
+
+    it('should fill in placeholders', function () {
+      assert.equal(
+        ckan.i18n._('hello %(name)s!', {name: 'Julia'}),
+        'HELLO Julia!'
+      );
+    });
+
+    it('should fill in placeholders when no translation exists', function () {
+      assert.equal(
+        ckan.i18n._('no %(attr)s translation', {attr: 'good'}),
+        'no good translation'
+      );
+    });
+  });
+
+  describe('.ngettext(singular, plural, number, [values])', function () {
+    var ngettext = ckan.i18n.ngettext;
+
+    it('should return the translated strings', function () {
+      assert.equal(ngettext('bar', 'bars', 1), 'BAR');
+      assert.equal(ngettext('bar', 'bars', 0), 'BARS');
+      assert.equal(ngettext('bar', 'bars', 2), 'BARS');
+    });
+
+    it('should return the key when no translation exists', function () {
+      assert.equal(
+        ngettext('no translation', 'no translations', 1),
+        'no translation'
+      );
+      assert.equal(
+        ngettext('no translation', 'no translations', 0),
+        'no translations'
+      );
+      assert.equal(
+        ngettext('no translation', 'no translations', 2),
+        'no translations'
+      );
+    });
+
+    it('should fill in placeholders', function () {
+      assert.equal(
+        ngettext('%(color)s shirt', '%(color)s shirts', 1, {color: 'RED'}),
+        'RED SHIRT'
+      );
+      assert.equal(
+        ngettext('%(color)s shirt', '%(color)s shirts', 0, {color: 'RED'}),
+        'RED SHIRTS'
+      );
+      assert.equal(
+        ngettext('%(color)s shirt', '%(color)s shirts', 2, {color: 'RED'}),
+        'RED SHIRTS'
+      );
+    });
+
+    it('should fill in placeholders when no translation exists', function () {
+      assert.equal(
+        ngettext('no %(attr)s translation', 'no %(attr)s translations',
+                 1, {attr: 'good'}),
+        'no good translation'
+      );
+      assert.equal(
+        ngettext('no %(attr)s translation', 'no %(attr)s translations',
+                 0, {attr: 'good'}),
+        'no good translations'
+      );
+      assert.equal(
+        ngettext('no %(attr)s translation', 'no %(attr)s translations',
+                 2, {attr: 'good'}),
+        'no good translations'
+      );
+    });
+
+    it('should provide a magic `num` placeholder', function () {
+      assert.equal(ngettext('%(num)d item', '%(num)d items', 1), '1 ITEM');
+      assert.equal(ngettext('%(num)d item', '%(num)d items', 0), '0 ITEMS');
+      assert.equal(ngettext('%(num)d item', '%(num)d items', 2), '2 ITEMS');
+    });
+
+    it('should provide `num` when no translation exists', function () {
+      assert.equal(
+        ngettext('%(num)d missing translation',
+                 '%(num)d missing translations', 1),
+        '1 missing translation'
+      );
+      assert.equal(
+        ngettext('%(num)d missing translation',
+                 '%(num)d missing translations', 0),
+        '0 missing translations'
+      );
+      assert.equal(
+        ngettext('%(num)d missing translation',
+                 '%(num)d missing translations', 2),
+        '2 missing translations'
+      );
+    });
+  });
+});

--- a/ckan/public/base/test/spec/module.spec.js
+++ b/ckan/public/base/test/spec/module.spec.js
@@ -376,6 +376,28 @@ describe('ckan.module(id, properties|callback)', function () {
       });
     });
 
+    describe('._()', function () {
+      it('should be a shortcut for ckan.i18n._', function () {
+        /*
+         * In a module, this._ is a shortcut for ckan.i18n._,
+         * but it's not a direct reference.
+         */
+        assert.equal(this.module._('foo'), 'FOO');
+      });
+    });
+
+    describe('.ngettext()', function () {
+      it('should be a shortcut for ckan.i18n.ngettext', function () {
+        /*
+         * In a module, this.ngettext is a shortcut for ckan.i18n.ngettext,
+         * but it's not a direct reference.
+         */
+        assert.equal(this.module.ngettext('bar', 'bars', 1), 'BAR');
+        assert.equal(this.module.ngettext('bar', 'bars', 0), 'BARS');
+        assert.equal(this.module.ngettext('bar', 'bars', 2), 'BARS');
+      });
+    });
+
     describe('.remove()', function () {
       it('should teardown the module', function () {
         var target = sinon.stub(this.module, 'teardown');

--- a/ckan/public/base/test/spec/module.spec.js
+++ b/ckan/public/base/test/spec/module.spec.js
@@ -20,6 +20,7 @@ describe('ckan.module(id, properties|callback)', function () {
   });
 
   it('should pass jQuery, i18n.translate() and i18n into the function', function () {
+    // Note: This behavior is deprecated but kept for backwards-compatibility
     var target = sinon.stub().returns({});
     ckan.module('test', target);
 
@@ -329,6 +330,7 @@ describe('ckan.module(id, properties|callback)', function () {
     });
 
     describe('.i18n()', function () {
+      // Note: This function is deprecated but kept for backwards-compatibility
       beforeEach(function () {
         this.i18n = {
           first: 'first string',

--- a/ckan/public/base/test/spec/modules/confirm-action.spec.js
+++ b/ckan/public/base/test/spec/modules/confirm-action.spec.js
@@ -74,14 +74,11 @@ describe('ckan.module.ConfirmActionModule()', function () {
       assert.calledWith(jQuery.fn.modal, {show: false});
     });
 
-    it('should insert the localized strings', function () {
+    it('should allow to customize the content', function () {
+      this.module.options.content = 'some custom content';
       var target = this.module.createModal();
-      var i18n = this.module.options.i18n;
 
-      assert.equal(target.find('h3').text(), i18n.heading.fetch());
-      assert.equal(target.find('.modal-body').text(), i18n.content.fetch());
-      assert.equal(target.find('.btn-primary').text(), i18n.confirm.fetch());
-      assert.equal(target.find('.btn-cancel').text(), i18n.cancel.fetch());
+      assert.equal(target.find('.modal-body').text(), 'some custom content');
     });
   });
 

--- a/ckan/public/base/test/spec/sandbox.spec.js
+++ b/ckan/public/base/test/spec/sandbox.spec.js
@@ -66,6 +66,20 @@ describe('ckan.sandbox()', function () {
         assert.ok(target.window === window);
       });
     });
+
+    describe('.i18n', function () {
+      it('should be available while being deprecated', function () {
+        var target = new Sandbox();
+        assert.equal(target.i18n, ckan.i18n);
+      });
+    });
+
+    describe('.translate', function () {
+      it('should be available while being deprecated', function () {
+        var target = new Sandbox();
+        assert.equal(target.translate, ckan.i18n.translate);
+      });
+    });
   });
 
   describe('sandbox.extend()', function () {
@@ -94,4 +108,5 @@ describe('ckan.sandbox()', function () {
       });
     });
   });
+
 });

--- a/ckan/templates/admin/config.html
+++ b/ckan/templates/admin/config.html
@@ -13,8 +13,7 @@
       {{ autoform.generate(form_items, data, errors) }}
     {% endblock %}
     <div class="form-actions">
-      {% set locale = h.dump_json({'content': _('Are you sure you want to reset the config?')}) %}
-      <a href="{% url_for controller='admin', action='reset_config' %}" class="btn btn-danger pull-left" data-module="confirm-action" data-module-i18n="{{ locale }}">{{ _('Reset') }}</a>
+      <a href="{% url_for controller='admin', action='reset_config' %}" class="btn btn-danger pull-left" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to reset the config?') }}">{{ _('Reset') }}</a>
       <button type="submit" class="btn btn-primary" name="save">{{ _('Update Config') }}</button>
     </div>
   </form>

--- a/ckan/templates/group/member_new.html
+++ b/ckan/templates/group/member_new.html
@@ -55,8 +55,7 @@
     {{ form.select('role', label=_('Role'), options=c.roles, selected=c.user_role, error='', attrs=format_attrs) }}
     <div class="form-actions">
       {% if user %}
-        {% set locale = h.dump_json({'content': _('Are you sure you want to delete this member?')}) %}
-        <a href="{% url_for controller='group', action='member_delete', id=c.group_dict.id, user=user.id %}" class="btn btn-danger pull-left" data-module="confirm-action" data-module-i18n="{{ locale }}">{{ _('Delete') }}</a>
+        <a href="{% url_for controller='group', action='member_delete', id=c.group_dict.id, user=user.id %}" class="btn btn-danger pull-left" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?') }}">{{ _('Delete') }}</a>
         <button class="btn btn-primary" type="submit" name="submit" >
           {{ _('Save') }}
         </button>

--- a/ckan/templates/group/members.html
+++ b/ckan/templates/group/members.html
@@ -27,12 +27,11 @@
         </td>
         <td>{{ role }}</td>
         <td>
-          {% set locale = h.dump_json({'content': _('Are you sure you want to delete this member?')}) %}
           <div class="btn-group pull-right">
             <a class="btn btn-small" href="{% url_for controller='group', action='member_new', id=c.group_dict.id, user=user_id %}" title="{{ _('Edit') }}">
               <i class="icon-wrench"></i>
             </a>
-            <a class="btn btn-danger btn-small" href="{% url_for controller='group', action='member_delete', id=c.group_dict.id, user=user_id %}" data-module="confirm-action" data-module-i18n="{{ locale }}" title="{{ _('Delete') }}">{% block delete_button_text %}<i class="icon-remove"></i>{% endblock %}</a>
+            <a class="btn btn-danger btn-small" href="{% url_for controller='group', action='member_delete', id=c.group_dict.id, user=user_id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?') }}" title="{{ _('Delete') }}">{% block delete_button_text %}<i class="icon-remove"></i>{% endblock %}</a>
           </div>
         </td>
       </tr>

--- a/ckan/templates/group/snippets/group_form.html
+++ b/ckan/templates/group/snippets/group_form.html
@@ -57,8 +57,7 @@
   <div class="form-actions">
     {% block delete_button %}
       {% if h.check_access('group_delete', {'id': data.id})  %}
-        {% set locale = h.dump_json({'content': _('Are you sure you want to delete this Group?')}) %}
-        <a class="btn btn-danger pull-left" href="{% url_for controller='group', action='delete', id=data.id %}" data-module="confirm-action" data-module-i18n="{{ locale }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+        <a class="btn btn-danger pull-left" href="{% url_for controller='group', action='delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this Group?') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
       {% endif %}
     {% endblock %}
     <button class="btn btn-primary" name="save" type="submit">{% block save_text %}{{ _('Save Group') }}{% endblock %}</button>

--- a/ckan/templates/organization/member_new.html
+++ b/ckan/templates/organization/member_new.html
@@ -56,8 +56,7 @@
     {{ form.select('role', label=_('Role'), options=c.roles, selected=c.user_role, error='', attrs=format_attrs) }}
     <div class="form-actions">
       {% if user %}
-        {% set locale = h.dump_json({'content': _('Are you sure you want to delete this member?')}) %}
-        <a href="{% url_for controller='organization', action='member_delete', id=c.group_dict.id, user=user.id %}" class="btn btn-danger pull-left" data-module="confirm-action" data-module-i18n="{{ locale }}">{{ _('Delete') }}</a>
+        <a href="{% url_for controller='organization', action='member_delete', id=c.group_dict.id, user=user.id %}" class="btn btn-danger pull-left" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?' }}">{{ _('Delete') }}</a>
         <button class="btn btn-primary" type="submit" name="submit" >
           {{ _('Update Member') }}
         </button>

--- a/ckan/templates/organization/members.html
+++ b/ckan/templates/organization/members.html
@@ -27,12 +27,11 @@
           </td>
           <td>{{ role }}</td>
           <td>
-            {% set locale = h.dump_json({'content': _('Are you sure you want to delete this member?')}) %}
             <div class="btn-group pull-right">
               <a class="btn btn-small" href="{% url_for controller='organization', action='member_new', id=c.group_dict.id, user=user_id %}" title="{{ _('Edit') }}">
                 <i class="icon-wrench"></i>
               </a>
-              <a class="btn btn-danger btn-small" href="{% url_for controller='organization', action='member_delete', id=c.group_dict.id, user=user_id %}" data-module="confirm-action" data-module-i18n="{{ locale }}" title="{{ _('Delete') }}">{% block delete_button_text %}<i class="icon-remove"></i>{% endblock %}</a>
+              <a class="btn btn-danger btn-small" href="{% url_for controller='organization', action='member_delete', id=c.group_dict.id, user=user_id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?') }}" title="{{ _('Delete') }}">{% block delete_button_text %}<i class="icon-remove"></i>{% endblock %}</a>
             </div>
           </td>
         </tr>

--- a/ckan/templates/organization/snippets/organization_form.html
+++ b/ckan/templates/organization/snippets/organization_form.html
@@ -57,8 +57,7 @@
   <div class="form-actions">
     {% block delete_button %}
       {% if h.check_access('organization_delete', {'id': data.id})  %}
-        {% set locale = h.dump_json({'content': _('Are you sure you want to delete this Organization? This will delete all the public and private datasets belonging to this organization.')}) %}
-        <a class="btn btn-danger pull-left" href="{% url_for controller='organization', action='delete', id=data.id %}" data-module="confirm-action" data-module-i18n="{{ locale }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+        <a class="btn btn-danger pull-left" href="{% url_for controller='organization', action='delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this Organization? This will delete all the public and private datasets belonging to this organization.') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
       {% endif %}
     {% endblock %}
     <button class="btn btn-primary" name="save" type="submit">{% block save_text %}{{ _('Save Organization') }}{% endblock %}</button>

--- a/ckan/templates/package/snippets/package_form.html
+++ b/ckan/templates/package/snippets/package_form.html
@@ -36,8 +36,7 @@ then itself be extended to add/remove blocks of functionality. #}
       {% endblock %}
       {% block delete_button %}
         {% if h.check_access('package_delete', {'id': data.id}) and not data.state == 'deleted' %}
-          {% set locale = h.dump_json({'content': _('Are you sure you want to delete this dataset?')}) %}
-          <a class="btn btn-danger pull-left" href="{% url_for controller='package', action='delete', id=data.id %}" data-module="confirm-action" data-module-i18n="{{ locale }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+          <a class="btn btn-danger pull-left" href="{% url_for controller='package', action='delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this dataset?') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
         {% endif %}
       {% endblock %}
       {% block save_button %}

--- a/ckan/templates/package/snippets/resource_form.html
+++ b/ckan/templates/package/snippets/resource_form.html
@@ -62,8 +62,7 @@
     {% block delete_button %}
       {% if data.id %}
         {% if h.check_access('resource_delete', {'id': data.id})  %}
-          {% set locale = h.dump_json({'content': _('Are you sure you want to delete this resource?')}) %}
-          <a class="btn btn-danger pull-left" href="{% url_for controller='package', action='resource_delete', resource_id=data.id, id=pkg_name %}" data-module="confirm-action" data-module-i18n="{{ locale }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+          <a class="btn btn-danger pull-left" href="{% url_for controller='package', action='resource_delete', resource_id=data.id, id=pkg_name %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this resource?') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
         {% endif %}
       {% endif %}
     {% endblock %}

--- a/ckan/templates/user/edit_user_form.html
+++ b/ckan/templates/user/edit_user_form.html
@@ -42,14 +42,12 @@
   <div class="form-actions">
     {% block delete_button %}
       {% if h.check_access('user_delete', {'id': data.id})  %}
-        {% set locale = h.dump_json({'content': _('Are you sure you want to delete this User?')}) %}
-        <a class="btn btn-danger pull-left" href="{% url_for controller='user', action='delete', id=data.id %}" data-module="confirm-action" data-module-i18n="{{ locale }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+        <a class="btn btn-danger pull-left" href="{% url_for controller='user', action='delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this User?') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
       {% endif %}
     {% endblock %}
     {% block generate_button %}
       {% if h.check_access('user_generate_apikey', {'id': data.id})  %}
-        {% set locale = h.dump_json({'content': _('Are you sure you want to regenerate the API key?')}) %}
-        <a class="btn btn-warning" href="{% url_for controller='user', action='generate_apikey', id=data.id %}" data-module="confirm-action" data-module-i18n="{{ locale }}">{% block generate_button_text %}{{ _('Regenerate API Key') }}{% endblock %}</a>
+        <a class="btn btn-warning" href="{% url_for controller='user', action='generate_apikey', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to regenerate the API key?') }}">{% block generate_button_text %}{{ _('Regenerate API Key') }}{% endblock %}</a>
       {% endif %}
     {% endblock %}
     {{ form.required_message() }}

--- a/ckanext/example_theme/v16_initialize_a_javascript_module/fanstatic/example_theme_popover.js
+++ b/ckanext/example_theme/v16_initialize_a_javascript_module/fanstatic/example_theme_popover.js
@@ -3,7 +3,7 @@
 // being taken, and disables some confusing and bad JavaScript features.
 "use strict";
 
-ckan.module('example_theme_popover', function ($, _) {
+ckan.module('example_theme_popover', function ($) {
   return {
     initialize: function () {
       console.log("I've been initialized for element: ", this.el);

--- a/ckanext/example_theme/v17_popover/fanstatic/example_theme_popover.js
+++ b/ckanext/example_theme/v17_popover/fanstatic/example_theme_popover.js
@@ -11,7 +11,7 @@
  * num_resources - the number of resources that the dataset has.
  *
  */
-ckan.module('example_theme_popover', function ($, _) {
+ckan.module('example_theme_popover', function ($) {
   return {
     initialize: function () {
 

--- a/ckanext/example_theme/v18_snippet_api/fanstatic/example_theme_popover.js
+++ b/ckanext/example_theme/v18_snippet_api/fanstatic/example_theme_popover.js
@@ -1,6 +1,6 @@
 "use strict";
 
-ckan.module('example_theme_popover', function ($, _) {
+ckan.module('example_theme_popover', function ($) {
   return {
     initialize: function () {
 

--- a/ckanext/example_theme/v19_01_error/fanstatic/example_theme_popover.js
+++ b/ckanext/example_theme/v19_01_error/fanstatic/example_theme_popover.js
@@ -1,6 +1,6 @@
 "use strict";
 
-ckan.module('example_theme_popover', function ($, _) {
+ckan.module('example_theme_popover', function ($) {
   return {
     initialize: function () {
 

--- a/ckanext/example_theme/v19_02_error_handling/fanstatic/example_theme_popover.js
+++ b/ckanext/example_theme/v19_02_error_handling/fanstatic/example_theme_popover.js
@@ -1,6 +1,6 @@
 "use strict";
 
-ckan.module('example_theme_popover', function ($, _) {
+ckan.module('example_theme_popover', function ($) {
   return {
     initialize: function () {
       $.proxyAll(this, /_on/);

--- a/ckanext/example_theme/v20_pubsub/fanstatic/example_theme_popover.js
+++ b/ckanext/example_theme/v20_pubsub/fanstatic/example_theme_popover.js
@@ -1,6 +1,6 @@
 "use strict";
 
-ckan.module('example_theme_popover', function ($, _) {
+ckan.module('example_theme_popover', function ($) {
   return {
     initialize: function () {
       $.proxyAll(this, /_on/);

--- a/ckanext/example_theme/v21_custom_jquery_plugin/fanstatic/example_theme_popover.js
+++ b/ckanext/example_theme/v21_custom_jquery_plugin/fanstatic/example_theme_popover.js
@@ -1,6 +1,6 @@
 "use strict";
 
-ckan.module('example_theme_popover', function ($, _) {
+ckan.module('example_theme_popover', function ($) {
   return {
     initialize: function () {
       $.proxyAll(this, /_on/);

--- a/ckanext/reclineview/theme/public/recline_view.js
+++ b/ckanext/reclineview/theme/public/recline_view.js
@@ -1,12 +1,6 @@
-this.ckan.module('recline_view', function (jQuery, _) {
+this.ckan.module('recline_view', function (jQuery) {
   return {
     options: {
-      i18n: {
-        errorLoadingPreview: "Could not load view",
-        errorDataProxy: "DataProxy returned an error",
-        errorDataStore: "DataStore returned an error",
-        previewNotAvailableForDataType: "View not available for data type: "
-      },
       site_url: "",
       controlsClassName: "controls"
     },
@@ -31,7 +25,7 @@ this.ckan.module('recline_view', function (jQuery, _) {
       var self = this;
 
       function showError(msg){
-        msg = msg || _('error loading view');
+        msg = msg || self._('error loading view');
         window.parent.ckan.pubsub.publish('data-viewer-error', msg);
       }
 
@@ -63,7 +57,7 @@ this.ckan.module('recline_view', function (jQuery, _) {
       var query = new recline.Model.Query();
       query.set({ size: reclineView.limit || 100 });
       query.set({ from: reclineView.offset || 0 });
-      
+
       var urlFilters = {};
       try {
         if (window.parent.ckan.views && window.parent.ckan.views.filters) {
@@ -71,18 +65,18 @@ this.ckan.module('recline_view', function (jQuery, _) {
         }
       } catch(e) {}
       var defaultFilters = reclineView.filters || {},
-          filters = $.extend({}, defaultFilters, urlFilters);
-      $.each(filters, function (field,values) {
+          filters = jQuery.extend({}, defaultFilters, urlFilters);
+      jQuery.each(filters, function (field,values) {
         query.addFilter({type: 'term', field: field, term: values});
       });
 
       dataset.queryState.set(query.toJSON(), {silent: true});
 
-      errorMsg = this.options.i18n.errorLoadingPreview + ': '
+      errorMsg = this._('Could not load view') + ': ';
       if (resourceData.backend == 'ckan') {
-        errorMsg += this.options.i18n.errorDataStore;
+        errorMsg += this._('DataStore returned an error');
       } else if (resourceData.backend == 'dataproxy'){
-        errorMsg += this.options.i18n.errorDataProxy;
+        errorMsg += this._('DataProxy returned an error');
       }
       dataset.fetch()
         .done(function(dataset){
@@ -138,10 +132,10 @@ this.ckan.module('recline_view', function (jQuery, _) {
       // recline_view automatically adds itself to the DOM, so we don't
       // need to bother with it.
       if(reclineView.view_type !== 'recline_view') {
-        var newElements = $('<div />');
+        var newElements = jQuery('<div />');
         this._renderControls(newElements, controls, this.options.controlsClassName);
         newElements.append(view.el);
-        $(this.el).html(newElements);
+        jQuery(this.el).html(newElements);
         view.visible = true;
         view.render();
       }
@@ -158,15 +152,22 @@ this.ckan.module('recline_view', function (jQuery, _) {
       if (map_config.type == 'mapbox') {
           // MapBox base map
           if (!map_config['mapbox.map_id'] || !map_config['mapbox.access_token']) {
-            throw '[CKAN Map Widgets] You need to provide a map ID ([account].[handle]) and an access token when using a MapBox layer. ' +
-                  'See http://www.mapbox.com/developers/api-overview/ for details';
+            throw '[CKAN Map Widgets] You need to provide a map ID ' +
+                  '([account].[handle]) and an access token when using a ' +
+                  'MapBox layer. See ' +
+                  'http://www.mapbox.com/developers/api-overview/ for details';
           }
-
-          tile_url = '//{s}.tiles.mapbox.com/v4/' + map_config['mapbox.map_id'] + '/{z}/{x}/{y}.png?access_token=' + map_config['mapbox.access_token'];
+          tile_url = '//{s}.tiles.mapbox.com/v4/' +
+                     map_config['mapbox.map_id'] +
+                     '/{z}/{x}/{y}.png?access_token=' +
+                     map_config['mapbox.access_token'];
           handle = map_config['mapbox.map_id'];
           subdomains = map_config.subdomains || 'abcd';
-          attribution = map_config.attribution || 'Data: <a href="http://osm.org/copyright" target="_blank">OpenStreetMap</a>, Design: <a href="http://mapbox.com/about/maps" target="_blank">MapBox</a>';
-
+          attribution = map_config.attribution ||
+                        'Data: <a href="http://osm.org/copyright" ' +
+                        'target="_blank">OpenStreetMap</a>, Design: <a ' +
+                        'href="http://mapbox.com/about/maps" ' +
+                        'target="_blank">MapBox</a>';
       } else if (map_config.type == 'custom') {
           // Custom XYZ layer
           tile_url = map_config['custom.url'] || '';
@@ -189,21 +190,21 @@ this.ckan.module('recline_view', function (jQuery, _) {
       var views = [
         {
           id: 'grid',
-          label: 'Grid',
+          label: this._('Grid'),
           view: new recline.View.SlickGrid({
             model: dataset
           })
         },
         {
           id: 'graph',
-          label: 'Graph',
+          label: this._('Graph'),
           view: new recline.View.Graph({
             model: dataset
           })
         },
         {
           id: 'map',
-          label: 'Map',
+          label: this._('Map'),
           view: new recline.View.Map(this._reclineMapViewOptions(dataset, map_config))
         }
       ];
@@ -211,7 +212,7 @@ this.ckan.module('recline_view', function (jQuery, _) {
       var sidebarViews = [
         {
           id: 'valueFilter',
-          label: 'Filters',
+          label: this._('Filters'),
           view: new recline.View.ValueFilter({
             model: dataset
           })
@@ -232,11 +233,11 @@ this.ckan.module('recline_view', function (jQuery, _) {
     },
 
     _renderControls: function (el, controls, className) {
-      var controlsEl = $("<div class=\"clearfix " + className + "\" />");
+      var controlsEl = jQuery("<div class=\"clearfix " + className + "\" />");
       for (var i = 0; i < controls.length; i++) {
         controlsEl.append(controls[i].el);
       }
-      $(el).append(controlsEl);
+      jQuery(el).append(controlsEl);
     }
   };
 });

--- a/ckanext/stats/public/ckanext/stats/javascript/modules/plot.js
+++ b/ckanext/stats/public/ckanext/stats/javascript/modules/plot.js
@@ -26,7 +26,7 @@
  * can also be applied to parse the value. Only data-type="date" is currently
  * supported and expects data-value to be a unix timestamp.
  */
-this.ckan.module('plot', function (jQuery, _) {
+this.ckan.module('plot', function (jQuery) {
   return {
     /* Holds the jQuery.plot() object when created */
     graph: null,

--- a/ckanext/textview/theme/public/text_view.js
+++ b/ckanext/textview/theme/public/text_view.js
@@ -1,9 +1,6 @@
-ckan.module('text_view', function (jQuery, _) {
+ckan.module('text_view', function (jQuery) {
   return {
     options: {
-      i18n: {
-        error: _('An error occurred: %(text)s %(error)s')
-      },
       parameters: {
         json: {
           contentType: 'application/json',
@@ -70,7 +67,8 @@ ckan.module('text_view', function (jQuery, _) {
           if (textStatus == 'error' && jqXHR.responseText.length) {
             self.el.html(jqXHR.responseText);
           } else {
-            self.el.html(self.i18n('error', {text: textStatus, error: errorThrown}));
+            self.el.html(self_('An error occurred: %(text)s %(error)s',
+                               {text: textStatus, error: errorThrown}));
           }
         }
       });

--- a/doc/contributing/frontend/index.rst
+++ b/doc/contributing/frontend/index.rst
@@ -11,11 +11,6 @@ Frontend development guidelines
    template-blocks
    javascript-module-tutorial
 
-.. seealso::
-
-   :doc:`/contributing/string-i18n`
-     How to mark strings for translation.
-
 -----------------------------
 Install frontend dependencies
 -----------------------------
@@ -165,7 +160,7 @@ JavaScript
 The core of the CKAN JavaScript is split up into three areas.
 
 -  Core (such as i18n, pub/sub and API clients)
--  :doc:`javascript-module-tutorial` (small HTML components or widgets)
+-  Modules (small HTML components or widgets)
 -  jQuery Plugins (very small reusable components)
 
 Core
@@ -202,7 +197,7 @@ factory function.
 
 ::
 
-    ckan.module('my-module', function (jQuery, _) {
+    ckan.module('my-module', function (jQuery) {
       return {
         initialize: function () {
           // Called when a module is created.
@@ -232,7 +227,7 @@ and allow different areas of the UI to update where relevant.
 
 ::
 
-    ckan.module('language-picker', function (jQuery, _) {
+    ckan.module('language-picker', function (jQuery) {
       return {
         initialize: function () {
           var sandbox = this.sandbox;
@@ -243,7 +238,7 @@ and allow different areas of the UI to update where relevant.
       }
     });
 
-    ckan.module('language-notifier', function (jQuery, _) {
+    ckan.module('language-notifier', function (jQuery) {
       return {
         initialize: function () {
           this.sandbox.subscribe('change:lang', function (lang) {
@@ -261,7 +256,7 @@ CKAN API, all functionality should be provided via the client object.
 
 ::
 
-    ckan.module('my-module', function (jQuery, _) {
+    ckan.module('my-module', function (jQuery) {
       return {
         initialize: function () {
           this.sandbox.client.getCompletions(this.options.completionsUrl);
@@ -269,42 +264,12 @@ CKAN API, all functionality should be provided via the client object.
       }
     });
 
-i18n/Jed
-========
 
-`Jed <http://slexaxton.github.com/Jed/>`_ is a Gettext implementation in
-JavaScript. It is used throughout the application to create translatable
-strings. An instance of Jed is available on the ``ckan.i18n`` object.
+Internationalization
+====================
 
-Modules get access to the ``translate()`` function via both the initial
-factory function and the ``this.sandbox.translate()`` object.
+See :ref:`javascript_i18n`.
 
-String interpolation can be provided using the
-`sprintf formatting <http://www.diveintojavascript.com/projects/javascript-sprintf>`_.
-We always use the named arguments to keep in line with the Python translations.
-And we name the translate function passed into ``ckan.module()`` ``_``.
-
-::
-
-    ckan.module('my-module', function (jQuery, _) {
-      return {
-        initialize: function () {
-          // Through sandbox translation
-          this.sandbox.translate('my string');
-
-          // Keyword arguments
-          _('Hello %(name)s').fetch({name: 'Bill'}); // Hello Bill
-
-          // Multiple.
-          _("I like your %(color)s %(fruit)s.").fetch({color: 'red', fruit: 'apple');
-
-          // Plurals.
-          _("I have %(num)d apple.")
-            .ifPlural(2, "I have %(num)d apples.")
-            .fetch({num: 2, fruit: 'apple');
-        }
-      };
-    });
 
 Life cycle
 ==========
@@ -326,11 +291,6 @@ the module to set themselves up.
 Modules should also provide a ``teardown()`` method this isn't used at
 the moment except in the unit tests to restore state but may become
 useful in the future.
-
-Internationalization
-====================
-
-See :ref:`javascript_i18n`.
 
 
 jQuery plugins

--- a/doc/contributing/frontend/javascript-module-tutorial.rst
+++ b/doc/contributing/frontend/javascript-module-tutorial.rst
@@ -41,7 +41,7 @@ A module can be created by calling ``ckan.module()``:
 
 ::
 
-    ckan.module('favorite', function (jQuery, _) {
+    ckan.module('favorite', function (jQuery) {
       return {};
     });
 
@@ -62,7 +62,7 @@ your module and if present calls the ``.initialize()`` method.
 
 ::
 
-    ckan.module('favorite', function (jQuery, _) {
+    ckan.module('favorite', function (jQuery) {
       return {
         initialize: function () {
           console.log('I've been called for element: %o', this.el);
@@ -146,11 +146,10 @@ This will override the defaults in the options object.
 
 ::
 
-    ckan.module('favorite', function (jQuery, _) {
+    ckan.module('favorite', function (jQuery) {
       return {
         options: {
-          dataset: '',
-          i18n: {...}
+          dataset: ''
         }
         initialize: function () {
           console.log('this dataset is: %s', this.options.dataset);
@@ -175,10 +174,8 @@ the user if the request fails. Again we can use
       request.fail(jQuery.proxy(this._onError, this));
     },
     _onError: function () {
-      var message = this.i18n('error', {id: this.button.val()});
-
       // Notify allows global messages to be displayed to the user.
-      this.sandbox.notify(message, 'error');
+      this.sandbox.notify('An error occurred!', 'error');
     }
 
 Module Scope
@@ -230,7 +227,7 @@ Now in our other module 'user-favorite-counter' we can listen for this.
 
 ::
 
-    ckan.module('user-favorite-counter', function (jQuery, _) {
+    ckan.module('user-favorite-counter', function (jQuery) {
       return {
         initialize: function () {
           jQuery.proxyAll(this, /_on/);

--- a/doc/contributing/frontend/templating.rst
+++ b/doc/contributing/frontend/templating.rst
@@ -85,39 +85,12 @@ be extended:
 Most template pages will define enough blocks so that the extending page
 can customise as little or as much as required.
 
+
 Internationalisation
 --------------------
 
-Jinja2 provides a couple of helpers for
-`internationalisation <http://Jinja2.pocoo.org/docs/templates/#i18n>`_.
-The most common is to use the ``_()`` function:
+See :ref:`jinja_i18n`.
 
-::
-
-    {% block page_content.html %}
-      <h1>{{ _('My page title') }}</h1>
-      <p>{{ _('This content will be added to the page') }}</p>
-    {% endblock %}
-
-Variables can be provided using the "format" function:
-
-::
-
-    {% block page_content.html %}
-      <p>{{ _('Welcome to CKAN {name}').format(name=username) }}</p>
-    {% endblock %}
-
-For longer multiline blocks the ``{% trans %}`` block can be used.
-
-::
-
-    {% block page_content.html %}
-      <p>
-        {% trans name=username %}
-          Welcome to CKAN {{ name }}
-        {% endtrans %}
-      </p>
-    {% endblock %}
 
 Conventions
 -----------

--- a/doc/contributing/javascript.rst
+++ b/doc/contributing/javascript.rst
@@ -402,10 +402,10 @@ than escaping newlines within a string::
       '</li>'
     ].join('');
 
-Always localise text strings within your templates. If you are including them
-inline this can always be done with jQuery::
+Always :ref:`localise text strings <javascript_i18n>` within your template. If
+you are including them inline this can be done with jQuery::
 
-    jQuery(template).find('span').text(_('This is my text string'));
+    jQuery(template).find('span').text(this._('This is my text string'));
 
 Larger templates can be loaded in using the CKAN snippet API. Modules get
 access to this functionality via the ``sandbox.client`` object::

--- a/doc/contributing/string-i18n.rst
+++ b/doc/contributing/string-i18n.rst
@@ -38,6 +38,8 @@ string internationalization when reviewing a pull request.
    existing code.
 
 
+.. _jinja_i18n:
+
 ------------------------------------------------
 Internationalizating strings in Jinja2 templates
 ------------------------------------------------
@@ -197,82 +199,62 @@ To handle different plural and singular forms of a string, use ``ungettext()``:
 Internationalizing strings in JavaScript code
 ---------------------------------------------
 
-Each :ref:`CKAN JavaScript module <javascript_modules>` receives the ``_``
-translation function during construction:
+Each :ref:`CKAN JavaScript module <javascript_modules>` offers the methods
+``_`` and ``ngettext`` for translating singular and plural strings,
+respectively:
 
 .. code-block:: javascript
 
-    this.ckan.module('i18n-demo', function($, _) {  // Note the `_`
-      ...
-    };
-
-Alternatively, you can use :ref:`this.sandbox.translate <this_sandbox>` (for
-which ``_`` is a shortcut).
-
-In contrast to Python code and Jinja templates, in Javascript ``_`` does not
-directly return the translated string. Instead, it returns a Jed_ translation
-object. Use its ``fetch`` method to get the translated singular string:
-
-.. code-block:: javascript
-
-    _('Translate me!').fetch()
-
-.. _Jed: http://slexaxton.github.io/Jed/
-
-Placeholders can be `specified in the string`_, their values are passed via
-``fetch``:
-
-.. _specified in the string: http://www.diveintojavascript.com/projects/javascript-sprintf
-
-.. code-block:: javascript
-
-    _('Hello, %(name)s!').fetch({name: 'John Doe'})
-
-For plural forms, use the ``ifPlural`` method:
-
-.. code-block:: javascript
-
-    var numDeleted = deletePackages();
-    console.log(
-      _('Deleted %(number)d package')
-        .ifPlural(numDeleted, 'Deleted %(number)d packages')
-        .fetch({number: numDeleted})
-    );
-
-However, you should not distribute your translateable strings all over your
-JavaScript module. Instead, collect them in ``options.i18n`` and then use the
-``this.i18n`` function to look them up:
-
-.. code-block:: javascript
-
-    this.ckan.module('i18n-demo', function($, _) {
-      return {
-        options: {
-          i18n: {
-            deleting _('Deleting...'),
-            deleted: function (data) {
-              return _('Deleted %(number)d package')
-                .isPlural(data.number, 'Deleted %(number)d packages');
+    this.ckan.module('i18n-demo', function($) {
+        return {
+            initialize: function () {
+                console.log(this._('Translate me!'));
+                console.log(this.ngettext('%(num)d item', '%(num)d items', 3));
             }
-          }
-        },
-
-        // ...
-
-        deleteSomeStuff: function() {
-          console.log(this.i18n('deleting'));
-          var numDeleted = deletePackages();
-          console.log(this.i18n('deleted', {number: numDeleted}));
-        }
-      };
+        };
     };
 
-As you can see, each entry in ``options.i18n`` maps an identifier to either a
-prepared Jed object (as returned by ``_``) or to a function that takes an
-object and then returns a Jed object. The latter form is for passing
-placeholders and constructing plural forms. Note that you should not call
-``fetch`` for the values in ``options.i18n``, that is handled automatically by
-``this.i18n``.
+To translate a fixed singular string, use ``_``. It returns the translation of
+the string for the currently selected locale. If the current locale doesn't
+provide a translation for the string then it is returned unchanged.
+
+.. code-block:: javascript
+
+    this._('Something that should be translated')
+
+Placeholders are supported via `sprintf-syntax`_, the corresponding values are
+passed via another parameter:
+
+.. _sprintf-syntax: http://www.diveintojavascript.com/projects/javascript-sprintf
+
+.. code-block:: javascript
+
+    this._("My name is %(name)s and I'm from %(hometown)s.",
+           {name: 'Sarah', hometown: 'Cape Town'})
+
+``ngettext`` allows you to translate a string that may be either singular or
+plural, depending on some variable:
+
+.. code-block:: javascript
+
+    this.ngettext('Deleted %(num)d item',
+                  'Deleted %(num)d items',
+                  items.length)
+
+If ``items.length`` is 1 then the translation for the first argument will be
+returned, otherwise that of the second argument. ``num`` is a magical
+placeholder that is automatically provided by ``ngettext`` and contains the
+value of the third parameter.
+
+Like ``_``, ``ngettext`` can take additional placeholders:
+
+.. code-block:: javascript
+
+    this.ngettext("I'm %(name)s and I'm %(num)d year old",
+                  "I'm %(name)s and I'm %(num)d years old",
+                  age,
+                  {name: 'John'})
+
 
 .. note::
 
@@ -288,6 +270,13 @@ placeholders and constructing plural forms. Note that you should not call
         # Update .po files as desired
         python setup.py compile_catalog   # Compile .mo files for Python/Jinja
         paster trans js                   # Compile JavaScript catalogs
+
+
+.. note::
+
+    Prior to CKAN 2.7, JavaScript modules received a similar but different
+    ``_`` function for string translation as a parameter. This is still
+    supported but deprecated and will be removed in a future release.
 
 -------------------------------------------------
 General guidelines for internationalizing strings

--- a/doc/extensions/translating-extensions.rst
+++ b/doc/extensions/translating-extensions.rst
@@ -4,14 +4,11 @@ Internationalizing strings in extensions
 
 .. seealso::
 
-   In order to internationalize your extension you must mark the strings for
-   internationalization. You can find out how to do this by reading
+   In order to internationalize your extension you must :doc:`mark its strings
+   for internationalization </contributing/string-i18n>`. See also
    :doc:`/contributing/i18n`.
 
-.. seealso::
-
-   In this tutorial we are assuming that you have read the
-   :doc:`/extensions/tutorial`.
+   This tutorial assumes that you have read the :doc:`/extensions/tutorial`.
 
 We will create a simple extension to demonstrate the translation of strings
 inside extensions. After running::

--- a/doc/theming/javascript-module-objects-and-methods.rst
+++ b/doc/theming/javascript-module-objects-and-methods.rst
@@ -30,8 +30,6 @@ module to use, including:
 
   * :js:data:`this.sandbox.client`, an API client for calling the API
 
-  * :ref:`Internationalization functions <javascript i18n>`
-
   * :js:data:`this.sandbox.jQuery`, a jQuery find function that is not bound to
     the module's HTML element. ``this.sandbox.jQuery('a')`` will return all the
     ``<a>`` elements on the entire page.
@@ -55,11 +53,8 @@ module to use, including:
   circumstances where a module may need to use ``window`` (for example if a
   vendor plugin that the module uses needs it).
 
-* ``this.i18n``, a helper function for getting localized strings from
-  ``this.options``. English strings marked for translation can be added to the
-  module's ``this.options`` object, and ``this.i18n()`` can be called to
-  retrieve the localized version of a string according to the current user's
-  language. See :ref:`javascript i18n`.
+* ``this._`` and ``this.ngettext`` for string internationalization. See
+  :ref:`javascript i18n`.
 
 * ``this.remove()``, a method that tears down the module and removes it from
   the page (this usually called by CKAN, not by the module itself).

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ directory = ckan/i18n
 statistics = true
 
 [extract_messages]
-keywords = translate isPlural
 add_comments = TRANSLATORS:
 output_file = ckan/i18n/ckan.pot
 width = 80


### PR DESCRIPTION
This PR makes plural translations in JS extractable (#3151).

As discussed in #3151, this PR adds two new JS functions `ckan.i18n._` and `ckan.i18n.ngettext` for singular and plural translations. In contrast to the previous `ckan.i18n.translate` function they do not expose the Jed instance which we use for the actual translation but return the fully translated strings (with inserted placeholder values where appropriate).

Correspondingly, JS CKAN modules now have `this._` and `this.ngettext` methods as shortcuts for the functions described above. The methods replace the old `this.i18n` / `this.options.i18n` functionality. Similarly, module declaration functions should not take `ckan.i18n` and `ckan.i18n.translate` arguments anymore.

The existing modules have been updated accordingly.

The old behavior has been left in place and should still work but is marked as deprecated. The changes should therefore be backwards-compatible.

The PR is a WIP, in particular the documentation has not been updated. However, the main changes are implemented and I think it's a good time to get some feedback to make sure that we agree on the details.

I haven't included the resulting changes in `ckan.pot` (i.e. the now extracted plural strings) since, as far as I understand, the actual translations are not managed via PRs.
