### PR TITLE
Increase minimum password requirements in line with industry standard

### DIFF
--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -583,8 +583,9 @@ def user_password_validator(key, data, errors, context):
         errors[('password',)].append(_('Passwords must be strings'))
     elif value == '':
         pass
-    elif len(value) < 4:
-        errors[('password',)].append(_('Your password must be 4 characters or longer'))
+    elif len(value) < 8:
+        errors[('password',)].append(_('Your password must be 8 characters or '
+                                       'longer'))
 
 def user_passwords_match(key, data, errors, context):
 

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -31,8 +31,8 @@ class TestRegisterUser(helpers.FunctionalTestBase):
         form['name'] = 'newuser'
         form['fullname'] = 'New User'
         form['email'] = 'test@test.com'
-        form['password1'] = 'testpassword'
-        form['password2'] = 'testpassword'
+        form['password1'] = 'TestPassword1'
+        form['password2'] = 'TestPassword1'
         response = submit_and_follow(app, form, name='save')
         response = response.follow()
         assert_equal(200, response.status_int)
@@ -50,14 +50,14 @@ class TestRegisterUser(helpers.FunctionalTestBase):
         form['name'] = 'newuser'
         form['fullname'] = 'New User'
         form['email'] = 'test@test.com'
-        form['password1'] = 'testpassword'
+        form['password1'] = 'TestPassword1'
         form['password2'] = ''
 
         response = form.submit('save')
         assert_true('The passwords you entered do not match' in response)
 
     def test_create_user_as_sysadmin(self):
-        admin_pass = 'pass'
+        admin_pass = 'RandomPassword123'
         sysadmin = factories.Sysadmin(password=admin_pass)
         app = self._get_test_app()
 
@@ -82,8 +82,8 @@ class TestRegisterUser(helpers.FunctionalTestBase):
         form['name'] = 'newestuser'
         form['fullname'] = 'Newest User'
         form['email'] = 'test@test.com'
-        form['password1'] = 'testpassword'
-        form['password2'] = 'testpassword'
+        form['password1'] = 'NewPassword1'
+        form['password2'] = 'NewPassword1'
         response2 = form.submit('save')
         assert '/user/activity' in response2.location
 
@@ -106,7 +106,7 @@ class TestLoginView(helpers.FunctionalTestBase):
 
         # fill it in
         login_form['login'] = user['name']
-        login_form['password'] = 'pass'
+        login_form['password'] = 'RandomPassword123'
 
         # submit it
         submit_response = login_form.submit()
@@ -137,7 +137,7 @@ class TestLoginView(helpers.FunctionalTestBase):
 
         # fill it in
         login_form['login'] = user['name']
-        login_form['password'] = 'badpass'
+        login_form['password'] = 'BadPass1'
 
         # submit it
         submit_response = login_form.submit()
@@ -253,7 +253,7 @@ class TestUserEdit(helpers.FunctionalTestBase):
         )
 
     def test_edit_user(self):
-        user = factories.User(password='pass')
+        user = factories.User(password='TestPassword1')
         app = self._get_test_app()
         env = {'REMOTE_USER': user['name'].encode('ascii')}
         response = app.get(
@@ -276,9 +276,9 @@ class TestUserEdit(helpers.FunctionalTestBase):
         form['email'] = 'new@example.com'
         form['about'] = 'new about'
         form['activity_streams_email_notifications'] = True
-        form['old_password'] = 'pass'
-        form['password1'] = 'newpass'
-        form['password2'] = 'newpass'
+        form['old_password'] = 'TestPassword1'
+        form['password1'] = 'NewPass1'
+        form['password2'] = 'NewPass1'
         response = submit_and_follow(app, form, env, 'save')
 
         user = model.Session.query(model.User).get(user['id'])
@@ -299,7 +299,7 @@ class TestUserEdit(helpers.FunctionalTestBase):
         form['email'] = 'new@example.com'
 
         # factory returns user with password 'pass'
-        form.fields['old_password'][0].value = 'wrong-pass'
+        form.fields['old_password'][0].value = 'Wrong-pass1'
 
         response = webtest_submit(form, 'save', status=200, extra_environ=env)
         assert_true('Old Password: incorrect password' in response)
@@ -314,14 +314,14 @@ class TestUserEdit(helpers.FunctionalTestBase):
         form['email'] = 'new@example.com'
 
         # factory returns user with password 'pass'
-        form.fields['old_password'][0].value = 'pass'
+        form.fields['old_password'][0].value = 'RandomPassword123'
 
         response = submit_and_follow(app, form, env, 'save')
         assert_true('Profile updated' in response)
 
     def test_edit_user_logged_in_username_change(self):
 
-        user_pass = 'pass'
+        user_pass = 'TestPassword1'
         user = factories.User(password=user_pass)
         app = self._get_test_app()
 
@@ -350,7 +350,7 @@ class TestUserEdit(helpers.FunctionalTestBase):
         assert_true('That login name can not be modified' in response)
 
     def test_edit_user_logged_in_username_change_by_name(self):
-        user_pass = 'pass'
+        user_pass = 'TestPassword1'
         user = factories.User(password=user_pass)
         app = self._get_test_app()
 
@@ -379,7 +379,7 @@ class TestUserEdit(helpers.FunctionalTestBase):
         assert_true('That login name can not be modified' in response)
 
     def test_edit_user_logged_in_username_change_by_id(self):
-        user_pass = 'pass'
+        user_pass = 'TestPassword1'
         user = factories.User(password=user_pass)
         app = self._get_test_app()
 
@@ -408,7 +408,7 @@ class TestUserEdit(helpers.FunctionalTestBase):
         assert_true('That login name can not be modified' in response)
 
     def test_perform_reset_for_key_change(self):
-        password = 'password'
+        password = 'TestPassword1'
         params = {'password1': password, 'password2': password}
         user = factories.User()
         user_obj = helpers.model.User.by_name(user['name'])
@@ -434,10 +434,10 @@ class TestUserEdit(helpers.FunctionalTestBase):
 
         form = response.forms['user-edit-form']
 
-        # factory returns user with password 'pass'
-        form.fields['old_password'][0].value = 'pass'
-        form.fields['password1'][0].value = 'newpass'
-        form.fields['password2'][0].value = 'newpass'
+        # factory returns user with password 'RandomPassword123'
+        form.fields['old_password'][0].value = 'RandomPassword123'
+        form.fields['password1'][0].value = 'NewPassword1'
+        form.fields['password2'][0].value = 'NewPassword1'
 
         response = submit_and_follow(app, form, env, 'save')
         assert_true('Profile updated' in response)
@@ -452,10 +452,10 @@ class TestUserEdit(helpers.FunctionalTestBase):
 
         form = response.forms['user-edit-form']
 
-        # factory returns user with password 'pass'
-        form.fields['old_password'][0].value = 'wrong-pass'
-        form.fields['password1'][0].value = 'newpass'
-        form.fields['password2'][0].value = 'newpass'
+        # factory returns user with password 'RandomPassword123'
+        form.fields['old_password'][0].value = 'Wrong-Pass1'
+        form.fields['password1'][0].value = 'NewPassword1'
+        form.fields['password2'][0].value = 'NewPassword1'
 
         response = webtest_submit(form, 'save', status=200, extra_environ=env)
         assert_true('Old Password: incorrect password' in response)

--- a/ckan/tests/factories.py
+++ b/ckan/tests/factories.py
@@ -107,7 +107,7 @@ class User(factory.Factory):
 
     # These are the default params that will be used to create new users.
     fullname = 'Mr. Test User'
-    password = 'pass'
+    password = 'RandomPassword123'
     about = 'Just another test user.'
 
     # Generate a different user name param for each user that gets created.
@@ -211,7 +211,7 @@ class Sysadmin(factory.Factory):
     FACTORY_FOR = ckan.model.User
 
     fullname = 'Mr. Test Sysadmin'
-    password = 'pass'
+    password = 'RandomPassword123'
     about = 'Just another test sysadmin.'
 
     name = factory.Sequence(lambda n: 'test_sysadmin_{0:02d}'.format(n))

--- a/ckan/tests/legacy/functional/api/test_activity.py
+++ b/ckan/tests/legacy/functional/api/test_activity.py
@@ -1418,7 +1418,7 @@ class TestActivity:
         # Create a new user.
         user_dict = {'name': 'testuser',
                 'about': 'Just a test user', 'email': 'me@test.org',
-                'password': 'testpass'}
+                'password': 'TestPassword1'}
         response = self.app.post('/api/action/user_create',
             json.dumps(user_dict),
             extra_environ={'Authorization': str(self.sysadmin_user['apikey'])})

--- a/ckan/tests/legacy/functional/api/test_dashboard.py
+++ b/ckan/tests/legacy/functional/api/test_dashboard.py
@@ -22,7 +22,7 @@ class TestDashboard(object):
         params = json.dumps({
             'name': 'mr_new_user',
             'email': 'mr@newuser.com',
-            'password': 'iammrnew',
+            'password': 'TestPassword1',
             })
         response = cls.app.post('/api/action/user_create', params=params,
                 extra_environ={'Authorization': str(cls.testsysadmin['apikey'])})
@@ -32,6 +32,7 @@ class TestDashboard(object):
 
     @classmethod
     def setup_class(cls):
+        ckan.model.repo.rebuild_db()
         ckan.lib.search.clear_all()
         CreateTestData.create()
         cls.app = paste.fixture.TestApp(pylons.test.pylonsapp)

--- a/ckan/tests/legacy/functional/api/test_email_notifications.py
+++ b/ckan/tests/legacy/functional/api/test_email_notifications.py
@@ -78,7 +78,7 @@ class TestEmailNotifications(mock_mail_server.SmtpServerHarness,
         # Register a new user.
         sara = tests.call_action_api(self.app, 'user_create',
                 apikey=self.testsysadmin['apikey'], name='sara',
-                email='sara@sararollins.com', password='sara',
+                email='sara@sararollins.com', password='TestPassword1',
                 fullname='Sara Rollins',
                 activity_streams_email_notifications=True)
 
@@ -220,7 +220,7 @@ class TestEmailNotificationsUserPreference(
         # Register a new user.
         sara = tests.call_action_api(self.app, 'user_create',
                 apikey=self.testsysadmin['apikey'], name='sara',
-                email='sara@sararollins.com', password='sara',
+                email='sara@sararollins.com', password='TestPassword1',
                 fullname='Sara Rollins')
 
         # Save the user for later tests to use.
@@ -367,7 +367,7 @@ class TestEmailNotificationsIniSetting(
         # Register a new user.
         sara = tests.call_action_api(self.app, 'user_create',
                 apikey=self.testsysadmin['apikey'], name='sara',
-                email='sara@sararollins.com', password='sara',
+                email='sara@sararollins.com', password='TestPassword1',
                 fullname='Sara Rollins')
 
         # Save the user for later tests to use.
@@ -453,7 +453,7 @@ class TestEmailNotificationsSinceIniSetting(
         # Register a new user.
         sara = tests.call_action_api(self.app, 'user_create',
                 apikey=self.testsysadmin['apikey'], name='sara',
-                email='sara@sararollins.com', password='sara',
+                email='sara@sararollins.com', password='TestPassword1',
                 fullname='Sara Rollins')
 
         # Save the user for later tests to use.

--- a/ckan/tests/legacy/functional/api/test_user.py
+++ b/ckan/tests/legacy/functional/api/test_user.py
@@ -88,7 +88,7 @@ class TestCreateUserApiDisabled(PylonsTestCase):
         params = {
             'name': 'testinganewusersysadmin',
             'email': 'testinganewuser@ckan.org',
-            'password': 'random',
+            'password': 'TestPassword1',
         }
         res = self.app.post(
             '/api/3/action/user_create',
@@ -102,7 +102,7 @@ class TestCreateUserApiDisabled(PylonsTestCase):
         params = {
             'name': 'testinganewuseranon',
             'email': 'testinganewuser@ckan.org',
-            'password': 'random',
+            'password': 'TestPassword1',
         }
         res = self.app.post('/api/3/action/user_create', json.dumps(params),
                             expect_errors=True)
@@ -138,7 +138,7 @@ class TestCreateUserApiEnabled(PylonsTestCase):
         params = {
             'name': 'testinganewusersysadmin',
             'email': 'testinganewuser@ckan.org',
-            'password': 'random',
+            'password': 'TestPassword1',
         }
         res = self.app.post(
             '/api/3/action/user_create',
@@ -151,7 +151,7 @@ class TestCreateUserApiEnabled(PylonsTestCase):
         params = {
             'name': 'testinganewuseranon',
             'email': 'testinganewuser@ckan.org',
-            'password': 'random',
+            'password': 'TestPassword1',
         }
         res = self.app.post('/api/3/action/user_create', json.dumps(params))
         res_dict = res.json
@@ -186,7 +186,7 @@ class TestCreateUserWebDisabled(PylonsTestCase):
         params = {
             'name': 'testinganewuser',
             'email': 'testinganewuser@ckan.org',
-            'password': 'random',
+            'password': 'TestPassword1',
         }
         res = self.app.post('/api/3/action/user_create', json.dumps(params),
                             expect_errors=True)
@@ -222,7 +222,7 @@ class TestCreateUserWebEnabled(PylonsTestCase):
         params = {
             'name': 'testinganewuser',
             'email': 'testinganewuser@ckan.org',
-            'password': 'random',
+            'password': 'TestPassword1',
         }
         res = self.app.post('/api/3/action/user_create', json.dumps(params),
                             expect_errors=True)
@@ -250,7 +250,7 @@ class TestUserActions(object):
         data_dict = {
             'name': 'a-new-user',
             'email': 'a.person@example.com',
-            'password': 'supersecret',
+            'password': 'TestPassword1',
         }
 
         user_dict = logic.get_action('user_create')(context, data_dict)

--- a/ckan/tests/legacy/functional/test_activity.py
+++ b/ckan/tests/legacy/functional/test_activity.py
@@ -44,7 +44,7 @@ class TestActivity(HtmlCheckMethods):
                 'fullname': 'Billy Beane',
                 'about': 'General Manager, Oakland Athletics',
                 'email': 'billy@beane.org',
-                'password': 'b1lly'}
+                'password': 'TestPassword1'}
         context = {
             'model': ckan.model,
             'session': ckan.model.Session,

--- a/ckan/tests/legacy/functional/test_user.py
+++ b/ckan/tests/legacy/functional/test_user.py
@@ -104,7 +104,7 @@ class TestUserController(FunctionalTestCase, HtmlCheckMethods, PylonsTestCase, S
         assert user.apikey in res, res
 
     def test_perform_reset_user_password_link_key_incorrect(self):
-        CreateTestData.create_user(name='jack', password='test1')
+        CreateTestData.create_user(name='jack', password='TestPassword1')
         # Make up a key - i.e. trying to hack this
         user = model.User.by_name(u'jack')
         offset = url_for(controller='user',
@@ -114,7 +114,7 @@ class TestUserController(FunctionalTestCase, HtmlCheckMethods, PylonsTestCase, S
         res = self.app.get(offset, status=403) # error
 
     def test_perform_reset_user_password_link_key_missing(self):
-        CreateTestData.create_user(name='jack', password='test1')
+        CreateTestData.create_user(name='jack', password='TestPassword1')
         user = model.User.by_name(u'jack')
         offset = url_for(controller='user',
                          action='perform_reset',
@@ -132,7 +132,7 @@ class TestUserController(FunctionalTestCase, HtmlCheckMethods, PylonsTestCase, S
         res = self.app.get(offset, status=404)
 
     def test_perform_reset_activates_pending_user(self):
-        password = 'password'
+        password = 'TestPassword1'
         params = { 'password1': password, 'password2': password }
         user = CreateTestData.create_user(name='pending_user',
                                           email='user@email.com')
@@ -150,7 +150,7 @@ class TestUserController(FunctionalTestCase, HtmlCheckMethods, PylonsTestCase, S
         assert user.is_active(), user
 
     def test_perform_reset_doesnt_activate_deleted_user(self):
-        password = 'password'
+        password = 'TestPassword1'
         params = { 'password1': password, 'password2': password }
         user = CreateTestData.create_user(name='deleted_user',
                                           email='user@email.com')

--- a/ckan/tests/legacy/logic/test_action.py
+++ b/ckan/tests/legacy/logic/test_action.py
@@ -254,8 +254,8 @@ class TestAction(WsgiAppCase):
         res_obj = json.loads(res.body)
         assert "/api/3/action/help_show?name=user_create" in res_obj['help']
         assert res_obj['success'] is False
-        assert res_obj['error'] == { '__type': 'Validation Error',
-                'password': ['Your password must be 4 characters or longer']}
+        assert_equal(res_obj['error'], { '__type': 'Validation Error',
+                'password': ['Your password must be 8 characters or longer']})
 
     def test_12_user_update(self):
         normal_user_dict = {'id': self.normal_user.id,

--- a/ckan/tests/legacy/logic/test_auth.py
+++ b/ckan/tests/legacy/logic/test_auth.py
@@ -60,7 +60,7 @@ class TestAuth(tests.WsgiAppCase):
     @classmethod
     def create_user(cls, name):
         user = {'name': name,
-                'password': 'pass',
+                'password': 'TestPassword1',
                 'email': 'moo@moo.com'}
         res = cls._call_api('user_create', user, 'sysadmin', 200)
         cls.apikeys[name] = str(json.loads(res.body)['result']['apikey'])
@@ -105,7 +105,7 @@ class TestAuthOrgs(TestAuth):
 
     def test_01_create_users(self):
         user = {'name': 'user_no_auth',
-                'password': 'pass',
+                'password': 'TestPassword1',
                 'email': 'moo@moo.com'}
 
         self._call_api('user_create', user, 'random_key', 403)

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -70,8 +70,10 @@ class TestUserInvite(object):
     @mock.patch('ckan.lib.mailer.send_invite')
     @mock.patch('random.SystemRandom')
     def test_works_even_if_username_already_exists(self, rand, _):
-        rand.return_value.random.side_effect = [1000, 1000, 1000, 2000,
-                                                3000, 4000, 5000]
+        # usernames
+        rand.return_value.random.side_effect = [1000, 1000, 2000, 3000]
+        # passwords (need to set something, otherwise choice will break)
+        rand.return_value.choice.side_effect = 'TestPassword1' * 3
 
         for _ in range(3):
             invited_user = self._invite_user_to_group(email='same@email.com')

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -671,7 +671,7 @@ class TestUserShow(helpers.FunctionalTestBase):
 
     def test_user_show_sysadmin_password_hash(self):
 
-        user = factories.User(password='test')
+        user = factories.User(password='TestPassword1')
 
         sysadmin = factories.User(sysadmin=True)
 

--- a/ckan/tests/logic/auth/test_init.py
+++ b/ckan/tests/logic/auth/test_init.py
@@ -128,7 +128,7 @@ class TestGetObject(object):
                                    context={'user': user_name},
                                    name='test_user',
                                    email='a@a.com',
-                                   password='pass')
+                                   password='TestPassword1')
         context = {'model': core_model}
         obj = logic_auth.get_user_object(context, {'id': user['id']})
 

--- a/ckan/tests/logic/test_validators.py
+++ b/ckan/tests/logic/test_validators.py
@@ -584,4 +584,31 @@ class TestExistsValidator(helpers.FunctionalTestBase):
         ctx = self._make_context()
         v = validators.role_exists('', ctx)
 
+
+class TestPasswordValidator(object):
+
+    def test_ok(self):
+        passwords = ['MyPassword1', 'my1Password', '1PasswordMY']
+        key = ('password',)
+
+        @t.does_not_modify_errors_dict
+        def call_validator(*args, **kwargs):
+            return validators.user_password_validator(*args, **kwargs)
+        for password in passwords:
+            errors = factories.validator_errors_dict()
+            errors[key] = []
+            call_validator(key, {key: password}, errors, None)
+
+    def test_too_short(self):
+        password = 'MyPass1'
+        key = ('password',)
+
+        @adds_message_to_errors_dict('Your password must be 8 characters or '
+                                     'longer')
+        def call_validator(*args, **kwargs):
+            return validators.user_password_validator(*args, **kwargs)
+        errors = factories.validator_errors_dict()
+        errors[key] = []
+        call_validator(key, {key: password}, errors, None)
+
 # TODO: Need to test when you are not providing owner_org and the validator queries for the dataset with package_show


### PR DESCRIPTION
Requires: >8 chars, upper & lower & number.

8 chars is mentioned here: https://www.gov.uk/service-manual/design/passwords

The constraint of requiring one of upper/lower/number is typical these days.

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

