### PR TITLE
[#3282] Fix exception when requesting /e or /n

### DIFF
--- a/ckan/lib/i18n.py
+++ b/ckan/lib/i18n.py
@@ -27,8 +27,9 @@ def get_locales_from_config():
     the config AND also the locals available subject to the config. '''
     locales_offered = config.get('ckan.locales_offered', '').split()
     filtered_out = config.get('ckan.locales_filtered_out', '').split()
-    locale_default = config.get('ckan.locale_default', 'en')
+    locale_default = [config.get('ckan.locale_default', 'en')]
     locale_order = config.get('ckan.locale_order', '').split()
+
     known_locales = get_locales()
     all_locales = (set(known_locales) |
                    set(locales_offered) |


### PR DESCRIPTION
Fixes #3282

Due to a bug in how we construct the list of available locales in
`get_locales_from_config` we ended up with `e` and `n` in it. If you
actually requested a URL with /e/ as the lang code you got an exception
because Pylons raised a `LanguageError` when trying to access the `e` or
`n` language files.