### PR TITLE
[#3260] Removed idle connection

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -104,6 +104,11 @@ def load_environment(global_conf, app_conf):
 
     app_globals.reset()
 
+    # issue #3260: remove idle transaction
+    # Session that was used for getting all config params nor committed,
+    # neither removed and we have idle connection as result
+    model.Session.commit()
+
     # Build JavaScript translations. Must be done after plugins have
     # been loaded.
     build_js_translations()


### PR DESCRIPTION
In the end of `load_environment` db session committed, which prevent creation of idle connection during startup