### PR TITLE
Use wheel & update pip in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get -q -y update \
         python-dev \
         python-pip \
         python-virtualenv \
+        python-wheel \
         libpq-dev \
         libxml2-dev \
         libxslt-dev \
@@ -43,7 +44,8 @@ RUN mkdir -p $CKAN_VENV $CKAN_CONFIG $CKAN_STORAGE_PATH && \
 
 # Setup CKAN
 ADD . $CKAN_VENV/src/ckan/
-RUN ckan-pip install --upgrade -r $CKAN_VENV/src/ckan/requirements.txt && \
+RUN ckan-pip install -U pip && \
+    ckan-pip install --upgrade --no-cache-dir -r $CKAN_VENV/src/ckan/requirements.txt && \
     ckan-pip install -e $CKAN_VENV/src/ckan/ && \
     ln -s $CKAN_VENV/src/ckan/ckan/config/who.ini $CKAN_CONFIG/who.ini && \
     cp -v $CKAN_VENV/src/ckan/contrib/docker/ckan-entrypoint.sh /ckan-entrypoint.sh && \


### PR DESCRIPTION
### Proposed fixes:

Added ``wheel`` to system in Dockerfile and disable cache in pip.

### Features:

Adding ``wheel`` allows faster python package installation. We use Python libraries, which are partially written in C ++. They require a compilation that takes a while, unless we use the compiled libraries provided by the wheel. There is many compatible, compiled libraries than to [manylinux](https://github.com/pypa/manylinux).

We disable cache in pip to avoid preparing wheel packages. Besides, the cache does not make sense, because the rebuilt container will not have access to it. 