### PR TITLE
Fix cors header when all origins are allowed

### DIFF
--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -54,7 +54,7 @@ def set_cors_headers_for_response(response):
 
         cors_origin_allowed = None
         if asbool(config.get(u'ckan.cors.origin_allow_all')):
-            cors_origin_allowed = u'*'
+            cors_origin_allowed = b'*'
         elif config.get(u'ckan.cors.origin_whitelist') and \
                 request.headers.get(u'Origin') \
                 in config[u'ckan.cors.origin_whitelist'].split(u' '):


### PR DESCRIPTION
Fixes #3855 

### Proposed fixes:
When all origins are allowed, the header was still unicode instead of str, the previous commit fixes all others.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
