### PR TITLE
Fix ExtDeprecationWarning

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,7 @@ beautifulsoup4==4.5.1
 coveralls   #Let Unpinned - Requires latest coveralls
 docutils==0.12
 factory-boy==2.1.1
-Flask-DebugToolbar==0.10.0
+Flask-DebugToolbar==0.10.1
 httpretty==0.8.3
 mock==2.0.0
 pycodestyle==2.2.0


### PR DESCRIPTION
This warning is seen when running paster commands when you've installed dev-requirements.txt

```
(default)vagrant@vagrant-ubuntu-trusty-64:/vagrant/src/ckan$ paster --plugin=ckan jobs -c $CKAN_INI worker
/usr/lib/ckan/default/local/lib/python2.7/site-packages/flask/exthook.py:71: ExtDeprecationWarning: Importing flask.ext.sqlalchemy is deprecated, use flask_sqlalchemy instead.
  .format(x=modname), ExtDeprecationWarning
```
It's raised at this moment:
```
  File "/vagrant/src/ckan/ckan/lib/cli.py", line 2647, in command
    self._load_config()
  File "/vagrant/src/ckan/ckan/lib/cli.py", line 321, in _load_config
    self.site_user = load_config(self.options.config, load_site_user)
  File "/vagrant/src/ckan/ckan/lib/cli.py", line 235, in load_config
    flask_app = _get_test_app().flask_app
  File "/vagrant/src/ckan/ckan/tests/helpers.py", line 171, in _get_test_app
    app = ckan.config.middleware.make_app(config['global_conf'], **config)
  File "/vagrant/src/ckan/ckan/config/middleware/__init__.py", line 59, in make_app
    flask_app = make_flask_stack(conf, **app_conf)
  File "/vagrant/src/ckan/ckan/config/middleware/flask_app.py", line 76, in make_flask_stack
    from flask_debugtoolbar import DebugToolbarExtension
```
Upgrading the version of the Flask debug toolbar fixes it. This is a simple point release, and is the latest currently on pypi - see changelog: https://pypi.python.org/pypi/Flask-DebugToolbar