### PR TITLE
Fixed typo in "16. enable PostGIS on the main database"

### DIFF
--- a/doc/maintaining/upgrading/upgrade-postgres.rst
+++ b/doc/maintaining/upgrading/upgrade-postgres.rst
@@ -212,7 +212,7 @@ Upgrading
         sudo -u postgres psql --cluster 9.4/main -d |database| -f /usr/share/postgresql/9.4/contrib/postgis-2.1/postgis.sql
         sudo -u postgres psql --cluster 9.4/main -d |database| -f /usr/share/postgresql/9.4/contrib/postgis-2.1/spatial_ref_sys.sql
         sudo -u postgres psql --cluster 9.4/main -d |database| -c 'ALTER TABLE geometry_columns OWNER TO ckan_default;'
-        sudo -u postgres psql --cluster 9.4/main -d |database| -c 'ALTER TABLE geometry_columns OWNER TO ckan_default;'
+        sudo -u postgres psql --cluster 9.4/main -d |database| -c 'ALTER TABLE spatial_ref_sys OWNER TO ckan_default;'
 
    To check if PostGIS was properly installed:
 


### PR DESCRIPTION



### Proposed fixes:
Documentation database-upgrade:
Change of owner for PostGIS table spatial_ref_sys instead of duplicate line.
Compare [ckanext-spatial docu](http://docs.ckan.org/projects/ckanext-spatial/en/latest/install.html#ubuntu-14-04-postgresql-9-3-and-postgis-2-1) (3.)


### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
