### PR TITLE
[#2346] Dashboard_activity_list_html() dosen't pass user id

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -3349,11 +3349,13 @@ def dashboard_activity_list_html(context, data_dict):
     '''
     activity_stream = dashboard_activity_list(context, data_dict)
     model = context['model']
+    user_id = context['user']
     offset = data_dict.get('offset', 0)
     extra_vars = {
         'controller': 'user',
         'action': 'dashboard',
         'offset': offset,
+        'id': user_id
     }
     return activity_streams.activity_list_to_html(context, activity_stream,
                                                   extra_vars)


### PR DESCRIPTION
Fixes #

Load more don't work on Dashboard page, because dashboard_activity_list_html() don't pass id as an argument, so in activity-stream.js the user_activity_list_html() gives us an error.

### Proposed fixes:

Fix it by passing id from context as we do with model= context['model']. As a result context['user'] gives us the name of current user and we can use it, because user_activity_list_html() can take both id and username as id.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
