### PR TITLE
Tolerate missing system_info table

### DIFF
--- a/ckan/model/system_info.py
+++ b/ckan/model/system_info.py
@@ -53,11 +53,15 @@ SystemInfoRevision = vdm.sqlalchemy.create_object_version(meta.mapper,
 
 def get_system_info(key, default=None):
     ''' get data from system_info table '''
-    obj = meta.Session.query(SystemInfo).filter_by(key=key).first()
-    if obj:
-        return obj.value
-    else:
-        return default
+    from sqlalchemy.exc import ProgrammingError
+    try:
+        obj = meta.Session.query(SystemInfo).filter_by(key=key).first()
+        if obj:
+            return obj.value
+    except ProgrammingError:
+        meta.Session.rollback()
+    return default
+
 
 
 def delete_system_info(key, default=None):


### PR DESCRIPTION
If you have an old or incomplete database some commands (such as db clean) will fail because they can't find the system_info table.

```python-traceback
$ cd ckan; paster db clean -c test-core.ini; paster db init -c test-core.ini
Traceback (most recent call last):
  File "/home/ubuntu/virtualenvs/venv-system/bin/paster", line 11, in <module>
    sys.exit(run())
  File "/home/ubuntu/virtualenvs/venv-system/local/lib/python2.7/site-packages/paste/script/command.py", line 102, in run
    invoke(command, command_name, options, args[1:])
  File "/home/ubuntu/virtualenvs/venv-system/local/lib/python2.7/site-packages/paste/script/command.py", line 141, in invoke
    exit_code = runner.run(args)
  File "/home/ubuntu/virtualenvs/venv-system/local/lib/python2.7/site-packages/paste/script/command.py", line 236, in run
    result = self.command()
  File "/home/ubuntu/ckanext-scheming/ckan/ckan/lib/cli.py", line 217, in command
    self._load_config(cmd!='upgrade')
  File "/home/ubuntu/ckanext-scheming/ckan/ckan/lib/cli.py", line 161, in _load_config
    load_environment(conf.global_conf, conf.local_conf)
  File "/home/ubuntu/ckanext-scheming/ckan/ckan/config/environment.py", line 99, in load_environment
    app_globals.reset()
  File "/home/ubuntu/ckanext-scheming/ckan/ckan/lib/app_globals.py", line 172, in reset
    get_config_value(key)
  File "/home/ubuntu/ckanext-scheming/ckan/ckan/lib/app_globals.py", line 139, in get_config_value
    value = model.get_system_info(key)
  File "/home/ubuntu/ckanext-scheming/ckan/ckan/model/system_info.py", line 56, in get_system_info
    obj = meta.Session.query(SystemInfo).filter_by(key=key).first()
  File "/home/ubuntu/virtualenvs/venv-system/local/lib/python2.7/site-packages/sqlalchemy/orm/query.py", line 2334, in first
    ret = list(self[0:1])
  File "/home/ubuntu/virtualenvs/venv-system/local/lib/python2.7/site-packages/sqlalchemy/orm/query.py", line 2201, in __getitem__
    return list(res)
  File "/home/ubuntu/virtualenvs/venv-system/local/lib/python2.7/site-packages/sqlalchemy/orm/query.py", line 2405, in __iter__
    return self._execute_and_instances(context)
  File "/home/ubuntu/virtualenvs/venv-system/local/lib/python2.7/site-packages/sqlalchemy/orm/query.py", line 2420, in _execute_and_instances
    result = conn.execute(querycontext.statement, self._params)
  File "/home/ubuntu/virtualenvs/venv-system/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 727, in execute
    return meth(self, multiparams, params)
  File "/home/ubuntu/virtualenvs/venv-system/local/lib/python2.7/site-packages/sqlalchemy/sql/elements.py", line 322, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/home/ubuntu/virtualenvs/venv-system/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 824, in _execute_clauseelement
    compiled_sql, distilled_params
  File "/home/ubuntu/virtualenvs/venv-system/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 954, in _execute_context
    context)
  File "/home/ubuntu/virtualenvs/venv-system/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1116, in _handle_dbapi_exception
    exc_info
  File "/home/ubuntu/virtualenvs/venv-system/local/lib/python2.7/site-packages/sqlalchemy/util/compat.py", line 189, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb)
  File "/home/ubuntu/virtualenvs/venv-system/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 947, in _execute_context
    context)
  File "/home/ubuntu/virtualenvs/venv-system/local/lib/python2.7/site-packages/sqlalchemy/engine/default.py", line 435, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.ProgrammingError: (ProgrammingError) column system_info.state does not exist
LINE 1: ...info_key, system_info.value AS system_info_value, system_inf...
                                                             ^
 'SELECT system_info.id AS system_info_id, system_info.key AS system_info_key, system_info.value AS system_info_value, system_info.state AS system_info_state, system_info.revision_id AS system_info_revision_id \nFROM system_info \nWHERE system_info.key = %(key_1)s \n LIMIT %(param_1)s' {'param_1': 1, 'key_1': 'ckan.site_description'}
```

This change treats a missing system_info table the same as no overridden configuration.