### PR TITLE
ckan datastore: convert data error to unicode instead of str to avoid decode error

### DIFF
--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -141,7 +141,7 @@ def datastore_create(context, data_dict):
     try:
         result = db.create(context, data_dict)
     except db.InvalidDataError as err:
-        raise p.toolkit.ValidationError(str(err))
+        raise p.toolkit.ValidationError(unicode(err))
 
     # Set the datastore_active flag on the resource if necessary
     if resource.extras.get('datastore_active') is not True:


### PR DESCRIPTION
The database layer throws exceptions with localized error message which could contain non-ascii characters. The code in the datastore tries to convert that error message to an ascii string which fails if it contains unicode characters.

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport