### PR TITLE
use "select for update" when retrieving package information for resource_create() / resource_update()

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -286,11 +286,9 @@ def resource_create(context, data_dict):
     if not data_dict.get('url'):
         data_dict['url'] = ''
 
-    # lock the package record in the db when selected via package_show()
-    context['for_update'] = True
-
+    # using "for_update" to lock the package record in the db when selected via package_show()
     pkg_dict = _get_action('package_show')(
-        dict(context, return_type='dict'),
+        dict(context, return_type='dict', for_update=True),
         {'id': package_id})
 
     _check_access('resource_create', context, data_dict)
@@ -330,7 +328,6 @@ def resource_create(context, data_dict):
                   uploader.get_max_resource_size())
 
     model.repo.commit()
-    context.pop('for_update')
 
     #  Run package show again to get out actual last_resource
     updated_pkg_dict = _get_action('package_show')(context, {'id': package_id})

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -286,6 +286,9 @@ def resource_create(context, data_dict):
     if not data_dict.get('url'):
         data_dict['url'] = ''
 
+    # lock the package record in the db when selected via package_show()
+    context['for_update'] = True
+
     pkg_dict = _get_action('package_show')(
         dict(context, return_type='dict'),
         {'id': package_id})
@@ -327,6 +330,7 @@ def resource_create(context, data_dict):
                   uploader.get_max_resource_size())
 
     model.repo.commit()
+    context.pop('for_update')
 
     #  Run package show again to get out actual last_resource
     updated_pkg_dict = _get_action('package_show')(context, {'id': package_id})

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -286,7 +286,7 @@ def resource_create(context, data_dict):
     if not data_dict.get('url'):
         data_dict['url'] = ''
 
-    # using "for_update" to lock the package record in the db when selected via package_show()
+    # using "for_update" to lock the package record in the db
     pkg_dict = _get_action('package_show')(
         dict(context, return_type='dict', for_update=True),
         {'id': package_id})

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -973,7 +973,9 @@ def package_show(context, data_dict):
     context['session'] = model.Session
     name_or_id = data_dict.get("id") or _get_or_bust(data_dict, 'name_or_id')
 
-    pkg = model.Package.get(name_or_id)
+    for_update = context.get('for_update', False)
+
+    pkg = model.Package.get(name_or_id, for_update=for_update)
 
     if pkg is None:
         raise NotFound

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -78,10 +78,10 @@ def resource_update(context, data_dict):
     _check_access('resource_update', context, data_dict)
     del context["resource"]
 
-    # lock the package record in the db when selected via package_show()
-    context['for_update'] = True
     package_id = resource.package.id
-    pkg_dict = _get_action('package_show')(dict(context, return_type='dict'),
+
+    # using "for_update" to lock the package record in the db when selected via package_show()
+    pkg_dict = _get_action('package_show')(dict(context, return_type='dict', for_update=True),
         {'id': package_id})
 
     for n, p in enumerate(pkg_dict['resources']):
@@ -124,8 +124,6 @@ def resource_update(context, data_dict):
 
     upload.upload(id, uploader.get_max_resource_size())
     model.repo.commit()
-
-    context.pop('for_update')
 
     resource = _get_action('resource_show')(context, {'id': id})
 

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -78,6 +78,8 @@ def resource_update(context, data_dict):
     _check_access('resource_update', context, data_dict)
     del context["resource"]
 
+    # lock the package record in the db when selected via package_show()
+    context['for_update'] = True
     package_id = resource.package.id
     pkg_dict = _get_action('package_show')(dict(context, return_type='dict'),
         {'id': package_id})
@@ -122,6 +124,8 @@ def resource_update(context, data_dict):
 
     upload.upload(id, uploader.get_max_resource_size())
     model.repo.commit()
+
+    context.pop('for_update')
 
     resource = _get_action('resource_show')(context, {'id': id})
 

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -80,9 +80,9 @@ def resource_update(context, data_dict):
 
     package_id = resource.package.id
 
-    # using "for_update" to lock the package record in the db when selected via package_show()
-    pkg_dict = _get_action('package_show')(dict(context, return_type='dict', for_update=True),
-        {'id': package_id})
+    # using "for_update" to lock the package record in the db
+    pkg_dict = _get_action('package_show')(dict(context, return_type='dict',
+                                                for_update=True), {'id': package_id})
 
     for n, p in enumerate(pkg_dict['resources']):
         if p['id'] == id:

--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -77,12 +77,18 @@ class Package(vdm.sqlalchemy.RevisionedObjectMixin,
         return meta.Session.query(cls).filter(cls.name.contains(text_query.lower()))
 
     @classmethod
-    def get(cls, reference):
+    def get(cls, reference, for_update=False):
         '''Returns a package object referenced by its id or name.'''
         if not reference:
             return None
 
-        pkg = meta.Session.query(cls).get(reference)
+        query = meta.Session.query(cls)
+
+        # "for_update" is used for resource_create(), resource_update(). They use the package id not name.
+        if for_update:
+            query = query.with_for_update()
+        pkg = query.get(reference)
+
         if pkg == None:
             pkg = cls.by_name(reference)
         return pkg

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -676,6 +676,23 @@ class TestResourceCreate(object):
         assert 'extras' not in resource
         assert 'someotherkey' not in resource
 
+    @mock.patch("ckan.model.Package.get", wraps=model.Package.get)
+    def test_for_update_was_used(self, package_get):
+        '''
+        :param package_get: Mock function that wraps ckan.model.Package.get
+        :type package_get: mock.Mock
+        '''
+        params = {
+            'package_id': factories.Dataset()['id'],
+            'url': 'http://data',
+            'name': 'A nice resource',
+        }
+        package_get.reset_mock()
+
+        resource = helpers.call_action('resource_create', {}, **params)
+
+        package_get.assert_any_call(resource['package_id'], for_update=True)
+
 
 class TestMemberCreate(object):
     @classmethod

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -1332,6 +1332,23 @@ class TestResourceUpdate(object):
         # View is created
         assert_equals(len(res_views), 1)
 
+    @mock.patch("ckan.model.Package.get", wraps=model.Package.get)
+    def test_for_update_was_used(self, package_get):
+        '''
+        :param package_get: Mock function that wraps ckan.model.Package.get
+        :type package_get: mock.Mock
+        '''
+        resource = factories.Resource(url="http://someurl")
+        package_get.reset_mock()
+
+        modified_resource = helpers.call_action('resource_update',
+                                           id=resource['id'],
+                                           url='http://anotherurl')
+        package_get.assert_any_call(resource['package_id'], for_update=True)
+
+        assert_equals(modified_resource['url'], 'http://anotherurl')
+
+
 
 class TestConfigOptionUpdate(object):
     @classmethod

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -1342,12 +1342,11 @@ class TestResourceUpdate(object):
         package_get.reset_mock()
 
         modified_resource = helpers.call_action('resource_update',
-                                           id=resource['id'],
-                                           url='http://anotherurl')
+                                                id=resource['id'],
+                                                url='http://anotherurl')
         package_get.assert_any_call(resource['package_id'], for_update=True)
 
         assert_equals(modified_resource['url'], 'http://anotherurl')
-
 
 
 class TestConfigOptionUpdate(object):


### PR DESCRIPTION
The discussion thread about this problem can be found in the ckan dev list here: https://lists.okfn.org/pipermail/ckan-dev/2017-July/011047.html

The main idea:
The resource_create() ( and similarly resource_update() ) does a package_show() followed later by a package_update() can potentially lead to a lost resource in some special cases.

Since postgres uses by default "read committed" transaction isolation the following could happen:
2 almost simultaneous requests (R1, R2) come to the API and are dealt with by different processes/threads. Both are modifying dataset D which already has one resource (resource1)

TIMELINE
 (R1) starts resource_create(resource2) on dataset D
 (R2) starts resource_update(resource1) on dataset D
 (R2) does package_show(D) => gets D with just resource1
 (R2) changes resource1 in D
 (R1) does package_show(D) => gets D with resource1
 (R1) adds resource2 to D => D.resources = [resource1, resource2]
 (R1) does package_update(D)
 (R1) resource_create() finishes, everything is committed successfully to the db => D has 2 resources in the db
 (R2) does package_update(D) - please note that here D only has one resource as read in step 3
 (R2) resource_update() finishes, everything is committed successfully to the db => D has just resource1 (resource2 disappears)

I've changed a bit package_show() and the get() function from Package model to use "with_for_update()" from sqlalchemy.

CAVEATS/TODO
- This does NOT tackle in any way the problem mentioned by @wardi about "a user opens a resource or dataset edit page in their browser in the morning, then makes some changes and submits them in the afternoon"
- this does NOT tackle potential similar problems with package_patch()

