### PR TITLE
Avoid duplicate Datapusher jobs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ others, make a new page on the `CKAN wiki`_, and tell us about it on
 Copying and License
 -------------------
 
-This material is copyright (c) 2006-2014 Open Knowledge Foundation.
+This material is copyright (c) 2006-2017 Open Knowledge International and contributors.
 
 It is open and licensed under the GNU Affero General Public License (AGPL) v3.0
 whose full text may be found at:

--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -159,6 +159,7 @@ ckan.feeds.author_link =
 
 #ckan.datapusher.formats = csv xls xlsx tsv application/csv application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
 #ckan.datapusher.url = http://127.0.0.1:8800/
+#ckan.datapusher.assume_task_stale_after = 3600
 
 # Resource Proxy settings
 # Preview size limit, default: 1MB

--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -89,12 +89,13 @@ def datapusher_submit(context, data_dict):
             'task_type': 'datapusher',
             'key': 'datapusher'
         })
-
-        if existing_task and existing_task.get('state') == 'pending':
+        assume_task_stale_after = datetime.timedelta(seconds=int(
+            config.get('ckan.datapusher.assume_task_stale_after', 3600)))
+        if existing_task.get('state') == 'pending':
             updated = datetime.datetime.strptime(
                 existing_task['last_updated'], '%Y-%m-%dT%H:%M:%S.%f')
             time_since_last_updated = datetime.datetime.now() - updated
-            if time_since_last_updated > datetime.timedelta(days=1):
+            if time_since_last_updated > assume_task_stale_after:
                 # it's been a while since the job was last updated - it's more
                 # likely something went wrong with it and the state wasn't
                 # updated than its still in progress. Let it be restarted.

--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -84,18 +84,33 @@ def datapusher_submit(context, data_dict):
         'error': '{}',
     }
     try:
-        task_id = p.toolkit.get_action('task_status_show')(context, {
+        existing_task = p.toolkit.get_action('task_status_show')(context, {
             'entity_id': res_id,
             'task_type': 'datapusher',
             'key': 'datapusher'
-        })['id']
-        task['id'] = task_id
+        })
+
+        if existing_task and existing_task.get('state') == 'pending':
+            updated = datetime.datetime.strptime(
+                existing_task['last_updated'], '%Y-%m-%dT%H:%M:%S.%f')
+            time_since_last_updated = datetime.datetime.now() - updated
+            if time_since_last_updated > datetime.timedelta(days=1):
+                # it's been a while since the job was last updated - it's more
+                # likely something went wrong with it and the state wasn't
+                # updated than its still in progress. Let it be restarted.
+                log.info('A pending task was found %r, but it is only %s hours'
+                         'old', existing_task['id'], time_since_last_updated)
+            else:
+                log.info('A pending task was found %s for this resource, so '
+                         'skipping this duplicate task', existing_task['id'])
+                return False
+
+        task['id'] = existing_task['id']
     except logic.NotFound:
         pass
 
     context['ignore_auth'] = True
-    result = p.toolkit.get_action('task_status_update')(context, task)
-    task_id = result['id']
+    p.toolkit.get_action('task_status_update')(context, task)
 
     try:
         r = requests.post(

--- a/ckanext/datapusher/tests/test_action.py
+++ b/ckanext/datapusher/tests/test_action.py
@@ -3,6 +3,7 @@
 import datetime
 
 from nose.tools import eq_
+import mock
 
 import ckan.plugins as p
 from ckan.tests import helpers, factories
@@ -278,3 +279,21 @@ class TestDataPusherAction(object):
 
         # Not called
         eq_(len(mock_datapusher_submit.mock_calls), 1)
+
+    def test_duplicated_tasks(self):
+        def submit(res, user):
+            return helpers.call_action(
+                'datapusher_submit', context=dict(user=user['name']),
+                resource_id=res['id'])
+
+        user = factories.User()
+        res = factories.Resource(user=user)
+        with mock.patch('requests.post') as r_mock:
+            r_mock().json = mock.Mock(
+                side_effect=lambda: dict.fromkeys(
+                    ['job_id', 'job_key']))
+            r_mock.reset_mock()
+            submit(res, user)
+            submit(res, user)
+
+            eq_(1, r_mock.call_count)

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -1425,6 +1425,22 @@ running on port 8800. If you want to manually install the DataPusher, follow
 the installation `instructions <http://docs.ckan.org/projects/datapusher>`_.
 
 
+.. _ckan.datapusher.assume_task_stale_after:
+
+ckan.datapusher.assume_task_stale_after
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+  ckan.datapusher.assume_task_stale_after = 86400
+
+Default value:  ``3600`` (one hour)
+
+In case a DataPusher task gets stuck and fails to recover, this is the minimum
+amount of time (in seconds) after a resource is submitted to DataPusher that the
+resource can be submitted again.
+
+
 User Settings
 -------------------------
 


### PR DESCRIPTION
Fixes #2721
Fixes #2334

Thanks @clementmouchet for the initial code for this.

<img width="712" alt="screen shot 2017-04-04 at 11 43 00" src="https://cloud.githubusercontent.com/assets/307612/24653000/e9fb87ce-192b-11e7-9ac5-430e6acba541.png">

Test this PR manually by double-clicking the "Upload to Datastore" button and seeing that the second one of the tasks is skipped, seeing this in the logs:
```
2017-04-04 10:32:17,633 INFO  [ckanext.datapusher.logic.action] A pending task was found 3fcabb2a-a965-4216-877e-0202c00ee8e7 for this resource, so skipping this duplicate task
```

Ideally in this code some signals would be added in, to do the check and update atomically, but as it stands, it avoids the problem for 99.9% of cases.