### PR TITLE
Fix JS error on tests that was breaking the CircleCI build

### DIFF
--- a/ckan/public/base/javascript/modules/basic-form.js
+++ b/ckan/public/base/javascript/modules/basic-form.js
@@ -11,7 +11,7 @@ this.ckan.module('basic-form', function (jQuery) {
       // consecutive form submissions.
       this.el.on('submit', this._onSubmit);
     },
-    _onSubmit() {
+    _onSubmit: function () {
 
       // The button is not disabled immediately so that its value can be sent
       // the first time the form is submitted, because the "save" field is


### PR DESCRIPTION
A change introduced in #3779 had a syntax that is not supported in node.
This broke the JS tests, and the CircleCI build.
