### PR TITLE
[#3292] iUploader interface two attributes were added to documentation

### DIFF
--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1618,6 +1618,10 @@ class IUploader(Interface):
         :param resource: resource dict
         :type resource: dictionary
 
+        Optional attributes:
+            filesize (int):  Uploaded file filesize.
+            mimetype (str):  Uploaded file mimetype.
+
         ``upload(id, max_size)``
 
         Perform the actual upload.

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1618,7 +1618,9 @@ class IUploader(Interface):
         :param resource: resource dict
         :type resource: dictionary
 
-        Optional attributes:
+        Optionally, this method can set the following two attributes
+        on the class instance so they are set in the resource object:
+            
             filesize (int):  Uploaded file filesize.
             mimetype (str):  Uploaded file mimetype.
 


### PR DESCRIPTION
Fixes #3292
Added two new attributes description into the iUploader interface.

### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply

