### PR TITLE
Catch invalid sort param exception

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -177,8 +177,8 @@ class GroupController(base.BaseController):
                 'sort': sort_by,
                 'type': group_type or 'group',
             }
-            global_results = self._action('group_list')(context,
-                                                        data_dict_global_results)
+            global_results = self._action('group_list')(
+                context, data_dict_global_results)
         except ValidationError as e:
             if e.error_dict and e.error_dict.get('message'):
                 msg = e.error_dict['message']

--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -170,14 +170,24 @@ class GroupController(base.BaseController):
             context['user_id'] = c.userobj.id
             context['user_is_admin'] = c.userobj.sysadmin
 
-        data_dict_global_results = {
-            'all_fields': False,
-            'q': q,
-            'sort': sort_by,
-            'type': group_type or 'group',
-        }
-        global_results = self._action('group_list')(context,
-                                                    data_dict_global_results)
+        try:
+            data_dict_global_results = {
+                'all_fields': False,
+                'q': q,
+                'sort': sort_by,
+                'type': group_type or 'group',
+            }
+            global_results = self._action('group_list')(context,
+                                                        data_dict_global_results)
+        except ValidationError as e:
+            if e.error_dict and e.error_dict.get('message'):
+                msg = e.error_dict['message']
+            else:
+                msg = str(e)
+            h.flash_error(msg)
+            c.page = h.Page([], 0)
+            return render(self._index_template(group_type),
+                          extra_vars={'group_type': group_type})
 
         data_dict_page_results = {
             'all_fields': True,

--- a/ckan/tests/controllers/test_group.py
+++ b/ckan/tests/controllers/test_group.py
@@ -53,6 +53,20 @@ class TestGroupController(helpers.FunctionalTestBase):
         assert groups[-1]['title'] not in response2
         assert groups[0]['title'] in response2
 
+    def test_invalid_sort_param_does_not_crash(self):
+        app = self._get_test_app()
+        group_url = url_for(controller='group',
+                            action='index',
+                            sort='title desc nope')
+
+        app.get(url=group_url)
+
+        group_url = url_for(controller='group',
+                            action='index',
+                            sort='title nope desc nope')
+
+        app.get(url=group_url)
+
 
 def _get_group_new_page(app):
     user = factories.User()


### PR DESCRIPTION
Fixes #3629 

Providing a sort param like `sort=title xx desc` or `sort=title xx` causes an exception due to an uncaught `ValidationError`

