### PR TITLE
Add space between icon and text in buttons in image upload module

### DIFF
--- a/ckan/public-bs2/base/css/fuchsia.css
+++ b/ckan/public-bs2/base/css/fuchsia.css
@@ -7951,6 +7951,11 @@ h4 small {
   width: 14px;
   margin-top: 1px;
 }
+.nav-tabs .fa:last-child,
+.module-heading .fa:last-child,
+.btn .fa:last-child {
+  margin-right: 3px;
+}
 .wrapper {
   *zoom: 1;
   background-color: #FFF;

--- a/ckan/public-bs2/base/css/green.css
+++ b/ckan/public-bs2/base/css/green.css
@@ -7951,6 +7951,11 @@ h4 small {
   width: 14px;
   margin-top: 1px;
 }
+.nav-tabs .fa:last-child,
+.module-heading .fa:last-child,
+.btn .fa:last-child {
+  margin-right: 3px;
+}
 .wrapper {
   *zoom: 1;
   background-color: #FFF;

--- a/ckan/public-bs2/base/css/main.css
+++ b/ckan/public-bs2/base/css/main.css
@@ -7951,6 +7951,11 @@ h4 small {
   width: 14px;
   margin-top: 1px;
 }
+.nav-tabs .fa:last-child,
+.module-heading .fa:last-child,
+.btn .fa:last-child {
+  margin-right: 3px;
+}
 .wrapper {
   *zoom: 1;
   background-color: #FFF;

--- a/ckan/public-bs2/base/css/maroon.css
+++ b/ckan/public-bs2/base/css/maroon.css
@@ -7951,6 +7951,11 @@ h4 small {
   width: 14px;
   margin-top: 1px;
 }
+.nav-tabs .fa:last-child,
+.module-heading .fa:last-child,
+.btn .fa:last-child {
+  margin-right: 3px;
+}
 .wrapper {
   *zoom: 1;
   background-color: #FFF;

--- a/ckan/public-bs2/base/css/red.css
+++ b/ckan/public-bs2/base/css/red.css
@@ -7951,6 +7951,11 @@ h4 small {
   width: 14px;
   margin-top: 1px;
 }
+.nav-tabs .fa:last-child,
+.module-heading .fa:last-child,
+.btn .fa:last-child {
+  margin-right: 3px;
+}
 .wrapper {
   *zoom: 1;
   background-color: #FFF;

--- a/ckan/public-bs2/base/less/icons.less
+++ b/ckan/public-bs2/base/less/icons.less
@@ -194,3 +194,13 @@
     margin-top: 1px;
   }
 }
+
+.nav-tabs,
+.module-heading,
+.btn {
+  .fa {
+    &:last-child {
+      margin-right: 3px;
+    }
+  }
+}


### PR DESCRIPTION
_Issue appears only in master._

When Font Awesome got updated to v4 in the Bootstrap 3 migration PR, there was no space between the icon and the text in buttons in the image upload module. This was fixed in Bootstrap 3 mode, but it wasn't in Bootstrap 2 mode.

The following screenshot illustrates that.

![screenshot from 2017-07-16 18-28-13](https://user-images.githubusercontent.com/520213/28249351-8ca6e954-6a54-11e7-8ebf-d918f7b92f0d.png)
