### PR TITLE
datastore: dump more formats

### DIFF
--- a/ckanext/datastore/controller.py
+++ b/ckanext/datastore/controller.py
@@ -18,12 +18,13 @@ from ckan.plugins.toolkit import (
 from ckanext.datastore.writer import (
     csv_writer,
     tsv_writer,
+    json_writer,
 )
 
 int_validator = get_validator('int_validator')
 boolean_validator = get_validator('boolean_validator')
 
-DUMP_FORMATS = 'csv', 'tsv'
+DUMP_FORMATS = 'csv', 'tsv', 'json'
 PAGINATE_BY = 10000
 
 
@@ -45,6 +46,8 @@ class DatastoreController(BaseController):
                 return csv_writer(response, columns, resource_id, bom)
             if fmt == 'tsv':
                 return tsv_writer(response, columns, resource_id, bom)
+            if fmt == 'json':
+                return json_writer(response, columns, resource_id, bom)
             abort(400, _(
                 u'format: must be one of %s') % u', '.join(DUMP_FORMATS))
 

--- a/ckanext/datastore/controller.py
+++ b/ckanext/datastore/controller.py
@@ -19,12 +19,13 @@ from ckanext.datastore.writer import (
     csv_writer,
     tsv_writer,
     json_writer,
+    xml_writer,
 )
 
 int_validator = get_validator('int_validator')
 boolean_validator = get_validator('boolean_validator')
 
-DUMP_FORMATS = 'csv', 'tsv', 'json'
+DUMP_FORMATS = 'csv', 'tsv', 'json', 'xml'
 PAGINATE_BY = 10000
 
 
@@ -48,6 +49,8 @@ class DatastoreController(BaseController):
                 return tsv_writer(response, columns, resource_id, bom)
             if fmt == 'json':
                 return json_writer(response, columns, resource_id, bom)
+            if fmt == 'xml':
+                return xml_writer(response, columns, resource_id, bom)
             abort(400, _(
                 u'format: must be one of %s') % u', '.join(DUMP_FORMATS))
 

--- a/ckanext/datastore/controller.py
+++ b/ckanext/datastore/controller.py
@@ -42,15 +42,15 @@ class DatastoreController(BaseController):
         bom = boolean_validator(request.GET.get('bom'), {})
         fmt = request.GET.get('format', 'csv')
 
-        def start_writer(columns):
+        def start_writer(fields):
             if fmt == 'csv':
-                return csv_writer(response, columns, resource_id, bom)
+                return csv_writer(response, fields, resource_id, bom)
             if fmt == 'tsv':
-                return tsv_writer(response, columns, resource_id, bom)
+                return tsv_writer(response, fields, resource_id, bom)
             if fmt == 'json':
-                return json_writer(response, columns, resource_id, bom)
+                return json_writer(response, fields, resource_id, bom)
             if fmt == 'xml':
-                return xml_writer(response, columns, resource_id, bom)
+                return xml_writer(response, fields, resource_id, bom)
             abort(400, _(
                 u'format: must be one of %s') % u', '.join(DUMP_FORMATS))
 
@@ -69,7 +69,7 @@ class DatastoreController(BaseController):
         result = result_page(offset, limit)
         columns = [x['id'] for x in result['fields']]
 
-        with start_writer(columns) as wr:
+        with start_writer(result['fields']) as wr:
             while True:
                 if limit is not None and limit <= 0:
                     break

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -248,7 +248,7 @@ class DatastorePlugin(p.SingletonPlugin):
     def before_map(self, m):
         m.connect('/datastore/dump/{resource_id}',
                   controller='ckanext.datastore.controller:DatastoreController',
-                  action='dump_csv')
+                  action='dump')
         return m
 
     def before_show(self, resource_dict):

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -248,7 +248,7 @@ class DatastorePlugin(p.SingletonPlugin):
     def before_map(self, m):
         m.connect('/datastore/dump/{resource_id}',
                   controller='ckanext.datastore.controller:DatastoreController',
-                  action='dump')
+                  action='dump_csv')
         return m
 
     def before_show(self, resource_dict):

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -1,10 +1,12 @@
+# encoding: utf-8
+
 from contextlib import contextmanager
 from email.utils import encode_rfc2231
 import json
 
 import unicodecsv
 
-UTF8_BOM = u'\uFEFF'.encode('utf-8')
+UTF8_BOM = u'\uFEFF'.encode(u'utf-8')
 
 
 @contextmanager
@@ -22,13 +24,13 @@ def csv_writer(response, columns, name=None, bom=False):
     >>>    d.writerow(row2)
     '''
 
-    if hasattr(response, 'headers'):
-        response.headers['Content-Type'] = 'text/csv; charset=utf-8'
+    if hasattr(response, u'headers'):
+        response.headers['Content-Type'] = b'text/csv; charset=utf-8'
         if name:
             response.headers['Content-disposition'] = (
-                'attachment; filename="{name}.csv"'.format(
+                b'attachment; filename="{name}.csv"'.format(
                     name=encode_rfc2231(name)))
-    wr = unicodecsv.writer(response, encoding='utf-8')
+    wr = unicodecsv.writer(response, encoding=u'utf-8')
     if bom:
         response.write(UTF8_BOM)
     wr.writerow(columns)
@@ -50,15 +52,15 @@ def tsv_writer(response, columns, name=None, bom=False):
     >>>    d.writerow(row2)
     '''
 
-    if hasattr(response, 'headers'):
+    if hasattr(response, u'headers'):
         response.headers['Content-Type'] = (
-            'text/tab-separated-values; charset=utf-8')
+            b'text/tab-separated-values; charset=utf-8')
         if name:
             response.headers['Content-disposition'] = (
-                'attachment; filename="{name}.tsv"'.format(
+                b'attachment; filename="{name}.tsv"'.format(
                     name=encode_rfc2231(name)))
     wr = unicodecsv.writer(
-        response, encoding='utf-8', dialect=unicodecsv.excel_tab)
+        response, encoding=u'utf-8', dialect=unicodecsv.excel_tab)
     if bom:
         response.write(UTF8_BOM)
     wr.writerow(columns)
@@ -80,12 +82,12 @@ def json_writer(response, columns, name=None, bom=False):
     >>>    d.writerow(row2)
     '''
 
-    if hasattr(response, 'headers'):
+    if hasattr(response, u'headers'):
         response.headers['Content-Type'] = (
-            'application/json; charset=utf-8')
+            b'application/json; charset=utf-8')
         if name:
             response.headers['Content-disposition'] = (
-                'attachment; filename="{name}.json"'.format(
+                b'attachment; filename="{name}.json"'.format(
                     name=encode_rfc2231(name)))
     if bom:
         response.write(UTF8_BOM)
@@ -109,5 +111,5 @@ class JSONWriter(object):
         self.response.write(json.dumps(
             {k: v for (k, v) in zip(self.columns, row)},
             ensure_ascii=False,
-            separators=(',', ':'),
-            sort_keys=True).encode('utf-8'))
+            separators=(u',', u':'),
+            sort_keys=True).encode(u'utf-8'))

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -3,6 +3,7 @@
 from contextlib import contextmanager
 from email.utils import encode_rfc2231
 import json
+from xml.etree.cElementTree import Element, SubElement, ElementTree
 
 import unicodecsv
 
@@ -113,3 +114,54 @@ class JSONWriter(object):
             ensure_ascii=False,
             separators=(u',', u':'),
             sort_keys=True).encode(u'utf-8'))
+
+
+@contextmanager
+def xml_writer(response, columns, name=None, bom=False):
+    u'''Context manager for writing UTF-8 XML data to response
+
+    :param response: file-like or response-like object for writing
+        data and headers (response-like objects only)
+    :param columns: list of column names
+    :param name: file name (for headers, response-like objects only)
+    :param bom: True to include a UTF-8 BOM at the start of the file
+
+    >>> with xml_writer(response, fields) as d:
+    >>>    d.writerow(row1)
+    >>>    d.writerow(row2)
+    '''
+
+    if hasattr(response, u'headers'):
+        response.headers['Content-Type'] = (
+            b'text/xml; charset=utf-8')
+        if name:
+            response.headers['Content-disposition'] = (
+                b'attachment; filename="{name}.xml"'.format(
+                    name=encode_rfc2231(name)))
+    if bom:
+        response.write(UTF8_BOM)
+    response.write(b'<data>\n')
+    yield XMLWriter(response, columns)
+    response.write(b'</data>\n')
+
+
+class XMLWriter(object):
+    def __init__(self, response, columns):
+        self.response = response
+        self.id_col = columns[0] == u'_id'
+        if self.id_col:
+            columns = columns[1:]
+        self.columns = columns
+
+    def writerow(self, row):
+        root = Element(u'row')
+        if self.id_col:
+            root.attrib[u'_id'] = unicode(row[0])
+            row = row[1:]
+        for k, v in zip(self.columns, row):
+            if v is None:
+                SubElement(root, k).attrib[u'xsi:nil'] = u'true'
+                continue
+            SubElement(root, k).text = unicode(v)
+        ElementTree(root).write(self.response, encoding=u'utf-8')
+        self.response.write(b'\n')

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -92,7 +92,9 @@ def json_writer(response, columns, name=None, bom=False):
                     name=encode_rfc2231(name)))
     if bom:
         response.write(UTF8_BOM)
-    response.write(b'{\n  "data": [')
+    response.write(
+        b'{\n  "columns": %s,\n  "data": [' % json.dumps(
+            columns, ensure_ascii=False, separators=(u',', u':')))
     yield JSONWriter(response, columns)
     response.write(b'\n]}\n')
 
@@ -110,7 +112,7 @@ class JSONWriter(object):
         else:
             self.response.write(b',\n    ')
         self.response.write(json.dumps(
-            {k: v for (k, v) in zip(self.columns, row)},
+            row,
             ensure_ascii=False,
             separators=(u',', u':'),
             sort_keys=True).encode(u'utf-8'))

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -1,4 +1,6 @@
 from contextlib import contextmanager
+from email.utils import encode_rfc2231
+import json
 
 import unicodecsv
 
@@ -24,7 +26,8 @@ def csv_writer(response, columns, name=None, bom=False):
         response.headers['Content-Type'] = 'text/csv; charset=utf-8'
         if name:
             response.headers['Content-disposition'] = (
-                'attachment; filename="{name}.csv"'.format(name=name))
+                'attachment; filename="{name}.csv"'.format(
+                    name=encode_rfc2231(name)))
     wr = unicodecsv.writer(response, encoding='utf-8')
     if bom:
         response.write(UTF8_BOM)
@@ -49,13 +52,62 @@ def tsv_writer(response, columns, name=None, bom=False):
 
     if hasattr(response, 'headers'):
         response.headers['Content-Type'] = (
-            'text/csv;tab-separated-values charset=utf-8')
+            'text/tab-separated-values; charset=utf-8')
         if name:
             response.headers['Content-disposition'] = (
-                'attachment; filename="{name}.tsv"'.format(name=name))
+                'attachment; filename="{name}.tsv"'.format(
+                    name=encode_rfc2231(name)))
     wr = unicodecsv.writer(
         response, encoding='utf-8', dialect=unicodecsv.excel_tab)
     if bom:
         response.write(UTF8_BOM)
     wr.writerow(columns)
     yield wr
+
+
+@contextmanager
+def json_writer(response, columns, name=None, bom=False):
+    u'''Context manager for writing UTF-8 JSON data to response
+
+    :param response: file-like or response-like object for writing
+        data and headers (response-like objects only)
+    :param columns: list of column names
+    :param name: file name (for headers, response-like objects only)
+    :param bom: True to include a UTF-8 BOM at the start of the file
+
+    >>> with json_writer(response, fields) as d:
+    >>>    d.writerow(row1)
+    >>>    d.writerow(row2)
+    '''
+
+    if hasattr(response, 'headers'):
+        response.headers['Content-Type'] = (
+            'application/json; charset=utf-8')
+        if name:
+            response.headers['Content-disposition'] = (
+                'attachment; filename="{name}.json"'.format(
+                    name=encode_rfc2231(name)))
+    if bom:
+        response.write(UTF8_BOM)
+    response.write(b'{\n  "data": [')
+    yield JSONWriter(response, columns)
+    response.write(b'\n]}\n')
+
+
+class JSONWriter(object):
+    def __init__(self, response, columns):
+        self.response = response
+        self.columns = columns
+        self.first = True
+
+    def writerow(self, row):
+        if self.first:
+            self.first = False
+            self.response.write(b'\n    ')
+        else:
+            self.response.write(b',\n    ')
+        self.response.write(json.dumps(
+            {k: v for (k, v) in zip(self.columns, row)},
+            ensure_ascii=False,
+            separators=(',', ':'),
+            sort_keys=True).encode('utf-8'))

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -20,7 +20,7 @@ def csv_writer(response, columns, name=None, bom=False):
     :param name: file name (for headers, response-like objects only)
     :param bom: True to include a UTF-8 BOM at the start of the file
 
-    >>> with csv_writer(response, fields) as d:
+    >>> with csv_writer(response, columns) as d:
     >>>    d.writerow(row1)
     >>>    d.writerow(row2)
     '''
@@ -48,7 +48,7 @@ def tsv_writer(response, columns, name=None, bom=False):
     :param name: file name (for headers, response-like objects only)
     :param bom: True to include a UTF-8 BOM at the start of the file
 
-    >>> with tsv_writer(response, fields) as d:
+    >>> with tsv_writer(response, columns) as d:
     >>>    d.writerow(row1)
     >>>    d.writerow(row2)
     '''
@@ -78,7 +78,7 @@ def json_writer(response, columns, name=None, bom=False):
     :param name: file name (for headers, response-like objects only)
     :param bom: True to include a UTF-8 BOM at the start of the file
 
-    >>> with json_writer(response, fields) as d:
+    >>> with json_writer(response, columns) as d:
     >>>    d.writerow(row1)
     >>>    d.writerow(row2)
     '''
@@ -126,7 +126,7 @@ def xml_writer(response, columns, name=None, bom=False):
     :param name: file name (for headers, response-like objects only)
     :param bom: True to include a UTF-8 BOM at the start of the file
 
-    >>> with xml_writer(response, fields) as d:
+    >>> with xml_writer(response, columns) as d:
     >>>    d.writerow(row1)
     >>>    d.writerow(row2)
     '''

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -1,0 +1,61 @@
+from contextlib import contextmanager
+
+import unicodecsv
+
+UTF8_BOM = u'\uFEFF'.encode('utf-8')
+
+
+@contextmanager
+def csv_writer(response, columns, name=None, bom=False):
+    u'''Context manager for writing UTF-8 CSV data to response
+
+    :param response: file-like or response-like object for writing
+        data and headers (response-like objects only)
+    :param columns: list of column names
+    :param name: file name (for headers, response-like objects only)
+    :param bom: True to include a UTF-8 BOM at the start of the file
+
+    >>> with csv_writer(response, fields) as d:
+    >>>    d.writerow(row1)
+    >>>    d.writerow(row2)
+    '''
+
+    if hasattr(response, 'headers'):
+        response.headers['Content-Type'] = 'text/csv; charset=utf-8'
+        if name:
+            response.headers['Content-disposition'] = (
+                'attachment; filename="{name}.csv"'.format(name=name))
+    wr = unicodecsv.writer(response, encoding='utf-8')
+    if bom:
+        response.write(UTF8_BOM)
+    wr.writerow(columns)
+    yield wr
+
+
+@contextmanager
+def tsv_writer(response, columns, name=None, bom=False):
+    u'''Context manager for writing UTF-8 TSV data to response
+
+    :param response: file-like or response-like object for writing
+        data and headers (response-like objects only)
+    :param columns: list of column names
+    :param name: file name (for headers, response-like objects only)
+    :param bom: True to include a UTF-8 BOM at the start of the file
+
+    >>> with tsv_writer(response, fields) as d:
+    >>>    d.writerow(row1)
+    >>>    d.writerow(row2)
+    '''
+
+    if hasattr(response, 'headers'):
+        response.headers['Content-Type'] = (
+            'text/csv;tab-separated-values charset=utf-8')
+        if name:
+            response.headers['Content-disposition'] = (
+                'attachment; filename="{name}.tsv"'.format(name=name))
+    wr = unicodecsv.writer(
+        response, encoding='utf-8', dialect=unicodecsv.excel_tab)
+    if bom:
+        response.write(UTF8_BOM)
+    wr.writerow(columns)
+    yield wr

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -11,16 +11,16 @@ UTF8_BOM = u'\uFEFF'.encode(u'utf-8')
 
 
 @contextmanager
-def csv_writer(response, columns, name=None, bom=False):
+def csv_writer(response, fields, name=None, bom=False):
     u'''Context manager for writing UTF-8 CSV data to response
 
     :param response: file-like or response-like object for writing
         data and headers (response-like objects only)
-    :param columns: list of column names
+    :param fields: list of datastore fields
     :param name: file name (for headers, response-like objects only)
     :param bom: True to include a UTF-8 BOM at the start of the file
 
-    >>> with csv_writer(response, columns) as d:
+    >>> with csv_writer(response, fields) as d:
     >>>    d.writerow(row1)
     >>>    d.writerow(row2)
     '''
@@ -34,21 +34,21 @@ def csv_writer(response, columns, name=None, bom=False):
     wr = unicodecsv.writer(response, encoding=u'utf-8')
     if bom:
         response.write(UTF8_BOM)
-    wr.writerow(columns)
+    wr.writerow(f['id'] for f in fields)
     yield wr
 
 
 @contextmanager
-def tsv_writer(response, columns, name=None, bom=False):
+def tsv_writer(response, fields, name=None, bom=False):
     u'''Context manager for writing UTF-8 TSV data to response
 
     :param response: file-like or response-like object for writing
         data and headers (response-like objects only)
-    :param columns: list of column names
+    :param fields: list of datastore fields
     :param name: file name (for headers, response-like objects only)
     :param bom: True to include a UTF-8 BOM at the start of the file
 
-    >>> with tsv_writer(response, columns) as d:
+    >>> with tsv_writer(response, fields) as d:
     >>>    d.writerow(row1)
     >>>    d.writerow(row2)
     '''
@@ -64,21 +64,21 @@ def tsv_writer(response, columns, name=None, bom=False):
         response, encoding=u'utf-8', dialect=unicodecsv.excel_tab)
     if bom:
         response.write(UTF8_BOM)
-    wr.writerow(columns)
+    wr.writerow(f['id'] for f in fields)
     yield wr
 
 
 @contextmanager
-def json_writer(response, columns, name=None, bom=False):
+def json_writer(response, fields, name=None, bom=False):
     u'''Context manager for writing UTF-8 JSON data to response
 
     :param response: file-like or response-like object for writing
         data and headers (response-like objects only)
-    :param columns: list of column names
+    :param fields: list of datastore fields
     :param name: file name (for headers, response-like objects only)
     :param bom: True to include a UTF-8 BOM at the start of the file
 
-    >>> with json_writer(response, columns) as d:
+    >>> with json_writer(response, fields) as d:
     >>>    d.writerow(row1)
     >>>    d.writerow(row2)
     '''
@@ -93,9 +93,9 @@ def json_writer(response, columns, name=None, bom=False):
     if bom:
         response.write(UTF8_BOM)
     response.write(
-        b'{\n  "columns": %s,\n  "data": [' % json.dumps(
-            columns, ensure_ascii=False, separators=(u',', u':')))
-    yield JSONWriter(response, columns)
+        b'{\n  "fields": %s,\n  "records": [' % json.dumps(
+            fields, ensure_ascii=False, separators=(u',', u':')))
+    yield JSONWriter(response, [f['id'] for f in fields])
     response.write(b'\n]}\n')
 
 
@@ -119,16 +119,16 @@ class JSONWriter(object):
 
 
 @contextmanager
-def xml_writer(response, columns, name=None, bom=False):
+def xml_writer(response, fields, name=None, bom=False):
     u'''Context manager for writing UTF-8 XML data to response
 
     :param response: file-like or response-like object for writing
         data and headers (response-like objects only)
-    :param columns: list of column names
+    :param fields: list of datastore fields
     :param name: file name (for headers, response-like objects only)
     :param bom: True to include a UTF-8 BOM at the start of the file
 
-    >>> with xml_writer(response, columns) as d:
+    >>> with xml_writer(response, fields) as d:
     >>>    d.writerow(row1)
     >>>    d.writerow(row2)
     '''
@@ -143,7 +143,7 @@ def xml_writer(response, columns, name=None, bom=False):
     if bom:
         response.write(UTF8_BOM)
     response.write(b'<data>\n')
-    yield XMLWriter(response, columns)
+    yield XMLWriter(response, [f['id'] for f in fields])
     response.write(b'</data>\n')
 
 

--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -275,14 +275,16 @@ API reference
 
 .. _dump:
 
-Download resource as CSV
-------------------------
+Download resource
+-----------------
 
 A DataStore resource can be downloaded in the `CSV`_ file format from ``{CKAN-URL}/datastore/dump/{RESOURCE-ID}``.
 
 For an Excel-compatible CSV file use ``{CKAN-URL}/datastore/dump/{RESOURCE-ID}?bom=true``.
 
-For tab-separated values use ``{CKAN-URL}/datastore/dump/{RESOURCE-ID}?format=tsv``.
+Other formats are also supported. For tab-separated values use
+``{CKAN-URL}/datastore/dump/{RESOURCE-ID}?format=tsv`` and for JSON use
+``{CKAN-URL}/datastore/dump/{RESOURCE-ID}?format=json``.
 
 .. _CSV: https://en.wikipedia.org/wiki/Comma-separated_values
 

--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -282,9 +282,10 @@ A DataStore resource can be downloaded in the `CSV`_ file format from ``{CKAN-UR
 
 For an Excel-compatible CSV file use ``{CKAN-URL}/datastore/dump/{RESOURCE-ID}?bom=true``.
 
-Other formats are also supported. For tab-separated values use
-``{CKAN-URL}/datastore/dump/{RESOURCE-ID}?format=tsv`` and for JSON use
-``{CKAN-URL}/datastore/dump/{RESOURCE-ID}?format=json``.
+Other formats supported include tab-separated values (``?format=tsv``),
+JSON (``?format=json``) and XML (``?format=xml``). E.g. to download an Excel-compatible
+tab-separated file use
+``{CKAN-URL}/datastore/dump/{RESOURCE-ID}?format=tsv&bom=true``.
 
 .. _CSV: https://en.wikipedia.org/wiki/Comma-separated_values
 

--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -280,7 +280,9 @@ Download resource as CSV
 
 A DataStore resource can be downloaded in the `CSV`_ file format from ``{CKAN-URL}/datastore/dump/{RESOURCE-ID}``.
 
-For an Excel-compatible CSV file use ``{CKAN-URL}/datastore/dump/{RESOURCE-ID}&bom=true``
+For an Excel-compatible CSV file use ``{CKAN-URL}/datastore/dump/{RESOURCE-ID}?bom=true``.
+
+For tab-separated values use ``{CKAN-URL}/datastore/dump/{RESOURCE-ID}?format=tsv``.
 
 .. _CSV: https://en.wikipedia.org/wiki/Comma-separated_values
 

--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -280,6 +280,8 @@ Download resource as CSV
 
 A DataStore resource can be downloaded in the `CSV`_ file format from ``{CKAN-URL}/datastore/dump/{RESOURCE-ID}``.
 
+For an Excel-compatible CSV file use ``{CKAN-URL}/datastore/dump/{RESOURCE-ID}&bom=true``
+
 .. _CSV: https://en.wikipedia.org/wiki/Comma-separated_values
 
 


### PR DESCRIPTION
Extend the datastore controller to dump CSV with BOM (CSV for Excel), JSON, TSV, XML formats as well as plain CSV