### PR TITLE
Change CORS header keys and values to string instead of unicode

### DIFF
--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -62,12 +62,12 @@ def set_cors_headers_for_response(response):
             cors_origin_allowed = request.headers.get(u'Origin')
 
         if cors_origin_allowed is not None:
-            response.headers[u'Access-Control-Allow-Origin'] = \
+            response.headers['Access-Control-Allow-Origin'] = \
                 cors_origin_allowed
-            response.headers[u'Access-Control-Allow-Methods'] = \
-                u'POST, PUT, GET, DELETE, OPTIONS'
-            response.headers[u'Access-Control-Allow-Headers'] = \
-                u'X-CKAN-API-KEY, Authorization, Content-Type'
+            response.headers['Access-Control-Allow-Methods'] = \
+                'POST, PUT, GET, DELETE, OPTIONS'
+            response.headers['Access-Control-Allow-Headers'] = \
+                'X-CKAN-API-KEY, Authorization, Content-Type'
 
     return response
 

--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -62,12 +62,12 @@ def set_cors_headers_for_response(response):
             cors_origin_allowed = request.headers.get(u'Origin')
 
         if cors_origin_allowed is not None:
-            response.headers['Access-Control-Allow-Origin'] = \
+            response.headers[b'Access-Control-Allow-Origin'] = \
                 cors_origin_allowed
-            response.headers['Access-Control-Allow-Methods'] = \
-                'POST, PUT, GET, DELETE, OPTIONS'
-            response.headers['Access-Control-Allow-Headers'] = \
-                'X-CKAN-API-KEY, Authorization, Content-Type'
+            response.headers[b'Access-Control-Allow-Methods'] = \
+                b'POST, PUT, GET, DELETE, OPTIONS'
+            response.headers[b'Access-Control-Allow-Headers'] = \
+                b'X-CKAN-API-KEY, Authorization, Content-Type'
 
     return response
 


### PR DESCRIPTION
The CORS header keys and values being unicode raised problems when using uWSGI with CKAN. uWSGI expects the header keys to be string instead of unicode which results in a TypeError. 

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
