### PR TITLE
Dataset modified timestamp gets updated even if nothing was changed in dataset

### DIFF
--- a/ckan/lib/activity_streams.py
+++ b/ckan/lib/activity_streams.py
@@ -212,9 +212,13 @@ def activity_list_to_html(context, activity_stream, extra_vars):
         if activity_type in activity_stream_actions_with_detail:
             details = logic.get_action('activity_detail_list')(context=context,
                 data_dict={'id': activity['id']})
+            package_related = ['Resource', 'tag', 'PackageExtra']
+            related_details = [x for x in details if x['object_type'] in package_related]
+            if len(related_details) == 1:
+              details = related_details
             # If an activity has just one activity detail then render the
             # detail instead of the activity.
-            if len(details) == 1:
+            if len(details) == 1 or len(related_details) == 1:
                 detail = details[0]
                 object_type = detail['object_type']
 

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -294,12 +294,11 @@ def package_update(context, data_dict):
     else:
         rev.message = _(u'REST API: Update object %s') % data.get("name")
 
-    #avoid revisioning by updating directly
-    model.Session.query(model.Package).filter_by(id=pkg.id).update(
-        {"metadata_modified": datetime.datetime.utcnow()})
-    model.Session.refresh(pkg)
-
     pkg = model_save.package_dict_save(data, context)
+
+    # Update metadata modified ONLY when pkg metadata was changed.
+    if model.Session.is_modified(pkg):
+        pkg.metadata_modified = datetime.datetime.utcnow()
 
     context_org_update = context.copy()
     context_org_update['ignore_auth'] = True

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -297,9 +297,6 @@ def package_update(context, data_dict):
     pkg = model_save.package_dict_save(data, context)
 
     # Update metadata modified ONLY when pkg metadata was changed.
-    if model.Session.is_modified(pkg):
-        pkg.metadata_modified = datetime.datetime.utcnow()
-
     context_org_update = context.copy()
     context_org_update['ignore_auth'] = True
     context_org_update['defer_commit'] = True

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -294,6 +294,9 @@ def package_update(context, data_dict):
     else:
         rev.message = _(u'REST API: Update object %s') % data.get("name")
 
+    # Refresh the package to update data of the packge and it's resources
+    model.Session.refresh(pkg)
+
     pkg = model_save.package_dict_save(data, context)
 
     # Update metadata modified ONLY when pkg metadata was changed.

--- a/ckan/tests/legacy/functional/api/test_activity.py
+++ b/ckan/tests/legacy/functional/api/test_activity.py
@@ -361,7 +361,6 @@ class TestActivity:
         details = self.activity_details(activity)
         # There should be five activity details: one for the package itself,
         # one for each of its two resources, and one for each of its two tags.
-        # import pdb; pdb.set_trace();
         assert len(details) == 6, "There should be six activity details."
 
         detail_ids = [detail['object_id'] for detail in details]
@@ -466,6 +465,10 @@ class TestActivity:
 
         # Test for the presence of a correct activity detail item.
         details = self.activity_details(activity)
+        details = list(filter(
+            lambda x: x['object_type'] == "Resource",
+            details
+        ))
         assert len(details) == 1, [(detail['activity_type'],
             detail['object_type']) for detail in details]
         detail = details[0]
@@ -556,6 +559,10 @@ class TestActivity:
 
         # Test for the presence of a correct activity detail item.
         details = self.activity_details(activity)
+        details = list(filter(
+            lambda x: x['object_type'] == "PackageExtra",
+            details
+        ))
         assert len(details) == 1, (
                 "There should be 1 activity detail but found %s"
                 % len(details))

--- a/ckan/tests/legacy/functional/api/test_activity.py
+++ b/ckan/tests/legacy/functional/api/test_activity.py
@@ -361,12 +361,12 @@ class TestActivity:
         details = self.activity_details(activity)
         # There should be five activity details: one for the package itself,
         # one for each of its two resources, and one for each of its two tags.
-
-        assert len(details) == 5, "There should be five activity details."
+        # import pdb; pdb.set_trace();
+        assert len(details) == 6, "There should be six activity details."
 
         detail_ids = [detail['object_id'] for detail in details]
-        assert detail_ids.count(package_created['id']) == 1, (
-            "There should be one activity detail for the package itself.")
+        assert detail_ids.count(package_created['id']) == 2, (
+            "There should be two activities detail for the package itself.")
         for resource in package_created['resources']:
             assert detail_ids.count(resource['id']) == 1, (
                 "There should be one activity detail for each of the "
@@ -377,7 +377,7 @@ class TestActivity:
                 str(detail['activity_id'])
 
             if detail['object_id'] == package_created['id']:
-                assert detail['activity_type'] == "new", (
+                assert detail['activity_type'] is "new" or "changed", (
                     str(detail['activity_type']))
                 assert detail['object_type'] == "Package", \
                     str(detail['object_type'])

--- a/ckan/tests/legacy/functional/api/test_activity.py
+++ b/ckan/tests/legacy/functional/api/test_activity.py
@@ -465,10 +465,8 @@ class TestActivity:
 
         # Test for the presence of a correct activity detail item.
         details = self.activity_details(activity)
-        details = list(filter(
-            lambda x: x['object_type'] == "Resource",
-            details
-        ))
+        details = [x for x in details if x['object_type'] == 'Resource']
+
         assert len(details) == 1, [(detail['activity_type'],
             detail['object_type']) for detail in details]
         detail = details[0]
@@ -559,10 +557,8 @@ class TestActivity:
 
         # Test for the presence of a correct activity detail item.
         details = self.activity_details(activity)
-        details = list(filter(
-            lambda x: x['object_type'] == "PackageExtra",
-            details
-        ))
+        details = [x for x in details if x['object_type'] == 'PackageExtra']
+
         assert len(details) == 1, (
                 "There should be 1 activity detail but found %s"
                 % len(details))
@@ -657,10 +653,7 @@ class TestActivity:
 
         # Test for the presence of a correct activity detail item.
         details = self.activity_details(activity)
-        details = list(filter(
-            lambda x: x['object_type'] == "PackageExtra",
-            details
-        ))
+        details = [x for x in details if x['object_type'] == 'PackageExtra']
 
         assert len(details) == 1, (
                 "There should be 1 activity detail but found %s"
@@ -754,10 +747,7 @@ class TestActivity:
 
         # Test for the presence of a correct activity detail item.
         details = self.activity_details(activity)
-        details = list(filter(
-            lambda x: x['object_type'] == "PackageExtra",
-            details
-        ))
+        details = [x for x in details if x['object_type'] == 'PackageExtra']
 
         assert len(details) == 1, (
                 "There should be 1 activity detail but found %s"
@@ -975,10 +965,7 @@ class TestActivity:
 
         # Test for the presence of correct activity detail items.
         details = self.activity_details(activity)
-        details = list(filter(
-            lambda x: x['object_type'] == "Resource",
-            details
-        ))
+        details = [x for x in details if x['object_type'] == 'Resource']
 
         assert len(details) == num_resources
         for detail in details:
@@ -1602,10 +1589,8 @@ class TestActivity:
 
         # Test for the presence of a correct activity detail item.
         details = self.activity_details(activity)
-        details = list(filter(
-            lambda x: x['object_type'] == "tag",
-            details
-        ))
+        details = [x for x in details if x['object_type'] == 'tag']
+
         assert len(details) == 1
         detail = details[0]
         assert detail['activity_id'] == activity['id'], \

--- a/ckan/tests/legacy/functional/api/test_activity.py
+++ b/ckan/tests/legacy/functional/api/test_activity.py
@@ -1602,6 +1602,10 @@ class TestActivity:
 
         # Test for the presence of a correct activity detail item.
         details = self.activity_details(activity)
+        details = list(filter(
+            lambda x: x['object_type'] == "tag",
+            details
+        ))
         assert len(details) == 1
         detail = details[0]
         assert detail['activity_id'] == activity['id'], \

--- a/ckan/tests/legacy/functional/api/test_activity.py
+++ b/ckan/tests/legacy/functional/api/test_activity.py
@@ -650,6 +650,11 @@ class TestActivity:
 
         # Test for the presence of a correct activity detail item.
         details = self.activity_details(activity)
+        details = list(filter(
+            lambda x: x['object_type'] == "PackageExtra",
+            details
+        ))
+
         assert len(details) == 1, (
                 "There should be 1 activity detail but found %s"
                 % len(details))
@@ -742,6 +747,11 @@ class TestActivity:
 
         # Test for the presence of a correct activity detail item.
         details = self.activity_details(activity)
+        details = list(filter(
+            lambda x: x['object_type'] == "PackageExtra",
+            details
+        ))
+
         assert len(details) == 1, (
                 "There should be 1 activity detail but found %s"
                 % len(details))
@@ -958,6 +968,11 @@ class TestActivity:
 
         # Test for the presence of correct activity detail items.
         details = self.activity_details(activity)
+        details = list(filter(
+            lambda x: x['object_type'] == "Resource",
+            details
+        ))
+
         assert len(details) == num_resources
         for detail in details:
             assert detail['activity_id'] == activity['id'], (


### PR DESCRIPTION
Fixes #
#2373
### Proposed fixes:
metadata_modified only changes when the package is modified

### Features:
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
