### PR TITLE
[#3579]  Fix for number of datasets that displayes on My orgs tab

### DIFF
--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -331,7 +331,7 @@ def _get_members(context, group, member_type):
 def get_group_dataset_counts():
     '''For all public groups, return their dataset counts, as a SOLR facet'''
     query = search.PackageSearchQuery()
-    q = {'q': '+capacity:public',
+    q = {'q': '',
          'fl': 'groups', 'facet.field': ['groups', 'owner_org'],
          'facet.limit': -1, 'rows': 1}
     query.run(q)


### PR DESCRIPTION
It seems that the problem was with the query that showed only public datasets, while /organization page showed with private for users that at least members of those datasets.