### PR TITLE
DictizationErrors print better

### DIFF
--- a/ckan/lib/navl/dictization_functions.py
+++ b/ckan/lib/navl/dictization_functions.py
@@ -47,9 +47,17 @@ class State(object):
 
 class DictizationError(Exception):
     def __str__(self):
+        return unicode(self).encode('utf8')
+
+    def __unicode__(self):
         if hasattr(self, 'error') and self.error:
-            return repr(self.error)
-        return ''
+            return u'{}: {}'.format(self.__class__.__name__, repr(self.error))
+        return self.__class__.__name__
+
+    def __repr__(self):
+        if hasattr(self, 'error') and self.error:
+            return '<{} {}>'.format(self.__class__.__name__, repr(self.error))
+        return '<{}>'.format(self.__class__.__name__)
 
 
 class Invalid(DictizationError):

--- a/ckan/tests/lib/navl/test_dictization_functions.py
+++ b/ckan/tests/lib/navl/test_dictization_functions.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 import nose
-from ckan.lib.navl.dictization_functions import validate
+from ckan.lib.navl.dictization_functions import validate, Invalid
 
 
 eq_ = nose.tools.eq_
@@ -49,3 +49,44 @@ class TestValidate(object):
         context = {}
 
         data, errors = validate(data_dict, schema, context)
+
+
+class TestDictizationError(object):
+
+    def test_str_error(self):
+        err_obj = Invalid('Some ascii error')
+        eq_(str(err_obj), "Invalid: 'Some ascii error'")
+
+    def test_unicode_error(self):
+        err_obj = Invalid('Some ascii error')
+        eq_(unicode(err_obj), u"Invalid: 'Some ascii error'")
+
+    def test_repr_error(self):
+        err_obj = Invalid('Some ascii error')
+        eq_(repr(err_obj), "<Invalid 'Some ascii error'>")
+
+    # Error msgs should be ascii, but let's just see what happens for unicode
+
+    def test_str_unicode_error(self):
+        err_obj = Invalid(u'Some unicode \xa3 error')
+        eq_(str(err_obj), "Invalid: u'Some unicode \\xa3 error'")
+
+    def test_unicode_unicode_error(self):
+        err_obj = Invalid(u'Some unicode \xa3 error')
+        eq_(unicode(err_obj), "Invalid: u'Some unicode \\xa3 error'")
+
+    def test_repr_unicode_error(self):
+        err_obj = Invalid(u'Some unicode \xa3 error')
+        eq_(repr(err_obj), "<Invalid u'Some unicode \\xa3 error'>")
+
+    def test_str_blank(self):
+        err_obj = Invalid('')
+        eq_(str(err_obj), "Invalid")
+
+    def test_unicode_blank(self):
+        err_obj = Invalid('')
+        eq_(unicode(err_obj), u"Invalid")
+
+    def test_repr_blank(self):
+        err_obj = Invalid('')
+        eq_(repr(err_obj), "<Invalid>")


### PR DESCRIPTION
I came across this when debugging. When you print a DictizationError (e.g. during package_update) it shows as `''`, when it has a string inside.

This PR is based on #3102 but with tests and fixes associated with @wardi's feedback. Now if self.error isn't set, you just get the classname.