### PR TITLE
Updated value for `ckan.auth.user_create_groups

### DIFF
--- a/doc/extensions/tutorial.rst
+++ b/doc/extensions/tutorial.rst
@@ -257,8 +257,9 @@ dictionary:
 Whenever a user tries to create a new group via the web interface or the API,
 CKAN calls the :func:`~ckan.logic.auth.create.group_create` authorization
 function to decide whether to allow the action. Let's override this function
-and simply prevent anyone from creating new groups. Edit your ``plugin.py``
-file so that it looks like this:
+and simply prevent anyone from creating new groups(Note: this is default behavior.
+In order to go further, you need to change ``ckan.auth.user_create_groups`` to `True`
+in configuration file). Edit your ``plugin.py`` file so that it looks like this:
 
 .. literalinclude:: ../../ckanext/example_iauthfunctions/plugin_v2.py
 

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -486,9 +486,9 @@ ckan.auth.user_create_groups
 
 Example::
 
- ckan.auth.user_create_groups = False
+ ckan.auth.user_create_groups = True
 
-Default value: ``True``
+Default value: ``False``
 
 
 Allow users to create groups.


### PR DESCRIPTION
Now documentation contains correct default value - False.
Also this option mentioned in writhing extension guide