### PR TITLE
Remove exposed ports

### DIFF
--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -12,17 +12,11 @@ ckan:
 db:
   container_name: db
   image: ckan/postgresql:latest
-  ports:
-    - "5432:5432"
   
 solr:
   container_name: solr
   image: ckan/solr:latest
-  ports: 
-    - "8983:8983"
     
 redis:
   container_name: redis
   image: redis:latest
-  ports: 
-    - "6379:6379"


### PR DESCRIPTION
No need to expose ports externally when using the container names already provides the necessary access to the ports internally from the containers.
