### PR TITLE
Fix pep8 issue in tests/controllers/test_api.py

### DIFF
--- a/ckan/tests/controllers/test_api.py
+++ b/ckan/tests/controllers/test_api.py
@@ -281,7 +281,7 @@ class TestApiController(helpers.FunctionalTestBase):
             'http://test.ckan.net/api/3/action/datastore_search_sql?sql=SELECT * from &#34;588dfa82-760c-45a2-b78a-e3bc314a4a9b&#34; WHERE title LIKE &#39;jones&#39;',
             "url: 'http://test.ckan.net/api/3/action/datastore_search'",
             "http://test.ckan.net/api/3/action/datastore_search?resource_id=588dfa82-760c-45a2-b78a-e3bc314a4a9b&amp;limit=5&amp;q=title:jones",
-            )
+        )
         for url in expected_urls:
             assert url in page, url
 


### PR DESCRIPTION
[Circle CI complains](https://circleci.com/gh/ckan/ckan/3246?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) ckan/tests/controllers/test_api.py E123 ln:284 closing bracket does not match indentation of opening bracket's line

Fixes: Circle CI build failure

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
