### PR TITLE
Column name length on Datastore upload

### DIFF
--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -855,6 +855,20 @@ def create_table(context, data_dict):
     field_ids = _pluck('id', supplied_fields)
     records = data_dict.get('records')
 
+    fields_errors = []
+
+    for field_id in field_ids:
+        # Postgres has a limit of 63 characters for a column name
+        if len(field_id) > 63:
+            message = 'Column heading "{0}" exceeds limit of 63 '\
+                'characters.'.format(field_id)
+            fields_errors.append(message)
+
+    if fields_errors:
+        raise ValidationError({
+            'fields': fields_errors
+        })
+
     # if type is field is not given try and guess or throw an error
     for field in supplied_fields:
         if 'type' not in field:

--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -240,6 +240,21 @@ class TestDatastoreCreateNewTests(object):
 
         assert_equal(resource['datastore_active'], False)
 
+    @raises(p.toolkit.ValidationError)
+    def test_create_exceeds_column_name_limit(self):
+        package = factories.Dataset()
+        data = {
+            'resource': {
+                'package_id': package['id']
+            },
+            'fields': [{
+                'id': 'This is a really long name for a column. Column names '
+                'in Postgres have a limit of 63 characters',
+                'type': 'text'
+            }]
+        }
+        result = helpers.call_action('datastore_create', **data)
+
 
 class TestDatastoreCreate(tests.WsgiAppCase):
     sysadmin_user = None


### PR DESCRIPTION
Fixes #2804 

Postgres has a limit of 63 characters for column names.

When a resource is inserted in Datastore, if it contains column headings that have names longer than 63 characters a `ValidationError` is raised showing affected columns.

### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport