### PR TITLE
Fix unicode auth exception

### DIFF
--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -366,7 +366,7 @@ class BaseController(WSGIController):
         if not apikey:
             return None
         self.log.debug("Received API Key: %s" % apikey)
-        apikey = unicode(apikey)
+        apikey = apikey.decode('utf8', 'ignore')
         query = model.Session.query(model.User)
         user = query.filter_by(apikey=apikey).first()
         return user

--- a/ckan/tests/lib/test_base.py
+++ b/ckan/tests/lib/test_base.py
@@ -3,6 +3,7 @@
 from nose import tools as nose_tools
 
 import ckan.tests.helpers as helpers
+import ckan.tests.factories as factories
 
 
 class TestRenderSnippet(helpers.FunctionalTestBase):
@@ -18,6 +19,38 @@ class TestRenderSnippet(helpers.FunctionalTestBase):
     def test_comment_absent_if_debug_false(self):
         response = self._get_test_app().get('/')
         assert '<!-- Snippet ' not in response
+
+
+class TestGetUserForApikey(helpers.FunctionalTestBase):
+
+    def test_apikey_missing(self):
+        app = self._get_test_app()
+        request_headers = {}
+
+        app.get('/dataset/new', headers=request_headers, status=403)
+
+    def test_apikey_in_authorization_header(self):
+        user = factories.Sysadmin()
+        app = self._get_test_app()
+        request_headers = {'Authorization': str(user['apikey'])}
+
+        app.get('/dataset/new', headers=request_headers)
+
+    def test_apikey_in_x_ckan_header(self):
+        user = factories.Sysadmin()
+        app = self._get_test_app()
+        # non-standard header name is defined in test-core.ini
+        request_headers = {'X-Non-Standard-CKAN-API-Key': str(user['apikey'])}
+
+        app.get('/dataset/new', headers=request_headers)
+
+    def test_apikey_contains_unicode(self):
+        # there is no valid apikey containing unicode, but we should fail
+        # nicely if unicode is supplied
+        app = self._get_test_app()
+        request_headers = {'Authorization': '\xc2\xb7'}
+
+        app.get('/dataset/new', headers=request_headers, status=403)
 
 
 class TestCORS(helpers.FunctionalTestBase):


### PR DESCRIPTION
Fixes bug where a bit of unicode in the Authorization request header causes an Exception. Very minor, but I don't like getting the emails occasionally.

### Features:

- [x] includes tests covering changes
- [na] includes updated documentation
- [no] includes user-visible changes
- [no] includes API changes
- [it's so minor it's not worth it] includes bugfix for possible backport

Please [X] all the boxes above that apply
