### PR TITLE
[docker] remove config and home volumes

### DIFF
--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -3,8 +3,6 @@
 version: "3"
 
 volumes:
-  ckan_config:
-  ckan_home:
   ckan_storage:
   pg_data:
 
@@ -34,8 +32,6 @@ services:
       - DS_RO_PASS=${DATASTORE_READONLY_PASSWORD}
 
     volumes:
-      - ckan_config:/etc/ckan
-      - ckan_home:/usr/lib/ckan
       - ckan_storage:/var/lib/ckan
 
   datapusher:


### PR DESCRIPTION
I would like to open up discussion on the current docker-compose volume setup. At the moment the ckan service is using three volumes:

https://github.com/ckan/ckan/blob/6f311192c5a89319772cd1e4e970c89e28aaf405/contrib/docker/docker-compose.yml#L36-L39

The main point is on `ckan-home`, which includes the virtualenv and source code. This is somewhat deceiving when updating dependencies or code. 

Multiple people have reported issues where code or dependencies have been updated, used `docker-compose down` and rebuild, but changes don't propagate because the volume still contains previous iteration. To resolve this `docker volume prune` needs to be run when rebuilding. 

Sharing the config & source code through a volume is an anti-pattern when used with containers, as it prevents an immutable approach for containers. I'm also unaware of any uses or benefits this might have. If this is to keep several instances 'in sync' this probably would be better addressed through orchestration. For that reason I propose removing the home and config volumes. 

Please let me know if anyone has any thoughts on this.