### PR TITLE
[#3365] Fix intermittent test failures in test_jobs

### DIFF
--- a/ckan/lib/jobs.py
+++ b/ckan/lib/jobs.py
@@ -207,6 +207,14 @@ def test_job(*args):
 class Worker(rq.Worker):
     u'''
     CKAN-specific worker.
+
+    Note that starting an instance of this class (via the ``work``
+    method) disposes the currently active database engine and the
+    associated session. This is necessary to prevent their corruption by
+    the forked worker process. Both the engine and the session
+    automatically re-initialize afterwards once they are used. However,
+    non-committed changes are rolled back and instance variables bound
+    to the old session have to be re-fetched from the database.
     '''
     def __init__(self, queues=None, *args, **kwargs):
         u'''
@@ -234,12 +242,27 @@ class Worker(rq.Worker):
         return result
 
     def execute_job(self, job, *args, **kwargs):
+        # We shut down all database connections and the engine to make sure
+        # that they are not shared with the child process and closed there
+        # while still being in use in the main process, see
+        #
+        #   https://github.com/ckan/ckan/issues/3365
+        #
+        # Note that this rolls back any non-committed changes in the session.
+        # Both `Session` and `engine` automatically re-initialize themselve
+        # when they are used the next time.
+        log.debug(u'Disposing database engine before fork')
+        meta.Session.remove()
+        meta.engine.dispose()
+
+        # The original implementation performs the actual fork
         queue = remove_queue_name_prefix(job.origin)
-        log.info(u'Worker {} has started job {} from queue "{}"'.format(
+        log.info(u'Worker {} starts job {} from queue "{}"'.format(
                  self.key, job.id, queue))
         result = super(Worker, self).execute_job(job, *args, **kwargs)
         log.info(u'Worker {} has finished job {} from queue "{}"'.format(
                  self.key, job.id, queue))
+
         return result
 
     def register_death(self, *args, **kwargs):


### PR DESCRIPTION
This PR is WIP to fix the intermittent test failures of the background job tests (#3365).

I can't reproduce these failures locally, so I'm going to use this PR to find out what's going wrong when running the tests on CircleCI.