### PR TITLE
[#3520] Import DebugToolbar only in debug mode

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 import os
-import importlib
 import inspect
 import itertools
 import pkgutil
@@ -13,7 +12,6 @@ from flask.sessions import SessionInterface
 from werkzeug.exceptions import HTTPException
 from werkzeug.routing import Rule
 
-from flask_debugtoolbar import DebugToolbarExtension
 
 from beaker.middleware import SessionMiddleware
 from paste.deploy.converters import asbool
@@ -70,6 +68,7 @@ def make_flask_stack(conf, **app_conf):
                            ' with the SECRET_KEY config option')
 
     if debug:
+        from flask_debugtoolbar import DebugToolbarExtension
         app.config['DEBUG_TB_INTERCEPT_REDIRECTS'] = False
         DebugToolbarExtension(app)
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-# These are packages that required when running ckan tests and building the docs
+# These are packages that are required by ckan developers - for running ckan in debug mode, running ckan tests, building the docs and to pip-compile the requirements.in file.
 
 beautifulsoup4==4.5.1
 coveralls   #Let Unpinned - Requires latest coveralls


### PR DESCRIPTION
Fixes #3520 

Only import the Flask DebugToolbar middleware on debug mode, as this is not a core requirement, just a dev one.
