### PR TITLE
Fix an incorrect error message.

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -390,11 +390,14 @@ class PackageController(base.BaseController):
         try:
             return render(template,
                           extra_vars={'dataset_type': package_type})
-        except ckan.lib.render.TemplateNotFound:
-            msg = _("Viewing {package_type} datasets in {format} format is "
-                    "not supported (template file {file} not found).".format(
-                        package_type=package_type, format=format,
-                        file=template))
+        except ckan.lib.render.TemplateNotFound as e:
+            msg = _(
+                "Viewing datasets of type \"{package_type}\" is "
+                "not supported ({file_!r}).".format(
+                    package_type=package_type,
+                    file_=e.message
+                )
+            )
             abort(404, msg)
 
         assert False, "We should never get here"


### PR DESCRIPTION
This is a small legacy codefix.

If a sub-template cannot be found anywhere inside an IDatasetForm template assumptions are made in the displayed error message as to which template failed. This PR turns:

```
Viewing record datasets in <built-in function format> format is not supported (template file scheming/package/read.html not found).
```

into:

```
Viewing datasets of type "record" is not supported ('Template scheming/display_snippets/text cannot be found').
```