### PR TITLE
Shrink datastore_create response size

### DIFF
--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -76,7 +76,7 @@ def datastore_create(context, data_dict):
 
     **Results:**
 
-    :returns: The newly created data object.
+    :returns: The newly created data object, excluding ``records`` passed.
     :rtype: dictionary
 
     See :ref:`fields` and :ref:`records` for details on how to lay out records.
@@ -168,6 +168,7 @@ def datastore_create(context, data_dict):
     result.pop('id', None)
     result.pop('private', None)
     result.pop('connection_url', None)
+    result.pop('records', None)
     return result
 
 

--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -536,7 +536,6 @@ class TestDatastoreCreate():
         res = res_dict['result']
         assert res['resource_id'] == data['resource_id']
         assert res['fields'] == data['fields'], res['fields']
-        assert res['records'] == data['records']
 
         c = self.Session.connection()
         results = c.execute('select * from "{0}"'.format(resource.id))
@@ -770,7 +769,6 @@ class TestDatastoreCreate():
         assert res_dict['success'] is True
         res = res_dict['result']
         assert res['fields'] == data['fields'], res['fields']
-        assert res['records'] == data['records']
 
         # Get resource details
         data = {


### PR DESCRIPTION
when passing records to datastore_create, the same records are all passed back in the response. There's no reason I can see for this and there are no records returned from datastore_upsert. Remove the records from the response for speed and consistency.