### PR TITLE
Fix misplaced search icon in organization bulk process

### DIFF
--- a/ckan/public-bs2/base/css/fuchsia.css
+++ b/ckan/public-bs2/base/css/fuchsia.css
@@ -7273,7 +7273,7 @@ textarea {
   display: block;
   position: absolute;
   top: 50%;
-  margin-top: -10px;
+  margin-top: 1px;
   right: 10px;
   height: 20px;
   padding: 0;

--- a/ckan/public-bs2/base/css/green.css
+++ b/ckan/public-bs2/base/css/green.css
@@ -7273,7 +7273,7 @@ textarea {
   display: block;
   position: absolute;
   top: 50%;
-  margin-top: -10px;
+  margin-top: 1px;
   right: 10px;
   height: 20px;
   padding: 0;

--- a/ckan/public-bs2/base/css/main.css
+++ b/ckan/public-bs2/base/css/main.css
@@ -7273,7 +7273,7 @@ textarea {
   display: block;
   position: absolute;
   top: 50%;
-  margin-top: -10px;
+  margin-top: 1px;
   right: 10px;
   height: 20px;
   padding: 0;

--- a/ckan/public-bs2/base/css/maroon.css
+++ b/ckan/public-bs2/base/css/maroon.css
@@ -7273,7 +7273,7 @@ textarea {
   display: block;
   position: absolute;
   top: 50%;
-  margin-top: -10px;
+  margin-top: 1px;
   right: 10px;
   height: 20px;
   padding: 0;

--- a/ckan/public-bs2/base/css/red.css
+++ b/ckan/public-bs2/base/css/red.css
@@ -7273,7 +7273,7 @@ textarea {
   display: block;
   position: absolute;
   top: 50%;
-  margin-top: -10px;
+  margin-top: 1px;
   right: 10px;
   height: 20px;
   padding: 0;

--- a/ckan/public-bs2/base/less/search.less
+++ b/ckan/public-bs2/base/less/search.less
@@ -19,7 +19,7 @@
       display: block;
       position: absolute;
       top: 50%;
-      margin-top: -10px;
+      margin-top: 1px;
       right: 10px;
       height: 20px;
       padding: 0;

--- a/ckan/public/base/css/fuchsia.css
+++ b/ckan/public/base/css/fuchsia.css
@@ -8257,7 +8257,7 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
   display: block;
   position: absolute;
   top: 50%;
-  margin-top: -10px;
+  margin-top: 1px;
   right: 10px;
   height: 20px;
   padding: 0;

--- a/ckan/public/base/css/green.css
+++ b/ckan/public/base/css/green.css
@@ -8257,7 +8257,7 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
   display: block;
   position: absolute;
   top: 50%;
-  margin-top: -10px;
+  margin-top: 1px;
   right: 10px;
   height: 20px;
   padding: 0;

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -8257,7 +8257,7 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
   display: block;
   position: absolute;
   top: 50%;
-  margin-top: -10px;
+  margin-top: 1px;
   right: 10px;
   height: 20px;
   padding: 0;

--- a/ckan/public/base/css/maroon.css
+++ b/ckan/public/base/css/maroon.css
@@ -8257,7 +8257,7 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
   display: block;
   position: absolute;
   top: 50%;
-  margin-top: -10px;
+  margin-top: 1px;
   right: 10px;
   height: 20px;
   padding: 0;

--- a/ckan/public/base/css/red.css
+++ b/ckan/public/base/css/red.css
@@ -8257,7 +8257,7 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
   display: block;
   position: absolute;
   top: 50%;
-  margin-top: -10px;
+  margin-top: 1px;
   right: 10px;
   height: 20px;
   padding: 0;

--- a/ckan/public/base/less/search.less
+++ b/ckan/public/base/less/search.less
@@ -18,7 +18,7 @@
             display: block;
             position: absolute;
             top: 50%;
-            margin-top: -10px;
+            margin-top: 1px;
             right: 10px;
             height: 20px;
             padding: 0;

--- a/ckan/templates-bs2/snippets/search_form.html
+++ b/ckan/templates-bs2/snippets/search_form.html
@@ -11,7 +11,7 @@
   {% block search_input %}
     <div class="search-input control-group {{ search_class }}">
       <label for="field-giant-search">{% block header_site_search_label %}{{ _('Search Datasets') }}{% endblock %}</label>
-      <input id="field-giant-search" type="text" class="search" name="q" value="{{ query }}" autocomplete="off" placeholder="{{ placeholder }}">
+      <input id="field-giant-search" type="text" class="search form-control" name="q" value="{{ query }}" autocomplete="off" placeholder="{{ placeholder }}">
       {% block search_input_button %}
       <button type="submit" value="search">
         <i class="fa fa-search"></i>

--- a/ckan/templates/snippets/search_form.html
+++ b/ckan/templates/snippets/search_form.html
@@ -11,7 +11,7 @@
   {% block search_input %}
     <div class="search-input form-group {{ search_class }}">
       <label for="field-giant-search">{% block header_site_search_label %}{{ _('Search Datasets') }}{% endblock %}</label>
-      <input id="field-giant-search" type="text" class="search" name="q" value="{{ query }}" autocomplete="off" placeholder="{{ placeholder }}">
+      <input id="field-giant-search" type="text" class="search form-control" name="q" value="{{ query }}" autocomplete="off" placeholder="{{ placeholder }}">
       {% block search_input_button %}
       <button type="submit" value="search">
         <i class="fa fa-search"></i>
@@ -70,7 +70,7 @@
             </span>
           {% endfor %}
         {% endfor %}
-      </p>     
+      </p>
       <a class="show-filters btn btn-default">{{ _('Filter Results') }}</a>
     {% endif %}
   {% endblock %}


### PR DESCRIPTION
_Issue only in master._

In an organization's bulk process http://localhost:5000/organization/bulk_process/test, the search icon inside the input field for searching datasets is misplaced.

![screenshot from 2017-07-16 14-54-45](https://user-images.githubusercontent.com/520213/28247723-bd563442-6a36-11e7-9f91-8def54752176.png)
