### PR TITLE
3220 switched abort from 404 to 401, user redirected to login page

### DIFF
--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -80,7 +80,7 @@ class UserController(base.BaseController):
         try:
             user_dict = get_action('user_show')(context, data_dict)
         except NotFound:
-            abort(404, _('User not found'))
+            abort(401, _('Authorize to see this page'))
         except NotAuthorized:
             abort(403, _('Not authorized to see this page'))
 


### PR DESCRIPTION
Fixes #
Anonymous users are now redirected to login page instead of Page not found 404 when trying to access /dashboard page.
### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply

