### PR TITLE
Remove unused imports from model package

### DIFF
--- a/ckan/model/__init__.py
+++ b/ckan/model/__init__.py
@@ -11,126 +11,17 @@ from sqlalchemy import MetaData, __version__ as sqav, Table
 from sqlalchemy.util import OrderedDict
 
 import meta
-from meta import (
-    Session,
-    engine_is_sqlite,
-    engine_is_pg,
-)
-from core import (
-    System,
-    Revision,
-    State,
-    revision_table,
-)
-from package import (
-    Package,
-    PACKAGE_NAME_MIN_LENGTH,
-    PACKAGE_NAME_MAX_LENGTH,
-    PACKAGE_VERSION_MAX_LENGTH,
-    package_table,
-    package_revision_table,
-    PackageTagRevision,
-    PackageRevision,
-)
-from tag import (
-    Tag,
-    PackageTag,
-    MAX_TAG_LENGTH,
-    MIN_TAG_LENGTH,
-    tag_table,
-    package_tag_table,
-    package_tag_revision_table,
-)
-from user import (
-    User,
-    user_table,
-)
+from core import Revision
+from package import Package
+from tag import PackageTag
+from user import User
 from group import (
     Member,
     Group,
-    member_revision_table,
-    group_revision_table,
-    group_table,
-    GroupRevision,
-    MemberRevision,
-    member_table,
 )
-from group_extra import (
-    GroupExtra,
-    group_extra_table,
-    GroupExtraRevision,
-)
-from package_extra import (
-    PackageExtra,
-    PackageExtraRevision,
-    package_extra_table,
-    extra_revision_table,
-)
-from resource import (
-    Resource,
-    ResourceRevision,
-    DictProxy,
-    resource_table,
-    resource_revision_table,
-)
-from resource_view import (
-    ResourceView,
-    resource_view_table,
-)
-from tracking import (
-    tracking_summary_table,
-    TrackingSummary,
-    tracking_raw_table
-)
-from rating import (
-    Rating,
-    MIN_RATING,
-    MAX_RATING,
-)
-from package_relationship import (
-    PackageRelationship,
-    package_relationship_table,
-    package_relationship_revision_table,
-)
-from task_status import (
-    TaskStatus,
-    task_status_table,
-)
-from vocabulary import (
-    Vocabulary,
-    VOCABULARY_NAME_MAX_LENGTH,
-    VOCABULARY_NAME_MIN_LENGTH,
-)
-from activity import (
-    Activity,
-    ActivityDetail,
-    activity_table,
-    activity_detail_table,
-)
-from term_translation import (
-    term_translation_table,
-)
-from follower import (
-    UserFollowingUser,
-    UserFollowingDataset,
-    UserFollowingGroup,
-)
-from system_info import (
-    system_info_table,
-    system_info_revision_table,
-    SystemInfo,
-    SystemInfoRevision,
-    get_system_info,
-    set_system_info,
-    delete_system_info,
-)
-from domain_object import (
-    DomainObjectOperation,
-    DomainObject,
-)
-from dashboard import (
-    Dashboard,
-)
+from package_extra import PackageExtra
+from resource import Resource
+from system_info import SystemInfo
 
 import ckan.migration
 

--- a/ckan/model/group.py
+++ b/ckan/model/group.py
@@ -10,7 +10,6 @@ import core
 import package as _package
 import types as _types
 import domain_object
-import user as _user
 
 __all__ = ['group_table', 'Group',
            'Member', 'GroupRevision', 'MemberRevision',

--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -23,7 +23,7 @@ import ckan.lib.dictization as dictization
 
 __all__ = ['Package', 'package_table', 'package_revision_table',
            'PACKAGE_NAME_MAX_LENGTH', 'PACKAGE_NAME_MIN_LENGTH',
-           'PACKAGE_VERSION_MAX_LENGTH', 'PackageTag', 'PackageTagRevision',
+           'PACKAGE_VERSION_MAX_LENGTH', 'PackageTagRevision',
            'PackageRevision']
 
 

--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -1,11 +1,10 @@
 # encoding: utf-8
 
 import datetime
-from calendar import timegm
 import logging
 logger = logging.getLogger(__name__)
 
-from sqlalchemy.sql import select, and_, union, or_
+from sqlalchemy.sql import and_, or_
 from sqlalchemy import orm
 from sqlalchemy import types, Column, Table
 from ckan.common import config
@@ -68,7 +67,6 @@ class Package(vdm.sqlalchemy.RevisionedObjectMixin,
     text_search_fields = ['name', 'title']
 
     def __init__(self, **kw):
-        from ckan import model
         super(Package, self).__init__(**kw)
 
     @classmethod

--- a/ckan/model/resource.py
+++ b/ckan/model/resource.py
@@ -8,11 +8,10 @@ from sqlalchemy import orm
 from ckan.common import config
 import vdm.sqlalchemy
 import vdm.sqlalchemy.stateful
-from sqlalchemy import types, func, Column, Table, ForeignKey, and_
+from sqlalchemy import types, func, Column, Table, ForeignKey
 
 import meta
 import core
-import package as _package
 import types as _types
 import extension
 import activity

--- a/ckan/model/tag.py
+++ b/ckan/model/tag.py
@@ -2,7 +2,7 @@
 
 import vdm.sqlalchemy
 from sqlalchemy.orm import relation
-from sqlalchemy import types, Column, Table, ForeignKey, and_, UniqueConstraint
+from sqlalchemy import types, Column, Table, ForeignKey, UniqueConstraint
 
 import package as _package
 import extension as _extension

--- a/ckan/model/user.py
+++ b/ckan/model/user.py
@@ -2,7 +2,6 @@
 
 import datetime
 import re
-import os
 from hashlib import sha1, md5
 
 import passlib.utils


### PR DESCRIPTION
This PR removes many unused imports from the model package to make it clearer what's being used where.

I'm not sure if a new test is necessary for these changes. I can write one if need be. Otherwise, they can be verified by running a linter on the package before and after the commits, e.g., `flake8 --select F401,F821,F822 ckan/ckan/model` to detect the unused imports and undefined name in __all__  before the changes and again after applying the changes to verify that there are no unused imports and no (new) undefined names.