### PR TITLE
Fix missing code snippets in Testing doc page

### DIFF
--- a/ckan/tests/logic/action/__init__.py
+++ b/ckan/tests/logic/action/__init__.py
@@ -27,8 +27,8 @@ expected, and invalid inputs raise the expected exceptions).
 Here's an example of a simple :mod:`ckan.logic.action` test:
 
 .. literalinclude:: ../../ckan/tests/logic/action/test_update.py
-   :start-after: ## START-AFTER
-   :end-before: ## END-BEFORE
+   :start-after: # START-AFTER
+   :end-before: # END-BEFORE
 
 .. todo::
 

--- a/ckan/tests/logic/auth/__init__.py
+++ b/ckan/tests/logic/auth/__init__.py
@@ -13,7 +13,7 @@ Tests for auth functions should use the
 Here's an example of a simple :py:mod:`ckan.logic.auth` test:
 
 .. literalinclude:: ../../ckan/tests/logic/auth/test_update.py
-   :start-after: ## START-AFTER
-   :end-before: ## END-BEFORE
+   :start-after: # START-AFTER
+   :end-before: # END-BEFORE
 
 '''

--- a/doc/contributing/testing.rst
+++ b/doc/contributing/testing.rst
@@ -206,8 +206,8 @@ Most CKAN tests should follow this form. Here's an example of a simple action
 function test demonstrating the recipe:
 
 .. literalinclude:: /../ckan/tests/logic/action/test_update.py
-   :start-after: ## START-AFTER
-   :end-before: ## END-BEFORE
+   :start-after: # START-AFTER
+   :end-before: # END-BEFORE
 
 One common exception is when you want to use a ``for`` loop to call the
 function being tested multiple times, passing it lots of different arguments
@@ -215,8 +215,8 @@ that should all produce the same return value and/or side effects. For example,
 this test from :py:mod:`ckan.tests.logic.action.test_update`:
 
 .. literalinclude:: /../ckan/tests/logic/action/test_update.py
-   :start-after: ## START-FOR-LOOP-EXAMPLE
-   :end-before: ## END-FOR-LOOP-EXAMPLE
+   :start-after: # START-FOR-LOOP-EXAMPLE
+   :end-before: # END-FOR-LOOP-EXAMPLE
 
 The behavior of :py:func:`~ckan.logic.action.update.user_update` is the same
 for every invalid value.
@@ -342,8 +342,8 @@ going on, but here's an example of a test from
 out :py:mod:`ckan.model`:
 
 .. literalinclude:: /../ckan/tests/logic/auth/test_update.py
-   :start-after: ## START-AFTER
-   :end-before: ## END-BEFORE
+   :start-after: # START-AFTER
+   :end-before: # END-BEFORE
 
 ----
 
@@ -412,8 +412,8 @@ make these common asserts easy. To use one of these decorators you have to:
 Here's an example of a simple validator test that uses this technique:
 
 .. literalinclude:: /../ckan/tests/logic/test_validators.py
-   :start-after: ## START-AFTER
-   :end-before: ## END-BEFORE
+   :start-after: # START-AFTER
+   :end-before: # END-BEFORE
 
 
 No tests for :mod:`ckan.logic.schema.py`


### PR DESCRIPTION
In the [Testing coding standards](http://docs.ckan.org/en/latest/contributing/testing.html) doc page, some code snippets were missing due to having double `#` in the `start-after` and `end-before` statements.

Fixes #3635

### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport