### PR TITLE
[#2364] Add resource format for GeoJSON

### DIFF
--- a/ckan/config/resource_formats.json
+++ b/ckan/config/resource_formats.json
@@ -69,7 +69,7 @@
   ["TAR", "TAR Compressed File", "application/x-tar", []],
   ["PNG", "PNG Image File", "image/png", []],
   ["RSS", "RSS feed", "application/rss+xml", []],
-  ["GeoJSON", "Geographic JavaScript Object Notation", null, []],
+  ["GeoJSON", "Geographic JavaScript Object Notation", "application/geo+json", ["geojson"]],
   ["SHP", "Shapefile", null, ["esri shapefile"]],
   ["TORRENT", "Torrent", "application/x-bittorrent", ["bittorrent"]],
   ["ICS", "iCalendar", "text/calendar", ["ifb", "iCal"]],


### PR DESCRIPTION
Fixes #2364

### Proposed fixes:
This adds the official mimetype for GeoJSON: https://tools.ietf.org/html/rfc7946