### PR TITLE
fix broken language toggle url when there is params in current url

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -383,6 +383,12 @@ def full_current_url():
 
 
 @core_helper
+def current_url():
+    ''' Returns current url unquoted'''
+    return urllib.unquote(request.environ['CKAN_CURRENT_URL'])
+
+
+@core_helper
 def lang():
     ''' Return the language code for the current locale eg `en` '''
     return request.environ.get('CKAN_LANG')

--- a/ckan/templates/snippets/language_selector.html
+++ b/ckan/templates/snippets/language_selector.html
@@ -1,10 +1,9 @@
-{% set current_url = request.environ.CKAN_CURRENT_URL %}
 {% set current_lang = request.environ.CKAN_LANG %}
 <form class="form-inline form-select lang-select" action="{% url_for controller='util', action='redirect' %}" data-module="select-switch" method="POST">
   <label for="field-lang-select">{{ _('Language') }}</label>
   <select id="field-lang-select" name="url" data-module="autocomplete" data-module-dropdown-class="lang-dropdown" data-module-container-class="lang-container">
     {% for locale in h.get_available_locales() %}
-      <option value="{% url_for current_url, locale=locale.short_name %}" {% if locale.identifier == current_lang %}selected="selected"{% endif %}>
+      <option value="{% url_for h.current_url(), locale=locale.short_name %}" {% if locale.identifier == current_lang %}selected="selected"{% endif %}>
         {{ locale.display_name or locale.english_name }}
       </option>
     {% endfor %}

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -1312,6 +1312,16 @@ class TestSearch(helpers.FunctionalTestBase):
 
         assert dataset1['name'] in page.body.decode('utf8')
 
+    def test_search_language_toggle(self):
+        dataset1 = factories.Dataset()
+
+        offset = url_for(controller='package', action='search', q=dataset1['name'])
+        app = self._get_test_app()
+        page = app.get(offset)
+
+        assert dataset1['name'] in page.body.decode('utf8')
+        assert ('q=' + dataset1['name']) in page.body.decode('utf8')
+
     def test_search_sort_by_blank(self):
         factories.Dataset()
 


### PR DESCRIPTION
Fixes #
if current url is /en/dataset?q=xxxx, then change to another language will generate bad url.
### Proposed fixes:



### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
