### PR TITLE
Performance improvements in group_activity_query

### DIFF
--- a/ckan/model/activity.py
+++ b/ckan/model/activity.py
@@ -3,7 +3,15 @@
 import datetime
 
 from sqlalchemy import (
-    orm, types, Column, Table, ForeignKey, desc, or_, union_all)
+    orm,
+    types,
+    Column,
+    Table,
+    ForeignKey,
+    desc,
+    or_,
+    union_all
+)
 
 import ckan.model
 import meta
@@ -182,14 +190,29 @@ def _group_activity_query(group_id):
         # Return a query with no results.
         return model.Session.query(model.Activity).filter("0=1")
 
-    dataset_ids = [dataset.id for dataset in group.packages()]
+    q = model.Session.query(
+        model.Activity
+    ).join(
+        model.Member,
+        model.Activity.object_id == model.Member.table_id
+    ).join(
+        model.Package,
+        model.Package.id == model.Member.table_id
+    ).filter(
+        # We only care about activity either on the the group itself or on
+        # packages within that group.
+        # FIXME: This means that activity that occured while a package belonged
+        # to a group but was then removed will not show up. This may not be
+        # desired.
+        or_(
+            model.Member.group_id == group_id,
+            model.Activity.object_id == group_id
+        ),
+        model.Member.state == 'active',
+        model.Member.table_name == 'package',
+        model.Package.private == False
+    )
 
-    q = model.Session.query(model.Activity)
-    if dataset_ids:
-        q = q.filter(or_(model.Activity.object_id == group_id,
-            model.Activity.object_id.in_(dataset_ids)))
-    else:
-        q = q.filter(model.Activity.object_id == group_id)
     return q
 
 


### PR DESCRIPTION
Currently, attempting to view the activity feed (a very user-visible feature) of an organization or group with even a few thousand packages will take between 10s to never. This is caused by poor logic inside `group_activity_query` which among other things loads every single dataset owned by that group/org into memory, gets the IDs, throws them out, and then does a gigantic `IN` query against every `object_id`.

With this change, rendering org activity with 18000 datasets takes <= 700ms (with no query being above 250ms) and most of that time can be reduced through two changes:

- The controller should be changed to sort and page based off the `Activity.timestamp` column, which should also be indexed. This solves the offset/limit performance once you're many pages in.
- Template improvements as a significant amount of time is spent rendering each activity item.

However, these two changes may break existing themes and will be left for another PR. This PR as it is causes no breaking changes and can be safely backported.