### PR TITLE
#3104 / pager helper can receive new kwargs: symbol_previous, symbol_next, page_alt_text

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1100,8 +1100,8 @@ class Page(paginate.Page):
 
     def _pagerlink(self, page, text, extra_attributes=None, pager_text=None):
 
-        if text.isdigit() and page_text:
-            text = literal(page_text + text)
+        if text.isdigit() and pager_text:
+            text = literal(pager_text + text)
         anchor = super(Page, self)._pagerlink(page, text)
         extra_attributes = extra_attributes or {}
         return HTML.li(anchor, **extra_attributes)

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1080,9 +1080,10 @@ class Page(paginate.Page):
     # our custom layout set as default.
 
     def pager(self, *args, **kwargs):
-        prev_link = kwargs['symbol_previous'] if 'symbol_previous' in kwargs else u'«'
-        next_link = kwargs['symbol_next'] if 'symbol_next' in kwargs else u'»'
-        pager_item_text = kwargs['page_alt_text'] if 'page_alt_text' in kwargs else None
+        print(kwargs)
+        prev_link = kwargs.get('symbol_previous', u'«')
+        next_link = kwargs.get('symbol_next', u'»')
+        pager_item_text = kwargs.get('pager_item_text', None)
         kwargs.update(
             format=u"<ul>$link_previous ~2~ $link_next</ul>",
             symbol_previous=literal(prev_link),
@@ -1090,12 +1091,15 @@ class Page(paginate.Page):
             curpage_attr={'class': 'active'},
             link_attr={'class': 'pager_link'}
         )
-        self._pagerlink = partial(self._pagerlink, page_alt_text=pager_item_text)
+        self._pagerlink = partial(
+            self._pagerlink,
+            pager_text=pager_item_text
+        )
         return super(Page, self).pager(*args, **kwargs)
 
     # Put each page link into a <li> (for Bootstrap to style it)
 
-    def _pagerlink(self, page, text, extra_attributes=None, page_alt_text=None):
+    def _pagerlink(self, page, text, extra_attributes=None, pager_text=None):
 
         if text.isdigit() and page_alt_text:
             text = literal(page_alt_text + text)

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1080,9 +1080,13 @@ class Page(paginate.Page):
     # our custom layout set as default.
 
     def pager(self, *args, **kwargs):
-        prev_link = kwargs.get('symbol_previous', u'«')
-        next_link = kwargs.get('symbol_next', u'»')
+        prev_link = kwargs.get('symbol_previous') or u'«'
+        next_link = kwargs.get('symbol_next') or u'»'
         pager_item_text = kwargs.get('pager_item_text', None)
+
+        if 'pager_item_text' in kwargs:
+            del kwargs['pager_item_text']
+
         kwargs.update(
             format=u"<ul>$link_previous ~2~ $link_next</ul>",
             symbol_previous=literal(prev_link),
@@ -1099,9 +1103,8 @@ class Page(paginate.Page):
     # Put each page link into a <li> (for Bootstrap to style it)
 
     def _pagerlink(self, page, text, extra_attributes=None, pager_text=None):
-
-        if text.isdigit() and pager_text:
-            text = literal(pager_text + text)
+        if (isinstance(text, int) or text.isdigit()) and pager_text:
+            text = literal(pager_text + str(text))
         anchor = super(Page, self)._pagerlink(page, text)
         extra_attributes = extra_attributes or {}
         return HTML.li(anchor, **extra_attributes)

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1080,7 +1080,6 @@ class Page(paginate.Page):
     # our custom layout set as default.
 
     def pager(self, *args, **kwargs):
-        print(kwargs)
         prev_link = kwargs.get('symbol_previous', u'«')
         next_link = kwargs.get('symbol_next', u'»')
         pager_item_text = kwargs.get('pager_item_text', None)
@@ -1101,8 +1100,8 @@ class Page(paginate.Page):
 
     def _pagerlink(self, page, text, extra_attributes=None, pager_text=None):
 
-        if text.isdigit() and page_alt_text:
-            text = literal(page_alt_text + text)
+        if text.isdigit() and page_text:
+            text = literal(page_text + text)
         anchor = super(Page, self)._pagerlink(page, text)
         extra_attributes = extra_attributes or {}
         return HTML.li(anchor, **extra_attributes)

--- a/ckan/templates/group/index.html
+++ b/ckan/templates/group/index.html
@@ -34,7 +34,7 @@
     {% endif %}
   {% endblock %}
   {% block page_pagination %}
-    {{ c.page.pager(q=c.q or '', sort=c.sort_by_selected or '') }}
+    {% snippet 'group/snippets/pager.html', q=c.q or '', page=c.page, sort=c.sort_by_selected or '' %}
   {% endblock %}
 {% endblock %}
 

--- a/ckan/templates/group/read.html
+++ b/ckan/templates/group/read.html
@@ -26,7 +26,7 @@
     {% endif %}
   {% endblock %}
   {% block page_pagination %}
-     {% snippet 'group/snippets/pager.html', q=c.q or '', page=c.page %}
+     {% snippet 'snippets/pager.html', q=c.q or '', page=c.page %}
   {% endblock %}
 {% endblock %}
 

--- a/ckan/templates/group/read.html
+++ b/ckan/templates/group/read.html
@@ -26,7 +26,7 @@
     {% endif %}
   {% endblock %}
   {% block page_pagination %}
-    {{ c.page.pager(q=c.q) }}
+    {% snippet 'snippets/pager.html', q=c.q %}
   {% endblock %}
 {% endblock %}
 

--- a/ckan/templates/group/read.html
+++ b/ckan/templates/group/read.html
@@ -26,7 +26,7 @@
     {% endif %}
   {% endblock %}
   {% block page_pagination %}
-    {% snippet 'snippets/pager.html', q=c.q, page=c.page %}
+     {% snippet 'group/snippets/pager.html', q=c.q or '', page=c.page %}
   {% endblock %}
 {% endblock %}
 

--- a/ckan/templates/group/read.html
+++ b/ckan/templates/group/read.html
@@ -26,7 +26,7 @@
     {% endif %}
   {% endblock %}
   {% block page_pagination %}
-    {% snippet 'snippets/pager.html', q=c.q %}
+    {% snippet 'snippets/pager.html', q=c.q, page=c.page %}
   {% endblock %}
 {% endblock %}
 

--- a/ckan/templates/group/snippets/pager.html
+++ b/ckan/templates/group/snippets/pager.html
@@ -1,14 +1,16 @@
 {% extends "snippets/pager.html" %}
 
-{% if page.page_count > 1 %}
-    <div class='pagination pagination-centered'>
-        {{ page.pager(
-            q=q,
-            sort=sort,
-            symbol_previous=symbol_previous,
-            symbol_next=symbol_next,
-            pager_item_text=pager_item_text
-            )
-        }}
-    </div>
-{% endif %}
+{% block pager %}
+    {% if page.page_count > 1 %}
+        <div class='pagination pagination-centered'>
+            {{ page.pager(
+                q=q,
+                sort=sort,
+                symbol_previous=symbol_previous,
+                symbol_next=symbol_next,
+                pager_item_text=pager_item_text
+                )
+            }}
+        </div>
+    {% endif %}
+{% endblock %}

--- a/ckan/templates/group/snippets/pager.html
+++ b/ckan/templates/group/snippets/pager.html
@@ -1,11 +1,10 @@
-{% set pager_item_text = pager_item_text or None %}
-{% set symbol_previous = symbol_previous or None %}
-{% set symbol_next = symbol_next or None %}
+{% extends "snippets/pager.html" %}
 
 {% if page.page_count > 1 %}
     <div class='pagination pagination-centered'>
         {{ page.pager(
             q=q,
+            sort=sort,
             symbol_previous=symbol_previous,
             symbol_next=symbol_next,
             pager_item_text=pager_item_text

--- a/ckan/templates/organization/bulk_process.html
+++ b/ckan/templates/organization/bulk_process.html
@@ -108,5 +108,5 @@
       {% endblock %}
     </aside>
   </div>
-  {{ c.page.pager() }}
+  {% snippet 'organization/snippets/pager.html', q=c.q or '', page=c.page %}
 {% endblock %}

--- a/ckan/templates/organization/index.html
+++ b/ckan/templates/organization/index.html
@@ -34,7 +34,7 @@
     {% endif %}
   {% endblock %}
   {% block page_pagination %}
-    {{ c.page.pager(q=c.q or '', sort=c.sort_by_selected or '') }}
+    {% snippet 'organization/snippets/pager.html', q=c.q or '', page=c.page, sort=c.sort_by_selected or '' %}
   {% endblock %}
 {% endblock %}
 

--- a/ckan/templates/organization/read.html
+++ b/ckan/templates/organization/read.html
@@ -30,7 +30,7 @@
     {% endif %}
   {% endblock %}
   {% block page_pagination %}
-    {% snippet 'organization/snippets/pager.html', q=c.q or '', page=c.page %}
+    {% snippet 'snippets/pager.html', q=c.q or '', page=c.page %}
   {% endblock %}
 {% endblock %}
 

--- a/ckan/templates/organization/read.html
+++ b/ckan/templates/organization/read.html
@@ -30,7 +30,7 @@
     {% endif %}
   {% endblock %}
   {% block page_pagination %}
-    {{ c.page.pager(q=c.q) }}
+    {% snippet 'snippets/pager.html', q=c.q %}
   {% endblock %}
 {% endblock %}
 

--- a/ckan/templates/organization/read.html
+++ b/ckan/templates/organization/read.html
@@ -30,7 +30,7 @@
     {% endif %}
   {% endblock %}
   {% block page_pagination %}
-    {% snippet 'snippets/pager.html', q=c.q %}
+    {% snippet 'snippets/pager.html', q=c.q, page=c.page %}
   {% endblock %}
 {% endblock %}
 

--- a/ckan/templates/organization/read.html
+++ b/ckan/templates/organization/read.html
@@ -30,7 +30,7 @@
     {% endif %}
   {% endblock %}
   {% block page_pagination %}
-    {% snippet 'snippets/pager.html', q=c.q, page=c.page %}
+    {% snippet 'organization/snippets/pager.html', q=c.q or '', page=c.page %}
   {% endblock %}
 {% endblock %}
 

--- a/ckan/templates/organization/snippets/pager.html
+++ b/ckan/templates/organization/snippets/pager.html
@@ -1,14 +1,16 @@
 {% extends "snippets/pager.html" %}
 
-{% if page.page_count > 1 %}
-    <div class='pagination pagination-centered'>
-        {{ page.pager(
-            q=q,
-            sort=sort,
-            symbol_previous=symbol_previous,
-            symbol_next=symbol_next,
-            pager_item_text=pager_item_text
-            )
-        }}
-    </div>
-{% endif %}
+{% block pager %}
+    {% if page.page_count > 1 %}
+        <div class='pagination pagination-centered'>
+            {{ page.pager(
+                q=q,
+                sort=sort,
+                symbol_previous=symbol_previous,
+                symbol_next=symbol_next,
+                pager_item_text=pager_item_text
+                )
+            }}
+        </div>
+    {% endif %}
+{% endblock %}

--- a/ckan/templates/organization/snippets/pager.html
+++ b/ckan/templates/organization/snippets/pager.html
@@ -1,11 +1,10 @@
-{% set pager_item_text = pager_item_text or None %}
-{% set symbol_previous = symbol_previous or None %}
-{% set symbol_next = symbol_next or None %}
+{% extends "snippets/pager.html" %}
 
 {% if page.page_count > 1 %}
     <div class='pagination pagination-centered'>
         {{ page.pager(
             q=q,
+            sort=sort,
             symbol_previous=symbol_previous,
             symbol_next=symbol_next,
             pager_item_text=pager_item_text

--- a/ckan/templates/package/search.html
+++ b/ckan/templates/package/search.html
@@ -40,7 +40,7 @@
     </div>
 
     {% block page_pagination %}
-      {{ c.page.pager(q=c.q) }}
+      {% snippet 'snippets/pager.html', q=c.q %}
     {% endblock %}
   </section>
 

--- a/ckan/templates/package/search.html
+++ b/ckan/templates/package/search.html
@@ -40,7 +40,7 @@
     </div>
 
     {% block page_pagination %}
-      {% snippet 'snippets/pager.html', q=c.q %}
+      {% snippet 'snippets/pager.html', q=c.q, page=c.page %}
     {% endblock %}
   </section>
 

--- a/ckan/templates/revision/list.html
+++ b/ckan/templates/revision/list.html
@@ -9,11 +9,11 @@
 {% block primary_content_inner %}
   <h1>{{ _('Revision History') }}</h1>
 
-  {{ c.page.pager() }}
+  {% snippet "revision/snippets/pager.html", page=c.page %}
 
   {% block revisions_list %}
     {% snippet "revision/snippets/revisions_list.html", revisions=c.page.items %}
   {% endblock %}
 
-  {{ c.page.pager() }}
+  {% snippet "revision/snippets/pager.html", page=c.page %}
 {% endblock %}

--- a/ckan/templates/revision/snippets/pager.html
+++ b/ckan/templates/revision/snippets/pager.html
@@ -1,11 +1,8 @@
-{% set pager_item_text = pager_item_text or None %}
-{% set symbol_previous = symbol_previous or None %}
-{% set symbol_next = symbol_next or None %}
+{% extends "snippets/pager.html" %}
 
 {% if page.page_count > 1 %}
     <div class='pagination pagination-centered'>
         {{ page.pager(
-            q=q,
             symbol_previous=symbol_previous,
             symbol_next=symbol_next,
             pager_item_text=pager_item_text

--- a/ckan/templates/revision/snippets/pager.html
+++ b/ckan/templates/revision/snippets/pager.html
@@ -1,12 +1,14 @@
 {% extends "snippets/pager.html" %}
 
-{% if page.page_count > 1 %}
-    <div class='pagination pagination-centered'>
-        {{ page.pager(
-            symbol_previous=symbol_previous,
-            symbol_next=symbol_next,
-            pager_item_text=pager_item_text
-            )
-        }}
-    </div>
-{% endif %}
+{% block pager %}
+    {% if page.page_count > 1 %}
+        <div class='pagination pagination-centered'>
+            {{ page.pager(
+                symbol_previous=symbol_previous,
+                symbol_next=symbol_next,
+                pager_item_text=pager_item_text
+                )
+            }}
+        </div>
+    {% endif %}
+{% endblock %}

--- a/ckan/templates/snippets/pager.html
+++ b/ckan/templates/snippets/pager.html
@@ -1,3 +1,5 @@
-<div class='pagination pagination-centered'>
-    {{ c.page.pager(q=c.q) }}
-</div>
+{% if page.page_count > 1 %}
+    <div class='pagination pagination-centered'>
+        {{ page.pager(q=q) }}
+    </div>
+{% endif %}

--- a/ckan/templates/snippets/pager.html
+++ b/ckan/templates/snippets/pager.html
@@ -2,14 +2,16 @@
 {% set symbol_previous = symbol_previous or None %}
 {% set symbol_next = symbol_next or None %}
 
-{% if page.page_count > 1 %}
-    <div class='pagination pagination-centered'>
-        {{ page.pager(
-            q=q,
-            symbol_previous=symbol_previous,
-            symbol_next=symbol_next,
-            pager_item_text=pager_item_text
-            )
-        }}
-    </div>
-{% endif %}
+{% block pager %}
+    {% if page.page_count > 1 %}
+        <div class='pagination pagination-centered'>
+            {{ page.pager(
+                q=q,
+                symbol_previous=symbol_previous,
+                symbol_next=symbol_next,
+                pager_item_text=pager_item_text
+                )
+            }}
+        </div>
+    {% endif %}
+{% endblock %}

--- a/ckan/templates/snippets/pager.html
+++ b/ckan/templates/snippets/pager.html
@@ -1,4 +1,4 @@
-{% if page.page_count > 1 %}
+{% if  page|attr('page_count') > 1 %}
     <div class='pagination pagination-centered'>
         {{ page.pager(q=q) }}
     </div>

--- a/ckan/templates/snippets/pager.html
+++ b/ckan/templates/snippets/pager.html
@@ -1,0 +1,3 @@
+<div class='pagination pagination-centered'>
+    {{ c.page.pager(q=c.q) }}
+</div>

--- a/ckan/templates/tag/index.html
+++ b/ckan/templates/tag/index.html
@@ -21,7 +21,7 @@
       {% endblock %}
     </div>
     {% block page_pagination %}
-      {% snippet 'snippets/pager.html', q=c.q %}
+      {% snippet 'snippets/pager.html', q=c.q, page=c.page %}
     {% endblock %}
   </article>
 {% endblock %}

--- a/ckan/templates/tag/index.html
+++ b/ckan/templates/tag/index.html
@@ -21,7 +21,7 @@
       {% endblock %}
     </div>
     {% block page_pagination %}
-      {% snippet 'snippets/pager.html', q=c.q, page=c.page %}
+      {{ c.page.pager(q=c.q) }}
     {% endblock %}
   </article>
 {% endblock %}

--- a/ckan/templates/tag/index.html
+++ b/ckan/templates/tag/index.html
@@ -21,7 +21,7 @@
       {% endblock %}
     </div>
     {% block page_pagination %}
-      {{ c.page.pager(q=c.q) }}
+      {% snippet 'snippets/pager.html', q=c.q %}
     {% endblock %}
   </article>
 {% endblock %}

--- a/ckan/templates/user/list.html
+++ b/ckan/templates/user/list.html
@@ -23,7 +23,7 @@
       {% endblock %}
     </div>
     {% block page_pagination %}
-      {{ c.page.pager(q=c.q, order_by=c.order_by) }}
+      {% snippet 'user/snippets/pager.html', q=c.q, order_by=c.order_by, page=c.page %}
     {% endblock %}
   </article>
 {% endblock %}

--- a/ckan/templates/user/snippets/pager.html
+++ b/ckan/templates/user/snippets/pager.html
@@ -1,14 +1,16 @@
 {% extends "snippets/pager.html" %}
 
-{% if page.page_count > 1 %}
-    <div class='pagination pagination-centered'>
-        {{ page.pager(
-            q=q,
-            order_by=order_by,
-            symbol_previous=symbol_previous,
-            symbol_next=symbol_next,
-            pager_item_text=pager_item_text
-            )
-        }}
-    </div>
-{% endif %}
+{% block pager %}
+    {% if page.page_count > 1 %}
+        <div class='pagination pagination-centered'>
+            {{ page.pager(
+                q=q,
+                order_by=order_by,
+                symbol_previous=symbol_previous,
+                symbol_next=symbol_next,
+                pager_item_text=pager_item_text
+                )
+            }}
+        </div>
+    {% endif %}
+{% endblock %}

--- a/ckan/templates/user/snippets/pager.html
+++ b/ckan/templates/user/snippets/pager.html
@@ -1,11 +1,10 @@
-{% set pager_item_text = pager_item_text or None %}
-{% set symbol_previous = symbol_previous or None %}
-{% set symbol_next = symbol_next or None %}
+{% extends "snippets/pager.html" %}
 
 {% if page.page_count > 1 %}
     <div class='pagination pagination-centered'>
         {{ page.pager(
             q=q,
+            order_by=order_by,
             symbol_previous=symbol_previous,
             symbol_next=symbol_next,
             pager_item_text=pager_item_text

--- a/ckan/tests/legacy/functional/test_pagination.py
+++ b/ckan/tests/legacy/functional/test_pagination.py
@@ -102,12 +102,12 @@ class TestPaginationGroup(TestController):
 
     def test_group_index(self):
         res = self.app.get(url_for(controller='group', action='index'))
-        assert 'href="/group?q=&amp;sort=&amp;page=2"' in res, res
+        assert 'href="/group?sort=&amp;q=&amp;page=2"' in res, res
         grp_numbers = scrape_search_results(res, 'group')
         assert_equal(['00', '01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20'], grp_numbers)
 
         res = self.app.get(url_for(controller='group', action='index', page=2))
-        assert 'href="/group?q=&amp;sort=&amp;page=1"' in res
+        assert 'href="/group?sort=&amp;q=&amp;page=1"' in res
         grp_numbers = scrape_search_results(res, 'group')
         assert_equal(['21'], grp_numbers)
 


### PR DESCRIPTION
Fixes #
Now devs can override pager snippet and extend pager arguments up to 3 new kwargs. To modify prev and next links, and prepend additional text to pager items links (HTML can be used, using literals). 

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
