### PR TITLE
[#3598] Adding two new methods for IPackageController

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -152,6 +152,9 @@ def package_create(context, data_dict):
 
     _check_access('package_create', context, data_dict)
 
+    for item in plugins.PluginImplementations(plugins.IPackageController):
+        item.before_package_create(context, data_dict)
+
     if 'api_version' not in context:
         # check_data_dict() is deprecated. If the package_plugin has a
         # check_data_dict() we'll call it, if it doesn't have the method we'll

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -272,6 +272,9 @@ def package_update(context, data_dict):
     else:
         schema = package_plugin.update_package_schema()
 
+    for item in plugins.PluginImplementations(plugins.IPackageController):
+        item.before_package_update(context, data_dict)
+
     if 'api_version' not in context:
         # check_data_dict() is deprecated. If the package_plugin has a
         # check_data_dict() we'll call it, if it doesn't have the method we'll

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -612,12 +612,26 @@ class IPackageController(Interface):
         '''
         pass
 
+    def before_package_create(self, context, pkg_dict):
+        u'''
+            Extensions will receive the data dict before the package
+            will be validated and created.
+        '''
+        pass
+
     def after_create(self, context, pkg_dict):
         u'''
             Extensions will receive the validated data dict after the package
             has been created (Note that the create method will return a package
             domain object, which may not include all fields). Also the newly
             created package id will be added to the dict.
+        '''
+        pass
+
+    def before_package_update(self, context, pkg_dict):
+        u'''
+            Extensions will receive the data dict before the package
+            will be validated and updated.
         '''
         pass
 

--- a/ckan/tests/legacy/ckantestplugins.py
+++ b/ckan/tests/legacy/ckantestplugins.py
@@ -129,10 +129,17 @@ class MockPackageControllerPlugin(p.SingletonPlugin):
         self.calls['before_view'] += 1
         return data_dict
 
+    def before_package_create(self, context, data_dict):
+        self.calls['before_package_create'] += 1
+        return data_dict
+
     def after_create(self, context, data_dict):
         self.calls['after_create'] += 1
         self.id_in_dict = 'id' in data_dict
+        return data_dict
 
+    def before_package_update(self, context, data_dict):
+        self.calls['before_package_update'] += 1
         return data_dict
 
     def after_update(self, context, data_dict):


### PR DESCRIPTION
Added two methods to IPackageController, so that user can hook the dict that he sends before the actual create/update.
Modified their name in order to solve the issue with naming conflicts.
