### PR TITLE
Fix creating test data with paster

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -306,10 +306,6 @@ class CkanCommand(paste.script.command.Command):
     def _load_config(self, load_site_user=True):
         load_config(self.options.config, load_site_user)
 
-    def _setup_app(self):
-        cmd = paste.script.appinstall.SetupCommand('setup-app')
-        cmd.run([self.filename])
-
 
 class ManageDb(CkanCommand):
     '''Perform various tasks on the database.
@@ -1477,7 +1473,6 @@ class CreateTestDataCommand(CkanCommand):
 
     def command(self):
         self._load_config()
-        self._setup_app()
         from ckan import plugins
         from create_test_data import CreateTestData
 


### PR DESCRIPTION
In CKAN 2.7 and master, when running the command `paster create-test-data`, an error shows up:

```python
  File "/home/klikster/envs/ckan/bin/paster", line 11, in <module>
    sys.exit(run())
  File "/home/klikster/envs/ckan/local/lib/python2.7/site-packages/paste/script/command.py", line 102, in run
    invoke(command, command_name, options, args[1:])
  File "/home/klikster/envs/ckan/local/lib/python2.7/site-packages/paste/script/command.py", line 141, in invoke
    exit_code = runner.run(args)
  File "/home/klikster/envs/ckan/local/lib/python2.7/site-packages/paste/script/command.py", line 236, in run
    result = self.command()
  File "/home/klikster/envs/ckan/src/ckan/ckan/lib/cli.py", line 1482, in command
    self._setup_app()
  File "/home/klikster/envs/ckan/src/ckan/ckan/lib/cli.py", line 311, in _setup_app
    cmd.run([self.filename])
AttributeError: 'CreateTestDataCommand' object has no attribute 'filename'
```

The reason for this is because when running the command, the [`_setup_app()`](https://github.com/ckan/ckan/blob/master/ckan/lib/cli.py#L1480) method in `cli.py` is called, and that method uses `self.filename` which is not defined anywhere in the code.

In versions prior to CKAN 2.7, `self.filename` was defined in the method [`_get_config()`](https://github.com/ckan/ckan/blob/dev-v2.6/ckan/lib/cli.py#L134).

A solution which I found to work is to remove the call for `_setup_app()`. Test data is created even without calling that method.

Also, I removed the definition of that method itself, since it's not used anywhere in the codebase. If you think it should be there for some reason, I will put it back.