### PR TITLE
type override for next datapusher run

### DIFF
--- a/ckanext/datastore/controller.py
+++ b/ckanext/datastore/controller.py
@@ -21,6 +21,14 @@ from ckanext.datastore.writer import (
     json_writer,
     xml_writer,
 )
+from ckan.logic import (
+    clean_dict,
+    tuplize_dict,
+    parse_params,
+)
+import ckan.lib.navl.dictization_functions as dict_fns
+
+from itertools import izip_longest
 
 int_validator = get_validator('int_validator')
 boolean_validator = get_validator('boolean_validator')
@@ -75,16 +83,21 @@ class DatastoreController(BaseController):
         fields = [f for f in rec['fields'] if not f['id'].startswith('_')]
 
         if request.method == 'POST':
+            data = clean_dict(dict_fns.unflatten(tuplize_dict(parse_params(
+                request.params))))
+            info = data.get(u'info')
+            if not isinstance(info, list):
+                info = []
+            info = info[:len(fields)]
+
             get_action('datastore_create')(None, {
                 'resource_id': resource_id,
                 'force': True,
                 'fields': [{
                     'id': f['id'],
                     'type': f['type'],
-                    'info': {
-                        'label': request.POST.get('f{0}label'.format(i)),
-                        'notes': request.POST.get('f{0}notes'.format(i)),
-                    }} for i, f in enumerate(fields, 1)]})
+                    'info': fi if isinstance(fi, dict) else {}
+                    } for f, fi in izip_longest(fields, info)]})
 
             h.redirect_to(
                 controller='ckanext.datastore.controller:DatastoreController',

--- a/ckanext/datastore/controller.py
+++ b/ckanext/datastore/controller.py
@@ -22,7 +22,6 @@ from ckanext.datastore.writer import (
     xml_writer,
 )
 from ckan.logic import (
-    clean_dict,
     tuplize_dict,
     parse_params,
 )
@@ -83,8 +82,8 @@ class DatastoreController(BaseController):
         fields = [f for f in rec['fields'] if not f['id'].startswith('_')]
 
         if request.method == 'POST':
-            data = clean_dict(dict_fns.unflatten(tuplize_dict(parse_params(
-                request.params))))
+            data = dict_fns.unflatten(tuplize_dict(parse_params(
+                request.params)))
             info = data.get(u'info')
             if not isinstance(info, list):
                 info = []

--- a/ckanext/datastore/templates/datastore/dictionary.html
+++ b/ckanext/datastore/templates/datastore/dictionary.html
@@ -14,10 +14,10 @@
     {% block dictionary_form %}
       {% for f in fields %}
         <h3>{{ _( "Field {num}.").format(num=loop.index) }} {{ f.id }} ({{ f.type }})</h3>
-        {{ form.input('f' ~ loop.index ~ 'label',
+        {{ form.input('info__' ~ loop.index ~ '__label',
           label=_('Label'), id='field-f' ~ loop.index ~ 'label',
           value=f.get('info', {}).get('label', ''), classes=['control-full']) }}
-        {{ form.markdown('f' ~ loop.index ~ 'notes',
+        {{ form.markdown('info__' ~ loop.index ~ '__notes',
           label=_('Description'), id='field-d' ~ loop.index ~ 'notes',
           value=f.get('info', {}).get('notes', '')) }}
       {% endfor %}

--- a/ckanext/datastore/templates/datastore/dictionary.html
+++ b/ckanext/datastore/templates/datastore/dictionary.html
@@ -14,6 +14,13 @@
     {% block dictionary_form %}
       {% for f in fields %}
         <h3>{{ _( "Field {num}.").format(num=loop.index) }} {{ f.id }} ({{ f.type }})</h3>
+        {{ form.select('info__' ~ loop.index ~ '__type_override',
+          label=_('Type Override'), options=[
+          {'name': '', 'value': ''},
+          {'name': 'text', 'value': 'text'},
+          {'name': 'numeric', 'value': 'numeric'},
+          {'name': 'timestamp', 'value': 'timestamp'},
+          ], selected=f.get('info', {}).get('type_override', '')) }}
         {{ form.input('info__' ~ loop.index ~ '__label',
           label=_('Label'), id='field-f' ~ loop.index ~ 'label',
           value=f.get('info', {}).get('label', ''), classes=['control-full']) }}


### PR DESCRIPTION
This adds a "Type Override" field to the data dictionary form that will be read by datapusher when re-uploading.

If datapusher guesses the wrong column types the upload will fail part-way. With this change the user can go to the data dictionary to override the column types so that the next upload may work better.

Currently only text, numeric and timestamp types are supported (the ones used by the default datapusher install)