### PR TITLE
cli: fix passing of concurrency arg for celery

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -1076,7 +1076,7 @@ class Celery(CkanCommand):
         from ckan.lib.celery_app import celery
         celery_args = []
         if len(self.args) == 2 and self.args[1] == 'concurrency':
-            celery_args.append['--concurrency=1']
+            celery_args.append('--concurrency=1')
         celery.worker_main(argv=['celeryd', '--loglevel=INFO'] + celery_args)
 
     def view(self):


### PR DESCRIPTION
Allows running only one worker, required as a work-around for race conditions that can happen if e.g. two jobs update extras.