### PR TITLE
Fix solr-jetty 'JSP support' during install on 14.04

### DIFF
--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -215,6 +215,7 @@ site_url
 
 .. include:: solr.rst
 
+
 .. _postgres-init:
 
 -------------------------


### PR DESCRIPTION
Fixes #2939 & #1651

This is based on PR #2966 but with a minor fix.
