### PR TITLE
add email validation to default_user_schema

### DIFF
--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -406,7 +406,7 @@ def default_user_schema():
         'password': [user_password_validator, user_password_not_empty,
                      ignore_missing, unicode],
         'password_hash': [ignore_missing, ignore_not_sysadmin, unicode],
-        'email': [not_empty, unicode],
+        'email': [not_empty, unicode, email_validator],
         'about': [ignore_missing, user_about_validator, unicode],
         'created': [ignore],
         'openid': [ignore_missing],


### PR DESCRIPTION
As for PR #3600 and making email required, its good to have validation of the user prompt for the email. In the default_user_schema is added `email_validator` method to check if the entered email is valid and in case of wrong input, adequate message will be displayed 
