### PR TITLE
Data dictionary flash message

### DIFF
--- a/ckanext/datastore/controller.py
+++ b/ckanext/datastore/controller.py
@@ -98,6 +98,9 @@ class DatastoreController(BaseController):
                     'info': fi if isinstance(fi, dict) else {}
                     } for f, fi in izip_longest(fields, info)]})
 
+            h.flash_success(_('Data Dictionary saved. Any type overrides will '
+                              'take effect when the resource is next uploaded '
+                              'to DataStore'))
             h.redirect_to(
                 controller='ckanext.datastore.controller:DatastoreController',
                 action='dictionary',


### PR DESCRIPTION
Flash message on submit of the data dictionary form.

<img width="743" alt="screen shot 2017-08-29 at 07 25 33" src="https://user-images.githubusercontent.com/307612/29807565-6e7a8580-8c8c-11e7-8184-0eaa379df05d.png">

Because:
* When you submit there is no obvious page to take you, so it just leaves you on the form, which is slightly disconcerting. So there is use in reassuring the user.
* I was expecting the type_override to take effect straight away, so it is useful to have it explained that it takes another action before the column type is changed. (Arguably it should cause a re-upload, but that may take some time to complete and so I think it is clearer if this being left to the the DataStore tab to start and see the progress.)

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
