### PR TITLE
Restrict access to `members` and `bulk_actions`

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -382,7 +382,7 @@ class GroupController(base.BaseController):
         data_dict = {'id': id, 'type': group_type}
 
         try:
-            self._check_access('bulk_update_public', context, data_dict)
+            self._check_access('bulk_update_public', context, {'org_id': id})
             # Do not query for the group datasets when dictizing, as they will
             # be ignored and get requested on the controller anyway
             data_dict['include_datasets'] = False
@@ -638,7 +638,7 @@ class GroupController(base.BaseController):
 
         try:
             data_dict = {'id': id}
-            self._check_access('group_edit_permissions', context, data_dict)
+            check_access('group_edit_permissions', context, data_dict)
             c.members = self._action('member_list')(
                 context, {'id': id, 'object_type': 'user'}
             )

--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -382,13 +382,16 @@ class GroupController(base.BaseController):
         data_dict = {'id': id, 'type': group_type}
 
         try:
+            self._check_access('bulk_update_public', context, data_dict)
             # Do not query for the group datasets when dictizing, as they will
             # be ignored and get requested on the controller anyway
             data_dict['include_datasets'] = False
             c.group_dict = self._action('group_show')(context, data_dict)
             c.group = context['group']
-        except (NotFound, NotAuthorized):
+        except NotFound:
             abort(404, _('Group not found'))
+        except NotAuthorized:
+            abort(403, _('User %r not authorized to edit %s') % (c.user, id))
 
         if not c.group_dict['is_organization']:
             # FIXME: better error
@@ -634,14 +637,21 @@ class GroupController(base.BaseController):
                    'user': c.user}
 
         try:
+            data_dict = {'id': id}
+            self._check_access('group_edit_permissions', context, data_dict)
             c.members = self._action('member_list')(
                 context, {'id': id, 'object_type': 'user'}
             )
-            data_dict = {'id': id}
             data_dict['include_datasets'] = False
             c.group_dict = self._action('group_show')(context, data_dict)
-        except (NotFound, NotAuthorized):
+        except NotFound:
             abort(404, _('Group not found'))
+        except NotAuthorized:
+            abort(
+                403,
+                _('User %r not authorized to edit members of %s') % (
+                    c.user, id))
+
         return self._render_template('group/members.html', group_type)
 
     def member_new(self, id):

--- a/ckan/logic/auth/update.py
+++ b/ckan/logic/auth/update.py
@@ -166,23 +166,6 @@ def group_edit_permissions(context, data_dict):
         return {'success': True}
 
 
-def organization_edit_permissions(context, data_dict):
-    user = context['user']
-    group = logic_auth.get_group_object(context, data_dict)
-
-    authorized = authz.has_user_permission_for_group_or_org(
-        group.id, user, 'update')
-
-    if not authorized:
-        return {
-            'success': False,
-            'msg': _('User %s not authorized to edit'
-                     ' permissions of organization %s') %
-            (str(user), group.id)}
-    else:
-        return {'success': True}
-
-
 @logic.auth_allow_anonymous_access
 def user_update(context, data_dict):
     user = context['user']

--- a/ckan/logic/auth/update.py
+++ b/ckan/logic/auth/update.py
@@ -153,14 +153,32 @@ def group_edit_permissions(context, data_dict):
     user = context['user']
     group = logic_auth.get_group_object(context, data_dict)
 
-    authorized = authz.has_user_permission_for_group_or_org(group.id,
-                                                                user,
-                                                                'update')
+    authorized = authz.has_user_permission_for_group_or_org(
+        group.id, user, 'update')
 
     if not authorized:
-        return {'success': False,
-                'msg': _('User %s not authorized to edit permissions of group %s') %
-                        (str(user), group.id)}
+        return {
+            'success': False,
+            'msg': _('User %s not authorized to'
+                     ' edit permissions of group %s') %
+            (str(user), group.id)}
+    else:
+        return {'success': True}
+
+
+def organization_edit_permissions(context, data_dict):
+    user = context['user']
+    group = logic_auth.get_group_object(context, data_dict)
+
+    authorized = authz.has_user_permission_for_group_or_org(
+        group.id, user, 'update')
+
+    if not authorized:
+        return {
+            'success': False,
+            'msg': _('User %s not authorized to edit'
+                     ' permissions of organization %s') %
+            (str(user), group.id)}
     else:
         return {'success': True}
 

--- a/ckan/tests/controllers/test_group.py
+++ b/ckan/tests/controllers/test_group.py
@@ -282,9 +282,12 @@ class TestGroupMembership(helpers.FunctionalTestBase):
 
         group = self._create_group(user_one['name'], other_users)
 
+        env = {'REMOTE_USER': user_one['name'].encode('ascii')}
+
         member_list_url = url_for(controller='group', action='members',
                                   id=group['id'])
-        member_list_response = app.get(member_list_url)
+        member_list_response = app.get(
+            member_list_url, extra_environ=env)
 
         assert_true('2 members' in member_list_response)
 
@@ -375,7 +378,7 @@ class TestGroupMembership(helpers.FunctionalTestBase):
         env = {'REMOTE_USER': user_one['name'].encode('ascii')}
         remove_response = app.post(remove_url, extra_environ=env, status=302)
         # redirected to member list after removal
-        remove_response = remove_response.follow()
+        remove_response = remove_response.follow(extra_environ=env)
 
         assert_true('Group member has been deleted.' in remove_response)
         assert_true('1 members' in remove_response)


### PR DESCRIPTION
After this fix only users with permission `bulk_update_public` will
be able to visit `bulc_process` page and only those who have
`group_edit_permissions' will be able to visit `members` page

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
