### PR TITLE
Datapusher output - display multiline logs properly

### DIFF
--- a/ckanext/datapusher/templates/datapusher/resource_data.html
+++ b/ckanext/datapusher/templates/datapusher/resource_data.html
@@ -68,7 +68,9 @@
         <li class="item no-avatar{{ class }}">
           <i class="fa icon fa-{{ icon }}"></i>
           <p>
-            {{ item.message | urlize }}<br>
+            {% for line in item.message.strip().split('\n') %}
+              {{ line | urlize }}<br>
+            {% endfor %}
             <span class="date" title="{{ h.render_datetime(item.timestamp, with_hours=True) }}">
               {{ h.time_ago_from_timestamp(item.timestamp) }}
               <a href="#" data-target="popover" data-content="<dl>{% for key, value in item.iteritems() %}<dt>{{ key }}</dt><dd>{{ value }}</dd>{% endfor %}</dl>" data-html="true">{{ _('Details') }}</a>


### PR DESCRIPTION
This is for the datapusher logs, displayed to admins at e.g. `/dataset/simple/resource_data/ee29d2e5-cee3-4472-a431-9299dc8d3f92`

This change means carriage-returns in the log are displayed properly. e.g. the third item here:
<img width="675" alt="screen shot 2017-04-04 at 09 28 36" src="https://cloud.githubusercontent.com/assets/307612/24648650/2c0e56f6-191c-11e7-884a-2c2158a16587.png">
