### PR TITLE
Datapusher CLI - bypass typing y

### DIFF
--- a/ckanext/datapusher/cli.py
+++ b/ckanext/datapusher/cli.py
@@ -24,19 +24,29 @@ class DatapusherCommand(cli.CkanCommand):
     summary = __doc__.split('\n')[0]
     usage = __doc__
 
+    def __init__(self, name):
+        super(DatapusherCommand, self).__init__(name)
+
+        self.parser.add_option('-y', dest='yes',
+                               action='store_true', default=False,
+                               help='Always answer yes to questions')
+
     def command(self):
         if self.args and self.args[0] == 'resubmit':
-            self._confirm_or_abort()
+            if not self.options.yes:
+                self._confirm_or_abort()
 
             self._load_config()
             self._resubmit_all()
         elif self.args and self.args[0] == 'submit_all':
-            self._confirm_or_abort()
+            if not self.options.yes:
+                self._confirm_or_abort()
 
             self._load_config()
             self._submit_all_packages()
         elif self.args and self.args[0] == 'submit':
-            self._confirm_or_abort()
+            if not self.options.yes:
+                self._confirm_or_abort()
 
             if len(self.args) != 2:
                 print "This command requires an argument\n"


### PR DESCRIPTION
Before this PR:
```
(default)vagrant@vagrant-ubuntu-trusty-64:~$ paster --plugin=ckan datapusher submit -c $CKAN_INI simple
Data in any datastore resource that isn't in their source files (e.g. data added using the datastore API) will be permanently lost. Are you sure you want to proceed? [y/n] y
Submitting 1 datastore resources
Submitting ee29d2e5-cee3-4472-a431-9299dc8d3f92... OK
```
i.e. you had to type "y" then return.

After:
```
paster --plugin=ckan datapusher submit -y -c $CKAN_INI simple
Submitting 1 datastore resources
Submitting ee29d2e5-cee3-4472-a431-9299dc8d3f92... OK
```