### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/bin/running_stats.py
+++ b/bin/running_stats.py
@@ -42,7 +42,7 @@ class StatsCount(dict):
     report_value_limit = 150
     
     def _init_category(self, category):
-        if not self.has_key(category):
+        if category not in self:
             self[category] = copy.deepcopy(self._init_value)
         
     def increment(self, category):

--- a/ckan/ckan_nose_plugin.py
+++ b/ckan/ckan_nose_plugin.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import print_function
 from nose.plugins import Plugin
 from inspect import isclass
 import hashlib
@@ -94,7 +95,7 @@ class CkanNose(Plugin):
 
     def finalize(self, report):
         if self.segments:
-            print 'Segments: %s' % self.segments
+            print('Segments: %s' % self.segments)
 
     def configure(self, settings, config):
         CkanNose.settings = settings

--- a/ckan/config/middleware/pylons_app.py
+++ b/ckan/config/middleware/pylons_app.py
@@ -151,7 +151,7 @@ def make_pylons_stack(conf, full_stack=True, static_files=True,
             path = os.path.join(storage_directory, 'storage')
             try:
                 os.makedirs(path)
-            except OSError, e:
+            except OSError as e:
                 # errno 17 is file already exists
                 if e.errno != 17:
                     raise

--- a/ckan/controllers/admin.py
+++ b/ckan/controllers/admin.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 from ckan.common import config
 
 import ckan.lib.base as base
@@ -9,7 +10,7 @@ import ckan.lib.navl.dictization_functions as dict_fns
 import ckan.model as model
 import ckan.logic as logic
 import ckan.plugins as plugins
-from home import CACHE_PARAMETERS
+from .home import CACHE_PARAMETERS
 
 
 c = base.c
@@ -100,7 +101,7 @@ class AdminController(base.BaseController):
 
                 data = logic.get_action('config_option_update')(
                     {'user': c.user}, data_dict)
-            except logic.ValidationError, e:
+            except logic.ValidationError as e:
                 errors = e.error_dict
                 error_summary = e.error_summary
                 vars = {'data': data, 'errors': errors,
@@ -179,7 +180,7 @@ class AdminController(base.BaseController):
                         # page Ensure that whatever 'head' pointer is used
                         # gets moved down to the next revision
                         model.repo.purge_revision(revision, leave_record=False)
-                    except Exception, inst:
+                    except Exception as inst:
                         msg = _('Problem purging revision %s: %s') % (id, inst)
                         msgs.append(msg)
                 h.flash_success(_('Purge complete'))

--- a/ckan/controllers/api.py
+++ b/ckan/controllers/api.py
@@ -144,7 +144,7 @@ class ApiController(base.BaseController):
     def _set_response_header(self, name, value):
         try:
             value = str(value)
-        except Exception, inst:
+        except Exception as inst:
             msg = "Couldn't convert '%s' header value '%s' to string: %s" % \
                 (name, value, inst)
             raise Exception(msg)
@@ -179,7 +179,7 @@ class ApiController(base.BaseController):
             side_effect_free = getattr(function, 'side_effect_free', False)
             request_data = self._get_request_data(
                 try_url_params=side_effect_free)
-        except ValueError, inst:
+        except ValueError as inst:
             log.info('Bad Action API request data: %s', inst)
             return self._finish_bad_request(
                 _('JSON Error: %s') % inst)
@@ -202,7 +202,7 @@ class ApiController(base.BaseController):
             result = function(context, request_data)
             return_dict['success'] = True
             return_dict['result'] = result
-        except DataError, e:
+        except DataError as e:
             log.info('Format incorrect (Action API): %s - %s',
                      e.error, request_data)
             return_dict['error'] = {'__type': 'Integrity Error',
@@ -210,7 +210,7 @@ class ApiController(base.BaseController):
                                     'data': request_data}
             return_dict['success'] = False
             return self._finish(400, return_dict, content_type='json')
-        except NotAuthorized, e:
+        except NotAuthorized as e:
             return_dict['error'] = {'__type': 'Authorization Error',
                                     'message': _('Access denied')}
             return_dict['success'] = False
@@ -219,14 +219,14 @@ class ApiController(base.BaseController):
                 return_dict['error']['message'] += u': %s' % e
 
             return self._finish(403, return_dict, content_type='json')
-        except NotFound, e:
+        except NotFound as e:
             return_dict['error'] = {'__type': 'Not Found Error',
                                     'message': _('Not found')}
             if unicode(e):
                 return_dict['error']['message'] += u': %s' % e
             return_dict['success'] = False
             return self._finish(404, return_dict, content_type='json')
-        except ValidationError, e:
+        except ValidationError as e:
             error_dict = e.error_dict
             error_dict['__type'] = 'Validation Error'
             return_dict['error'] = error_dict
@@ -234,18 +234,18 @@ class ApiController(base.BaseController):
             # CS nasty_string ignore
             log.info('Validation error (Action API): %r', str(e.error_dict))
             return self._finish(409, return_dict, content_type='json')
-        except search.SearchQueryError, e:
+        except search.SearchQueryError as e:
             return_dict['error'] = {'__type': 'Search Query Error',
                                     'message': 'Search Query is invalid: %r' %
                                     e.args}
             return_dict['success'] = False
             return self._finish(400, return_dict, content_type='json')
-        except search.SearchError, e:
+        except search.SearchError as e:
             return_dict['error'] = {'__type': 'Search Error',
                                     'message': 'Search error: %r' % e.args}
             return_dict['success'] = False
             return self._finish(409, return_dict, content_type='json')
-        except search.SearchIndexError, e:
+        except search.SearchIndexError as e:
             return_dict['error'] = {
                 '__type': 'Search Index Error',
                 'message': 'Unable to add package to search index: %s' %
@@ -294,9 +294,9 @@ class ApiController(base.BaseController):
                 _('Cannot list entity of this type: %s') % register)
         try:
             return self._finish_ok(action(context, {'id': id}))
-        except NotFound, e:
+        except NotFound as e:
             return self._finish_not_found(unicode(e))
-        except NotAuthorized, e:
+        except NotAuthorized as e:
             return self._finish_not_authz(unicode(e))
 
     def show(self, ver=None, register=None, subregister=None,
@@ -323,9 +323,9 @@ class ApiController(base.BaseController):
                 _('Cannot read entity of this type: %s') % register)
         try:
             return self._finish_ok(action(context, data_dict))
-        except NotFound, e:
+        except NotFound as e:
             return self._finish_not_found(unicode(e))
-        except NotAuthorized, e:
+        except NotAuthorized as e:
             return self._finish_not_authz(unicode(e))
 
     def create(self, ver=None, register=None, subregister=None,
@@ -347,7 +347,7 @@ class ApiController(base.BaseController):
             request_data = self._get_request_data()
             data_dict = {'id': id, 'id2': id2, 'rel': subregister}
             data_dict.update(request_data)
-        except ValueError, inst:
+        except ValueError as inst:
             return self._finish_bad_request(
                 _('JSON Error: %s') % inst)
 
@@ -366,15 +366,15 @@ class ApiController(base.BaseController):
                                           data_dict.get("id")))
             return self._finish_ok(response_data,
                                    resource_location=location)
-        except NotAuthorized, e:
+        except NotAuthorized as e:
             return self._finish_not_authz(unicode(e))
-        except NotFound, e:
+        except NotFound as e:
             return self._finish_not_found(unicode(e))
-        except ValidationError, e:
+        except ValidationError as e:
             # CS: nasty_string ignore
             log.info('Validation error (REST create): %r', str(e.error_dict))
             return self._finish(409, e.error_dict, content_type='json')
-        except DataError, e:
+        except DataError as e:
             log.info('Format incorrect (REST create): %s - %s',
                      e.error, request_data)
             error_dict = {
@@ -410,7 +410,7 @@ class ApiController(base.BaseController):
             request_data = self._get_request_data()
             data_dict = {'id': id, 'id2': id2, 'rel': subregister}
             data_dict.update(request_data)
-        except ValueError, inst:
+        except ValueError as inst:
             return self._finish_bad_request(
                 _('JSON Error: %s') % inst)
 
@@ -422,15 +422,15 @@ class ApiController(base.BaseController):
         try:
             response_data = action(context, data_dict)
             return self._finish_ok(response_data)
-        except NotAuthorized, e:
+        except NotAuthorized as e:
             return self._finish_not_authz(unicode(e))
-        except NotFound, e:
+        except NotFound as e:
             return self._finish_not_found(unicode(e))
-        except ValidationError, e:
+        except ValidationError as e:
             # CS: nasty_string ignore
             log.info('Validation error (REST update): %r', str(e.error_dict))
             return self._finish(409, e.error_dict, content_type='json')
-        except DataError, e:
+        except DataError as e:
             log.info('Format incorrect (REST update): %s - %s',
                      e.error, request_data)
             error_dict = {
@@ -469,11 +469,11 @@ class ApiController(base.BaseController):
         try:
             response_data = action(context, data_dict)
             return self._finish_ok(response_data)
-        except NotAuthorized, e:
+        except NotAuthorized as e:
             return self._finish_not_authz(unicode(e))
-        except NotFound, e:
+        except NotFound as e:
             return self._finish_not_found(unicode(e))
-        except ValidationError, e:
+        except ValidationError as e:
             # CS: nasty_string ignore
             log.info('Validation error (REST delete): %r', str(e.error_dict))
             return self._finish(409, e.error_dict, content_type='json')
@@ -497,7 +497,7 @@ class ApiController(base.BaseController):
                 since_time_str = request.params['since_time']
                 try:
                     since_time = h.date_str_to_datetime(since_time_str)
-                except ValueError, inst:
+                except ValueError as inst:
                     return self._finish_bad_request('ValueError: %s' % inst)
             else:
                 return self._finish_bad_request(
@@ -511,7 +511,7 @@ class ApiController(base.BaseController):
         elif register in ['dataset', 'package', 'resource']:
             try:
                 params = MultiDict(self._get_search_params(request.params))
-            except ValueError, e:
+            except ValueError as e:
                 return self._finish_bad_request(
                     _('Could not read parameters: %r' % e))
 
@@ -571,7 +571,7 @@ class ApiController(base.BaseController):
                         del params['callback']
                     results = query.run(params)
                 return self._finish_ok(results)
-            except search.SearchError, e:
+            except search.SearchError as e:
                 log.exception(e)
                 return self._finish_bad_request(
                     _('Bad search option: %s') % e)
@@ -585,7 +585,7 @@ class ApiController(base.BaseController):
             try:
                 qjson_param = request_params['qjson'].replace('\\\\u', '\\u')
                 params = h.json.loads(qjson_param, encoding='utf8')
-            except ValueError, e:
+            except ValueError as e:
                 raise ValueError(_('Malformed qjson value: %r')
                                  % e)
         elif len(request_params) == 1 and \
@@ -785,7 +785,7 @@ class ApiController(base.BaseController):
                     request_data = keys[0]
                 else:
                     request_data = urllib.unquote_plus(request.body)
-            except Exception, inst:
+            except Exception as inst:
                 msg = "Could not find the POST data: %r : %s" % \
                       (request.POST, inst)
                 raise ValueError(msg)
@@ -799,7 +799,7 @@ class ApiController(base.BaseController):
                     request_data = request.body
                 else:
                     request_data = None
-            except Exception, inst:
+            except Exception as inst:
                 msg = "Could not extract request body data: %s" % \
                       (inst)
                 raise ValueError(msg)
@@ -814,7 +814,7 @@ class ApiController(base.BaseController):
         if request_data and request.content_type != 'multipart/form-data':
             try:
                 request_data = h.json.loads(request_data, encoding='utf8')
-            except ValueError, e:
+            except ValueError as e:
                 raise ValueError('Error decoding JSON data. '
                                  'Error: %r '
                                  'JSON data extracted from the request: %r' %

--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -364,7 +364,7 @@ class GroupController(base.BaseController):
 
             c.sort_by_selected = sort_by
 
-        except search.SearchError, se:
+        except search.SearchError as se:
             log.error('Group search error: %r', se.args)
             c.query_error = True
             c.page = h.Page(collection=[])
@@ -542,11 +542,11 @@ class GroupController(base.BaseController):
 
             # Redirect to the appropriate _read route for the type of group
             h.redirect_to(group['type'] + '_read', id=group['name'])
-        except (NotFound, NotAuthorized), e:
+        except (NotFound, NotAuthorized) as e:
             abort(404, _('Group not found'))
         except dict_fns.DataError:
             abort(400, _(u'Integrity Error'))
-        except ValidationError, e:
+        except ValidationError as e:
             errors = e.error_dict
             error_summary = e.error_summary
             return self.new(data_dict, errors, error_summary)
@@ -572,11 +572,11 @@ class GroupController(base.BaseController):
                 self._force_reindex(group)
 
             h.redirect_to('%s_read' % group['type'], id=group['name'])
-        except (NotFound, NotAuthorized), e:
+        except (NotFound, NotAuthorized) as e:
             abort(404, _('Group not found'))
         except dict_fns.DataError:
             abort(400, _(u'Integrity Error'))
-        except ValidationError, e:
+        except ValidationError as e:
             errors = e.error_dict
             error_summary = e.error_summary
             return self.edit(id, data_dict, errors, error_summary)
@@ -718,7 +718,7 @@ class GroupController(base.BaseController):
             abort(403, _('Unauthorized to add member to group %s') % '')
         except NotFound:
             abort(404, _('Group not found'))
-        except ValidationError, e:
+        except ValidationError as e:
             h.flash_error(e.error_summary)
         return self._render_template('group/member_new.html', group_type)
 

--- a/ckan/controllers/home.py
+++ b/ckan/controllers/home.py
@@ -26,7 +26,7 @@ class HomeController(base.BaseController):
         except logic.NotAuthorized:
             base.abort(403, _('Not authorized to see this page'))
         except (sqlalchemy.exc.ProgrammingError,
-                sqlalchemy.exc.OperationalError), e:
+                sqlalchemy.exc.OperationalError) as e:
             # postgres and sqlite errors for missing tables
             msg = str(e)
             if ('relation' in msg and 'does not exist' in msg) or \

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 import logging
 from urllib import urlencode
 import datetime
@@ -24,7 +25,7 @@ import ckan.plugins as p
 import ckan.lib.render
 
 from ckan.common import OrderedDict, _, json, request, c, response
-from home import CACHE_PARAMETERS
+from .home import CACHE_PARAMETERS
 
 log = logging.getLogger(__name__)
 
@@ -280,14 +281,14 @@ class PackageController(base.BaseController):
             )
             c.search_facets = query['search_facets']
             c.page.items = query['results']
-        except SearchQueryError, se:
+        except SearchQueryError as se:
             # User's search parameters are invalid, in such a way that is not
             # achievable with the web interface, so return a proper error to
             # discourage spiders which are the main cause of this.
             log.info('Dataset search query rejected: %r', se.args)
             abort(400, _('Invalid search query: {error_message}')
                   .format(error_message=str(se)))
-        except SearchError, se:
+        except SearchError as se:
             # May be bad input from the user, but may also be more serious like
             # bad code causing a SOLR syntax error, or a problem connecting to
             # SOLR
@@ -354,9 +355,9 @@ class PackageController(base.BaseController):
                 try:
                     date = h.date_str_to_datetime(revision_ref)
                     context['revision_date'] = date
-                except TypeError, e:
+                except TypeError as e:
                     abort(400, _('Invalid revision format: %r') % e.args)
-                except ValueError, e:
+                except ValueError as e:
                     abort(400, _('Invalid revision format: %r') % e.args)
         elif len(split) > 2:
             abort(400, _('Invalid revision format: %r') %
@@ -570,7 +571,7 @@ class PackageController(base.BaseController):
                     get_action('resource_update')(context, data)
                 else:
                     get_action('resource_create')(context, data)
-            except ValidationError, e:
+            except ValidationError as e:
                 errors = e.error_dict
                 error_summary = e.error_summary
                 return self.resource_edit(id, resource_id, data,
@@ -676,7 +677,7 @@ class PackageController(base.BaseController):
                     get_action('resource_update')(context, data)
                 else:
                     get_action('resource_create')(context, data)
-            except ValidationError, e:
+            except ValidationError as e:
                 errors = e.error_dict
                 error_summary = e.error_summary
                 return self.new_resource(id, data, errors, error_summary)
@@ -919,17 +920,17 @@ class PackageController(base.BaseController):
                                      package_type=package_type)
         except NotAuthorized:
             abort(403, _('Unauthorized to read package %s') % '')
-        except NotFound, e:
+        except NotFound as e:
             abort(404, _('Dataset not found'))
         except dict_fns.DataError:
             abort(400, _(u'Integrity Error'))
-        except SearchIndexError, e:
+        except SearchIndexError as e:
             try:
                 exc_str = unicode(repr(e.args))
             except Exception:  # We don't like bare excepts
                 exc_str = unicode(str(e))
             abort(500, _(u'Unable to add package to search index.') + exc_str)
-        except ValidationError, e:
+        except ValidationError as e:
             errors = e.error_dict
             error_summary = e.error_summary
             if is_an_update:
@@ -967,17 +968,17 @@ class PackageController(base.BaseController):
                                      package_type=package_type)
         except NotAuthorized:
             abort(403, _('Unauthorized to read package %s') % id)
-        except NotFound, e:
+        except NotFound as e:
             abort(404, _('Dataset not found'))
         except dict_fns.DataError:
             abort(400, _(u'Integrity Error'))
-        except SearchIndexError, e:
+        except SearchIndexError as e:
             try:
                 exc_str = unicode(repr(e.args))
             except Exception:  # We don't like bare excepts
                 exc_str = unicode(str(e))
             abort(500, _(u'Unable to update search index.') + exc_str)
-        except ValidationError, e:
+        except ValidationError as e:
             errors = e.error_dict
             error_summary = e.error_summary
             return self.edit(name_or_id, data_dict, errors, error_summary)
@@ -1420,7 +1421,7 @@ class PackageController(base.BaseController):
         # update resource should tell us early if the user has privilages.
         try:
             check_access('resource_update', context, {'id': resource_id})
-        except NotAuthorized, e:
+        except NotAuthorized as e:
             abort(403, _('User %r not authorized to edit %s') % (c.user, id))
 
         # get resource and package data
@@ -1460,7 +1461,7 @@ class PackageController(base.BaseController):
                     data = get_action('resource_view_update')(context, data)
                 else:
                     data = get_action('resource_view_create')(context, data)
-            except ValidationError, e:
+            except ValidationError as e:
                 # Could break preview if validation error
                 to_preview = False
                 errors = e.error_dict

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -243,7 +243,7 @@ class UserController(base.BaseController):
             user = get_action('user_create')(context, data_dict)
         except NotAuthorized:
             abort(403, _('Unauthorized to create user %s') % '')
-        except NotFound, e:
+        except NotFound as e:
             abort(404, _('User not found'))
         except DataError:
             abort(400, _(u'Integrity Error'))
@@ -251,7 +251,7 @@ class UserController(base.BaseController):
             error_msg = _(u'Bad Captcha. Please try again.')
             h.flash_error(error_msg)
             return self.new(data_dict)
-        except ValidationError, e:
+        except ValidationError as e:
             errors = e.error_dict
             error_summary = e.error_summary
             return self.new(data_dict, errors, error_summary)
@@ -373,11 +373,11 @@ class UserController(base.BaseController):
             h.redirect_to(controller='user', action='read', id=user['name'])
         except NotAuthorized:
             abort(403, _('Unauthorized to edit user %s') % id)
-        except NotFound, e:
+        except NotFound as e:
             abort(404, _('User not found'))
         except DataError:
             abort(400, _(u'Integrity Error'))
-        except ValidationError, e:
+        except ValidationError as e:
             errors = e.error_dict
             error_summary = e.error_summary
             return self.edit(id, data_dict, errors, error_summary)
@@ -497,7 +497,7 @@ class UserController(base.BaseController):
                     h.flash_success(_('Please check your inbox for '
                                     'a reset code.'))
                     h.redirect_to('/')
-                except mailer.MailerException, e:
+                except mailer.MailerException as e:
                     h.flash_error(_('Could not send reset link: %s') %
                                   unicode(e))
         return render('user/request_reset.html')
@@ -518,7 +518,7 @@ class UserController(base.BaseController):
             user_dict = get_action('user_show')(context, data_dict)
 
             user_obj = context['user_obj']
-        except NotFound, e:
+        except NotFound as e:
             abort(404, _('User not found'))
 
         c.reset_key = request.params.get('key')
@@ -544,13 +544,13 @@ class UserController(base.BaseController):
                 h.redirect_to('/')
             except NotAuthorized:
                 h.flash_error(_('Unauthorized to edit user %s') % id)
-            except NotFound, e:
+            except NotFound as e:
                 h.flash_error(_('User not found'))
             except DataError:
                 h.flash_error(_(u'Integrity Error'))
-            except ValidationError, e:
+            except ValidationError as e:
                 h.flash_error(u'%r' % e.error_dict)
-            except ValueError, ve:
+            except ValueError as ve:
                 h.flash_error(unicode(ve))
             user_dict['state'] = user_state
 

--- a/ckan/i18n/check_po_files.py
+++ b/ckan/i18n/check_po_files.py
@@ -7,6 +7,7 @@
 
 for usage.
 '''
+from __future__ import print_function
 import polib
 import re
 import paste.script.command
@@ -58,13 +59,13 @@ class CheckPoFiles(paste.script.command.Command):
     def command(self):
 
         for path in self.args:
-            print u'Checking file {}'.format(path)
+            print(u'Checking file {}'.format(path))
             errors = check_po_file(path)
             if errors:
                 for msgid, msgstr in errors:
-                    print 'Format specifiers don\'t match:'
-                    print u'    {0} -> {1}'.format(
-                        msgid, msgstr.encode('ascii', 'replace'))
+                    print('Format specifiers don\'t match:')
+                    print(u'    {0} -> {1}'.format(
+                        msgid, msgstr.encode('ascii', 'replace')))
 
 
 def check_po_file(path):

--- a/ckan/lib/activity_streams_session_extension.py
+++ b/ckan/lib/activity_streams_session_extension.py
@@ -135,7 +135,7 @@ class DatasetActivitySessionExtension(SessionExtension):
                     if activity_detail is not None:
                         if not package.id in activities:
                             activities[package.id] = activity
-                        if activity_details.has_key(activity.id):
+                        if activity.id in activity_details:
                             activity_details[activity.id].append(
                                 activity_detail)
                         else:

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -188,7 +188,7 @@ def render(template_name, extra_vars=None, cache_key=None, cache_type=None,
         else:
             return cached_template(template_name, render_template)
 
-    except ckan.exceptions.CkanUrlException, e:
+    except ckan.exceptions.CkanUrlException as e:
         raise ckan.exceptions.CkanUrlException(
             '\nAn Exception has been raised for template %s\n%s' %
             (template_name, e.message))

--- a/ckan/lib/celery_app.py
+++ b/ckan/lib/celery_app.py
@@ -56,7 +56,7 @@ for entry_point in iter_entry_points(group='ckan.celery_task'):
         default_config['CELERY_IMPORTS'].extend(
             entry_point.load()()
         )
-    except VersionConflict, e:
+    except VersionConflict as e:
         error = 'ERROR in entry point load: %s %s' % (entry_point, e)
         log.critical(error)
         pass

--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+from __future__ import print_function
+from __future__ import absolute_import
 import collections
 import csv
 import multiprocessing as mp
@@ -140,7 +142,7 @@ def user_add(args):
         }
         user_dict = logic.get_action('user_create')(context, data_dict)
         pprint(user_dict)
-    except logic.ValidationError, e:
+    except logic.ValidationError as e:
         error(traceback.format_exc())
 
 ## from http://code.activestate.com/recipes/577058/ MIT licence.
@@ -353,7 +355,7 @@ class ManageDb(CkanCommand):
 
             model.repo.init_db()
             if self.verbose:
-                print 'Initialising DB: SUCCESS'
+                print('Initialising DB: SUCCESS')
         elif cmd == 'clean' or cmd == 'drop':
 
             # remove any *.pyc version files to prevent conflicts
@@ -367,7 +369,7 @@ class ManageDb(CkanCommand):
             model.repo.clean_db()
             search.clear_all()
             if self.verbose:
-                print 'Cleaning DB: SUCCESS'
+                print('Cleaning DB: SUCCESS')
         elif cmd == 'upgrade':
             if len(self.args) > 1:
                 model.repo.upgrade_db(self.args[1])
@@ -384,7 +386,7 @@ class ManageDb(CkanCommand):
         elif cmd == 'create-from-model':
             model.repo.create_db()
             if self.verbose:
-                print 'Creating DB: SUCCESS'
+                print('Creating DB: SUCCESS')
         elif cmd == 'migrate-filestore':
             self.migrate_filestore()
         else:
@@ -417,14 +419,14 @@ class ManageDb(CkanCommand):
         pg_dump_cmd += ' %(db_name)s' % self.db_details
         pg_dump_cmd += ' > %s' % filepath
         self._run_cmd(pg_dump_cmd)
-        print 'Dumped database to: %s' % filepath
+        print('Dumped database to: %s' % filepath)
 
     def _postgres_load(self, filepath):
         import ckan.model as model
         assert not model.repo.are_tables_created(), "Tables already found. You need to 'db clean' before a load."
         pg_cmd = self._get_psql_cmd() + ' -f %s' % filepath
         self._run_cmd(pg_cmd)
-        print 'Loaded CKAN database: %s' % filepath
+        print('Loaded CKAN database: %s' % filepath)
 
     def _run_cmd(self, command_line):
         import subprocess
@@ -435,7 +437,7 @@ class ManageDb(CkanCommand):
     def dump(self):
         deprecation_warning(u"Use PostgreSQL's pg_dump instead.")
         if len(self.args) < 2:
-            print 'Need pg_dump filepath'
+            print('Need pg_dump filepath')
             return
         dump_path = self.args[1]
 
@@ -445,23 +447,23 @@ class ManageDb(CkanCommand):
     def load(self, only_load=False):
         deprecation_warning(u"Use PostgreSQL's pg_restore instead.")
         if len(self.args) < 2:
-            print 'Need pg_dump filepath'
+            print('Need pg_dump filepath')
             return
         dump_path = self.args[1]
 
         psql_cmd = self._get_psql_cmd() + ' -f %s'
         pg_cmd = self._postgres_load(dump_path)
         if not only_load:
-            print 'Upgrading DB'
+            print('Upgrading DB')
             import ckan.model as model
             model.repo.upgrade_db()
 
-            print 'Rebuilding search index'
+            print('Rebuilding search index')
             import ckan.lib.search
             ckan.lib.search.rebuild()
         else:
-            print 'Now remember you have to call \'db upgrade\' and then \'search-index rebuild\'.'
-        print 'Done'
+            print('Now remember you have to call \'db upgrade\' and then \'search-index rebuild\'.')
+        print('Done')
 
     def migrate_filestore(self):
         from ckan.model import Session
@@ -474,8 +476,8 @@ class ManageDb(CkanCommand):
         for id, revision_id, url in results:
             response = requests.get(url, stream=True)
             if response.status_code != 200:
-                print "failed to fetch %s (code %s)" % (url,
-                                                        response.status_code)
+                print("failed to fetch %s (code %s)" % (url,
+                                                        response.status_code))
                 continue
             resource_upload = ResourceUpload({'id': id})
             assert resource_upload.storage_path, "no storage configured aborting"
@@ -484,7 +486,7 @@ class ManageDb(CkanCommand):
             filepath = resource_upload.get_path(id)
             try:
                 os.makedirs(directory)
-            except OSError, e:
+            except OSError as e:
                 ## errno 17 is file already exists
                 if e.errno != 17:
                     raise
@@ -501,11 +503,11 @@ class ManageDb(CkanCommand):
                             "revision_id = :revision_id",
                             {'id': id, 'revision_id': revision_id})
             Session.commit()
-            print "Saved url %s" % url
+            print("Saved url %s" % url)
 
     def version(self):
         from ckan.model import Session
-        print Session.execute('select version from migrate_version;').fetchall()
+        print(Session.execute('select version from migrate_version;').fetchall())
 
 
 class SearchIndexCommand(CkanCommand):
@@ -555,7 +557,7 @@ Default is false.''')
     def command(self):
         if not self.args:
             # default to printing help
-            print self.usage
+            print(self.usage)
             return
 
         cmd = self.args[0]
@@ -574,7 +576,7 @@ Default is false.''')
         elif cmd == 'clear':
             self.clear()
         else:
-            print 'Command %s not recognized' % cmd
+            print('Command %s not recognized' % cmd)
 
     def rebuild(self):
         from ckan.lib.search import rebuild, commit
@@ -602,7 +604,7 @@ Default is false.''')
         from ckan.lib.search import show
 
         if not len(self.args) == 2:
-            print 'Missing parameter: dataset-name'
+            print('Missing parameter: dataset-name')
             return
         index = show(self.args[1])
         pprint(index)
@@ -684,7 +686,7 @@ class Notification(CkanCommand):
             for package in Session.query(Package):
                 dome.notify(package, DomainObjectOperation.changed)
         else:
-            print 'Command %s not recognized' % cmd
+            print('Command %s not recognized' % cmd)
 
 
 class RDFExport(CkanCommand):
@@ -703,7 +705,7 @@ class RDFExport(CkanCommand):
 
         if not self.args:
             # default to run
-            print RDFExport.__doc__
+            print(RDFExport.__doc__)
         else:
             self.export_datasets(self.args[0])
 
@@ -738,13 +740,13 @@ class RDFExport(CkanCommand):
                 fname = os.path.join(out_folder, dd['name']) + ".rdf"
                 try:
                     r = urllib2.urlopen(url).read()
-                except urllib2.HTTPError, e:
+                except urllib2.HTTPError as e:
                     if e.code == 404:
                         error('Please install ckanext-dcat and enable the ' +
                               '`dcat` plugin to use the RDF serializations')
                 with open(fname, 'wb') as f:
                     f.write(r)
-            except IOError, ioe:
+            except IOError as ioe:
                 sys.stderr.write(str(ioe) + "\n")
 
 
@@ -781,56 +783,56 @@ class Sysadmin(CkanCommand):
         elif cmd == 'remove':
             self.remove()
         else:
-            print 'Command %s not recognized' % cmd
+            print('Command %s not recognized' % cmd)
 
     def list(self):
         import ckan.model as model
-        print 'Sysadmins:'
+        print('Sysadmins:')
         sysadmins = model.Session.query(model.User).filter_by(sysadmin=True,
                                                               state='active')
-        print 'count = %i' % sysadmins.count()
+        print('count = %i' % sysadmins.count())
         for sysadmin in sysadmins:
-            print '%s name=%s email=%s id=%s' % (
+            print('%s name=%s email=%s id=%s' % (
                 sysadmin.__class__.__name__,
                 sysadmin.name,
                 sysadmin.email,
-                sysadmin.id)
+                sysadmin.id))
 
     def add(self):
         import ckan.model as model
 
         if len(self.args) < 2:
-            print 'Need name of the user to be made sysadmin.'
+            print('Need name of the user to be made sysadmin.')
             return
         username = self.args[1]
 
         user = model.User.by_name(unicode(username))
         if not user:
-            print 'User "%s" not found' % username
+            print('User "%s" not found' % username)
             makeuser = raw_input('Create new user: %s? [y/n]' % username)
             if makeuser == 'y':
                 user_add(self.args[1:])
                 user = model.User.by_name(unicode(username))
             else:
-                print 'Exiting ...'
+                print('Exiting ...')
                 return
 
         user.sysadmin = True
         model.Session.add(user)
         model.repo.commit_and_remove()
-        print 'Added %s as sysadmin' % username
+        print('Added %s as sysadmin' % username)
 
     def remove(self):
         import ckan.model as model
 
         if len(self.args) < 2:
-            print 'Need name of the user to be made sysadmin.'
+            print('Need name of the user to be made sysadmin.')
             return
         username = self.args[1]
 
         user = model.User.by_name(unicode(username))
         if not user:
-            print 'Error: user "%s" not found!' % username
+            print('Error: user "%s" not found!' % username)
             return
         user.sysadmin = False
         model.repo.commit_and_remove()
@@ -886,24 +888,24 @@ class UserCmd(CkanCommand):
 
     def list(self):
         import ckan.model as model
-        print 'Users:'
+        print('Users:')
         users = model.Session.query(model.User).filter_by(state='active')
-        print 'count = %i' % users.count()
+        print('count = %i' % users.count())
         for user in users:
-            print self.get_user_str(user)
+            print(self.get_user_str(user))
 
     def show(self):
         import ckan.model as model
 
         username = self.args[0]
         user = model.User.get(unicode(username))
-        print 'User: \n', user
+        print('User: \n', user)
 
     def setpass(self):
         import ckan.model as model
 
         if len(self.args) < 2:
-            print 'Need name of the user.'
+            print('Need name of the user.')
             return
         username = self.args[1]
         user = model.User.get(username)
@@ -912,20 +914,20 @@ class UserCmd(CkanCommand):
         password = self.password_prompt()
         user.password = password
         model.repo.commit_and_remove()
-        print 'Done'
+        print('Done')
 
     def search(self):
         import ckan.model as model
 
         if len(self.args) < 2:
-            print 'Need user name query string.'
+            print('Need user name query string.')
             return
         query_str = self.args[1]
 
         query = model.User.search(query_str)
-        print '%i users matching %r:' % (query.count(), query_str)
+        print('%i users matching %r:' % (query.count(), query_str))
         for user in query.all():
-            print self.get_user_str(user)
+            print(self.get_user_str(user))
 
     @classmethod
     def password_prompt(cls):
@@ -945,7 +947,7 @@ class UserCmd(CkanCommand):
         import ckan.model as model
 
         if len(self.args) < 2:
-            print 'Need name of the user.'
+            print('Need name of the user.')
             return
         username = self.args[1]
 
@@ -974,7 +976,7 @@ class DatasetCmd(CkanCommand):
         self._load_config()
 
         if not self.args:
-            print self.usage
+            print(self.usage)
         else:
             cmd = self.args[0]
             if cmd == 'delete':
@@ -990,12 +992,12 @@ class DatasetCmd(CkanCommand):
 
     def list(self):
         import ckan.model as model
-        print 'Datasets:'
+        print('Datasets:')
         datasets = model.Session.query(model.Package)
-        print 'count = %i' % datasets.count()
+        print('count = %i' % datasets.count())
         for dataset in datasets:
             state = ('(%s)' % dataset.state) if dataset.state != 'active' else ''
-            print '%s %s %s' % (dataset.id, dataset.name, state)
+            print('%s %s %s' % (dataset.id, dataset.name, state))
 
     def _get_dataset(self, dataset_ref):
         import ckan.model as model
@@ -1017,7 +1019,7 @@ class DatasetCmd(CkanCommand):
         dataset.delete()
         model.repo.commit_and_remove()
         dataset = self._get_dataset(dataset_ref)
-        print '%s %s -> %s' % (dataset.name, old_state, dataset.state)
+        print('%s %s -> %s' % (dataset.name, old_state, dataset.state))
 
     def purge(self, dataset_ref):
         import ckan.logic as logic
@@ -1028,7 +1030,7 @@ class DatasetCmd(CkanCommand):
         context = {'user': site_user['name']}
         logic.get_action('dataset_purge')(
             context, {'id': dataset_ref})
-        print '%s purged' % name
+        print('%s purged' % name)
 
 
 class Celery(CkanCommand):
@@ -1086,13 +1088,13 @@ class Celery(CkanCommand):
         from kombu.transport.sqlalchemy.models import Message
         q = model.Session.query(Message)
         q_visible = q.filter_by(visible=True)
-        print '%i messages (total)' % q.count()
-        print '%i visible messages' % q_visible.count()
+        print('%i messages (total)' % q.count())
+        print('%i visible messages' % q_visible.count())
         for message in q:
             if message.visible:
-                print '%i: Visible' % (message.id)
+                print('%i: Visible' % (message.id))
             else:
-                print '%i: Invisible Sent:%s' % (message.id, message.sent_at)
+                print('%i: Invisible Sent:%s' % (message.id, message.sent_at))
 
     def clean(self):
         deprecation_warning(u'Use `paster jobs clear` instead.')
@@ -1101,13 +1103,13 @@ class Celery(CkanCommand):
         query = model.Session.execute("select * from kombu_message")
         tasks_initially = query.rowcount
         if not tasks_initially:
-            print 'No tasks to delete'
+            print('No tasks to delete')
             sys.exit(0)
         query = model.Session.execute("delete from kombu_message")
         query = model.Session.execute("select * from kombu_message")
         tasks_afterwards = query.rowcount
-        print '%i of %i tasks deleted' % (tasks_initially - tasks_afterwards,
-                                          tasks_initially)
+        print('%i of %i tasks deleted' % (tasks_initially - tasks_afterwards,
+                                          tasks_initially))
         if tasks_afterwards:
             error('Failed to delete all tasks')
         model.repo.commit_and_remove()
@@ -1139,22 +1141,22 @@ class Ratings(CkanCommand):
         elif cmd == 'clean-anonymous':
             self.clean(user_ratings=False)
         else:
-            print 'Command %s not recognized' % cmd
+            print('Command %s not recognized' % cmd)
 
     def count(self):
         import ckan.model as model
         q = model.Session.query(model.Rating)
-        print "%i ratings" % q.count()
+        print("%i ratings" % q.count())
         q = q.filter(model.Rating.user_id is None)
-        print "of which %i are anonymous ratings" % q.count()
+        print("of which %i are anonymous ratings" % q.count())
 
     def clean(self, user_ratings=True):
         import ckan.model as model
         q = model.Session.query(model.Rating)
-        print "%i ratings" % q.count()
+        print("%i ratings" % q.count())
         if not user_ratings:
             q = q.filter(model.Rating.user_id is None)
-            print "of which %i are anonymous ratings" % q.count()
+            print("of which %i are anonymous ratings" % q.count())
         ratings = q.all()
         for rating in ratings:
             rating.purge()
@@ -1221,7 +1223,7 @@ class Tracking(CkanCommand):
         while start_date < end_date:
             stop_date = start_date + datetime.timedelta(1)
             self.update_tracking(engine, start_date)
-            print 'tracking updated for %s' % start_date
+            print('tracking updated for %s' % start_date)
             start_date = stop_date
 
         self.update_tracking_solr(engine, start_date_solrsync)
@@ -1355,21 +1357,21 @@ class Tracking(CkanCommand):
 
         total = len(package_ids)
         not_found = 0
-        print '%i package index%s to be rebuilt starting from %s' % (total, '' if total < 2 else 'es', start_date)
+        print('%i package index%s to be rebuilt starting from %s' % (total, '' if total < 2 else 'es', start_date))
 
         from ckan.lib.search import rebuild
         for package_id in package_ids:
             try:
                 rebuild(package_id)
             except logic.NotFound:
-                print "Error: package %s not found." % (package_id)
+                print("Error: package %s not found." % (package_id))
                 not_found += 1
             except KeyboardInterrupt:
-                print "Stopped."
+                print("Stopped.")
                 return
             except:
                 raise
-        print 'search index rebuilding done.' + (' %i not found.' % (not_found) if not_found else "")
+        print('search index rebuilding done.' + (' %i not found.' % (not_found) if not_found else ""))
 
 
 class PluginInfo(CkanCommand):
@@ -1409,21 +1411,21 @@ class PluginInfo(CkanCommand):
 
         for plugin in plugins:
             p = plugins[plugin]
-            print plugin + ':'
-            print '-' * (len(plugin) + 1)
+            print(plugin + ':')
+            print('-' * (len(plugin) + 1))
             if p['doc']:
-                print p['doc']
-            print 'Implements:'
+                print(p['doc'])
+            print('Implements:')
             for i in p['implements']:
                 extra = None
                 if i == 'ITemplateHelpers':
                     extra = self.template_helpers(p['class'])
                 if i == 'IActions':
                     extra = self.actions(p['class'])
-                print '    %s' % i
+                print('    %s' % i)
                 if extra:
-                    print extra
-            print
+                    print(extra)
+            print()
 
     def actions(self, cls):
         ''' Return readable action function info. '''
@@ -1488,20 +1490,20 @@ class CreateTestDataCommand(CkanCommand):
     def command(self):
         self._load_config()
         from ckan import plugins
-        from create_test_data import CreateTestData
+        from .create_test_data import CreateTestData
 
         if self.args:
             cmd = self.args[0]
         else:
             cmd = 'basic'
         if self.verbose:
-            print 'Creating %s test data' % cmd
+            print('Creating %s test data' % cmd)
         if cmd == 'basic':
             CreateTestData.create_basic_test_data()
         elif cmd == 'user':
             CreateTestData.create_test_user()
-            print 'Created user %r with password %r and apikey %r' % ('tester',
-                                                                      'tester', 'tester')
+            print('Created user %r with password %r and apikey %r' % ('tester',
+                                                                      'tester', 'tester'))
         elif cmd == 'search':
             CreateTestData.create_search_test_data()
         elif cmd == 'gov':
@@ -1515,10 +1517,10 @@ class CreateTestDataCommand(CkanCommand):
         elif cmd == 'hierarchy':
             CreateTestData.create_group_hierarchy_test_data()
         else:
-            print 'Command %s not recognized' % cmd
+            print('Command %s not recognized' % cmd)
             raise NotImplementedError
         if self.verbose:
-            print 'Creating %s test data: Complete!' % cmd
+            print('Creating %s test data: Complete!' % cmd)
 
 
 class Profile(CkanCommand):
@@ -1575,7 +1577,7 @@ class Profile(CkanCommand):
                 res = self.app.get(url, status=[200],
                                    extra_environ={'REMOTE_USER': user})
             except paste.fixture.AppError:
-                print 'App error: ', url.strip()
+                print('App error: ', url.strip())
             except KeyboardInterrupt:
                 raise
             except Exception:
@@ -1588,8 +1590,8 @@ class Profile(CkanCommand):
         stats = pstats.Stats(output_filename)
         stats.sort_stats('cumulative')
         stats.print_stats(0.1)  # show only top 10% of lines
-        print 'Only top 10% of lines shown'
-        print 'Written profile to: %s' % output_filename
+        print('Only top 10% of lines shown')
+        print('Written profile to: %s' % output_filename)
 
 
 class CreateColorSchemeCommand(CkanCommand):
@@ -1778,7 +1780,7 @@ class CreateColorSchemeCommand(CkanCommand):
         import math
         saturation -= math.trunc(saturation)
 
-        print hue, saturation
+        print(hue, saturation)
         import colorsys
         ''' Create n related colours '''
         colors = []
@@ -1812,7 +1814,7 @@ class CreateColorSchemeCommand(CkanCommand):
             rgb = None
             if arg == 'clear':
                 os.remove(path)
-                print 'custom colors removed.'
+                print('custom colors removed.')
             elif arg.startswith('#'):
                 color = arg[1:]
                 if len(color) == 3:
@@ -1820,7 +1822,7 @@ class CreateColorSchemeCommand(CkanCommand):
                 elif len(color) == 6:
                     rgb = [int(x, 16) for x in re.findall('..', color)]
                 else:
-                    print 'ERROR: invalid color'
+                    print('ERROR: invalid color')
             elif arg.lower() in self.color_list:
                 color = self.color_list[arg.lower()][1:]
                 rgb = [int(x, 16) for x in re.findall('..', color)]
@@ -1828,7 +1830,7 @@ class CreateColorSchemeCommand(CkanCommand):
                 try:
                     hue = float(self.args[0])
                 except ValueError:
-                    print 'ERROR argument `%s` not recognised' % arg
+                    print('ERROR argument `%s` not recognised' % arg)
             if rgb:
                 import colorsys
                 hue, lightness, saturation = colorsys.rgb_to_hls(*rgb)
@@ -1844,10 +1846,10 @@ class CreateColorSchemeCommand(CkanCommand):
             colors = self.create_colors(hue, saturation=saturation, lightness=lightness)
             for i in xrange(len(self.rules)):
                 f.write('%s: %s;\n' % (self.rules[i], colors[i]))
-                print '%s: %s;\n' % (self.rules[i], colors[i])
+                print('%s: %s;\n' % (self.rules[i], colors[i]))
             f.close
-            print 'Color scheme has been created.'
-        print 'Make sure less is run for changes to take effect.'
+            print('Color scheme has been created.')
+        print('Make sure less is run for changes to take effect.')
 
 
 class TranslationsCommand(CkanCommand):
@@ -1875,7 +1877,7 @@ class TranslationsCommand(CkanCommand):
         elif command == 'js':
             build_js_translations()
         else:
-            print 'command not recognised'
+            print('command not recognised')
 
     def mangle_po(self):
         ''' This will mangle the zh_TW translations for translation coverage
@@ -1920,7 +1922,7 @@ class TranslationsCommand(CkanCommand):
         out_mo = os.path.join(out_dir, 'ckan.mo')
         po.save(out_po)
         po.save_as_mofile(out_mo)
-        print 'zh_TW has been mangled'
+        print('zh_TW has been mangled')
 
 
 class MinifyCommand(CkanCommand):
@@ -1983,7 +1985,7 @@ class MinifyCommand(CkanCommand):
             return
 
         if path_only.endswith('.min'):
-            print 'removing %s' % path
+            print('removing %s' % path)
             os.remove(path)
 
     def minify_file(self, path):
@@ -2017,7 +2019,7 @@ class MinifyCommand(CkanCommand):
         elif path.endswith('.js'):
             f.write(rjsmin.jsmin(source))
         f.close()
-        print "Minified file '{0}'".format(path)
+        print("Minified file '{0}'".format(path))
 
 
 class LessCommand(CkanCommand):
@@ -2099,7 +2101,7 @@ class LessCommand(CkanCommand):
         self.compile_less(root, less_bin, 'main')
 
     def compile_less(self, root, less_bin, color):
-        print 'compile %s.css' % color
+        print('compile %s.css' % color)
         import subprocess
         main_less = os.path.join(root, 'less', 'main.less')
         main_css = os.path.join(root, 'css', '%s.css' % color)
@@ -2108,7 +2110,7 @@ class LessCommand(CkanCommand):
 
         process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         output = process.communicate()
-        print output
+        print(output)
 
 
 class FrontEndBuildCommand(CkanCommand):
@@ -2214,7 +2216,7 @@ Not used when using the `-d` option.''')
     def command(self):
         self._load_config()
         if not self.args:
-            print self.usage
+            print(self.usage)
         elif self.args[0] == 'create':
             view_plugin_types = self.args[1:]
             self.create_views(view_plugin_types)
@@ -2224,7 +2226,7 @@ Not used when using the `-d` option.''')
         elif self.args[0] == 'clean':
             self.clean_views()
         else:
-            print self.usage
+            print(self.usage)
 
     _page_size = 100
 
@@ -2353,7 +2355,7 @@ Not used when using the `-d` option.''')
 
         try:
             user_search_params = json.loads(self.options.search_params)
-        except ValueError, e:
+        except ValueError as e:
             error('Unable to parse JSON search parameters: {0}'.format(e))
 
         if user_search_params.get('q'):
@@ -2501,22 +2503,22 @@ Not used when using the `-d` option.''')
         results = model.ResourceView.get_count_not_in_view_types(names)
 
         if not results:
-            print 'No resource views to delete'
+            print('No resource views to delete')
             return
 
-        print 'This command will delete.\n'
+        print('This command will delete.\n')
         for row in results:
-            print '%s of type %s' % (row[1], row[0])
+            print('%s of type %s' % (row[1], row[0]))
 
         result = query_yes_no('Do you want to delete these resource views:', default='no')
 
         if result == 'no':
-            print 'Not Deleting.'
+            print('Not Deleting.')
             return
 
         model.ResourceView.delete_not_in_view_types(names)
         model.Session.commit()
-        print 'Deleted resource views.'
+        print('Deleted resource views.')
 
 
 class ConfigToolCommand(paste.script.command.Command):
@@ -2546,7 +2548,7 @@ class ConfigToolCommand(paste.script.command.Command):
         help='Supply an options file to merge in')
 
     def command(self):
-        import config_tool
+        from . import config_tool
         if len(self.args) < 1:
             self.parser.error('Not enough arguments (got %i, need at least 1)'
                               % len(self.args))
@@ -2571,7 +2573,7 @@ class ConfigToolCommand(paste.script.command.Command):
                 config_tool.config_edit_using_option_strings(
                     config_filepath, options, self.options.section,
                     edit=self.options.edit)
-            except config_tool.ConfigToolError, e:
+            except config_tool.ConfigToolError as e:
                 error(traceback.format_exc())
 
 

--- a/ckan/lib/config_tool.py
+++ b/ckan/lib/config_tool.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import print_function
 import re
 
 INSERT_NEW_SECTIONS_BEFORE_SECTION = 'app:main'
@@ -170,8 +171,8 @@ def make_changes(input_lines, new_sections, changes):
             for option in changes.get(section, 'add'):
                 write_option(option)
             write_option('')
-            print 'Created option %s = "%s" (NEW section "%s")' % \
-                (option.key, option.value, section)
+            print('Created option %s = "%s" (NEW section "%s")' % \
+                (option.key, option.value, section))
 
     for line in input_lines:
         # leave blank lines alone
@@ -205,12 +206,12 @@ def make_changes(input_lines, new_sections, changes):
             key = existing_option.key
             if existing_option.id in options_already_edited:
                 if not existing_option.is_commented_out:
-                    print 'Commented out repeat of %s (section "%s")' % \
-                        (key, section)
+                    print('Commented out repeat of %s (section "%s")' % \
+                        (key, section))
                     existing_option.comment_out()
                 else:
-                    print 'Left commented out repeat of %s (section "%s")' % \
-                        (key, section)
+                    print('Left commented out repeat of %s (section "%s")' % \
+                        (key, section))
             elif not existing_option.is_commented_out and \
                     updated_option.is_commented_out:
                 changes_made = 'Commented out %s (section "%s")' % \
@@ -233,7 +234,7 @@ def make_changes(input_lines, new_sections, changes):
                         (key, existing_option.value, section)
 
             if changes_made:
-                print changes_made
+                print(changes_made)
                 write_option(updated_option)
                 options_already_edited.add(updated_option.id)
             else:

--- a/ckan/lib/create_test_data.py
+++ b/ckan/lib/create_test_data.py
@@ -161,7 +161,7 @@ class CreateTestData(object):
                 rev.message = u'Creating test packages.'
                 pkg_dict = {}
                 for field in cls.pkg_core_fields:
-                    if item.has_key(field):
+                    if field in item:
                         pkg_dict[field] = unicode(item[field])
                 if model.Package.by_name(pkg_dict['name']):
                     log.warning('Cannot create package "%s" as it already exists.' % \
@@ -648,7 +648,7 @@ search_items = [{'name':'gils',
               'tags':'registry,country-usa,government,federal,gov,workshop-20081101,penguin'.split(','),
               'resources':[{'url':'http://www.dcsf.gov.uk/rsgateway/DB/SFR/s000859/SFR17_2009_tables.xls',
                           'format':'XLS',
-                          'last_modified': datetime.datetime(2005,10,01),
+                          'last_modified': datetime.datetime(2005,10,0o1),
                           'description':'December 2009 | http://www.statistics.gov.uk/hub/id/119-36345'},
                           {'url':'http://www.dcsf.gov.uk/rsgateway/DB/SFR/s000860/SFR17_2009_key.doc',
                           'format':'DOC',

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -474,7 +474,7 @@ def tag_list_dictize(tag_list, context):
         # the same as its name, but the display_name might get changed later
         # (e.g.  translated into another language by the multilingual
         # extension).
-        assert not dictized.has_key('display_name')
+        assert 'display_name' not in dictized
         dictized['display_name'] = dictized['name']
 
         if context.get('for_view'):
@@ -685,7 +685,7 @@ def package_to_api(pkg, context):
 
 def vocabulary_dictize(vocabulary, context, include_datasets=False):
     vocabulary_dict = d.table_dictize(vocabulary, context)
-    assert not vocabulary_dict.has_key('tags')
+    assert 'tags' not in vocabulary_dict
 
     vocabulary_dict['tags'] = [tag_dictize(tag, context, include_datasets)
                                for tag in vocabulary.tags]

--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -525,7 +525,7 @@ def activity_dict_save(activity_dict, context):
     object_id = activity_dict['object_id']
     revision_id = activity_dict['revision_id']
     activity_type = activity_dict['activity_type']
-    if activity_dict.has_key('data'):
+    if 'data' in activity_dict:
         data = activity_dict['data']
     else:
         data = None
@@ -562,7 +562,7 @@ def vocabulary_dict_save(vocabulary_dict, context):
     vocabulary_obj = model.Vocabulary(vocabulary_name)
     session.add(vocabulary_obj)
 
-    if vocabulary_dict.has_key('tags'):
+    if 'tags' in vocabulary_dict:
         vocabulary_tag_list_save(vocabulary_dict['tags'], vocabulary_obj,
             context)
 
@@ -575,10 +575,10 @@ def vocabulary_dict_update(vocabulary_dict, context):
 
     vocabulary_obj = model.vocabulary.Vocabulary.get(vocabulary_dict['id'])
 
-    if vocabulary_dict.has_key('name'):
+    if 'name' in vocabulary_dict:
         vocabulary_obj.name = vocabulary_dict['name']
 
-    if vocabulary_dict.has_key('tags'):
+    if 'tags' in vocabulary_dict:
         vocabulary_tag_list_save(vocabulary_dict['tags'], vocabulary_obj,
             context)
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -5,6 +5,7 @@
 Consists of functions to typically be used within templates, but also
 available to Controllers. This module is available to templates as 'h'.
 '''
+from __future__ import absolute_import
 import email.utils
 import datetime
 import logging
@@ -33,7 +34,7 @@ from routes import redirect_to as _routes_redirect_to
 from routes import url_for as _routes_default_url_for
 from flask import url_for as _flask_default_url_for
 from werkzeug.routing import BuildError as FlaskRouteBuildError
-import i18n
+from . import i18n
 
 import ckan.exceptions
 import ckan.model as model
@@ -2417,7 +2418,7 @@ def resource_formats():
         with open(format_file_path) as format_file:
             try:
                 file_resource_formats = json.loads(format_file.read())
-            except ValueError, e:
+            except ValueError as e:
                 # includes simplejson.decoder.JSONDecodeError
                 raise ValueError('Invalid JSON syntax in %s: %s' %
                                  (format_file_path, e))

--- a/ckan/lib/jinja_extensions.py
+++ b/ckan/lib/jinja_extensions.py
@@ -178,7 +178,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 continue
             try:
                 contents = f.read().decode(self.encoding)
-            except UnicodeDecodeError, e:
+            except UnicodeDecodeError as e:
                 log.critical(
                     'Template corruption in `%s` unicode decode errors'
                     % filename
@@ -206,7 +206,7 @@ class BaseExtension(ext.Extension):
 
     def parse(self, parser):
         stream = parser.stream
-        tag = stream.next()
+        tag = next(stream)
         # get arguments
         args = []
         kwargs = []

--- a/ckan/lib/jobs.py
+++ b/ckan/lib/jobs.py
@@ -17,6 +17,7 @@ prefixed names. Use the functions ``add_queue_name_prefix`` and
 
 .. versionadded:: 2.7
 '''
+from __future__ import print_function
 
 import logging
 

--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -62,7 +62,7 @@ def _mail_recipient(recipient_name, recipient_email,
 
     try:
         smtp_connection.connect(smtp_server)
-    except socket.error, e:
+    except socket.error as e:
         log.exception(e)
         raise MailerException('SMTP server could not be connected to: "%s" %s'
                               % (smtp_server, e))
@@ -89,7 +89,7 @@ def _mail_recipient(recipient_name, recipient_email,
         smtp_connection.sendmail(mail_from, [recipient_email], msg.as_string())
         log.info("Sent email to {0}".format(recipient_email))
 
-    except smtplib.SMTPException, e:
+    except smtplib.SMTPException as e:
         msg = '%r' % e
         log.exception(msg)
         raise MailerException(msg)

--- a/ckan/lib/munge.py
+++ b/ckan/lib/munge.py
@@ -156,8 +156,8 @@ def munge_filename(filename):
     # Clean up
     filename = filename.lower().strip()
     filename = substitute_ascii_equivalents(filename)
-    filename = re.sub(ur'[^a-zA-Z0-9_. -]', '', filename).replace(u' ', u'-')
-    filename = re.sub(ur'-+', u'-', filename)
+    filename = re.sub(u'[^a-zA-Z0-9_. -]', '', filename).replace(u' ', u'-')
+    filename = re.sub(u'-+', u'-', filename)
 
     # Enforce length constraints
     name, ext = os.path.splitext(filename)

--- a/ckan/lib/navl/dictization_functions.py
+++ b/ckan/lib/navl/dictization_functions.py
@@ -218,7 +218,7 @@ def convert(converter, key, converted_data, errors, context):
         try:
             value = converted_data.get(key)
             value = converter().to_python(value, state=context)
-        except fe.Invalid, e:
+        except fe.Invalid as e:
             errors[key].append(e.msg)
         return
 
@@ -226,7 +226,7 @@ def convert(converter, key, converted_data, errors, context):
         try:
             value = converted_data.get(key)
             value = converter.to_python(value, state=context)
-        except fe.Invalid, e:
+        except fe.Invalid as e:
             errors[key].append(e.msg)
         return
 
@@ -234,22 +234,22 @@ def convert(converter, key, converted_data, errors, context):
         value = converter(converted_data.get(key))
         converted_data[key] = value
         return
-    except TypeError, e:
+    except TypeError as e:
         # hack to make sure the type error was caused by the wrong
         # number of arguments given.
         if converter.__name__ not in str(e):
             raise
-    except Invalid, e:
+    except Invalid as e:
         errors[key].append(e.error)
         return
 
     try:
         converter(key, converted_data, errors, context)
         return
-    except Invalid, e:
+    except Invalid as e:
         errors[key].append(e.error)
         return
-    except TypeError, e:
+    except TypeError as e:
         # hack to make sure the type error was caused by the wrong
         # number of arguments given.
         if converter.__name__ not in str(e):
@@ -259,7 +259,7 @@ def convert(converter, key, converted_data, errors, context):
         value = converter(converted_data.get(key), context)
         converted_data[key] = value
         return
-    except Invalid, e:
+    except Invalid as e:
         errors[key].append(e.error)
         return
 

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+from __future__ import print_function
+from __future__ import absolute_import
 import logging
 import sys
 import cgitb
@@ -13,10 +15,10 @@ import ckan.model as model
 import ckan.plugins as p
 import ckan.logic as logic
 
-from common import (SearchIndexError, SearchError, SearchQueryError,
+from .common import (SearchIndexError, SearchError, SearchQueryError,
                     make_connection, is_available, SolrSettings)
-from index import PackageSearchIndex, NoopSearchIndex
-from query import (TagSearchQuery, ResourceSearchQuery, PackageSearchQuery,
+from .index import PackageSearchIndex, NoopSearchIndex
+from .query import (TagSearchQuery, ResourceSearchQuery, PackageSearchQuery,
                    QueryOptions, convert_legacy_parameters_to_solr)
 
 log = logging.getLogger(__name__)
@@ -72,7 +74,7 @@ def index_for(_type):
     try:
         _type_n = _normalize_type(_type)
         return _INDICES[_type_n]()
-    except KeyError, ke:
+    except KeyError as ke:
         log.warn("Unknown search type: %s" % _type)
         return NoopSearchIndex()
 
@@ -83,7 +85,7 @@ def query_for(_type):
     try:
         _type_n = _normalize_type(_type)
         return _QUERIES[_type_n]()
-    except KeyError, ke:
+    except KeyError as ke:
         raise SearchError("Unknown search type: %s" % _type)
 
 
@@ -99,7 +101,7 @@ def dispatch_by_operation(entity_type, entity, operation):
             index.remove_dict(entity)
         else:
             log.warn("Unknown operation: %s" % operation)
-    except Exception, ex:
+    except Exception as ex:
         log.exception(ex)
         # we really need to know about any exceptions, so reraise
         # (see #1172)
@@ -193,7 +195,7 @@ def rebuild(package_id=None, only_missing=False, force=False, refresh=False,
                     ),
                     defer_commit
                 )
-            except Exception, e:
+            except Exception as e:
                 log.error(u'Error while indexing dataset %s: %s' %
                           (pkg_id, repr(e)))
                 if force:
@@ -221,11 +223,11 @@ def check():
     pkgs = set([pkg.id for pkg in pkgs_q])
     indexed_pkgs = set(package_query.get_all_entity_ids(max_results=len(pkgs)))
     pkgs_not_indexed = pkgs - indexed_pkgs
-    print 'Packages not indexed = %i out of %i' % (len(pkgs_not_indexed),
-                                                   len(pkgs))
+    print('Packages not indexed = %i out of %i' % (len(pkgs_not_indexed),
+                                                   len(pkgs)))
     for pkg_id in pkgs_not_indexed:
         pkg = model.Session.query(model.Package).get(pkg_id)
-        print pkg.revision.timestamp.strftime('%Y-%m-%d'), pkg.name
+        print(pkg.revision.timestamp.strftime('%Y-%m-%d'), pkg.name)
 
 
 def show(package_reference):

--- a/ckan/lib/search/common.py
+++ b/ckan/lib/search/common.py
@@ -55,7 +55,7 @@ def is_available():
     try:
         conn = make_connection()
         conn.search(q="*:*", rows=1)
-    except Exception, e:
+    except Exception as e:
         log.exception(e)
         return False
     return True

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 import socket
 import string
 import logging
@@ -14,7 +15,7 @@ import pysolr
 from ckan.common import config
 from paste.deploy.converters import asbool
 
-from common import SearchIndexError, make_connection
+from .common import SearchIndexError, make_connection
 from ckan.model import PackageRelationship
 import ckan.model as model
 from ckan.plugins import (PluginImplementations,
@@ -50,11 +51,11 @@ def clear_index():
     query = "+site_id:\"%s\"" % (config.get('ckan.site_id'))
     try:
         conn.delete(q=query)
-    except socket.error, e:
+    except socket.error as e:
         err = 'Could not connect to SOLR %r: %r' % (conn.url, e)
         log.error(err)
         raise SearchIndexError(err)
-    except pysolr.SolrError, e:
+    except pysolr.SolrError as e:
         err = 'SOLR %r exception: %r' % (conn.url, e)
         log.error(err)
         raise SearchIndexError(err)
@@ -293,12 +294,12 @@ class PackageSearchIndex(SearchIndex):
             if not asbool(config.get('ckan.search.solr_commit', 'true')):
                 commit = False
             conn.add(docs=[pkg_dict], commit=commit)
-        except pysolr.SolrError, e:
+        except pysolr.SolrError as e:
             msg = 'Solr returned an error: {0}'.format(
                 e[:1000] # limit huge responses
             )
             raise SearchIndexError(msg)
-        except socket.error, e:
+        except socket.error as e:
             err = 'Could not connect to Solr using {0}: {1}'.format(conn.url, str(e))
             log.error(err)
             raise SearchIndexError(err)
@@ -310,7 +311,7 @@ class PackageSearchIndex(SearchIndex):
         try:
             conn = make_connection()
             conn.commit(waitSearcher=False)
-        except Exception, e:
+        except Exception as e:
             log.exception(e)
             raise SearchIndexError(e)
 
@@ -323,6 +324,6 @@ class PackageSearchIndex(SearchIndex):
         try:
             commit = asbool(config.get('ckan.search.solr_commit', 'true'))
             conn.delete(q=query, commit=commit)
-        except Exception, e:
+        except Exception as e:
             log.exception(e)
             raise SearchIndexError(e)

--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -270,7 +270,7 @@ class PackageSearchQuery(SearchQuery):
         log.debug('Package query: %r' % query)
         try:
             solr_response = conn.search(**query)
-        except pysolr.SolrError, e:
+        except pysolr.SolrError as e:
             raise SearchError('SOLR returned an error running query: %r Error: %r' %
                               (query, e))
 
@@ -358,7 +358,7 @@ class PackageSearchQuery(SearchQuery):
         log.debug('Package query: %r' % query)
         try:
             solr_response = conn.search(**query)
-        except pysolr.SolrError, e:
+        except pysolr.SolrError as e:
             # Error with the sort parameter.  You see slightly different
             # error messages depending on whether the SOLR JSON comes back
             # or Jetty gets in the way converting it to HTML - not sure why

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -105,7 +105,7 @@ class Upload(object):
                                          'uploads', object_type)
         try:
             os.makedirs(self.storage_path)
-        except OSError, e:
+        except OSError as e:
             # errno 17 is file already exists
             if e.errno != 17:
                 raise
@@ -191,7 +191,7 @@ class ResourceUpload(object):
         self.storage_path = os.path.join(path, 'resources')
         try:
             os.makedirs(self.storage_path)
-        except OSError, e:
+        except OSError as e:
             # errno 17 is file already exists
             if e.errno != 17:
                 raise
@@ -230,7 +230,7 @@ class ResourceUpload(object):
                     self.mimetype = magic.from_buffer(self.upload_file.read(),
                                                       mime=True)
                     self.upload_file.seek(0, os.SEEK_SET)
-                except IOError, e:
+                except IOError as e:
                     # Not that important if call above fails
                     self.mimetype = None
 
@@ -272,7 +272,7 @@ class ResourceUpload(object):
         if self.filename:
             try:
                 os.makedirs(directory)
-            except OSError, e:
+            except OSError as e:
                 # errno 17 is file already exists
                 if e.errno != 17:
                     raise
@@ -306,5 +306,5 @@ class ResourceUpload(object):
         if self.clear:
             try:
                 os.remove(filepath)
-            except OSError, e:
+            except OSError as e:
                 pass

--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -297,7 +297,7 @@ def check_access(action, context, data_dict=None):
         if not logic_authorization['success']:
             msg = logic_authorization.get('msg', '')
             raise NotAuthorized(msg)
-    except NotAuthorized, e:
+    except NotAuthorized as e:
         log.debug(u'check access NotAuthorized - %s user=%s "%s"',
                   action, user, unicode(e))
         raise

--- a/ckan/logic/action/__init__.py
+++ b/ckan/logic/action/__init__.py
@@ -19,9 +19,9 @@ def rename_keys(dict_, key_map, reverse=False, destructive=False):
     for key, mapping in key_map.items():
         if reverse:
             key, mapping = (mapping, key)
-        if (not destructive) and new_dict.has_key(mapping):
+        if (not destructive) and mapping in new_dict:
             continue
-        if dict_.has_key(key):
+        if key in dict_:
             value = dict_[key]
             new_dict[mapping] = value
             del new_dict[key]

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -315,7 +315,7 @@ def resource_create(context, data_dict):
         context['use_cache'] = False
         _get_action('package_update')(context, pkg_dict)
         context.pop('defer_commit')
-    except ValidationError, e:
+    except ValidationError as e:
         try:
             raise ValidationError(e.error_dict['resources'][-1])
         except (KeyError, IndexError):

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -186,7 +186,7 @@ def resource_delete(context, data_dict):
                 r['id'] == id]
     try:
         pkg_dict = _get_action('package_update')(context, pkg_dict)
-    except ValidationError, e:
+    except ValidationError as e:
         errors = e.error_dict['resources'][-1]
         raise ValidationError(errors)
 
@@ -566,7 +566,7 @@ def tag_delete(context, data_dict):
     '''
     model = context['model']
 
-    if not data_dict.has_key('id') or not data_dict['id']:
+    if 'id' not in data_dict or not data_dict['id']:
         raise ValidationError({'id': _('id not in data')})
     tag_id_or_name = _get_or_bust(data_dict, 'id')
 
@@ -599,7 +599,7 @@ def package_relationship_delete_rest(context, data_dict):
 def _unfollow(context, data_dict, schema, FollowerClass):
     model = context['model']
 
-    if not context.has_key('user'):
+    if 'user' not in context:
         raise ckan.logic.NotAuthorized(
                 _("You must be logged in to unfollow something."))
     userobj = model.User.get(context['user'])

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -114,7 +114,7 @@ def resource_update(context, data_dict):
         context['use_cache'] = False
         updated_pkg_dict = _get_action('package_update')(context, pkg_dict)
         context.pop('defer_commit')
-    except ValidationError, e:
+    except ValidationError as e:
         try:
             raise ValidationError(e.error_dict['resources'][-1])
         except (KeyError, IndexError):
@@ -960,7 +960,7 @@ def vocabulary_update(context, data_dict):
         raise NotFound(_('Could not find vocabulary "%s"') % vocab_id)
 
     data_dict['id'] = vocab.id
-    if data_dict.has_key('name'):
+    if 'name' in data_dict:
         if data_dict['name'] == vocab.name:
             del data_dict['name']
 

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -126,7 +126,7 @@ def isodate(value, context):
         return None
     try:
         date = h.date_str_to_datetime(value)
-    except (TypeError, ValueError), e:
+    except (TypeError, ValueError) as e:
         raise Invalid(_('Date format incorrect'))
     return date
 
@@ -302,7 +302,7 @@ def object_id_validator(key, activity_dict, errors, context):
 
     '''
     activity_type = activity_dict[('activity_type',)]
-    if object_id_validators.has_key(activity_type):
+    if activity_type in object_id_validators:
         object_id = activity_dict[('object_id',)]
         return object_id_validators[activity_type](object_id, context)
     else:
@@ -355,7 +355,7 @@ def package_name_validator(key, data, errors, context):
     else:
         package_id = data.get(key[:-1] + ('id',))
     if package_id and package_id is not missing:
-        query = query.filter(model.Package.id <> package_id)
+        query = query.filter(model.Package.id != package_id)
     result = query.first()
     if result and result.state != State.DELETED:
         errors[key].append(_('That URL is already in use.'))
@@ -404,7 +404,7 @@ def group_name_validator(key, data, errors, context):
     else:
         group_id = data.get(key[:-1] + ('id',))
     if group_id and group_id is not missing:
-        query = query.filter(model.Group.id <> group_id)
+        query = query.filter(model.Group.id != group_id)
     result = query.first()
     if result:
         errors[key].append(_('Group name already exists in database'))
@@ -666,7 +666,7 @@ def tag_not_in_vocabulary(key, tag_dict, errors, context):
     tag_name = tag_dict[('name',)]
     if not tag_name:
         raise Invalid(_('No tag name'))
-    if tag_dict.has_key(('vocabulary_id',)):
+    if ('vocabulary_id',) in tag_dict:
         vocabulary_id = tag_dict[('vocabulary_id',)]
     else:
         vocabulary_id = None

--- a/ckan/migration/versions/018_adjust_licenses.py
+++ b/ckan/migration/versions/018_adjust_licenses.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import print_function
 from sqlalchemy import *
 from migrate import *
 import uuid
@@ -123,7 +124,7 @@ def downgrade(migrate_engine):
 def _check_map_has_old_license_titles(old_license_titles, map):
     for title in old_license_titles.values():
         if title not in map:
-            raise Exception, "The old license title '%s' wasn't found in the upgrade map. Decide which new license id should be substituted for this license and add an entry to the map (in ckan/migration/versions/018_adjust_licenses.py)." % title
+            raise Exception("The old license title '%s' wasn't found in the upgrade map. Decide which new license id should be substituted for this license and add an entry to the map (in ckan/migration/versions/018_adjust_licenses.py)." % title)
 
 def _get_old_license_titles(migrate_engine):
     "Returns a dict of old license titles, keyed by old license id."
@@ -160,7 +161,7 @@ def _switch_package_license_ids(old_ids, old_license_titles, map):
             old_license_title = old_license_titles[old_license_id]
             new_license_id = map[old_license_title]
             new_ids[package_id] = new_license_id
-            print "Switched license_id %s to %s" % (old_license_id, new_license_id)
+            print("Switched license_id %s to %s" % (old_license_id, new_license_id))
     return new_ids
 
 def _set_new_package_license_ids(migrate_engine, new_ids):

--- a/ckan/migration/versions/083_remove_related_items.py
+++ b/ckan/migration/versions/083_remove_related_items.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import print_function
 WARNING = """
 
 WARNING: The 'related' tables were not deleted as they currently contain data.
@@ -17,7 +18,7 @@ def upgrade(migrate_engine):
     existing = migrate_engine.execute("SELECT COUNT(*) FROM related;")\
         .fetchone()
     if existing[0] > 0:
-        print WARNING
+        print(WARNING)
         return
 
     migrate_engine.execute('''

--- a/ckan/model/__init__.py
+++ b/ckan/model/__init__.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 import warnings
 import logging
 import re
@@ -10,19 +11,19 @@ from vdm.sqlalchemy.base import SQLAlchemySession
 from sqlalchemy import MetaData, __version__ as sqav, Table
 from sqlalchemy.util import OrderedDict
 
-import meta
-from meta import (
+from . import meta
+from .meta import (
     Session,
     engine_is_sqlite,
     engine_is_pg,
 )
-from core import (
+from .core import (
     System,
     Revision,
     State,
     revision_table,
 )
-from package import (
+from .package import (
     Package,
     PACKAGE_NAME_MIN_LENGTH,
     PACKAGE_NAME_MAX_LENGTH,
@@ -32,7 +33,7 @@ from package import (
     PackageTagRevision,
     PackageRevision,
 )
-from tag import (
+from .tag import (
     Tag,
     PackageTag,
     MAX_TAG_LENGTH,
@@ -41,11 +42,11 @@ from tag import (
     package_tag_table,
     package_tag_revision_table,
 )
-from user import (
+from .user import (
     User,
     user_table,
 )
-from group import (
+from .group import (
     Member,
     Group,
     member_revision_table,
@@ -55,67 +56,67 @@ from group import (
     MemberRevision,
     member_table,
 )
-from group_extra import (
+from .group_extra import (
     GroupExtra,
     group_extra_table,
     GroupExtraRevision,
 )
-from package_extra import (
+from .package_extra import (
     PackageExtra,
     PackageExtraRevision,
     package_extra_table,
     extra_revision_table,
 )
-from resource import (
+from .resource import (
     Resource,
     ResourceRevision,
     DictProxy,
     resource_table,
     resource_revision_table,
 )
-from resource_view import (
+from .resource_view import (
     ResourceView,
     resource_view_table,
 )
-from tracking import (
+from .tracking import (
     tracking_summary_table,
     TrackingSummary,
     tracking_raw_table
 )
-from rating import (
+from .rating import (
     Rating,
     MIN_RATING,
     MAX_RATING,
 )
-from package_relationship import (
+from .package_relationship import (
     PackageRelationship,
     package_relationship_table,
     package_relationship_revision_table,
 )
-from task_status import (
+from .task_status import (
     TaskStatus,
     task_status_table,
 )
-from vocabulary import (
+from .vocabulary import (
     Vocabulary,
     VOCABULARY_NAME_MAX_LENGTH,
     VOCABULARY_NAME_MIN_LENGTH,
 )
-from activity import (
+from .activity import (
     Activity,
     ActivityDetail,
     activity_table,
     activity_detail_table,
 )
-from term_translation import (
+from .term_translation import (
     term_translation_table,
 )
-from follower import (
+from .follower import (
     UserFollowingUser,
     UserFollowingDataset,
     UserFollowingGroup,
 )
-from system_info import (
+from .system_info import (
     system_info_table,
     system_info_revision_table,
     SystemInfo,
@@ -124,11 +125,11 @@ from system_info import (
     set_system_info,
     delete_system_info,
 )
-from domain_object import (
+from .domain_object import (
     DomainObjectOperation,
     DomainObject,
 )
-from dashboard import (
+from .dashboard import (
     Dashboard,
 )
 

--- a/ckan/model/activity.py
+++ b/ckan/model/activity.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 import datetime
 
 from sqlalchemy import (
@@ -16,9 +17,9 @@ from sqlalchemy import (
 )
 
 import ckan.model
-import meta
-import types as _types
-import domain_object
+from . import meta
+from . import types as _types
+from . import domain_object
 
 __all__ = ['Activity', 'activity_table',
            'ActivityDetail', 'activity_detail_table',

--- a/ckan/model/core.py
+++ b/ckan/model/core.py
@@ -1,9 +1,10 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 import datetime
 
-import domain_object
-import meta
+from . import domain_object
+from . import meta
 import vdm.sqlalchemy
 from sqlalchemy import Column, DateTime, Text, Boolean
 

--- a/ckan/model/dashboard.py
+++ b/ckan/model/dashboard.py
@@ -1,8 +1,9 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 import datetime
 import sqlalchemy
-import meta
+from . import meta
 
 dashboard_table = sqlalchemy.Table('dashboard', meta.metadata,
     sqlalchemy.Column('user_id', sqlalchemy.types.UnicodeText,

--- a/ckan/model/domain_object.py
+++ b/ckan/model/domain_object.py
@@ -1,13 +1,14 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 import datetime
 
 import sqlalchemy as sa
 from sqlalchemy import orm
 from sqlalchemy.util import OrderedDict
 
-import meta
-import core
+from . import meta
+from . import core
 
 __all__ = ['DomainObject', 'DomainObjectOperation']
 
@@ -107,7 +108,7 @@ class DomainObject(object):
         for col in table.c:
             try:
                 repr += u' %s=%s' % (col.name, getattr(self, col.name))
-            except Exception, inst:
+            except Exception as inst:
                 repr += u' %s=%s' % (col.name, inst)
 
         repr += '>'

--- a/ckan/model/follower.py
+++ b/ckan/model/follower.py
@@ -1,12 +1,15 @@
 # encoding: utf-8
 
-import meta
+from __future__ import absolute_import
+# encoding: utf-8
+
+from . import meta
 import datetime
 import sqlalchemy
 
-import core
+from . import core
 import ckan.model
-import domain_object
+from . import domain_object
 
 
 class ModelFollowingModel(domain_object.DomainObject):

--- a/ckan/model/group.py
+++ b/ckan/model/group.py
@@ -1,16 +1,17 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 import datetime
 
 from sqlalchemy import orm, types, Column, Table, ForeignKey, or_, and_, text
 import vdm.sqlalchemy
 
-import meta
-import core
-import package as _package
-import types as _types
-import domain_object
-import user as _user
+from . import meta
+from . import core
+from . import package as _package
+from . import types as _types
+from . import domain_object
+from . import user as _user
 
 __all__ = ['group_table', 'Group',
            'Member', 'GroupRevision', 'MemberRevision',
@@ -350,7 +351,7 @@ class Group(vdm.sqlalchemy.RevisionedObjectMixin,
         this group. Ordered by most recent first.
         '''
         results = {}
-        from group_extra import GroupExtra
+        from .group_extra import GroupExtra
         for grp_rev in self.all_revisions:
             if not grp_rev.revision in results:
                 results[grp_rev.revision] = []

--- a/ckan/model/group_extra.py
+++ b/ckan/model/group_extra.py
@@ -1,14 +1,15 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 import vdm.sqlalchemy
 import vdm.sqlalchemy.stateful
 from sqlalchemy import orm, types, Column, Table, ForeignKey
 
-import group
-import meta
-import core
-import types as _types
-import domain_object
+from . import group
+from . import meta
+from . import core
+from . import types as _types
+from . import domain_object
 
 
 __all__ = ['GroupExtra', 'group_extra_table', 'GroupExtraRevision']

--- a/ckan/model/license.py
+++ b/ckan/model/license.py
@@ -117,12 +117,12 @@ class LicenseRegister(object):
         try:
             response = urllib2.urlopen(license_url)
             response_body = response.read()
-        except Exception, inst:
+        except Exception as inst:
             msg = "Couldn't connect to licenses service %r: %s" % (license_url, inst)
             raise Exception(msg)
         try:
             license_data = json.loads(response_body)
-        except Exception, inst:
+        except Exception as inst:
             msg = "Couldn't read response from licenses service %r: %s" % (response_body, inst)
             raise Exception(inst)
         self._create_license_list(license_data, license_url)

--- a/ckan/model/meta.py
+++ b/ckan/model/meta.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 import datetime
 
 from paste.deploy.converters import asbool
@@ -9,7 +10,7 @@ from sqlalchemy import MetaData, and_
 import sqlalchemy.orm as orm
 from sqlalchemy.orm.session import SessionExtension
 
-import extension
+from . import extension
 import ckan.lib.activity_streams_session_extension as activity
 
 __all__ = ['Session', 'engine_is_sqlite', 'engine_is_pg']

--- a/ckan/model/modification.py
+++ b/ckan/model/modification.py
@@ -1,13 +1,14 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 import logging
 
 from ckan.lib.search import SearchIndexError
 
 import ckan.plugins as plugins
-import domain_object
-import package as _package
-import resource
+from . import domain_object
+from . import package as _package
+from . import resource
 
 log = logging.getLogger(__name__)
 
@@ -75,12 +76,12 @@ class DomainObjectModificationExtension(plugins.SingletonPlugin):
                 plugins.IDomainObjectModification):
             try:
                 observer.notify(entity, operation)
-            except SearchIndexError, search_error:
+            except SearchIndexError as search_error:
                 log.exception(search_error)
                 # Reraise, since it's pretty crucial to ckan if it can't index
                 # a dataset
                 raise
-            except Exception, ex:
+            except Exception as ex:
                 log.exception(ex)
                 # Don't reraise other exceptions since they are generally of
                 # secondary importance so shouldn't disrupt the commit.

--- a/ckan/model/package_extra.py
+++ b/ckan/model/package_extra.py
@@ -1,17 +1,18 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 import vdm.sqlalchemy
 import vdm.sqlalchemy.stateful
 from sqlalchemy import orm, types, Column, Table, ForeignKey
 
-import meta
-import core
-import package as _package
-import extension
-import domain_object
-import types as _types
+from . import meta
+from . import core
+from . import package as _package
+from . import extension
+from . import domain_object
+from . import types as _types
 import ckan.lib.dictization
-import activity
+from . import activity
 
 __all__ = ['PackageExtra', 'package_extra_table', 'PackageExtraRevision',
            'extra_revision_table']

--- a/ckan/model/package_relationship.py
+++ b/ckan/model/package_relationship.py
@@ -1,13 +1,14 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 import vdm.sqlalchemy
 from sqlalchemy import orm, types, Column, Table, ForeignKey
 
-import meta
-import core
-import package as _package
-import types as _types
-import domain_object
+from . import meta
+from . import core
+from . import package as _package
+from . import types as _types
+from . import domain_object
 
 # i18n only works when this is run as part of pylons,
 # which isn't the case for paster commands.
@@ -161,7 +162,7 @@ class PackageRelationship(vdm.sqlalchemy.RevisionedObjectMixin,
             for j in range(2):
                 if type_ == types[j]:
                     return cls.types_printable[i][j]
-        raise TypeError, type_
+        raise TypeError(type_)
 
 meta.mapper(PackageRelationship, package_relationship_table, properties={
     'subject':orm.relation(_package.Package, primaryjoin=\

--- a/ckan/model/rating.py
+++ b/ckan/model/rating.py
@@ -1,14 +1,15 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 import datetime
 
 from sqlalchemy import orm, types, Column, Table, ForeignKey
 
-import meta
-import package as _package
-import user
-import domain_object
-import types as _types
+from . import meta
+from . import package as _package
+from . import user
+from . import domain_object
+from . import types as _types
 
 __all__ = ['Rating', 'MIN_RATING', 'MAX_RATING']
 

--- a/ckan/model/resource.py
+++ b/ckan/model/resource.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 import datetime
 
 from sqlalchemy.util import OrderedDict
@@ -10,13 +11,13 @@ import vdm.sqlalchemy
 import vdm.sqlalchemy.stateful
 from sqlalchemy import types, func, Column, Table, ForeignKey, and_
 
-import meta
-import core
-import package as _package
-import types as _types
-import extension
-import activity
-import domain_object
+from . import meta
+from . import core
+from . import package as _package
+from . import types as _types
+from . import extension
+from . import activity
+from . import domain_object
 import ckan.lib.dictization
 from .package import Package
 import ckan.model

--- a/ckan/model/resource_view.py
+++ b/ckan/model/resource_view.py
@@ -1,10 +1,11 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 import sqlalchemy as sa
 
-import meta
-import types as _types
-import domain_object
+from . import meta
+from . import types as _types
+from . import domain_object
 
 __all__ = ['ResourceView', 'resource_view_table']
 

--- a/ckan/model/system_info.py
+++ b/ckan/model/system_info.py
@@ -6,13 +6,14 @@ configuration options.
 
 For more details, check :doc:`maintaining/configuration`.
 '''
+from __future__ import absolute_import
 
 from sqlalchemy import types, Column, Table
 
 import vdm.sqlalchemy
-import meta
-import core
-import domain_object
+from . import meta
+from . import core
+from . import domain_object
 
 __all__ = ['system_info_revision_table', 'system_info_table', 'SystemInfo',
            'SystemInfoRevision', 'get_system_info', 'set_system_info']

--- a/ckan/model/tag.py
+++ b/ckan/model/tag.py
@@ -1,17 +1,18 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 import vdm.sqlalchemy
 from sqlalchemy.orm import relation
 from sqlalchemy import types, Column, Table, ForeignKey, and_, UniqueConstraint
 
-import package as _package
-import extension as _extension
-import core
-import meta
-import types as _types
-import domain_object
-import vocabulary
-import activity
+from . import package as _package
+from . import extension as _extension
+from . import core
+from . import meta
+from . import types as _types
+from . import domain_object
+from . import vocabulary
+from . import activity
 import ckan  # this import is needed
 import ckan.lib.dictization
 

--- a/ckan/model/task_status.py
+++ b/ckan/model/task_status.py
@@ -1,11 +1,12 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 from datetime import datetime
 from sqlalchemy import types, Column, Table, UniqueConstraint
 
-import meta
-import types as _types
-import domain_object
+from . import meta
+from . import types as _types
+from . import domain_object
 
 __all__ = ['TaskStatus', 'task_status_table']
 

--- a/ckan/model/term_translation.py
+++ b/ckan/model/term_translation.py
@@ -1,8 +1,9 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 from sqlalchemy import Column, Table
 from sqlalchemy.types import UnicodeText
-import meta
+from . import meta
 
 __all__ = ['term_translation_table']
 

--- a/ckan/model/tracking.py
+++ b/ckan/model/tracking.py
@@ -1,9 +1,10 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 from sqlalchemy import types, Column, Table, text
 
-import meta
-import domain_object
+from . import meta
+from . import domain_object
 
 __all__ = ['tracking_summary_table', 'TrackingSummary', 'tracking_raw_table']
 

--- a/ckan/model/types.py
+++ b/ckan/model/types.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 ## IMPORTS FIXED
+from __future__ import absolute_import
 import datetime
 import copy
 import uuid
@@ -8,7 +9,7 @@ import simplejson as json
 
 from sqlalchemy import types
 
-import meta
+from . import meta
 
 __all__ = ['iso_date_to_datetime_for_sqlite', 'make_uuid', 'UuidType',
            'JsonType', 'JsonDictType']

--- a/ckan/model/user.py
+++ b/ckan/model/user.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 import datetime
 import re
 import os
@@ -12,10 +13,10 @@ from sqlalchemy.orm import synonym
 from sqlalchemy import types, Column, Table, func
 import vdm.sqlalchemy
 
-import meta
-import core
-import types as _types
-import domain_object
+from . import meta
+from . import core
+from . import types as _types
+from . import domain_object
 
 
 user_table = Table('user', meta.metadata,

--- a/ckan/model/vocabulary.py
+++ b/ckan/model/vocabulary.py
@@ -1,11 +1,12 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 from sqlalchemy import types, Column, Table
 
-import meta
-import types as _types
-import tag
-import domain_object
+from . import meta
+from . import types as _types
+from . import tag
+from . import domain_object
 
 VOCABULARY_NAME_MIN_LENGTH = 2
 VOCABULARY_NAME_MAX_LENGTH = 100

--- a/ckan/pastertemplates/__init__.py
+++ b/ckan/pastertemplates/__init__.py
@@ -12,6 +12,7 @@ See:
 * http://pythonpaste.org/script/developer.html#templates
 
 """
+from __future__ import print_function
 import sys
 
 import jinja2
@@ -59,7 +60,7 @@ class CkanextTemplate(Template):
         sys.setdefaultencoding('utf-8')
 
         if not vars['project'].startswith('ckanext-'):
-            print "\nError: Project name must start with 'ckanext-'"
+            print("\nError: Project name must start with 'ckanext-'")
             sys.exit(1)
 
         # The project name without the ckanext-.

--- a/ckan/plugins/__init__.py
+++ b/ckan/plugins/__init__.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 from ckan.plugins.core import *
 from ckan.plugins.interfaces import *
 
-import toolkit
+from . import toolkit

--- a/ckan/plugins/core.py
+++ b/ckan/plugins/core.py
@@ -3,6 +3,7 @@
 '''
 Provides plugin services to the CKAN
 '''
+from __future__ import absolute_import
 
 from contextlib import contextmanager
 import logging
@@ -13,7 +14,7 @@ from pyutilib.component.core import SingletonPlugin as _pca_SingletonPlugin
 from pyutilib.component.core import Plugin as _pca_Plugin
 from paste.deploy.converters import asbool
 
-import interfaces
+from . import interfaces
 
 from ckan.common import config
 

--- a/ckan/plugins/toolkit_sphinx_extension.py
+++ b/ckan/plugins/toolkit_sphinx_extension.py
@@ -170,7 +170,7 @@ def source_read(app, docname, source):
             source_ += format_function(name, thing, docstring=custom_docstring)
         elif inspect.isclass(thing):
             source_ += format_class(name, thing, docstring=custom_docstring)
-        elif isinstance(thing, types.ObjectType):
+        elif isinstance(thing, object):
             source_ += format_object(name, thing, docstring=custom_docstring)
 
         else:

--- a/ckan/tests/legacy/__init__.py
+++ b/ckan/tests/legacy/__init__.py
@@ -86,7 +86,7 @@ class BaseCase(object):
         import commands
         (status, output) = commands.getstatusoutput(cmd)
         if status:
-            raise Exception, "Couldn't execute cmd: %s: %s" % (cmd, output)
+            raise Exception("Couldn't execute cmd: %s: %s" % (cmd, output))
 
     @classmethod
     def _paster(cls, cmd, config_path_rel):
@@ -279,7 +279,7 @@ class CkanServerCase(BaseCase):
         pid = process.pid
         pid = int(pid)
         if os.system("kill -9 %d" % pid):
-            raise Exception, "Can't kill foreign CKAN instance (pid: %d)." % pid
+            raise Exception("Can't kill foreign CKAN instance (pid: %d)." % pid)
 
 
 class TestController(CommonFixtureMethods, CkanServerCase, WsgiAppCase, BaseCase):

--- a/ckan/tests/legacy/functional/api/base.py
+++ b/ckan/tests/legacy/functional/api/base.py
@@ -186,8 +186,8 @@ class ApiTestCase(object):
     def loads(self, chars):
         try:
             return json.loads(chars)
-        except ValueError, inst:
-            raise Exception, "Couldn't loads string '%s': %s" % (chars, inst)
+        except ValueError as inst:
+            raise Exception("Couldn't loads string '%s': %s" % (chars, inst))
 
     def assert_json_response(self, res, expected_in_body=None):
         content_type = res.header_dict['Content-Type']

--- a/ckan/tests/legacy/functional/api/model/test_package.py
+++ b/ckan/tests/legacy/functional/api/model/test_package.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import print_function
 import copy
 
 from nose.tools import assert_equal, assert_raises
@@ -453,7 +454,7 @@ class PackagesTestCase(BaseModelApiTestCase):
                 self.assert_equal(package.extras[key], value)
             # NB: key4 set to '' creates it
             # but: key2 set to None will delete it
-            assert not package.extras.has_key('key2')
+            assert 'key2' not in package.extras
         finally:
             self.purge_package_by_name(new_fixture_data['name'])
 
@@ -606,7 +607,7 @@ class PackagesTestCase(BaseModelApiTestCase):
         try:
             package1_offset = self.package_offset(package1_name)
             # trying to rename package 1 to package 2's name
-            print package1_offset, package2_data
+            print(package1_offset, package2_data)
             self.post(package1_offset, package2_data, self.STATUS_409_CONFLICT, extra_environ=self.admin_extra_environ)
         finally:
             self.purge_package_by_name(package2_name)

--- a/ckan/tests/legacy/functional/api/model/test_relationships.py
+++ b/ckan/tests/legacy/functional/api/model/test_relationships.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import print_function
 from nose.tools import assert_equal 
 from nose.plugins.skip import SkipTest
 
@@ -255,7 +256,7 @@ class RelationshipsTestCase(BaseModelApiTestCase):
         # Currently it just ignores the changed type and subject/object
         res = self.app.put(offset, params=postparams, status=[200],
                            extra_environ=self.extra_environ)
-        print res.body
+        print(res.body)
         assert 'cat' not in res.body
         assert 'Matilda' not in res.body
         assert 'Tabby' in res.body
@@ -294,7 +295,7 @@ class RelationshipsTestCase(BaseModelApiTestCase):
                 for r in relationships:
                     msg += '%s %s %s; ' % (r['subject'], r['type'], r['object'])
                 msg += '.'
-            raise Exception, msg
+            raise Exception(msg)
 
     def check_relationships_rest(self, pkg1_name, pkg2_name=None,
                                  expected_relationships=[]):
@@ -312,7 +313,7 @@ class RelationshipsTestCase(BaseModelApiTestCase):
                 raise Exception('Unexpected relationship: %s %s %s' %
                                 (rel['subject'], rel['type'], rel['object']))
             for field in ('subject', 'object', 'type', 'comment'):
-                if the_expected_rel.has_key(field):
+                if field in the_expected_rel:
                     value = rel[field]
                     expected = the_expected_rel[field]
                     assert value == expected, (value, expected, field, rel)

--- a/ckan/tests/legacy/functional/api/test_package_search.py
+++ b/ckan/tests/legacy/functional/api/test_package_search.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import print_function
 from nose.tools import assert_raises
 from nose.plugins.skip import SkipTest
 
@@ -225,7 +226,7 @@ class LegacyOptionsTestCase(ApiTestCase, ControllerTestCase):
         query = {'q': '', 'tags':['tolstoy', 'russian', u'Flexible \u30a1']}
         json_query = self.dumps(query)
         offset = self.base_url + '?qjson=%s' % json_query
-        print offset
+        print(offset)
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)
         self.assert_results(res_dict, [u'annakarenina'])
@@ -350,7 +351,7 @@ class LegacyOptionsTestCase(ApiTestCase, ControllerTestCase):
     def test_11_pagination_syntax_error(self):
         offset = self.base_url + '?all_fields=1&q="tags:russian"&start=should_be_integer&rows=1&order_by=name' # invalid offset value
         res = self.app.get(offset, status=400)
-        print res.body
+        print(res.body)
         assert('should_be_integer' in res.body)
 
     def test_13_just_groups(self):
@@ -393,7 +394,7 @@ class TestPackageSearchApi3(Api3TestCase, PackageSearchApiTestCase):
         query = {'q': 'tags:tolstoy tags:russian'}
         json_query = self.dumps(query)
         offset = self.base_url + '?qjson=%s' % json_query
-        print offset
+        print(offset)
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)
         self.assert_results(res_dict, [u'annakarenina'])
@@ -465,7 +466,7 @@ class TestPackageSearchApi3(Api3TestCase, PackageSearchApiTestCase):
     def test_11_pagination_syntax_error(self):
         offset = self.base_url + '?fl=*&q=tags:russian&start=should_be_integer&rows=1&sort=name asc' # invalid offset value
         res = self.app.get(offset, status=400)
-        print res.body
+        print(res.body)
         assert('should_be_integer' in res.body)
 
     def test_12_v1_or_v2_syntax(self):

--- a/ckan/tests/legacy/functional/api/test_user.py
+++ b/ckan/tests/legacy/functional/api/test_user.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import print_function
 import paste
 from ckan.common import config
 from nose.tools import assert_equal
@@ -32,7 +33,7 @@ class TestUserApi(ControllerTestCase):
             },
             status=200,
         )
-        print response.json
+        print(response.json)
         assert set(response.json[0].keys()) == set(['id', 'name', 'fullname'])
         assert_equal(response.json[0]['name'], u'testsysadmin')
         assert_equal(response.header('Content-Type'), 'application/json;charset=utf-8')
@@ -45,7 +46,7 @@ class TestUserApi(ControllerTestCase):
             },
             status=200,
         )
-        print response.json
+        print(response.json)
         assert_equal(len(response.json), 2)
 
     def test_autocomplete_limit(self):
@@ -57,7 +58,7 @@ class TestUserApi(ControllerTestCase):
             },
             status=200,
         )
-        print response.json
+        print(response.json)
         assert_equal(len(response.json), 1)
 
 

--- a/ckan/tests/legacy/functional/test_error.py
+++ b/ckan/tests/legacy/functional/test_error.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
-from base import FunctionalTestCase
+from __future__ import absolute_import
+from .base import FunctionalTestCase
 
 class TestError(FunctionalTestCase):
     def test_without_redirect(self):

--- a/ckan/tests/legacy/functional/test_group.py
+++ b/ckan/tests/legacy/functional/test_group.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 import mock
 
 import ckan.model as model
@@ -8,7 +9,7 @@ import ckan.lib.search as search
 from ckan.lib.create_test_data import CreateTestData
 from ckan.logic import get_action
 from ckan.tests.legacy import *
-from base import FunctionalTestCase
+from .base import FunctionalTestCase
 
 
 class TestGroup(FunctionalTestCase):

--- a/ckan/tests/legacy/functional/test_package.py
+++ b/ckan/tests/legacy/functional/test_package.py
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+from __future__ import print_function
+from __future__ import absolute_import
 import datetime
 
 from ckan.common import config, c
@@ -10,7 +12,7 @@ from ckan.tests.legacy import *
 import ckan.tests.legacy as tests
 from ckan.tests.legacy.html_check import HtmlCheckMethods
 from ckan.tests.legacy.pylons_controller import PylonsTestCase
-from base import FunctionalTestCase
+from .base import FunctionalTestCase
 import ckan.model as model
 from ckan.lib.create_test_data import CreateTestData
 from ckan.logic.action import get, update
@@ -61,7 +63,7 @@ class TestPackageForm(TestPackageBase):
         assert license.title in main_div, (license.title, main_div_str)
         tag_names = list(params['tags'])
         self.check_named_element(main_div, 'ul', *tag_names)
-        if params.has_key('state'):
+        if 'state' in params:
             assert 'State: %s' % params['state'] in main_div.replace('</strong>', ''), main_div_str
         if isinstance(params['extras'], dict):
             extras = []
@@ -109,7 +111,7 @@ class TestPackageForm(TestPackageBase):
         return unescaped_str.replace('<', '&lt;')
 
     def check_form_filled_correctly(self, res, **params):
-        if params.has_key('pkg'):
+        if 'pkg' in params:
             for key, value in params['pkg'].as_dict().items():
                 if key == 'license':
                     key = 'license_id'
@@ -133,7 +135,7 @@ class TestPackageForm(TestPackageBase):
             tags = params['tags']
         for tag in tags:
             self.check_tag(main_res, prefix+'tag_string', tag)
-        if params.has_key('state'):
+        if 'state' in params:
             self.check_tag_and_data(main_res, 'selected', str(params['state']))
         if isinstance(params['extras'], dict):
             extras = []
@@ -333,15 +335,15 @@ class TestReadAtRevision(FunctionalTestCase, HtmlCheckMethods):
         offset = self.offset + '@%s' % self.revision_ids[0]
         res = self.app.get(offset, status=200)
         main_html = pkg_html = side_html = res.body
-        print 'MAIN', main_html
+        print('MAIN', main_html)
         assert 'This is an old revision of this dataset' in main_html
         assert 'at January 1, 2011, 00:00' in main_html
         self.check_named_element(main_html, 'a', 'href="/dataset/%s"' % self.pkg_name)
-        print 'PKG', pkg_html
+        print('PKG', pkg_html)
         assert 'title1' in res
         assert 'key2' not in pkg_html
         assert 'value3' not in pkg_html
-        print 'SIDE', side_html
+        print('SIDE', side_html)
         assert 'tag3.' not in side_html
         assert 'tag 2' not in side_html
 
@@ -349,15 +351,15 @@ class TestReadAtRevision(FunctionalTestCase, HtmlCheckMethods):
         offset = self.offset + '@%s' % self.revision_ids[1]
         res = self.app.get(offset, status=200)
         main_html = pkg_html = side_html = res.body
-        print 'MAIN', main_html
+        print('MAIN', main_html)
         assert 'This is an old revision of this dataset' in main_html
         assert 'at January 2, 2011, 00:00' in main_html
         self.check_named_element(main_html, 'a', 'href="/dataset/%s"' % self.pkg_name)
-        print 'PKG', pkg_html
+        print('PKG', pkg_html)
         assert 'title2' in res
         assert 'key2' in pkg_html
         assert 'value2' in pkg_html
-        print 'SIDE', side_html
+        print('SIDE', side_html)
         assert 'tag3.' not in side_html
         assert 'tag 2' in side_html
 
@@ -365,17 +367,17 @@ class TestReadAtRevision(FunctionalTestCase, HtmlCheckMethods):
         offset = self.offset + '@%s' % self.revision_ids[2]
         res = self.app.get(offset, status=200)
         main_html = pkg_html = side_html = res.body
-        print 'MAIN', main_html
+        print('MAIN', main_html)
         assert 'This is an old revision of this dataset' in main_html
         # It is not an old revision, but working that out is hard. The request
         # was for a particular revision, so assume it is old.
         assert 'at January 3, 2011, 00:00' in main_html
         self.check_named_element(main_html, 'a', 'href="/dataset/%s"' % self.pkg_name)
-        print 'PKG', pkg_html
+        print('PKG', pkg_html)
         assert 'title3' in res
         assert 'key2' in pkg_html
         assert 'value3' in pkg_html
-        print 'SIDE', side_html
+        print('SIDE', side_html)
         assert 'tag3.' in side_html
         assert 'tag 2' in side_html
 
@@ -432,7 +434,7 @@ class TestEdit(TestPackageForm):
         # not allowed to edit groups for now
         prefix = 'Dataset-%s-' % self.pkgid
         fv = self.res.forms['dataset-edit']
-        assert not fv.fields.has_key(prefix + 'groups')
+        assert prefix + 'groups' not in fv.fields
 
 
     def test_redirect_after_edit_using_param(self):

--- a/ckan/tests/legacy/functional/test_revision.py
+++ b/ckan/tests/legacy/functional/test_revision.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import print_function
 from ckan.tests.legacy import TestController, CreateTestData, url_for
 import ckan.model as model
 
@@ -30,22 +31,22 @@ class TestRevisionController(TestController):
             # res2 = res.click('^%s$' % link_exp)
             res2 = res.click(link_exp)
         except:
-            print "\nThe first response (list):\n\n"
-            print str(res)
-            print "\nThe link that couldn't be followed:"
-            print str(link_exp)
+            print("\nThe first response (list):\n\n")
+            print(str(res))
+            print("\nThe link that couldn't be followed:")
+            print(str(link_exp))
             raise
         try:
             assert res2_exp in res2
         except:
-            print "\nThe first response (list):\n\n"
-            print str(res)
-            print "\nThe second response (item):\n\n"
-            print str(res2)
-            print "\nThe followed link:"
-            print str(link_exp)
-            print "\nThe expression that couldn't be found:"
-            print str(res2_exp)
+            print("\nThe first response (list):\n\n")
+            print(str(res))
+            print("\nThe second response (item):\n\n")
+            print(str(res2))
+            print("\nThe followed link:")
+            print(str(link_exp))
+            print("\nThe expression that couldn't be found:")
+            print(str(res2_exp))
             raise
 
     def create_updating_revision(self, name, **kwds):
@@ -75,7 +76,7 @@ class TestRevisionController(TestController):
         model.Session.commit()
         model.Session.remove()
         if not model.repo.history()[0].packages:
-            raise Exception, "Didn't set up revision right."
+            raise Exception("Didn't set up revision right.")
 
     def create_deleting_revision(self, name):
         rev = model.repo.new_revision()

--- a/ckan/tests/legacy/functional/test_user.py
+++ b/ckan/tests/legacy/functional/test_user.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 from ckan.lib.helpers import url_for
 from nose.tools import assert_equal
 from ckan.common import config
@@ -10,7 +11,7 @@ from ckan.tests.legacy.html_check import HtmlCheckMethods
 from ckan.tests.legacy.pylons_controller import PylonsTestCase
 from ckan.tests.legacy.mock_mail_server import SmtpServerHarness
 import ckan.model as model
-from base import FunctionalTestCase
+from .base import FunctionalTestCase
 from ckan.lib.mailer import get_reset_link, create_reset_key
 
 class TestUserController(FunctionalTestCase, HtmlCheckMethods, PylonsTestCase, SmtpServerHarness):

--- a/ckan/tests/legacy/lib/test_dictization.py
+++ b/ckan/tests/legacy/lib/test_dictization.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import print_function
 from nose.tools import assert_equal, assert_not_in, assert_in
 from pprint import pprint, pformat
 from difflib import unified_diff
@@ -212,8 +213,8 @@ class TestBasicDictize:
         del dictize['organization']
         as_dict_string = pformat(as_dict)
         dictize_string = pformat(dictize)
-        print as_dict_string
-        print dictize_string
+        print(as_dict_string)
+        print(dictize_string)
 
         assert as_dict == dictize, "\n".join(unified_diff(as_dict_string.split("\n"), dictize_string.split("\n")))
 
@@ -229,8 +230,8 @@ class TestBasicDictize:
 
         as_dict_string = pformat(as_dict)
         dictize_string = pformat(dictize)
-        print as_dict_string
-        print dictize_string
+        print(as_dict_string)
+        print(dictize_string)
 
         assert package_to_api2(pkg, context) == dictize, "\n".join(unified_diff(as_dict_string.split("\n"), dictize_string.split("\n")))
 
@@ -254,8 +255,8 @@ class TestBasicDictize:
         del dictize['organization']
         as_dict_string = pformat(as_dict)
         dictize_string = pformat(dictize)
-        print as_dict_string
-        print dictize_string
+        print(as_dict_string)
+        print(dictize_string)
 
         assert as_dict == dictize, "\n".join(unified_diff(as_dict_string.split("\n"), dictize_string.split("\n")))
 
@@ -335,7 +336,7 @@ class TestBasicDictize:
 
         sorted_resource_revisions = sorted(resources_revisions, key=lambda x: (x.revision_timestamp, x.url))[::-1]
         for res in sorted_resource_revisions:
-            print res.id, res.revision_timestamp, res.state
+            print(res.id, res.revision_timestamp, res.state)
         assert len(sorted_resource_revisions) == 3
 
         # Make sure we remove changeable fields BEFORE we store the pretty-printed version
@@ -413,7 +414,7 @@ class TestBasicDictize:
         second_dictized['extras'][0]['value'] = u'new_value'
         second_dictized['state'] = 'active'
 
-        print '\n'.join(unified_diff(pformat(second_dictized).split('\n'), pformat(third_dictized).split('\n')))
+        print('\n'.join(unified_diff(pformat(second_dictized).split('\n'), pformat(third_dictized).split('\n'))))
         assert second_dictized == third_dictized
 
         context['revision_id'] = sorted_packages[3].revision_id #original state

--- a/ckan/tests/legacy/lib/test_navl.py
+++ b/ckan/tests/legacy/lib/test_navl.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import print_function
 from ckan.lib.navl.dictization_functions import (flatten_schema,
                                    get_all_key_combinations,
                                    make_full_schema,
@@ -97,7 +98,7 @@ def test_make_full_schema():
 
     full_schema = make_full_schema(data, schema)
 
-    print set(full_schema.keys()) - set(data.keys())
+    print(set(full_schema.keys()) - set(data.keys()))
 
     assert set(full_schema.keys()) - set(data.keys()) == set([('2', 1, '__before'),
                                                               ('2', 0, '__after'),
@@ -110,7 +111,7 @@ def test_make_full_schema():
                                                               ('__junk',),
                                                              ])
 
-    print set(data.keys()) - set(full_schema.keys())
+    print(set(data.keys()) - set(full_schema.keys()))
 
     assert set(data.keys()) - set(full_schema.keys()) == set([('4',),
                                                               ('4', 1, '30')])
@@ -137,8 +138,8 @@ def test_identity_validation():
 
     
     converted_data, errors = validate_flattened(data, schema)
-    print errors
-    print converted_data
+    print(errors)
+    print(converted_data)
 
     assert not errors
 
@@ -295,7 +296,7 @@ def test_simple():
 
     converted_data, errors = validate(data, schema)
 
-    print errors
+    print(errors)
     assert errors == {'numbers': [{'code': [u'Missing value']}, {}]}
 
 

--- a/ckan/tests/legacy/lib/test_solr_schema_version.py
+++ b/ckan/tests/legacy/lib/test_solr_schema_version.py
@@ -39,7 +39,7 @@ class TestSolrSchemaVersionCheck(TestController):
 
             #Should not happen
             assert False
-        except SearchError,e:
+        except SearchError as e:
             assert 'Could not extract version info' in str(e)
 
         # An exception is thrown if the schema version is not supported
@@ -49,7 +49,7 @@ class TestSolrSchemaVersionCheck(TestController):
 
             #Should not happen
             assert False
-        except SearchError,e:
+        except SearchError as e:
             assert 'SOLR schema version not supported' in str(e)
 
 

--- a/ckan/tests/legacy/lib/test_solr_search_index.py
+++ b/ckan/tests/legacy/lib/test_solr_search_index.py
@@ -20,7 +20,7 @@ class TestSolrConfig(TestController):
             # solr.SolrConnection.query will throw a socket.error if it
             # can't connect to the SOLR instance
             q = conn.search(q="*:*", rows=1)
-        except pysolr.SolrError, e:
+        except pysolr.SolrError as e:
             if not config.get('solr_url'):
                 raise AssertionError("Config option 'solr_url' needs to be defined in this CKAN's development.ini. Default of %s didn't work: %s" % (search.DEFAULT_SOLR_URL, e))
             else:

--- a/ckan/tests/legacy/misc/test_sync.py
+++ b/ckan/tests/legacy/misc/test_sync.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import print_function
 import os
 import subprocess
 import urllib2
@@ -41,14 +42,14 @@ class _TestSync(TestController):
         while True:
             try:
                 f = urllib2.urlopen('http://localhost:5050%s' % offset)
-            except urllib2.URLError, e:
+            except urllib2.URLError as e:
                 if hasattr(e, 'reason') and type(e.reason) == urllib2.socket.error:
                     # i.e. process not started up yet
                     count += 1
                     time.sleep(1)
                     assert count < 5, '%s: %r; %r' % (offset, e, e.args)
                 else:
-                    print 'Error opening url: %s' % offset
+                    print('Error opening url: %s' % offset)
                     assert 0, e # Print exception
             else:
                 break

--- a/ckan/tests/legacy/models/test_resource.py
+++ b/ckan/tests/legacy/models/test_resource.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import print_function
 from sqlalchemy import MetaData, __version__ as sqav
 from nose.tools import assert_equal, raises
 
@@ -122,7 +123,7 @@ class TestResource:
         assert len(pkg.resources_all) == 3, len(pkg.resources)
         lastres = pkg.resources[2]
         assert lastres.position == 2, lastres
-        print lastres
+        print(lastres)
         assert lastres.url == self.urls[0], (self.urls, lastres.url)
 
 

--- a/ckan/tests/legacy/test_coding_standards.py
+++ b/ckan/tests/legacy/test_coding_standards.py
@@ -16,6 +16,7 @@ Please do not add new files to the list as any new files should meet the
 current coding standards.  Please add comments by files that fail if there
 are legitimate reasons for the failure.
 '''
+from __future__ import print_function
 
 import cStringIO
 import inspect

--- a/ckan/tests/logic/action/test_delete.py
+++ b/ckan/tests/logic/action/test_delete.py
@@ -149,7 +149,7 @@ class TestDeleteTags(object):
         # through in NotFound as unicode.
         try:
             helpers.call_action('tag_delete', id=u'Delta symbol: \u0394')
-        except logic.NotFound, e:
+        except logic.NotFound as e:
             assert u'Delta symbol: \u0394' in unicode(e)
         else:
             assert 0, 'Should have raised NotFound'

--- a/ckan/tests/logic/test_validators.py
+++ b/ckan/tests/logic/test_validators.py
@@ -151,7 +151,7 @@ class TestValidators(object):
             # Non-string names aren't allowed as names.
             13,
             23.7,
-            100L,
+            100,
             1.0j,
             None,
             True,
@@ -229,7 +229,7 @@ class TestValidators(object):
         non_string_values = [
             13,
             23.7,
-            100L,
+            100,
             1.0j,
             None,
             True,

--- a/ckan/tests/test_coding_standards.py
+++ b/ckan/tests/test_coding_standards.py
@@ -124,7 +124,7 @@ def test_source_files_specify_encoding():
 
     Empty files and files that only contain comments are ignored.
     '''
-    pattern = re.compile(ur'#.*?coding[:=][ \t]*utf-?8')
+    pattern = re.compile(u'#.*?coding[:=][ \t]*utf-?8')
     decode_errors = []
     no_specification = []
     for abs_path, rel_path in walk_python_files():

--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -95,7 +95,7 @@ def _finish_ok(response_data=None,
         status_int = 201
         try:
             resource_location = str(resource_location)
-        except Exception, inst:
+        except Exception as inst:
             msg = \
                 u"Couldn't convert '%s' header value '%s' to string: %s" % \
                 (u'Location', resource_location, inst)
@@ -171,7 +171,7 @@ def _get_request_data(try_url_params=False):
                 request.form.values()[0] in [u'1', u'']):
             try:
                 request_data = json.loads(request.form.keys()[0])
-            except ValueError, e:
+            except ValueError as e:
                 raise ValueError(
                     u'Error decoding JSON data. '
                     'Error: %r '
@@ -185,7 +185,7 @@ def _get_request_data(try_url_params=False):
           request.content_type != u'multipart/form-data'):
         try:
             request_data = request.get_json()
-        except BadRequest, e:
+        except BadRequest as e:
             raise ValueError(u'Error decoding JSON data. '
                              'Error: %r '
                              'JSON data extracted from the request: %r' %
@@ -258,7 +258,7 @@ def action(logic_function, ver=API_DEFAULT_VERSION):
 
         request_data = _get_request_data(
             try_url_params=side_effect_free)
-    except ValueError, inst:
+    except ValueError as inst:
         log.info(u'Bad Action API request data: %s', inst)
         return _finish_bad_request(
             _(u'JSON Error: %s') % inst)
@@ -282,7 +282,7 @@ def action(logic_function, ver=API_DEFAULT_VERSION):
         result = function(context, request_data)
         return_dict[u'success'] = True
         return_dict[u'result'] = result
-    except DataError, e:
+    except DataError as e:
         log.info(u'Format incorrect (Action API): %s - %s',
                  e.error, request_data)
         return_dict[u'error'] = {u'__type': u'Integrity Error',
@@ -290,7 +290,7 @@ def action(logic_function, ver=API_DEFAULT_VERSION):
                                  u'data': request_data}
         return_dict[u'success'] = False
         return _finish(400, return_dict, content_type=u'json')
-    except NotAuthorized, e:
+    except NotAuthorized as e:
         return_dict[u'error'] = {u'__type': u'Authorization Error',
                                  u'message': _(u'Access denied')}
         return_dict[u'success'] = False
@@ -299,14 +299,14 @@ def action(logic_function, ver=API_DEFAULT_VERSION):
             return_dict[u'error'][u'message'] += u': %s' % e
 
         return _finish(403, return_dict, content_type=u'json')
-    except NotFound, e:
+    except NotFound as e:
         return_dict[u'error'] = {u'__type': u'Not Found Error',
                                  u'message': _(u'Not found')}
         if unicode(e):
             return_dict[u'error'][u'message'] += u': %s' % e
         return_dict[u'success'] = False
         return _finish(404, return_dict, content_type=u'json')
-    except ValidationError, e:
+    except ValidationError as e:
         error_dict = e.error_dict
         error_dict[u'__type'] = u'Validation Error'
         return_dict[u'error'] = error_dict
@@ -314,18 +314,18 @@ def action(logic_function, ver=API_DEFAULT_VERSION):
         # CS nasty_string ignore
         log.info(u'Validation error (Action API): %r', str(e.error_dict))
         return _finish(409, return_dict, content_type=u'json')
-    except SearchQueryError, e:
+    except SearchQueryError as e:
         return_dict[u'error'] = {u'__type': u'Search Query Error',
                                  u'message': u'Search Query is invalid: %r' %
                                  e.args}
         return_dict[u'success'] = False
         return _finish(400, return_dict, content_type=u'json')
-    except SearchError, e:
+    except SearchError as e:
         return_dict[u'error'] = {u'__type': u'Search Error',
                                  u'message': u'Search error: %r' % e.args}
         return_dict[u'success'] = False
         return _finish(409, return_dict, content_type=u'json')
-    except SearchIndexError, e:
+    except SearchIndexError as e:
         return_dict[u'error'] = {
             u'__type': u'Search Index Error',
             u'message': u'Unable to add package to search index: %s' %

--- a/ckanext/datapusher/cli.py
+++ b/ckanext/datapusher/cli.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import print_function
 import sys
 
 import ckan.lib.cli as cli
@@ -49,14 +50,14 @@ class DatapusherCommand(cli.CkanCommand):
                 self._confirm_or_abort()
 
             if len(self.args) != 2:
-                print "This command requires an argument\n"
-                print self.usage
+                print("This command requires an argument\n")
+                print(self.usage)
                 sys.exit(1)
 
             self._load_config()
             self._submit_package(self.args[1])
         else:
-            print self.usage
+            print(self.usage)
 
     def _confirm_or_abort(self):
         question = (
@@ -66,7 +67,7 @@ class DatapusherCommand(cli.CkanCommand):
         )
         answer = cli.query_yes_no(question, default=None)
         if not answer == 'yes':
-            print "Aborting..."
+            print("Aborting...")
             sys.exit(0)
 
     def _resubmit_all(self):
@@ -89,9 +90,9 @@ class DatapusherCommand(cli.CkanCommand):
         try:
             pkg = package_show({'model': model, 'ignore_auth': True},
                                {'id': pkg_id.strip()})
-        except Exception, e:
-            print e
-            print "Package '{}' was not found".format(pkg_id)
+        except Exception as e:
+            print(e)
+            print("Package '{}' was not found".format(pkg_id))
             sys.exit(1)
 
         resource_ids = [r['id'] for r in pkg['resources']]
@@ -100,17 +101,17 @@ class DatapusherCommand(cli.CkanCommand):
     def _submit(self, resources):
         import ckan.model as model
 
-        print 'Submitting %d datastore resources' % len(resources)
+        print('Submitting %d datastore resources' % len(resources))
         user = p.toolkit.get_action('get_site_user')(
             {'model': model, 'ignore_auth': True}, {})
         datapusher_submit = p.toolkit.get_action('datapusher_submit')
         for resource_id in resources:
-            print ('Submitting %s...' % resource_id),
+            print(('Submitting %s...' % resource_id), end=' ')
             data_dict = {
                 'resource_id': resource_id,
                 'ignore_hash': True,
             }
             if datapusher_submit({'user': user['name']}, data_dict):
-                print 'OK'
+                print('OK')
             else:
-                print 'Fail'
+                print('Fail')

--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -134,7 +134,7 @@ def datapusher_submit(context, data_dict):
                 }
             }))
         r.raise_for_status()
-    except requests.exceptions.ConnectionError, e:
+    except requests.exceptions.ConnectionError as e:
         error = {'message': 'Could not connect to DataPusher.',
                  'details': str(e)}
         task['error'] = json.dumps(error)
@@ -143,7 +143,7 @@ def datapusher_submit(context, data_dict):
         p.toolkit.get_action('task_status_update')(context, task)
         raise p.toolkit.ValidationError(error)
 
-    except requests.exceptions.HTTPError, e:
+    except requests.exceptions.HTTPError as e:
         m = 'An Error occurred while sending the job: {0}'.format(e.message)
         try:
             body = e.response.json()

--- a/ckanext/datapusher/plugin.py
+++ b/ckanext/datapusher/plugin.py
@@ -136,7 +136,7 @@ class DatapusherPlugin(p.SingletonPlugin):
                         p.toolkit.get_action('datapusher_submit')(context, {
                             'resource_id': entity.id
                         })
-                    except p.toolkit.ValidationError, e:
+                    except p.toolkit.ValidationError as e:
                         # If datapusher is offline want to catch error instead
                         # of raising otherwise resource save will fail with 500
                         log.critical(e)

--- a/ckanext/datapusher/tests/test.py
+++ b/ckanext/datapusher/tests/test.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import print_function
 import datetime
 import json
 
@@ -215,7 +216,7 @@ class TestDatastoreCreate():
         auth = {'Authorization': str(user.apikey)}
         res = self.app.post('/api/action/datapusher_hook', params=postparams,
                             extra_environ=auth, status=200)
-        print res.body
+        print(res.body)
         res_dict = json.loads(res.body)
 
         assert res_dict['success'] is True

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -314,7 +314,7 @@ def _change_privilege(context, data_dict, what):
         })
     try:
         context['connection'].execute(sql)
-    except ProgrammingError, e:
+    except ProgrammingError as e:
         log.critical("Error making resource private. {0!r}".format(e.message))
         raise ValidationError({
             'privileges': [
@@ -534,7 +534,7 @@ def create_alias(context, data_dict):
                     })
 
                 context['connection'].execute(sql_alias_string)
-        except DBAPIError, e:
+        except DBAPIError as e:
             if e.orig.pgcode in [_PG_ERR_CODE['duplicate_table'],
                                  _PG_ERR_CODE['duplicate_alias']]:
                 raise ValidationError({
@@ -638,7 +638,7 @@ def _is_valid_pg_type(context, type_name):
         connection = context['connection']
         try:
             connection.execute('SELECT %s::regtype', type_name)
-        except ProgrammingError, e:
+        except ProgrammingError as e:
             if e.orig.pgcode in [_PG_ERR_CODE['undefined_object'],
                                  _PG_ERR_CODE['syntax_error']]:
                 return False
@@ -1436,7 +1436,7 @@ def upsert(context, data_dict):
         upsert_data(context, data_dict)
         trans.commit()
         return _unrename_json_field(data_dict)
-    except IntegrityError, e:
+    except IntegrityError as e:
         if e.orig.pgcode == _PG_ERR_CODE['unique_violation']:
             raise ValidationError({
                 'constraints': ['Cannot insert records or create index because'
@@ -1447,19 +1447,19 @@ def upsert(context, data_dict):
                 }
             })
         raise
-    except DataError, e:
+    except DataError as e:
         raise ValidationError({
             'data': e.message,
             'info': {
                 'orig': [str(e.orig)]
             }})
-    except DBAPIError, e:
+    except DBAPIError as e:
         if e.orig.pgcode == _PG_ERR_CODE['query_canceled']:
             raise ValidationError({
                 'query': ['Query took too long']
             })
         raise
-    except Exception, e:
+    except Exception as e:
         trans.rollback()
         raise
     finally:
@@ -1477,7 +1477,7 @@ def search(context, data_dict):
         context['connection'].execute(
             u'SET LOCAL statement_timeout TO {0}'.format(timeout))
         return search_data(context, data_dict)
-    except DBAPIError, e:
+    except DBAPIError as e:
         if e.orig.pgcode == _PG_ERR_CODE['query_canceled']:
             raise ValidationError({
                 'query': ['Search took too long']
@@ -1522,7 +1522,7 @@ def search_sql(context, data_dict):
 
         return format_results(context, results, data_dict)
 
-    except ProgrammingError, e:
+    except ProgrammingError as e:
         if e.orig.pgcode == _PG_ERR_CODE['permission_denied']:
             raise toolkit.NotAuthorized({
                 'permissions': ['Not authorized to read resource.']
@@ -1540,7 +1540,7 @@ def search_sql(context, data_dict):
                 'orig': [_remove_explain(str(e.orig))]
             }
         })
-    except DBAPIError, e:
+    except DBAPIError as e:
         if e.orig.pgcode == _PG_ERR_CODE['query_canceled']:
             raise ValidationError({
                 'query': ['Query took too long']
@@ -1823,7 +1823,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
                 _change_privilege(context, data_dict, 'REVOKE')
             trans.commit()
             return _unrename_json_field(data_dict)
-        except IntegrityError, e:
+        except IntegrityError as e:
             if e.orig.pgcode == _PG_ERR_CODE['unique_violation']:
                 raise ValidationError({
                     'constraints': ['Cannot insert records or create index'
@@ -1834,19 +1834,19 @@ class DatastorePostgresqlBackend(DatastoreBackend):
                     }
                 })
             raise
-        except DataError, e:
+        except DataError as e:
             raise ValidationError({
                 'data': e.message,
                 'info': {
                     'orig': [str(e.orig)]
                 }})
-        except DBAPIError, e:
+        except DBAPIError as e:
             if e.orig.pgcode == _PG_ERR_CODE['query_canceled']:
                 raise ValidationError({
                     'query': ['Query took too long']
                 })
             raise
-        except Exception, e:
+        except Exception as e:
             trans.rollback()
             raise
         finally:

--- a/ckanext/datastore/commands.py
+++ b/ckanext/datastore/commands.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import print_function
 import os
 
 from ckan.lib.cli import (

--- a/ckanext/datastore/tests/test_disable.py
+++ b/ckanext/datastore/tests/test_disable.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from __future__ import print_function
 import nose
 
 from ckan.common import config
@@ -21,7 +22,7 @@ class TestDisable(object):
     def test_disable_sql_search(self):
         config['ckan.datastore.sqlsearch.enabled'] = False
         with p.use_plugin('datastore') as the_plugin:
-            print p.toolkit.get_action('datastore_search_sql')
+            print(p.toolkit.get_action('datastore_search_sql'))
         config['ckan.datastore.sqlsearch.enabled'] = True
 
     def test_enabled_sql_search(self):

--- a/ckanext/resourceproxy/controller.py
+++ b/ckanext/resourceproxy/controller.py
@@ -70,15 +70,15 @@ def proxy_resource(context, data_dict):
                 base.abort(409, headers={'content-encoding': ''},
                            detail='Content is too large to be proxied.')
 
-    except requests.exceptions.HTTPError, error:
+    except requests.exceptions.HTTPError as error:
         details = 'Could not proxy resource. Server responded with %s %s' % (
             error.response.status_code, error.response.reason)
         base.abort(409, detail=details)
-    except requests.exceptions.ConnectionError, error:
+    except requests.exceptions.ConnectionError as error:
         details = '''Could not proxy resource because a
                             connection error occurred. %s''' % error
         base.abort(502, detail=details)
-    except requests.exceptions.Timeout, error:
+    except requests.exceptions.Timeout as error:
         details = 'Could not proxy resource because the connection timed out.'
         base.abort(504, detail=details)
 

--- a/ckanext/stats/controller.py
+++ b/ckanext/stats/controller.py
@@ -1,8 +1,9 @@
 # encoding: utf-8
 
+from __future__ import absolute_import
 import ckan.plugins as p
 from ckan.lib.base import BaseController
-import stats as stats_lib
+from . import stats as stats_lib
 import ckan.lib.helpers as h
 
 

--- a/ckanext/stats/tests/test_stats_lib.py
+++ b/ckanext/stats/tests/test_stats_lib.py
@@ -92,7 +92,7 @@ class TestStatsPlugin(StatsFixture):
     def test_top_tags(self):
         tags = Stats.top_tags()
         tags = [(tag.name, count) for tag, count in tags]
-        assert_equal(tags, [('tag1', 1L)])
+        assert_equal(tags, [('tag1', 1)])
 
     def test_top_package_creators(self):
         creators = Stats.top_package_creators()

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -338,8 +338,8 @@ htmlhelp_basename = 'CKANdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class [howto/manual]).
 latex_documents = [
-  ('contents', 'CKAN.tex', ur'CKAN documentation',
-   ur'CKAN contributors', 'manual'),
+  ('contents', 'CKAN.tex', u'CKAN documentation',
+   u'CKAN contributors', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of


### PR DESCRIPTION
Fixes #3309 (PARTIAL FIX!!)

Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3. There would _definitely_ be more work required to complete the port to Python 3 but this is a minimal, safe first step.

Run: `futurize --stage1 -w **/*.py`  # done in zsh for ** globbing

See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes

$ `pip install future`
$ `git checkout -b modernize-python2-code`
$ `futurize --stage1 -w **/*.py`  # done in zsh for ** globbing
$ `git commit --all -m "Modernize Python 2 code to get ready for Python 3"`
$ `git push --set-upstream origin modernize-python2-code`