### PR TITLE
[#3315] Mark remaining strings in JS modules as translatable

### DIFF
--- a/ckan/public/base/javascript/modules/resource-view-filters.js
+++ b/ckan/public/base/javascript/modules/resource-view-filters.js
@@ -6,7 +6,7 @@ this.ckan.module('resource-view-filters', function (jQuery) {
         resourceId = self.options.resourceId,
         fields = self.options.fields,
         dropdownTemplate = self.options.dropdownTemplate,
-        addFilterTemplate = self.options.addFilterTemplate,
+        addFilterTemplate = '<a href="#">' + self._('Add Filter') + '</a>';
         filtersDiv = $('<div></div>');
 
     var filters = ckan.views.filters.get();
@@ -26,7 +26,8 @@ this.ckan.module('resource-view-filters', function (jQuery) {
   }
 
   function _buildAddFilterButton(el, template, fields, filters, onChangeCallback) {
-    var addFilterButton = $(template),
+    var self = this,
+        addFilterButton = $(template),
         currentFilters = Object.keys(filters),
         fieldsNotFiltered = $.grep(fields, function (field) {
           return !filters.hasOwnProperty(field);
@@ -48,7 +49,7 @@ this.ckan.module('resource-view-filters', function (jQuery) {
       // TODO: Remove element from "data" when some select selects it.
       addFilterInput.select2({
         data: data,
-        placeholder: 'Select a field',
+        placeholder: self._('Select a field'),
         width: 'resolve',
       }).on('change', onChangeCallback);
 
@@ -175,9 +176,6 @@ this.ckan.module('resource-view-filters', function (jQuery) {
         '  {filter}:',
         '  <div class="resource-view-filter-values"></div>',
         '</div>',
-      ].join('\n'),
-      addFilterTemplate: [
-        '<a href="#">Add Filter</a>',
       ].join('\n')
     }
   };

--- a/ckanext/example_theme/v18_snippet_api/fanstatic/example_theme_popover.js
+++ b/ckanext/example_theme/v18_snippet_api/fanstatic/example_theme_popover.js
@@ -18,7 +18,7 @@ ckan.module('example_theme_popover', function ($) {
       // Add a Bootstrap popover to the button. Since we don't have the HTML
       // from the snippet yet, we just set the content to "Loading..."
       this.el.popover({title: this.options.title, html: true,
-                       content: 'Loading...', placement: 'left'});
+                       content: this._('Loading...'), placement: 'left'});
 
       // Add an event handler to the button, when the user clicks the button
       // our _onClick() function will be called.

--- a/ckanext/example_theme/v19_01_error/fanstatic/example_theme_popover.js
+++ b/ckanext/example_theme/v19_01_error/fanstatic/example_theme_popover.js
@@ -18,7 +18,7 @@ ckan.module('example_theme_popover', function ($) {
       // Add a Bootstrap popover to the button. Since we don't have the HTML
       // from the snippet yet, we just set the content to "Loading..."
       this.el.popover({title: this.options.title, html: true,
-                       content: 'Loading...', placement: 'left'});
+                       content: this._('Loading...'), placement: 'left'});
 
       // Add an event handler to the button, when the user clicks the button
       // our _onClick() function will be called.

--- a/ckanext/example_theme/v19_02_error_handling/fanstatic/example_theme_popover.js
+++ b/ckanext/example_theme/v19_02_error_handling/fanstatic/example_theme_popover.js
@@ -5,7 +5,7 @@ ckan.module('example_theme_popover', function ($) {
     initialize: function () {
       $.proxyAll(this, /_on/);
       this.el.popover({title: this.options.title, html: true,
-                       content: 'Loading...', placement: 'left'});
+                       content: this._('Loading...'), placement: 'left'});
       this.el.on('click', this._onClick);
     },
 

--- a/ckanext/example_theme/v20_pubsub/fanstatic/example_theme_popover.js
+++ b/ckanext/example_theme/v20_pubsub/fanstatic/example_theme_popover.js
@@ -5,7 +5,7 @@ ckan.module('example_theme_popover', function ($) {
     initialize: function () {
       $.proxyAll(this, /_on/);
       this.el.popover({title: this.options.title, html: true,
-                       content: 'Loading...', placement: 'left'});
+                       content: this._('Loading...'), placement: 'left'});
       this.el.on('click', this._onClick);
 
       // Subscribe to 'dataset_popover_clicked' events.

--- a/ckanext/example_theme/v21_custom_jquery_plugin/fanstatic/example_theme_popover.js
+++ b/ckanext/example_theme/v21_custom_jquery_plugin/fanstatic/example_theme_popover.js
@@ -5,7 +5,7 @@ ckan.module('example_theme_popover', function ($) {
     initialize: function () {
       $.proxyAll(this, /_on/);
       this.el.popover({title: this.options.title, html: true,
-                       content: 'Loading...', placement: 'left'});
+                       content: this._('Loading...'), placement: 'left'});
       this.el.on('click', this._onClick);
       this.sandbox.subscribe('dataset_popover_clicked',
                              this._onPopoverClicked);


### PR DESCRIPTION
Fixes #3315 by marking all remaining user-visible strings in JS code as translatable.