### PR TITLE
#3189 Datastore doesn't add site_url to resource created via API

### DIFF
--- a/ckanext/datapusher/tests/test.py
+++ b/ckanext/datapusher/tests/test.py
@@ -96,7 +96,7 @@ class TestDatastoreCreate(tests.WsgiAppCase):
 
         res = tests.call_action_api(
             self.app, 'resource_show', id=res_dict['result']['resource_id'])
-        assert res['url'] == '/datastore/dump/' + res['id'], res
+        assert res['url'].endswith('/datastore/dump/' + res['id']), res
 
     @httpretty.activate
     def test_providing_res_with_url_calls_datapusher_correctly(self):

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -257,7 +257,8 @@ class DatastorePlugin(p.SingletonPlugin):
         if resource_dict.get('url_type') == 'datastore':
             resource_dict['url'] = p.toolkit.url_for(
                 controller='ckanext.datastore.controller:DatastoreController',
-                action='dump', resource_id=resource_dict['id'])
+                action='dump', resource_id=resource_dict['id'],
+                qualified=True)
 
         if 'datastore_active' not in resource_dict:
             resource_dict[u'datastore_active'] = False

--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -45,6 +45,20 @@ class TestDatastoreCreateNewTests(object):
         index_names = self._get_index_names(resource_id)
         assert resource_id + '_pkey' in index_names
 
+    def test_create_creates_url_with_site_name(self):
+        package = factories.Dataset()
+        data = {
+            'resource': {
+                'boo%k': 'crime',
+                'package_id': package['id']
+            },
+        }
+        result = helpers.call_action('datastore_create', **data)
+        resource_id = result['resource_id']
+        resource = helpers.call_action('resource_show', id=resource_id)
+        url = resource['url']
+        assert url.startswith(config.get('ckan.site_url'))
+
     def test_create_index_on_specific_fields(self):
         package = factories.Dataset()
         data = {


### PR DESCRIPTION
Small change in datastore plugin, that generates
fully-qualified url during datastore creation