### PR TITLE
[#3875] Fix language switcher in CKAN webpages

### DIFF
--- a/ckan/templates/snippets/language_selector.html
+++ b/ckan/templates/snippets/language_selector.html
@@ -3,7 +3,7 @@
   <label for="field-lang-select">{{ _('Language') }}</label>
   <select id="field-lang-select" name="url" data-module="autocomplete" data-module-dropdown-class="lang-dropdown" data-module-container-class="lang-container">
     {% for locale in h.get_available_locales() %}
-      <option value="{% url_for h.current_url(), locale=locale.short_name %}" {% if locale.identifier == current_lang %}selected="selected"{% endif %}>
+      <option value="{% url_for h.current_url(), locale=locale %}" {% if locale == current_lang %}selected="selected"{% endif %}>
         {{ locale.display_name or locale.english_name }}
       </option>
     {% endfor %}


### PR DESCRIPTION
Fixes #3875

### Proposed fixes:

Issue: Language switcher not working because variables 'locale.short_name' and 'locale.identifier' are undefined.
Comment: Within the CKAN 2.5.x codebase, this problem occurs in v2.5.6 and v2.5.7. It is related to a partial cherrypick of the solution for issue: #3073.
Solution: Revert to the original code. Therefore, use variable 'locale' instead. This solution should be merged into the CKAN v2.5.8 branch, as per this pull request.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
