### PR TITLE
Allow slug preview to work with autocomplete fields

### DIFF
--- a/ckan/public/base/javascript/modules/slug-preview.js
+++ b/ckan/public/base/javascript/modules/slug-preview.js
@@ -18,7 +18,7 @@ this.ckan.module('slug-preview-target', {
 
       // Watch for updates to the target field and update the hidden slug field
       // triggering the "change" event manually.
-      el.on('keyup.slug-preview', function (event) {
+      el.on('keyup.slug-preview input.slug-preview', function (event) {
         sandbox.publish('slug-target-changed', this.value);
         //slug.val(this.value).trigger('change');
       });


### PR DESCRIPTION
Fixes #2501 

I tested on Chrome and Firefox and it works.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport