### PR TITLE
fix the  subscript of  show() func of usercommand

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -886,7 +886,7 @@ class UserCmd(CkanCommand):
     def show(self):
         import ckan.model as model
 
-        username = self.args[0]
+        username = self.args[1]
         user = model.User.get(unicode(username))
         print 'User: \n', user
 


### PR DESCRIPTION
when I type the command as：
$ paster user show johnsonqrr -c /etc/ckan/default/development.ini
It returns none,and I add 'print self.args' in the 874th line, I get the result as : ['show', 'johnsonqrr'],when I change  self.args[0] to self.args[1], the command worked successfully.

I'm not very sure if I've done the right change, please tell me !

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
