### PR TITLE
Fix random order of translation files

### DIFF
--- a/ckan/lib/i18n.py
+++ b/ckan/lib/i18n.py
@@ -36,6 +36,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 '''
 
+import collections
 import json
 import logging
 import os
@@ -362,7 +363,7 @@ def build_js_translations():
     # Collect all language codes (an extension might add support for a
     # language that isn't supported by CKAN core, yet).
     langs = set()
-    i18n_dirs = {ckan_i18n_dir: u'ckan'}
+    i18n_dirs = collections.OrderedDict([(ckan_i18n_dir, u'ckan')])
     for item in os.listdir(ckan_i18n_dir):
         if os.path.isdir(os.path.join(ckan_i18n_dir, item)):
             langs.add(item)

--- a/ckan/tests/lib/_i18n_build_js_translations/de/LC_MESSAGES/ckanext-test_js_translations.po
+++ b/ckan/tests/lib/_i18n_build_js_translations/de/LC_MESSAGES/ckanext-test_js_translations.po
@@ -12,6 +12,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.1.1\n"
+"Language: de\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 # Overriding a JS translation from CKAN core
 msgid "Loading..."


### PR DESCRIPTION
During the generation of the JS translation files the order of the input files previously was random by accident, as it implicitly depended on the order of a normal Python dict. This randomly broke the ability of extensions to override JS translations from CKAN core.

This PR fixes that issue by using an OrderedDict to ensure that translation files provided by extensions are loaded after those of CKAN core. It also fixes a minor issue with the related test data that was uncovered during debugging.