### PR TITLE
Fix of `Add Dataset` button on search page.

### DIFF
--- a/ckan/config/routing.py
+++ b/ckan/config/routing.py
@@ -183,7 +183,7 @@ def make_map():
     with SubMapper(map, controller='package') as m:
         m.connect('search', '/dataset', action='search',
                   highlight_actions='index search')
-        m.connect('add dataset', '/dataset/new', action='new')
+        m.connect('dataset_new', '/dataset/new', action='new')
         m.connect('/dataset/{action}',
                   requirements=dict(action='|'.join([
                       'list',


### PR DESCRIPTION
[#3643] assumes, that `add dataset` route is named as `dataset_new`.
I just updated route's name, as it not used anywhere else and it won't
break anything.
