### PR TITLE
[#3760] Push a test request context at the start of paster commands

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -28,6 +28,7 @@ import ckan.include.rjsmin as rjsmin
 import ckan.include.rcssmin as rcssmin
 import ckan.plugins as p
 from ckan.common import config
+from ckan.tests.helpers import _get_test_app
 
 
 #NB No CKAN imports are allowed until after the config file is loaded.
@@ -223,6 +224,11 @@ def load_config(config, load_site_user=True):
     # first time.
     from ckan.config.environment import load_environment
     load_environment(conf.global_conf, conf.local_conf)
+
+    flask_app = _get_test_app().flask_app
+    flask_context = flask_app.test_request_context()
+
+    flask_context.push()
 
     registry = Registry()
     registry.prepare()


### PR DESCRIPTION
Fixes #3760 

This is in order to avoid Flask `RuntimeErrors` when trying to generate URLs without a request context being present. A test request context is pushed on `load_config()`, a function that all commands call.

The only thing I'm not 100% happy about is that there is no obvious place to `pop()` the context after finishing the command. This is probably not a big deal now but if we ever put some logic in [`teardown_request()`](http://flask.pocoo.org/docs/0.12/api/#flask.Flask.teardown_request) that might not get called.

For the traditional paster `Command` based commands that extend `CkanCommand` I guess we could override the `run()` method and do something like:

```python

class CkanCommand(paster.script.commands.Command):
     # ...
     def run(self, args):
         super(CkanCommand, self).run(args)
         if self.flask_context:
              self.flask_context.pop()
```

But for the new style, click-based commands like the [datastore ones](https://github.com/ckan/ckan/blob/master/ckanext/datastore/commands.py#L21) I'm not sure how this could be done without explicitly calling a cleanup method.

cc @wardi 


