### PR TITLE
Update copyright name, years and include contributors, as per README.rst

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,7 +2,7 @@ License
 +++++++
 
 CKAN - Data Catalogue Software
-Copyright (C) 2007 Open Knowledge Foundation
+Copyright (c) 2006-2017 Open Knowledge International and contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -95,7 +95,7 @@ master_doc = 'contents'
 # General information about the project.
 project = u'CKAN'
 project_short_name = u'CKAN'
-copyright = u'''&copy; 2009-2013, <a href="http://okfn.org/">Open Knowledge Foundation</a>.
+copyright = u'''&copy; 2009-2017 <a href="https://okfn.org/">Open Knowledge International</a> and <a href="https://github.com/ckan/ckan/graphs/contributors">contributors</a>.
     Licensed under <a
     href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons
     Attribution ShareAlike (Unported) v3.0 License</a>.<br />


### PR DESCRIPTION
I notice that the README copyright message now acknowledges contributors too:
https://github.com/ckan/ckan/blob/master/README.rst#copying-and-license
so this brings the other copyright messages in line with that one - in the license file and docs footer.