### PR TITLE
Bugfix for #3357, fix package group listing

### DIFF
--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -244,7 +244,8 @@ def package_dictize(pkg, context):
                from_obj=member.join(group, group.c.id == member.c.group_id)
                ).where(member.c.table_id == pkg.id)\
                 .where(member.c.state == 'active') \
-                .where(group.c.is_organization == False)
+                .where(group.c.is_organization == False) \
+                .where(group.c.type == 'group')
     result = execute(q, member, context)
     context['with_capacity'] = False
     ## no package counts as cannot fetch from search index at the same

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -573,7 +573,8 @@ def group_list_authz(context, data_dict):
 
     q = model.Session.query(model.Group) \
         .filter(model.Group.is_organization == False) \
-        .filter(model.Group.state == 'active')
+        .filter(model.Group.state == 'active') \
+        .filter(model.Group.type == data_dict.get('type', 'group'))
 
     if not sysadmin or am_member:
         q = q.filter(model.Group.id.in_(group_ids))


### PR DESCRIPTION
Fixes #3357 

### Proposed fixes:

Fixes package group listing to check for group type in addition to the is_organization attribute.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply

