### PR TITLE
Fix layout on mobile/desktop for bulk process in organization

### DIFF
--- a/ckan/public/base/css/fuchsia.css
+++ b/ckan/public/base/css/fuchsia.css
@@ -8315,6 +8315,12 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
   border-bottom-width: 0;
   margin-bottom: 0;
 }
+.search-form .search-input-group {
+  margin-bottom: 12px;
+}
+.search-form .search-input-group .input-group-btn .btn {
+  margin-top: 25px;
+}
 .tertiary .control-order-by {
   float: none;
   margin: 0;
@@ -9058,7 +9064,6 @@ h4 small {
 }
 .primary .primary {
   float: left;
-  width: 467px;
   margin-left: 0;
   margin-bottom: 20px;
 }
@@ -9069,9 +9074,6 @@ h4 small {
   margin-top: 0;
 }
 .primary .tertiary {
-  float: left;
-  width: 180px;
-  margin-left: 18px;
   margin-bottom: 20px;
 }
 @media (min-width: 768px) {

--- a/ckan/public/base/css/green.css
+++ b/ckan/public/base/css/green.css
@@ -8315,6 +8315,12 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
   border-bottom-width: 0;
   margin-bottom: 0;
 }
+.search-form .search-input-group {
+  margin-bottom: 12px;
+}
+.search-form .search-input-group .input-group-btn .btn {
+  margin-top: 25px;
+}
 .tertiary .control-order-by {
   float: none;
   margin: 0;
@@ -9058,7 +9064,6 @@ h4 small {
 }
 .primary .primary {
   float: left;
-  width: 467px;
   margin-left: 0;
   margin-bottom: 20px;
 }
@@ -9069,9 +9074,6 @@ h4 small {
   margin-top: 0;
 }
 .primary .tertiary {
-  float: left;
-  width: 180px;
-  margin-left: 18px;
   margin-bottom: 20px;
 }
 @media (min-width: 768px) {

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -8315,6 +8315,12 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
   border-bottom-width: 0;
   margin-bottom: 0;
 }
+.search-form .search-input-group {
+  margin-bottom: 12px;
+}
+.search-form .search-input-group .input-group-btn .btn {
+  margin-top: 25px;
+}
 .tertiary .control-order-by {
   float: none;
   margin: 0;
@@ -9058,7 +9064,6 @@ h4 small {
 }
 .primary .primary {
   float: left;
-  width: 467px;
   margin-left: 0;
   margin-bottom: 20px;
 }
@@ -9069,9 +9074,6 @@ h4 small {
   margin-top: 0;
 }
 .primary .tertiary {
-  float: left;
-  width: 180px;
-  margin-left: 18px;
   margin-bottom: 20px;
 }
 @media (min-width: 768px) {

--- a/ckan/public/base/css/maroon.css
+++ b/ckan/public/base/css/maroon.css
@@ -8315,6 +8315,12 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
   border-bottom-width: 0;
   margin-bottom: 0;
 }
+.search-form .search-input-group {
+  margin-bottom: 12px;
+}
+.search-form .search-input-group .input-group-btn .btn {
+  margin-top: 25px;
+}
 .tertiary .control-order-by {
   float: none;
   margin: 0;
@@ -9058,7 +9064,6 @@ h4 small {
 }
 .primary .primary {
   float: left;
-  width: 467px;
   margin-left: 0;
   margin-bottom: 20px;
 }
@@ -9069,9 +9074,6 @@ h4 small {
   margin-top: 0;
 }
 .primary .tertiary {
-  float: left;
-  width: 180px;
-  margin-left: 18px;
   margin-bottom: 20px;
 }
 @media (min-width: 768px) {

--- a/ckan/public/base/css/red.css
+++ b/ckan/public/base/css/red.css
@@ -8315,6 +8315,12 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
   border-bottom-width: 0;
   margin-bottom: 0;
 }
+.search-form .search-input-group {
+  margin-bottom: 12px;
+}
+.search-form .search-input-group .input-group-btn .btn {
+  margin-top: 25px;
+}
 .tertiary .control-order-by {
   float: none;
   margin: 0;
@@ -9058,7 +9064,6 @@ h4 small {
 }
 .primary .primary {
   float: left;
-  width: 467px;
   margin-left: 0;
   margin-bottom: 20px;
 }
@@ -9069,9 +9074,6 @@ h4 small {
   margin-top: 0;
 }
 .primary .tertiary {
-  float: left;
-  width: 180px;
-  margin-left: 18px;
   margin-bottom: 20px;
 }
 @media (min-width: 768px) {

--- a/ckan/public/base/less/layout.less
+++ b/ckan/public/base/less/layout.less
@@ -144,7 +144,6 @@
 .primary {
     .primary {
         float: left;
-        width: 467px;
         margin-left: 0;
         margin-bottom: 20px;
         h1,
@@ -157,9 +156,6 @@
         }
     }
     .tertiary {
-        float: left;
-        width: 180px;
-        margin-left: 18px;
         margin-bottom: 20px;
     }
 }

--- a/ckan/public/base/less/search.less
+++ b/ckan/public/base/less/search.less
@@ -87,6 +87,14 @@
         border-bottom-width: 0;
         margin-bottom: 0;
     }
+    .search-input-group {
+        margin-bottom: 12px;
+        .input-group-btn {
+            .btn {
+                margin-top: 25px;
+            }
+        }
+    }
 }
 
 .tertiary {

--- a/ckan/templates/organization/bulk_process.html
+++ b/ckan/templates/organization/bulk_process.html
@@ -7,9 +7,9 @@
 {% endblock %}
 
 {% block primary_content_inner %}
-  <div class="clearfix">
+  <div class="row">
     <h1 class="hide-heading">{{ _('Edit datasets') }}</h1>
-    <div class="primary">
+    <div class="primary col-md-8">
       <h3 class="page-heading">
         {% block page_heading %}
           {%- if c.page.item_count -%}
@@ -89,7 +89,7 @@
         {% endif %}
       {% endblock %}
     </div>
-    <aside class="tertiary">
+    <aside class="tertiary col-md-4">
       {% block tertiary_content %}
 
         {% block search_form %}

--- a/ckan/templates/snippets/search_form.html
+++ b/ckan/templates/snippets/search_form.html
@@ -9,14 +9,15 @@
 <form {% if form_id %}id="{{ form_id }}" {% endif %}class="search-form{% if no_bottom_border %} no-bottom-border{% endif %}" method="get" data-module="select-switch">
 
   {% block search_input %}
-    <div class="search-input form-group {{ search_class }}">
+    <div class="input-group search-input-group">
       <label for="field-giant-search">{% block header_site_search_label %}{{ _('Search Datasets') }}{% endblock %}</label>
-      <input id="field-giant-search" type="text" class="search" name="q" value="{{ query }}" autocomplete="off" placeholder="{{ placeholder }}">
+      <input id="field-giant-search" type="text" class="form-control" name="q" value="{{ query }}" autocomplete="off" placeholder="{{ placeholder }}">
       {% block search_input_button %}
-      <button type="submit" value="search">
-        <i class="fa fa-search"></i>
-        <span>{{ _('Submit') }}</span>
-      </button>
+      <span class="input-group-btn">
+        <button class="btn btn-default" type="submit" value="search">
+          <i class="fa fa-search"></i>
+        </button>
+      </span>
       {% endblock %}
     </div>
   {% endblock %}
@@ -70,7 +71,7 @@
             </span>
           {% endfor %}
         {% endfor %}
-      </p>     
+      </p>
       <a class="show-filters btn btn-default">{{ _('Filter Results') }}</a>
     {% endif %}
   {% endblock %}


### PR DESCRIPTION
_Issue only in master._

In the organization's bulk process, the layout got messed up with the inclusion of Bootstrap 3. 

There was extra space and the layout was using fixed widths instead of using Bootstrap's responsive classes.

With this PR, the layout is properly shown on mobile and desktop.

Here are 2 screenshots showing the extra space on smaller/bigger screen.

![screenshot from 2017-07-16 16-58-35](https://user-images.githubusercontent.com/520213/28248647-24a98e94-6a48-11e7-89a0-1a502e524453.png)

![screenshot from 2017-07-16 16-58-59](https://user-images.githubusercontent.com/520213/28248648-28223f9e-6a48-11e7-8003-988890245eb6.png)
