### PR TITLE
Update dashboard_organizations.html

### DIFF
--- a/ckan/templates/user/dashboard_organizations.html
+++ b/ckan/templates/user/dashboard_organizations.html
@@ -10,7 +10,7 @@
 
 {% block primary_content_inner %}
   <h2 class="hide-heading">{{ _('My Organizations') }}</h2>
-  {% set organizations = h.organizations_available() %}
+  {% set organizations = h.organizations_available(permission='read') %}
   {% if organizations %}
     <div class="wide">
       {% snippet "organization/snippets/organization_list.html", organizations=organizations %}


### PR DESCRIPTION
Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply

Add the permission parameter set to 'read' in order to retrieve organization people are members of and not only the ones the have edit rights on.