### PR TITLE
Backport #3366 for ckan 2.6

### DIFF
--- a/ckan/model/system_info.py
+++ b/ckan/model/system_info.py
@@ -53,11 +53,14 @@ SystemInfoRevision = vdm.sqlalchemy.create_object_version(meta.mapper,
 
 def get_system_info(key, default=None):
     ''' get data from system_info table '''
-    obj = meta.Session.query(SystemInfo).filter_by(key=key).first()
-    if obj:
-        return obj.value
-    else:
-        return default
+    from sqlalchemy.exc import ProgrammingError
+    try:
+        obj = meta.Session.query(SystemInfo).filter_by(key=key).first()
+        if obj:
+            return obj.value
+    except ProgrammingError:
+        meta.Session.rollback()
+    return default
 
 
 def delete_system_info(key, default=None):


### PR DESCRIPTION
Fixes #3366 

### Proposed fixes:
Backports https://github.com/ckan/ckan/pull/3366 to ckan 2.6, ckan 2.7 already has it.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
