### PR TITLE
Fixes #3796 and an issue with some deployments of CKAN losing Action API

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -355,7 +355,9 @@ def _register_core_blueprints(app):
     def is_blueprint(mm):
         return isinstance(mm, Blueprint)
 
-    for loader, name, _ in pkgutil.iter_modules(['ckan/views'], 'ckan.views.'):
+    path = os.path.join(os.path.dirname(__file__), '..', '..', 'views')
+
+    for loader, name, _ in pkgutil.iter_modules([path], 'ckan.views.'):
         module = loader.find_module(name).load_module(name)
         for blueprint in inspect.getmembers(module, is_blueprint):
             app.register_blueprint(blueprint[1])


### PR DESCRIPTION
This PR fixes an issue with some deployments of CKAN losing the Action API. The patch from @amercader resolves an issue reported on ckan-dev and IRC where sometimes flask routes aren't getting loaded and the action API is lost as a result. Incidentally, it fixes #3796 :-D