### PR TITLE
Fix size for sidebar image

### DIFF
--- a/ckan/public/base/css/fuchsia.css
+++ b/ckan/public/base/css/fuchsia.css
@@ -9109,6 +9109,8 @@ h4 small {
 .context-info .image img,
 .context-info .image a {
   display: block;
+  width: 100%;
+  height: 100%;
   border-radius: 4px;
 }
 .context-info p {

--- a/ckan/public/base/css/green.css
+++ b/ckan/public/base/css/green.css
@@ -9109,6 +9109,8 @@ h4 small {
 .context-info .image img,
 .context-info .image a {
   display: block;
+  width: 100%;
+  height: 100%;
   border-radius: 4px;
 }
 .context-info p {

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -9109,6 +9109,8 @@ h4 small {
 .context-info .image img,
 .context-info .image a {
   display: block;
+  width: 100%;
+  height: 100%;
   border-radius: 4px;
 }
 .context-info p {

--- a/ckan/public/base/css/maroon.css
+++ b/ckan/public/base/css/maroon.css
@@ -9109,6 +9109,8 @@ h4 small {
 .context-info .image img,
 .context-info .image a {
   display: block;
+  width: 100%;
+  height: 100%;
   border-radius: 4px;
 }
 .context-info p {

--- a/ckan/public/base/css/red.css
+++ b/ckan/public/base/css/red.css
@@ -9109,6 +9109,8 @@ h4 small {
 .context-info .image img,
 .context-info .image a {
   display: block;
+  width: 100%;
+  height: 100%;
   border-radius: 4px;
 }
 .context-info p {

--- a/ckan/public/base/less/layout.less
+++ b/ckan/public/base/less/layout.less
@@ -205,6 +205,8 @@
         img,
         a {
             display: block;
+            width: 100%;
+            height: 100%;
             .border-radius(4px);
         }
     }


### PR DESCRIPTION
The image that shows up in the left sidebar in organizations/groups/user profiles is not properly scaled to the available space.

Here are 2 screenshots the demonstrate the issue. The first one is taken on a smaller size screen and the second on a bigger size screen.

![screenshot from 2017-07-16 18-03-08](https://user-images.githubusercontent.com/520213/28249178-30b1c716-6a51-11e7-9a4b-0d3529de1677.png)

![screenshot from 2017-07-16 18-03-20](https://user-images.githubusercontent.com/520213/28249205-36d8c48c-6a51-11e7-8beb-5c65e52d14ae.png)

This PR will change it to use responsive size of the image so that it scales nicely to whatever browser size.
