### PR TITLE
add vsode folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ fl_notes.txt
 .noseids
 *~
 .idea
+.vscode
 
 # custom style
 ckan/public/base/less/custom.less


### PR DESCRIPTION
As the vscode becames more popular IDE for python development, its good to have its folder to gitignore 
