### PR TITLE
Support for JS translations in extensions

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -22,6 +22,7 @@ import ckan.lib.search as search
 import ckan.logic as logic
 import ckan.authz as authz
 import ckan.lib.jinja_extensions as jinja_extensions
+from ckan.lib.i18n import build_js_translations
 
 from ckan.common import _, ungettext, config
 from ckan.exceptions import CkanConfigurationException
@@ -102,6 +103,11 @@ def load_environment(global_conf, app_conf):
     p.load_all()
 
     app_globals.reset()
+
+    # Build JavaScript translations. Must be done after plugins have
+    # been loaded.
+    build_js_translations()
+
 
 # A mapping of config settings that can be overridden by env vars.
 # Note: Do not remove the following lines, they are used in the docs

--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -1779,98 +1779,17 @@ class TranslationsCommand(CkanCommand):
     def command(self):
         self._load_config()
         from ckan.common import config
-        self.ckan_path = os.path.join(os.path.dirname(__file__), '..')
-        i18n_path = os.path.join(self.ckan_path, 'i18n')
-        self.i18n_path = config.get('ckan.i18n_directory', i18n_path)
+        from ckan.lib.i18n import build_js_translations
+        ckan_path = os.path.join(os.path.dirname(__file__), '..')
+        self.i18n_path = config.get('ckan.i18n_directory',
+                                    os.path.join(ckan_path, 'i18n'))
         command = self.args[0]
         if command == 'mangle':
             self.mangle_po()
         elif command == 'js':
-            self.build_js_translations()
+            build_js_translations()
         else:
             print 'command not recognised'
-
-    def po2dict(self, po, lang):
-        '''Convert po object to dictionary data structure (ready for JSON).
-
-        This function is from pojson
-        https://bitbucket.org/obviel/pojson
-
-Copyright (c) 2010, Fanstatic Developers
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-      names of its contributors may be used to endorse or promote products
-      derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL FANSTATIC DEVELOPERS BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-'''
-        result = {}
-
-        result[''] = {}
-        result['']['plural-forms'] = po.metadata['Plural-Forms']
-        result['']['lang'] = lang
-        result['']['domain'] = 'ckan'
-
-        for entry in po:
-            if entry.obsolete:
-                continue
-            # check if used in js file we only include these
-            occurrences = entry.occurrences
-            js_use = False
-            for occurrence in occurrences:
-                if occurrence[0].endswith('.js'):
-                    js_use = True
-                    continue
-            if not js_use:
-                continue
-            if entry.msgstr:
-                result[entry.msgid] = [None, entry.msgstr]
-            elif entry.msgstr_plural:
-                plural = [entry.msgid_plural]
-                result[entry.msgid] = plural
-                ordered_plural = sorted(entry.msgstr_plural.items())
-                for order, msgstr in ordered_plural:
-                    plural.append(msgstr)
-        return result
-
-    def build_js_translations(self):
-        import polib
-        import simplejson as json
-
-        def create_js(source, lang):
-            print 'Generating', lang
-            po = polib.pofile(source)
-            data = self.po2dict(po, lang)
-            data = json.dumps(data, sort_keys=True,
-                              ensure_ascii=False, indent=2 * ' ')
-            out_dir = os.path.abspath(os.path.join(self.ckan_path, 'public',
-                                                   'base', 'i18n'))
-            out_file = open(os.path.join(out_dir, '%s.js' % lang), 'w')
-            out_file.write(data.encode('utf-8'))
-            out_file.close()
-
-        for l in os.listdir(self.i18n_path):
-            if os.path.isdir(os.path.join(self.i18n_path, l)):
-                f = os.path.join(self.i18n_path, l, 'LC_MESSAGES', 'ckan.po')
-                create_js(f, l)
-        print 'Completed generating JavaScript translations'
 
     def mangle_po(self):
         ''' This will mangle the zh_TW translations for translation coverage

--- a/ckan/lib/i18n.py
+++ b/ckan/lib/i18n.py
@@ -348,6 +348,7 @@ def build_js_translations():
     ``ckan.i18n_directory``. These include only those translation
     strings that are actually used in JS files.
     '''
+    log.debug(u'Generating JavaScript translations')
     ckan_dir = os.path.join(os.path.dirname(__file__), u'..')
     ckan_i18n_dir = config.get(u'ckan.i18n_directory',
                                os.path.join(ckan_dir, u'i18n'))
@@ -379,6 +380,10 @@ def build_js_translations():
                                  domain + u'.po')
                     for i18n_dir, domain in i18n_dirs.iteritems()]
         po_files = [fn for fn in po_files if os.path.isfile(fn)]
-        log.debug(u'Generating JS translations for {}'.format(lang))
+        latest = max(os.path.getmtime(fn) for fn in po_files)
         dest_file = os.path.join(dest_dir, lang + u'.js')
-        _build_js_translation(lang, po_files, js_entries, dest_file)
+        if os.path.isfile(dest_file) and os.path.getmtime(dest_file) > latest:
+            log.debug(u'JS translation for "{}" is up to date'.format(lang))
+        else:
+            log.debug(u'Generating JS translation for "{}"'.format(lang))
+            _build_js_translation(lang, po_files, js_entries, dest_file)

--- a/ckan/lib/i18n.py
+++ b/ckan/lib/i18n.py
@@ -1,5 +1,41 @@
 # encoding: utf-8
 
+'''
+Internationalization utilities.
+
+This module contains code from the pojson project, which is subject to
+the following license (see https://bitbucket.org/obviel/pojson):
+
+Copyright (c) 2010, Fanstatic Developers
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of the organization nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FANSTATIC
+DEVELOPERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+'''
+
 import json
 import logging
 import os
@@ -244,95 +280,105 @@ def set_lang(language_code):
         _set_lang(language_code)
 
 
-def _po2dict(po, lang):
+def _get_js_translation_entries(filename):
     '''
-    Convert po object to dictionary data structure (ready for JSON).
+    Extract IDs of PO entries that are used in JavaScript files.
 
-    This function is from pojson
-    https://bitbucket.org/obviel/pojson
-
-    Copyright (c) 2010, Fanstatic Developers
-    All rights reserved.
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions
-    are met:
-
-        * Redistributions of source code must retain the above copyright
-          notice, this list of conditions and the following disclaimer.
-        * Redistributions in binary form must reproduce the above
-          copyright notice, this list of conditions and the following
-          disclaimer in the documentation and/or other materials
-          provided with the distribution.
-        * Neither the name of the <organization> nor the
-          names of its contributors may be used to endorse or promote
-          products derived from this software without specific prior
-          written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FANSTATIC
-    DEVELOPERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-    EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-    PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-    PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-    OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-    USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-    DAMAGE.
+    :param filename: PO filename
+    :type filename: string
+    :return: The IDs of those entries which occur in a ``*.js`` file
+    :rtype: set
     '''
+    js_entries = set()
+    for entry in polib.pofile(filename):
+        if entry.obsolete:
+            continue
+        for occ in entry.occurrences:
+            if occ[0].endswith(u'.js'):
+                js_entries.add(entry.msgid)
+    return js_entries
+
+
+def _build_js_translation(lang, source_filenames, entries, dest_filename):
+    '''
+    Build JavaScript translations for a single language.
+
+    Collects translations for a language from several PO files and
+    stores the entries in a JSON file.
+
+    :param lang: Language code
+    :type lang: string
+    :param source_filenames: Filenames of PO files
+    :type source_filenames: List of strings
+    :param entries: List of entry IDs. Only entries whose IDs are in
+                    this list are exported.
+    :type entries: List of strings
+    :param dest_filename: Output filename
+    '''
+    pos = [polib.pofile(fn) for fn in source_filenames]
+
     result = {}
-
     result[u''] = {}
-    result[u''][u'plural-forms'] = po.metadata[u'Plural-Forms']
+    result[u''][u'plural-forms'] = pos[0].metadata[u'Plural-Forms']
     result[u''][u'lang'] = lang
     result[u''][u'domain'] = u'ckan'
 
-    for entry in po:
-        if entry.obsolete:
-            continue
-        # check if used in js file we only include these
-        occurrences = entry.occurrences
-        js_use = False
-        for occurrence in occurrences:
-            if occurrence[0].endswith(u'.js'):
-                js_use = True
+    for po in pos:
+        for entry in po:
+            if entry.msgid not in entries:
                 continue
-        if not js_use:
-            continue
-        if entry.msgstr:
-            result[entry.msgid] = [None, entry.msgstr]
-        elif entry.msgstr_plural:
-            plural = [entry.msgid_plural]
-            result[entry.msgid] = plural
-            ordered_plural = sorted(entry.msgstr_plural.items())
-            for order, msgstr in ordered_plural:
-                plural.append(msgstr)
-    return result
+            if entry.msgstr:
+                result[entry.msgid] = [None, entry.msgstr]
+            elif entry.msgstr_plural:
+                plural = result[entry.msgid] = [entry.msgid_plural]
+                ordered_plural = sorted(entry.msgstr_plural.items())
+                for order, msgstr in ordered_plural:
+                    plural.append(msgstr)
+    with open(dest_filename, u'w') as f:
+        s = json.dumps(result, sort_keys=True, indent=2, ensure_ascii=False)
+        f.write(s.encode(u'utf-8'))
 
 
 def build_js_translations():
     '''
     Build JavaScript translation files.
 
-    Takes the PO files from ``ckan/i18n`` and creates corresponding JS
-    translation files in ``ckan.i18n_directory``. These include only
-    those translation strings that are actually used in JS files.
+    Takes the PO files from CKAN and from plugins that implement
+    ``ITranslation`` and creates corresponding JS translation files in
+    ``ckan.i18n_directory``. These include only those translation
+    strings that are actually used in JS files.
     '''
-    ckan_dir = os.path.join(os.path.dirname(__file__), '..')
-    source_dir = config.get('ckan.i18n_directory',
-                            os.path.join(ckan_dir, 'i18n'))
-    dest_dir = os.path.join(ckan_dir, 'public', 'base', 'i18n')
-    for lang in os.listdir(source_dir):
-        if os.path.isdir(os.path.join(source_dir, lang)):
-            log.debug('Generating JS translations for {}'.format(lang))
-            source_file = os.path.join(source_dir, lang, 'LC_MESSAGES',
-                                       'ckan.po')
-            po = polib.pofile(source_file)
-            data = _po2dict(po, lang)
-            dest_file = os.path.join(dest_dir, '%s.js' % lang)
-            with open(dest_file, 'w') as f:
-                s = json.dumps(data, sort_keys=True, indent=2,
-                               ensure_ascii=False)
-                f.write(s.encode('utf-8'))
+    ckan_dir = os.path.join(os.path.dirname(__file__), u'..')
+    ckan_i18n_dir = config.get(u'ckan.i18n_directory',
+                               os.path.join(ckan_dir, u'i18n'))
+    dest_dir = os.path.join(ckan_dir, u'public', u'base', u'i18n')
+
+    # Collect all language codes (an extension might add support for a
+    # language that isn't supported by CKAN core, yet).
+    langs = set()
+    i18n_dirs = {ckan_i18n_dir: u'ckan'}
+    for item in os.listdir(ckan_i18n_dir):
+        if os.path.isdir(os.path.join(ckan_i18n_dir, item)):
+            langs.add(item)
+    for plugin in PluginImplementations(ITranslation):
+        langs.update(plugin.i18n_locales())
+        i18n_dirs[plugin.i18n_directory()] = plugin.i18n_domain()
+
+    # Find out which translation entries are used in JS files. We use
+    # the POT files for that, since they contain all translation entries
+    # (even those for which no translation exists, yet).
+    js_entries = set()
+    for i18n_dir, domain in i18n_dirs.iteritems():
+        pot_file = os.path.join(i18n_dir, domain + u'.pot')
+        if os.path.isfile(pot_file):
+            js_entries.update(_get_js_translation_entries(pot_file))
+
+    # Build translations for each language
+    for lang in sorted(langs):
+        po_files = [os.path.join(i18n_dir, lang, u'LC_MESSAGES',
+                                 domain + u'.po')
+                    for i18n_dir, domain in i18n_dirs.iteritems()]
+        po_files = [fn for fn in po_files if os.path.isfile(fn)]
+        log.debug(u'Generating JS translations for {}'.format(lang))
+        dest_file = os.path.join(dest_dir, lang + u'.js')
+        _build_js_translation(lang, po_files, js_entries, dest_file)

--- a/ckan/lib/i18n.py
+++ b/ckan/lib/i18n.py
@@ -63,6 +63,12 @@ log = logging.getLogger(__name__)
 # we don't have a Portuguese territory translation currently.
 LOCALE_ALIASES['pt'] = 'pt_BR'
 
+# CKAN root directory
+_CKAN_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), u'..'))
+
+# Output directory for generated JavaScript translations
+_JS_TRANSLATIONS_DIR = os.path.join(_CKAN_DIR, u'public', u'base', u'i18n')
+
 
 def get_locales_from_config():
     ''' despite the name of this function it gets the locales defined by
@@ -349,10 +355,8 @@ def build_js_translations():
     strings that are actually used in JS files.
     '''
     log.debug(u'Generating JavaScript translations')
-    ckan_dir = os.path.join(os.path.dirname(__file__), u'..')
     ckan_i18n_dir = config.get(u'ckan.i18n_directory',
-                               os.path.join(ckan_dir, u'i18n'))
-    dest_dir = os.path.join(ckan_dir, u'public', u'base', u'i18n')
+                               os.path.join(_CKAN_DIR, u'i18n'))
 
     # Collect all language codes (an extension might add support for a
     # language that isn't supported by CKAN core, yet).
@@ -381,7 +385,7 @@ def build_js_translations():
                     for i18n_dir, domain in i18n_dirs.iteritems()]
         po_files = [fn for fn in po_files if os.path.isfile(fn)]
         latest = max(os.path.getmtime(fn) for fn in po_files)
-        dest_file = os.path.join(dest_dir, lang + u'.js')
+        dest_file = os.path.join(_JS_TRANSLATIONS_DIR, lang + u'.js')
         if os.path.isfile(dest_file) and os.path.getmtime(dest_file) > latest:
             log.debug(u'JS translation for "{}" is up to date'.format(lang))
         else:

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1547,6 +1547,9 @@ class IAuthenticator(Interface):
 
 
 class ITranslation(Interface):
+    u'''
+    Allows extensions to provide their own translation strings.
+    '''
     def i18n_directory(self):
         u'''Change the directory of the .mo translation files'''
 

--- a/ckan/tests/lib/_i18n_build_js_translations/ckanext-test_js_translations.pot
+++ b/ckan/tests/lib/_i18n_build_js_translations/ckanext-test_js_translations.pot
@@ -1,0 +1,36 @@
+# Manually maintained helper file for `ckan/tests/lib/test_i18n.py`.
+
+msgid ""
+msgstr ""
+"Project-Id-Version: ckan 2.5.0b\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2015-11-26 13:42+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.1.1\n"
+
+# Overriding a JS translation from CKAN core
+#: ckan/public/base/javascript/modules/activity-stream.js:20
+#: ckan/public/base/javascript/modules/popover-context.js:45
+#: ckan/templates/package/snippets/data_api_button.html:8
+#: ckan/templates/tests/mock_json_resource_preview_template.html:7
+#: ckan/templates/tests/mock_resource_preview_template.html:7
+#: ckanext/reclineview/theme/templates/recline_view.html:12
+#: ckanext/textview/theme/templates/text_view.html:9
+msgid "Loading..."
+msgstr ""
+
+# Introducing a (fake) JS translation string that doesn't occur in CKAN core
+#: ckanext/test_js_translations/does-not-exist.js:1
+msgid "Test JS Translations 1"
+msgstr ""
+
+# Introducing a (fake) translation string that doesn't occur in JS
+#: ckanext/test_js_translations/does-not-exist.py:1
+msgid "Test JS Translations 2"
+msgstr ""
+

--- a/ckan/tests/lib/_i18n_build_js_translations/de/LC_MESSAGES/ckanext-test_js_translations.po
+++ b/ckan/tests/lib/_i18n_build_js_translations/de/LC_MESSAGES/ckanext-test_js_translations.po
@@ -1,0 +1,27 @@
+# Manually maintained helper file for `ckan/tests/lib/test_i18n.py`.
+
+msgid ""
+msgstr ""
+"Project-Id-Version: ckan 2.5.0b\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2015-11-26 13:42+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.1.1\n"
+
+# Overriding a JS translation from CKAN core
+msgid "Loading..."
+msgstr "foo"
+
+# Introducing a (fake) JS translation string that doesn't occur in CKAN core
+msgid "Test JS Translations 1"
+msgstr "bar"
+
+# Introducing a (fake) translation string that doesn't occur in JS
+msgid "Test JS Translations 2"
+msgstr "baz"
+

--- a/ckan/tests/lib/test_i18n.py
+++ b/ckan/tests/lib/test_i18n.py
@@ -1,0 +1,141 @@
+# encoding: utf-8
+
+u'''
+Tests for ``ckan.lib.i18n``.
+'''
+
+import codecs
+import json
+import os.path
+import shutil
+import tempfile
+
+from nose.tools import eq_, ok_, raises
+
+from ckan.lib import i18n
+from ckan import plugins
+from ckan.lib.plugins import DefaultTranslation
+
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+I18N_DIR = os.path.join(HERE, u'_i18n_build_js_translations')
+
+
+class TestJSTranslationsPlugin(plugins.SingletonPlugin, DefaultTranslation):
+    u'''
+    CKAN plugin for testing JavaScript translations from extensions.
+
+    Registered in ``setup.py`` as ``test_js_translations_plugin``.
+    '''
+    plugins.implements(plugins.ITranslation)
+
+    def i18n_directory(self):
+        return I18N_DIR
+
+    def i18n_domain(self):
+        return u'ckanext-test_js_translations'
+
+
+class TestBuildJSTranslations(object):
+    u'''
+    Tests for ``ckan.lib.i18n.build_js_translations``.
+    '''
+    @classmethod
+    def setup_class(cls):
+        if not plugins.plugin_loaded(u'test_js_translations_plugin'):
+            plugins.load(u'test_js_translations_plugin')
+
+    @classmethod
+    def teardown_class(cls):
+        plugins.unload(u'test_js_translations_plugin')
+
+    def setup(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def teardown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def build_js_translations(self):
+        u'''
+        Build JS translations in temporary directory.
+        '''
+        old_translations_dir = i18n._JS_TRANSLATIONS_DIR
+        i18n._JS_TRANSLATIONS_DIR = self.temp_dir
+        try:
+            return i18n.build_js_translations()
+        finally:
+            i18n._JS_TRANSLATIONS_DIR = old_translations_dir
+
+    def test_output_is_valid(self):
+        u'''
+        Test that the generated JS files are valid.
+        '''
+        def check_file(path):
+            with codecs.open(path, u'r', encoding=u'utf-8') as f:
+                data = json.load(f)
+            eq_(data[u''].get(u'domain', None), u'ckan')
+
+        self.build_js_translations()
+        files = os.listdir(self.temp_dir)
+
+        # Check that all locales have been generated
+        eq_(set(i18n.get_locales()).difference([u'en']),
+            set(os.path.splitext(fn)[0] for fn in files))
+
+        # Check that each file is valid
+        for filename in files:
+            check_file(os.path.join(self.temp_dir, filename))
+
+    def test_regenerate_only_if_necessary(self):
+        u'''
+        Test that translation files are only generated when necessary.
+        '''
+        self.build_js_translations()
+        mtimes = {}
+        for filename in os.listdir(self.temp_dir):
+            fullname = os.path.join(self.temp_dir, filename)
+            mtimes[filename] = os.path.getmtime(fullname)
+
+        # Remove an output file and back-date another one
+        removed_filename, outdated_filename = sorted(mtimes.keys())[:2]
+        removed_mtime = mtimes.pop(removed_filename)
+        outdated_mtime = mtimes.pop(outdated_filename)
+        os.remove(os.path.join(self.temp_dir, removed_filename))
+        os.utime(os.path.join(self.temp_dir, outdated_filename), (0, 0))
+
+        self.build_js_translations()
+
+        # Make sure deleted file has been rebuild
+        ok_(os.path.isfile(os.path.join(self.temp_dir, removed_filename)))
+
+        # Make sure outdated file has been rebuild
+        fullname = os.path.join(self.temp_dir, outdated_filename)
+        ok_(os.path.getmtime(fullname) >= outdated_mtime)
+
+        # Make sure the other files have not been rebuild
+        for filename in os.listdir(self.temp_dir):
+            if filename in [removed_filename, outdated_filename]:
+                continue
+            fullname = os.path.join(self.temp_dir, filename)
+            new_mtime = os.path.getmtime(fullname)
+            eq_(new_mtime, mtimes[filename])
+
+    def test_translations_from_extensions(self):
+        u'''
+        Test that translations from extensions are taken into account.
+        '''
+        self.build_js_translations()
+        filename = os.path.join(self.temp_dir, u'de.js')
+        with codecs.open(filename, u'r', encoding=u'utf-8') as f:
+            de = json.load(f)
+
+        # Check overriding a JS translation from CKAN core
+        ok_(u'Loading...' in de)
+        eq_(de[u'Loading...'], [None, u'foo'])
+
+        # Check introducing a new JS translation
+        ok_(u'Test JS Translations 1' in de)
+        eq_(de[u'Test JS Translations 1'], [None, u'bar'])
+
+        # Check that non-JS strings are not exported
+        ok_(u'Test JS Translations 2' not in de)

--- a/doc/contributing/string-i18n.rst
+++ b/doc/contributing/string-i18n.rst
@@ -277,18 +277,17 @@ placeholders and constructing plural forms. Note that you should not call
 .. note::
 
     CKAN's JavaScript code automatically downloads the appropriate translations
-    at request time from the CKAN server. The corresponding translation files
-    are generated beforehand using ``paster trans js``. During development you
-    need to run that command manually if you're updating JavaScript
-    translations::
+    at request time from the CKAN server. Since CKAN 2.7 the corresponding
+    translation files are regenerated automatically if necessary when CKAN
+    starts.
+
+    You can also regenerate the translation files manually using ``paster trans
+    js``::
 
         python setup.py extract_messages  # Extract translatable strings
         # Update .po files as desired
         python setup.py compile_catalog   # Compile .mo files for Python/Jinja
         paster trans js                   # Compile JavaScript catalogs
-
-    Also note that extensions currently `cannot provide translations for
-    JS strings <https://github.com/ckan/ideas-and-roadmap/issues/176>`_.
 
 -------------------------------------------------
 General guidelines for internationalizing strings

--- a/doc/extensions/translating-extensions.rst
+++ b/doc/extensions/translating-extensions.rst
@@ -30,6 +30,12 @@ containing:
 This template provides a sample string that we will internationalize in this
 tutorial.
 
+.. note::
+
+    While this tutorial only covers Python/Jinja templates it is also possible
+    (since CKAN 2.7) to :ref:`translate strings in an extension's JavaScript
+    modules <javascript_i18n>`.
+
 ---------------
 Extract strings
 ---------------
@@ -163,13 +169,4 @@ implement the ``ITranslation`` interface yourself.
    ~ckan.plugins.interfaces.ITranslation.i18n_directory
    ~ckan.plugins.interfaces.ITranslation.i18n_locales
    ~ckan.plugins.interfaces.ITranslation.i18n_domain
-
-----------
-JavaScript
-----------
-Extensions currently `cannot provide their own translations for JavaScript
-strings <https://github.com/ckan/ideas-and-roadmap/issues/176>`_.
-
-However, they can re-use existing JavaScript translations from CKAN. See
-:ref:`javascript_i18n` for details.
 

--- a/doc/maintaining/paster.rst
+++ b/doc/maintaining/paster.rst
@@ -504,8 +504,14 @@ trans: Translation helper functions
 
 Usage::
 
-    trans js      - generate the javascript translations
+    trans js      - generate the JavaScript translations
     trans mangle  - mangle the zh_TW translations for testing
+
+.. note::
+
+    Since version 2.7 the JavaScript translation files are automatically
+    regenerated if necessary when CKAN is started. Hence you usually do not
+    need to run ``paster trans js`` manually.
 
 
 .. _paster-user:

--- a/setup.py
+++ b/setup.py
@@ -167,6 +167,7 @@ entry_points = {
         'test_routing_plugin = ckan.tests.config.test_middleware:MockRoutingPlugin',
         'test_helpers_plugin = ckan.tests.lib.test_helpers:TestHelpersPlugin',
         'test_feed_plugin = ckan.tests.controllers.test_feed:MockFeedPlugin',
+        'test_js_translations_plugin = ckan.tests.lib.test_i18n:TestJSTranslationsPlugin',
     ],
     'babel.extractors': [
         'ckan = ckan.lib.extract:extract_ckan',


### PR DESCRIPTION
This PR is a WIP to support JavaScript translations in extensions (ckan/ideas-and-roadmap#176).

Currently, CKAN's translation files for JavaScript are generated "manually" using `paster trans js`. The generated files take only the translations from core CKAN into account.

This PR introduces the following changes:
- Translations from extensions that implement `ITranslation` are taken into account. Hence, extensions may override CKAN translations used in JS or introduce their own translatable strings in JS.
- Translations are only (re-)generated if they're out-of-date, i.e. if there's a PO-file for the language that's newer than the generated JS file.
- Translations are re-generated during server startup (if necessary).

With these changes, translations in extensions work transparently for both Jinja and JS. No changes to the extensions are necessary. Running `paster trans js` isn't required anymore, but the command has been kept in case one wants to work on translations without constantly restarting the server.

I'd love to get some feedback on that approach. Once there's a consensus I'll add the missing tests and update the documentation.
