### PR TITLE
Only create harvest tables if not already existing

### DIFF
--- a/ckan/migration/versions/023_add_harvesting.py
+++ b/ckan/migration/versions/023_add_harvesting.py
@@ -32,8 +32,8 @@ def upgrade(migrate_engine):
     )
 
     metadata.bind = migrate_engine
-    harvest_source_table.create()
-    harvesting_job_table.create()
+    harvest_source_table.create(checkfirst=True)
+    harvesting_job_table.create(checkfirst=True)
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine


### PR DESCRIPTION
When initializing a fresh CKAN database with ckanext-harvest installed and declared in configuration, `db init` command fails with the following error (with CKAN 2.6.4):
```
2017-11-07 16:32:13,406 DEBUG [ckanext.harvest.model] Harvest tables defined in memory
2017-11-07 16:32:13,413 DEBUG [ckanext.harvest.model] Harvest table creation deferred
2017-11-07 16:32:13,447 DEBUG [ckanext.spatial.plugin] Setting up the spatial model
2017-11-07 16:32:13,525 DEBUG [ckanext.spatial.model.package_extent] Spatial tables defined in memory
2017-11-07 16:32:13,532 DEBUG [ckanext.spatial.model.package_extent] Spatial tables creation deferred
Traceback (most recent call last):
  File "/home/ckan/venv/bin/paster", line 11, in <module>
    sys.exit(run())
  File "/home/ckan/venv/lib/python2.7/site-packages/paste/script/command.py", line 102, in run
    invoke(command, command_name, options, args[1:])
  File "/home/ckan/venv/lib/python2.7/site-packages/paste/script/command.py", line 141, in invoke
    exit_code = runner.run(args)
  File "/home/ckan/venv/lib/python2.7/site-packages/paste/script/command.py", line 236, in run
    result = self.command()
  File "/home/ckan/src/ckan/ckan/lib/cli.py", line 223, in command
    model.repo.init_db()
  File "/home/ckan/src/ckan/ckan/model/__init__.py", line 188, in init_db
    self.upgrade_db()
  File "/home/ckan/src/ckan/ckan/model/__init__.py", line 285, in upgrade_db
    mig.upgrade(self.metadata.bind, self.migrate_repository, version=version)
  File "/home/ckan/venv/lib/python2.7/site-packages/migrate/versioning/api.py", line 186, in upgrade
    return _migrate(url, repository, version, upgrade=True, err=err, **opts)
  File "<decorator-gen-16>", line 2, in _migrate
  File "/home/ckan/venv/lib/python2.7/site-packages/migrate/versioning/util/__init__.py", line 160, in with_engine
    return f(*a, **kw)
  File "/home/ckan/venv/lib/python2.7/site-packages/migrate/versioning/api.py", line 366, in _migrate
    schema.runchange(ver, change, changeset.step)
  File "/home/ckan/venv/lib/python2.7/site-packages/migrate/versioning/schema.py", line 93, in runchange
    change.run(self.engine, step)
  File "/home/ckan/venv/lib/python2.7/site-packages/migrate/versioning/script/py.py", line 148, in run
    script_func(engine)
  File "/home/ckan/src/ckan/ckan/migration/versions/023_add_harvesting.py", line 35, in upgrade
    harvest_source_table.create()
  File "/home/ckan/venv/lib/python2.7/site-packages/sqlalchemy/sql/schema.py", line 648, in create
    checkfirst=checkfirst)
  File "/home/ckan/venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1555, in _run_visitor
    conn._run_visitor(visitorcallable, element, **kwargs)
  File "/home/ckan/venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1202, in _run_visitor
    **kwargs).traverse_single(element)
  File "/home/ckan/venv/lib/python2.7/site-packages/sqlalchemy/sql/visitors.py", line 119, in traverse_single
    return meth(obj, **kw)
  File "/home/ckan/venv/lib/python2.7/site-packages/sqlalchemy/sql/ddl.py", line 728, in visit_table
    self.connection.execute(CreateTable(table))
  File "/home/ckan/venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 727, in execute
    return meth(self, multiparams, params)
  File "/home/ckan/venv/lib/python2.7/site-packages/sqlalchemy/sql/ddl.py", line 67, in _execute_on_connection
    return connection._execute_ddl(self, multiparams, params)
  File "/home/ckan/venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 781, in _execute_ddl
    compiled
  File "/home/ckan/venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 954, in _execute_context
    context)
  File "/home/ckan/venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1116, in _handle_dbapi_exception
    exc_info
  File "/home/ckan/venv/lib/python2.7/site-packages/sqlalchemy/util/compat.py", line 189, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb)
  File "/home/ckan/venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 947, in _execute_context
    context)
  File "/home/ckan/venv/lib/python2.7/site-packages/sqlalchemy/engine/default.py", line 435, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.ProgrammingError: (ProgrammingError) relation "harvest_source" already exists
 '\nCREATE TABLE harvest_source (\n\tid TEXT NOT NULL, \n\tstatus TEXT, \n\turl TEXT NOT NULL, \n\tdescription TEXT, \n\tuser_ref TEXT, \n\tpublisher_ref TEXT, \n\tcreated TIMESTAMP WITHOUT TIME ZONE, \n\tPRIMARY KEY (id)
, \n\tUNIQUE (url)\n)\n\n' {}
```

This patch passes `checkfirst=True` to `Table.create()` calls for harvest tables to avoid this.

Would be worth backporting to other release branches.