### PR TITLE
suppression of the id argument on group_list api requests

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -74,7 +74,7 @@ of all the datasets in the ``data-explorer`` group on demo.ckan.org, install
 HTTPie and then call the ``group_list`` API function by running this command
 in a terminal::
 
-    http http://demo.ckan.org/api/3/action/group_list id=data-explorer
+    http http://demo.ckan.org/api/3/action/group_list
 
 The response from CKAN will look like this::
 
@@ -138,9 +138,6 @@ with this Python code::
     import urllib
     import json
     import pprint
-
-    # Use the json module to dump a dictionary to a string for posting.
-    data_string = urllib.quote(json.dumps({'id': 'data-explorer'}))
 
     # Make the HTTP request.
     response = urllib2.urlopen('http://demo.ckan.org/api/3/action/group_list',


### PR DESCRIPTION
Fixes #

### Proposed fixes:

suppression of the id argument

### Features:

- [x ] includes API changes

Suppression of the id=data-explorer on the httpie and the python script examples