### PR TITLE
fix KeyError: 'content-type'

### DIFF
--- a/ckanext/resourceproxy/controller.py
+++ b/ckanext/resourceproxy/controller.py
@@ -58,7 +58,7 @@ def proxy_resource(context, data_dict):
         if not did_get:
             r = requests.get(url, stream=True)
 
-        base.response.content_type = r.headers['content-type']
+        base.response.content_type = r.headers.get('content-type', '')
         base.response.charset = r.encoding
 
         length = 0


### PR DESCRIPTION
Fixes #

### Proposed fixes:

Prevent keyerror by using get() instead of accesing dict index directly

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply

For an unknow reason "KeyError: 'content-type'" is triggered when content-type is not set. It is triggered or not depending on error level in configuration