### PR TITLE
clarify ckan.auth.create_user_via_api setting does not apply to sysadmins

### DIFF
--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -547,7 +547,7 @@ Example::
 Default value: ``False``
 
 
-Allow new user accounts to be created via the API.
+Allow new user accounts to be created via the API by anyone. When ``False`` only sysadmins are authorised.
 
 .. _ckan.auth.create_user_via_web:
 


### PR DESCRIPTION
Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
