### PR TITLE
group/org show include_dataset_count param

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,9 @@ API changes and deprecations:
    helper) now return all organizations a user belongs to regardless of
    capacity (Admin, Editor or Member), not just the ones where she is an
    administrator (#2457)
+ * ``organization_list_for_user`` (and the ``h.organizations_available()``
+   helper) now default to not include package_count. Pass
+   include_dataset_count=True if you need the package_count values.
  * ``resource['size']`` will change from string to long integer (#3205)
 
 v2.6.0 2016-11-02

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -350,7 +350,7 @@ def group_dictize(group, context,
     like tags are included unless you specify it in the params.
 
     :param packages_field: determines the format of the `packages` field - can
-    be `datasets` or None.
+    be `datasets`, `dataset_count` or None.
     '''
     assert packages_field in ('datasets', 'dataset_count', None)
     if packages_field == 'dataset_count':

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1664,12 +1664,15 @@ def groups_available(am_member=False):
 
 
 @core_helper
-def organizations_available(permission='manage_group'):
+def organizations_available(
+        permission='manage_group', include_dataset_count=False):
     '''Return a list of organizations that the current user has the specified
     permission for.
     '''
     context = {'user': c.user}
-    data_dict = {'permission': permission}
+    data_dict = {
+        'permission': permission,
+        'include_dataset_count': include_dataset_count}
     return logic.get_action('organization_list_for_user')(context, data_dict)
 
 

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -628,6 +628,9 @@ def organization_list_for_user(context, data_dict):
         returned organizations, for example ``"read"`` or ``"create_dataset"``
         (optional, default: ``"manage_group"``)
     :type permission: string
+    :param include_dataset_count: include the package_count in each org
+        (optional, default: ``False``)
+    :type include_dataset_count: boolean
 
     :returns: list of organizations that the user has the given permission for
     :rtype: list of dicts
@@ -697,7 +700,7 @@ def organization_list_for_user(context, data_dict):
 
     context['with_capacity'] = True
     orgs_list = model_dictize.group_list_dictize(orgs_and_capacities, context,
-        with_package_counts=False)
+        with_package_counts=asbool(data_dict.get('include_dataset_count')))
     return orgs_list
 
 

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1210,8 +1210,12 @@ def _group_or_org_show(context, data_dict, is_org=False):
     group = model.Group.get(id)
     context['group'] = group
 
-    include_datasets = asbool(data_dict.get('include_datasets', False))
-    packages_field = 'datasets' if include_datasets else 'dataset_count'
+    if asbool(data_dict.get('include_datasets', False)):
+        packages_field = 'datasets'
+    elif asbool(data_dict.get('include_dataset_count', True)):
+        packages_field = 'dataset_count'
+    else:
+        packages_field = None
 
     include_tags = asbool(data_dict.get('include_tags', True))
     include_users = asbool(data_dict.get('include_users', True))
@@ -1275,9 +1279,12 @@ def group_show(context, data_dict):
 
     :param id: the id or name of the group
     :type id: string
-    :param include_datasets: include a list of the group's datasets
+    :param include_datasets: include a truncated list of the group's datasets
          (optional, default: ``False``)
-    :type id: boolean
+    :type include_datasets: boolean
+    :param include_dataset_count: include the full package_count
+         (optional, default: ``True``)
+    :type include_dataset_count: boolean
     :param include_extras: include the group's extra fields
          (optional, default: ``True``)
     :type id: boolean
@@ -1307,9 +1314,12 @@ def organization_show(context, data_dict):
 
     :param id: the id or name of the organization
     :type id: string
-    :param include_datasets: include a list of the organization's datasets
+    :param include_datasets: include a truncated list of the org's datasets
          (optional, default: ``False``)
-    :type id: boolean
+    :type include_datasets: boolean
+    :param include_dataset_count: include the full package_count
+         (optional, default: ``True``)
+    :type include_dataset_count: boolean
     :param include_extras: include the organization's extra fields
          (optional, default: ``True``)
     :type id: boolean

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -454,6 +454,9 @@ def group_list(context, data_dict):
         packages in the `package_count` property.
         (optional, default: ``False``)
     :type all_fields: boolean
+    :param include_dataset_count: if all_fields, include the full package_count
+        (optional, default: ``True``)
+    :type include_dataset_count: boolean
     :param include_extras: if all_fields, include the group extra fields
         (optional, default: ``False``)
     :type include_extras: boolean
@@ -467,9 +470,7 @@ def group_list(context, data_dict):
         (optional, default: ``False``).
     :type include_users: boolean
 
-
     :rtype: list of strings
-
     '''
     _check_access('group_list', context, data_dict)
     return _group_or_org_list(context, data_dict)
@@ -503,6 +504,9 @@ def organization_list(context, data_dict):
         packages in the `package_count` property.
         (optional, default: ``False``)
     :type all_fields: boolean
+    :param include_dataset_count: if all_fields, include the full package_count
+        (optional, default: ``True``)
+    :type include_dataset_count: boolean
     :param include_extras: if all_fields, include the organization extra fields
         (optional, default: ``False``)
     :type include_extras: boolean

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -692,7 +692,8 @@ def organization_list_for_user(context, data_dict):
             (org, group_ids_to_capacities[org.id]) for org in orgs_q.all()]
 
     context['with_capacity'] = True
-    orgs_list = model_dictize.group_list_dictize(orgs_and_capacities, context)
+    orgs_list = model_dictize.group_list_dictize(orgs_and_capacities, context,
+        with_package_counts=False)
     return orgs_list
 
 

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -340,7 +340,7 @@ def default_show_group_schema():
     schema['created'] = []
     schema['display_name'] = []
     schema['extras'] = {'__extras': [keep_extras]}
-    schema['package_count'] = []
+    schema['package_count'] = [ignore_missing]
     schema['packages'] = {'__extras': [keep_extras]}
     schema['revision_id'] = []
     schema['state'] = []

--- a/ckan/templates/user/dashboard_organizations.html
+++ b/ckan/templates/user/dashboard_organizations.html
@@ -10,7 +10,8 @@
 
 {% block primary_content_inner %}
   <h2 class="hide-heading">{{ _('My Organizations') }}</h2>
-  {% set organizations = h.organizations_available(permission='manage_group') %}
+  {% set organizations = h.organizations_available(permission='manage_group',
+     include_dataset_count=True) %}
   {% if organizations %}
     <div class="wide">
       {% snippet "organization/snippets/organization_list.html", organizations=organizations, show_capacity=True %}


### PR DESCRIPTION
Make it possible to suppress package_count calculation if we don't need it from some action calls