### PR TITLE
[3513] minimum setuptools version

### DIFF
--- a/bin/travis-install-dependencies
+++ b/bin/travis-install-dependencies
@@ -29,6 +29,7 @@ sudo -E -u postgres ./bin/postgres_init/1_create_ckan_db.sh
 sudo -E -u postgres ./bin/postgres_init/2_create_ckan_datastore_db.sh
 
 export PIP_USE_MIRRORS=true
+pip install -r requirement-setuptools.txt --allow-all-external
 pip install -r requirements.txt --allow-all-external
 pip install -r dev-requirements.txt --allow-all-external
 

--- a/circle.yml
+++ b/circle.yml
@@ -23,6 +23,7 @@ dependencies:
            && chmod +x ~/.local/bin/circleci-matrix"
 
     override:
+        - pip install -r requirement-setuptools.txt
         - pip install -r requirements.txt
         - pip install -r dev-requirements.txt
         - python setup.py develop

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -94,7 +94,13 @@ a. Create a Python `virtual environment <http://www.virtualenv.org>`_
 
        |activate|
 
-b. Install the CKAN source code into your virtualenv.
+b. Install the recommended version of 'setuptools':
+
+   .. parsed-literal::
+
+       pip install -r |virtualenv|/src/ckan/requirement-setuptools.txt
+
+c. Install the CKAN source code into your virtualenv.
    To install the latest stable release of CKAN (CKAN |latest_release_version|),
    run:
 
@@ -116,7 +122,7 @@ b. Install the CKAN source code into your virtualenv.
       production websites! Only install this version if you're doing CKAN
       development.
 
-c. Install the Python modules that CKAN requires into your virtualenv:
+d. Install the Python modules that CKAN requires into your virtualenv:
 
    .. versionchanged:: 2.1
       In CKAN 2.0 and earlier the requirement file was called
@@ -125,12 +131,6 @@ c. Install the Python modules that CKAN requires into your virtualenv:
    .. parsed-literal::
 
        pip install -r |virtualenv|/src/ckan/requirements.txt
-
-d. Install the recommended version of 'setuptools':
-
-   .. parsed-literal::
-
-       pip install -r |virtualenv|/src/ckan/requirement-setuptools.txt
 
 e. Deactivate and reactivate your virtualenv, to make sure you're using the
    virtualenv's copies of commands like ``paster`` rather than any system-wide

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -126,11 +126,11 @@ c. Install the Python modules that CKAN requires into your virtualenv:
 
        pip install -r |virtualenv|/src/ckan/requirements.txt
 
-d. Upgrade 'setuptools':
+d. Install the recommended version of 'setuptools':
 
    .. parsed-literal::
 
-       pip install -U setuptools       
+       pip install -r |virtualenv|/src/ckan/requirement-setuptools.txt
 
 e. Deactivate and reactivate your virtualenv, to make sure you're using the
    virtualenv's copies of commands like ``paster`` rather than any system-wide

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -126,7 +126,13 @@ c. Install the Python modules that CKAN requires into your virtualenv:
 
        pip install -r |virtualenv|/src/ckan/requirements.txt
 
-d. Deactivate and reactivate your virtualenv, to make sure you're using the
+d. Upgrade 'setuptools':
+
+   .. parsed-literal::
+
+       pip install -U setuptools       
+
+e. Deactivate and reactivate your virtualenv, to make sure you're using the
    virtualenv's copies of commands like ``paster`` rather than any system-wide
    installed copies:
 

--- a/requirement-setuptools.txt
+++ b/requirement-setuptools.txt
@@ -1,0 +1,1 @@
+setuptools==20.4

--- a/setup.py
+++ b/setup.py
@@ -6,16 +6,23 @@ if os.environ.get('USER', '') == 'vagrant':
     del os.link
 
 try:
-    from setuptools import setup, find_packages, __version__
+    from setuptools import (setup, find_packages,
+                            __version__ as setuptools_version)
 except ImportError:
     from ez_setup import use_setuptools
     use_setuptools()
-    from setuptools import setup, find_packages, __version__
+    from setuptools import (setup, find_packages,
+                            __version__ as setuptools_version)
 
-assert __version__ >= '18.5', 'setuptools version error'\
-    '\nYou need a newer version of setuptools. Do this:\n' \
-    '    pip install -U setuptools\n' \
-    'before installing ckan into your python environment again.'
+MIN_SETUPTOOLS_VERSION = 18.5
+assert setuptools_version >= str(MIN_SETUPTOOLS_VERSION) and \
+    int(setuptools_version.split('.')[0]) >= int(MIN_SETUPTOOLS_VERSION),\
+    ('setuptools version error'
+     '\nYou need a newer version of setuptools.\n'
+     'You have %s and you need at least %s.\nDo this:\n'
+     '    pip install -U setuptools\n' \
+     'and then try again to install ckan into your python environment.' %
+     (setuptools_version, MIN_SETUPTOOLS_VERSION))
     
 from ckan import (__version__, __description__, __long_description__,
                   __license__)

--- a/setup.py
+++ b/setup.py
@@ -17,18 +17,18 @@ except ImportError:
 from ckan import (__version__, __description__, __long_description__,
                   __license__)
 
-MIN_SETUPTOOLS_VERSION = 18.5
-SUGGESTED_SETUPTOOLS_VERSION = 18.5
+MIN_SETUPTOOLS_VERSION = 20.4
 assert setuptools_version >= str(MIN_SETUPTOOLS_VERSION) and \
     int(setuptools_version.split('.')[0]) >= int(MIN_SETUPTOOLS_VERSION),\
     ('setuptools version error'
      '\nYou need a newer version of setuptools.\n'
-     'You have {current}, you need at least {minimum} and the suggested '
-     'version is {suggested}.\nDo this:\n'
-     '    pip install setuptools=={suggested}\n'
+     'You have {current}, you need at least {minimum}'
+     '\nInstall the recommended version:\n'
+     '    pip install -r requirement-setuptools.txt\n'
      'and then try again to install ckan into your python environment.'.format(
-         current=setuptools_version, minimum=MIN_SETUPTOOLS_VERSION,
-         suggested=SUGGESTED_SETUPTOOLS_VERSION))
+         current=setuptools_version,
+         minimum=MIN_SETUPTOOLS_VERSION
+         ))
 
 
 entry_points = {

--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,17 @@ if os.environ.get('USER', '') == 'vagrant':
     del os.link
 
 try:
-    from setuptools import setup, find_packages
+    from setuptools import setup, find_packages, __version__
 except ImportError:
     from ez_setup import use_setuptools
     use_setuptools()
-    from setuptools import setup, find_packages
+    from setuptools import setup, find_packages, __version__
 
+assert __version__ >= '18.5', 'setuptools version error'\
+    '\nYou need a newer version of setuptools. Do this:\n' \
+    '    pip install -U setuptools\n' \
+    'before installing ckan into your python environment again.'
+    
 from ckan import (__version__, __description__, __long_description__,
                   __license__)
 

--- a/setup.py
+++ b/setup.py
@@ -14,18 +14,22 @@ except ImportError:
     from setuptools import (setup, find_packages,
                             __version__ as setuptools_version)
 
+from ckan import (__version__, __description__, __long_description__,
+                  __license__)
+
 MIN_SETUPTOOLS_VERSION = 18.5
+SUGGESTED_SETUPTOOLS_VERSION = 18.5
 assert setuptools_version >= str(MIN_SETUPTOOLS_VERSION) and \
     int(setuptools_version.split('.')[0]) >= int(MIN_SETUPTOOLS_VERSION),\
     ('setuptools version error'
      '\nYou need a newer version of setuptools.\n'
-     'You have %s and you need at least %s.\nDo this:\n'
-     '    pip install -U setuptools\n' \
-     'and then try again to install ckan into your python environment.' %
-     (setuptools_version, MIN_SETUPTOOLS_VERSION))
-    
-from ckan import (__version__, __description__, __long_description__,
-                  __license__)
+     'You have {current}, you need at least {minimum} and the suggested '
+     'version is {suggested}.\nDo this:\n'
+     '    pip install setuptools=={suggested}\n'
+     'and then try again to install ckan into your python environment.'.format(
+         current=setuptools_version, minimum=MIN_SETUPTOOLS_VERSION,
+         suggested=SUGGESTED_SETUPTOOLS_VERSION))
+
 
 entry_points = {
     'nose.plugins.0.10': [


### PR DESCRIPTION
Fixes #3513 

It's a problem to pin setuptools in requirements.txt, because it is generated from requirements.in by pip-compile, and that specifically excludes setuptools:
```
# The following packages are commented out because they are
# considered to be unsafe in a requirements file:
# setuptools
```
I can't see a way to hack pip-compile, so we'd have add it back to requirements.txt manually every time we run pip-compile, which is not ideal.

I tried adding it to setup.py:
```
    install_requires=[
        'setuptools>=18.5',  # required for html5lib
        # ALL other dependencies should be put in requirements.in/.txt
    ],
```
But I get this error when I do `python setup.py develop`:
```
  File "/home/vagrant/ckan/local/lib/python2.7/site-packages/packaging/requirements.py", line 59, in <module>
    MARKER_EXPR = originalTextFor(MARKER_EXPR())("marker")
TypeError: __call__() takes exactly 2 arguments (1 given)
```
Clearly it is difficult for setuptools to upgrade itself while running.

Final try was to add the requirement as code in setup.py, so that it checks the version but won't try and upgrade itself - it tells the user how to do this. See PR.

## Testing

```
(ckan)vagrant@precise64:/vagrant/src/ckan$ pip install setuptools==2.2
...

(ckan)vagrant@precise64:/vagrant/src/ckan$ python setup.py develop
Traceback (most recent call last):
  File "setup.py", line 31, in <module>
    suggested=SUGGESTED_SETUPTOOLS_VERSION))
AssertionError: setuptools version error
You need a newer version of setuptools.
You have 2.2, you need at least 18.5 and the suggested version is 18.5.
Do this:
    pip install setuptools==18.5
and then try again to install ckan into your python environment.

(ckan)vagrant@precise64:/vagrant/src/ckan$ pip install setuptools==18.5
...
  Found existing installation: setuptools 2.2
    Uninstalling setuptools-2.2:
      Successfully uninstalled setuptools-2.2
Successfully installed setuptools-18.5

(ckan)vagrant@precise64:/vagrant/src/ckan$ python setup.py develop
...
Installed /vagrant/src/ckan
```