### PR TITLE
allow datastore_search_sql on private datasets

### DIFF
--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -46,7 +46,7 @@ def owner_org_validator(key, data, errors, context):
     if not group:
         raise Invalid(_('Organization does not exist'))
     group_id = group.id
-    if not(user.sysadmin or
+    if not context.get(u'ignore_auth', False) and not(user.sysadmin or
            authz.has_user_permission_for_group_or_org(
                group_id, user.name, 'create_dataset')):
         raise Invalid(_('You cannot add a dataset to this organization'))

--- a/ckanext/datastore/backend/__init__.py
+++ b/ckanext/datastore/backend/__init__.py
@@ -181,24 +181,6 @@ class DatastoreBackend:
         """
         raise NotImplementedError()
 
-    def make_private(self, context, data_dict):
-        """Do not display resource in search results.
-
-        Called by `datastore_make_private`.
-        :param resource_id: id of resource that should become private
-        :type resource_id: string
-        """
-        raise NotImplementedError()
-
-    def make_public(self, context, data_dict):
-        """Enable serch for resource.
-
-        Called by `datastore_make_public`.
-        :param resource_id: id of resource that should become public
-        :type resource_id: string
-        """
-        raise NotImplementedError()
-
     def resource_exists(self, id):
         """Define whether resource exists in datastore.
         """

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1535,11 +1535,11 @@ def search_sql(context, data_dict):
         table_names = datastore_helpers.get_table_names_from_sql(context, sql)
         log.debug('Tables involved in input SQL: {0!r}'.format(table_names))
 
-        system_tables = [t for t in table_names if t.startswith('pg_')]
-        if len(system_tables):
+        if any(t.startswith('pg_') for t in table_names):
             raise toolkit.NotAuthorized({
                 'permissions': ['Not authorized to access system tables']
             })
+        context['check_access'](table_names)
 
         results = context['connection'].execute(sql)
 

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -525,57 +525,6 @@ def datastore_search_sql(context, data_dict):
     return result
 
 
-def datastore_make_private(context, data_dict):
-    ''' Deny access to the DataStore table through
-    :meth:`~ckanext.datastore.logic.action.datastore_search_sql`.
-
-    This action is called automatically when a CKAN dataset becomes
-    private or a new DataStore table is created for a CKAN resource
-    that belongs to a private dataset.
-
-    :param resource_id: id of resource that should become private
-    :type resource_id: string
-    '''
-    backend = DatastoreBackend.get_active_backend()
-    if 'id' in data_dict:
-        data_dict['resource_id'] = data_dict['id']
-    res_id = _get_or_bust(data_dict, 'resource_id')
-
-    if not _resource_exists(context, data_dict):
-        raise p.toolkit.ObjectNotFound(p.toolkit._(
-            u'Resource "{0}" was not found.'.format(res_id)
-        ))
-
-    p.toolkit.check_access('datastore_change_permissions', context, data_dict)
-
-    backend.make_private(context, data_dict)
-
-
-def datastore_make_public(context, data_dict):
-    ''' Allow access to the DataStore table through
-    :meth:`~ckanext.datastore.logic.action.datastore_search_sql`.
-
-    This action is called automatically when a CKAN dataset becomes
-    public.
-
-    :param resource_id: if of resource that should become public
-    :type resource_id: string
-    '''
-    backend = DatastoreBackend.get_active_backend()
-    if 'id' in data_dict:
-        data_dict['resource_id'] = data_dict['id']
-    res_id = _get_or_bust(data_dict, 'resource_id')
-
-    if not _resource_exists(context, data_dict):
-        raise p.toolkit.ObjectNotFound(p.toolkit._(
-            u'Resource "{0}" was not found.'.format(res_id)
-        ))
-
-    p.toolkit.check_access('datastore_change_permissions', context, data_dict)
-
-    backend.make_public(context, data_dict)
-
-
 def set_datastore_active_flag(model, data_dict, flag):
     '''
     Set appropriate datastore_active flag on CKAN resource.

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -505,9 +505,21 @@ def datastore_search_sql(context, data_dict):
     '''
     backend = DatastoreBackend.get_active_backend()
 
-    p.toolkit.check_access('datastore_search_sql', context, data_dict)
+    def check_access(table_names):
+        '''
+        Raise NotAuthorized if current user is not allowed to access
+        any of the tables passed
 
-    result = backend.search_sql(context, data_dict)
+        :type table_names: list strings
+        '''
+        p.toolkit.check_access(
+            'datastore_search_sql',
+            dict(context, table_names=table_names),
+            data_dict)
+
+    result = backend.search_sql(
+        dict(context, check_access=check_access),
+        data_dict)
     result.pop('id', None)
     result.pop('connection_url', None)
     return result

--- a/ckanext/datastore/logic/auth.py
+++ b/ckanext/datastore/logic/auth.py
@@ -54,8 +54,12 @@ def datastore_search(context, data_dict):
 @p.toolkit.auth_allow_anonymous_access
 def datastore_search_sql(context, data_dict):
     '''need access to view all tables in query'''
+
     for name in context['table_names']:
-        name_auth = datastore_auth(context, {'id': name}, 'resource_show')
+        name_auth = datastore_auth(
+            dict(context), # required because check_access mutates context
+            {'id': name},
+            'resource_show')
         if not name_auth['success']:
             return {
                 'success': False,

--- a/ckanext/datastore/logic/auth.py
+++ b/ckanext/datastore/logic/auth.py
@@ -53,6 +53,13 @@ def datastore_search(context, data_dict):
 
 @p.toolkit.auth_allow_anonymous_access
 def datastore_search_sql(context, data_dict):
+    '''need access to view all tables in query'''
+    for name in context['table_names']:
+        name_auth = datastore_auth(context, {'id': name}, 'resource_show')
+        if not name_auth['success']:
+            return {
+                'success': False,
+                'msg': 'Not authorized to read resource.'}
     return {'success': True}
 
 

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -97,10 +97,6 @@ class DatastorePlugin(p.SingletonPlugin):
         # if a resource is new, it cannot have a datastore resource, yet
         if operation == model.domain_object.DomainObjectOperation.changed:
             context = {'model': model, 'ignore_auth': True}
-            if entity.private:
-                func = p.toolkit.get_action('datastore_make_private')
-            else:
-                func = p.toolkit.get_action('datastore_make_public')
             for resource in entity.resources:
                 try:
                     func(context, {
@@ -128,9 +124,6 @@ class DatastorePlugin(p.SingletonPlugin):
                 actions.update({
                     'datastore_search_sql': action.datastore_search_sql,
                 })
-            actions.update({
-                'datastore_make_private': action.datastore_make_private,
-                'datastore_make_public': action.datastore_make_public})
         return actions
 
     # IAuthFunctions


### PR DESCRIPTION
We're using EXPLAIN to list the tables that a user is accessing in datastore_search_sql, but we're blocking access to all private tables by removing access at the postgres permission level.

Instead of denying all sql on private datasets, let's call the resource_show auth method for each table the user is accessing and refuse the query only when any of those checks fail.
