### PR TITLE
Fix Explore button not working

### DIFF
--- a/ckan/templates-bs2/package/snippets/resource_item.html
+++ b/ckan/templates-bs2/package/snippets/resource_item.html
@@ -18,11 +18,11 @@
   {% block resource_item_explore %}
   {% if not url_is_edit %}
   <div class="dropdown btn-group">
-    <a class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
+    <button class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
       <i class="fa fa-share"></i>
       {{ _('Explore') }}
       <span class="caret"></span>
-    </a>
+    </button>
     <ul class="dropdown-menu">
       {% block resource_item_explore_links %}
       <li>

--- a/ckan/templates-bs2/package/snippets/resource_item.html
+++ b/ckan/templates-bs2/package/snippets/resource_item.html
@@ -18,7 +18,7 @@
   {% block resource_item_explore %}
   {% if not url_is_edit %}
   <div class="dropdown btn-group">
-    <a href="#" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
+    <a class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
       <i class="fa fa-share"></i>
       {{ _('Explore') }}
       <span class="caret"></span>


### PR DESCRIPTION
_Issue appears only in master._

When jQuery was upgraded to v3, the Explore button stopped working in a dataset page.

This PR fixes that.