### PR TITLE
get_translated: fall back to .po files

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2299,7 +2299,8 @@ def get_translated(data_dict, field):
     try:
         return data_dict[field+'_translated'][language]
     except KeyError:
-        return _(data_dict.get(field, ''))
+        val = data_dict.get(field, '')
+        return _(val) if isinstance(val, basestring) else val
 
 
 @core_helper

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2299,7 +2299,7 @@ def get_translated(data_dict, field):
     try:
         return data_dict[field+'_translated'][language]
     except KeyError:
-        return data_dict.get(field, '')
+        return _(data_dict.get(field, ''))
 
 
 @core_helper

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2300,7 +2300,7 @@ def get_translated(data_dict, field):
         return data_dict[field+'_translated'][language]
     except KeyError:
         val = data_dict.get(field, '')
-        return _(val) if isinstance(val, basestring) else val
+        return _(val) if val and isinstance(val, basestring) else val
 
 
 @core_helper


### PR DESCRIPTION
if the translated language for the field is not provided by a `*_translated` value, then we should try to find it from .po files.

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
