### PR TITLE
Fix dataset count display for groups

### DIFF
--- a/ckan/templates/group/snippets/group_item.html
+++ b/ckan/templates/group/snippets/group_item.html
@@ -28,9 +28,9 @@ Example:
     {% endif %}
   {% endblock %}
   {% block datasets %}
-    {% if group.packages %}
-      <strong class="count">{{ ungettext('{num} Dataset', '{num} Datasets', group.packages).format(num=group.packages) }}</strong>
-    {% elif group.packages == 0 %}
+    {% if group.package_count %}
+      <strong class="count">{{ ungettext('{num} Dataset', '{num} Datasets', group.package_count).format(num=group.package_count) }}</strong>
+    {% elif group.package_count == 0 %}
       <span class="count">{{ _('0 Datasets') }}</span>
     {% endif %}
   {% endblock %}


### PR DESCRIPTION
Dataset counts were not displayed at all for group items.
The template never actually rendered  'X Datasets' or '0 Datasets'
because the template checked `packages` rather than `package_count`.

### Proposed fixes:

Check `package_count` to get the dataset count.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
