### PR TITLE
javascript: use ckan locale instead of browser locale to format dates

### DIFF
--- a/ckan/public/base/javascript/main.js
+++ b/ckan/public/base/javascript/main.js
@@ -20,7 +20,6 @@ this.ckan = this.ckan || {};
   ckan.initialize = function () {
     var body = jQuery('body');
     var locale = jQuery('html').attr('lang');
-    var browserLocale = window.navigator.userLanguage || window.navigator.language;
     var location = window.location;
     var root = location.protocol + '//' + location.host;
 
@@ -33,7 +32,7 @@ this.ckan = this.ckan || {};
 
     // Convert all datetimes to the users timezone
     jQuery('.automatic-local-datetime').each(function() {
-        moment.locale(browserLocale);
+        moment.locale(locale);
         var date = moment(jQuery(this).data('datetime'));
         if (date.isValid()) {
             jQuery(this).html(date.format("LL, LT ([UTC]Z)")); 


### PR DESCRIPTION
The current implementation of the automatic conversion of dates into the timezone of the browser uses the language of the browser to format/translate the date. The problem is when the browser language is different from the current ckan language, the date is translated into a different language than the rest of the ckan interface. With this pull request we always use the current ckan locale to translate the date.

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport
