### PR TITLE
[WIP] Add Vagrant build for CKAN 2.7.2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,8 +10,8 @@ Vagrant.configure("2") do |config|
   config.vm.network "forwarded_port", guest: 8983, host: 8983  # Solr
 
   config.vm.provision "shell", inline: <<-SHELL
-    # for file in /vagrant/contrib/vagrant/bin/??_*.sh; do
-    #   bash "$file";
-    # done;
+    for file in /vagrant/contrib/vagrant/bin/??_*.sh; do
+      bash "$file";
+    done;
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,17 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/ubuntu-16.04"
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine.
+  config.vm.network "forwarded_port", guest: 5000, host: 5000  # CKAN paster serve
+  config.vm.network "forwarded_port", guest: 8983, host: 8983  # Solr
+
+  config.vm.provision "shell", inline: <<-SHELL
+    # for file in /vagrant/contrib/vagrant/bin/??_*.sh; do
+    #   bash "$file";
+    # done;
+  SHELL
+end

--- a/contrib/vagrant/bin/01_initial_apt.sh
+++ b/contrib/vagrant/bin/01_initial_apt.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e;
+
+# Install system packages
+sudo apt-get update;
+sudo apt-get install git-core -y;
+sudo apt-get install python-dev python-pip python-virtualenv -y;
+sudo apt-get install postgresql libpq-dev -y;
+sudo apt-get install solr-jetty openjdk-8-jdk -y;
+sudo apt-get install redis-server -y;

--- a/contrib/vagrant/bin/02_python_structure.sh
+++ b/contrib/vagrant/bin/02_python_structure.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e;
+# Make virtualenv
+sudo mkdir -p /usr/lib/ckan/default
+sudo chown -R `whoami` /usr/lib/ckan/default
+virtualenv --no-site-packages /usr/lib/ckan/default
+. /usr/lib/ckan/default/bin/activate;
+
+# Install required setuptools version
+pip install -r /vagrant/requirement-setuptools.txt
+# Install CKAN
+pip install -e /vagrant;
+# Install CKAN dependencies
+pip install -r /vagrant/requirements.txt

--- a/contrib/vagrant/bin/03_setup_postgres.sh
+++ b/contrib/vagrant/bin/03_setup_postgres.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e;
+
+sudo -u postgres psql -l;
+
+sudo -u postgres psql <<EOL
+ CREATE USER ckan_default password 'pass' SUPERUSER CREATEDB;
+ CREATE DATABASE ckan_default OWNER ckan_default;
+ GRANT ALL PRIVILEGES ON DATABASE "ckan_default" to ckan_default;
+EOL

--- a/contrib/vagrant/bin/04_generate_ckan_config.sh
+++ b/contrib/vagrant/bin/04_generate_ckan_config.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e;
+
+sudo mkdir -p /etc/ckan/default;
+sudo chown -R `whoami` /etc/ckan/;
+
+. /usr/lib/ckan/default/bin/activate;
+/usr/lib/ckan/default/bin/paster make-config ckan /etc/ckan/default/development.ini;
+
+sed -E -i 's#^sqlalchemy.url(.+?)$#sqlalchemy.url = postgresql://ckan_default:pass@localhost/ckan_default#g' /etc/ckan/default/development.ini;
+sed -E -i 's#^ckan.site_id(.+?)$#ckan.site_id = default#g' /etc/ckan/default/development.ini;
+sed -E -i 's#^ckan.site_url(.+?)$#ckan.site_url = http://localhost#g' /etc/ckan/default/development.ini;

--- a/contrib/vagrant/bin/05_setup_solr.sh
+++ b/contrib/vagrant/bin/05_setup_solr.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e;
+
+# Update SOLR startup script
+sudo sed -E -i 's@#*NO_START(.+?)$@NO_START=0@g' /etc/default/jetty8;
+sudo sed -E -i 's@#*JETTY_HOST(.+?)$@JETTY_HOST=0.0.0.0@g' /etc/default/jetty8;
+sudo sed -E -i 's@#*JETTY_PORT(.+?)$@JETTY_PORT=8983@g' /etc/default/jetty8;
+
+# Restart Jetty8
+sudo service jetty8 restart;
+
+# Replace the default schema.xml file with a symlink to the CKAN schema file
+sudo mv /etc/solr/conf/schema.xml /etc/solr/conf/schema.xml.bak;
+sudo ln -s /vagrant/ckan/config/solr/schema.xml /etc/solr/conf/schema.xml;
+sudo service jetty8 restart;
+sed -i 's#solr_url(.+?)$#http://127.0.0.1:8983/solr#g' /etc/ckan/default/development.ini;

--- a/contrib/vagrant/bin/06_make_link_who.sh
+++ b/contrib/vagrant/bin/06_make_link_who.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e;
+
+ln -s /vagrant/who.ini /etc/ckan/default/who.ini;

--- a/contrib/vagrant/bin/07_setup_database.sh
+++ b/contrib/vagrant/bin/07_setup_database.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e;
+
+. /usr/lib/ckan/default/bin/activate;
+
+cd /vagrant;
+paster db init -c /etc/ckan/default/development.ini;

--- a/contrib/vagrant/bin/08_bashrc.sh
+++ b/contrib/vagrant/bin/08_bashrc.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set +e;
+
+cat <<EOL >> /home/vagrant/.bashrc
+export CKAN_INI=/etc/ckan/default/development.ini
+. /usr/lib/ckan/default/bin/activate;
+cd /vagrant;
+EOL

--- a/contrib/vagrant/bin/09_test_pip.sh
+++ b/contrib/vagrant/bin/09_test_pip.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e;
+
+. /usr/lib/ckan/default/bin/activate;
+/usr/lib/ckan/default/bin/pip install -r /vagrant/dev-requirements.txt

--- a/contrib/vagrant/bin/10_test_postgres.sh
+++ b/contrib/vagrant/bin/10_test_postgres.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e;
+
+sudo -u postgres psql <<EOL
+ CREATE DATABASE ckan_test OWNER ckan_default;
+ GRANT ALL PRIVILEGES ON DATABASE "ckan_test" to ckan_default;
+EOL

--- a/contrib/vagrant/bin/11_test_solr_multicore.sh
+++ b/contrib/vagrant/bin/11_test_solr_multicore.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e;
+
+sudo cp -r /usr/share/solr/ /etc/solr/ckan
+curl 'http://localhost:8983/solr/admin/cores?action=CREATE&name=ckan&instanceDir=/etc/solr/ckan'
+sudo sed -i 's#solr_url(.+?)$#http://127.0.0.1:8983/solr/ckan#g' /etc/ckan/default/development.ini;

--- a/contrib/vagrant/bin/12_install_datastore.sh
+++ b/contrib/vagrant/bin/12_install_datastore.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Implements of http://docs.ckan.org/en/ckan-2.7.2/maintaining/datastore.html
+set -e;
+
+# Enable the plugin
+sudo sed -i -E 's#ckan.plugins = (.+?)$#ckan.plugins = stats text_view image_view recline_view datastore#g' /etc/ckan/default/development.ini;
+
+# Create users and databases
+sudo -u postgres psql <<EOL
+ CREATE USER datastore_default password 'pass';
+
+ CREATE DATABASE datastore_default OWNER ckan_default;
+ CREATE DATABASE datastore_test OWNER ckan_default;
+EOL
+# GRANT ALL PRIVILEGES ON DATABASE "datastore_default" to ckan_default;
+# GRANT SELECT ON DATABASE "datastore_test" to ckan_default;
+
+# Set URLs
+sudo sed -E -i 's%#*ckan.datastore.write_url(.+?)$%ckan.datastore.write_url = postgresql://ckan_default:pass@localhost/datastore_default%g' /etc/ckan/default/development.ini;
+sudo sed -E -i 's%#*ckan.datastore.read_url(.+?)$%ckan.datastore.read_url = postgresql://datastore_default:pass@localhost/datastore_default%g' /etc/ckan/default/development.ini;
+
+# Set permissions
+
+. /usr/lib/ckan/default/bin/activate;
+
+paster --plugin=ckan datastore set-permissions -c /etc/ckan/default/development.ini | sudo -u postgres psql --set ON_ERROR_STOP=1

--- a/contrib/vagrant/bin/revert_03_setup_postgres.sh
+++ b/contrib/vagrant/bin/revert_03_setup_postgres.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set +e;
+
+sudo -u postgres psql -c 'drop database ckan_default'
+sudo -u postgres psql -c 'drop user ckan_default'

--- a/contrib/vagrant/bin/run_ckan_serve
+++ b/contrib/vagrant/bin/run_ckan_serve
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+paster serve /etc/ckan/default/development.ini $@;

--- a/contrib/vagrant/bin/run_ckan_test
+++ b/contrib/vagrant/bin/run_ckan_test
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+nosetests --ckan --with-pylons=/vagrant/test-core.ini $@;

--- a/contrib/vagrant/bin/test_03_test_postgres.sh
+++ b/contrib/vagrant/bin/test_03_test_postgres.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set +e;
+
+PGHOST=localhost PGPASSWORD="pass" psql -U ckan_default;
+
+


### PR DESCRIPTION
Not for every optimum solution is to use Docker in an automated test & development environment. It can give you limitations when testing extensions espacially. I've developed a series of scripts that make it possible to create a stack efficiently in the Vagrant environment.

The entire environment will be available after the command is executed:
```
vagrant up 
```

Alternatively, it is possible to perform stepwise during testing of building:
```bash
for file in ./contrib/vagrant/bin/??_*.sh; do
    name=$(basename "$file"); 
    vagrant ssh default -c "/vagrant/contrib/vagrant/bin/$name"; 
    vagrant snapshot save default "$name"; 
done;
```

This is a proposal for change, so no docs at all. I assume the code will be extended, including CI integration to provide additional automated testing. Starting from the branches of ``ckan-2.7.2``, I get errors during testing and after many hours I have no idea about the source of the problem. 

The last lines of the test result:
```
$ ./contrib/vagrant/bin/run_ckan_test ckanext

(…)

ERROR: ckanext.reclineview.tests.test_view.TestReclineViewDatastoreOnly.test_create_datastore_only_view
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/vagrant/ckanext/reclineview/tests/test_view.py", line 121, in test_create_datastore_only_view
    result = self.app.get(url)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/paste/fixture.py", line 208, in get
    return self.do_request(req, status=status)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/paste/fixture.py", line 389, in do_request
    **req.environ)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/paste/wsgilib.py", line 343, in raw_interactive
    app_iter = application(basic_environ, start_response)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/paste/lint.py", line 170, in lint_app
    iterator = application(environ, start_response_wrapper)
  File "/vagrant/ckan/config/middleware/__init__.py", line 136, in __call__
    return self.apps[app_name](environ, start_response)
  File "/vagrant/ckan/config/middleware/common_middleware.py", line 216, in __call__
    return self.app(environ, start_response)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/paste/cascade.py", line 130, in __call__
    return self.apps[-1](environ, start_response)
  File "/vagrant/ckan/config/middleware/common_middleware.py", line 61, in __call__
    return self.app(environ, start_response)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/paste/registry.py", line 379, in __call__
    app_iter = self.application(environ, start_response)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/repoze/who/middleware.py", line 86, in __call__
    app_iter = app(environ, wrapper.wrap_start_response)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/pylons/middleware.py", line 201, in __call__
    self.app, environ, catch_exc_info=True)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/pylons/util.py", line 94, in call_wsgi_application
    app_iter = application(environ, start_response)
  File "/usr/lib/ckan/default/local/lib/p_metadata" does not existython2.7/site-packages/weberror/errormiddleware.py", line 165, in __call__
    return self.application(environ, start_response)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webob/dec.py", line 147, in __call__
    resp = self.call_func(req, *args, **self.kwargs)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webob/dec.py", line 208, in call_func
    return self.func(req, *args, **kwargs)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/fanstatic/publisher.py", line 234, in __call__
    return request.get_response(self.app)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webob/request.py", line 1053, in get_response
    application, catch_exc_info=False)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webob/request.py", line 1022, in call_application
    app_iter = application(self.environ, start_response)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webob/dec.py", line 147, in __call__
    resp = self.call_func(req, *args, **self.kwargs)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webob/dec.py", line 208, in call_func
    return self.func(req, *args, **kwargs)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/fanstatic/injector.py", line 54, in __call__
    response = request.get_response(self.app)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webob/request.py", line 1053, in get_response
    application, catch_exc_info=False)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webob/request.py", line 1022, in call_application
    app_iter = application(self.environ, start_response)
  File "/vagrant/ckan/config/middleware/pylons_app.py", line 250, in inner
    result = application(environ, start_response)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/beaker/middleware.py", line 73, in __call__
    return self.app(environ, start_response)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/beaker/middleware.py", line 156, in __call__
    return self.wrap_app(environ, session_start_response)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/routes/middleware.py", line 131, in __call__
    response = self.app(environ, start_response)
  File "/vagrant/ckan/config/middleware/common_middleware.py", line 80, in __call__
    return self.app(environ, start_response)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/pylons/wsgiapp.py", line 125, in __call__
    response = self.dispatch(controller, environ, start_response)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/pylons/wsgiapp.py", line 324, in dispatch
    return controller(environ, start_response)
  File "/vagrant/ckan/lib/base.py", line 212, in __call__
    res = WSGIController.__call__(self, environ, start_response)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/pylons/controllers/core.py", line 221, in __call__
    response = self._dispatch_call()
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/pylons/controllers/core.py", line 172, in _dispatch_call
    response = self._inspect_call(func)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/pylons/controllers/core.py", line 107, in _inspect_call
    result = self._perform_call(func, args)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/pylons/controllers/core.py", line 60, in _perform_call
    return func(**args)
  File "/vagrant/ckan/controllers/package.py", line 1123, in resource_read
    return render(template, extra_vars=vars)
  File "/vagrant/ckan/lib/base.py", line 177, in render
    return cached_template(template_name, render_template)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/pylons/templating.py", line 249, in cached_template
    return render_func()
  File "/vagrant/ckan/lib/base.py", line 131, in render_template
    return render_jinja2(template_name, globs)
  File "/vagrant/ckan/lib/base.py", line 88, in render_jinja2
    return template.render(**extra_vars)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/jinja2/environment.py", line 989, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/jinja2/environment.py", line 754, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/vagrant/ckanext/datastore/templates/package/resource_read.html", line 1, in top-level template code
    {% ckan_extends %}
  File "/vagrant/ckan/templates/package/resource_read.html", line 3, in top-level template code
    {% set res = c.resource %}
  File "/vagrant/ckan/templates/package/base.html", line 3, in top-level template code
    {% set pkg = c.pkg_dict or pkg_dict %}
  File "/vagrant/ckan/templates/page.html", line 1, in top-level template code
    {% extends "base.html" %}
  File "/vagrant/ckan/templates/base.html", line 103, in top-level template code
    {%- block page %}{% endblock -%}
  File "/vagrant/ckan/templates/page.html", line 19, in block "page"
    {%- block content %}
  File "/vagrant/ckan/templates/page.html", line 22, in block "content"
    {% block main_content %}
  File "/vagrant/ckan/templates/page.html", line 54, in block "main_content"
    {% block pre_primary %}
  File "/vagrant/ckan/templates/package/resource_read.html", line 22, in block "pre_primary"
    {% block resource %}
  File "/vagrant/ckan/templates/package/resource_read.html", line 24, in block "resource"
    {% block resource_inner %}
  File "/vagrant/ckan/templates/package/resource_read.html", line 73, in block "resource_inner"
    {% block data_preview %}
  File "/vagrant/ckan/templates/package/resource_read.html", line 74, in block "data_preview"
    {% block resource_view %}
  File "/vagrant/ckan/templates/package/resource_read.html", line 88, in block "resource_view"
    {% block resource_view_content %}
  File "/vagrant/ckan/templates/package/resource_read.html", line 98, in block "resource_view_content"
    {% snippet 'package/snippets/resource_view.html',
  File "/vagrant/ckan/lib/jinja_extensions.py", line 246, in _call
    return base.render_snippet(args[0], **kwargs)
  File "/vagrant/ckan/lib/base.py", line 78, in render_snippet
    renderer='snippet')
  File "/vagrant/ckan/lib/base.py", line 177, in render
    return cached_template(template_name, render_template)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/pylons/templating.py", line 249, in cached_template
    return render_func()
  File "/vagrant/ckan/lib/base.py", line 131, in render_template
    return render_jinja2(template_name, globs)
  File "/vagrant/ckan/lib/base.py", line 88, in render_jinja2
    return template.render(**extra_vars)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/jinja2/environment.py", line 989, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/jinja2/environment.py", line 754, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/vagrant/ckan/templates/package/snippets/resource_view.html", line 3, in top-level template code
    {% block resource_view %}
  File "/vagrant/ckan/templates/package/snippets/resource_view.html", line 16, in block "resource_view"
    {% snippet 'package/snippets/resource_view_filters.html', resource=resource %}
  File "/vagrant/ckan/lib/jinja_extensions.py", line 246, in _call
    return base.render_snippet(args[0], **kwargs)
  File "/vagrant/ckan/lib/base.py", line 78, in render_snippet
    renderer='snippet')
  File "/vagrant/ckan/lib/base.py", line 177, in render
    return cached_template(template_name, render_template)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/pylons/templating.py", line 249, in cached_template
    return render_func()
  File "/vagrant/ckan/lib/base.py", line 131, in render_template
    return render_jinja2(template_name, globs)
  File "/vagrant/ckan/lib/base.py", line 88, in render_jinja2
    return template.render(**extra_vars)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/jinja2/environment.py", line 989, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/jinja2/environment.py", line 754, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/vagrant/ckan/templates/package/snippets/resource_view_filters.html", line 5, in top-level template code
    data-module-fields="{{ h.dump_json(h.resource_view_get_fields(resource)) }}"
  File "/vagrant/ckan/lib/helpers.py", line 2063, in resource_view_get_fields
    result = logic.get_action('datastore_search')({}, data)
  File "/vagrant/ckan/logic/__init__.py", line 457, in wrapped
    result = _action(context, data_dict, **kw)
  File "/vagrant/ckan/logic/__init__.py", line 576, in wrapper
    return action(context, data_dict)
  File "/vagrant/ckanext/datastore/logic/action.py", line 453, in datastore_search
    res_exists, real_id = backend.resource_id_from_alias(res_id)
  File "/vagrant/ckanext/datastore/backend/postgres.py", line 1903, in resource_id_from_alias
    results = self._get_write_engine().execute(resources_sql, id=alias)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1690, in execute
    return connection.execute(statement, *multiparams, **params)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 727, in execute
    return meth(self, multiparams, params)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/sql/elements.py", line 322, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 824, in _execute_clauseelement
    compiled_sql, distilled_params
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 954, in _execute_context
    context)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1116, in _handle_dbapi_exception
    exc_info
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/util/compat.py", line 189, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 947, in _execute_context
    context)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/engine/default.py", line 435, in do_execute
    cursor.execute(statement, parameters)
ProgrammingError: (ProgrammingError) relation "_table_metadata" does not exist
LINE 1: SELECT alias_of FROM "_table_metadata"
                             ^
 'SELECT alias_of FROM "_table_metadata"\n                                        WHERE name = %(id)s' {'id': u'af18a06c-46bf-40fd-a5e8-0337c2b3b6da'}
-------------------- >> begin captured logging << --------------------
ckan.model: INFO: Database table data deleted
ckan.model: INFO: Database initialised
ckan.model: INFO: Database rebuilt
ckan.model: INFO: Database table data deleted
ckan.model: INFO: Database initialised
ckan.model: INFO: Database rebuilt
factory.generate: DEBUG: BaseFactory: Preparing ckan.tests.factories.Dataset(extra={})
factory.containers: DEBUG: LazyStub: Computing values for ckan.tests.factories.Dataset(notes='Just another test dataset.', name=<OrderedDeclarationWrapper for <factory.declarations.Sequence object at 0x7f53ac2e1510>>, title='Test Dataset')
factory.generate: DEBUG: Sequence: Computing next value of <function <lambda> at 0x7f53ac2e4de8> for seq=53
factory.containers: DEBUG: LazyStub: Computed values, got ckan.tests.factories.Dataset(notes='Just another test dataset.', name='test_dataset_53', title='Test Dataset')
factory.generate: DEBUG: BaseFactory: Generating ckan.tests.factories.Dataset(notes='Just another test dataset.', name='test_dataset_53', title='Test Dataset')
ckan.model.modification: ERROR: (ProgrammingError) relation "_table_metadata" does not exist
LINE 1: SELECT 1 FROM "_table_metadata"
                      ^
 'SELECT 1 FROM "_table_metadata"\n            WHERE name = %(id)s AND alias_of IS NULL' {'id': u'af18a06c-46bf-40fd-a5e8-0337c2b3b6da'}
Traceback (most recent call last):
  File "/vagrant/ckan/model/modification.py", line 88, in notify
    observer.notify(entity, operation)
  File "/vagrant/ckanext/datastore/plugin.py", line 106, in notify
    'resource_id': resource.id})
  File "/vagrant/ckan/logic/__init__.py", line 457, in wrapped
    result = _action(context, data_dict, **kw)
  File "/vagrant/ckanext/datastore/logic/action.py", line 557, in datastore_make_public
    if not _resource_exists(context, data_dict):
  File "/vagrant/ckanext/datastore/logic/action.py", line 626, in _resource_exists
    return backend.resource_exists(res_id)
  File "/vagrant/ckanext/datastore/backend/postgres.py", line 1895, in resource_exists
    results = self._get_write_engine().execute(resources_sql, id=id)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1690, in execute
    return connection.execute(statement, *multiparams, **params)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 727, in execute
    return meth(self, multiparams, params)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/sql/elements.py", line 322, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 824, in _execute_clauseelement
    compiled_sql, distilled_params
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 954, in _execute_context
    context)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1116, in _handle_dbapi_exception
    exc_info
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/util/compat.py", line 189, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 947, in _execute_context
    context)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/engine/default.py", line 435, in do_execute
    cursor.execute(statement, parameters)
ProgrammingError: (ProgrammingError) relation "_table_metadata" does not exist
LINE 1: SELECT 1 FROM "_table_metadata"
                      ^
 'SELECT 1 FROM "_table_metadata"\n            WHERE name = %(id)s AND alias_of IS NULL' {'id': u'af18a06c-46bf-40fd-a5e8-0337c2b3b6da'}
ckan.model.modification: ERROR: (ProgrammingError) relation "_table_metadata" does not exist
LINE 1: SELECT 1 FROM "_table_metadata"
                      ^
 'SELECT 1 FROM "_table_metadata"\n            WHERE name = %(id)s AND alias_of IS NULL' {'id': u'af18a06c-46bf-40fd-a5e8-0337c2b3b6da'}
Traceback (most recent call last):
  File "/vagrant/ckan/model/modification.py", line 88, in notify
    observer.notify(entity, operation)
  File "/vagrant/ckanext/datastore/plugin.py", line 106, in notify
    'resource_id': resource.id})
  File "/vagrant/ckan/logic/__init__.py", line 457, in wrapped
    result = _action(context, data_dict, **kw)
  File "/vagrant/ckanext/datastore/logic/action.py", line 557, in datastore_make_public
    if not _resource_exists(context, data_dict):
  File "/vagrant/ckanext/datastore/logic/action.py", line 626, in _resource_exists
    return backend.resource_exists(res_id)
  File "/vagrant/ckanext/datastore/backend/postgres.py", line 1895, in resource_exists
    results = self._get_write_engine().execute(resources_sql, id=id)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1690, in execute
    return connection.execute(statement, *multiparams, **params)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 727, in execute
    return meth(self, multiparams, params)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/sql/elements.py", line 322, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 824, in _execute_clauseelement
    compiled_sql, distilled_params
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 954, in _execute_context
    context)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1116, in _handle_dbapi_exception
    exc_info
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/util/compat.py", line 189, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 947, in _execute_context
    context)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/sqlalchemy/engine/default.py", line 435, in do_execute
    cursor.execute(statement, parameters)
ProgrammingError: (ProgrammingError) relation "_table_metadata" does not exist
LINE 1: SELECT 1 FROM "_table_metadata"
                      ^
 'SELECT 1 FROM "_table_metadata"\n            WHERE name = %(id)s AND alias_of IS NULL' {'id': u'af18a06c-46bf-40fd-a5e8-0337c2b3b6da'}
ckanext.datastore.logic.action: DEBUG: Setting datastore_active=True on resource af18a06c-46bf-40fd-a5e8-0337c2b3b6da
ckan.lib.maintain: WARNING: Function _resource_preview() in module ckan.controllers.package has been deprecated and will be removed in a later release of ckan. Resource preview is deprecated. Please use the new resource views
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 238 tests in 230.349s

FAILED (errors=31)
```
