### PR TITLE
Setting of datastore_active flag moved to separate function

### DIFF
--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -149,47 +149,7 @@ def datastore_create(context, data_dict):
         log.debug(
             'Setting datastore_active=True on resource {0}'.format(resource.id)
         )
-        # issue #3245: race condition
-        update_dict = {'datastore_active': True}
-
-        # get extras(for entity update) and package_id(for search index update)
-        res_query = model.Session.query(
-            model.resource_table.c.extras,
-            model.resource_table.c.package_id
-        ).filter(
-            model.Resource.id == data_dict['resource_id']
-        )
-        extras, package_id = res_query.one()
-
-        # update extras in database for record and its revision
-        extras.update(update_dict)
-        res_query.update({'extras': extras}, synchronize_session=False)
-
-        model.Session.query(model.resource_revision_table).filter(
-            model.ResourceRevision.id == data_dict['resource_id'],
-            model.ResourceRevision.current is True
-        ).update({'extras': extras}, synchronize_session=False)
-
-        model.Session.commit()
-
-        # get package with  updated resource from solr
-        # find changed resource, patch it and reindex package
-        psi = search.PackageSearchIndex()
-        solr_query = search.PackageSearchQuery()
-        q = {
-            'q': 'id:"{0}"'.format(package_id),
-            'fl': 'data_dict',
-            'wt': 'json',
-            'fq': 'site_id:"%s"' % config.get('ckan.site_id'),
-            'rows': 1
-        }
-        for record in solr_query.run(q)['results']:
-            solr_data_dict = json.loads(record['data_dict'])
-            for resource in solr_data_dict['resources']:
-                if resource['id'] == data_dict['resource_id']:
-                    resource.update(update_dict)
-                    psi.index_package(solr_data_dict)
-                    break
+        set_datastore_active_flag(model, data_dict, True)
 
     result.pop('id', None)
     result.pop('private', None)
@@ -396,11 +356,9 @@ def datastore_delete(context, data_dict):
     if (not data_dict.get('filters') and
             resource.extras.get('datastore_active') is True):
         log.debug(
-            'Setting datastore_active=True on resource {0}'.format(resource.id)
+            'Setting datastore_active=False on resource {0}'.format(resource.id)
         )
-        p.toolkit.get_action('resource_patch')(
-            context, {'id': data_dict['resource_id'],
-                      'datastore_active': False})
+        set_datastore_active_flag(model, data_dict, False)
 
     result.pop('id', None)
     result.pop('connection_url')
@@ -596,6 +554,53 @@ def datastore_make_public(context, data_dict):
     p.toolkit.check_access('datastore_change_permissions', context, data_dict)
 
     db.make_public(context, data_dict)
+
+
+def set_datastore_active_flag(model, data_dict, flag):
+    '''
+    Set appropriate datastore_active flag on CKAN resource.
+
+    Called after creation or deletion of DataStore table.
+    '''
+    update_dict = {'datastore_active': flag}
+
+    # get extras(for entity update) and package_id(for search index update)
+    res_query = model.Session.query(
+        model.resource_table.c.extras,
+        model.resource_table.c.package_id
+    ).filter(
+        model.Resource.id == data_dict['resource_id']
+    )
+    extras, package_id = res_query.one()
+
+    # update extras in database for record and its revision
+    extras.update(update_dict)
+    res_query.update({'extras': extras}, synchronize_session=False)
+    model.Session.query(model.resource_revision_table).filter(
+        model.ResourceRevision.id == data_dict['resource_id'],
+        model.ResourceRevision.current is True
+    ).update({'extras': extras}, synchronize_session=False)
+
+    model.Session.commit()
+
+    # get package with  updated resource from solr
+    # find changed resource, patch it and reindex package
+    psi = search.PackageSearchIndex()
+    solr_query = search.PackageSearchQuery()
+    q = {
+        'q': 'id:"{0}"'.format(package_id),
+        'fl': 'data_dict',
+        'wt': 'json',
+        'fq': 'site_id:"%s"' % config.get('ckan.site_id'),
+        'rows': 1
+    }
+    for record in solr_query.run(q)['results']:
+        solr_data_dict = json.loads(record['data_dict'])
+        for resource in solr_data_dict['resources']:
+            if resource['id'] == data_dict['resource_id']:
+                resource.update(update_dict)
+                psi.index_package(solr_data_dict)
+                break
 
 
 def _resource_exists(context, data_dict):


### PR DESCRIPTION
Changes from #3331 put into separate function.

Because the same approach is needed not only when creating new DataStore item (fixed in #3331), but also when deleting one (and setting datastore_active to False).