### PR TITLE
Datastore deleted inside `after_delete` of IResourceController

### DIFF
--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -281,14 +281,13 @@ class DatastorePlugin(p.SingletonPlugin):
             if res.extras.get('datastore_active') is True]
 
         for res in deleted:
-            try:
-                logic.get_action('datastore_delete')(
-                    context, {'resource_id': res.id, 'force': True})
-            except logic.NotFound:
-                # resource was just deleted, so it's expected situation
-                res.extras['datastore_active'] = False
-                res_query.update(
-                    {'extras': res.extras}, synchronize_session=False)
+            db.delete(context, {
+                'resource_id': res.id,
+                'connection_url': self.write_url
+            })
+            res.extras['datastore_active'] = False
+            res_query.update(
+                {'extras': res.extras}, synchronize_session=False)
 
     def datastore_validate(self, context, data_dict, fields_types):
         column_names = fields_types.keys()

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -9,6 +9,7 @@ import sqlalchemy.engine.url as sa_url
 import ckan.plugins as p
 import ckan.logic as logic
 import ckan.model as model
+from ckan.model.core import State
 from ckan.common import config
 import ckanext.datastore.logic.action as action
 import ckanext.datastore.logic.auth as auth
@@ -251,6 +252,8 @@ class DatastorePlugin(p.SingletonPlugin):
                   action='dump')
         return m
 
+    # IResourceController
+
     def before_show(self, resource_dict):
         # Modify the resource url of datastore resources so that
         # they link to the datastore dumps.
@@ -264,6 +267,28 @@ class DatastorePlugin(p.SingletonPlugin):
             resource_dict[u'datastore_active'] = False
 
         return resource_dict
+
+    def after_delete(self, context, resources):
+        model = context['model']
+        pkg = context['package']
+        res_query = model.Session.query(model.Resource)
+        query = res_query.filter(
+            model.Resource.package_id == pkg.id,
+            model.Resource.state == State.DELETED
+        )
+        deleted = [
+            res for res in query.all()
+            if res.extras.get('datastore_active') is True]
+
+        for res in deleted:
+            try:
+                logic.get_action('datastore_delete')(
+                    context, {'resource_id': res.id, 'force': True})
+            except logic.NotFound:
+                # resource was just deleted, so it's expected situation
+                res.extras['datastore_active'] = False
+                res_query.update(
+                    {'extras': res.extras}, synchronize_session=False)
 
     def datastore_validate(self, context, data_dict, fields_types):
         column_names = fields_types.keys()

--- a/ckanext/datastore/tests/test_delete.py
+++ b/ckanext/datastore/tests/test_delete.py
@@ -11,10 +11,14 @@ import ckan.lib.create_test_data as ctd
 import ckan.model as model
 import ckan.tests.legacy as tests
 from ckan.common import config
+import ckan.tests.factories as factories
+import ckan.tests.helpers as helpers
+from ckan.logic import NotFound
 
 import ckanext.datastore.db as db
 from ckanext.datastore.tests.helpers import rebuild_all_dbs, set_url_type
 
+assert_raises = nose.tools.assert_raises
 
 class TestDatastoreDelete(tests.WsgiAppCase):
     sysadmin_user = None
@@ -98,6 +102,23 @@ class TestDatastoreDelete(tests.WsgiAppCase):
             assert expected_msg in str(e)
 
         self.Session.remove()
+
+    def test_datastore_deleted_during_resource_deletion(self):
+        package = factories.Dataset()
+        data = {
+            'resource': {
+                'boo%k': 'crime',
+                'author': ['tolstoy', 'dostoevsky'],
+                'package_id': package['id']
+            },
+        }
+        result = helpers.call_action('datastore_create', **data)
+        resource_id = result['resource_id']
+        helpers.call_action('resource_delete', id=resource_id)
+
+        assert_raises(
+            NotFound, helpers.call_action, 'datastore_search',
+            resource_id=resource_id)
 
     def test_delete_invalid_resource_id(self):
         postparams = '%s=1' % json.dumps({'resource_id': 'bad'})

--- a/ckanext/datastore/tests/test_delete.py
+++ b/ckanext/datastore/tests/test_delete.py
@@ -20,6 +20,7 @@ from ckanext.datastore.tests.helpers import rebuild_all_dbs, set_url_type
 
 assert_raises = nose.tools.assert_raises
 
+
 class TestDatastoreDelete(tests.WsgiAppCase):
     sysadmin_user = None
     normal_user = None


### PR DESCRIPTION
#3422 
After resource had been successfully removed:
1. Get all removed resources of parent dataset
2. Filter out those ones, without active datastore
3. Remove datastore for remaining(it will remove some old datastores first time and will only remove datastore of current resource in consequent runs, so no overhead here)
4. Catch `NotFound`. Resource was just deleted, so `datastore_delete`'s call to `resource_patch` will rise this error.
5. Manually update extras of removed dataset. Not sure whether it required, but this is expected behavior in some way, so just let's do it. Yeah, i directly update resource, but i definitely have access to this resource if `after_delete` have been called. 