### PR TITLE
Document DataStore limitations

### DIFF
--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -16,8 +16,6 @@ When a resource is added to the DataStore, you get:
 The DataStore is integrated into the :doc:`CKAN API </api/index>` and
 authorization system.
 
-The DataStore extension only imports the first worksheet of a spreadsheet. It does not support duplicate column headers.
-
 The DataStore is generally used alongside the
 `DataPusher <http://docs.ckan.org/projects/datapusher>`_, which will
 automatically upload data to the DataStore from suitable files, whether

--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -232,8 +232,8 @@ alongside CKAN.
 
 To install this please look at the docs here: http://docs.ckan.org/projects/datapusher
 
-.. note:: The DataPusher only imports the first worksheet of a spreadsheet. It does also
-   not support duplicate column headers.
+.. note:: The DataPusher only imports the first worksheet of a spreadsheet. It also does
+   not support duplicate column headers. That includes blank column headings.
 
 -----------------
 The DataStore API

--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -234,6 +234,8 @@ alongside CKAN.
 
 To install this please look at the docs here: http://docs.ckan.org/projects/datapusher
 
+.. note:: The DataPusher only imports the first worksheet of a spreadsheet. It does also
+   not support duplicate column headers.
 
 -----------------
 The DataStore API

--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -16,6 +16,8 @@ When a resource is added to the DataStore, you get:
 The DataStore is integrated into the :doc:`CKAN API </api/index>` and
 authorization system.
 
+The DataStore extension only imports the first worksheet of a spreadsheet. It does not support duplicate column headers.
+
 The DataStore is generally used alongside the
 `DataPusher <http://docs.ckan.org/projects/datapusher>`_, which will
 automatically upload data to the DataStore from suitable files, whether


### PR DESCRIPTION
Fixes no issue

### Proposed fixes:

- Document the limitations of the DataStore extension so people don't have to discover it after installation of datastore + datapusher

### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
