### PR TITLE
Datatables view can't be used as a default view

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -230,6 +230,7 @@ def load_config(config, load_site_user=True):
     import pylons
     registry.register(pylons.translator, MockTranslator())
 
+    site_user = None
     if model.user_table.exists() and load_site_user:
         # If the DB has already been initialized, create and register
         # a pylons context object, and add the site user to it, so the
@@ -248,6 +249,8 @@ def load_config(config, load_site_user=True):
     request_config = routes.request_config()
     request_config.host = parsed.netloc + parsed.path
     request_config.protocol = parsed.scheme
+
+    return site_user
 
 
 def paster_click_group(summary):
@@ -305,7 +308,7 @@ class CkanCommand(paste.script.command.Command):
     group_name = 'ckan'
 
     def _load_config(self, load_site_user=True):
-        load_config(self.options.config, load_site_user)
+        self.site_user = load_config(self.options.config, load_site_user)
 
     def _setup_app(self):
         cmd = paste.script.appinstall.SetupCommand('setup-app')

--- a/ckanext/datatablesview/plugin.py
+++ b/ckanext/datatablesview/plugin.py
@@ -8,6 +8,7 @@ import ckan.plugins.toolkit as toolkit
 
 default = toolkit.get_validator(u'default')
 boolean_validator = toolkit.get_validator(u'boolean_validator')
+ignore_missing = toolkit.get_validator(u'ignore_missing')
 
 
 class DataTablesView(p.SingletonPlugin):
@@ -46,7 +47,7 @@ class DataTablesView(p.SingletonPlugin):
             u'default_title': p.toolkit._(u'Table'),
             u'schema': {
                 u'responsive': [default(False), boolean_validator],
-                u'show_fields': [],
+                u'show_fields': [ignore_missing],
                 u'filterable': [default(True), boolean_validator],
             }
         }


### PR DESCRIPTION
Result in CKAN log:

```
StatementError: <ckan.lib.navl.dictization_functions.Missing object at 0x7f408ab2b0d0> is not JSON serializable (original cause: TypeError: <ckan.lib.navl.dictization_functions.Missing object at 0x7f408ab2b0d0> is not JSON serializable) u'INSERT INTO resource_view (id, resource_id, title, description, view_type, "order", config) VALUES (%(id)s, %(resource_id)s, %(title)s, %(description)s, %(view_type)s, %(order)s, %(config)s)' [{'description': u'', 'title': u'Table', 'resource_id': u'3423dd5d-e4e9-4612-b226-a42e7c88d431', 'view_type': u'datatables_view', 'config': {u'filterable': True, u'responsive': False, u'show_fields': <ckan.lib.navl.dictization_functions.Missing object at 0x7f408ab2b0d0>}, 'order': 0}]
```

The key bit is this:
```
'config': {
  u'filterable': True,
  u'responsive': False,
  u'show_fields': <ckan.lib.navl.dictization_functions.Missing object at 0x7f408ab2b0d0>
}
```

Even though `show_fields` is defined with a default of `[]` in the view config schema (https://github.com/ckan/ckan/blob/master/ckanext/datatablesview/plugin.py#L49)

Which raises two questions:

1. How to (in plugin.py) force a default of [] for show_fields
2. What should the default behaviour actually be? Is there a facility to intervene in the default-setting process to do a query on the datastore resource and get (all) the fields? Or would a [] OR "all" option be possible in the schema?
