### PR TITLE
[#3233] Fix recline map config helpers

### DIFF
--- a/ckanext/reclineview/plugin.py
+++ b/ckanext/reclineview/plugin.py
@@ -58,6 +58,7 @@ class ReclineViewBase(p.SingletonPlugin):
     '''
     p.implements(p.IConfigurer, inherit=True)
     p.implements(p.IResourceView, inherit=True)
+    p.implements(p.ITemplateHelpers, inherit=True)
 
     def update_config(self, config):
         '''
@@ -80,13 +81,16 @@ class ReclineViewBase(p.SingletonPlugin):
     def view_template(self, context, data_dict):
         return 'recline_view.html'
 
+    def get_helpers(self):
+        return {
+            'get_map_config': get_mapview_config
+        }
+
 
 class ReclineView(ReclineViewBase):
     '''
     This extension views resources using a Recline MultiView.
     '''
-
-    p.implements(p.ITemplateHelpers, inherit=True)
 
     def info(self):
         return {'name': 'recline_view',
@@ -108,11 +112,6 @@ class ReclineView(ReclineViewBase):
             return resource_format.lower() in ['csv', 'xls', 'xlsx', 'tsv']
         else:
             return False
-
-    def get_helpers(self):
-        return {
-            'get_map_config': get_mapview_config
-        }
 
 
 class ReclineGridView(ReclineViewBase):
@@ -190,8 +189,6 @@ class ReclineMapView(ReclineViewBase):
     This extension views resources using a Recline map.
     '''
 
-    p.implements(p.ITemplateHelpers, inherit=True)
-
     map_field_types = [{'value': 'lat_long',
                         'text': 'Latitude / Longitude fields'},
                        {'value': 'geojson', 'text': 'GeoJSON'}]
@@ -252,8 +249,3 @@ class ReclineMapView(ReclineViewBase):
 
     def form_template(self, context, data_dict):
         return 'recline_map_form.html'
-
-    def get_helpers(self):
-        return {
-            'get_mapview_config': get_mapview_config
-        }

--- a/ckanext/reclineview/theme/templates/recline_view.html
+++ b/ckanext/reclineview/theme/templates/recline_view.html
@@ -2,7 +2,7 @@
 
 {% block page %}
 
-  {% set map_config = h.get_map_config() or h.get_mapview_config() %}
+  {% set map_config = h.get_map_config() %}
   <div data-module="recline_view"
        data-module-site_url="{{ h.dump_json(h.url('/', locale='default', qualified=true)) }}"
        data-module-resource = "{{ h.dump_json(resource_json) }}";


### PR DESCRIPTION
Previously recline_view and recline_map_view registered two separate names for the same helper function, and the template checked for both. But if you didn't load one of the plugins then you got a `HelperError` as one of them hadn't been registered.

This makes all recline plugins load the same helper so it only has one name and makes the template check for this unique name.