### PR TITLE
[#2649] Fix resource extras being lost during resource edit

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -554,7 +554,7 @@ class PackageController(base.BaseController):
                 clean_dict(dict_fns.unflatten(tuplize_dict(parse_params(
                                                            request.POST))))
             # we don't want to include save as it is part of the form
-            del data['save']
+            data.pop('save', None)
 
             context = {'model': model, 'session': model.Session,
                        'api_version': 3, 'for_edit': True,
@@ -564,7 +564,7 @@ class PackageController(base.BaseController):
             try:
                 if resource_id:
                     data['id'] = resource_id
-                    get_action('resource_update')(context, data)
+                    get_action('resource_patch')(context, data)
                 else:
                     get_action('resource_create')(context, data)
             except ValidationError, e:

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -994,6 +994,28 @@ class TestResourceNew(helpers.FunctionalTestBase):
         )
 
 
+class TestResourceEdit(helpers.FunctionalTestBase):
+
+    # See issue #2649
+    def test_resource_edit_keeps_extras(self):
+        resource = factories.Resource(name=u'A resource', my_extra=u'foobar')
+        app = helpers._get_test_app()
+        response = app.get(
+            url_for(
+                controller=u'package',
+                action=u'resource_edit',
+                id=resource[u'package_id'],
+                resource_id=resource[u'id'],
+            ),
+        )
+        user = factories.User()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        submit_and_follow(app, response.forms[u'resource-edit'], env)
+        result = helpers.call_action(u'resource_show', id=resource[u'id'])
+        assert_true(u'my_extra' in result)
+        assert_equal(result[u'my_extra'], resource[u'my_extra'])
+
+
 class TestResourceView(helpers.FunctionalTestBase):
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
This is a partial fix for the issues regarding resource extras being lost during resource edits (#2649). In particular, this PR fixes the problem in the case of existing resources being edited via the web UI. That sub-problem was caused by not storing the extras in the edit form and then calling `resource_update` with the POSTed data. This PR changes that behavior to use `resource_patch` instead.

This PR *does not fix* the related issue also described in #2649 by @wardi where extras from custom schemas are dropped during the editing of resource drafts.