### PR TITLE
config option for type used to display all dataset types

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -228,10 +228,12 @@ class PackageController(base.BaseController):
                 # Only show datasets of this particular type
                 fq += ' +dataset_type:{type}'.format(type=package_type)
             else:
-                # Unless changed via config options, don't show non standard
-                # dataset types on the default search page
+                # Unless changed via config options or url parameter,
+                # don't show non standard dataset types on the default
+                # search page
                 if not asbool(
-                        config.get('ckan.search.show_all_types', 'False')):
+                        config.get('ckan.search.show_all_types', 'False')) \
+                        and not request.params.get('_show_all_types', False):
                     fq += ' +dataset_type:dataset'
 
             facets = OrderedDict()

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -224,17 +224,26 @@ class PackageController(base.BaseController):
                        'user': c.user, 'for_view': True,
                        'auth_user_obj': c.userobj}
 
-            if package_type and package_type != 'dataset':
+            # Unless changed via config options, don't show other dataset
+            # types any search page. Potential alternatives are do show them 
+            # on the default search page (dataset) or on one other search page
+            search_all_type = config.get('ckan.search.show_all_types', 'false')
+            search_all = False            
+
+            try:
+                #If the "type" is set to True or False, convert to bool
+                search_all = asbool(search_all_type)
+            #Otherwise we treat as a string representing a type
+            except ValueError:
+                if package_type and package_type == search_all_type:
+                    search_all = True
+                
+            if not package_type:
+                package_type = 'dataset'
+ 
+            if not search_all:
                 # Only show datasets of this particular type
                 fq += ' +dataset_type:{type}'.format(type=package_type)
-            else:
-                # Unless changed via config options or url parameter,
-                # don't show non standard dataset types on the default
-                # search page
-                if not asbool(
-                        config.get('ckan.search.show_all_types', 'False')) \
-                        and not request.params.get('_show_all_types', False):
-                    fq += ' +dataset_type:dataset'
 
             facets = OrderedDict()
 

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -236,8 +236,7 @@ class PackageController(base.BaseController):
             # Otherwise we treat as a string representing a type
             except ValueError:
                 if package_type and package_type == search_all_type:
-                    search_all = True
- 
+                    search_all = True 
             if not package_type:
                 package_type = 'dataset'
 

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -227,7 +227,8 @@ class PackageController(base.BaseController):
             # Unless changed via config options, don't show other dataset
             # types any search page. Potential alternatives are do show them
             # on the default search page (dataset) or on one other search page
-            search_all_type = config.get('ckan.search.show_all_types', 'dataset')
+            search_all_type = config.get(
+                                  'ckan.search.show_all_types', 'dataset')
             search_all = False
 
             try:

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -227,20 +227,23 @@ class PackageController(base.BaseController):
             # Unless changed via config options, don't show other dataset
             # types any search page. Potential alternatives are do show them
             # on the default search page (dataset) or on one other search page
-            search_all_type = config.get('ckan.search.show_all_types', 'false')
+            search_all_type = config.get('ckan.search.show_all_types', 'dataset')
             search_all = False
 
             try:
                 # If the "type" is set to True or False, convert to bool
+                # and we know that no type was specified, so use traditional
+                # behaviour of applying this only to dataset type
                 search_all = asbool(search_all_type)
+                search_all_type = 'dataset'
             # Otherwise we treat as a string representing a type
             except ValueError:
-                if package_type and package_type == search_all_type:
-                    search_all = True
+                search_all = True
+
             if not package_type:
                 package_type = 'dataset'
 
-            if not search_all:
+            if not search_all or package_type != search_all_type:
                 # Only show datasets of this particular type
                 fq += ' +dataset_type:{type}'.format(type=package_type)
 

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -236,7 +236,7 @@ class PackageController(base.BaseController):
             # Otherwise we treat as a string representing a type
             except ValueError:
                 if package_type and package_type == search_all_type:
-                    search_all = True 
+                    search_all = True
             if not package_type:
                 package_type = 'dataset'
 

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -225,22 +225,22 @@ class PackageController(base.BaseController):
                        'auth_user_obj': c.userobj}
 
             # Unless changed via config options, don't show other dataset
-            # types any search page. Potential alternatives are do show them 
+            # types any search page. Potential alternatives are do show them
             # on the default search page (dataset) or on one other search page
             search_all_type = config.get('ckan.search.show_all_types', 'false')
-            search_all = False            
+            search_all = False
 
             try:
-                #If the "type" is set to True or False, convert to bool
+                # If the "type" is set to True or False, convert to bool
                 search_all = asbool(search_all_type)
-            #Otherwise we treat as a string representing a type
+            # Otherwise we treat as a string representing a type
             except ValueError:
                 if package_type and package_type == search_all_type:
                     search_all = True
-                
+ 
             if not package_type:
                 package_type = 'dataset'
- 
+
             if not search_all:
                 # Only show datasets of this particular type
                 fq += ' +dataset_type:{type}'.format(type=package_type)

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -654,12 +654,16 @@ ckan.search.show_all_types
 
 Example::
 
- ckan.search.show_all_types = true
+ ckan.search.show_all_types = dataset
 
 Default value:  ``false``
 
-Controls whether the default search page (``/dataset``) should show only
-standard datasets or also custom dataset types.
+Controls whether a search page (e.g. ``/dataset``) should also show 
+custom dataset types. The default is ``false`` meaning that no search 
+page for any type will show other types. ``true`` will show other types 
+on the ``/dataset`` search page. Any other value (e.g. ``dataset`` or 
+``document`` will be treated as a dataset type and that type's search 
+page will show datasets of all types.
 
 .. _ckan.search.default_include_private:
 
@@ -668,7 +672,7 @@ ckan.search.default_include_private
 
 Example::
 
- ckan.search.defalt_include_private = false
+ ckan.search.default_include_private = false
 
 Default value:  ``true``
 


### PR DESCRIPTION
This commit allows display of all package types via url argument (_show_all_types=True) similar to the ckan.search.show_all_types config option.

The User story is such:
I start building a CKAN site and realise I want to archive a bunch of things that aren't really "datasets" - let's say documents. I create a new dataset type and schema and am broadly happy that datasets and documents are handled separately in CKAN. However, there are few, _theme-specific_ places where I would like to provide a common listing, for example by hyperlinking metadata fields on a dataset/document description field (e.g. now show me _everything_ from year 2005) or under a list of common categories I use on my front page or in a menu to different listings of data.

The only way I've been able to think of to resolve such a use case is to create a third (second custom) dataset type for my actual datasets and then set the ckan.search.show_all_types option to True and rearrange links so that most of the time I go to one dataset type or the other and in certain cases use the default /dataset to show everything. This seems like overkill and also creates terrible problems with nomenclature: what alternative name to I give a dataset that is actually... a dataset? I can't think of a good English word.