### PR TITLE
apply triggers to existing datastore resource

### DIFF
--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -161,6 +161,37 @@ def datastore_create(context, data_dict):
     return result
 
 
+def datastore_trigger_each_row(context, data_dict):
+    ''' update each record with trigger
+
+    The datastore_trigger_each_row API action allows you to apply triggers to
+    an existing DataStore resource.
+
+    :param resource_id: resource id that the data is going to be stored under.
+    :type resource_id: string
+
+    **Results:**
+
+    :returns: The rowcount in the table.
+    :rtype: int
+
+    '''
+    res_id = data_dict['resource_id']
+    p.toolkit.check_access('datastore_trigger_each_row', context, data_dict)
+
+    connection = db.get_write_engine().connect()
+
+    sql = sqlalchemy.text(u'''update {0} set _id=_id '''.format(
+                          datastore_helpers.identifier(res_id)))
+    try:
+        results = connection.execute(sql)
+    except sqlalchemy.exc.DatabaseError as err:
+        message = err.args[0].split('\n')[0].decode('utf8')
+        raise p.toolkit.ValidationError({
+                u'records': [message.split(u') ', 1)[-1]]})
+    return results.rowcount
+
+
 def datastore_upsert(context, data_dict):
     '''Updates or inserts into a table in the DataStore
 

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -161,10 +161,10 @@ def datastore_create(context, data_dict):
     return result
 
 
-def datastore_trigger_each_row(context, data_dict):
+def datastore_run_triggers(context, data_dict):
     ''' update each record with trigger
 
-    The datastore_trigger_each_row API action allows you to apply triggers to
+    The datastore_run_triggers API action allows you to re-apply exisitng triggers to
     an existing DataStore resource.
 
     :param resource_id: resource id that the data is going to be stored under.

--- a/ckanext/datastore/logic/auth.py
+++ b/ckanext/datastore/logic/auth.py
@@ -67,3 +67,8 @@ def datastore_function_create(context, data_dict):
 
 def datastore_function_delete(context, data_dict):
     return {'success': False}
+
+
+def datastore_trigger_each_row(context, data_dict):
+    '''sysadmin-only: functions can be used to skip access checks'''
+    return {'success': False}

--- a/ckanext/datastore/logic/auth.py
+++ b/ckanext/datastore/logic/auth.py
@@ -69,6 +69,6 @@ def datastore_function_delete(context, data_dict):
     return {'success': False}
 
 
-def datastore_trigger_each_row(context, data_dict):
+def datastore_run_triggers(context, data_dict):
     '''sysadmin-only: functions can be used to skip access checks'''
     return {'success': False}

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -225,7 +225,7 @@ class DatastorePlugin(p.SingletonPlugin):
             'datastore_info': action.datastore_info,
             'datastore_function_create': action.datastore_function_create,
             'datastore_function_delete': action.datastore_function_delete,
-            'datastore_trigger_each_row': action.datastore_trigger_each_row,
+            'datastore_run_triggers': action.datastore_run_triggers,
         }
         if not self.legacy_mode:
             if self.enable_sql_search:
@@ -248,7 +248,7 @@ class DatastorePlugin(p.SingletonPlugin):
             'datastore_change_permissions': auth.datastore_change_permissions,
             'datastore_function_create': auth.datastore_function_create,
             'datastore_function_delete': auth.datastore_function_delete,
-            'datastore_trigger_each_row': auth.datastore_trigger_each_row,
+            'datastore_run_triggers': auth.datastore_run_triggers,
         }
 
     def before_map(self, m):

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -225,6 +225,7 @@ class DatastorePlugin(p.SingletonPlugin):
             'datastore_info': action.datastore_info,
             'datastore_function_create': action.datastore_function_create,
             'datastore_function_delete': action.datastore_function_delete,
+            'datastore_trigger_each_row': action.datastore_trigger_each_row,
         }
         if not self.legacy_mode:
             if self.enable_sql_search:
@@ -247,6 +248,7 @@ class DatastorePlugin(p.SingletonPlugin):
             'datastore_change_permissions': auth.datastore_change_permissions,
             'datastore_function_create': auth.datastore_function_create,
             'datastore_function_delete': auth.datastore_function_delete,
+            'datastore_trigger_each_row': auth.datastore_trigger_each_row,
         }
 
     def before_map(self, m):


### PR DESCRIPTION
Fixes #
A system administrator level API to actively apply triggers to existing datastore resource without end user's action.
### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [x] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
