### PR TITLE
[#3694] Fix datastore setup that was being scuppered by log statement…

### DIFF
--- a/ckan/lib/fanstatic_resources.py
+++ b/ckan/lib/fanstatic_resources.py
@@ -235,7 +235,7 @@ public = config.get('ckan.base_public_folder')
 base_path = os.path.abspath(os.path.join(
     os.path.dirname(__file__), '..', public, 'base'))
 
-log.info('Base path {0}'.format(base_path))
+log.debug('Base path {0}'.format(base_path))
 create_library('vendor', os.path.join(base_path, 'vendor'), depend_base=False)
 
 create_library('base', os.path.join(base_path, 'javascript'),

--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -101,7 +101,7 @@ def datapusher_submit(context, data_dict):
                 # likely something went wrong with it and the state wasn't
                 # updated than its still in progress. Let it be restarted.
                 log.info('A pending task was found %r, but it is only %s hours'
-                         'old', existing_task['id'], time_since_last_updated)
+                         ' old', existing_task['id'], time_since_last_updated)
             else:
                 log.info('A pending task was found %s for this resource, so '
                          'skipping this duplicate task', existing_task['id'])


### PR DESCRIPTION
Also, an unrelated log spacing improvement.

Fixes #3694 


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
