### PR TITLE
add `postgres` alias for pg backend

### DIFF
--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -61,6 +61,7 @@ class DatastorePlugin(p.SingletonPlugin):
     def register_backends(self):
         return {
             'postgresql': DatastorePostgresqlBackend,
+            'postgres': DatastorePostgresqlBackend,
         }
 
     # IConfigurer


### PR DESCRIPTION
As suggested by @mattfullerton , added alias `postgres` for `postgresql` backend