### PR TITLE
[#3798] Keep root_path out of site_logo until needed

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -438,7 +438,9 @@ def url_for_static_or_external(*args, **kw):
     if kw.get('qualified', False):
         kw['protocol'], kw['host'] = get_site_protocol_and_host()
     my_url = _routes_default_url_for(*args, **kw)
-    return _local_url(my_url, locale='default', **kw)
+    if not is_url(my_url):
+        my_url = _local_url(my_url, locale='default', **kw)
+    return my_url
 
 
 @core_helper

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -1278,7 +1278,7 @@ def config_option_update(context, data_dict):
                 and not value.startswith('/'):
             image_path = 'uploads/admin/'
 
-            value = h.url_for_static('{0}{1}'.format(image_path, value))
+            value = '{0}{1}'.format(image_path, value)
 
         # Save value in database
         model.set_system_info(key, value)


### PR DESCRIPTION
Fixes #3798 

### Proposed fixes:

For external urls, `url_for_static_or_external` would prefix it with the root_path. Instead, it now skips the last bit of processing if the url is already a fully-qualified url.

For site logo uploads, since the header template passes the value through `url_for_static_or_external` when rendering, I removed the call to `url_for_static` which would have added prefix twice

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
