### PR TITLE
Solr init in make_connection

### DIFF
--- a/ckan/lib/search/common.py
+++ b/ckan/lib/search/common.py
@@ -62,6 +62,9 @@ def is_available():
 
 
 def make_connection(decode_dates=True):
+    SolrSettings.init(config.get('solr_url'),
+                      config.get('solr_user'),
+                      config.get('solr_password'))
     solr_url, solr_user, solr_password = SolrSettings.get()
     if decode_dates:
         decoder = simplejson.JSONDecoder(object_hook=solr_datetime_decoder)


### PR DESCRIPTION
Fixes # 
Init solr connection in make_connection when using celeryd.
make_connection() fails on SolrSettings.get() because there isn't initialization of SolrSettings.
### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
