### PR TITLE
[#3615] Fix for datastore_search action

### DIFF
--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -506,10 +506,10 @@ class DatastorePlugin(p.SingletonPlugin):
         lang_literal = literal_string(lang)
         query_literal = literal_string(query)
         if plain:
-            statement = u"plainto_tsquery({lang_literal}, {query_literal}) {query_alias}"
+            statement = u"plainto_tsquery({query_literal}) {query_alias}".format(
+            query_literal=query_literal, query_alias=query_alias)
         else:
-            statement = u"to_tsquery({lang_literal}, {query_literal}) {query_alias}"
-        statement = statement.format(lang_literal=lang_literal,
+            statement = u"to_tsquery({lang_literal}, {query_literal}) {query_alias}".format(lang_literal=lang_literal,
             query_literal=query_literal, query_alias=query_alias)
         if field is None:
             rank_field = '_full_text'


### PR DESCRIPTION
I was trying to reproduce this bug with pure SQL query right in database on 9.5 Postgres version, but it seems to work as it should be.
On 9.4 version it's broken.
After some investigation I found the problem in **_build_query_and_rank_statements method**,
as far a I understand from [this](https://www.postgresql.org/docs/9.4/static/textsearch-controls.html) page at postgres doc, 'english' param is used to split the words by small parts for text search, but it seems that we don't actually need this for our plain text search, as without it, the query returns all results. I also assume that this also be problem with Postgres version, as at 9.5 it works fine with the 'english' param.

This fix is only for 2.6 and lower version, as 2.7 plugin file was slightly changed.
