### PR TITLE
Apply env. variables to CKAN config

### DIFF
--- a/contrib/docker/ckan-entrypoint.sh
+++ b/contrib/docker/ckan-entrypoint.sh
@@ -26,13 +26,13 @@ write_config () {
 
   ckan-paster make-config ckan "$CONFIG"
 
-  # In case want to use the config from ckan.ini use this
-  #ckan-paster --plugin=ckan config-tool "$CONFIG" -e \
-  #    "sqlalchemy.url = ${CKAN_SQLALCHEMY_URL}" \
-  #    "solr_url = ${CKAN_SOLR_URL}" \
-  #    "ckan.redis.url = ${CKAN_REDIS_URL}" \
-  #    "ckan.storage_path = ${CKAN_STORAGE_PATH}" \
-  #    "ckan.site_url = ${CKAN_SITE_URL}"
+  # Apply config
+  ckan-paster --plugin=ckan config-tool "$CONFIG" -e \
+      "sqlalchemy.url = ${CKAN_SQLALCHEMY_URL}" \
+      "solr_url = ${CKAN_SOLR_URL}" \
+      "ckan.redis.url = ${CKAN_REDIS_URL}" \
+      "ckan.storage_path = ${CKAN_STORAGE_PATH}" \
+      "ckan.site_url = ${CKAN_SITE_URL}"
 }
 
 link_postgres_url () {


### PR DESCRIPTION
Complements https://github.com/ckan/ckan/pull/3553 by applying the environment variables. I'm not sure if this will really work on its own, but adding the environment variables (DB_PORT_5432_TCP_ADDR etc.) in the docker-compose.yml environment section will definitely work.