### PR TITLE
Add notes on running tests with Solr multicore

### DIFF
--- a/doc/contributing/test.rst
+++ b/doc/contributing/test.rst
@@ -96,7 +96,11 @@ To enable multi-core:
 
        curl 'http://localhost:8983/solr/admin/cores?action=CREATE&name=ckan&instanceDir=/etc/solr/ckan'
 
-If successful the status should be 0 - some XML containing: ``<int name="status">0</int>``
+   If successful the status should be 0 - some XML containing: ``<int name="status">0</int>``
+
+4. Edit your main ckan config (e.g. |development.ini|) and adjust the solr_url to match::
+
+       solr_url = http://127.0.0.1:8983/solr/ckan
 
 
 ~~~~~~~~~~~~~

--- a/doc/contributing/test.rst
+++ b/doc/contributing/test.rst
@@ -63,6 +63,42 @@ This database connection is specified in the ``test-core.ini`` file by the
 You should also make sure that the :ref:`Redis database <ckan_redis_url>`
 configured in ``test-core.ini`` is different from your production database.
 
+
+.. _solr-multi-core:
+
+~~~~~~~~~~~~~~~~~~~~~~~~~
+Configure Solr Multi-core
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The tests assume that Solr is configured 'multi-core', whereas the default
+Solr set-up is often 'single-core'. You can ask Solr how many cores it has
+configured::
+
+    curl -s 'http://127.0.0.1:8983/solr/admin/cores?action=STATUS' |python -c 'import sys;import xml.dom.minidom;s=sys.stdin.read();print xml.dom.minidom.parseString(s).toprettyxml()'
+
+You can also tell from your ckan config::
+
+    grep solr_url /etc/ckan/default/production.ini
+    # single-core: solr_url = http://127.0.0.1:8983/solr
+    # multi-core:  solr_url = http://127.0.0.1:8983/solr/ckan
+
+To enable multi-core:
+
+1. Find the ``instanceDir`` of the existing Solr core. It is found in the output of the curl command above.
+
+       e.g. ``/usr/share/solr/`` or ``/opt/solr/example/solr/collection1``
+
+2. Make a copy of that core's directory e.g.::
+
+       sudo cp -r /usr/share/solr/ /etc/solr/ckan
+
+3. Configure Solr with the new core::
+
+       curl 'http://localhost:8983/solr/admin/cores?action=CREATE&name=ckan&instanceDir=/etc/solr/ckan'
+
+If successful the status should be 0 - some XML containing: ``<int name="status">0</int>``
+
+
 ~~~~~~~~~~~~~
 Run the tests
 ~~~~~~~~~~~~~
@@ -75,7 +111,7 @@ run the tests for CKAN core and for the core extensions::
 
 The speed of the PostgreSQL tests can be improved by running PostgreSQL in
 memory and turning off durability, as described
-`in the PostgreSQL documentation <http://www.postgresql.org/docs/9.0/static/non-durability.html>`_. 
+`in the PostgreSQL documentation <http://www.postgresql.org/docs/9.0/static/non-durability.html>`_.
 
 By default the tests will keep the database between test runs. If you wish to
 drop and reinitialize the database before the run you can use the ``reset-db``
@@ -160,6 +196,14 @@ nosetests
    One final check - the version of nose should be at least 1.0. Check with::
 
          pip freeze | grep -i nose
+
+SolrError
+=========
+
+``SolrError: Solr responded with an error (HTTP 404): [Reason: None]
+<html><head><meta content="text/html; charset=ISO-8859-1" http-equiv="Content-Type" /><title>Error 404 NOT_FOUND</title></head><body><h2>HTTP ERROR 404</h2><p>Problem accessing /solr/ckan/select/. Reason:<pre>    NOT_FOUND</pre></p><hr /><i><small>Powered by Jetty://</small></i>``
+
+This means your solr_url is not corresponding with your SOLR. When running tests, it is usually easiest to change your set-up to match the default solr_url in test-core.ini. Often this means switching to multi-core - see :ref:`solr-multi-core`.
 
 
 ---------------


### PR DESCRIPTION
I'm aware there is a desire to change the install instructions to use Solr multicore, a more recent version of Solr and switch to Tomcat. However, right now the tests fail because the test-core.ini specifies a solr_url that assumes you're multi-core. So this is just a quick fix for that really. But when the wider solr changes do occur, there will still be plenty of people still running the existing single core set-up and they may appreciate these hints to get the tests going too.

I tested this on Trusty Solr 3.6 on jetty and have reasonable confidence it will work on other set-ups. But I'd welcome any advice on any incompatibilities with these instructions.