### PR TITLE
[#3876] delete organization

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -639,6 +639,9 @@ class GroupController(base.BaseController):
             abort(403, _('Unauthorized to delete group %s') % '')
         except NotFound:
             abort(404, _('Group not found'))
+        except ValidationError as e:
+            h.flash_error(e.error_dict['message'])
+            h.redirect_to(controller='organization', action='read', id=id)
         return self._render_template('group/confirm_delete.html', group_type)
 
     def members(self, id):

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -396,7 +396,8 @@ def group_delete(context, data_dict):
 def organization_delete(context, data_dict):
     '''Delete an organization.
 
-    You must be authorized to delete the organization.
+    You must be authorized to delete the organization
+    and no datsets should belong to the organization
 
     :param id: the name or id of the organization
     :type id: string

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -355,8 +355,8 @@ def _group_or_org_delete(context, data_dict, is_org=False):
                         .count()
         if datasets:
             if not authz.check_config_permission('ckan.auth.create_unowned_dataset'):
-                raise ValidationError('Organization cannot be deleted while it '
-                                      'still has datasets')
+                raise ValidationError(_('Organization cannot be deleted while it '
+                                      'still has datasets'))
 
     rev = model.repo.new_revision()
     rev.author = user

--- a/ckan/templates-bs2/organization/snippets/organization_form.html
+++ b/ckan/templates-bs2/organization/snippets/organization_form.html
@@ -57,7 +57,7 @@
   <div class="form-actions">
     {% block delete_button %}
       {% if h.check_access('organization_delete', {'id': data.id})  %}
-        <a class="btn btn-danger pull-left" href="{% url_for controller='organization', action='delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this Organization? This will delete all the public and private datasets belonging to this organization.') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+        <a class="btn btn-danger pull-left" href="{% url_for controller='organization', action='delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this Organization? Note*: Deleting cannot be performed while public and private datasets are belonging to this organization.') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
       {% endif %}
     {% endblock %}
     <button class="btn btn-primary" name="save" type="submit">{% block save_text %}{{ _('Save Organization') }}{% endblock %}</button>

--- a/ckan/templates/organization/snippets/organization_form.html
+++ b/ckan/templates/organization/snippets/organization_form.html
@@ -57,7 +57,7 @@
   <div class="form-actions">
     {% block delete_button %}
       {% if h.check_access('organization_delete', {'id': data.id})  %}
-        <a class="btn btn-danger pull-left" href="{% url_for controller='organization', action='delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this Organization? This will delete all the public and private datasets belonging to this organization.') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+        <a class="btn btn-danger pull-left" href="{% url_for controller='organization', action='delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this Organization? Note*: Deleting cannot be performed while public and private datasets are belonging to this organization.') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
       {% endif %}
     {% endblock %}
     <button class="btn btn-primary" name="save" type="submit">{% block save_text %}{{ _('Save Organization') }}{% endblock %}</button>

--- a/ckan/templates/organization/snippets/organization_form.html
+++ b/ckan/templates/organization/snippets/organization_form.html
@@ -57,7 +57,7 @@
   <div class="form-actions">
     {% block delete_button %}
       {% if h.check_access('organization_delete', {'id': data.id})  %}
-        <a class="btn btn-danger pull-left" href="{% url_for controller='organization', action='delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this Organization? Note*: Deleting cannot be performed while public and private datasets are belonging to this organization.') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+        <a class="btn btn-danger pull-left" href="{% url_for controller='organization', action='delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this Organization? Note*: Deleting cannot be performed while public or private datasets belong to this organization.') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
       {% endif %}
     {% endblock %}
     <button class="btn btn-primary" name="save" type="submit">{% block save_text %}{{ _('Save Organization') }}{% endblock %}</button>

--- a/ckan/tests/controllers/test_organization.py
+++ b/ckan/tests/controllers/test_organization.py
@@ -210,9 +210,9 @@ class TestOrganizationDelete(helpers.FunctionalTestBase):
                                            id=self.organization['id'])
         assert_equal(organization['state'], 'active')
 
+    @helpers.change_config('ckan.auth.create_unowned_dataset', False)
     def test_delete_organization_with_datasets(self):
         ''' Test deletion of organization that has datasets'''
-        config['ckan.auth.create_unowned_dataset'] = False
         text = 'Organization cannot be deleted while it still has datasets'
         datasets = [factories.Dataset(owner_org=self.organization['id'])
                     for i in range(0, 5)]

--- a/ckan/tests/controllers/test_organization.py
+++ b/ckan/tests/controllers/test_organization.py
@@ -213,7 +213,6 @@ class TestOrganizationDelete(helpers.FunctionalTestBase):
     def test_delete_organization_with_datasets(self):
         ''' Test deletion of organization that has datasets'''
         config['ckan.auth.create_unowned_dataset'] = False
-        
         text = 'Organization cannot be deleted while it still has datasets'
         datasets = [factories.Dataset(owner_org=self.organization['id'])
                     for i in range(0, 5)]

--- a/ckan/tests/controllers/test_organization.py
+++ b/ckan/tests/controllers/test_organization.py
@@ -229,6 +229,16 @@ class TestOrganizationDelete(helpers.FunctionalTestBase):
             self.app, form, name='delete', extra_environ=self.user_env)
         assert text in response.body
 
+    def test_delete_organization_with_unknown_dataset_true(self):
+        ''' Test deletion of organization that has datasets and unknown
+            datasets are set to true'''
+        dataset = factories.Dataset(owner_org=self.organization['id'])
+        assert_equal(dataset['owner_org'], self.organization['id'])
+        helpers.call_action('organization_delete', id=self.organization['id'])
+
+        dataset = helpers.call_action('package_show', id=dataset['id'])
+        assert_equal(dataset['owner_org'], None)
+
 
 class TestOrganizationBulkProcess(helpers.FunctionalTestBase):
     def setup(self):
@@ -237,9 +247,10 @@ class TestOrganizationBulkProcess(helpers.FunctionalTestBase):
         self.user = factories.User()
         self.user_env = {'REMOTE_USER': self.user['name'].encode('ascii')}
         self.organization = factories.Organization(user=self.user)
-        self.organization_bulk_url = url_for(controller='organization',
-                                             action='bulk_process',
-                                             id=self.organization['id'])
+        self.organization_bulk_url = url_for(
+            controller='organization',
+            action='bulk_process',
+            id=self.organization['id'])
 
     def test_make_private(self):
         datasets = [factories.Dataset(owner_org=self.organization['id'])


### PR DESCRIPTION
Fixes #3876 

### Proposed fixes:
Deleting organization while there are datasets related to it, was causing issues and with this fix deleting of organization could be performed only on empty organization
When users tries to delete the organization, check for datasets is performed and if the 'ckan.auth.create_unowned_dataset' is set to False,  validation error will rise and display error mesage to UI

### Features:
- [X] includes tests covering changes
- [x] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
