### PR TITLE
Fix Travis CI templates in extension

### DIFF
--- a/ckan/pastertemplates/template/+dot+travis.yml_tmpl
+++ b/ckan/pastertemplates/template/+dot+travis.yml_tmpl
@@ -4,6 +4,7 @@ python:
     - "2.7"
 services:
     - postgresql
+    - redis-server
 install:
     - bash bin/travis-build.bash
     - pip install coveralls

--- a/ckan/pastertemplates/template/+dot+travis.yml_tmpl
+++ b/ckan/pastertemplates/template/+dot+travis.yml_tmpl
@@ -2,7 +2,8 @@ language: python
 sudo: required
 python:
     - "2.7"
-env: PGVERSION=9.1
+services:
+    - postgresql
 install:
     - bash bin/travis-build.bash
     - pip install coveralls

--- a/ckan/pastertemplates/template/bin/travis-build.bash_tmpl
+++ b/ckan/pastertemplates/template/bin/travis-build.bash_tmpl
@@ -5,7 +5,7 @@ echo "This is travis-build.bash..."
 
 echo "Installing the packages that CKAN requires..."
 sudo apt-get update -qq
-sudo apt-get install postgresql-$PGVERSION solr-jetty libcommons-fileupload-java:amd64=1.2.2-1
+sudo apt-get install postgresql-$PGVERSION solr-jetty libcommons-fileupload-java
 
 echo "Installing CKAN and its Python dependencies..."
 git clone https://github.com/ckan/ckan

--- a/ckan/pastertemplates/template/bin/travis-build.bash_tmpl
+++ b/ckan/pastertemplates/template/bin/travis-build.bash_tmpl
@@ -5,7 +5,7 @@ echo "This is travis-build.bash..."
 
 echo "Installing the packages that CKAN requires..."
 sudo apt-get update -qq
-sudo apt-get install solr-jetty libcommons-fileupload-java
+sudo apt-get install solr-jetty
 
 echo "Installing CKAN and its Python dependencies..."
 git clone https://github.com/ckan/ckan

--- a/ckan/pastertemplates/template/bin/travis-build.bash_tmpl
+++ b/ckan/pastertemplates/template/bin/travis-build.bash_tmpl
@@ -5,7 +5,7 @@ echo "This is travis-build.bash..."
 
 echo "Installing the packages that CKAN requires..."
 sudo apt-get update -qq
-sudo apt-get install postgresql-$PGVERSION solr-jetty libcommons-fileupload-java
+sudo apt-get install solr-jetty libcommons-fileupload-java
 
 echo "Installing CKAN and its Python dependencies..."
 git clone https://github.com/ckan/ckan


### PR DESCRIPTION
The Travis CI scripts generated by the extension template have been broken due to changes on Travis (e.g. ckan/ckanext-pages#57, ckan/ckanext-showcase#51). This PR fixes the templates. Per [suggestion](https://github.com/ckan/ckanext-pages/issues/57#issuecomment-330179922) of @amercader, it also switches to using the PostgreSQL provided by Travis instead of manually installing it (cf. ckan/ckanext-dcat@6e5f9f7).

Unfortunately this kind of change is hard to test. Here's how I did it:

- [Check out this PR](https://help.github.com/articles/checking-out-pull-requests-locally/)
- [Use it to create a new CKAN extension](http://docs.ckan.org/en/ckan-2.7.0/extensions/tutorial.html#creating-a-new-extension). Use the name of an existing extension for which you already have Travis set up.
- Copy the following files from the new extension to a temporary branch of the existing extension:
  - `.travis.yml`
  - `bin/travis-build.bash`
- Push the temporary branch so that Travis runs it.