### PR TITLE
[#3265] Fixes removal of memberships on user_delete

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -861,12 +861,9 @@ class UserCmd(CkanCommand):
             return
         username = self.args[1]
 
-        user = model.User.by_name(unicode(username))
-        if not user:
-            print 'Error: user "%s" not found!' % username
-            return
-        user.delete()
-        model.repo.commit_and_remove()
+        p.toolkit.get_action('user_delete')(
+            {'model': model, 'ignore_auth': True},
+            {'id': username})
         print('Deleted user: %s' % username)
 
 

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -56,7 +56,7 @@ def user_delete(context, data_dict):
     user.delete()
 
     user_memberships = model.Session.query(model.Member).filter(
-        model.Member.table_id == user_id).all()
+        model.Member.table_id == user.id).all()
 
     for membership in user_memberships:
         membership.delete()

--- a/ckan/tests/logic/action/test_delete.py
+++ b/ckan/tests/logic/action/test_delete.py
@@ -491,6 +491,74 @@ class TestDatasetPurge(object):
                       helpers.call_action, 'dataset_purge', id='123')
 
 
+class TestUserDelete(object):
+    def setup(self):
+        helpers.reset_db()
+
+    def test_user_delete(self):
+        user = factories.User()
+        context = {}
+        params = {u'id': user[u'id']}
+
+        helpers.call_action(u'user_delete', context, **params)
+
+        # It is still there but with state=deleted
+        user_obj = model.User.get(user[u'id'])
+        assert_equals(user_obj.state, u'deleted')
+
+    def test_user_delete_removes_memberships(self):
+        user = factories.User()
+        factories.Organization(
+            users=[{u'name': user[u'id'], u'capacity': u'admin'}])
+
+        factories.Group(
+            users=[{u'name': user[u'id'], u'capacity': u'admin'}])
+
+        user_memberships = model.Session.query(model.Member).filter(
+            model.Member.table_id == user[u'id']).all()
+
+        assert_equals(len(user_memberships), 2)
+
+        assert_equals([m.state for m in user_memberships],
+                      [u'active', u'active'])
+
+        context = {}
+        params = {u'id': user[u'id']}
+
+        helpers.call_action(u'user_delete', context, **params)
+
+        user_memberships = model.Session.query(model.Member).filter(
+            model.Member.table_id == user[u'id']).all()
+
+        # Member objects are still there, but flagged as deleted
+        assert_equals(len(user_memberships), 2)
+
+        assert_equals([m.state for m in user_memberships],
+                      [u'deleted', u'deleted'])
+
+    def test_user_delete_removes_memberships_when_using_name(self):
+        user = factories.User()
+        factories.Organization(
+            users=[{u'name': user[u'id'], u'capacity': u'admin'}])
+
+        factories.Group(
+            users=[{u'name': user[u'id'], u'capacity': u'admin'}])
+
+        context = {}
+        params = {u'id': user[u'name']}
+
+        helpers.call_action(u'user_delete', context, **params)
+
+        user_memberships = model.Session.query(model.Member).filter(
+            model.Member.table_id == user[u'id']).all()
+
+        # Member objects are still there, but flagged as deleted
+        assert_equals(len(user_memberships), 2)
+
+        assert_equals([m.state for m in user_memberships],
+                      [u'deleted', u'deleted'])
+
+
 class TestJobClear(helpers.FunctionalRQTestBase):
 
     def test_all_queues(self):


### PR DESCRIPTION
Fixes #3265

There were two issues:

* When getting the user memberships the value passed on the data_dict was used, so if it was the name no memberships were found
* The paster user remove command didn't use the action function, so all the membership removal was bypassed


Added missing tests as well