### PR TITLE
Fix html rendering of apache and nginx config file paths.

### DIFF
--- a/doc/maintaining/installing/deployment.rst
+++ b/doc/maintaining/installing/deployment.rst
@@ -112,7 +112,7 @@ CKAN to run in).
 6. Create the Apache config file
 --------------------------------
 
-Create your site's Apache config file at ``|apache_config_file|``, with the
+Create your site's Apache config file at |apache_config_file|, with the
 following contents:
 
 .. parsed-literal::
@@ -203,7 +203,7 @@ Open ``/etc/apache2/ports.conf``. We need to replace the default port 80 with th
 8. Create the Nginx config file
 -------------------------------
 
-Create your site's Nginx config file at ``|nginx_config_file|``, with the
+Create your site's Nginx config file at |nginx_config_file|, with the
 following contents:
 
 .. parsed-literal::


### PR DESCRIPTION
- [x] includes updated documentation

Sphinx doesn't allow substitutions in verbatim (double backticks) blocks.
This caused the substitutions to not be expanded.  See
http://docs.ckan.org/en/latest/maintaining/installing/deployment.html
at the start of sections 6 and 8.

Alternatively, if it's preferred to keep the current markup, the substitution can be replaced by the full path (with a comment in ``conf.py``.