### PR TITLE
Port fixes and features in Bootstrap 2 mode

### DIFF
--- a/ckan/public-bs2/base/css/fuchsia.css
+++ b/ckan/public-bs2/base/css/fuchsia.css
@@ -6361,7 +6361,7 @@ textarea {
 }
 @media (min-width: 980px) {
   .form-horizontal .info-block {
-    padding: 0 0 6px 25px;
+    padding: 6px 0 6px 0;
   }
   .form-horizontal .info-inline {
     float: right;

--- a/ckan/public-bs2/base/css/fuchsia.css
+++ b/ckan/public-bs2/base/css/fuchsia.css
@@ -7273,7 +7273,7 @@ textarea {
   display: block;
   position: absolute;
   top: 50%;
-  margin-top: -10px;
+  margin-top: 1px;
   right: 10px;
   height: 20px;
   padding: 0;

--- a/ckan/public-bs2/base/css/green.css
+++ b/ckan/public-bs2/base/css/green.css
@@ -6361,7 +6361,7 @@ textarea {
 }
 @media (min-width: 980px) {
   .form-horizontal .info-block {
-    padding: 0 0 6px 25px;
+    padding: 6px 0 6px 0;
   }
   .form-horizontal .info-inline {
     float: right;

--- a/ckan/public-bs2/base/css/green.css
+++ b/ckan/public-bs2/base/css/green.css
@@ -7273,7 +7273,7 @@ textarea {
   display: block;
   position: absolute;
   top: 50%;
-  margin-top: -10px;
+  margin-top: 1px;
   right: 10px;
   height: 20px;
   padding: 0;

--- a/ckan/public-bs2/base/css/main.css
+++ b/ckan/public-bs2/base/css/main.css
@@ -6361,7 +6361,7 @@ textarea {
 }
 @media (min-width: 980px) {
   .form-horizontal .info-block {
-    padding: 0 0 6px 25px;
+    padding: 6px 0 6px 0;
   }
   .form-horizontal .info-inline {
     float: right;

--- a/ckan/public-bs2/base/css/main.css
+++ b/ckan/public-bs2/base/css/main.css
@@ -7273,7 +7273,7 @@ textarea {
   display: block;
   position: absolute;
   top: 50%;
-  margin-top: -10px;
+  margin-top: 1px;
   right: 10px;
   height: 20px;
   padding: 0;

--- a/ckan/public-bs2/base/css/maroon.css
+++ b/ckan/public-bs2/base/css/maroon.css
@@ -6361,7 +6361,7 @@ textarea {
 }
 @media (min-width: 980px) {
   .form-horizontal .info-block {
-    padding: 0 0 6px 25px;
+    padding: 6px 0 6px 0;
   }
   .form-horizontal .info-inline {
     float: right;

--- a/ckan/public-bs2/base/css/maroon.css
+++ b/ckan/public-bs2/base/css/maroon.css
@@ -7273,7 +7273,7 @@ textarea {
   display: block;
   position: absolute;
   top: 50%;
-  margin-top: -10px;
+  margin-top: 1px;
   right: 10px;
   height: 20px;
   padding: 0;

--- a/ckan/public-bs2/base/css/red.css
+++ b/ckan/public-bs2/base/css/red.css
@@ -6361,7 +6361,7 @@ textarea {
 }
 @media (min-width: 980px) {
   .form-horizontal .info-block {
-    padding: 0 0 6px 25px;
+    padding: 6px 0 6px 0;
   }
   .form-horizontal .info-inline {
     float: right;

--- a/ckan/public-bs2/base/css/red.css
+++ b/ckan/public-bs2/base/css/red.css
@@ -7273,7 +7273,7 @@ textarea {
   display: block;
   position: absolute;
   top: 50%;
-  margin-top: -10px;
+  margin-top: 1px;
   right: 10px;
   height: 20px;
   padding: 0;

--- a/ckan/public-bs2/base/javascript/modules/autocomplete.js
+++ b/ckan/public-bs2/base/javascript/modules/autocomplete.js
@@ -24,7 +24,7 @@ this.ckan.module('autocomplete', function (jQuery) {
       label: false,
       items: 10,
       source: null,
-      interval: 1000,
+      interval: 300,
       dropdownClass: '',
       containerClass: ''
     },

--- a/ckan/public-bs2/base/javascript/modules/follow.js
+++ b/ckan/public-bs2/base/javascript/modules/follow.js
@@ -2,7 +2,7 @@
  * Handles calling the API to follow the current user
  *
  * action - This being the action that the button should perform. Currently: "follow" or "unfollow"
- * type - The being the type of object the user is trying to support. Currently: "user" or "group"
+ * type - The being the type of object the user is trying to support. Currently: "user", "group" or "dataset"
  * id - id of the objec the user is trying to follow
  * loading - State management helper
  *
@@ -62,6 +62,7 @@ this.ckan.module('follow', function($) {
 		_onClickLoaded: function(json) {
 			var options = this.options;
 			var sandbox = this.sandbox;
+			var oldAction = options.action;
 			options.loading = false;
 			this.el.removeClass('disabled');
 			if (options.action == 'follow') {
@@ -71,7 +72,7 @@ this.ckan.module('follow', function($) {
 				options.action = 'follow';
 				this.el.html('<i class="fa fa-plus-circle"></i> ' + this._('Follow')).removeClass('btn-danger').addClass('btn-success');
 			}
-			sandbox.publish('follow-' + options.action + '-' + options.id);
+			sandbox.publish('follow-' + oldAction + '-' + options.id);
 		}
 	};
 });

--- a/ckan/public-bs2/base/javascript/modules/followers-counter.js
+++ b/ckan/public-bs2/base/javascript/modules/followers-counter.js
@@ -1,0 +1,91 @@
+/* Updates the Followers counter in the UI when the Follow/Unfollow button
+* is clicked.
+*
+* id - id of the object the user is trying to follow/unfollow.
+* num_followers - Number of followers the object has.
+*
+* Example
+*
+*   <dd data-module="followers-counter"
+*       data-module-id="object-id"
+*       data-module-num_followers="6">
+*     <span>6</span>
+*   </dd>
+*
+*/
+this.ckan.module('followers-counter', function($) {
+  'use strict';
+
+  return {
+    options: {
+      id: null,
+      num_followers: 0
+    },
+
+    /* Subscribe to events when the Follow/Unfollow button is clicked.
+    *
+    * Returns nothing.
+    */
+    initialize: function() {
+      $.proxyAll(this, /_on/);
+
+      this.counterEl = this.$('span');
+      this.objId = this.options.id;
+
+      this.sandbox.subscribe('follow-follow-' + this.objId, this._onFollow);
+      this.sandbox.subscribe('follow-unfollow-' + this.objId, this._onUnfollow);
+    },
+
+    /* Calls a function to update the counter when the Follow button is clicked.
+    *
+    * Returns nothing.
+    */
+    _onFollow: function() {
+      this._updateCounter({action: 'follow'});
+    },
+
+    /* Calls a function to update the counter when the Unfollow button is clicked.
+    *
+    * Returns nothing.
+    */
+    _onUnfollow: function() {
+      this._updateCounter({action: 'unfollow'});
+    },
+
+    /* Handles updating the UI for Followers counter.
+    *
+    * Returns nothing.
+    */
+    _updateCounter: function(options) {
+      var locale = $('html').attr('lang');
+      var action = options.action;
+      var incrementedFollowers;
+
+      if (action === 'follow') {
+        incrementedFollowers = (++this.options.num_followers).toLocaleString(locale);
+      } else if (action === 'unfollow') {
+        incrementedFollowers = (--this.options.num_followers).toLocaleString(locale);
+      }
+
+      // Only update the value if it's less than 1000, because for larger
+      // numbers the change won't be noticeable since the value is converted
+      // to SI number abbreviated with "k", "m" and so on.
+      if (this.options.num_followers < 1000) {
+        this.counterEl.text(incrementedFollowers);
+        this.counterEl.removeAttr('title');
+      } else {
+        this.counterEl.attr('title', incrementedFollowers);
+      }
+    },
+
+    /* Remove any subscriptions to prevent memory leaks. This function is
+     * called when a module element is removed from the page.
+     *
+     * Returns nothing.
+     */
+    teardown: function() {
+      this.sandbox.unsubscribe('follow-follow-' + this.objId, this._onFollow);
+      this.sandbox.unsubscribe('follow-unfollow-' + this.objId, this._onUnfollow);
+    }
+  }
+});

--- a/ckan/public-bs2/base/javascript/modules/image-upload.js
+++ b/ckan/public-bs2/base/javascript/modules/image-upload.js
@@ -129,6 +129,11 @@ this.ckan.module('image-upload', function($) {
      * Returns String.
      */
     _fileNameFromUpload: function(url) {
+      // If it's a local CKAN image return the entire URL.
+      if (/^\/base\/images/.test(url)) {
+        return url;
+      }
+
       // remove fragment (#)
       url = url.substring(0, (url.indexOf("#") === -1) ? url.length : url.indexOf("#"));
       // remove query string

--- a/ckan/public-bs2/base/javascript/modules/resource-reorder.js
+++ b/ckan/public-bs2/base/javascript/modules/resource-reorder.js
@@ -38,7 +38,7 @@ this.ckan.module('resource-reorder', function($) {
     initialize: function() {
       jQuery.proxyAll(this, /_on/);
 
-      var labelText = this._(this.labelText);
+      var labelText = this._(this.options.labelText);
 
       this.html_title = $(this.template.title)
         .text(labelText)

--- a/ckan/public-bs2/base/javascript/modules/resource-view-filters.js
+++ b/ckan/public-bs2/base/javascript/modules/resource-view-filters.js
@@ -6,7 +6,7 @@ this.ckan.module('resource-view-filters', function (jQuery) {
         resourceId = self.options.resourceId,
         fields = self.options.fields,
         dropdownTemplate = self.options.dropdownTemplate,
-        addFilterTemplate = '<a href="#">' + self._('Add Filter') + '</a>',
+        addFilterTemplate = '<a class="btn btn-primary" href="#">' + self._('Add Filter') + '</a>',
         filtersDiv = $('<div></div>');
 
     var filters = ckan.views.filters.get();

--- a/ckan/public-bs2/base/javascript/modules/resource-view-filters.js
+++ b/ckan/public-bs2/base/javascript/modules/resource-view-filters.js
@@ -11,7 +11,8 @@ this.ckan.module('resource-view-filters', function (jQuery) {
 
     var filters = ckan.views.filters.get();
     _appendDropdowns(filtersDiv, resourceId, dropdownTemplate, fields, filters);
-    var addFilterButton = _buildAddFilterButton(filtersDiv, addFilterTemplate, fields, filters, function (evt) {
+    var addFilterButton = _buildAddFilterButton(self, filtersDiv, addFilterTemplate,
+                                                fields, filters, function (evt) {
       // Build filters object with this element's val as key and a placeholder
       // value so _appendDropdowns() will create its dropdown
       var filters = {};
@@ -25,9 +26,8 @@ this.ckan.module('resource-view-filters', function (jQuery) {
     self.el.append(addFilterButton);
   }
 
-  function _buildAddFilterButton(el, template, fields, filters, onChangeCallback) {
-    var self = this,
-        addFilterButton = $(template),
+  function _buildAddFilterButton(self, el, template, fields, filters, onChangeCallback) {
+    var addFilterButton = $(template),
         currentFilters = Object.keys(filters),
         fieldsNotFiltered = $.grep(fields, function (field) {
           return !filters.hasOwnProperty(field);

--- a/ckan/public-bs2/base/javascript/modules/slug-preview.js
+++ b/ckan/public-bs2/base/javascript/modules/slug-preview.js
@@ -18,7 +18,7 @@ this.ckan.module('slug-preview-target', {
 
       // Watch for updates to the target field and update the hidden slug field
       // triggering the "change" event manually.
-      el.on('keyup.slug-preview', function (event) {
+      el.on('keyup.slug-preview input.slug-preview', function (event) {
         sandbox.publish('slug-target-changed', this.value);
         //slug.val(this.value).trigger('change');
       });

--- a/ckan/public-bs2/base/javascript/plugins/jquery.url-helpers.js
+++ b/ckan/public-bs2/base/javascript/plugins/jquery.url-helpers.js
@@ -119,14 +119,14 @@
       '4f0 4f1 4f2 4f3 4f4 4f5 4f6 4f7 4f8 4f9 4fa 4fb 4fc 4fd 4fe 4ff ' +
       '50a 50b 50c 50d 50e 50f 51a 51b 51c 51d 53a 53b 53c 53d 53e 53f ' +
       '54a 54b 54c 54d 54e 54f 56a 56b 56c 56d 56e 56f 57a 57b 57c 57d ' +
-      '57e 57f').split(' ');
+      '57e 57f 5f').split(' ');
 
   var replacement = ('- 0 1 2 3 4 5 6 7 8 9 A B C D E F G H I P Q R S T ' +
       'U V W X Y a b c d e f g h i p q r s t u v w x y A a A a A a C c C c ' +
       'D d E e E e E e E e G g G g H h H h I i I i IJ ij J j K k k L l L l ' +
       'N n N n N n n O o OE oe R r R r R r S s T t T t T t U u U u U u W w ' +
-      'Y y Y Z b B b b b b C C c D E F f G Y h i I K k A a A a E e E e I i ' + 
-      'R r R r U u U u S s n d 8 8 Z z A a E e O o Y y l n t j db qp < ? ? ' + 
+      'Y y Y Z b B b b b b C C c D E F f G Y h i I K k A a A a E e E e I i ' +
+      'R r R r U u U u S s n d 8 8 Z z A a E e O o Y y l n t j db qp < ? ? ' +
       'B U A E e J j a a a b c e d d e e g g g Y x u h h i i w m n n N o oe ' +
       'm o r R R S f f f f t t u Z Z 3 3 ? ? 5 C O B a e i o u c d A ' +
       'E H i A B r A E Z H O I E E T r E S I I J jb A B B r D E X 3 N N P ' +
@@ -154,7 +154,7 @@
       'h H h E e E e I X x K k jt jt H h H h H h M m l A a A a AE ae E e ' +
       'e e E e X X 3 3 3 3 N n N n O o O o O o E e Y y Y y Y y H h R r bI ' +
       'bi F f X x X x H h G g T t Q q W w d r L Iu O y m o N U Y S d h l ' +
-      'lu d y w 2 n u y un').split(' ');
+      'lu d y w 2 n u y un _').split(' ');
 
   // Map the Unicode characters to their counterparts in an object.
   var map = {};

--- a/ckan/public-bs2/base/javascript/resource.config
+++ b/ckan/public-bs2/base/javascript/resource.config
@@ -44,6 +44,7 @@ ckan =
     modules/dataset-visibility.js
     modules/media-grid.js
     modules/image-upload.js
+    modules/followers-counter.js
 
 main =
     apply_html_class

--- a/ckan/public-bs2/base/less/forms.less
+++ b/ckan/public-bs2/base/less/forms.less
@@ -170,7 +170,7 @@ textarea {
 
 @media (min-width: 980px) {
   .form-horizontal .info-block {
-    padding: 0 0 6px 25px;
+    padding: 6px 0 6px 0;
   }
   .form-horizontal .info-inline {
     float: right;

--- a/ckan/public-bs2/base/less/search.less
+++ b/ckan/public-bs2/base/less/search.less
@@ -19,7 +19,7 @@
       display: block;
       position: absolute;
       top: 50%;
-      margin-top: -10px;
+      margin-top: 1px;
       right: 10px;
       height: 20px;
       padding: 0;

--- a/ckan/public-bs2/base/test/index.html
+++ b/ckan/public-bs2/base/test/index.html
@@ -49,6 +49,7 @@
     <script src="../javascript/modules/image-upload.js"></script>
     <script src="../javascript/modules/confirm-action.js"></script>
     <script src="../javascript/modules/custom-fields.js"></script>
+    <script src="../javascript/modules/followers-counter.js"></script>
 
     <!-- Suite -->
     <script src="./spec/ckan.spec.js"></script>
@@ -66,6 +67,7 @@
     <script src="./spec/modules/basic-form.spec.js"></script>
     <script src="./spec/modules/autocomplete.spec.js"></script>
     <script src="./spec/modules/custom-fields.spec.js"></script>
+    <script src="./spec/modules/followers-counter.spec.js"></script>
     <script src="./spec/plugins/jquery.inherit.spec.js"></script>
     <script src="./spec/plugins/jquery.proxy-all.spec.js"></script>
     <script src="./spec/plugins/jquery.url-helpers.spec.js"></script>

--- a/ckan/public-bs2/base/test/spec/modules/followers-counter.spec.js
+++ b/ckan/public-bs2/base/test/spec/modules/followers-counter.spec.js
@@ -1,0 +1,186 @@
+/*globals describe beforeEach afterEach it assert sinon ckan jQuery */
+describe('ckan.module.FollowersCounterModule()', function() {
+    var FollowersCounterModule = ckan.module.registry['followers-counter'];
+
+    beforeEach(function() {
+      this.initialCounter = 10;
+      this.el = jQuery('<dd><span>' + this.initialCounter + '</span></dd>');
+      this.sandbox = ckan.sandbox();
+      this.module = new FollowersCounterModule(this.el, {}, this.sandbox);
+      this.module.options.num_followers = this.initialCounter;
+    });
+
+    afterEach(function() {
+      this.module.teardown();
+    });
+
+    describe('.initialize()', function() {
+      it('should bind callback methods to the module', function() {
+        var target = sinon.stub(jQuery, 'proxyAll');
+
+        this.module.initialize();
+
+        assert.called(target);
+        assert.calledWith(target, this.module, /_on/);
+
+        target.restore();
+      });
+
+      it('should subscribe to the "follow-follow-some-id" event', function() {
+        var target = sinon.stub(this.sandbox, 'subscribe');
+
+        this.module.options = {id: 'some-id'};
+        this.module.initialize();
+
+        assert.called(target);
+        assert.calledWith(target, 'follow-follow-some-id', this.module._onFollow);
+
+        target.restore();
+      });
+
+      it('should subscribe to the "follow-unfollow-some-id" event', function() {
+        var target = sinon.stub(this.sandbox, 'subscribe');
+
+        this.module.options = {id: 'some-id'};
+        this.module.initialize();
+
+        assert.called(target);
+        assert.calledWith(target, 'follow-unfollow-some-id', this.module._onUnfollow);
+
+        target.restore();
+      });
+    });
+
+    describe('.teardown()', function() {
+      it('should unsubscribe to the "follow-follow-some-id" event', function() {
+        var target = sinon.stub(this.sandbox, 'unsubscribe');
+
+        this.module.options = {id: 'some-id'};
+        this.module.initialize();
+        this.module.teardown();
+
+        assert.called(target);
+        assert.calledWith(target, 'follow-follow-some-id', this.module._onFollow);
+
+        target.restore();
+      });
+
+      it('should unsubscribe to the "follow-unfollow-some-id" event', function() {
+        var target = sinon.stub(this.sandbox, 'unsubscribe');
+
+        this.module.options = {id: 'some-id'};
+        this.module.initialize();
+        this.module.teardown();
+
+        assert.called(target);
+        assert.calledWith(target, 'follow-unfollow-some-id', this.module._onUnfollow);
+
+        target.restore();
+      });
+    });
+
+    describe('._onFollow', function() {
+      it('should call _onFollow on "follow-follow-some-id" event', function() {
+        var target = sinon.stub(this.module, '_onFollow');
+
+        this.module.options = {id: 'some-id'};
+        this.module.initialize();
+
+        this.sandbox.publish('follow-follow-some-id');
+
+        assert.called(target);
+      });
+
+      it('should call _updateCounter when ._onFollow is called', function() {
+        var target = sinon.stub(this.module, '_updateCounter');
+
+        this.module.options = {id: 'some-id'};
+        this.module.initialize();
+
+        this.module._onFollow();
+
+        assert.called(target);
+        assert.calledWith(target, {action: 'follow'});
+      });
+    });
+
+    describe('._onUnfollow', function() {
+      it('should call _onUnfollow on "follow-unfollow-some-id" event', function() {
+        var target = sinon.stub(this.module, '_onUnfollow');
+
+        this.module.options = {id: 'some-id'};
+        this.module.initialize();
+
+        this.sandbox.publish('follow-unfollow-some-id');
+
+        assert.called(target);
+      });
+
+      it('should call _updateCounter when ._onUnfollow is called', function() {
+        var target = sinon.stub(this.module, '_updateCounter');
+
+        this.module.options = {id: 'some-id'};
+        this.module.initialize();
+
+        this.module._onUnfollow();
+
+        assert.called(target);
+        assert.calledWith(target, {action: 'unfollow'});
+      });
+    });
+
+    describe('._updateCounter', function() {
+      it('should increment this.options.num_followers on calling _onFollow', function() {
+        this.module.initialize();
+        this.module._onFollow();
+
+        assert.equal(this.module.options.num_followers, ++this.initialCounter);
+      });
+
+      it('should increment the counter value in the DOM on calling _onFollow', function() {
+        var counterVal;
+
+        this.module.initialize();
+        this.module._onFollow();
+
+        counterVal = this.module.counterEl.text();
+        counterVal = parseInt(counterVal, 10);
+
+        assert.equal(counterVal, ++this.initialCounter);
+      });
+
+      it('should decrement this.options.num_followers on calling _onUnfollow', function() {
+        this.module.initialize();
+        this.module._onUnfollow();
+
+        assert.equal(this.module.options.num_followers, --this.initialCounter);
+      });
+
+      it('should decrement the counter value in the DOM on calling _onUnfollow', function() {
+        var counterVal;
+
+        this.module.initialize();
+        this.module._onUnfollow();
+
+        counterVal = this.module.counterEl.text();
+        counterVal = parseInt(counterVal, 10);
+
+        assert.equal(counterVal, --this.initialCounter);
+      });
+
+      it('should not change the counter value in the DOM when the value is greater than 1000', function() {
+        var beforeCounterVal = 1536;
+        var afterCounterVal;
+
+        this.module.options = {num_followers: beforeCounterVal};
+        this.module.initialize();
+        this.module.counterEl.text(this.module.options.num_followers);
+        this.module._onFollow();
+
+        afterCounterVal = this.module.counterEl.text();
+        afterCounterVal = parseInt(afterCounterVal, 10);
+
+        assert.equal(beforeCounterVal, afterCounterVal);
+      });
+    });
+  });

--- a/ckan/public-bs2/base/test/spec/plugins/jquery.url-helpers.spec.js
+++ b/ckan/public-bs2/base/test/spec/plugins/jquery.url-helpers.spec.js
@@ -43,5 +43,10 @@ describe('jQuery.url', function () {
       var target = jQuery.url.slugify('éåøç');
       assert.equal(target, 'eaoc');
     });
+
+    it('should allow underscore characters', function() {
+      var target = jQuery.url.slugify('apples_pears');
+      assert.equal(target, 'apples_pears');
+    });
   });
 });

--- a/ckan/templates-bs2/group/read.html
+++ b/ckan/templates-bs2/group/read.html
@@ -32,7 +32,12 @@
 
 {% block secondary_content %}
   {{ super() }}
-  {% for facet in c.facet_titles %}
-    {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id':c.group_dict.id}) }}
-  {% endfor %}
+  <div class="filters">
+    <div>
+      {% for facet in c.facet_titles %}
+        {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id':c.group_dict.id}) }}
+      {% endfor %}
+    </div>
+    <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span class="text">close</span></a>
+  </div>
 {% endblock %}

--- a/ckan/templates-bs2/group/snippets/group_item.html
+++ b/ckan/templates-bs2/group/snippets/group_item.html
@@ -28,9 +28,9 @@ Example:
     {% endif %}
   {% endblock %}
   {% block datasets %}
-    {% if group.packages %}
-      <strong class="count">{{ ungettext('{num} Dataset', '{num} Datasets', group.packages).format(num=group.packages) }}</strong>
-    {% elif group.packages == 0 %}
+    {% if group.package_count %}
+      <strong class="count">{{ ungettext('{num} Dataset', '{num} Datasets', group.package_count).format(num=group.package_count) }}</strong>
+    {% elif group.package_count == 0 %}
       <span class="count">{{ _('0 Datasets') }}</span>
     {% endif %}
   {% endblock %}

--- a/ckan/templates-bs2/group/snippets/info.html
+++ b/ckan/templates-bs2/group/snippets/info.html
@@ -30,7 +30,7 @@
       <div class="nums">
         <dl>
           <dt>{{ _('Followers') }}</dt>
-          <dd>{{ h.SI_number_span(group.num_followers) }}</dd>
+          <dd data-module="followers-counter" data-module-id="{{ group.id }}" data-module-num_followers="{{ group.num_followers }}">{{ h.SI_number_span(group.num_followers) }}</dd>
         </dl>
         <dl>
           <dt>{{ _('Datasets') }}</dt>

--- a/ckan/templates-bs2/macros/form.html
+++ b/ckan/templates-bs2/macros/form.html
@@ -118,7 +118,7 @@ Examples:
 {% macro markdown(name, id='', label='', value='', placeholder='', error="", classes=[], attrs={}, is_required=false) %}
   {% set classes = (classes|list) %}
   {% do classes.append('control-full') %}
-  {% set markdown_tooltip = "<pre><p>__Bold text__ or _italic text_</p><p># title<br>## secondary title<br>### etc</p><p>* list<br>* of<br>* items</p><p>http://auto.link.ed/</p></pre><p><b><a href='http://daringfireball.net/projects/markdown/syntax' target='_blank'>Full markdown syntax</a></b></p><p class='muted'><b>Please note:</b> HTML tags are stripped out for security reasons</p>" %} 
+  {% set markdown_tooltip = "<pre><p>__Bold text__ or _italic text_</p><p># title<br>## secondary title<br>### etc</p><p>* list<br>* of<br>* items</p><p>http://auto.link.ed/</p></pre><p><b><a href='http://daringfireball.net/projects/markdown/syntax' target='_blank'>Full markdown syntax</a></b></p><p class='muted'><b>Please note:</b> HTML tags are stripped out for security reasons</p>" %}
 
   {%- set extra_html = caller() if caller -%}
   {% call input_block(id or name, label or name, error, classes, control_classes=["editor"], extra_html=extra_html, is_required=is_required) %}
@@ -406,14 +406,14 @@ Example
 #}
 {% macro image_upload(data, errors, field_url='image_url', field_upload='image_upload', field_clear='clear_upload',
                       is_url=false, is_upload=false, is_upload_enabled=false, placeholder=false,
-                      url_label='', upload_label='')  %}
+                      url_label='', upload_label='', field_name='image_url')  %}
   {% set placeholder = placeholder if placeholder else _('http://example.com/my-image.jpg') %}
   {% set url_label = url_label or _('Image URL')  %}
   {% set upload_label = upload_label or _('Image')  %}
 
   {% if is_upload_enabled %}
   <div class="image-upload" data-module="image-upload" data-module-is_url="{{ 'true' if is_url else 'false' }}" data-module-is_upload="{{ 'true' if is_upload else 'false' }}"
-       data-module-field_url="{{ field_url }}" data-module-field_upload="{{ field_upload }}" data-module-field_clear="{{ field_clear }}" data-module-upload_label="{{ upload_label }}">
+       data-module-field_url="{{ field_url }}" data-module-field_upload="{{ field_upload }}" data-module-field_clear="{{ field_clear }}" data-module-upload_label="{{ upload_label }}" data-module-field_name="{{ field_name }}">
   {% endif %}
 
   {{ input(field_url, label=url_label, id='field-image-url', placeholder=placeholder, value=data.get(field_url), error=errors.get(field_url), classes=['control-full']) }}

--- a/ckan/templates-bs2/macros/form.html
+++ b/ckan/templates-bs2/macros/form.html
@@ -416,7 +416,7 @@ Example
        data-module-field_url="{{ field_url }}" data-module-field_upload="{{ field_upload }}" data-module-field_clear="{{ field_clear }}" data-module-upload_label="{{ upload_label }}" data-module-field_name="{{ field_name }}">
   {% endif %}
 
-  {{ input(field_url, label=url_label, id='field-image-url', placeholder=placeholder, value=data.get(field_url), error=errors.get(field_url), classes=['control-full']) }}
+  {{ input(field_url, label=url_label, id='field-image-url', type='url', placeholder=placeholder, value=data.get(field_url), error=errors.get(field_url), classes=['control-full']) }}
 
   {% if is_upload_enabled %}
     {{ input(field_upload, label=upload_label, id='field-image-upload', type='file', placeholder='', value='', error='', classes=['control-full']) }}

--- a/ckan/templates-bs2/organization/read.html
+++ b/ckan/templates-bs2/organization/read.html
@@ -35,7 +35,12 @@
 {% endblock %}
 
 {% block organization_facets %}
-  {% for facet in c.facet_titles %}
-    {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id':c.group_dict.id}) }}
-  {% endfor %}
+  <div class="filters">
+    <div>
+      {% for facet in c.facet_titles %}
+        {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id':c.group_dict.id}) }}
+      {% endfor %}
+    </div>
+    <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span class="text">close</span></a>
+  </div>
 {% endblock %}

--- a/ckan/templates-bs2/package/snippets/info.html
+++ b/ckan/templates-bs2/package/snippets/info.html
@@ -18,17 +18,18 @@ Example:
               <h1 class="heading">{{ h.dataset_display_name(pkg) }}</h1>
             {% endblock %}
             {% block nums %}
+              {% set num_followers = h.follow_count('dataset', pkg.id) %}
               <div class="nums">
                 <dl>
                   <dt>{{ _('Followers') }}</dt>
-                  <dd>{{ h.SI_number_span(h.follow_count('dataset', pkg.id)) }}</dd>
+                  <dd data-module="followers-counter" data-module-id="{{ pkg.id }}" data-module-num_followers="{{ num_followers }}">{{ h.SI_number_span(num_followers) }}</dd>
                 </dl>
               </div>
             {% endblock %}
             {% block follow_button %}
               {% if not hide_follow_button %}
                 <div class="follow_button">
-                  {{ h.follow_button('dataset', pkg.name) }}
+                  {{ h.follow_button('dataset', pkg.id) }}
                 </div>
               {% endif %}
             {% endblock %}

--- a/ckan/templates-bs2/package/snippets/resource_form.html
+++ b/ckan/templates-bs2/package/snippets/resource_form.html
@@ -4,7 +4,7 @@
 {% set errors = errors or {} %}
 {% set action = form_action or h.url_for(controller='package', action='new_resource', id=pkg_name) %}
 
-<form id="resource-edit" class="dataset-form dataset-resource-form form-horizontal" method="post" action="{{ action }}" data-module="basic-form resource-form" enctype="multipart/form-data" novalidate>
+<form id="resource-edit" class="dataset-form dataset-resource-form form-horizontal" method="post" action="{{ action }}" data-module="basic-form resource-form" enctype="multipart/form-data">
   {% block stages %}
     {# An empty stages variable will not show the stages #}
     {% if stage %}

--- a/ckan/templates-bs2/snippets/organization.html
+++ b/ckan/templates-bs2/snippets/organization.html
@@ -53,7 +53,7 @@ Example:
         <div class="nums">
           <dl>
             <dt>{{ _('Followers') }}</dt>
-            <dd>{{ h.SI_number_span(organization.num_followers) }}</dd>
+            <dd data-module="followers-counter" data-module-id="{{ organization.id }}" data-module-num_followers="{{ organization.num_followers }}">{{ h.SI_number_span(organization.num_followers) }}</dd>
           </dl>
           <dl>
             <dt>{{ _('Datasets') }}</dt>

--- a/ckan/templates-bs2/user/edit_user_form.html
+++ b/ckan/templates-bs2/user/edit_user_form.html
@@ -5,7 +5,7 @@
 
   <fieldset>
     <legend>{{ _('Change details') }}</legend>
-    {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], is_required=true) }}
+    {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], attrs={'readonly': ''}) }}
 
     {{ form.input('fullname', label=_('Full name'), id='field-fullname', value=data.fullname, error=errors.fullname, placeholder=_('eg. Joe Bloggs'), classes=['control-medium']) }}
 

--- a/ckan/templates-bs2/user/new_user_form.html
+++ b/ckan/templates-bs2/user/new_user_form.html
@@ -2,15 +2,17 @@
 
 <form id="user-register-form" class="form-horizontal" action="" method="post">
   {{ form.errors(error_summary) }}
-  {{ form.input("name", id="field-username", label=_("Username"), placeholder=_("username"), value=data.name, error=errors.name, classes=["control-medium"]) }}
+  {{ form.input("name", id="field-username", label=_("Username"), placeholder=_("username"), value=data.name, error=errors.name, classes=["control-medium"], is_required=True) }}
   {{ form.input("fullname", id="field-fullname", label=_("Full Name"), placeholder=_("Joe Bloggs"), value=data.fullname, error=errors.fullname, classes=["control-medium"]) }}
-  {{ form.input("email", id="field-email", label=_("Email"), type="email", placeholder=_("joe@example.com"), value=data.email, error=errors.email, classes=["control-medium"]) }}
-  {{ form.input("password1", id="field-password", label=_("Password"), type="password", placeholder="••••••••", value=data.password1, error=errors.password1, classes=["control-medium"]) }}
-  {{ form.input("password2", id="field-confirm-password", label=_("Confirm"), type="password", placeholder="••••••••", value=data.password2, error=errors.password1, classes=["control-medium"]) }}
+  {{ form.input("email", id="field-email", label=_("Email"), type="email", placeholder=_("joe@example.com"), value=data.email, error=errors.email, classes=["control-medium"], is_required=True) }}
+  {{ form.input("password1", id="field-password", label=_("Password"), type="password", placeholder="••••••••", value=data.password1, error=errors.password1, classes=["control-medium"], is_required=True) }}
+  {{ form.input("password2", id="field-confirm-password", label=_("Confirm"), type="password", placeholder="••••••••", value=data.password2, error=errors.password1, classes=["control-medium"], is_required=True) }}
 
   {% if g.recaptcha_publickey %}
     {% snippet "user/snippets/recaptcha.html", public_key=g.recaptcha_publickey %}
   {% endif %}
+
+  {{ form.required_message() }}
 
   <div class="form-actions">
     {% block form_actions %}

--- a/ckan/templates-bs2/user/read_base.html
+++ b/ckan/templates-bs2/user/read_base.html
@@ -47,7 +47,7 @@
       <div class="nums">
         <dl>
           <dt>{{ _('Followers') }}</dt>
-          <dd>{{ h.SI_number_span(user.num_followers) }}</dd>
+          <dd data-module="followers-counter" data-module-id="{{ user.id }}" data-module-num_followers="{{ user.num_followers }}">{{ h.SI_number_span(user.num_followers) }}</dd>
         </dl>
         <dl>
           <dt>{{ _('Datasets') }}</dt>


### PR DESCRIPTION
With the migration to Bootstrap 3, two additional folders were created for Bootstrap 2, `public-bs2` and `templates-bs2`. Until that PR was merged into master, some features and fixes that were made during that period, were done in the folders `public` and `templates`. So when the PR for Bootstrap 3 was merged, they are now missing from `public-bs2` and `templates-bs2`. 

This PR ports the following fixes and features that are now in Bootstrap 3 mode, but are missing in Bootstrap 2 mode: #3612, #3617, #3620, #3640, #3657, #3659, #3662, #3664, #3668, #3700, #3710, #3711, #3604, #3531