### PR TITLE
[#2345] datastore: only create _table_metadata view if it does not exist yet

### DIFF
--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -120,7 +120,6 @@ class DatastorePlugin(p.SingletonPlugin):
                      'of _table_metadata are skipped.')
         else:
             self._check_urls_and_permissions()
-            self._create_alias_table()
 
     def notify(self, entity, operation=None):
         if not isinstance(entity, model.Package) or self.legacy_mode:
@@ -215,34 +214,6 @@ class DatastorePlugin(p.SingletonPlugin):
             write_connection.execute(drop_foo_sql)
             write_connection.close()
         return True
-
-    def _create_alias_table(self):
-        mapping_sql = '''
-            SELECT DISTINCT
-                substr(md5(dependee.relname || COALESCE(dependent.relname, '')), 0, 17) AS "_id",
-                dependee.relname AS name,
-                dependee.oid AS oid,
-                dependent.relname AS alias_of
-                -- dependent.oid AS oid
-            FROM
-                pg_class AS dependee
-                LEFT OUTER JOIN pg_rewrite AS r ON r.ev_class = dependee.oid
-                LEFT OUTER JOIN pg_depend AS d ON d.objid = r.oid
-                LEFT OUTER JOIN pg_class AS dependent ON d.refobjid = dependent.oid
-            WHERE
-                (dependee.oid != dependent.oid OR dependent.oid IS NULL) AND
-                (dependee.relname IN (SELECT tablename FROM pg_catalog.pg_tables)
-                    OR dependee.relname IN (SELECT viewname FROM pg_catalog.pg_views)) AND
-                dependee.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname='public')
-            ORDER BY dependee.oid DESC;
-        '''
-        create_alias_table_sql = u'CREATE OR REPLACE VIEW "_table_metadata" AS {0}'.format(mapping_sql)
-        try:
-            connection = db._get_engine(
-                {'connection_url': self.write_url}).connect()
-            connection.execute(create_alias_table_sql)
-        finally:
-            connection.close()
 
     def get_actions(self):
         actions = {'datastore_create': action.datastore_create,

--- a/ckanext/datastore/set_permissions.sql
+++ b/ckanext/datastore/set_permissions.sql
@@ -48,3 +48,24 @@ GRANT SELECT ON ALL TABLES IN SCHEMA public TO "{readuser}";
 -- grant access to new tables and views by default
 ALTER DEFAULT PRIVILEGES FOR USER "{writeuser}" IN SCHEMA public
    GRANT SELECT ON TABLES TO "{readuser}";
+
+CREATE OR REPLACE VIEW "_table_metadata" AS
+    SELECT DISTINCT
+        substr(md5(dependee.relname || COALESCE(dependent.relname, '')), 0, 17) AS "_id",
+        dependee.relname AS name,
+        dependee.oid AS oid,
+        dependent.relname AS alias_of
+        -- dependent.oid AS oid
+    FROM
+        pg_class AS dependee
+        LEFT OUTER JOIN pg_rewrite AS r ON r.ev_class = dependee.oid
+        LEFT OUTER JOIN pg_depend AS d ON d.objid = r.oid
+        LEFT OUTER JOIN pg_class AS dependent ON d.refobjid = dependent.oid
+    WHERE
+        (dependee.oid != dependent.oid OR dependent.oid IS NULL) AND
+        (dependee.relname IN (SELECT tablename FROM pg_catalog.pg_tables)
+            OR dependee.relname IN (SELECT viewname FROM pg_catalog.pg_views)) AND
+        dependee.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname='public')
+    ORDER BY dependee.oid DESC;
+ALTER VIEW "_table_metadata" OWNER TO "{writeuser}";
+GRANT SELECT ON "_table_metadata" TO "{readuser}";


### PR DESCRIPTION
Fixes #2345
### Features:
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport
