### PR TITLE
Avoid _latest_release.rst confusion

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,1 +1,2 @@
 _substitutions.rst
+_latest_release.rst


### PR DESCRIPTION
_latest_release.rst was generated until recently, when it was [renamed](https://github.com/ckan/ckan/commit/f14bdd605bdc8b4d61ec2c54688c1eb3c980f7b4
) to _substitution.rst. However since the .gitignore was updated, anyone with the existing file are going to wonder why git says _latest_release.rst needs checking in. It's likely to confuse devs and there's a chance it will be checked in by mistake, so I'm adding it back to the .gitignore. 
