### PR TITLE
install package data via setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -189,6 +189,14 @@ setup(
     zip_safe=False,
     packages=find_packages(exclude=['ez_setup']),
     namespace_packages=['ckanext', 'ckanext.stats'],
+    include_package_data=True,
+    package_data={'ckan': [
+        'i18n/*/LC_MESSAGES/*.mo',
+        'migration/migrate.cfg',
+        'migration/README',
+        'migration/tests/test_dumps/*',
+        'migration/versions/*',
+    ]},
     message_extractors={
         'ckan': [
             ('**.py', 'python', None),


### PR DESCRIPTION
### Proposed fixes:

Installation via pip from a local checkout was not installing package data, including '.sql' migrations. this includes installs via pip and a `git+ssh` URL.

This fixes a regression introduced in c1d4dda4d39288ada8872d35323c976690ff4b5e

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
