### PR TITLE
Fixes #2657 by not ignoring filters when embedded

### DIFF
--- a/ckanext/reclineview/theme/public/recline_view.js
+++ b/ckanext/reclineview/theme/public/recline_view.js
@@ -63,17 +63,18 @@ this.ckan.module('recline_view', function (jQuery, _) {
       var query = new recline.Model.Query();
       query.set({ size: reclineView.limit || 100 });
       query.set({ from: reclineView.offset || 0 });
-
+      
+      var urlFilters = {};
       try {
         if (window.parent.ckan.views && window.parent.ckan.views.filters) {
-          var defaultFilters = reclineView.filters || {},
-              urlFilters = window.parent.ckan.views.filters.get(),
-              filters = $.extend({}, defaultFilters, urlFilters);
-          $.each(filters, function (field,values) {
-            query.addFilter({type: 'term', field: field, term: values});
-          });
+          urlFilters = window.parent.ckan.views.filters.get();
         }
       } catch(e) {}
+      var defaultFilters = reclineView.filters || {},
+          filters = $.extend({}, defaultFilters, urlFilters);
+      $.each(filters, function (field,values) {
+        query.addFilter({type: 'term', field: field, term: values});
+      });
 
       dataset.queryState.set(query.toJSON(), {silent: true});
 


### PR DESCRIPTION
Fixes #2657 

### Proposed fixes:
Do not ignore filters when "embedded" - i.e. not inside a CKAN parent window


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply

