### PR TITLE
Datastore dump ui interface

### DIFF
--- a/ckanext/datastore/controller.py
+++ b/ckanext/datastore/controller.py
@@ -21,13 +21,15 @@ from ckan.logic import (
     parse_params,
 )
 import ckan.lib.navl.dictization_functions as dict_fns
-
+from ckan.common import config
 from itertools import izip_longest
 
 int_validator = get_validator('int_validator')
 boolean_validator = get_validator('boolean_validator')
 
-DUMP_FORMATS = 'csv', 'tsv', 'json', 'xml'
+# DUMP_FORMATS = 'csv', 'tsv', 'json', 'xml'
+DUMP_FORMATS = config.get('ckan.dump_formats', '')
+
 PAGINATE_BY = 32000
 
 
@@ -46,7 +48,7 @@ class DatastoreController(BaseController):
 
         if fmt not in DUMP_FORMATS:
             abort(400, _(
-                u'format: must be one of %s') % u', '.join(DUMP_FORMATS))
+                u'format: must be one of:  %s') % u''.join(DUMP_FORMATS))
 
         try:
             dump_to(

--- a/ckanext/datastore/controller.py
+++ b/ckanext/datastore/controller.py
@@ -15,12 +15,7 @@ from ckan.plugins.toolkit import (
     c,
     h,
 )
-from ckanext.datastore.writer import (
-    csv_writer,
-    tsv_writer,
-    json_writer,
-    xml_writer,
-)
+from ckanext.datastore.writer import get_writers
 from ckan.logic import (
     tuplize_dict,
     parse_params,
@@ -113,18 +108,8 @@ class DatastoreController(BaseController):
 
 
 def dump_to(resource_id, output, fmt, offset, limit, options):
-    if fmt == 'csv':
-        writer_factory = csv_writer
-        records_format = 'csv'
-    elif fmt == 'tsv':
-        writer_factory = tsv_writer
-        records_format = 'tsv'
-    elif fmt == 'json':
-        writer_factory = json_writer
-        records_format = 'lists'
-    elif fmt == 'xml':
-        writer_factory = xml_writer
-        records_format = 'objects'
+
+    writer_factory, records_format = get_writers(fmt)
 
     def start_writer(fields):
         bom = options.get(u'bom', False)

--- a/ckanext/datastore/controller.py
+++ b/ckanext/datastore/controller.py
@@ -27,8 +27,7 @@ from itertools import izip_longest
 int_validator = get_validator('int_validator')
 boolean_validator = get_validator('boolean_validator')
 
-# DUMP_FORMATS = 'csv', 'tsv', 'json', 'xml'
-DUMP_FORMATS = config.get('ckan.dump_formats', '')
+DUMP_FORMATS = config.get('ckan.dump_formats')
 
 PAGINATE_BY = 32000
 

--- a/ckanext/datastore/interfaces.py
+++ b/ckanext/datastore/interfaces.py
@@ -170,3 +170,9 @@ class IDatastoreBackend(interfaces.Interface):
                   value
         """
         return {}
+
+
+class IWriter(interfaces.Interface):
+    ''' Allow custom implementation of writers'''
+    def get_writer(self):
+        return {}

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -22,8 +22,6 @@ from ckanext.datastore.backend.postgres import DatastorePostgresqlBackend
 log = logging.getLogger(__name__)
 _get_or_bust = logic.get_or_bust
 
-DEFAULT_FORMATS = []
-
 ValidationError = p.toolkit.ValidationError
 
 

--- a/ckanext/datastore/tests/test_dump.py
+++ b/ckanext/datastore/tests/test_dump.py
@@ -212,60 +212,60 @@ class TestWriterInterface(object):
         cls.normal_user = model.User.get('annafan')
         resource = model.Package.get('annakarenina').resources[0]
         cls.data = {
-            'resource_id': resource.id,
-            'force': True,
-            'aliases': 'books',
+            u'resource_id': resource.id,
+            u'force': True,
+            u'aliases': u'books',
             'fields': [
                 {
-                    'id': u'b\xfck',
-                    'type': 'text'
+                    u'id': u'b\xfck',
+                    u'type': u'text'
                 },
                 {
-                    'id': 'author',
-                    'type': 'text'
+                    u'id': u'author',
+                    u'type': u'text'
                 },
                 {
-                    'id': 'published'
+                    u'id': u'published'
                 },
                 {
-                    'id': u'characters',
+                    u'id': u'characters',
                     u'type': u'_text'
                 },
                 {
-                    'id': 'random_letters',
-                    'type': 'text[]'
+                    u'id': u'random_letters',
+                    u'type': u'text[]'
                 }
             ],
-            'records': [
+            u'records': [
                 {
-                    u'b\xfck': 'annakarenina',
-                    'author': 'tolstoy',
-                    'published': '2005-03-01',
-                    'nested': [
-                        'b',
-                        {'moo': 'moo'}
+                    u'b\xfck': u'annakarenina',
+                    u'author': u'tolstoy',
+                    u'published': u'2005-03-01',
+                    u'nested': [
+                        u'b',
+                        {u'moo': u'moo'}
                     ],
                     u'characters': [
                         u'Princess Anna',
                         u'Sergius'
                     ],
-                    'random_letters': [
-                        'a', 'e', 'x'
+                    u'random_letters': [
+                        u'a', u'e', u'x'
                     ]
                 },
                 {
-                    u'b\xfck': 'warandpeace',
-                    'author': 'tolstoy',
-                    'nested': {'a': 'b'},
-                    'random_letters': [
+                    u'b\xfck': u'warandpeace',
+                    u'author': u'tolstoy',
+                    u'nested': {u'a': u'b'},
+                    u'random_letters': [
 
                     ]
                 }
             ]
         }
         postparams = '%s=1' % json.dumps(cls.data)
-        auth = {'Authorization': str(cls.sysadmin_user.apikey)}
-        res = cls.app.post('/api/action/datastore_create', params=postparams,
+        auth = {u'Authorization': str(cls.sysadmin_user.apikey)}
+        res = cls.app.post(u'/api/action/datastore_create', params=postparams,
                            extra_environ=auth)
         res_dict = json.loads(res.body)
         assert res_dict['success'] is True
@@ -281,7 +281,7 @@ class TestWriterInterface(object):
 
     def test_dump_plugin(self):
         auth = {'Authorization': str(self.normal_user.apikey)}
-        res = self.app.get('/datastore/dump/{0}?limit=1&format=pdf'.format(
+        res = self.app.get(u'/datastore/dump/{0}?limit=1&format=pdf'.format(
             str(self.data['resource_id'])), extra_environ=auth)
 
 

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -14,6 +14,7 @@ from codecs import BOM_UTF8
 
 def get_writers(fmt):
 
+    import pdb; pdb.set_trace()
     for plugin in plugins.PluginImplementations(IWriter):
         if hasattr(plugin, 'get_writer'):
             plugin_writer = plugin.get_writer()

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -14,7 +14,6 @@ from codecs import BOM_UTF8
 
 def get_writers(fmt):
 
-    import pdb; pdb.set_trace()
     for plugin in plugins.PluginImplementations(IWriter):
         if hasattr(plugin, 'get_writer'):
             plugin_writer = plugin.get_writer()

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -3,11 +3,37 @@
 from contextlib import contextmanager
 from email.utils import encode_rfc2231
 from simplejson import dumps
+import plugins
 from xml.etree.cElementTree import Element, SubElement, ElementTree
+from ckanext.datastore.interfaces import IWriter
 
 import unicodecsv
 
 from codecs import BOM_UTF8
+
+
+def get_writers(fmt):
+
+    for plugin in plugins.PluginImplementations(IWriter):
+        if hasattr(plugin, 'get_writer'):
+            plugin_writer = plugin.get_writer()
+
+    if fmt == 'csv':
+        writer_factory = csv_writer
+        records_format = 'csv'
+    elif fmt == 'tsv':
+        writer_factory = tsv_writer
+        records_format = 'tsv'
+    elif fmt == 'json':
+        writer_factory = json_writer
+        records_format = 'lists'
+    elif fmt == 'xml':
+        writer_factory = xml_writer
+        records_format = 'objects'
+    else:
+        writer_factory = plugin_writer
+        records_format = 'objects'
+    return writer_factory, records_format
 
 
 @contextmanager

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -15,24 +15,24 @@ from codecs import BOM_UTF8
 def get_writers(fmt):
 
     for plugin in plugins.PluginImplementations(IWriter):
-        if hasattr(plugin, 'get_writer'):
+        if hasattr(plugin, u'get_writer'):
             plugin_writer = plugin.get_writer()
 
-    if fmt == 'csv':
+    if fmt == u'csv':
         writer_factory = csv_writer
-        records_format = 'csv'
-    elif fmt == 'tsv':
+        records_format = u'csv'
+    elif fmt == u'tsv':
         writer_factory = tsv_writer
-        records_format = 'tsv'
-    elif fmt == 'json':
+        records_format = u'tsv'
+    elif fmt == u'json':
         writer_factory = json_writer
-        records_format = 'lists'
-    elif fmt == 'xml':
+        records_format = u'lists'
+    elif fmt == u'xml':
         writer_factory = xml_writer
-        records_format = 'objects'
+        records_format = u'objects'
     else:
         writer_factory = plugin_writer
-        records_format = 'objects'
+        records_format = u'objects'
     return writer_factory, records_format
 
 

--- a/setup.py
+++ b/setup.py
@@ -199,6 +199,7 @@ entry_points = {
         'test_helpers_plugin = ckan.tests.lib.test_helpers:TestHelpersPlugin',
         'test_feed_plugin = ckan.tests.controllers.test_feed:MockFeedPlugin',
         'test_js_translations_plugin = ckan.tests.lib.test_i18n:TestJSTranslationsPlugin',
+        'test_writer_plugin = ckanext.datastore.tests.test_dump.MockWriterPlugin',
     ],
     'babel.extractors': [
         'ckan = ckan.lib.extract:extract_ckan',


### PR DESCRIPTION
As it was mentioned in #3821, i've tried to add interface to be used for custom data dump formats from extensions.  



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
