### PR TITLE
Fix for package_update exception when id is missing. 

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -242,7 +242,9 @@ def package_update(context, data_dict):
     '''
     model = context['model']
     user = context['user']
-    name_or_id = data_dict.get("id") or data_dict['name']
+    name_or_id = data_dict.get('id') or data_dict.get('name')
+    if name_or_id is None:
+        raise ValidationError({'id': _('Missing value')})
 
     pkg = model.Package.get(name_or_id)
     if pkg is None:

--- a/ckan/tests/legacy/logic/test_action.py
+++ b/ckan/tests/legacy/logic/test_action.py
@@ -138,58 +138,6 @@ class TestAction(WsgiAppCase):
         assert_equal(res_obj['result'][0]['match_field'], 'title')
         assert_equal(res_obj['result'][0]['match_displayed'], 'A Wonderful Story (warandpeace)')
 
-    def test_03_create_update_package(self):
-
-        package = {
-            'author': None,
-            'author_email': None,
-            'extras': [{'key': u'original media','value': u'"book"'}],
-            'license_id': u'other-open',
-            'maintainer': None,
-            'maintainer_email': None,
-            'name': u'annakareninanew',
-            'notes': u'Some test now',
-            'resources': [{'alt_url': u'alt123',
-                           'description': u'Full text.',
-                           'extras': {u'alt_url': u'alt123', u'size': u'123'},
-                           'format': u'plain text',
-                           'hash': u'abc123',
-                           'position': 0,
-                           'url': u'http://datahub.io/download/'},
-                          {'alt_url': u'alt345',
-                           'description': u'Index of the novel',
-                           'extras': {u'alt_url': u'alt345', u'size': u'345'},
-                           'format': u'JSON',
-                           'hash': u'def456',
-                           'position': 1,
-                           'url': u'http://datahub.io/index.json'}],
-            'tags': [{'name': u'russian'}, {'name': u'tolstoy'}],
-            'title': u'A Novel By Tolstoy',
-            'url': u'http://datahub.io',
-            'version': u'0.7a'
-        }
-
-        wee = json.dumps(package)
-        postparams = '%s=1' % json.dumps(package)
-        res = self.app.post('/api/action/package_create', params=postparams,
-                            extra_environ={'Authorization': str(self.sysadmin_user.apikey)})
-        package_created = json.loads(res.body)['result']
-        print package_created
-        package_created['name'] = 'moo'
-        postparams = '%s=1' % json.dumps(package_created)
-        res = self.app.post('/api/action/package_update', params=postparams,
-                            extra_environ={'Authorization': str(self.sysadmin_user.apikey)})
-
-        package_updated = json.loads(res.body)['result']
-        package_updated.pop('revision_id')
-        package_updated.pop('metadata_created')
-        package_updated.pop('metadata_modified')
-
-        package_created.pop('revision_id')
-        package_created.pop('metadata_created')
-        package_created.pop('metadata_modified')
-        assert package_updated == package_created#, (pformat(json.loads(res.body)), pformat(package_created['result']))
-
     def test_03_create_private_package(self):
 
         # Make an organization, because private datasets must belong to one.
@@ -248,29 +196,6 @@ class TestAction(WsgiAppCase):
                                               apikey=self.sysadmin_user.apikey,
                                               **package_dict)
         assert package_created_private['private'] is True
-
-
-    def test_18_create_package_not_authorized(self):
-        # I cannot understand the logic on this one we seem to be user
-        # tester but no idea how.
-        raise SkipTest
-
-        package = {
-            'extras': [{'key': u'original media','value': u'"book"'}],
-            'license_id': u'other-open',
-            'maintainer': None,
-            'maintainer_email': None,
-            'name': u'annakareninanew_not_authorized',
-            'notes': u'Some test now',
-            'tags': [{'name': u'russian'}, {'name': u'tolstoy'}],
-            'title': u'A Novel By Tolstoy',
-            'url': u'http://datahub.io',
-        }
-
-        wee = json.dumps(package)
-        postparams = '%s=1' % json.dumps(package)
-        res = self.app.post('/api/action/package_create', params=postparams,
-                                     status=StatusCodes.STATUS_403_ACCESS_DENIED)
 
     def test_41_create_resource(self):
 
@@ -493,45 +418,6 @@ class TestAction(WsgiAppCase):
                             status=400)
         res_obj = json.loads(res.body)
         assert_equal(res_obj, u'Bad request - Action name not known: bad_action_name')
-
-    def test_19_update_resource(self):
-        package = {
-            'name': u'annakareninanew',
-            'resources': [{
-                'alt_url': u'alt123',
-                'description': u'Full text.',
-                'extras': {u'alt_url': u'alt123', u'size': u'123'},
-                'format': u'plain text',
-                'hash': u'abc123',
-                'position': 0,
-                'url': u'http://datahub.io/download/'
-            }],
-            'title': u'A Novel By Tolstoy',
-            'url': u'http://datahub.io',
-        }
-
-        postparams = '%s=1' % json.dumps(package)
-        res = self.app.post('/api/action/package_create', params=postparams,
-                            extra_environ={'Authorization': str(self.sysadmin_user.apikey)})
-        package_created = json.loads(res.body)['result']
-
-        resource_created = package_created['resources'][0]
-        new_resource_url = u'http://www.annakareinanew.com/download/'
-        resource_created['url'] = new_resource_url
-        postparams = '%s=1' % json.dumps(resource_created)
-        res = self.app.post('/api/action/resource_update', params=postparams,
-                            extra_environ={'Authorization': str(self.sysadmin_user.apikey)})
-
-        resource_updated = json.loads(res.body)['result']
-        assert resource_updated['url'] == new_resource_url, resource_updated
-
-        resource_updated.pop('url')
-        resource_updated.pop('revision_id')
-        resource_updated.pop('revision_timestamp', None)
-        resource_created.pop('url')
-        resource_created.pop('revision_id')
-        resource_created.pop('revision_timestamp', None)
-        assert_equal(resource_updated, resource_created)
 
     def test_20_task_status_update(self):
         package_created = self._add_basic_package(u'test_task_status_update')

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -648,10 +648,10 @@ class TestResourceCreate(object):
             'resource_create',
             package_id=dataset['id'],
             somekey='somevalue',  # this is how to do resource extras
-            extras={u'someotherkey': u'alt234',}, # this isnt
+            extras={u'someotherkey': u'alt234'},  # this isnt
             format=u'plain text',
             url=u'http://datahub.io/download/',
-            )
+        )
 
         assert_equals(resource['somekey'], 'somevalue')
         assert 'extras' not in resource
@@ -793,15 +793,16 @@ class TestDatasetCreate(helpers.FunctionalTestBase):
         )
 
     def test_missing_id(self):
-        assert_raises(logic.ValidationError, helpers.call_action,
+        assert_raises(
+            logic.ValidationError, helpers.call_action,
             'package_create'
-            )
+        )
 
     def test_name(self):
         dataset = helpers.call_action(
             'package_create',
             name='some-name',
-            )
+        )
 
         assert_equals(dataset['name'], 'some-name')
         assert_equals(
@@ -813,7 +814,7 @@ class TestDatasetCreate(helpers.FunctionalTestBase):
             'package_create',
             name='test_title',
             title='New Title',
-            )
+        )
 
         assert_equals(dataset['title'], 'New Title')
         assert_equals(
@@ -827,7 +828,7 @@ class TestDatasetCreate(helpers.FunctionalTestBase):
             title='Test Extras',
             extras=[{'key': u'original media',
                      'value': u'"book"'}],
-            )
+        )
 
         assert_equals(dataset['extras'][0]['key'], 'original media')
         assert_equals(dataset['extras'][0]['value'], '"book"')
@@ -841,7 +842,7 @@ class TestDatasetCreate(helpers.FunctionalTestBase):
             name='test-license',
             title='Test License',
             license_id='other-open',
-            )
+        )
 
         assert_equals(dataset['license_id'], 'other-open')
         dataset = helpers.call_action('package_show', id=dataset['id'])
@@ -853,7 +854,7 @@ class TestDatasetCreate(helpers.FunctionalTestBase):
             name='test-notes',
             title='Test Notes',
             notes='some notes',
-            )
+        )
 
         assert_equals(dataset['notes'], 'some notes')
         dataset = helpers.call_action('package_show', id=dataset['id'])
@@ -868,7 +869,7 @@ class TestDatasetCreate(helpers.FunctionalTestBase):
                 {'alt_url': u'alt123',
                  'description': u'Full text.',
                  'somekey': 'somevalue',  # this is how to do resource extras
-                 'extras': {u'someotherkey': u'alt234',}, # this isnt
+                 'extras': {u'someotherkey': u'alt234'},  # this isnt
                  'format': u'plain text',
                  'hash': u'abc123',
                  'position': 0,
@@ -876,8 +877,9 @@ class TestDatasetCreate(helpers.FunctionalTestBase):
                 {'description': u'Index of the novel',
                  'format': u'JSON',
                  'position': 1,
-                 'url': u'http://datahub.io/index.json'}],
-            )
+                 'url': u'http://datahub.io/index.json'}
+            ],
+        )
 
         resources = dataset['resources']
         assert_equals(resources[0]['alt_url'], 'alt123')
@@ -915,14 +917,14 @@ class TestDatasetCreate(helpers.FunctionalTestBase):
             name='test-tags',
             title='Test Tags',
             tags=[{'name': u'russian'}, {'name': u'tolstoy'}],
-            )
+        )
 
         tag_names = sorted([tag_dict['name']
-                             for tag_dict in dataset['tags']])
+                            for tag_dict in dataset['tags']])
         assert_equals(tag_names, ['russian', 'tolstoy'])
         dataset = helpers.call_action('package_show', id=dataset['id'])
         tag_names = sorted([tag_dict['name']
-                             for tag_dict in dataset['tags']])
+                            for tag_dict in dataset['tags']])
         assert_equals(tag_names, ['russian', 'tolstoy'])
 
 

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -748,10 +748,6 @@ class TestMemberCreate(object):
 
 class TestDatasetCreate(helpers.FunctionalTestBase):
 
-    @classmethod
-    def teardown_class(cls):
-        helpers.reset_db()
-
     def test_normal_user_cant_set_id(self):
         user = factories.User()
         context = {

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -516,9 +516,10 @@ class TestDatasetUpdate(object):
         dataset = factories.Dataset(
             user=user)
 
-        assert_raises(logic.ValidationError, helpers.call_action,
+        assert_raises(
+            logic.ValidationError, helpers.call_action,
             'package_update'
-            )
+        )
 
     def test_name(self):
         user = factories.User()
@@ -529,7 +530,7 @@ class TestDatasetUpdate(object):
             'package_update',
             id=dataset['id'],
             name='new-name',
-            )
+        )
 
         assert_equals(dataset_['name'], 'new-name')
         assert_equals(
@@ -545,7 +546,7 @@ class TestDatasetUpdate(object):
             'package_update',
             id=dataset['id'],
             title='New Title',
-            )
+        )
 
         assert_equals(dataset_['title'], 'New Title')
         assert_equals(
@@ -562,7 +563,7 @@ class TestDatasetUpdate(object):
             id=dataset['id'],
             extras=[{'key': u'original media',
                      'value': u'"book"'}],
-            )
+        )
 
         assert_equals(dataset_['extras'][0]['key'], 'original media')
         assert_equals(dataset_['extras'][0]['value'], '"book"')
@@ -579,7 +580,7 @@ class TestDatasetUpdate(object):
             'package_update',
             id=dataset['id'],
             license_id='other-open',
-            )
+        )
 
         assert_equals(dataset_['license_id'], 'other-open')
         dataset_ = helpers.call_action('package_show', id=dataset['id'])
@@ -594,7 +595,7 @@ class TestDatasetUpdate(object):
             'package_update',
             id=dataset['id'],
             notes='some notes',
-            )
+        )
 
         assert_equals(dataset_['notes'], 'some notes')
         dataset_ = helpers.call_action('package_show', id=dataset['id'])
@@ -612,7 +613,7 @@ class TestDatasetUpdate(object):
                 {'alt_url': u'alt123',
                  'description': u'Full text.',
                  'somekey': 'somevalue',  # this is how to do resource extras
-                 'extras': {u'someotherkey': u'alt234',}, # this isnt
+                 'extras': {u'someotherkey': u'alt234'},  # this isnt
                  'format': u'plain text',
                  'hash': u'abc123',
                  'position': 0,
@@ -621,7 +622,7 @@ class TestDatasetUpdate(object):
                  'format': u'JSON',
                  'position': 1,
                  'url': u'http://datahub.io/index.json'}],
-            )
+        )
 
         resources_ = dataset_['resources']
         assert_equals(resources_[0]['alt_url'], 'alt123')
@@ -662,14 +663,14 @@ class TestDatasetUpdate(object):
             'package_update',
             id=dataset['id'],
             tags=[{'name': u'russian'}, {'name': u'tolstoy'}],
-            )
+        )
 
         tag_names = sorted([tag_dict['name']
-                             for tag_dict in dataset_['tags']])
+                            for tag_dict in dataset_['tags']])
         assert_equals(tag_names, ['russian', 'tolstoy'])
         dataset_ = helpers.call_action('package_show', id=dataset['id'])
         tag_names = sorted([tag_dict['name']
-                             for tag_dict in dataset_['tags']])
+                            for tag_dict in dataset_['tags']])
         assert_equals(tag_names, ['russian', 'tolstoy'])
 
 
@@ -1222,10 +1223,10 @@ class TestResourceUpdate(object):
             'resource_update',
             id=dataset['resources'][0]['id'],
             somekey='somevalue',  # this is how to do resource extras
-            extras={u'someotherkey': u'alt234',}, # this isnt
+            extras={u'someotherkey': u'alt234'},  # this isnt
             format=u'plain text',
             url=u'http://datahub.io/download/',
-            )
+        )
 
         assert_equals(resource['somekey'], 'somevalue')
         assert 'extras' not in resource

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -505,11 +505,7 @@ class TestUpdate(object):
             'group')
 
 
-class TestDatasetUpdate(object):
-
-    @classmethod
-    def teardown_class(cls):
-        helpers.reset_db()
+class TestDatasetUpdate(helpers.FunctionalTestBase):
 
     def test_missing_id(self):
         user = factories.User()

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -505,6 +505,174 @@ class TestUpdate(object):
             'group')
 
 
+class TestDatasetUpdate(object):
+
+    @classmethod
+    def teardown_class(cls):
+        helpers.reset_db()
+
+    def test_missing_id(self):
+        user = factories.User()
+        dataset = factories.Dataset(
+            user=user)
+
+        assert_raises(logic.ValidationError, helpers.call_action,
+            'package_update'
+            )
+
+    def test_name(self):
+        user = factories.User()
+        dataset = factories.Dataset(
+            user=user)
+
+        dataset_ = helpers.call_action(
+            'package_update',
+            id=dataset['id'],
+            name='new-name',
+            )
+
+        assert_equals(dataset_['name'], 'new-name')
+        assert_equals(
+            helpers.call_action('package_show', id=dataset['id'])['name'],
+            'new-name')
+
+    def test_title(self):
+        user = factories.User()
+        dataset = factories.Dataset(
+            user=user)
+
+        dataset_ = helpers.call_action(
+            'package_update',
+            id=dataset['id'],
+            title='New Title',
+            )
+
+        assert_equals(dataset_['title'], 'New Title')
+        assert_equals(
+            helpers.call_action('package_show', id=dataset['id'])['title'],
+            'New Title')
+
+    def test_extras(self):
+        user = factories.User()
+        dataset = factories.Dataset(
+            user=user)
+
+        dataset_ = helpers.call_action(
+            'package_update',
+            id=dataset['id'],
+            extras=[{'key': u'original media',
+                     'value': u'"book"'}],
+            )
+
+        assert_equals(dataset_['extras'][0]['key'], 'original media')
+        assert_equals(dataset_['extras'][0]['value'], '"book"')
+        dataset_ = helpers.call_action('package_show', id=dataset['id'])
+        assert_equals(dataset_['extras'][0]['key'], 'original media')
+        assert_equals(dataset_['extras'][0]['value'], '"book"')
+
+    def test_license(self):
+        user = factories.User()
+        dataset = factories.Dataset(
+            user=user)
+
+        dataset_ = helpers.call_action(
+            'package_update',
+            id=dataset['id'],
+            license_id='other-open',
+            )
+
+        assert_equals(dataset_['license_id'], 'other-open')
+        dataset_ = helpers.call_action('package_show', id=dataset['id'])
+        assert_equals(dataset_['license_id'], 'other-open')
+
+    def test_notes(self):
+        user = factories.User()
+        dataset = factories.Dataset(
+            user=user)
+
+        dataset_ = helpers.call_action(
+            'package_update',
+            id=dataset['id'],
+            notes='some notes',
+            )
+
+        assert_equals(dataset_['notes'], 'some notes')
+        dataset_ = helpers.call_action('package_show', id=dataset['id'])
+        assert_equals(dataset_['notes'], 'some notes')
+
+    def test_resources(self):
+        user = factories.User()
+        dataset = factories.Dataset(
+            user=user)
+
+        dataset_ = helpers.call_action(
+            'package_update',
+            id=dataset['id'],
+            resources=[
+                {'alt_url': u'alt123',
+                 'description': u'Full text.',
+                 'somekey': 'somevalue',  # this is how to do resource extras
+                 'extras': {u'someotherkey': u'alt234',}, # this isnt
+                 'format': u'plain text',
+                 'hash': u'abc123',
+                 'position': 0,
+                 'url': u'http://datahub.io/download/'},
+                {'description': u'Index of the novel',
+                 'format': u'JSON',
+                 'position': 1,
+                 'url': u'http://datahub.io/index.json'}],
+            )
+
+        resources_ = dataset_['resources']
+        assert_equals(resources_[0]['alt_url'], 'alt123')
+        assert_equals(resources_[0]['description'], 'Full text.')
+        assert_equals(resources_[0]['somekey'], 'somevalue')
+        assert 'extras' not in resources_[0]
+        assert 'someotherkey' not in resources_[0]
+        assert_equals(resources_[0]['format'], 'plain text')
+        assert_equals(resources_[0]['hash'], 'abc123')
+        assert_equals(resources_[0]['position'], 0)
+        assert_equals(resources_[0]['url'], 'http://datahub.io/download/')
+        assert_equals(resources_[1]['description'], 'Index of the novel')
+        assert_equals(resources_[1]['format'], 'JSON')
+        assert_equals(resources_[1]['url'], 'http://datahub.io/index.json')
+        assert_equals(resources_[1]['position'], 1)
+        resources_ = helpers.call_action(
+            'package_show', id=dataset['id'])['resources']
+        assert_equals(resources_[0]['alt_url'], 'alt123')
+        assert_equals(resources_[0]['description'], 'Full text.')
+        assert_equals(resources_[0]['somekey'], 'somevalue')
+        assert 'extras' not in resources_[0]
+        assert 'someotherkey' not in resources_[0]
+        assert_equals(resources_[0]['format'], 'plain text')
+        assert_equals(resources_[0]['hash'], 'abc123')
+        assert_equals(resources_[0]['position'], 0)
+        assert_equals(resources_[0]['url'], 'http://datahub.io/download/')
+        assert_equals(resources_[1]['description'], 'Index of the novel')
+        assert_equals(resources_[1]['format'], 'JSON')
+        assert_equals(resources_[1]['url'], 'http://datahub.io/index.json')
+        assert_equals(resources_[1]['position'], 1)
+
+    def test_tags(self):
+        user = factories.User()
+        dataset = factories.Dataset(
+            user=user)
+
+        dataset_ = helpers.call_action(
+            'package_update',
+            id=dataset['id'],
+            tags=[{'name': u'russian'}, {'name': u'tolstoy'}],
+            )
+
+        tag_names = sorted([tag_dict['name']
+                             for tag_dict in dataset_['tags']])
+        assert_equals(tag_names, ['russian', 'tolstoy'])
+        dataset_ = helpers.call_action('package_show', id=dataset['id'])
+        tag_names = sorted([tag_dict['name']
+                             for tag_dict in dataset_['tags']])
+        assert_equals(tag_names, ['russian', 'tolstoy'])
+
+
 class TestUpdateSendEmailNotifications(object):
     @classmethod
     def setup_class(cls):
@@ -1040,6 +1208,33 @@ class TestResourceUpdate(object):
         upd_size = int(res_update.pop('size'))  # 358 bytes
 
         assert org_size > upd_size
+
+    def test_extras(self):
+        user = factories.User()
+        dataset = factories.Dataset(
+            user=user,
+            resources=[dict(
+                format=u'json',
+                url=u'http://datahub.io/',
+            )])
+
+        resource = helpers.call_action(
+            'resource_update',
+            id=dataset['resources'][0]['id'],
+            somekey='somevalue',  # this is how to do resource extras
+            extras={u'someotherkey': u'alt234',}, # this isnt
+            format=u'plain text',
+            url=u'http://datahub.io/download/',
+            )
+
+        assert_equals(resource['somekey'], 'somevalue')
+        assert 'extras' not in resource
+        assert 'someotherkey' not in resource
+        resource = helpers.call_action(
+            'package_show', id=dataset['id'])['resources'][0]
+        assert_equals(resource['somekey'], 'somevalue')
+        assert 'extras' not in resource
+        assert 'someotherkey' not in resource
 
 
 class TestConfigOptionUpdate(object):


### PR DESCRIPTION
To reproduce:
```
$ ckanapi action package_update -r http://demo.ckan.org/
ckanapi.errors.CKANAPIError: ['http://demo.ckan.org/api/action/package_update', 500, u'\n    <html>\n    <head>\n    <title>Server Error</title>\n    \n    </head>\n    <body>\n    <h1>Server Error</h1>\n    An internal server error occurred\n    \n    </body>\n    </html>']
```

Also done in this ticket: modernize tests for package_create, package_update, resource_create, resource_update where its straightforward.

### Proposed fixes:



### Features:

- [x] includes tests covering changes
- [na] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
