### PR TITLE
[#3539] Fix call to pylons.set_lang

### DIFF
--- a/ckan/lib/i18n.py
+++ b/ckan/lib/i18n.py
@@ -225,7 +225,7 @@ def _set_lang(lang):
     if config.get('ckan.i18n_directory'):
         fake_config = {'pylons.paths': {'root': config['ckan.i18n_directory']},
                        'pylons.package': config['pylons.package']}
-        i18n.set_lang(lang, config=fake_config, class_=Translations)
+        i18n.set_lang(lang, pylons_config=fake_config, class_=Translations)
     else:
         i18n.set_lang(lang, class_=Translations)
 


### PR DESCRIPTION
Fixes #3539 

When ckan.i18n_directory was used we were passing the wrong keyword (`config`) instead of `pylons_config`
