### PR TITLE
datastore upsert performance

### DIFF
--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -349,22 +349,6 @@ def _validate_record(record, num, field_names):
         })
 
 
-def _to_full_text(fields, record):
-    full_text = []
-    ft_types = ['int8', 'int4', 'int2', 'float4', 'float8', 'date', 'time',
-                'timetz', 'timestamp', 'numeric', 'text']
-    for field in fields:
-        value = record.get(field['id'])
-        if not value:
-            continue
-
-        if field['type'].lower() in ft_types and unicode(value):
-            full_text.append(unicode(value))
-        else:
-            full_text.extend(json_get_values(value))
-    return ' '.join(set(full_text))
-
-
 def _where_clauses(data_dict, fields_types):
     filters = data_dict.get('filters', {})
     clauses = []
@@ -755,19 +739,6 @@ def convert(data, type_name):
     return unicode(data)
 
 
-def json_get_values(obj, current_list=None):
-    if current_list is None:
-        current_list = []
-    if isinstance(obj, list) or isinstance(obj, tuple):
-        for item in obj:
-            json_get_values(item, current_list)
-    elif isinstance(obj, dict):
-        json_get_values(obj.items(), current_list)
-    elif obj:
-        current_list.append(unicode(obj))
-    return current_list
-
-
 def check_fields(context, fields):
     '''Check if field types are valid.'''
     for field in fields:
@@ -1027,8 +998,11 @@ def upsert_data(context, data_dict):
     fields = _get_fields(context, data_dict)
     field_names = _pluck('id', fields)
     records = data_dict['records']
-    sql_columns = ", ".join(['"%s"' % name.replace(
-        '%', '%%') for name in field_names] + ['"_full_text"'])
+    sql_columns = ", ".join(
+        identifier(name) for name in field_names)
+    sql_full_text = " || ' ' || ".join(
+        identifier(name) + "::text"
+        for name in field_names)
 
     if method == _INSERT:
         rows = []
@@ -1042,13 +1016,12 @@ def upsert_data(context, data_dict):
                     # a tuple with an empty second value
                     value = (json.dumps(value), '')
                 row.append(value)
-            row.append(_to_full_text(fields, record))
             rows.append(row)
 
-        sql_string = u'''INSERT INTO "{res_id}" ({columns})
-            VALUES ({values}, to_tsvector(%s));'''.format(
-            res_id=data_dict['resource_id'],
-            columns=sql_columns,
+        sql_string = u'''INSERT INTO {res_id} ({columns})
+            VALUES ({values});'''.format(
+            res_id=identifier(data_dict['resource_id']),
+            columns=sql_columns.replace('%', '%%'),
             values=', '.join(['%s' for field in field_names])
         )
 
@@ -1104,18 +1077,16 @@ def upsert_data(context, data_dict):
 
             used_values = [record[field] for field in used_field_names]
 
-            full_text = _to_full_text(fields, record)
-
             if method == _UPDATE:
                 sql_string = u'''
                     UPDATE "{res_id}"
-                    SET ({columns}, "_full_text") = ({values}, to_tsvector(%s))
+                    SET ({columns}, "_full_text") = ({values}, NULL)
                     WHERE ({primary_key}) = ({primary_value});
                 '''.format(
                     res_id=data_dict['resource_id'],
                     columns=u', '.join(
-                        [u'"{0}"'.format(field)
-                         for field in used_field_names]),
+                        [identifier(field)
+                         for field in used_field_names]).replace('%', '%%'),
                     values=u', '.join(
                         ['%s' for _ in used_field_names]),
                     primary_key=u','.join(
@@ -1124,7 +1095,7 @@ def upsert_data(context, data_dict):
                 )
                 try:
                     results = context['connection'].execute(
-                        sql_string, used_values + [full_text] + unique_values)
+                        sql_string, used_values + unique_values)
                 except sqlalchemy.exc.DatabaseError as err:
                     raise ValidationError({
                         u'records': [_programming_error_summary(err)],
@@ -1139,10 +1110,10 @@ def upsert_data(context, data_dict):
             elif method == _UPSERT:
                 sql_string = u'''
                     UPDATE "{res_id}"
-                    SET ({columns}, "_full_text") = ({values}, to_tsvector(%s))
+                    SET ({columns}, "_full_text") = ({values}, NULL)
                     WHERE ({primary_key}) = ({primary_value});
-                    INSERT INTO "{res_id}" ({columns}, "_full_text")
-                           SELECT {values}, to_tsvector(%s)
+                    INSERT INTO "{res_id}" ({columns})
+                           SELECT {values}
                            WHERE NOT EXISTS (SELECT 1 FROM "{res_id}"
                                     WHERE ({primary_key}) = ({primary_value}));
                 '''.format(
@@ -1159,7 +1130,7 @@ def upsert_data(context, data_dict):
                 try:
                     context['connection'].execute(
                         sql_string,
-                        (used_values + [full_text] + unique_values) * 2)
+                        (used_values + unique_values) * 2)
                 except sqlalchemy.exc.DatabaseError as err:
                     raise ValidationError({
                         u'records': [_programming_error_summary(err)],
@@ -1391,7 +1362,8 @@ def _create_triggers(connection, resource_id, triggers):
     or "for_each" parameters from triggers list.
     '''
     existing = connection.execute(
-        u'SELECT tgname FROM pg_trigger WHERE tgrelid = %s::regclass',
+        u"""SELECT tgname FROM pg_trigger
+        WHERE tgrelid = %s::regclass AND tgname LIKE 't___'""",
         resource_id)
     sql_list = (
         [u'DROP TRIGGER {name} ON {table}'.format(
@@ -1411,6 +1383,14 @@ def _create_triggers(connection, resource_id, triggers):
             connection.execute(u';\n'.join(sql_list))
     except ProgrammingError as pe:
         raise ValidationError({u'triggers': [_programming_error_summary(pe)]})
+
+
+def _create_fulltext_trigger(connection, resource_id):
+    connection.execute(
+        u'''CREATE TRIGGER zfulltext
+        BEFORE INSERT OR UPDATE ON {table}
+        FOR EACH ROW EXECUTE PROCEDURE populate_full_text_trigger()'''.format(
+            table=identifier(resource_id)))
 
 
 def upsert(context, data_dict):
@@ -1804,6 +1784,9 @@ class DatastorePostgresqlBackend(DatastoreBackend):
             ).fetchone()
             if not result:
                 create_table(context, data_dict)
+                _create_fulltext_trigger(
+                    context['connection'],
+                    data_dict['resource_id'])
             else:
                 alter_table(context, data_dict)
             if 'triggers' in data_dict:

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -450,16 +450,16 @@ def datastore_search(context, data_dict):
 
     res_id = data_dict['resource_id']
 
-    res_exists, real_id = backend.resource_id_from_alias(res_id)
-    # Resource only has to exist in the datastore (because it could be an
-    # alias)
-
-    if not res_exists:
-        raise p.toolkit.ObjectNotFound(p.toolkit._(
-            'Resource "{0}" was not found.'.format(res_id)
-        ))
-
     if data_dict['resource_id'] not in WHITELISTED_RESOURCES:
+        res_exists, real_id = backend.resource_id_from_alias(res_id)
+        # Resource only has to exist in the datastore (because it could be an
+        # alias)
+
+        if not res_exists:
+            raise p.toolkit.ObjectNotFound(p.toolkit._(
+                'Resource "{0}" was not found.'.format(res_id)
+            ))
+
         # Replace potential alias with real id to simplify access checks
         if real_id:
             data_dict['resource_id'] = real_id

--- a/ckanext/datastore/set_permissions.sql
+++ b/ckanext/datastore/set_permissions.sql
@@ -49,6 +49,7 @@ GRANT SELECT ON ALL TABLES IN SCHEMA public TO {readuser};
 ALTER DEFAULT PRIVILEGES FOR USER {writeuser} IN SCHEMA public
    GRANT SELECT ON TABLES TO {readuser};
 
+-- a view for listing valid table (resource id) and view names
 CREATE OR REPLACE VIEW "_table_metadata" AS
     SELECT DISTINCT
         substr(md5(dependee.relname || COALESCE(dependent.relname, '')), 0, 17) AS "_id",
@@ -62,11 +63,45 @@ CREATE OR REPLACE VIEW "_table_metadata" AS
         LEFT OUTER JOIN pg_class AS dependent ON d.refobjid = dependent.oid
     WHERE
         (dependee.oid != dependent.oid OR dependent.oid IS NULL) AND
-	-- is a table (from pg_tables view definition)
-	-- or is a view (from pg_views view definition)
+        -- is a table (from pg_tables view definition)
+        -- or is a view (from pg_views view definition)
         (dependee.relkind = 'r'::"char" OR dependee.relkind = 'v'::"char")
-	AND dependee.relnamespace = (
-	    SELECT oid FROM pg_namespace WHERE nspname='public')
+        AND dependee.relnamespace = (
+            SELECT oid FROM pg_namespace WHERE nspname='public')
     ORDER BY dependee.oid DESC;
 ALTER VIEW "_table_metadata" OWNER TO {writeuser};
 GRANT SELECT ON "_table_metadata" TO {readuser};
+
+-- _full_text fields are now updated by a trigger when set to NULL
+CREATE OR REPLACE FUNCTION populate_full_text_trigger() RETURNS trigger
+AS $body$
+    BEGIN
+        IF NEW._full_text IS NOT NULL THEN
+            RETURN NEW;
+        END IF;
+        NEW._full_text := (
+            SELECT to_tsvector(string_agg(value, ' '))
+            FROM json_each_text(row_to_json(NEW.*))
+            WHERE key NOT LIKE '\_%');
+        RETURN NEW;
+    END;
+$body$ LANGUAGE plpgsql;
+
+-- migrate existing tables that don't have full text trigger applied
+DO $body$
+    BEGIN
+        EXECUTE coalesce(
+            (SELECT string_agg(
+                'CREATE TRIGGER zfulltext BEFORE INSERT OR UPDATE ON ' ||
+                quote_ident(relname) || 'FOR EACH ROW EXECUTE PROCEDURE ' ||
+                'populate_full_text_trigger();', ' ')
+            FROM pg_class
+            LEFT OUTER JOIN pg_trigger AS t
+                ON t.tgrelid = relname::regclass AND t.tgname = 'zfulltext'
+            WHERE relkind = 'r'::"char" AND t.tgname IS NULL
+                AND relnamespace = (
+                    SELECT oid FROM pg_namespace WHERE nspname='public')),
+            'SELECT 1;');
+    END;
+$body$;
+

--- a/ckanext/datastore/set_permissions.sql
+++ b/ckanext/datastore/set_permissions.sql
@@ -55,7 +55,6 @@ CREATE OR REPLACE VIEW "_table_metadata" AS
         dependee.relname AS name,
         dependee.oid AS oid,
         dependent.relname AS alias_of
-        -- dependent.oid AS oid
     FROM
         pg_class AS dependee
         LEFT OUTER JOIN pg_rewrite AS r ON r.ev_class = dependee.oid
@@ -63,9 +62,11 @@ CREATE OR REPLACE VIEW "_table_metadata" AS
         LEFT OUTER JOIN pg_class AS dependent ON d.refobjid = dependent.oid
     WHERE
         (dependee.oid != dependent.oid OR dependent.oid IS NULL) AND
-        (dependee.relname IN (SELECT tablename FROM pg_catalog.pg_tables)
-            OR dependee.relname IN (SELECT viewname FROM pg_catalog.pg_views)) AND
-        dependee.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname='public')
+	-- is a table (from pg_tables view definition)
+	-- or is a view (from pg_views view definition)
+        (dependee.relkind = 'r'::"char" OR dependee.relkind = 'v'::"char")
+	AND dependee.relnamespace = (
+	    SELECT oid FROM pg_namespace WHERE nspname='public')
     ORDER BY dependee.oid DESC;
 ALTER VIEW "_table_metadata" OWNER TO {writeuser};
 GRANT SELECT ON "_table_metadata" TO {readuser};

--- a/ckanext/datastore/set_permissions.sql
+++ b/ckanext/datastore/set_permissions.sql
@@ -86,6 +86,7 @@ AS $body$
         RETURN NEW;
     END;
 $body$ LANGUAGE plpgsql;
+ALTER FUNCTION populate_full_text_trigger() OWNER TO {writeuser};
 
 -- migrate existing tables that don't have full text trigger applied
 DO $body$

--- a/ckanext/datastore/tests/helpers.py
+++ b/ckanext/datastore/tests/helpers.py
@@ -26,7 +26,7 @@ def clear_db(Session):
         SELECT 'drop function ' || quote_ident(proname) || '();'
         FROM pg_proc
         INNER JOIN pg_namespace ns ON (pg_proc.pronamespace = ns.oid)
-        WHERE ns.nspname = 'public'
+        WHERE ns.nspname = 'public' AND proname != 'populate_full_text_trigger'
         '''
     drop_functions = u''.join(r[0] for r in c.execute(drop_functions_sql))
     if drop_functions:

--- a/ckanext/datastore/tests/test_db.py
+++ b/ckanext/datastore/tests/test_db.py
@@ -173,26 +173,6 @@ def test_upsert_with_insert_method_and_invalid_data(
         backend.InvalidDataError, db.upsert_data, context, data_dict)
 
 
-class TestJsonGetValues(object):
-    def test_returns_empty_list_if_called_with_none(self):
-        assert_equal(db.json_get_values(None), [])
-
-    def test_returns_list_with_value_if_called_with_string(self):
-        assert_equal(db.json_get_values('foo'), ['foo'])
-
-    def test_returns_list_with_only_the_original_truthy_values_if_called(self):
-        data = [None, 'foo', 42, 'bar', {}, []]
-        assert_equal(db.json_get_values(data), ['foo', '42', 'bar'])
-
-    def test_returns_flattened_list(self):
-        data = ['foo', ['bar', ('baz', 42)]]
-        assert_equal(db.json_get_values(data), ['foo', 'bar', 'baz', '42'])
-
-    def test_returns_only_truthy_values_from_dict(self):
-        data = {'foo': 'bar', 'baz': [42, None, {}, [], 'hey']}
-        assert_equal(db.json_get_values(data), ['foo', 'bar', 'baz', '42', 'hey'])
-
-
 class TestGetAllResourcesIdsInDatastore(object):
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
The `datastore_upsert` and `datastore_create` actions currently issue separate insert statements to the datastore database for every row added or updated instead of using a single query, which is simple but slow. The insert/update also abort completely if any individual row fails to be loaded.

This ticket is to track work improving performance and adding an option to continue when some records fail. When continuing on errors, each error will be collected and returned as a list of validation errors to the caller instead of as a single error.

Like #3523 we'll consider using the postgres `COPY` command to feed data to postgres. We can use [notices](http://initd.org/psycopg/docs/connection.html#connection.notices) to communicate errors from postgres to CKAN while loading data. This approach can work alongside data validation implemented in triggers #3428  if we choose a standard format for error text.