### PR TITLE
[#3447] Resource creation date use datetime.utcnow()

### DIFF
--- a/ckan/model/resource.py
+++ b/ckan/model/resource.py
@@ -48,7 +48,7 @@ resource_table = Table(
     Column('mimetype', types.UnicodeText),
     Column('mimetype_inner', types.UnicodeText),
     Column('size', types.BigInteger),
-    Column('created', types.DateTime, default=datetime.datetime.now),
+    Column('created', types.DateTime, default=datetime.datetime.utcnow),
     Column('last_modified', types.DateTime),
     Column('cache_url', types.UnicodeText),
     Column('cache_last_updated', types.DateTime),


### PR DESCRIPTION
### Fix:
Added datetime.utcnow() to the 'created' column, so it won't show now '-1 days ago' at additional information table.
