### PR TITLE
resource_search API optionally returns private resources

### DIFF
--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -610,7 +610,8 @@ def default_resource_search_schema():
         'fields': [ignore_missing],  # dict of fields
         'order_by': [ignore_missing, unicode],
         'offset': [ignore_missing, natural_number_validator],
-        'limit': [ignore_missing, natural_number_validator]
+        'limit': [ignore_missing, natural_number_validator],
+        'include_private': [ignore_missing, boolean_validator],
     }
     return schema
 


### PR DESCRIPTION
### Proposed fixes:

Add a new `include_private` flag to the `resource_search` endpoint

If set, return resources attached to private packages to which the
authenticated user has access.

CKAN 2.6 added the `include_private` flag to `package_search`. Adding equivalent functionality to the `resource_search` API is very useful to CKAN deployments which make use of private datasets.

### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
