### PR TITLE
Remove the ordereddict backport for Python < 2.7

### DIFF
--- a/ckan/tests/controllers/test_api.py
+++ b/ckan/tests/controllers/test_api.py
@@ -281,7 +281,7 @@ class TestApiController(helpers.FunctionalTestBase):
             'http://test.ckan.net/api/3/action/datastore_search_sql?sql=SELECT * from &#34;588dfa82-760c-45a2-b78a-e3bc314a4a9b&#34; WHERE title LIKE &#39;jones&#39;',
             "url: 'http://test.ckan.net/api/3/action/datastore_search'",
             "http://test.ckan.net/api/3/action/datastore_search?resource_id=588dfa82-760c-45a2-b78a-e3bc314a4a9b&amp;limit=5&amp;q=title:jones",
-            )
+        )
         for url in expected_urls:
             assert url in page, url
 

--- a/ckan/tests/controllers/test_api.py
+++ b/ckan/tests/controllers/test_api.py
@@ -281,7 +281,7 @@ class TestApiController(helpers.FunctionalTestBase):
             'http://test.ckan.net/api/3/action/datastore_search_sql?sql=SELECT * from &#34;588dfa82-760c-45a2-b78a-e3bc314a4a9b&#34; WHERE title LIKE &#39;jones&#39;',
             "url: 'http://test.ckan.net/api/3/action/datastore_search'",
             "http://test.ckan.net/api/3/action/datastore_search?resource_id=588dfa82-760c-45a2-b78a-e3bc314a4a9b&amp;limit=5&amp;q=title:jones",
-        )
+            )
         for url in expected_urls:
             assert url in page, url
 

--- a/requirements.in
+++ b/requirements.in
@@ -10,7 +10,6 @@ Flask-Babel==0.11.2
 Jinja2==2.8
 Markdown==2.6.7
 ofs==0.4.2
-ordereddict==1.1
 Pairtree==0.7.1-T
 passlib==1.6.5
 paste==1.7.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ Markdown==2.6.7
 MarkupSafe==0.23          # via jinja2, mako, webhelpers
 nose==1.3.7               # via pylons
 ofs==0.4.2
-# ordereddict==1.1        # Python 2.7+ use stdlib collections.OrderedDict
 Pairtree==0.7.1-T
 passlib==1.6.5
 paste==1.7.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ Markdown==2.6.7
 MarkupSafe==0.23          # via jinja2, mako, webhelpers
 nose==1.3.7               # via pylons
 ofs==0.4.2
-ordereddict==1.1
+# ordereddict==1.1        # Python 2.7+ use stdlib collections.OrderedDict
 Pairtree==0.7.1-T
 passlib==1.6.5
 paste==1.7.5.1


### PR DESCRIPTION
Fixes #3309 (PARTIAL FIX!!)  The [ordereddict backport](https://pypi.python.org/pypi/ordereddict) in no longer required because collections.OrderedDict is part of the Standard Library in Python 2.7 and Python 3.  This repo no longer supports Python < 2.7 which the backport is targeted at.

Circle CI build is failing because of the unrelated #3833

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
