### PR TITLE
Query performance improvements.

### DIFF
--- a/ckan/model/resource.py
+++ b/ckan/model/resource.py
@@ -189,7 +189,6 @@ meta.mapper(Resource, resource_table, properties={
                             ),
     )
 },
-order_by=[resource_table.c.package_id],
 extension=[vdm.sqlalchemy.Revisioner(resource_revision_table),
            extension.PluginMapperExtension(),
            ],

--- a/ckan/model/user.py
+++ b/ckan/model/user.py
@@ -9,7 +9,7 @@ import passlib.utils
 from passlib.hash import pbkdf2_sha512
 from sqlalchemy.sql.expression import or_
 from sqlalchemy.orm import synonym
-from sqlalchemy import types, Column, Table
+from sqlalchemy import types, Column, Table, func
 import vdm.sqlalchemy
 
 import meta
@@ -194,21 +194,45 @@ class User(vdm.sqlalchemy.StatefulObjectMixin,
     def number_of_edits(self):
         # have to import here to avoid circular imports
         import ckan.model as model
-        revisions_q = meta.Session.query(model.Revision)
-        revisions_q = revisions_q.filter_by(author=self.name)
-        return revisions_q.count()
+
+        # Get count efficiently without spawning the SQLAlchemy subquery
+        # wrapper. Reset the VDM-forced order_by on timestamp.
+        return meta.Session.execute(
+            meta.Session.query(
+                model.Revision
+            ).filter_by(
+                author=self.name
+            ).statement.with_only_columns(
+                [func.count()]
+            ).order_by(
+                None
+            )
+        ).scalar()
 
     def number_created_packages(self, include_private_and_draft=False):
         # have to import here to avoid circular imports
         import ckan.model as model
-        q = meta.Session.query(model.Package)\
-            .filter_by(creator_user_id=self.id)
+
+        # Get count efficiently without spawning the SQLAlchemy subquery
+        # wrapper. Reset the VDM-forced order_by on timestamp.
+        q = meta.Session.query(
+            model.Package
+        ).filter_by(
+            creator_user_id=self.id
+        )
+
         if include_private_and_draft:
             q = q.filter(model.Package.state != 'deleted')
         else:
-            q = q.filter_by(state='active')\
-                 .filter_by(private=False)
-        return q.count()
+            q = q.filter_by(state='active', private=False)
+
+        return meta.Session.execute(
+            q.statement.with_only_columns(
+                [func.count()]
+            ).order_by(
+                None
+            )
+        ).scalar()
 
     def activate(self):
         ''' Activate the user '''


### PR DESCRIPTION
Removes a forced order_by on revisions that causes poor query
performance on many other table queries.

Replaced `count()` queries on number_of_edits and number_of_packages
with vastly improved queries. SQLAlchemy uses subqueries for `count()`,
along with an odd default unindexed order_by on the table mapper
causing even trivial counts to perform unindexed table scans.

This change reduces the average query time for a user with 500k
revisions from 15 *seconds* to under 20ms.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
