### PR TITLE
Bugfix for negative date on new and existing datarequests made in the past 1 day

### DIFF
--- a/ckan/lib/formatters.py
+++ b/ckan/lib/formatters.py
@@ -99,7 +99,7 @@ def localised_nice_date(datetime_, show_date=False, with_hours=False):
         return months
 
     if not show_date:
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         if datetime_.tzinfo is not None:
             now = now.replace(tzinfo=datetime_.tzinfo)
         else:
@@ -107,7 +107,7 @@ def localised_nice_date(datetime_, show_date=False, with_hours=False):
             datetime_ = datetime_.replace(tzinfo=pytz.utc)
         date_diff = now - datetime_
         days = date_diff.days
-        if days < 1 and now > datetime_:
+        if days < 1:
             # less than one day
             seconds = date_diff.seconds
             if seconds < 3600:

--- a/ckan/lib/formatters.py
+++ b/ckan/lib/formatters.py
@@ -107,7 +107,7 @@ def localised_nice_date(datetime_, show_date=False, with_hours=False):
             datetime_ = datetime_.replace(tzinfo=pytz.utc)
         date_diff = now - datetime_
         days = date_diff.days
-        if days < 1:
+        if days < 1 and now > datetime_:
             # less than one day
             seconds = date_diff.seconds
             if seconds < 3600:

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -120,8 +120,7 @@ def _datestamp_to_datetime(datetime_):
 
     # all dates are considered UTC internally,
     # change output if `ckan.display_timezone` is available
-    datetime_ = datetime_.replace(tzinfo=pytz.utc)
-    datetime_ = datetime_.astimezone(get_display_timezone())
+    datetime_ = datetime_.replace(tzinfo=get_display_timezone())
 
     return datetime_
 


### PR DESCRIPTION
Fixes #
https://github.com/CodeForAfricaLabs/ckanext-datarequests/issues/4
Fixes the issue of negative dates on newly created data request items and comments. This also fixes the inaccurate time-ago since the creation of the data requests and comments.
<img width="1232" alt="screen shot 2017-09-19 at 11 24 31" src="https://user-images.githubusercontent.com/28535137/30630008-5c8394a4-9de7-11e7-9724-53227ac26edd.png">
![bug](https://user-images.githubusercontent.com/28535137/30630062-970be720-9de7-11e7-95d5-16301fd07c7e.png)
![bug2](https://user-images.githubusercontent.com/28535137/30630146-ee4260a0-9de7-11e7-90c9-3241efa1df68.png)


### Proposed fixes:
- During calculation for the time-ago since creation, the now time was being set as UTC first before evaluating if the time-opened had timezone information. This led to an offset being doubly applied to the now time. This fixes the issue by the current time remaining naive and timezone information only applied as the timezone for the time-opened, if it exists or UTC incase its missing.


<img width="1537" alt="screen shot 2017-09-20 at 09 42 39" src="https://user-images.githubusercontent.com/28535137/30630297-9e3aeca2-9de8-11e7-9143-d3a663c01fa1.png">
<img width="1559" alt="screen shot 2017-09-20 at 09 42 56" src="https://user-images.githubusercontent.com/28535137/30630298-9e42ec18-9de8-11e7-859d-54b20c0061df.png">

<img width="1567" alt="screen shot 2017-09-20 at 09 01 53" src="https://user-images.githubusercontent.com/28535137/30630094-bebf6d14-9de7-11e7-8059-c33e0638cbfb.png">
<img width="1307" alt="screen shot 2017-09-20 at 09 21 18" src="https://user-images.githubusercontent.com/28535137/30630108-cf9ddca6-9de7-11e7-86eb-7ea733de2d4d.png">

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
