### PR TITLE
Override defaults by using container names

### DIFF
--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -8,6 +8,16 @@ ckan:
       - redis
   ports:
       - "80:5000"
+  environment:
+      - DB_ENV_POSTGRES_USER=ckan
+      - DB_ENV_POSTGRES_PASSWORD=ckan
+      - DB_ENV_POSTGRES_DB=ckan
+      - DB_PORT_5432_TCP_ADDR=db
+      - DB_PORT_5432_TCP_PORT=5432
+      - SOLR_PORT_8983_TCP_ADDR=solr
+      - SOLR_PORT_8983_TCP_PORT=8983
+      - REDIS_PORT_6379_TCP_ADDR=redis
+      - REDIS_PORT_6379_TCP_PORT=6379
 
 db:
   container_name: db


### PR DESCRIPTION
This removes the need to map ports outside of the container

cf. #3572, #3569, #3553
