### PR TITLE
Fix filter results button not working for organization/group

### DIFF
--- a/ckan/templates/group/read.html
+++ b/ckan/templates/group/read.html
@@ -32,7 +32,12 @@
 
 {% block secondary_content %}
   {{ super() }}
-  {% for facet in c.facet_titles %}
-    {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id':c.group_dict.id}) }}
-  {% endfor %}
+  <div class="filters">
+    <div>
+      {% for facet in c.facet_titles %}
+        {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id':c.group_dict.id}) }}
+      {% endfor %}
+    </div>
+    <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span class="text">close</span></a>
+  </div>
 {% endblock %}

--- a/ckan/templates/organization/read.html
+++ b/ckan/templates/organization/read.html
@@ -35,7 +35,12 @@
 {% endblock %}
 
 {% block organization_facets %}
-  {% for facet in c.facet_titles %}
-    {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id':c.group_dict.id}) }}
-  {% endfor %}
+  <div class="filters">
+    <div>
+      {% for facet in c.facet_titles %}
+        {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id':c.group_dict.id}) }}
+      {% endfor %}
+    </div>
+    <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span class="text">close</span></a>
+  </div>
 {% endblock %}


### PR DESCRIPTION
Fixes #3593 

Filters in mobile are now shown for datasets in Organization/Group pages.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport