### PR TITLE
3499 skip url parsing in redirect

### DIFF
--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -397,8 +397,7 @@ class UserController(base.BaseController):
         if not c.user:
             came_from = request.params.get('came_from')
             if not came_from:
-                came_from = h.url_for(controller='user', action='logged_in',
-                                      __ckan_no_root=True)
+                came_from = h.url_for(controller='user', action='logged_in')
             c.login_handler = h.url_for(
                 self._get_repoze_handler('login_handler_path'),
                 came_from=came_from)
@@ -436,10 +435,9 @@ class UserController(base.BaseController):
         # Do any plugin logout stuff
         for item in p.PluginImplementations(p.IAuthenticator):
             item.logout()
-        url = h.url_for(controller='user', action='logged_out_page',
-                        __ckan_no_root=True)
+        url = h.url_for(controller='user', action='logged_out_page')
         h.redirect_to(self._get_repoze_handler('logout_handler_path') +
-                      '?came_from=' + url)
+                      '?came_from=' + url, parse_url=True)
 
     def logged_out(self):
         # redirect if needed

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -172,11 +172,16 @@ def redirect_to(*args, **kw):
                    '/user/logged_in']
     matching = [s for s in uargs if any(xs in s for xs in exempt_urls)]
 
+    _url = ''
+    skip_url_parsing = False
     if uargs and len(uargs) is 1 and isinstance(uargs[0], basestring) \
         and uargs[0].startswith('/') and len(matching) is 0:
-        return _routes_redirect_to(uargs[0])
+        skip_url_parsing = True
+        _url = uargs[0]
 
-    _url = url_for(*uargs, **kw)
+    if skip_url_parsing is False:
+        _url = url_for(*uargs, **kw)
+
     if _url.startswith('/'):
         _url = str(config['ckan.site_url'].rstrip('/') + _url)
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -153,6 +153,15 @@ def redirect_to(*args, **kw):
         toolkit.redirect_to('dataset_read', id='changed')
 
     '''
+    # Remove LANG from root_path so that we do not need to parse locales
+    root_path = config.get('ckan.root_path', None)
+    if root_path:
+        root_path = re.sub('/{{LANG}}', '', root_path)
+
+    # If args contain full url eg. http://example.com or url starting with root_path skip url parsing
+    if args and (is_url(args[0]) or ( root_path and args[0].startswith(root_path))) :
+        _routes_redirect_to(args[0])
+
     if are_there_flash_messages():
         kw['__no_cache__'] = True
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -166,17 +166,12 @@ def redirect_to(*args, **kw):
     uargs = map(lambda arg: str(arg) if isinstance(arg, unicode) else arg,
                 args)
 
-    # Repoze.who redirects with single strings
-    # which need to be parsed by url_for
-    exempt_urls = ['/user/logout', '/user/logged_out_redirect',
-                   '/user/logged_in']
-    matching = [s for s in uargs if any(xs in s for xs in exempt_urls)]
-
     _url = ''
     skip_url_parsing = False
+    parse_url = kw.pop('parse_url', False)
     if uargs and len(uargs) is 1 and isinstance(uargs[0], basestring) \
             and (uargs[0].startswith('/') or is_url(uargs[0])) \
-            and len(matching) is 0:
+            and parse_url is False:
         skip_url_parsing = True
         _url = uargs[0]
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -160,7 +160,7 @@ def redirect_to(*args, **kw):
 
     # If args contain full url eg. http://example.com or url starting with root_path skip url parsing
     if args and (is_url(args[0]) or ( root_path and args[0].startswith(root_path))) :
-        _routes_redirect_to(args[0])
+        return _routes_redirect_to(args[0])
 
     if are_there_flash_messages():
         kw['__no_cache__'] = True

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -159,14 +159,16 @@ def redirect_to(*args, **kw):
     # Routes router doesn't like unicode args
     uargs = map(lambda arg: str(arg) if isinstance(arg, unicode) else arg,
                 args)
-    
+
     # Remove LANG from root_path so that we do not need to parse locales
     root_path = config.get('ckan.root_path', None)
     if root_path:
         root_path = re.sub('/{{LANG}}', '', root_path)
 
-    # If args contain full url eg. http://example.com or url starting with root_path skip url parsing
-    if uargs and (is_url(uargs[0]) or ( root_path and uargs[0].startswith(root_path))) :
+    # If args contain full url eg. http://example.com
+    # or url starting with root_path skip url parsing
+    if uargs and (is_url(uargs[0])
+                  or (root_path and uargs[0].startswith(root_path))):
         return _routes_redirect_to(uargs[0])
 
     _url = url_for(*uargs, **kw)

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -175,7 +175,7 @@ def redirect_to(*args, **kw):
     _url = ''
     skip_url_parsing = False
     if uargs and len(uargs) is 1 and isinstance(uargs[0], basestring) \
-        and uargs[0].startswith('/') and len(matching) is 0:
+            and uargs[0].startswith('/') and len(matching) is 0:
         skip_url_parsing = True
         _url = uargs[0]
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -156,6 +156,7 @@ def redirect_to(*args, **kw):
 
         toolkit.redirect_to('http://example.com')
         toolkit.redirect_to('/dataset')
+        toolkit.redirect_to('/some/other/path')
 
     '''
     if are_there_flash_messages():
@@ -172,7 +173,7 @@ def redirect_to(*args, **kw):
     matching = [s for s in uargs if any(xs in s for xs in exempt_urls)]
 
     if uargs and len(uargs) is 1 and isinstance(uargs[0], basestring) \
-        and len(matching) is 0:
+        and uargs[0].startswith('/') and len(matching) is 0:
         return _routes_redirect_to(uargs[0])
 
     _url = url_for(*uargs, **kw)

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -153,21 +153,22 @@ def redirect_to(*args, **kw):
         toolkit.redirect_to('dataset_read', id='changed')
 
     '''
-    # Remove LANG from root_path so that we do not need to parse locales
-    root_path = config.get('ckan.root_path', None)
-    if root_path:
-        root_path = re.sub('/{{LANG}}', '', root_path)
-
-    # If args contain full url eg. http://example.com or url starting with root_path skip url parsing
-    if args and (is_url(args[0]) or ( root_path and args[0].startswith(root_path))) :
-        return _routes_redirect_to(args[0])
-
     if are_there_flash_messages():
         kw['__no_cache__'] = True
 
     # Routes router doesn't like unicode args
     uargs = map(lambda arg: str(arg) if isinstance(arg, unicode) else arg,
                 args)
+    
+    # Remove LANG from root_path so that we do not need to parse locales
+    root_path = config.get('ckan.root_path', None)
+    if root_path:
+        root_path = re.sub('/{{LANG}}', '', root_path)
+
+    # If args contain full url eg. http://example.com or url starting with root_path skip url parsing
+    if uargs and (is_url(uargs[0]) or ( root_path and uargs[0].startswith(root_path))) :
+        return _routes_redirect_to(uargs[0])
+
     _url = url_for(*uargs, **kw)
     if _url.startswith('/'):
         _url = str(config['ckan.site_url'].rstrip('/') + _url)

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -175,7 +175,8 @@ def redirect_to(*args, **kw):
     _url = ''
     skip_url_parsing = False
     if uargs and len(uargs) is 1 and isinstance(uargs[0], basestring) \
-            and uargs[0].startswith('/') and len(matching) is 0:
+            and (uargs[0].startswith('/') or is_url(uargs[0])) \
+            and len(matching) is 0:
         skip_url_parsing = True
         _url = uargs[0]
 


### PR DESCRIPTION
Fixes #3499 

### Proposed fixes:
If URL given to the h.redirect_to is a full URL or it begins with root_path if root_path is set, skip url_for parsing as it gives malformed URLs when the root_path is set. 


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
