### PR TITLE
[#3833] Extend Flask template dirs

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -251,7 +251,7 @@ def update_config():
     if extra_template_paths:
         # must be first for them to override defaults
         template_paths = extra_template_paths.split(',') + template_paths
-    config['pylons.app_globals'].template_paths = template_paths
+    config['computed_template_paths'] = template_paths
 
     # Set the default language for validation messages from formencode
     # to what is set as the default locale in the config

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -57,13 +57,10 @@ def make_flask_stack(conf, **app_conf):
     app.template_folder = os.path.join(root, 'templates')
     app.app_ctx_globals_class = CKAN_AppCtxGlobals
     app.url_rule_class = CKAN_Rule
-    extra_paths = config.get('computed_template_paths')
-
-    if extra_paths:
-        app.jinja_loader = ChoiceLoader([
-            app.jinja_loader,
-            CkanextTemplateLoader()
-        ])
+    app.jinja_loader = ChoiceLoader([
+        app.jinja_loader,
+        CkanextTemplateLoader()
+    ])
 
     # Update Flask config with the CKAN values. We use the common config
     # object as values might have been modified on `load_environment`

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -6,6 +6,8 @@ import inspect
 import itertools
 import pkgutil
 
+from jinja2 import ChoiceLoader, FileSystemLoader
+
 from flask import Flask, Blueprint
 from flask.ctx import _AppCtxGlobals
 from flask.sessions import SessionInterface
@@ -54,6 +56,13 @@ def make_flask_stack(conf, **app_conf):
     app.template_folder = os.path.join(root, 'templates')
     app.app_ctx_globals_class = CKAN_AppCtxGlobals
     app.url_rule_class = CKAN_Rule
+
+    extra_paths = config.get('computed_template_paths')
+    if extra_paths:
+        app.jinja_loader = ChoiceLoader([
+            app.jinja_loader,
+            FileSystemLoader(extra_paths)
+        ])
 
     # Update Flask config with the CKAN values. We use the common config
     # object as values might have been modified on `load_environment`

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -6,7 +6,7 @@ import inspect
 import itertools
 import pkgutil
 
-from jinja2 import ChoiceLoader, FileSystemLoader
+from jinja2 import ChoiceLoader
 
 from flask import Flask, Blueprint
 from flask.ctx import _AppCtxGlobals
@@ -26,6 +26,7 @@ from repoze.who.middleware import PluggableAuthenticationMiddleware
 import ckan.model as model
 from ckan.lib import helpers
 from ckan.lib import jinja_extensions
+from ckan.lib.render import CkanextTemplateLoader
 from ckan.common import config, g, request, ungettext
 import ckan.lib.app_globals as app_globals
 from ckan.plugins import PluginImplementations
@@ -56,12 +57,12 @@ def make_flask_stack(conf, **app_conf):
     app.template_folder = os.path.join(root, 'templates')
     app.app_ctx_globals_class = CKAN_AppCtxGlobals
     app.url_rule_class = CKAN_Rule
-
     extra_paths = config.get('computed_template_paths')
+
     if extra_paths:
         app.jinja_loader = ChoiceLoader([
             app.jinja_loader,
-            FileSystemLoader(extra_paths)
+            CkanextTemplateLoader()
         ])
 
     # Update Flask config with the CKAN values. We use the common config

--- a/ckan/lib/render.py
+++ b/ckan/lib/render.py
@@ -17,7 +17,7 @@ def reset_template_info_cache():
 def find_template(template_name):
     ''' looks through the possible template paths to find a template
     returns the full path is it exists. '''
-    template_paths = config['pylons.app_globals'].template_paths
+    template_paths = config['computed_template_paths']
     for path in template_paths:
         if os.path.exists(os.path.join(path, template_name.encode('utf-8'))):
             return os.path.join(path, template_name)

--- a/ckan/lib/render.py
+++ b/ckan/lib/render.py
@@ -4,6 +4,8 @@ import os
 import re
 import logging
 
+from jinja2 import FileSystemLoader
+
 from ckan.common import config
 
 log = logging.getLogger(__name__)
@@ -47,3 +49,16 @@ def template_info(template_name):
                   'template_type' : t_type,}
         _template_info_cache[template_name] = t_data
     return template_path, t_type
+
+
+class CkanextTemplateLoader(FileSystemLoader):
+    def __init__(self):
+        super(CkanextTemplateLoader, self).__init__([])
+
+    @property
+    def searchpath(self):
+        return config['computed_template_paths']
+
+    @searchpath.setter
+    def searchpath(self, _):
+        pass

--- a/ckan/tests/controllers/test_api.py
+++ b/ckan/tests/controllers/test_api.py
@@ -266,6 +266,7 @@ class TestApiController(helpers.FunctionalTestBase):
 
         if not p.plugin_loaded('datastore'):
             p.load('datastore')
+
         app = self._get_test_app()
         page = app.get(url, status=200)
         p.unload('datastore')
@@ -277,7 +278,7 @@ class TestApiController(helpers.FunctionalTestBase):
             '<code>http://test.ckan.net/api/3/action/datastore_search',
             'http://test.ckan.net/api/3/action/datastore_search_sql',
             'http://test.ckan.net/api/3/action/datastore_search?resource_id=588dfa82-760c-45a2-b78a-e3bc314a4a9b&amp;limit=5',
-            'http://test.ckan.net/api/3/action/datastore_search?resource_id=588dfa82-760c-45a2-b78a-e3bc314a4a9b&amp;q=jones',
+            'http://test.ckan.net/api/3/action/datastore_search?q=jones&amp;resource_id=588dfa82-760c-45a2-b78a-e3bc314a4a9b',
             'http://test.ckan.net/api/3/action/datastore_search_sql?sql=SELECT * from &#34;588dfa82-760c-45a2-b78a-e3bc314a4a9b&#34; WHERE title LIKE &#39;jones&#39;',
             "url: 'http://test.ckan.net/api/3/action/datastore_search'",
             "http://test.ckan.net/api/3/action/datastore_search?resource_id=588dfa82-760c-45a2-b78a-e3bc314a4a9b&amp;limit=5&amp;q=title:jones",

--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -445,7 +445,12 @@ def snippet(snippet_path, ver=API_REST_DEFAULT_VERSION):
         We only allow snippets in templates/ajax_snippets and its subdirs
     '''
     snippet_path = u'ajax_snippets/' + snippet_path
-    return render(snippet_path, extra_vars=dict(request.args))
+    # werkzeug.datastructures.ImmutableMultiDict.to_dict
+    # by default returns flattened dict with first occurences of each key.
+    # For retrieving multiple values per key, use named argument `flat`
+    # set to `False`
+    extra_vars = request.args.to_dict()
+    return render(snippet_path, extra_vars=extra_vars)
 
 
 def i18n_js_translations(lang, ver=API_REST_DEFAULT_VERSION):


### PR DESCRIPTION
Add additional template directories to template_loader during
creation of Flask app stack. Previously we put list of additional
dirs into `config['pylons.app_globals'].template_paths`, but
as we are migrating to Flask I moved this value to
`config['computed_template_paths']`. After this, inside
`make_flask_app`, default `jinja_loader` replaced with ChoiceLoader,
that will try to load templates from either default dirs or custom
ones.
