### PR TITLE
[#3443] Raise exception if Celery version is not supported

### DIFF
--- a/ckan/lib/celery_app.py
+++ b/ckan/lib/celery_app.py
@@ -10,9 +10,13 @@ import ConfigParser
 import logging
 import os
 
-from celery import Celery
 from ckan.common import config as ckan_config
 from pkg_resources import iter_entry_points, VersionConflict
+
+from celery import __version__ as celery_version, Celery
+if not celery_version.startswith(u'3.'):
+    raise ImportError(u'Only Celery version 3.x is supported.')
+
 
 log = logging.getLogger(__name__)
 

--- a/ckan/tests/lib/test_celery_app.py
+++ b/ckan/tests/lib/test_celery_app.py
@@ -1,0 +1,27 @@
+# encoding: utf-8
+
+u'''
+Tests for ``ckan.lib.celery_app``.
+'''
+
+from nose.tools import raises
+import mock
+
+
+class TestCeleryVersion(object):
+    u'''
+    Make sure that Celery's version is checked.
+    '''
+    @mock.patch.dict(u'sys.modules', {u'celery': mock.MagicMock()})
+    def check_celery_version(self, version):
+        import celery
+        celery.__version__ = version
+        import ckan.lib.celery_app
+        reload(ckan.lib.celery_app)
+
+    def test_3x(self):
+        self.check_celery_version(u'3.1.25')
+
+    @raises(ImportError)
+    def test_4x(self):
+        self.check_celery_version(u'4.0.0')


### PR DESCRIPTION
Fixes #3443 by checking Celery's version at import time. Unsupported versions (anything other than `3.x`) raise an `ImportError` and therefore behave as if Celery wasn't installed at all in places where it is optional. In places where Celery is mandatory the `ImportError` informs the user about the real problem.