### PR TITLE
Check group name and id in data_dict during package creation

### DIFF
--- a/ckan/logic/auth/create.py
+++ b/ckan/logic/auth/create.py
@@ -178,10 +178,8 @@ def _check_group_auth(context, data_dict):
     for group_blob in group_blobs:
         # group_blob might be a dict or a group_ref
         if isinstance(group_blob, dict):
-            if api_version == '1':
-                id = group_blob.get('name')
-            else:
-                id = group_blob.get('id')
+            # use group id by default, but we can accept name as well
+            id = group_blob.get('id') or group_blob.get('name')
             if not id:
                 continue
         else:

--- a/ckan/tests/legacy/functional/api/test_activity.py
+++ b/ckan/tests/legacy/functional/api/test_activity.py
@@ -192,13 +192,6 @@ class TestActivity:
                 }
         normal_user = model.User.get('annafan')
 
-        call_action(
-            'member_create',
-            id='roger',
-            object=normal_user.id,
-            object_type='user', capacity='admin'
-        )
-
         self.normal_user = {
                 'id': normal_user.id,
                 'apikey': normal_user.apikey,
@@ -285,7 +278,7 @@ class TestActivity:
         details['recently changed datasets stream'] = \
                 self.recently_changed_datasets_stream(apikey)
 
-        details['time'] = datetime.datetime.now()
+        details['time'] = datetime.datetime.utcnow()
         return details
 
     def _create_package(self, user, name=None):
@@ -305,6 +298,12 @@ class TestActivity:
                 group_ids=[group['name'] for group in request_data['groups']],
                 apikey=apikey)
         extra_environ = {'Authorization': str(user['apikey'])}
+
+        call_action('member_create',
+                    capacity='admin',
+                    object=user['id'],
+                    object_type='user',
+                    id='roger')
         response = self.app.post('/api/action/package_create',
                 json.dumps(request_data), extra_environ=extra_environ)
         response_dict = json.loads(response.body)
@@ -1414,7 +1413,7 @@ class TestActivity:
         a new user is created.
 
         """
-        before = datetime.datetime.now()
+        before = datetime.datetime.utcnow()
 
         # Create a new user.
         user_dict = {'name': 'testuser',

--- a/ckan/tests/legacy/functional/api/test_activity.py
+++ b/ckan/tests/legacy/functional/api/test_activity.py
@@ -21,6 +21,7 @@ import paste.fixture
 from nose import SkipTest
 from ckan.common import json
 import ckan.tests.legacy as tests
+from ckan.tests.helpers import call_action
 
 
 ##def package_update(context, data_dict):
@@ -190,6 +191,14 @@ class TestActivity:
                 'name': sysadmin_user.name,
                 }
         normal_user = model.User.get('annafan')
+
+        call_action(
+            'member_create',
+            id='roger',
+            object=normal_user.id,
+            object_type='user', capacity='admin'
+        )
+
         self.normal_user = {
                 'id': normal_user.id,
                 'apikey': normal_user.apikey,
@@ -291,8 +300,6 @@ class TestActivity:
 
         # Create a new package.
         request_data = make_package(name)
-        # quick fix for #3351
-        request_data['groups'] = []
 
         before = self.record_details(user_id=user_id,
                 group_ids=[group['name'] for group in request_data['groups']],

--- a/ckan/tests/legacy/functional/api/test_activity.py
+++ b/ckan/tests/legacy/functional/api/test_activity.py
@@ -291,6 +291,9 @@ class TestActivity:
 
         # Create a new package.
         request_data = make_package(name)
+        # quick fix for #3351
+        request_data['groups'] = []
+
         before = self.record_details(user_id=user_id,
                 group_ids=[group['name'] for group in request_data['groups']],
                 apikey=apikey)


### PR DESCRIPTION
With old checks api won't work correctly. If api_version == 3 and in group name specified instead of group id in package dict, then group won't be added in `groups` variable and no checks, whether user have permissions for this group, are performed