### PR TITLE
`render_markdown` breaks links with ampersands

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -24,7 +24,7 @@ from webhelpers import paginate
 import webhelpers.text as whtext
 import webhelpers.date as date
 from markdown import markdown
-from bleach import clean as clean_html
+from bleach import clean as clean_html, ALLOWED_TAGS
 from pylons import url as _pylons_default_url
 from ckan.common import config, is_flask_request
 from flask import redirect as _flask_redirect
@@ -47,6 +47,12 @@ import ckan
 from ckan.common import _, ungettext, g, c, request, session, json
 
 log = logging.getLogger(__name__)
+
+MARKDOWN_TAGS = set([
+    'del', 'dd', 'dl', 'dt', 'h1', 'h2',
+    'h3', 'img', 'kbd', 'p', 'pre', 's',
+    'sup', 'sub', 'strike', 'br', 'hr'
+]).union(ALLOWED_TAGS)
 
 
 class HelperAttributeDict(dict):
@@ -1859,7 +1865,7 @@ def render_markdown(data, auto_link=True, allow_html=False):
         data = markdown(data.strip())
     else:
         data = RE_MD_HTML_TAGS.sub('', data.strip())
-        data = markdown(clean_html(data, strip=True))
+        data = clean_html(markdown(data), strip=True, tags=MARKDOWN_TAGS)
     # tags can be added by tag:... or tag:"...." and a link will be made
     # from it
     if auto_link:

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -24,7 +24,7 @@ from webhelpers import paginate
 import webhelpers.text as whtext
 import webhelpers.date as date
 from markdown import markdown
-from bleach import clean as clean_html, ALLOWED_TAGS
+from bleach import clean as clean_html, ALLOWED_TAGS, ALLOWED_ATTRIBUTES
 from pylons import url as _pylons_default_url
 from ckan.common import config, is_flask_request
 from flask import redirect as _flask_redirect
@@ -53,6 +53,9 @@ MARKDOWN_TAGS = set([
     'h3', 'img', 'kbd', 'p', 'pre', 's',
     'sup', 'sub', 'strike', 'br', 'hr'
 ]).union(ALLOWED_TAGS)
+
+MARKDOWN_ATTRIBUTES = copy.deepcopy(ALLOWED_ATTRIBUTES)
+MARKDOWN_ATTRIBUTES.setdefault('img', []).extend(['src', 'alt', 'title'])
 
 
 class HelperAttributeDict(dict):
@@ -1865,7 +1868,9 @@ def render_markdown(data, auto_link=True, allow_html=False):
         data = markdown(data.strip())
     else:
         data = RE_MD_HTML_TAGS.sub('', data.strip())
-        data = clean_html(markdown(data), strip=True, tags=MARKDOWN_TAGS)
+        data = clean_html(
+            markdown(data), strip=True,
+            tags=MARKDOWN_TAGS, attributes=MARKDOWN_ATTRIBUTES)
     # tags can be added by tag:... or tag:"...." and a link will be made
     # from it
     if auto_link:

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -205,6 +205,45 @@ class TestHelpersRenderMarkdown(object):
         output = u'<ul>\n<li>[Foo (<a href="http://foo.bar" target="_blank" rel="nofollow">http://foo.bar</a>) * Bar] (<a href="http://foo.bar" target="_blank" rel="nofollow">http://foo.bar</a>)</li>\n</ul>'
         eq_(h.render_markdown(data), output)
 
+    def test_render_markdown_with_js(self):
+        data = u'[text](javascript: alert(1))'
+        output = u'<p><a>text</a></p>'
+        eq_(h.render_markdown(data), output)
+
+    def test_event_attributes(self):
+        data = u'<p onclick="some.script"><img onmouseover="some.script" src="image.png" /> and text</p>'
+        output = u'<p>and text</p>'
+        eq_(h.render_markdown(data), output)
+
+    def test_ampersand_in_links(self):
+        data = u'[link](/url?a=1&b=2)'
+        output = u'<p><a href="/url?a=1&amp;b=2">link</a></p>'
+        eq_(h.render_markdown(data), output)
+
+        data = u'http://example.com/page?a=1&b=2'
+        output = u'<p><a href="http://example.com/page?a=1&amp;b=2" target="_blank" rel="nofollow">http://example.com/page?a=1&amp;b=2</a></p>'
+        eq_(h.render_markdown(data), output)
+
+    def test_tags_h1(self):
+        data = u'#heading'
+        output = u'<h1>heading</h1>'
+        eq_(h.render_markdown(data), output)
+
+    def test_tags_h2(self):
+        data = u'##heading'
+        output = u'<h2>heading</h2>'
+        eq_(h.render_markdown(data), output)
+
+    def test_tags_h3(self):
+        data = u'###heading'
+        output = u'<h3>heading</h3>'
+        eq_(h.render_markdown(data), output)
+
+    def test_tags_img(self):
+        data = u'![image](/image.png)'
+        output = u'<p><img alt="image" src="/image.png"></p>'
+        eq_(h.render_markdown(data), output)
+
 
 class TestHelpersRemoveLineBreaks(object):
 


### PR DESCRIPTION
Added few additional allowed tags to `bleach.clean`
function and changed sanitization sequence so that
markdown applied first and only after that result cleaned