### PR TITLE
[#3332] Properly close database connections in background workers

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -284,6 +284,8 @@ def update_config():
     except sqlalchemy.exc.InternalError:
         # The database is not initialised.  Travis hits this
         pass
-    # if an extension or our code does not finish
-    # transaction properly db cli commands can fail
+
+    # Close current session and open database connections to ensure a clean
+    # clean environment even if an error occurs later on
     model.Session.remove()
+    model.Session.bind.dispose()


### PR DESCRIPTION
Fixes #3332.

RQ background workers exit via `os._exit`, which (by design) omits all of Python's usual clean up routines. As a result, the SQLAlchemy session and its associated database connections have to be cleaned up manually. This hadn't been done before, leading to sporadic exceptions due to SSL connections being unexpectedly closed.

This commit fixes that situation by properly closing each worker's SQLAlchemy session and its associated database connections.