### PR TITLE
Choose direction of recreated package relationship depending on its type

### DIFF
--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -232,16 +232,18 @@ class Package(vdm.sqlalchemy.RevisionedObjectMixin,
         if type_ in package_relationship.PackageRelationship.get_forward_types():
             subject = self
             object_ = related_package
+            direction = "forward"
         elif type_ in package_relationship.PackageRelationship.get_reverse_types():
             type_ = package_relationship.PackageRelationship.reverse_to_forward_type(type_)
             assert type_
             subject = related_package
             object_ = self
+            direction = "reverse"
         else:
             raise KeyError, 'Package relationship type: %r' % type_
 
         rels = self.get_relationships(with_package=related_package,
-                                      type=type_, active=False, direction="forward")
+                                      type=type_, active=False, direction=direction)
         if rels:
             rel = rels[0]
             if comment:


### PR DESCRIPTION
Fixes #
Previously recreated package relationships sometimes ignore direction of relationship. This fix is pretty small and it is easier to look at change than describe it :)
### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
