### PR TITLE
Groups inside resource.config can't be dependent on another groups

### DIFF
--- a/ckan/lib/fanstatic_resources.py
+++ b/ckan/lib/fanstatic_resources.py
@@ -161,7 +161,7 @@ def create_library(name, path, depend_base=True):
                         dep_resources = [dep]
                     else:
                         dep_resources = groups[dep]
-                    diff = set(dep_resources).difference(depends[resource])
+                    diff = [res for res in dep_resources if res not in depends[resource]]
                     depends[resource].extend(diff)
 
     # process each .js/.css file found

--- a/ckan/lib/fanstatic_resources.py
+++ b/ckan/lib/fanstatic_resources.py
@@ -157,8 +157,12 @@ def create_library(name, path, depend_base=True):
                 if resource not in depends:
                     depends[resource] = []
                 for dep in depends[group]:
-                    if dep not in depends[resource]:
-                        depends[resource].append(dep)
+                    if dep not in groups:
+                        dep_resources = [dep]
+                    else:
+                        dep_resources = groups[dep]
+                    diff = set(dep_resources).difference(depends[resource])
+                    depends[resource].extend(diff)
 
     # process each .js/.css file found
     resource_list = []


### PR DESCRIPTION
#3398 Now groups in resource.config['depends'] can define another groups from the same file as their dependencies.
It done by checking, whether dependency defined in the same *resource.config* as group. If so, it replaced with its resources. 
