### PR TITLE
Remove import from future to support Python 2.5

### DIFF
--- a/ckan/model/__init__.py
+++ b/ckan/model/__init__.py
@@ -1,6 +1,5 @@
 # encoding: utf-8
 
-from __future__ import with_statement   # necessary for python 2.5 support
 import warnings
 import logging
 import re


### PR DESCRIPTION
I think it's safe to assume that the with statement will be available everywhere CKAN is used.

This was breaking the extraction of translation messages by the latest Babel version.
