### PR TITLE
move mock from dev-requirements to requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,7 +6,6 @@ docutils==0.12
 factory-boy==2.1.1
 Flask-DebugToolbar==0.10.1
 httpretty==0.8.3
-mock==2.0.0
 pycodestyle==2.2.0
 pip-tools==1.7.0
 pyfakefs==2.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ Jinja2==2.8               # via flask
 Mako==1.0.4               # via pylons
 Markdown==2.6.7
 MarkupSafe==0.23          # via jinja2, mako, webhelpers
+mock==2.0.0
 nose==1.3.7               # via pylons
 ofs==0.4.2
 Pairtree==0.7.1-T


### PR DESCRIPTION
Fixes #3806 

as a consequence of https://github.com/ckan/ckan/issues/3760 mock isn't a dev-only dependency anymore, so moving it from `dev-requirements.txt` to `requirements.txt`

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
