### PR TITLE
[#3417] Missing `--ckan` option in extension template's Travis config

### DIFF
--- a/ckan/pastertemplates/template/bin/travis-run.sh_tmpl
+++ b/ckan/pastertemplates/template/bin/travis-run.sh_tmpl
@@ -3,4 +3,13 @@
 echo "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8983\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty
 sudo cp ckan/ckan/config/solr/schema.xml /etc/solr/conf/schema.xml
 sudo service jetty restart
-nosetests --nologcapture --with-pylons=subdir/test.ini --with-coverage --cover-package=ckanext.{{ project_shortname }} --cover-inclusive --cover-erase --cover-tests
+
+nosetests --ckan \
+          --nologcapture \
+          --with-pylons=subdir/test.ini \
+          --with-coverage \
+          --cover-package=ckanext.{{ project_shortname }} \
+          --cover-inclusive \
+          --cover-erase \
+          --cover-tests
+


### PR DESCRIPTION
Fixes #3417 by adding the missing `--ckan` parameter.