### PR TITLE
Track the 'URL' download link on the resource page.

### DIFF
--- a/ckan/templates/package/resource_read.html
+++ b/ckan/templates/package/resource_read.html
@@ -53,7 +53,7 @@
           {% block resource_read_title %}<h1 class="page-heading">{{ h.resource_display_name(res) | truncate(50) }}</h1>{% endblock %}
           {% block resource_read_url %}
             {% if res.url and h.is_url(res.url) %}
-              <p class="muted ellipsis">{{ _('URL:') }} <a href="{{ res.url }}" title="{{ res.url }}">{{ res.url }}</a></p>
+              <p class="muted ellipsis">{{ _('URL:') }} <a class="resource-url-analytics" href="{{ res.url }}" title="{{ res.url }}">{{ res.url }}</a></p>
             {% elif res.url %}
               <p class="muted ellipsis">{{ _('URL:') }} {{ res.url }}</p>
             {% endif %}


### PR DESCRIPTION

### Proposed fixes:

Adds the `resource-url-analytics` class to the resource page download link labelled 'URL' so that downloads via this link are tracked internally.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

This link didn't have the resource-url-analytics class that enabled internal tracking.