### PR TITLE
Add note about CKAN directory and personal repo

### DIFF
--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -106,6 +106,7 @@ b. Install the recommended ``setuptools`` version:
 
 c. Install the CKAN source code into your virtualenv.
    .. important::
+   
        For the following commands, make sure you are in your CKAN default directory. E.g.
     
       .. parsed-literal::

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -105,6 +105,13 @@ b. Install the recommended ``setuptools`` version:
        pip install setuptools==\ |min_setuptools_version|
 
 c. Install the CKAN source code into your virtualenv.
+   .. important::
+       For the following commands, make sure you are in your CKAN default directory. E.g.
+    
+      .. parsed-literal::
+      
+         cd /usr/lib/ckan/default/
+   
    To install the latest stable release of CKAN (CKAN |latest_release_version|),
    run:
 
@@ -120,6 +127,15 @@ c. Install the CKAN source code into your virtualenv.
 
        pip install -e 'git+\ |git_url|\#egg=ckan'
 
+   .. tip::
+      
+      If you would like to work submit a pull request with your changes, be sure you are working from a cloned repository.
+      Use your personal repository URL instead of the CKAN repository. E.g.
+      
+      .. parsed-literal::
+         
+         pip install -e 'git=https://github.com/{your-username}/ckan.git#egg=ckan'
+   
    .. warning::
 
       The development version may contain bugs and should not be used for


### PR DESCRIPTION
In order to help developers set up a CKAN development environment, they need to clone from a personal repository. This will make it easier to open a pull request, for developers who are not part of the CKAN organizaiton.

Also, there was a bit of ambiguity as to where to run the `pip install -e git+CKAN-repo` command. The command should be run from within `/usr/lib/ckan/default` so that subsequent steps work as expected.

Fixes #3736

### Proposed fixes:

Describes a bit better the process for setting up a development environment.

### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
