### PR TITLE
fixed negative date vaue when creating a data request or updating a p…

### DIFF
--- a/ckan/lib/formatters.py
+++ b/ckan/lib/formatters.py
@@ -99,7 +99,7 @@ def localised_nice_date(datetime_, show_date=False, with_hours=False):
         return months
 
     if not show_date:
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now()
         if datetime_.tzinfo is not None:
             now = now.replace(tzinfo=datetime_.tzinfo)
         else:

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -120,8 +120,7 @@ def _datestamp_to_datetime(datetime_):
 
     # all dates are considered UTC internally,
     # change output if `ckan.display_timezone` is available
-    datetime_ = datetime_.replace(tzinfo=pytz.utc)
-    datetime_ = datetime_.astimezone(get_display_timezone())
+    datetime_ = datetime_.replace(tzinfo=get_display_timezone())
 
     return datetime_
 


### PR DESCRIPTION
### What does this PR do?
Fix the negative date value being displayed when a user creates a new datarequest and also when a user updates his/her profile.

The image below shows when a user successfully creates a data request.
![image](https://user-images.githubusercontent.com/26963854/30977356-3821b350-a46f-11e7-872a-881df30610d6.png)

The image below shows when a user successfully updates his/her profile and then checks via the activity stream
![image](https://user-images.githubusercontent.com/26963854/30977378-4357752a-a46f-11e7-8664-10569ace197d.png)
