### PR TITLE
[#3606] Allow plugins to react to forks of the CKAN process

### DIFF
--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -38,6 +38,7 @@ __all__ = [
     u'IUploader',
     u'IBlueprint',
     u'IPermissionLabels',
+    u'IForkObserver',
 ]
 
 
@@ -1751,4 +1752,23 @@ class IPermissionLabels(Interface):
 
         :returns: permission labels
         :rtype: list of unicode strings
+        '''
+
+
+class IForkObserver(Interface):
+    u'''
+    Observe forks of the CKAN process.
+    '''
+    def before_fork(self):
+        u'''
+        Called shortly before the CKAN process is forked.
+        '''
+
+    def after_fork(self, pid):
+        u'''
+        Called shortly after the CKAN process is forked.
+
+        :param pid: ``0`` when running in the child, otherwise the
+                    child's PID.
+        :type pid: int
         '''

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1763,12 +1763,3 @@ class IForkObserver(Interface):
         u'''
         Called shortly before the CKAN process is forked.
         '''
-
-    def after_fork(self, pid):
-        u'''
-        Called shortly after the CKAN process is forked.
-
-        :param pid: ``0`` when running in the child, otherwise the
-                    child's PID.
-        :type pid: int
-        '''

--- a/ckanext/datastore/backend/__init__.py
+++ b/ckanext/datastore/backend/__init__.py
@@ -245,3 +245,15 @@ class DatastoreBackend:
         """Called by `datastore_function_delete` action.
         """
         raise NotImplementedError()
+
+    def before_fork(self):
+        """Called before the CKAN process is forked.
+        """
+
+    def after_fork(self, pid):
+        """Called after the CKAN process is forked.
+
+        :param pid: ``0`` when running in the child, otherwise the
+                    child's PID.
+        :type pid: int
+        """

--- a/ckanext/datastore/backend/__init__.py
+++ b/ckanext/datastore/backend/__init__.py
@@ -245,7 +245,3 @@ class DatastoreBackend:
         """Called by `datastore_function_delete` action.
         """
         raise NotImplementedError()
-
-    def before_fork(self):
-        """Called before the CKAN process is forked.
-        """

--- a/ckanext/datastore/backend/__init__.py
+++ b/ckanext/datastore/backend/__init__.py
@@ -249,11 +249,3 @@ class DatastoreBackend:
     def before_fork(self):
         """Called before the CKAN process is forked.
         """
-
-    def after_fork(self, pid):
-        """Called after the CKAN process is forked.
-
-        :param pid: ``0`` when running in the child, otherwise the
-                    child's PID.
-        :type pid: int
-        """

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1966,8 +1966,8 @@ class DatastorePostgresqlBackend(DatastoreBackend):
         return drop_function(*args, **kwargs)
 
     def before_fork(self):
-        # Dispose SQLAlchemy engines to avoid sharing them between
-        # parent and child processes.
+        # Called by DatastorePlugin.before_fork. Dispose SQLAlchemy engines
+        # to avoid sharing them between parent and child processes.
         _dispose_engines()
 
 

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -111,7 +111,6 @@ def get_write_engine():
 def _get_engine_from_url(connection_url):
     '''Get either read or write engine.'''
     engine = _engines.get(connection_url)
-
     if not engine:
         extras = {'url': connection_url}
         engine = sqlalchemy.engine_from_config(config,
@@ -119,6 +118,14 @@ def _get_engine_from_url(connection_url):
                                                **extras)
         _engines[connection_url] = engine
     return engine
+
+
+def _dispose_engines():
+    '''Dispose all database engines.'''
+    global _engines
+    for url, engine in _engines.items():
+        engine.dispose()
+    _engines = {}
 
 
 def _pluck(field, arr):
@@ -1957,6 +1964,11 @@ class DatastorePostgresqlBackend(DatastoreBackend):
 
     def drop_function(self, *args, **kwargs):
         return drop_function(*args, **kwargs)
+
+    def before_fork(self):
+        # Dispose SQLAlchemy engines to avoid sharing them between
+        # parent and child processes.
+        _dispose_engines()
 
 
 def create_function(name, arguments, rettype, definition, or_replace):

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -37,6 +37,7 @@ class DatastorePlugin(p.SingletonPlugin):
     p.implements(p.IRoutes, inherit=True)
     p.implements(p.IResourceController, inherit=True)
     p.implements(p.ITemplateHelpers)
+    p.implements(p.IForkObserver, inherit=True)
     p.implements(interfaces.IDatastore, inherit=True)
     p.implements(interfaces.IDatastoreBackend, inherit=True)
 
@@ -273,3 +274,11 @@ class DatastorePlugin(p.SingletonPlugin):
     def get_helpers(self):
         return {
             'datastore_dictionary': datastore_helpers.datastore_dictionary}
+
+    # IForkObserver
+
+    def before_fork(self):
+        self.backend.before_fork()
+
+    def after_fork(self, pid):
+        self.backend.after_fork(pid)

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -279,6 +279,3 @@ class DatastorePlugin(p.SingletonPlugin):
 
     def before_fork(self):
         self.backend.before_fork()
-
-    def after_fork(self, pid):
-        self.backend.after_fork(pid)

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -278,4 +278,9 @@ class DatastorePlugin(p.SingletonPlugin):
     # IForkObserver
 
     def before_fork(self):
-        self.backend.before_fork()
+        try:
+            before_fork = self.backend.before_fork
+        except AttributeError:
+            pass
+        else:
+            before_fork()


### PR DESCRIPTION
This is a WIP to fix #3606.

As discussed in #3606, the PR introduces a new interface (`IForkObserver`) to allow extensions to react to forks of the CKAN process. This is then used to prevent a sharing of DataStore's SQLAlchemy engines between parent and child processes, similar to what we're already doing for the core's engines.

In its current state, this PR fixes the problem of #3606 for me: if I manually enable the `datastore` plugin in `test-core.ini` the tests still succeed (without the PR some tests in `ckan/tests/lib/test_jobs.py` fail).

However, some parts of the PR are less than elegant, so I'd love to get some feedback and suggestions for improvements:

- In `ckan/lib/jobs.py` I monkey-patch `os.fork` to make sure that the implementations of `IForkObserver` are correctly notified. The monkey-patch is only temporarily while calling the `rq` method that performs the fork. An alternative would be to re-implement the `rq` method in question with the `IForkObserver` notifications. That would avoid the monkey-patch but would make updating `rq` more difficult since we would be messing even more with its internals than we already are.

- AFAIK only plugins can implement interfaces. This means that the `ckanext.datastore.plugin.Datastore` implements `IForkObserver` and then passes these events on to the active backend. Hence `ckanext.datastore.backend.DatastoreBackend` gets two new methods `before_fork` and `after_fork`, and `ckanext.datastore.backend.postgres.DatastorePostgresqlBackend` gets a new `before_fork` method. This is a lot of redirection and certainly not ideal. An slightly better alternative might be to keep these methods out of `DatastoreBackend` and then do some type checking in `Datastore.before_fork` to see whether the active backend is PostgreSQL (and if so, call its `before_fork` method).

In addition to these issues the PR is missing proper documentation. In addition, we haven't so far succeeded in creating a reproducibly failing test case for the original issue that doesn't rely on adding `datastore` to the list of plugins in `test-core.ini` (somehow, temporarily loading the plugin during the test case does not trigger the problem).