### PR TITLE
[#3799] Add some missing major changes to change log.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,20 +25,20 @@ Note: This version requires re-running the 'datastore set-permissions' command
 v2.7.0 2017-08-02
 =================
 
-Note: Starting from this version, CKAN requires at least Postgres 9.3
+General notes:
+ * Starting from this version, CKAN requires at least Postgres 9.3
+ * Starting from this version, CKAN requires a Redis database. Please
+   refer to the new `ckan.redis.url
+   <http://docs.ckan.org/en/ckan-2.7.0/maintaining/configuration.html#ckan-redis-url>`_
+   configuration option.
+ * This version requires a requirements upgrade on source installations
+ * This version requires a database upgrade
+ * This version does not require a Solr schema upgrade (You may want to
+   upgrade the schema if you want to target Solr>=5, see #2914)
+ * There are several old features being officially deprecated starting from
+   this version. Check the *Deprecations* section to be prepared.
 
-Note: This version requires a requirements upgrade on source installations
-
-Note: This version requires a database upgrade
-
-Note: This version does not require a Solr schema upgrade (You may want to
-         upgrade the schema if you want to target Solr>=5, see #2914)
-
-Note: There are several old features being officially deprecated starting from
-        this version. Check the *Deprecations* section to be prepared.
-
-
-Major:
+Major changes:
  * New datatables_view resource view plugin for tabular data (#3444)
  * IDataStoreBackend plugins for replacing the default DataStore Postgres backend (#3437)
  * datastore_search new result formats and performance improvements (#3523)
@@ -53,7 +53,7 @@ Major:
  * Generate complete datastore dump files (#3344)
  * A new system for asynchronous background jobs (#3165)
 
-Minor:
+Minor changes:
  * Renamed example theme plugin (#3576)
  * Localization support for groups (#3559)
  * Create new resource views when format changes (#3515)
@@ -110,7 +110,6 @@ API changes:
    to upgrade your code accordingly if you are using custom themes.
 
 Deprecations:
-
  * The API versions 1 and 2 (also known as the REST API, ie ``/api/rest/*`` will removed
    in favour of the version 3 (action API, ``/api/action/*``), which was introduced in
    CKAN 2.0. The REST API will be removed on CKAN 2.8.

--- a/doc/maintaining/upgrading/upgrade-package-to-minor-release.rst
+++ b/doc/maintaining/upgrading/upgrade-package-to-minor-release.rst
@@ -71,6 +71,11 @@ respectively.
    disabling all extensions on your ini file and re-enable them one by one
    to make sure they are working fine.
 
+#. If new configuration options have been introduced (check the
+   :doc:`/changelog` to find out) then check whether you need to change them
+   from their default values. See :doc:`/maintaining/configuration` for
+   details.
+
 #. Rebuild your search index by running the ``ckan search-index rebuild``
    command:
 

--- a/doc/maintaining/upgrading/upgrade-source.rst
+++ b/doc/maintaining/upgrading/upgrade-source.rst
@@ -11,6 +11,10 @@ Upgrading a source install
 The process for upgrading a source install is the same, no matter what type of
 CKAN release you're upgrading to:
 
+#. Check the :doc:`/changelog` for changes regarding the required 3rd-party
+   packages and their minimum versions (e.g. web, database and search servers)
+   and update their installations if necessary.
+
 #. Activate your virtualenv and switch to the ckan source directory, e.g.:
 
    .. parsed-literal::
@@ -53,6 +57,11 @@ CKAN release you're upgrading to:
 #. If there have been changes in the database schema (check the
    :doc:`/changelog` to find out) you need to :ref:`upgrade your database
    schema <db upgrade>`.
+
+#. If new configuration options have been introduced (check the
+   :doc:`/changelog` to find out) then check whether you need to change them
+   from their default values. See :doc:`/maintaining/configuration` for
+   details.
 
 #. Rebuild your search index by running the ``ckan search-index rebuild``
    command:


### PR DESCRIPTION
Fixes #3799.

The new hard requirement of Redis and the corresponding configuration option `ckan.redis.url` previously wasn't explicitly documented.

This commit also clarifies the update procedure for package and source installs w.r.t. new/changed 3rd-party package-requirements and configuration options.