### PR TITLE
Allow IValidator to override existing validators

### DIFF
--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -677,12 +677,8 @@ def get_validator(validator):
         converters = _import_module_functions('ckan.logic.converters')
         _validators_cache.update(converters)
 
-        for plugin in p.PluginImplementations(p.IValidators):
+        for plugin in reversed(list(p.PluginImplementations(p.IValidators))):
             for name, fn in plugin.get_validators().items():
-                if name in _validators_cache:
-                    raise NameConflict(
-                        'The validator %r is already defined' % (name,)
-                    )
                 log.debug('Validator function {0} from plugin {1} was inserted'
                           .format(name, plugin.name))
                 _validators_cache[name] = fn

--- a/ckanext/example_ivalidators/plugin.py
+++ b/ckanext/example_ivalidators/plugin.py
@@ -9,16 +9,26 @@ class ExampleIValidatorsPlugin(plugins.SingletonPlugin):
 
     def get_validators(self):
         return {
-            'equals_fortytwo': equals_fortytwo,
-            'negate': negate,
+            u'equals_fortytwo': equals_fortytwo,
+            u'negate': negate,
+            u'unicode_only': unicode_please,
             }
 
 
 def equals_fortytwo(value):
     if value != 42:
-        raise Invalid('not 42')
+        raise Invalid(u'not 42')
     return value
 
 
 def negate(value):
     return -value
+
+
+def unicode_please(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode(u'utf8')
+        except UnicodeDecodeError:
+            return value.decode(u'cp1252')
+    return unicode(value)

--- a/ckanext/example_ivalidators/tests/test_ivalidators.py
+++ b/ckanext/example_ivalidators/tests/test_ivalidators.py
@@ -27,3 +27,13 @@ class TestIValidators(object):
     def test_custom_converter_converts(self):
         c = get_validator('negate')
         assert_equals(c(19), -19)
+
+    def test_overridden_validator(self):
+        v = get_validator('unicode_only')
+        assert_equals(u'Hola cómo estás', v(b'Hola c\xf3mo est\xe1s'))
+
+
+class TestNoIValidators(object):
+    def test_no_overridden_validator(self):
+        v = get_validator('unicode_only')
+        assert_raises(Invalid, v, b'Hola c\xf3mo est\xe1s')


### PR DESCRIPTION
There are cases where overriding a built-in or plugin-defined validator is much simpler than redefining a one or more whole schemas.

This change allows IValidator plugins to override existing validators, following the established "first plugin wins" pattern. Validators are usually simple functions and they can be created with a number of different function signatures, so we don't attempt to "chain" validators like we do when overriding action methods. one validator wins and is the only one that will be called.

Current behaviour is to raise a NameConflict error, this will no longer happen.

The core schema.py imports validator functions directly, should we change schema.py to call get_validator() as part of the same PR for consistency, or make this only affect schemas defined in plugins or with ckanext-scheming?