### PR TITLE
Issue 2882 activity time

### DIFF
--- a/ckan/lib/formatters.py
+++ b/ckan/lib/formatters.py
@@ -99,12 +99,10 @@ def localised_nice_date(datetime_, show_date=False, with_hours=False):
         return months
 
     if not show_date:
-        now = datetime.datetime.utcnow()
-        if datetime_.tzinfo is not None:
-            now = now.replace(tzinfo=datetime_.tzinfo)
-        else:
-            now = now.replace(tzinfo=pytz.utc)
-            datetime_ = datetime_.replace(tzinfo=pytz.utc)
+        now = datetime.datetime.now(pytz.utc)
+        if datetime_.tzinfo is None:
+            datetime_ = datetime_.astimezone(pytz.utc)
+
         date_diff = now - datetime_
         days = date_diff.days
         if days < 1 and now > datetime_:

--- a/ckan/lib/formatters.py
+++ b/ckan/lib/formatters.py
@@ -101,7 +101,7 @@ def localised_nice_date(datetime_, show_date=False, with_hours=False):
     if not show_date:
         now = datetime.datetime.now(pytz.utc)
         if datetime_.tzinfo is None:
-            datetime_ = datetime_.astimezone(pytz.utc)
+            datetime_ = datetime_.replace(tzinfo=pytz.utc)
 
         date_diff = now - datetime_
         days = date_diff.days

--- a/ckan/migration/versions/085_adjust_activity_timestamps.py
+++ b/ckan/migration/versions/085_adjust_activity_timestamps.py
@@ -5,7 +5,7 @@ import datetime
 
 def upgrade(migrate_engine):
     """
-    The script assumes that the current timestamp was 
+    The script assumes that the current timestamp was
     recorded with the server's current set timezone
     """
     utc_now = datetime.datetime.utcnow()

--- a/ckan/migration/versions/085_adjust_activity_timestamps.py
+++ b/ckan/migration/versions/085_adjust_activity_timestamps.py
@@ -2,9 +2,11 @@
 
 import datetime
 
+
 def upgrade(migrate_engine):
     """
-    The script assumes that the current timestamp was recorded with the server's current set timezone
+    The script assumes that the current timestamp was 
+    recorded with the server's current set timezone
     """
     utc_now = datetime.datetime.utcnow()
     local_now = datetime.datetime.now()

--- a/ckan/migration/versions/085_adjust_activity_timestamps.py
+++ b/ckan/migration/versions/085_adjust_activity_timestamps.py
@@ -1,33 +1,14 @@
 # encoding: utf-8
 
-import pytz
-import tzlocal
-import logging
-
-log = logging.getLogger(__name__)
+import datetime
 
 def upgrade(migrate_engine):
-"""
-The script assumes that the current timestamp was recorded with the server's current set timezone
-"""
-    local_tz = tzlocal.get_localzone()
+    """
+    The script assumes that the current timestamp was recorded with the server's current set timezone
+    """
+    utc_now = datetime.datetime.utcnow()
+    local_now = datetime.datetime.now()
 
     with migrate_engine.begin() as connection:
-        sql = "select id, timestamp from activity"
-        results = connection.execute(sql)
-
-        log.info("Adjusting Activity timestamp, server's localtime zone: {tz}".format(tz=local_tz))
-
-        for row in results:
-            id, timestamp = row
-
-            timestamp = timestamp.replace(tzinfo=local_tz)
-            to_utc = timestamp.astimezone(pytz.utc)
-            to_utc = to_utc.replace(tzinfo=None)
-
-            update_sql = "update activity set timestamp = %s where id = %s"
-
-            connection.execute(update_sql, to_utc, id)
-
-            log.info("""Adjusting Activity timestamp to UTC for {id}: {old_ts} --> {new_ts}
-            """.format(id=id, old_ts=timestamp, new_ts=to_utc))
+        sql = "update activity set timestamp = timestamp + (%s - %s);"
+        connection.execute(sql, utc_now, local_now)

--- a/ckan/migration/versions/085_adjust_activity_timestamps.py
+++ b/ckan/migration/versions/085_adjust_activity_timestamps.py
@@ -1,0 +1,33 @@
+# encoding: utf-8
+
+import pytz
+import tzlocal
+import logging
+
+log = logging.getLogger(__name__)
+
+def upgrade(migrate_engine):
+"""
+The script assumes that the current timestamp was recorded with the server's current set timezone
+"""
+    local_tz = tzlocal.get_localzone()
+
+    with migrate_engine.begin() as connection:
+        sql = "select id, timestamp from activity"
+        results = connection.execute(sql)
+
+        log.info("Adjusting Activity timestamp, server's localtime zone: {tz}".format(tz=local_tz))
+
+        for row in results:
+            id, timestamp = row
+
+            timestamp = timestamp.replace(tzinfo=local_tz)
+            to_utc = timestamp.astimezone(pytz.utc)
+            to_utc = to_utc.replace(tzinfo=None)
+
+            update_sql = "update activity set timestamp = %s where id = %s"
+
+            connection.execute(update_sql, to_utc, id)
+
+            log.info("""Adjusting Activity timestamp to UTC for {id}: {old_ts} --> {new_ts}
+            """.format(id=id, old_ts=timestamp, new_ts=to_utc))

--- a/ckan/migration/versions/085_adjust_activity_timestamps.py
+++ b/ckan/migration/versions/085_adjust_activity_timestamps.py
@@ -4,7 +4,7 @@ import datetime
 
 
 def upgrade(migrate_engine):
-    """
+    u"""
     The script assumes that the current timestamp was
     recorded with the server's current set timezone
     """
@@ -12,5 +12,5 @@ def upgrade(migrate_engine):
     local_now = datetime.datetime.now()
 
     with migrate_engine.begin() as connection:
-        sql = "update activity set timestamp = timestamp + (%s - %s);"
+        sql = u"update activity set timestamp = timestamp + (%s - %s);"
         connection.execute(sql, utc_now, local_now)

--- a/ckan/model/activity.py
+++ b/ckan/model/activity.py
@@ -40,7 +40,7 @@ class Activity(domain_object.DomainObject):
     def __init__(self, user_id, object_id, revision_id, activity_type,
             data=None):
         self.id = _types.make_uuid()
-        self.timestamp = datetime.datetime.now()
+        self.timestamp = datetime.datetime.utcnow()
         self.user_id = user_id
         self.object_id = object_id
         self.revision_id = revision_id


### PR DESCRIPTION
Fixes #2882 

### Proposed fixes:

Activity timestamps are now created with a UTC timestamp.

A migration script is also included to adjust all stored timestamps in the Activity table, based on using the server's set timezone.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
