### PR TITLE
RDF template returns server error if package has no extras

### DIFF
--- a/ckan/templates/package/read.rdf
+++ b/ckan/templates/package/read.rdf
@@ -59,7 +59,7 @@
     <dct:rights rdf:resource="{{c.pkg_dict['license_url']}}"/>
     {% endif %}
 
-    {% for extra_dict in c.pkg_dict.get('extras',None) %}
+    {% for extra_dict in c.pkg_dict.get('extras',[]) %}
         <dct:relation>
           <rdf:Description>
             <rdfs:label>{{extra_dict.get('key','')}}</rdfs:label>


### PR DESCRIPTION
Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply

In very special situations, pkg_dict hasn't such key as 'extras'.
it results in server error, because rdf template uses `None` as
fallback value.

Replaced it with empty list - it's more logically