### PR TITLE
[#1517] Set default file size during resource upload instead of empty size

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -296,7 +296,7 @@ def resource_create(context, data_dict):
 
     upload = uploader.get_resource_uploader(data_dict)
 
-    if not 'size' in data_dict and hasattr(upload, 'upload_file'):
+    if 'size' not in data_dict and hasattr(upload, 'upload_file'):
         file_object = upload.upload_file
         file_object.seek(0, 2)
         data_dict['size'] = file_object.tell()

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -296,6 +296,12 @@ def resource_create(context, data_dict):
 
     upload = uploader.get_resource_uploader(data_dict)
 
+    if not 'size' in data_dict and hasattr(upload, 'upload_file'):
+        file_object = upload.upload_file
+        file_object.seek(0, 2)
+        data_dict['size'] = file_object.tell()
+        file_object.seek(0)
+
     pkg_dict['resources'].append(data_dict)
 
     try:


### PR DESCRIPTION
Fixes #1517

### Proposed fixes:
Default file size is added to the data_dict (if no user file size provided from API ) from the file_upload object that is provided by ResourceUpload Class, during resource_create action.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
