### PR TITLE
organization_create/_update crash if display_name passed

### DIFF
--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -323,7 +323,6 @@ def group_form_schema():
         "capacity": [ignore_missing],
         "__extras": [ignore]
     }
-    schema['display_name'] = [ignore_missing]
     return schema
 
 


### PR DESCRIPTION
simplest way to reproduce this is with `ckanapi dump organizations` then `ckanapi load organizations`, this leads to an AttributeError because our group form schema is accepting display_name, but there's no display_name in our model.