### PR TITLE
Check that resource is not None in "datastore_delete" action

### DIFF
--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -356,6 +356,7 @@ def datastore_delete(context, data_dict):
     resource = model.Resource.get(data_dict['resource_id'])
 
     if (not data_dict.get('filters') and
+            resource is not None and
             resource.extras.get('datastore_active') is True):
         log.debug(
             'Setting datastore_active=False on resource {0}'.format(


### PR DESCRIPTION
"resource" comes from a model.Resource.get() above which may return
None.

I have observed this while running "datastore_delete" action on no longer existing resources (cleanup up the datastore).