### PR TITLE
change solr schema.xml ref in dockerfile to local

### DIFF
--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -60,6 +60,11 @@ services:
   solr:
     container_name: solr
     image: ckan/solr:latest
+    # To build locally, remove the image reference above and uncommend this:
+    # build:
+    #   context: ../../
+    #   dockerfile: contrib/docker/solr/Dockerfile
+
 
   redis:
     container_name: redis

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -59,11 +59,9 @@ services:
 
   solr:
     container_name: solr
-    image: ckan/solr:latest
-    # To build locally, remove the image reference above and uncommend this:
-    # build:
-    #   context: ../../
-    #   dockerfile: contrib/docker/solr/Dockerfile
+    build:
+      context: ../../
+      dockerfile: contrib/docker/solr/Dockerfile
 
 
   redis:

--- a/contrib/docker/solr/Dockerfile
+++ b/contrib/docker/solr/Dockerfile
@@ -12,8 +12,8 @@ RUN mkdir -p /opt/solr/server/solr/$SOLR_CORE/conf
 RUN mkdir -p /opt/solr/server/solr/$SOLR_CORE/data
 
 # Adding Files
-ADD ./solrconfig.xml \
-https://raw.githubusercontent.com/ckan/ckan/master/ckan/config/solr/schema.xml \
+ADD ./contrib/docker/solr/solrconfig.xml \
+./ckan/config/solr/schema.xml \
 https://raw.githubusercontent.com/apache/lucene-solr/releases/lucene-solr/6.0.0/solr/server/solr/configsets/basic_configs/conf/currency.xml \
 https://raw.githubusercontent.com/apache/lucene-solr/releases/lucene-solr/6.0.0/solr/server/solr/configsets/basic_configs/conf/synonyms.txt \
 https://raw.githubusercontent.com/apache/lucene-solr/releases/lucene-solr/6.0.0/solr/server/solr/configsets/basic_configs/conf/stopwords.txt \


### PR DESCRIPTION
Fixes #3894
Changes the Dockerfile to use the local schema.xml located in `ckan/config/solr/` instead of the one in github master branch, avoiding version conflicts.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
