### PR TITLE
Prevent multiple consecutive form submissions

### DIFF
--- a/ckan/public-bs2/base/javascript/modules/basic-form.js
+++ b/ckan/public-bs2/base/javascript/modules/basic-form.js
@@ -2,7 +2,23 @@ this.ckan.module('basic-form', function (jQuery) {
   return {
     initialize: function () {
       var message = this._('There are unsaved modifications to this form');
+
+      $.proxyAll(this, /_on/);
+
       this.el.incompleteFormWarning(message);
+
+      // Disable the submit button on form submit, to prevent multiple
+      // consecutive form submissions.
+      this.el.on('submit', this._onSubmit);
+    },
+    _onSubmit() {
+
+      // The button is not disabled immediately so that its value can be sent
+      // the first time the form is submitted, because the "save" field is
+      // used in the backend.
+      setTimeout(function() {
+        this.el.find('button[name="save"]').attr('disabled', true);
+      }.bind(this), 0);
     }
   };
 });

--- a/ckan/public-bs2/base/test/spec/modules/basic-form.spec.js
+++ b/ckan/public-bs2/base/test/spec/modules/basic-form.spec.js
@@ -5,9 +5,11 @@ describe('ckan.module.BasicFormModule()', function () {
   beforeEach(function () {
     sinon.stub(jQuery.fn, 'incompleteFormWarning');
 
-    this.el = document.createElement('button');
+    this.el = document.createElement('form');
+    this.el.innerHTML = '<button name="save" type="submit">Save</button>'
     this.sandbox = ckan.sandbox();
     this.sandbox.body = this.fixture;
+    this.sandbox.body.append(this.el)
     this.module = new BasicFormModule(this.el, {}, this.sandbox);
   });
 
@@ -20,6 +22,18 @@ describe('ckan.module.BasicFormModule()', function () {
     it('should attach the jQuery.fn.incompleteFormWarning() to the form', function () {
       this.module.initialize();
       assert.called(jQuery.fn.incompleteFormWarning);
+    });
+
+    it('should disable the submit button on form submit', function(done) {
+      this.module.initialize();
+      this.module._onSubmit();
+
+      setTimeout(function() {
+        var buttonAttrDisabled = this.el.querySelector('button').getAttribute('disabled');
+
+        assert.ok(buttonAttrDisabled === 'disabled')
+        done();
+      }.bind(this), 0);
     });
   });
 });

--- a/ckan/public/base/javascript/modules/basic-form.js
+++ b/ckan/public/base/javascript/modules/basic-form.js
@@ -2,7 +2,23 @@ this.ckan.module('basic-form', function (jQuery) {
   return {
     initialize: function () {
       var message = this._('There are unsaved modifications to this form');
+
+      $.proxyAll(this, /_on/);
+
       this.el.incompleteFormWarning(message);
+
+      // Disable the submit button on form submit, to prevent multiple
+      // consecutive form submissions.
+      this.el.on('submit', this._onSubmit);
+    },
+    _onSubmit() {
+
+      // The button is not disabled immediately so that its value can be sent
+      // the first time the form is submitted, because the "save" field is
+      // used in the backend.
+      setTimeout(function() {
+        this.el.find('button[name="save"]').attr('disabled', true);
+      }.bind(this), 0);
     }
   };
 });

--- a/ckan/public/base/test/spec/modules/basic-form.spec.js
+++ b/ckan/public/base/test/spec/modules/basic-form.spec.js
@@ -5,9 +5,11 @@ describe('ckan.module.BasicFormModule()', function () {
   beforeEach(function () {
     sinon.stub(jQuery.fn, 'incompleteFormWarning');
 
-    this.el = document.createElement('button');
+    this.el = document.createElement('form');
+    this.el.innerHTML = '<button name="save" type="submit">Save</button>'
     this.sandbox = ckan.sandbox();
     this.sandbox.body = this.fixture;
+    this.sandbox.body.append(this.el)
     this.module = new BasicFormModule(this.el, {}, this.sandbox);
   });
 
@@ -20,6 +22,18 @@ describe('ckan.module.BasicFormModule()', function () {
     it('should attach the jQuery.fn.incompleteFormWarning() to the form', function () {
       this.module.initialize();
       assert.called(jQuery.fn.incompleteFormWarning);
+    });
+
+    it('should disable the submit button on form submit', function(done) {
+      this.module.initialize();
+      this.module._onSubmit();
+
+      setTimeout(function() {
+        var buttonAttrDisabled = this.el.querySelector('button').getAttribute('disabled');
+
+        assert.ok(buttonAttrDisabled === 'disabled')
+        done();
+      }.bind(this), 0);
     });
   });
 });


### PR DESCRIPTION
Fixes #3773 

### Features:

- [x] includes tests covering changes

This change is going to prevent sending multiple form submissions on every form where the `basic-module` is attached, such as the Organization/Group/Dataset forms.