### PR TITLE
Fix render_datetime for dates before year 1900

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1176,6 +1176,20 @@ def render_datetime(datetime_, date_format=None, with_hours=False):
 
     # if date_format was supplied we use it
     if date_format:
+
+        # See http://bugs.python.org/issue1777412
+        if datetime_.year < 1900:
+            date_format = date_format.replace('%y', str(datetime_.year)[-2:])
+            date_format = date_format.replace('%Y', str(datetime_.year))
+
+            # "2017" can be any year, since it will be replaced with the one
+            # provided in "date_format"
+            datetime_ = datetime.datetime(2017, datetime_.month, datetime_.day,
+                                          datetime_.hour, datetime_.minute,
+                                          datetime_.second)
+
+            return datetime_.strftime(date_format)
+
         return datetime_.strftime(date_format)
     # the localised date
     return formatters.localised_nice_date(datetime_, show_date=True,

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1179,12 +1179,16 @@ def render_datetime(datetime_, date_format=None, with_hours=False):
 
         # See http://bugs.python.org/issue1777412
         if datetime_.year < 1900:
-            date_format = date_format.replace('%y', str(datetime_.year)[-2:])
-            date_format = date_format.replace('%Y', str(datetime_.year))
+            year = str(datetime_.year)
 
-            # "2017" can be any year, since it will be replaced with the one
-            # provided in "date_format"
-            datetime_ = datetime.datetime(2017, datetime_.month, datetime_.day,
+            date_format = re.sub('(?<!%)((%%)*)%y',
+                                 r'\g<1>{year}'.format(year=year[-2:]),
+                                 date_format)
+            date_format = re.sub('(?<!%)((%%)*)%Y',
+                                 r'\g<1>{year}'.format(year=year),
+                                 date_format)
+
+            datetime_ = datetime.datetime(2016, datetime_.month, datetime_.day,
                                           datetime_.hour, datetime_.minute,
                                           datetime_.second)
 

--- a/ckan/tests/legacy/lib/test_helpers.py
+++ b/ckan/tests/legacy/lib/test_helpers.py
@@ -43,6 +43,16 @@ class TestHelpers(TestController):
         res = h.render_datetime('1875-04-13T20:40:20.123456', date_format='%Y')
         assert_equal(res, '1875')
 
+        res = h.render_datetime('1875-04-13T20:40:20.123456', date_format='%y')
+        assert_equal(res, '75')
+
+    def test_render_datetime_year_before_1900_escape_percent(self):
+        res = h.render_datetime('1875-04-13', date_format='%%%y')
+        assert_equal(res, '%75')
+
+        res = h.render_datetime('1875-04-13', date_format='%%%Y')
+        assert_equal(res, '%1875')
+
     def test_datetime_to_date_str(self):
         res = datetime.datetime(2008, 4, 13, 20, 40, 20, 123456).isoformat()
         assert_equal(res, '2008-04-13T20:40:20.123456')

--- a/ckan/tests/legacy/lib/test_helpers.py
+++ b/ckan/tests/legacy/lib/test_helpers.py
@@ -39,6 +39,10 @@ class TestHelpers(TestController):
         res = h.render_datetime(None)
         assert_equal(res, '')
 
+    def test_render_datetime_year_before_1900(self):
+        res = h.render_datetime('1875-04-13T20:40:20.123456', date_format='%Y')
+        assert_equal(res, '1875')
+
     def test_datetime_to_date_str(self):
         res = datetime.datetime(2008, 4, 13, 20, 40, 20, 123456).isoformat()
         assert_equal(res, '2008-04-13T20:40:20.123456')


### PR DESCRIPTION
Fixes #2228 

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport