### PR TITLE
Fix nav toggle icon

### DIFF
--- a/ckan/templates-bs2/header.html
+++ b/ckan/templates-bs2/header.html
@@ -73,9 +73,7 @@
   {% endblock %}
   <div class="container">
     <button data-target=".nav-collapse" data-toggle="collapse" class="btn btn-navbar" type="button">
-      <span class="fa-bar"></span>
-      <span class="fa-bar"></span>
-      <span class="fa-bar"></span>
+      <span class="fa fa-bars"></span>
     </button>
     {# The .header-image class hides the main text and uses image replacement for the title #}
     <hgroup class="{{ g.header_class }} pull-left">


### PR DESCRIPTION
_Issue appears only in master._

On browser viewport smaller than 980px, the icon for the navigation toggle is not shown.

![screenshot from 2017-07-23 17-26-05](https://user-images.githubusercontent.com/520213/28500643-0cfb72f6-6fcc-11e7-8c32-43d84014d798.png)
