### PR TITLE
Add an ckan.preview.image_formats config option for the image viewer

### DIFF
--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -106,6 +106,13 @@ ckan.plugins = stats text_view image_view recline_view
 # (plugins must be loaded in ckan.plugins)
 ckan.views.default_views = image_view text_view recline_view
 
+# Customize which text formats the text_view plugin will show
+#ckan.preview.json_formats = json
+#ckan.preview.xml_formats = xml rdf rdf+xml owl+xml atom rss
+#ckan.preview.text_formats = text plain text/plain
+
+# Customize which image formats the image_view plugin will show
+#ckan.preview.image_formats = png jpeg jpg gif
 
 ## Front-End Settings
 ckan.site_title = CKAN

--- a/ckanext/imageview/plugin.py
+++ b/ckanext/imageview/plugin.py
@@ -6,7 +6,7 @@ import ckan.plugins as p
 log = logging.getLogger(__name__)
 ignore_empty = p.toolkit.get_validator('ignore_empty')
 
-DEFAULT_IMAGE_FORMATS = ['png', 'jpeg', 'jpg', 'gif']
+DEFAULT_IMAGE_FORMATS = 'png jpeg jpg gif'
 
 
 class ImageView(p.SingletonPlugin):
@@ -17,8 +17,7 @@ class ImageView(p.SingletonPlugin):
 
     def update_config(self, config):
         p.toolkit.add_template_directory(config, 'theme/templates')
-        image_formats = config.get('ckan.preview.image_formats', '').split()
-        self.formats = image_formats or DEFAULT_IMAGE_FORMATS
+        self.formats = config.get('ckan.preview.image_formats', DEFAULT_IMAGE_FORMATS).split()
 
     def info(self):
         return {'name': 'image_view',

--- a/ckanext/imageview/plugin.py
+++ b/ckanext/imageview/plugin.py
@@ -17,7 +17,9 @@ class ImageView(p.SingletonPlugin):
 
     def update_config(self, config):
         p.toolkit.add_template_directory(config, 'theme/templates')
-        self.formats = config.get('ckan.preview.image_formats', DEFAULT_IMAGE_FORMATS).split()
+        self.formats = config.get(
+                'ckan.preview.image_formats',
+                DEFAULT_IMAGE_FORMATS).split()
 
     def info(self):
         return {'name': 'image_view',

--- a/ckanext/imageview/plugin.py
+++ b/ckanext/imageview/plugin.py
@@ -17,6 +17,8 @@ class ImageView(p.SingletonPlugin):
 
     def update_config(self, config):
         p.toolkit.add_template_directory(config, 'theme/templates')
+        image_formats = config.get('ckan.preview.image_formats', '').split()
+        self.formats = image_formats or DEFAULT_IMAGE_FORMATS
 
     def info(self):
         return {'name': 'image_view',
@@ -30,7 +32,7 @@ class ImageView(p.SingletonPlugin):
 
     def can_view(self, data_dict):
         return (data_dict['resource'].get('format', '').lower()
-                in DEFAULT_IMAGE_FORMATS)
+                in self.formats)
 
     def view_template(self, context, data_dict):
         return 'image_view.html'

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -1214,6 +1214,19 @@ Default value: ``text plain text/plain``
 
 Plain text based resource formats that will be rendered by the Text view plugin (``text_view``)
 
+.. _ckan.preview.image_formats:
+
+ckan.preview.image_formats
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+ ckan.preview.text_formats = png jpeg jpg gif
+
+Default value: ``png jpeg jpg gif``
+
+Image based resource formats that will be rendered by the Image view plugin (``image_view``)
+
 .. end_resource-views
 
 Theming Settings

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -1186,7 +1186,7 @@ Example::
 
 Default value: ``json``
 
-JSON based resource formats that will be rendered by the Text view plugin (``text_view``)
+Space-delimited list of JSON based resource formats that will be rendered by the Text view plugin (``text_view``)
 
 .. _ckan.preview.xml_formats:
 
@@ -1199,7 +1199,7 @@ Example::
 
 Default value: ``xml rdf rdf+xml owl+xml atom rss``
 
-XML based resource formats that will be rendered by the Text view plugin (``text_view``)
+Space-delimited list of XML based resource formats that will be rendered by the Text view plugin (``text_view``)
 
 .. _ckan.preview.text_formats:
 
@@ -1212,7 +1212,7 @@ Example::
 
 Default value: ``text plain text/plain``
 
-Plain text based resource formats that will be rendered by the Text view plugin (``text_view``)
+Space-delimited list of plain text based resource formats that will be rendered by the Text view plugin (``text_view``)
 
 .. _ckan.preview.image_formats:
 
@@ -1221,11 +1221,11 @@ ckan.preview.image_formats
 
 Example::
 
- ckan.preview.text_formats = png jpeg jpg gif
+ ckan.preview.image_formats = png jpeg jpg gif
 
 Default value: ``png jpeg jpg gif``
 
-Image based resource formats that will be rendered by the Image view plugin (``image_view``)
+Space-delimited list of image-based resource formats that will be rendered by the Image view plugin (``image_view``)
 
 .. end_resource-views
 

--- a/doc/maintaining/data-viewer.rst
+++ b/doc/maintaining/data-viewer.rst
@@ -200,7 +200,8 @@ View plugin: ``image_view``
 
 If the resource format is a common image format like PNG, JPEG or GIF, it adds
 an ``<img>`` tag pointing to the resource URL. You can provide an alternative
-URL on the edit view form.
+URL on the edit view form. The available formats can be configured using the
+:ref:`ckan.preview.image_formats` configuration option.
 
 Web page view
 +++++++++++++


### PR DESCRIPTION
Addresses http://stackoverflow.com/questions/41213685/recognised-file-types-for-image-preview

### Proposed fixes:

### Features:
Add an ckan.preview.image_formats config option for the image viewer	
- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
