### PR TITLE
Add setup.py classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -207,4 +207,12 @@ setup(
     # setup.py test command needs a TestSuite so does not work with py.test
     # test_suite = 'nose.collector',
     # tests_require=[ 'py >= 0.8.0-alpha2' ]
+    classifiers=[
+        # https://pypi.python.org/pypi?%3Aaction=list_classifiers
+        'Development Status :: 5 - Production/Stable',
+        'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2 :: Only'
+        'Programming Language :: Python :: 2.7',
+    ],
 )


### PR DESCRIPTION
It took me some time to find what Python versions are supported by CKAN, to fix that added classifiers to the setup.py.