### PR TITLE
Fix for exception when deleting a user that doesnt exist.

### DIFF
--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -45,13 +45,13 @@ def user_delete(context, data_dict):
     user_id = _get_or_bust(data_dict, 'id')
     user = model.User.get(user_id)
 
+    if user is None:
+        raise NotFound('User "{id}" was not found.'.format(id=user_id))
+
     # New revision, needed by the member table
     rev = model.repo.new_revision()
     rev.author = context['user']
     rev.message = _(u' Delete User: {0}').format(user.name)
-
-    if user is None:
-        raise NotFound('User "{id}" was not found.'.format(id=user_id))
 
     user.delete()
 

--- a/ckan/tests/logic/action/test_delete.py
+++ b/ckan/tests/logic/action/test_delete.py
@@ -506,6 +506,15 @@ class TestUserDelete(object):
         user_obj = model.User.get(user[u'id'])
         assert_equals(user_obj.state, u'deleted')
 
+    def test_user_delete_but_user_doesnt_exist(self):
+        context = {}
+        params = {u'id': 'unknown'}
+
+        assert_raises(
+            logic.NotFound,
+            helpers.call_action,
+            u'user_delete', context, **params)
+
     def test_user_delete_removes_memberships(self):
         user = factories.User()
         factories.Organization(


### PR DESCRIPTION
Fixes: exception when you user_delete and the id is not found.

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [x] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
