### PR TITLE
restrict anonymous access to user information, with ckan.public_user_…

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -647,9 +647,16 @@ class GroupController(base.BaseController):
         context = {'model': model, 'session': model.Session,
                    'user': c.user}
 
+        data_dict = {'id': id}
         try:
-            data_dict = {'id': id}
-            check_access('group_edit_permissions', context, data_dict)
+            check_access('group_show', context, data_dict)
+        except NotAuthorized:
+            abort(
+                403,
+                _('User %r not authorized to edit members of %s') % (
+                    c.user, id))
+
+        try:
             c.members = self._action('member_list')(
                 context, {'id': id, 'object_type': 'user'}
             )
@@ -657,11 +664,6 @@ class GroupController(base.BaseController):
             c.group_dict = self._action('group_show')(context, data_dict)
         except NotFound:
             abort(404, _('Group not found'))
-        except NotAuthorized:
-            abort(
-                403,
-                _('User %r not authorized to edit members of %s') % (
-                    c.user, id))
 
         return self._render_template('group/members.html', group_type)
 

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1223,7 +1223,10 @@ def _group_or_org_show(context, data_dict, is_org=False):
         packages_field = None
 
     include_tags = asbool(data_dict.get('include_tags', True))
-    include_users = asbool(data_dict.get('include_users', True))
+    if asbool(config.get('ckan.public_user_details', True)):
+	    include_users = asbool(data_dict.get('include_users', True))
+    else:
+	    include_users = asbool(data_dict.get('include_users', False))
     include_groups = asbool(data_dict.get('include_groups', True))
     include_extras = asbool(data_dict.get('include_extras', True))
     include_followers = asbool(data_dict.get('include_followers', True))
@@ -1294,7 +1297,7 @@ def group_show(context, data_dict):
          (optional, default: ``True``)
     :type id: boolean
     :param include_users: include the group's users
-         (optional, default: ``True``)
+         (optional, default: ``False``)
     :type id: boolean
     :param include_groups: include the group's sub groups
          (optional, default: ``True``)

--- a/ckan/logic/auth/__init__.py
+++ b/ckan/logic/auth/__init__.py
@@ -5,6 +5,7 @@ Helper functions to be used in the auth check functions
 '''
 
 import ckan.logic as logic
+import ckan.authz as authz
 
 
 def _get_object(context, data_dict, name, class_name):
@@ -42,3 +43,10 @@ def get_group_object(context, data_dict=None):
 
 def get_user_object(context, data_dict=None):
     return _get_object(context, data_dict, 'user_obj', 'User')
+
+
+def restrict_anon(context):
+    if authz.auth_is_anon_user(context):
+        return {'success': False}
+    else:
+        return {'success': True}

--- a/ckan/tests/logic/auth/test_get.py
+++ b/ckan/tests/logic/auth/test_get.py
@@ -12,6 +12,43 @@ import ckan.logic as logic
 from ckan import model
 
 
+class TestUserListAuth(object):
+
+    @helpers.change_config(u'ckan.public_user_details', u'false')
+    def test_auth_user_list(self):
+        context = {'user': None,
+                   'model': model}
+        assert_raises(logic.NotAuthorized, helpers.call_auth,
+                      'user_list', context=context)
+
+    def test_authed_user_list(self):
+        context = {'user': None,
+                   'model': model}
+        assert helpers.call_auth('user_list', context=context)
+
+
+class TestUserShowAuth(object):
+
+    def setup(self):
+        helpers.reset_db()
+
+    @helpers.change_config(u'ckan.public_user_details', u'false')
+    def test_auth_user_show(self):
+        fred = factories.User(name='fred')
+        fred['capacity'] = 'editor'
+        context = {'user': None,
+                   'model': model}
+        assert_raises(logic.NotAuthorized, helpers.call_auth,
+                      'user_show', context=context, id=fred['id'])
+
+    def test_authed_user_show(self):
+        fred = factories.User(name='fred')
+        fred['capacity'] = 'editor'
+        context = {'user': None,
+                   'model': model}
+        assert helpers.call_auth('user_show', context=context, id=fred['id'])
+
+
 class TestPackageShowAuth(object):
 
     def setup(self):
@@ -57,7 +94,8 @@ class TestGroupShowAuth(object):
     def test_group_show__deleted_group_is_visible_to_its_member(self):
 
         fred = factories.User(name='fred')
-        org = factories.Group(users=[fred])
+        fred['capacity'] = 'editor'
+        org = factories.Group(users=[fred], state='deleted')
         context = {'model': model}
         context['user'] = 'fred'
 
@@ -69,13 +107,31 @@ class TestGroupShowAuth(object):
 
         fred = factories.User(name='fred')
         fred['capacity'] = 'editor'
-        org = factories.Organization(users=[fred])
+        org = factories.Organization(users=[fred], state='deleted')
         context = {'model': model}
         context['user'] = 'fred'
 
         ret = helpers.call_auth('group_show', context=context,
                                 id=org['name'])
         assert ret
+
+    @helpers.change_config(u'ckan.public_user_details', u'false')
+    def test_group_show__user_is_hidden_to_public(self):
+        group = factories.Group()
+        context = {'model': model}
+        context['user'] = ''
+
+        assert_raises(logic.NotAuthorized, helpers.call_auth,
+                      'group_show', context=context,
+                      id=group['name'], include_users=True)
+
+    def test_group_show__user_is_avail_to_public(self):
+        group = factories.Group()
+        context = {'model': model}
+        context['user'] = ''
+
+        assert helpers.call_auth('group_show', context=context,
+                                 id=group['name'])
 
 
 class TestConfigOptionShowAuth(object):


### PR DESCRIPTION
…details (default true)

Fixes #
By default CKAN exposes all account names, full names, org membership of its users.

### Proposed fixes:
A new configuration option ckan.public_user_details with a default true value to maintain the current behavior.

When ckan.public_user_details=false, anonymous user access to user_show, user_list, and group member will be denied.

### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
