### PR TITLE
[#3271] make facets sortable by name

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -708,7 +708,8 @@ def default_group_type():
 
 
 @core_helper
-def get_facet_items_dict(facet, limit=None, exclude_active=False, int_sort=False):
+def get_facet_items_dict(facet, limit=None, exclude_active=False,
+                         int_sort=False):
     '''Return the list of unselected facet items for the given facet, sorted
     by count (default) or name.
 
@@ -741,7 +742,8 @@ def get_facet_items_dict(facet, limit=None, exclude_active=False, int_sort=False
             all_ints = all(map(isint, names))
             if all_ints:
                 return sorted(f, key=lambda it: -int(it['display_name']))
-        return sorted(f, key=lambda it: (-it['count'], it['display_name'].lower()))
+        return sorted(f, key=lambda it: (-it['count'],
+                      it['display_name'].lower()))
 
     try:
         facet_items = c.search_facets.get(facet)['items']
@@ -762,6 +764,7 @@ def get_facet_items_dict(facet, limit=None, exclude_active=False, int_sort=False
     # zero treated as infinite for hysterical raisins
     if limit is not None and limit > 0:
         return sort(facets)[:limit]
+
     return sort(facets)
 
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -727,7 +727,6 @@ def get_facet_items_dict(facet, limit=None, exclude_active=False,
     limit -- the max. number of facet items to return.
     exclude_active -- only return unselected facets.
     int_sort -- sort facets with int literals in 'display_name' numerically
-        and descending
     '''
 
     def sort(f):

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -708,14 +708,14 @@ def default_group_type():
 
 
 @core_helper
-def get_facet_items_dict(facet, limit=None, exclude_active=False):
+def get_facet_items_dict(facet, limit=None, exclude_active=False, int_sort=False):
     '''Return the list of unselected facet items for the given facet, sorted
-    by count.
+    by count (default) or name.
 
     Returns the list of unselected facet contraints or facet items (e.g. tag
     names like "russian" or "tolstoy") for the given search facet (e.g.
     "tags"), sorted by facet item count (i.e. the number of search results that
-    match each facet item).
+    match each facet item; this is default) or by name.
 
     Reads the complete list of facet items for the given facet from
     c.search_facets, and filters out the facet items that the user has already
@@ -725,28 +725,44 @@ def get_facet_items_dict(facet, limit=None, exclude_active=False):
     facet -- the name of the facet to filter.
     limit -- the max. number of facet items to return.
     exclude_active -- only return unselected facets.
-
+    int_sort -- sort facets with int literals in 'name' by name and descending
     '''
-    if not c.search_facets or \
-            not c.search_facets.get(facet) or \
-            not c.search_facets.get(facet).get('items'):
+
+    def isint(v):
+        try:
+            i = int(v)
+        except:
+            i = v
+        return isinstance(i, int)
+
+    def sort(f):
+        if int_sort:
+            names = map(lambda it: it['display_name'], f)
+            all_ints = all(map(isint, names))
+            if all_ints:
+                return sorted(f, key=lambda it: -int(it['display_name']))
+        return sorted(f, key=lambda it: (-it['count'], it['display_name'].lower()))
+
+    try:
+        facet_items = c.search_facets.get(facet)['items']
+    except:
         return []
+
     facets = []
-    for facet_item in c.search_facets.get(facet)['items']:
+    for facet_item in facet_items:
         if not len(facet_item['name'].strip()):
             continue
         if not (facet, facet_item['name']) in request.params.items():
             facets.append(dict(active=False, **facet_item))
         elif not exclude_active:
             facets.append(dict(active=True, **facet_item))
-    # Sort descendingly by count and ascendingly by case-sensitive display name
-    facets.sort(key=lambda it: (-it['count'], it['display_name'].lower()))
+
     if c.search_facets_limits and limit is None:
         limit = c.search_facets_limits.get(facet)
     # zero treated as infinite for hysterical raisins
     if limit is not None and limit > 0:
-        return facets[:limit]
-    return facets
+        return sort(facets)[:limit]
+    return sort(facets)
 
 
 @core_helper

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -726,24 +726,18 @@ def get_facet_items_dict(facet, limit=None, exclude_active=False,
     facet -- the name of the facet to filter.
     limit -- the max. number of facet items to return.
     exclude_active -- only return unselected facets.
-    int_sort -- sort facets with int literals in 'name' by name and descending
+    int_sort -- sort facets with int literals in 'display_name' numerically
+        and descending
     '''
-
-    def isint(v):
-        try:
-            i = int(v)
-        except:
-            i = v
-        return isinstance(i, int)
 
     def sort(f):
         if int_sort:
-            names = map(lambda it: it['display_name'], f)
-            all_ints = all(map(isint, names))
-            if all_ints:
+            try:
                 return sorted(f, key=lambda it: -int(it['display_name']))
+            except ValueError:
+                pass
         return sorted(f, key=lambda it: (-it['count'],
-                      it['display_name'].lower()))
+                                         it['display_name'].lower()))
 
     try:
         facet_items = c.search_facets.get(facet)['items']

--- a/ckan/templates/snippets/facet_list.html
+++ b/ckan/templates/snippets/facet_list.html
@@ -56,7 +56,9 @@ within_tertiary
             </h2>
           {% endblock %}
           {% block facet_list_items %}
-            {% with items = items or h.get_facet_items_dict(name) %}
+            {#  set int_sort=True if you have facets with int values and want to sort them
+                by name (number) instead of count #}
+            {% with items = items or h.get_facet_items_dict(name, int_sort=False) %}
             {% if items %}
               <nav>
                 <ul class="{{ nav_class or 'unstyled nav nav-simple nav-facet' }}">


### PR DESCRIPTION
### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes (optionally)
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Sorting of facet items is currently hardcoded. However, there might be
usecases where this is not the desired sorting and sorting key should be the
item title only.

This PR introduces a int_sort parameter for helpers.get_facet_items_dict(). It's
a very conservative change that enables sorting by name for facets with ints
(real or literal) only, assuming that this is the only usecase in which
descending sorting by name might be desirable. 