### PR TITLE
Initialize SolrSettings in make_connection

### DIFF
--- a/ckan/lib/search/common.py
+++ b/ckan/lib/search/common.py
@@ -5,6 +5,7 @@ import logging
 import re
 import pysolr
 import simplejson
+from ckan.common import config
 log = logging.getLogger(__name__)
 
 
@@ -62,6 +63,9 @@ def is_available():
 
 
 def make_connection(decode_dates=True):
+    SolrSettings.init(config.get('solr_url'),
+                      config.get('solr_user'),
+                      config.get('solr_password'))
     solr_url, solr_user, solr_password = SolrSettings.get()
     if decode_dates:
         decoder = simplejson.JSONDecoder(object_hook=solr_datetime_decoder)

--- a/ckan/lib/search/common.py
+++ b/ckan/lib/search/common.py
@@ -63,10 +63,11 @@ def is_available():
 
 
 def make_connection(decode_dates=True):
-    SolrSettings.init(config.get('solr_url'),
-                      config.get('solr_user'),
-                      config.get('solr_password'))
     solr_url, solr_user, solr_password = SolrSettings.get()
+    if solr_url is None:
+        SolrSettings.init(config.get('solr_url'),
+                          config.get('solr_user'),
+                          config.get('solr_password'))
     if decode_dates:
         decoder = simplejson.JSONDecoder(object_hook=solr_datetime_decoder)
         return pysolr.Solr(solr_url, decoder=decoder)


### PR DESCRIPTION
Fixes #
Init solr connection in make_connection when using celeryd.
make_connection() fails on SolrSettings.get() because there isn't initialization of SolrSettings.

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
