### PR TITLE
[#3373]Dashboard_mark_activities_old is set to utcnow() format

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -994,7 +994,7 @@ def dashboard_mark_activities_old(context, data_dict):
     model = context['model']
     user_id = model.User.get(context['user']).id
     model.Dashboard.get(user_id).activity_stream_last_viewed = (
-            datetime.datetime.now())
+            datetime.datetime.utcnow())
     if not context.get('defer_commit'):
         model.repo.commit()
 

--- a/ckan/model/dashboard.py
+++ b/ckan/model/dashboard.py
@@ -21,8 +21,8 @@ class Dashboard(object):
 
     def __init__(self, user_id):
         self.user_id = user_id
-        self.activity_stream_last_viewed = datetime.datetime.now()
-        self.email_last_sent = datetime.datetime.now()
+        self.activity_stream_last_viewed = datetime.datetime.utcnow()
+        self.email_last_sent = datetime.datetime.utcnow()
 
     @classmethod
     def get(cls, user_id):


### PR DESCRIPTION
The problem was that dashboard_mark_activities_old method was not changed to utcnow() format, so when datasets were updated, because of the time difference, user have seen them before he actually entered the page.

### Fixes:
I've adde utcnow() format for this method and now the time works fine. Also added untnow() to Dashboard model, so the time can be saved correctly.
