### PR TITLE
Deprecate notify_after_commit interface

### DIFF
--- a/ckan/model/modification.py
+++ b/ckan/model/modification.py
@@ -24,22 +24,11 @@ class DomainObjectModificationExtension(plugins.SingletonPlugin):
 
     plugins.implements(plugins.ISession, inherit=True)
 
-    def notify_observers(self, func):
-        """
-        Call func(observer) for all registered observers.
-
-        :param func: Any callable, which will be called for each observer
-        :returns: EXT_CONTINUE if no errors encountered, otherwise EXT_STOP
-        """
-        for observer in plugins.PluginImplementations(
-                plugins.IDomainObjectModification):
-            func(observer)
-
     def before_commit(self, session):
         self.notify_observers(session, self.notify)
 
     def after_commit(self, session):
-        self.notify_observers(session, self.notify_after_commit)
+        pass
 
     def notify_observers(self, session, method):
         session.flush()
@@ -86,21 +75,6 @@ class DomainObjectModificationExtension(plugins.SingletonPlugin):
                 plugins.IDomainObjectModification):
             try:
                 observer.notify(entity, operation)
-            except SearchIndexError, search_error:
-                log.exception(search_error)
-                # Reraise, since it's pretty crucial to ckan if it can't index
-                # a dataset
-                raise
-            except Exception, ex:
-                log.exception(ex)
-                # Don't reraise other exceptions since they are generally of
-                # secondary importance so shouldn't disrupt the commit.
-
-    def notify_after_commit(self, entity, operation):
-        for observer in plugins.PluginImplementations(
-                plugins.IDomainObjectModification):
-            try:
-                observer.notify_after_commit(entity, operation)
             except SearchIndexError, search_error:
                 log.exception(search_error)
                 # Reraise, since it's pretty crucial to ckan if it can't index

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -239,7 +239,10 @@ class IDomainObjectModification(Interface):
 
     def notify_after_commit(self, entity, operation):
         u'''
-        Send a notification after entity modification.
+        ** DEPRECATED **
+
+        Supposed to send a notification after entity modification, but it
+        doesn't work.
 
         :param entity: instance of module.Package.
         :param operation: 'new', 'changed' or 'deleted'.


### PR DESCRIPTION
Fixes #3633 

Marked notify_after_commit interface deprecated and removed non-working code that calls it.
