### PR TITLE
Changed required permission from 'update' to 'manage_group'

### DIFF
--- a/ckan/logic/auth/create.py
+++ b/ckan/logic/auth/create.py
@@ -195,7 +195,7 @@ def _check_group_auth(context, data_dict):
         groups = groups - set(pkg_groups)
 
     for group in groups:
-        if not authz.has_user_permission_for_group_or_org(group.id, user, 'update'):
+        if not authz.has_user_permission_for_group_or_org(group.id, user, 'manage_group'):
             return False
 
     return True


### PR DESCRIPTION
Fixes #3308 

### Proposed fixes:
Changed the required permission for has_user_permission_for_group_or_org from "update" to "manage_group". There is no such permission as "update" in ROLE_PERMISSIONS.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
