### PR TITLE
Removing set pkg_dict in package/edit_base.html

### DIFF
--- a/ckan/templates/package/edit_base.html
+++ b/ckan/templates/package/edit_base.html
@@ -1,7 +1,6 @@
 {% extends 'package/base.html' %}
 
 {% set pkg = c.pkg_dict %}
-{% set pkg_dict = c.pkg_dict %}
 
 {% block breadcrumb_content_selected %}{% endblock %}
 


### PR DESCRIPTION
### Proposed fixes:

This was causing `pkg_dict` to be overwritten by `c.pkg_dict`, which isn't a set variable while rendering `package/new_resource.html`.

I did a quick search for any other instances of `package/edit_base.html` being extended; Those templates look like they're not using `pkg_dict`.
### Features:
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
