### PR TITLE
Add new background job system to changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Major:
  * Datastore dump more formats: CSV, TSV, XML, JSON; BOM option (`#3390 <https://github.com/ckan/ckan/pull/3390>`_)
  * Common requests code for Flask and Pylons (`#3212 <https://github.com/ckan/ckan/pull/3212>`_)
  * Generate complete datastore dump files (`#3344 <https://github.com/ckan/ckan/pull/3344>`_)
+ * A new system for asynchronous background jobs (`#3165 <https://github.com/ckan/ckan/pull/3165>`_). The old Celery-based system is still available but deprecated. Please refer to the `documentation <http://docs.ckan.org/en/ckan-2.7.0/maintaining/background-tasks.html>`_ for details.
 
 Minor:
  * Renamed example theme plugin (`#3576 <https://github.com/ckan/ckan/pull/3576>`_)


### PR DESCRIPTION
Small PR to add the new background job system to the changelog in preparation for the 2.7 release (#3623).

I'm not sure how the changelog is managed, feel free to decline this PR if the changelog is updated in another way.

I've included a link to the documentation of the new system in the changelog. The link refers to a fixed version (2.7.0) which is not available yet but will work once 2.7.0 is on ReadTheDocs.