### PR TITLE
[Dockerfile] Ckan dockerfile refactoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,49 +3,49 @@
 FROM debian:jessie
 MAINTAINER Open Knowledge
 
-ENV CKAN_HOME /usr/lib/ckan/default
+ENV CKAN_HOME /usr/lib/ckan
+ENV CKAN_VENV $CKAN_HOME/default
 ENV CKAN_CONFIG /etc/ckan/default
 ENV CKAN_STORAGE_PATH /var/lib/ckan
 ENV CKAN_SITE_URL http://localhost:5000
 
+ENV DEBIAN_FRONTEND noninteractive
+
 # Install required packages
-RUN apt-get -q -y update && apt-get -q -y upgrade && DEBIAN_FRONTEND=noninteractive apt-get -q -y install \
-		python-dev \
-        python-pip \
-        python-virtualenv \
-        libpq-dev \
-        git-core \
-	&& apt-get -q clean
+RUN apt-get -q -y update && apt-get -q -y upgrade && apt-get -q -y install \
+    python-dev \
+    python-pip \
+    python-virtualenv \
+    libpq-dev \
+    git-core \
+    postgresql-client \
+    && apt-get -q clean && rm -rf /var/lib/apt/lists/*
+
+# add ckan user which runs all the ckan related stuff
+RUN useradd -r -u 900 -m -c "ckan account" -d $CKAN_HOME -s /bin/false ckan
 
 # SetUp Virtual Environment CKAN
-RUN mkdir -p $CKAN_HOME $CKAN_CONFIG $CKAN_STORAGE_PATH
-RUN virtualenv $CKAN_HOME
-RUN ln -s $CKAN_HOME/bin/pip /usr/local/bin/ckan-pip
-RUN ln -s $CKAN_HOME/bin/paster /usr/local/bin/ckan-paster
-
-# SetUp Requirements
-ADD ./requirements.txt $CKAN_HOME/src/ckan/requirements.txt
-RUN ckan-pip install --upgrade -r $CKAN_HOME/src/ckan/requirements.txt
-
-# TMP-BUGFIX https://github.com/ckan/ckan/issues/3388
-ADD ./dev-requirements.txt $CKAN_HOME/src/ckan/dev-requirements.txt
-RUN ckan-pip install --upgrade -r $CKAN_HOME/src/ckan/dev-requirements.txt
-
-# TMP-BUGFIX https://github.com/ckan/ckan/issues/3594
-RUN ckan-pip install --upgrade urllib3
+RUN mkdir -p $CKAN_VENV $CKAN_CONFIG $CKAN_STORAGE_PATH && \
+    virtualenv $CKAN_VENV && \
+    ln -s $CKAN_VENV/bin/pip /usr/local/bin/ckan-pip &&\
+    ln -s $CKAN_VENV/bin/paster /usr/local/bin/ckan-paster
 
 # SetUp CKAN
-ADD . $CKAN_HOME/src/ckan/
-RUN ckan-pip install -e $CKAN_HOME/src/ckan/
-RUN ln -s $CKAN_HOME/src/ckan/ckan/config/who.ini $CKAN_CONFIG/who.ini
+ADD . $CKAN_VENV/src/ckan/
+RUN ckan-pip install --upgrade -r $CKAN_VENV/src/ckan/requirements.txt && \
+    ckan-pip install -e $CKAN_VENV/src/ckan/ && \
+    ln -s $CKAN_VENV/src/ckan/ckan/config/who.ini $CKAN_CONFIG/who.ini && \
+    cp -v $CKAN_VENV/src/ckan/contrib/docker/ckan-entrypoint.sh /ckan-entrypoint.sh && \
+    chmod +x /ckan-entrypoint.sh && \
+    chown -R ckan:ckan $CKAN_HOME $CKAN_VENV $CKAN_CONFIG $CKAN_STORAGE_PATH
 
-# SetUp EntryPoint
-COPY ./contrib/docker/ckan-entrypoint.sh /
-RUN chmod +x /ckan-entrypoint.sh
 ENTRYPOINT ["/ckan-entrypoint.sh"]
 
 # Volumes
 VOLUME ["/etc/ckan/default"]
 VOLUME ["/var/lib/ckan"]
+
+USER ckan
 EXPOSE 5000
+
 CMD ["ckan-paster","serve","/etc/ckan/default/ckan.ini"]

--- a/contrib/docker/apache.wsgi
+++ b/contrib/docker/apache.wsgi
@@ -1,5 +1,5 @@
 import os
-ckan_home = os.environ.get('CKAN_HOME', '/usr/lib/ckan/default')
+ckan_home = os.environ.get('CKAN_VENV', '/usr/lib/ckan/default')
 activate_this = os.path.join(ckan_home, 'bin/activate_this.py')
 execfile(activate_this, dict(__file__=activate_this))
 

--- a/contrib/docker/ckan-entrypoint.sh
+++ b/contrib/docker/ckan-entrypoint.sh
@@ -79,6 +79,7 @@ if [ -z "$CKAN_SQLALCHEMY_URL" ]; then
     # wait for postgres db to be available, immediately after creation
     # its entrypoint creates the cluster and dbs and this can take a moment
     for tries in $(seq 30); do
+      echo "${tries} try from 30"
       psql -c 'SELECT 1;' 2> /dev/null && break
       sleep 0.3
     done
@@ -90,7 +91,7 @@ if [ -z "$CKAN_SOLR_URL" ]; then
     abort "ERROR: no CKAN_SOLR_URL specified and linked container called 'solr' was not found"
   fi
 fi
-    
+
 if [ -z "$CKAN_REDIS_URL" ]; then
   if ! CKAN_REDIS_URL=$(link_redis_url); then
     abort "ERROR: no CKAN_REDIS_URL specified and linked container called 'redis' was not found"


### PR DESCRIPTION
* Define DEBIAN_FRONTEND noninteractive as ENV var, since dist-upgrade
  can bring some terminal warnings
* Add postgresql-client, since we are using it during postgres check
  readiness
* Add and run ckan container under ckan user
* Decrease number of docker layers, by grouping all RUN stuff in single
  RUN command
* Update ckan env variables:
  + ENV CKAN_HOME /usr/lib/ckan
  + ENV CKAN_VENV $CKAN_HOME/default

