### PR TITLE
Allow overriding celery list params

### DIFF
--- a/ckan/lib/celery_app.py
+++ b/ckan/lib/celery_app.py
@@ -63,10 +63,11 @@ for entry_point in iter_entry_points(group='ckan.celery_task'):
 
 try:
     for key, value in config.items('app:celery'):
+        key = key.upper()
         if key in LIST_PARAMS:
-            default_config[key.upper()] = value.split()
+            default_config.setdefault(key, []).extend(value.split())
         else:
-            default_config[key.upper()] = value
+            default_config[key] = value
 except ConfigParser.NoSectionError:
     pass
 


### PR DESCRIPTION
The condition 'if key in LIST_PARAMS' was never satisfied because config
keys are lower case and LIST_PARAMS is upper case.

This allow overriding the CELERY_IMPORTS, ADMINS and ROUTES in ckan
config.

Also overriding list params should extend existings values (i.e. for
CELERY_IMPORTS)