### PR TITLE
[#3588] Fix for Upload Log time at resource Datastore tab

### DIFF
--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -290,10 +290,10 @@ def datapusher_status(context, data_dict):
             job_detail = r.json()
             for log in job_detail['logs']:
                 if 'timestamp' in log:
-                    date = datetime.datetime.strptime(
+                    date = time.strptime(
                         log['timestamp'], "%Y-%m-%dT%H:%M:%S.%f")
                     date = datetime.datetime.utcfromtimestamp(
-                        time.mktime(date.timetuple()))
+                        time.mktime(date))
                     log['timestamp'] = date
         except (requests.exceptions.ConnectionError,
                 requests.exceptions.HTTPError):

--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -4,6 +4,7 @@ import logging
 import json
 import urlparse
 import datetime
+import time
 
 from dateutil.parser import parse as parse_date
 
@@ -287,6 +288,11 @@ def datapusher_status(context, data_dict):
                                            'Authorization': job_key})
             r.raise_for_status()
             job_detail = r.json()
+            for log in job_detail['logs']:
+                if 'timestamp' in log:
+                    date = datetime.datetime.strptime(log['timestamp'], "%Y-%m-%dT%H:%M:%S.%f")
+                    date = datetime.datetime.utcfromtimestamp(time.mktime(date.timetuple()))
+                    log['timestamp'] = date
         except (requests.exceptions.ConnectionError,
                 requests.exceptions.HTTPError):
             job_detail = {'error': 'cannot connect to datapusher'}

--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -290,8 +290,10 @@ def datapusher_status(context, data_dict):
             job_detail = r.json()
             for log in job_detail['logs']:
                 if 'timestamp' in log:
-                    date = datetime.datetime.strptime(log['timestamp'], "%Y-%m-%dT%H:%M:%S.%f")
-                    date = datetime.datetime.utcfromtimestamp(time.mktime(date.timetuple()))
+                    date = datetime.datetime.strptime(
+                        log['timestamp'], "%Y-%m-%dT%H:%M:%S.%f")
+                    date = datetime.datetime.utcfromtimestamp(
+                        time.mktime(date.timetuple()))
                     log['timestamp'] = date
         except (requests.exceptions.ConnectionError,
                 requests.exceptions.HTTPError):

--- a/ckanext/datapusher/templates/datapusher/resource_data.html
+++ b/ckanext/datapusher/templates/datapusher/resource_data.html
@@ -72,7 +72,7 @@
               {{ line | urlize }}<br>
             {% endfor %}
             <span class="date" title="{{ h.render_datetime(item.timestamp, with_hours=True) }}">
-              {{ h.time_ago_from_timestamp(item.timestamp) }}
+              {{ h.time_ago_from_timestamp(status.last_updated) }}
               <a href="#" data-target="popover" data-content="<dl>{% for key, value in item.iteritems() %}<dt>{{ key }}</dt><dd>{{ value }}</dd>{% endfor %}</dl>" data-html="true">{{ _('Details') }}</a>
             </span>
           </p>

--- a/ckanext/datapusher/templates/datapusher/resource_data.html
+++ b/ckanext/datapusher/templates/datapusher/resource_data.html
@@ -72,7 +72,7 @@
               {{ line | urlize }}<br>
             {% endfor %}
             <span class="date" title="{{ h.render_datetime(item.timestamp, with_hours=True) }}">
-              {{ h.time_ago_from_timestamp(status.last_updated) }}
+              {{ h.time_ago_from_timestamp(item.timestamp) }}
               <a href="#" data-target="popover" data-content="<dl>{% for key, value in item.iteritems() %}<dt>{{ key }}</dt><dd>{{ value }}</dd>{% endfor %}</dl>" data-html="true">{{ _('Details') }}</a>
             </span>
           </p>


### PR DESCRIPTION
Added a fix for the time that display at Upload Log, it seems that **job_detail** at datapusher_status action gives already the time with +3 hours.
I've changed the variable that template uses for the display to the one that used in the table as the Upload Log will be match to the value in the table.
