### PR TITLE
[#3929] Allow custom metadata for database connection, to define schema for migrations

### DIFF
--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -47,9 +47,6 @@ who.log_file = %(cache_dir)s/who_log.ini
 ## Database Settings
 sqlalchemy.url = postgresql://ckan_default:pass@localhost/ckan_default
 
-## Migration Settings
-ckan.migrations.target_schema = public
-
 #ckan.datastore.write_url = postgresql://ckan_default:pass@localhost/datastore_default
 #ckan.datastore.read_url = postgresql://datastore_default:pass@localhost/datastore_default
 
@@ -96,6 +93,9 @@ ckan.site_id = default
 # ckan.cors.origin_allow_all = true
 # cors.origin_whitelist is a space separated list of allowed domains.
 # ckan.cors.origin_whitelist = http://example1.com http://example2.com
+
+## Migration Settings
+ckan.migrations.target_schema = public
 
 
 ## Plugins Settings

--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -47,6 +47,9 @@ who.log_file = %(cache_dir)s/who_log.ini
 ## Database Settings
 sqlalchemy.url = postgresql://ckan_default:pass@localhost/ckan_default
 
+## Migration Settings
+ckan.migrations.target_schema = public
+
 #ckan.datastore.write_url = postgresql://ckan_default:pass@localhost/datastore_default
 #ckan.datastore.read_url = postgresql://datastore_default:pass@localhost/datastore_default
 

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -131,7 +131,6 @@ def load_environment(global_conf, app_conf):
 # Start CONFIG_FROM_ENV_VARS
 CONFIG_FROM_ENV_VARS = {
     'sqlalchemy.url': 'CKAN_SQLALCHEMY_URL',
-    'ckan.migrations.target_schema': 'CKAN_MIGRATIONS_TARGET_SCHEMA',
     'ckan.datastore.write_url': 'CKAN_DATASTORE_WRITE_URL',
     'ckan.datastore.read_url': 'CKAN_DATASTORE_READ_URL',
     'ckan.redis.url': 'CKAN_REDIS_URL',

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -131,6 +131,7 @@ def load_environment(global_conf, app_conf):
 # Start CONFIG_FROM_ENV_VARS
 CONFIG_FROM_ENV_VARS = {
     'sqlalchemy.url': 'CKAN_SQLALCHEMY_URL',
+    'ckan.migrations.target_schema': 'CKAN_MIGRATIONS_TARGET_SCHEMA',
     'ckan.datastore.write_url': 'CKAN_DATASTORE_WRITE_URL',
     'ckan.datastore.read_url': 'CKAN_DATASTORE_READ_URL',
     'ckan.redis.url': 'CKAN_REDIS_URL',

--- a/ckan/migration/versions/001_add_existing_tables.py
+++ b/ckan/migration/versions/001_add_existing_tables.py
@@ -2,10 +2,10 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 def upgrade(migrate_engine):
-    meta = CkanMetaData()
+    meta = CkanMigrationMetaData()
 
     state = Table('state', meta,
       Column('id', Integer() ,  primary_key=True, nullable=False),

--- a/ckan/migration/versions/001_add_existing_tables.py
+++ b/ckan/migration/versions/001_add_existing_tables.py
@@ -2,10 +2,10 @@
 
 from sqlalchemy import *
 from migrate import *
-
+from ckan.model.metadata import CkanMetaData
 
 def upgrade(migrate_engine):
-    meta = MetaData()
+    meta = CkanMetaData()
 
     state = Table('state', meta,
       Column('id', Integer() ,  primary_key=True, nullable=False),

--- a/ckan/migration/versions/002_add_author_and_maintainer.py
+++ b/ckan/migration/versions/002_add_author_and_maintainer.py
@@ -2,11 +2,12 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import migrate.changeset
 
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
 
     # Upgrade operations go here. Don't create your own engine; use the engine

--- a/ckan/migration/versions/002_add_author_and_maintainer.py
+++ b/ckan/migration/versions/002_add_author_and_maintainer.py
@@ -2,12 +2,12 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import migrate.changeset
 
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
 
     # Upgrade operations go here. Don't create your own engine; use the engine

--- a/ckan/migration/versions/003_add_user_object.py
+++ b/ckan/migration/versions/003_add_user_object.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import uuid
 
 
@@ -10,7 +11,7 @@ def make_uuid():
 
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     user_table = Table('user', metadata,
             Column('id', UnicodeText, primary_key=True, default=make_uuid),
             Column('name', UnicodeText),

--- a/ckan/migration/versions/003_add_user_object.py
+++ b/ckan/migration/versions/003_add_user_object.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import uuid
 
 
@@ -11,7 +11,7 @@ def make_uuid():
 
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     user_table = Table('user', metadata,
             Column('id', UnicodeText, primary_key=True, default=make_uuid),
             Column('name', UnicodeText),

--- a/ckan/migration/versions/004_add_group_object.py
+++ b/ckan/migration/versions/004_add_group_object.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import uuid
 
 
@@ -11,7 +11,7 @@ def make_uuid():
 
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
 
     # you need to load this for foreign keys to work in package_group_table

--- a/ckan/migration/versions/004_add_group_object.py
+++ b/ckan/migration/versions/004_add_group_object.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import uuid
 
 
@@ -10,7 +11,7 @@ def make_uuid():
 
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
 
     # you need to load this for foreign keys to work in package_group_table

--- a/ckan/migration/versions/005_add_authorization_tables.py
+++ b/ckan/migration/versions/005_add_authorization_tables.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import uuid
 
 
@@ -9,7 +10,7 @@ def make_uuid():
     return unicode(uuid.uuid4())
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
 
     # you need to load these two for foreign keys to work 

--- a/ckan/migration/versions/005_add_authorization_tables.py
+++ b/ckan/migration/versions/005_add_authorization_tables.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import uuid
 
 
@@ -10,7 +10,7 @@ def make_uuid():
     return unicode(uuid.uuid4())
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
 
     # you need to load these two for foreign keys to work 

--- a/ckan/migration/versions/006_add_ratings.py
+++ b/ckan/migration/versions/006_add_ratings.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import uuid
 
 
@@ -9,7 +10,7 @@ def make_uuid():
     return unicode(uuid.uuid4())
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
 
     # you need to load these two for foreign keys to work 

--- a/ckan/migration/versions/006_add_ratings.py
+++ b/ckan/migration/versions/006_add_ratings.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import uuid
 
 
@@ -10,7 +10,7 @@ def make_uuid():
     return unicode(uuid.uuid4())
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
 
     # you need to load these two for foreign keys to work 

--- a/ckan/migration/versions/007_add_system_roles.py
+++ b/ckan/migration/versions/007_add_system_roles.py
@@ -2,13 +2,14 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import uuid
 
 
 
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
 
     user_object_role_table = Table('user_object_role', metadata, autoload=True)

--- a/ckan/migration/versions/007_add_system_roles.py
+++ b/ckan/migration/versions/007_add_system_roles.py
@@ -2,14 +2,14 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import uuid
 
 
 
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
 
     user_object_role_table = Table('user_object_role', metadata, autoload=True)

--- a/ckan/migration/versions/008_update_vdm_ids.py
+++ b/ckan/migration/versions/008_update_vdm_ids.py
@@ -5,7 +5,7 @@ import sqlalchemy.schema
 import uuid
 
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import migrate.changeset
 from migrate.changeset.constraint import ForeignKeyConstraint, PrimaryKeyConstraint
 
@@ -20,7 +20,7 @@ def make_uuid():
 # 4 create uuids for revisions (auto cascades elsewhere!)
 def upgrade(migrate_engine):
     global metadata
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
     dropped_fk_constraints = drop_constraints_and_alter_types()
     upgrade2(migrate_engine, dropped_fk_constraints)
@@ -57,7 +57,7 @@ def drop_constraints_and_alter_types():
 
 def upgrade2(migrate_engine, dropped_fk_constraints):
     # have changed type of cols so recreate metadata
-    metadata = CkanMetaData(migrate_engine)
+    metadata = CkanMigrationMetaData(migrate_engine)
 
     # 3 create foreign key constraints
     for fk_constraint in dropped_fk_constraints:

--- a/ckan/migration/versions/008_update_vdm_ids.py
+++ b/ckan/migration/versions/008_update_vdm_ids.py
@@ -5,6 +5,7 @@ import sqlalchemy.schema
 import uuid
 
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import migrate.changeset
 from migrate.changeset.constraint import ForeignKeyConstraint, PrimaryKeyConstraint
 
@@ -19,7 +20,7 @@ def make_uuid():
 # 4 create uuids for revisions (auto cascades elsewhere!)
 def upgrade(migrate_engine):
     global metadata
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
     dropped_fk_constraints = drop_constraints_and_alter_types()
     upgrade2(migrate_engine, dropped_fk_constraints)
@@ -56,7 +57,7 @@ def drop_constraints_and_alter_types():
 
 def upgrade2(migrate_engine, dropped_fk_constraints):
     # have changed type of cols so recreate metadata
-    metadata = MetaData(migrate_engine)
+    metadata = CkanMetaData(migrate_engine)
 
     # 3 create foreign key constraints
     for fk_constraint in dropped_fk_constraints:

--- a/ckan/migration/versions/009_add_creation_timestamps.py
+++ b/ckan/migration/versions/009_add_creation_timestamps.py
@@ -4,13 +4,14 @@ from datetime import datetime
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import migrate.changeset
 
 
 domain_obj_names = ['rating', 'group', 'user']
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
     # Use sql instead of migrate.changeset because user and group are sql
     # reserved words and migrate doesn't quote them.

--- a/ckan/migration/versions/009_add_creation_timestamps.py
+++ b/ckan/migration/versions/009_add_creation_timestamps.py
@@ -4,14 +4,14 @@ from datetime import datetime
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import migrate.changeset
 
 
 domain_obj_names = ['rating', 'group', 'user']
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
     # Use sql instead of migrate.changeset because user and group are sql
     # reserved words and migrate doesn't quote them.

--- a/ckan/migration/versions/010_add_user_about.py
+++ b/ckan/migration/versions/010_add_user_about.py
@@ -2,12 +2,12 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import migrate.changeset
 
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
     # Using sql because migrate doesn't quote reserved word 'user'
     user_sql = 'ALTER TABLE "user" ADD about TEXT'

--- a/ckan/migration/versions/010_add_user_about.py
+++ b/ckan/migration/versions/010_add_user_about.py
@@ -2,11 +2,12 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import migrate.changeset
 
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
     # Using sql because migrate doesn't quote reserved word 'user'
     user_sql = 'ALTER TABLE "user" ADD about TEXT'

--- a/ckan/migration/versions/011_add_package_search_vector.py
+++ b/ckan/migration/versions/011_add_package_search_vector.py
@@ -2,11 +2,12 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import migrate.changeset
 
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
 
     package_table = Table('package', metadata, autoload=True)

--- a/ckan/migration/versions/011_add_package_search_vector.py
+++ b/ckan/migration/versions/011_add_package_search_vector.py
@@ -2,12 +2,12 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import migrate.changeset
 
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
 
     package_table = Table('package', metadata, autoload=True)

--- a/ckan/migration/versions/012_add_resources.py
+++ b/ckan/migration/versions/012_add_resources.py
@@ -2,14 +2,14 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import migrate.changeset
 import vdm.sqlalchemy
 
 
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
 
     package_table = Table('package', metadata, autoload=True)

--- a/ckan/migration/versions/012_add_resources.py
+++ b/ckan/migration/versions/012_add_resources.py
@@ -2,13 +2,14 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import migrate.changeset
 import vdm.sqlalchemy
 
 
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
 
     package_table = Table('package', metadata, autoload=True)

--- a/ckan/migration/versions/013_add_hash.py
+++ b/ckan/migration/versions/013_add_hash.py
@@ -2,11 +2,12 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import migrate.changeset
 
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
     package_resource = Table('package_resource', metadata, autoload=True)
     column = Column('hash', UnicodeText)

--- a/ckan/migration/versions/013_add_hash.py
+++ b/ckan/migration/versions/013_add_hash.py
@@ -2,12 +2,12 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import migrate.changeset
 
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
     package_resource = Table('package_resource', metadata, autoload=True)
     column = Column('hash', UnicodeText)

--- a/ckan/migration/versions/014_hash_2.py
+++ b/ckan/migration/versions/014_hash_2.py
@@ -2,11 +2,12 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import migrate.changeset
 
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
     # When adding a column to a revisioned object, need to add it to it's
     # counterpart revision object too. Here is the counter-part for that in

--- a/ckan/migration/versions/014_hash_2.py
+++ b/ckan/migration/versions/014_hash_2.py
@@ -2,12 +2,12 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import migrate.changeset
 
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
     # When adding a column to a revisioned object, need to add it to it's
     # counterpart revision object too. Here is the counter-part for that in

--- a/ckan/migration/versions/015_remove_state_object.py
+++ b/ckan/migration/versions/015_remove_state_object.py
@@ -4,11 +4,12 @@ from sqlalchemy import *
 import sqlalchemy.sql as sql
 
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import migrate.changeset
 
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
     stateful_tables = [
             'license',

--- a/ckan/migration/versions/015_remove_state_object.py
+++ b/ckan/migration/versions/015_remove_state_object.py
@@ -4,12 +4,12 @@ from sqlalchemy import *
 import sqlalchemy.sql as sql
 
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import migrate.changeset
 
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
     stateful_tables = [
             'license',

--- a/ckan/migration/versions/016_uuids_everywhere.py
+++ b/ckan/migration/versions/016_uuids_everywhere.py
@@ -6,11 +6,11 @@ import uuid
 from sqlalchemy.sql import select
 
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import migrate.changeset
 from migrate.changeset.constraint import ForeignKeyConstraint, PrimaryKeyConstraint
 
-metadata = CkanMetaData()
+metadata = CkanMigrationMetaData()
 
 def make_uuid():
     return unicode(uuid.uuid4())
@@ -35,7 +35,7 @@ def make_uuid():
 
 def upgrade(migrate_engine):
     global metadata
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
     primary_table_name = 'package'
     foreign_tables = ['package_revision',
@@ -152,7 +152,7 @@ def add_fk_constraints(migrate_engine, dropped_fk_constraints, primary_table_nam
 
 def create_uuids(migrate_engine, primary_table_name, revision_table_name):
     # have changed type of cols so recreate metadata
-    metadata = CkanMetaData(migrate_engine)
+    metadata = CkanMigrationMetaData(migrate_engine)
 
     # 4 create uuids for primary entities and in related tables
     primary_table = Table(primary_table_name, metadata, autoload=True)

--- a/ckan/migration/versions/016_uuids_everywhere.py
+++ b/ckan/migration/versions/016_uuids_everywhere.py
@@ -6,10 +6,11 @@ import uuid
 from sqlalchemy.sql import select
 
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import migrate.changeset
 from migrate.changeset.constraint import ForeignKeyConstraint, PrimaryKeyConstraint
 
-metadata = MetaData()
+metadata = CkanMetaData()
 
 def make_uuid():
     return unicode(uuid.uuid4())
@@ -34,7 +35,7 @@ def make_uuid():
 
 def upgrade(migrate_engine):
     global metadata
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
     primary_table_name = 'package'
     foreign_tables = ['package_revision',
@@ -151,7 +152,7 @@ def add_fk_constraints(migrate_engine, dropped_fk_constraints, primary_table_nam
 
 def create_uuids(migrate_engine, primary_table_name, revision_table_name):
     # have changed type of cols so recreate metadata
-    metadata = MetaData(migrate_engine)
+    metadata = CkanMetaData(migrate_engine)
 
     # 4 create uuids for primary entities and in related tables
     primary_table = Table(primary_table_name, metadata, autoload=True)

--- a/ckan/migration/versions/017_add_pkg_relationships.py
+++ b/ckan/migration/versions/017_add_pkg_relationships.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import uuid
 
 
@@ -10,7 +11,7 @@ def make_uuid():
 
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
 
     package_table = Table('package', metadata, autoload=True)

--- a/ckan/migration/versions/017_add_pkg_relationships.py
+++ b/ckan/migration/versions/017_add_pkg_relationships.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import uuid
 
 
@@ -11,7 +11,7 @@ def make_uuid():
 
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
 
     package_table = Table('package', metadata, autoload=True)

--- a/ckan/migration/versions/018_adjust_licenses.py
+++ b/ckan/migration/versions/018_adjust_licenses.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import uuid
 
 
@@ -86,7 +87,7 @@ map = {
 }
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
     #print "Changing package license_ids to strings."
 

--- a/ckan/migration/versions/018_adjust_licenses.py
+++ b/ckan/migration/versions/018_adjust_licenses.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import uuid
 
 
@@ -87,7 +87,7 @@ map = {
 }
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
     #print "Changing package license_ids to strings."
 

--- a/ckan/migration/versions/019_pkg_relationships_state.py
+++ b/ckan/migration/versions/019_pkg_relationships_state.py
@@ -2,11 +2,12 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import migrate.changeset
 
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
 
     package_relationship_table = Table('package_relationship',

--- a/ckan/migration/versions/019_pkg_relationships_state.py
+++ b/ckan/migration/versions/019_pkg_relationships_state.py
@@ -2,12 +2,12 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import migrate.changeset
 
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
 
     package_relationship_table = Table('package_relationship',

--- a/ckan/migration/versions/020_add_changeset.py
+++ b/ckan/migration/versions/020_add_changeset.py
@@ -2,13 +2,14 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import datetime
 from migrate.changeset.constraint import PrimaryKeyConstraint
 
 
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
 
     revision_table = Table('revision', metadata,
             Column('id', UnicodeText, primary_key=True),

--- a/ckan/migration/versions/020_add_changeset.py
+++ b/ckan/migration/versions/020_add_changeset.py
@@ -2,14 +2,14 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import datetime
 from migrate.changeset.constraint import PrimaryKeyConstraint
 
 
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
 
     revision_table = Table('revision', metadata,
             Column('id', UnicodeText, primary_key=True),

--- a/ckan/migration/versions/022_add_group_extras.py
+++ b/ckan/migration/versions/022_add_group_extras.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import migrate.changeset
 import vdm.sqlalchemy
 import uuid
@@ -36,7 +37,7 @@ def make_uuid():
 
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
 
     group_table = Table('group', metadata, autoload=True)

--- a/ckan/migration/versions/022_add_group_extras.py
+++ b/ckan/migration/versions/022_add_group_extras.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import migrate.changeset
 import vdm.sqlalchemy
 import uuid
@@ -37,7 +37,7 @@ def make_uuid():
 
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
 
     group_table = Table('group', metadata, autoload=True)

--- a/ckan/migration/versions/023_add_harvesting.py
+++ b/ckan/migration/versions/023_add_harvesting.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import datetime
 import uuid
 from migrate.changeset.constraint import PrimaryKeyConstraint
@@ -11,7 +12,7 @@ def make_uuid():
     return unicode(uuid.uuid4())
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     harvest_source_table = Table('harvest_source', metadata,
             Column('id', UnicodeText, primary_key=True, default=make_uuid),
             Column('status', UnicodeText, default=u'New'),

--- a/ckan/migration/versions/023_add_harvesting.py
+++ b/ckan/migration/versions/023_add_harvesting.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import datetime
 import uuid
 from migrate.changeset.constraint import PrimaryKeyConstraint
@@ -12,7 +12,7 @@ def make_uuid():
     return unicode(uuid.uuid4())
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     harvest_source_table = Table('harvest_source', metadata,
             Column('id', UnicodeText, primary_key=True, default=make_uuid),
             Column('status', UnicodeText, default=u'New'),

--- a/ckan/migration/versions/024_add_harvested_document.py
+++ b/ckan/migration/versions/024_add_harvested_document.py
@@ -2,11 +2,12 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import datetime
 
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     harvested_document_table = Table('harvested_document', metadata,
             Column('id', UnicodeText, primary_key=True),
             Column('created', DateTime),

--- a/ckan/migration/versions/024_add_harvested_document.py
+++ b/ckan/migration/versions/024_add_harvested_document.py
@@ -2,12 +2,12 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import datetime
 
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     harvested_document_table = Table('harvested_document', metadata,
             Column('id', UnicodeText, primary_key=True),
             Column('created', DateTime),

--- a/ckan/migration/versions/025_add_authorization_groups.py
+++ b/ckan/migration/versions/025_add_authorization_groups.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 from datetime import datetime
 import migrate.changeset
 import vdm.sqlalchemy
@@ -14,7 +15,7 @@ def make_uuid():
 
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
 
     user_table = Table('user', metadata, autoload=True)

--- a/ckan/migration/versions/025_add_authorization_groups.py
+++ b/ckan/migration/versions/025_add_authorization_groups.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 from datetime import datetime
 import migrate.changeset
 import vdm.sqlalchemy
@@ -15,7 +15,7 @@ def make_uuid():
 
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
 
     user_table = Table('user', metadata, autoload=True)

--- a/ckan/migration/versions/026_authorization_group_user_pk.py
+++ b/ckan/migration/versions/026_authorization_group_user_pk.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 from datetime import datetime
 import migrate.changeset
 import vdm.sqlalchemy
@@ -13,7 +13,7 @@ def make_uuid():
     return unicode(uuid.uuid4())
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
 
     user_table = Table('user', metadata, autoload=True)

--- a/ckan/migration/versions/026_authorization_group_user_pk.py
+++ b/ckan/migration/versions/026_authorization_group_user_pk.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 from datetime import datetime
 import migrate.changeset
 import vdm.sqlalchemy
@@ -12,7 +13,7 @@ def make_uuid():
     return unicode(uuid.uuid4())
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
 
     user_table = Table('user', metadata, autoload=True)

--- a/ckan/migration/versions/027_adjust_harvester.py
+++ b/ckan/migration/versions/027_adjust_harvester.py
@@ -5,13 +5,14 @@ import warnings
 from sqlalchemy import exc as sa_exc
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import migrate.changeset
 
 def upgrade(migrate_engine):
     # ignore reflection warnings
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=sa_exc.SAWarning)
-        metadata = MetaData()
+        metadata = CkanMetaData()
         metadata.bind = migrate_engine
 
         harvest_source_table = Table('harvest_source', metadata, autoload=True)

--- a/ckan/migration/versions/027_adjust_harvester.py
+++ b/ckan/migration/versions/027_adjust_harvester.py
@@ -5,14 +5,14 @@ import warnings
 from sqlalchemy import exc as sa_exc
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import migrate.changeset
 
 def upgrade(migrate_engine):
     # ignore reflection warnings
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=sa_exc.SAWarning)
-        metadata = CkanMetaData()
+        metadata = CkanMigrationMetaData()
         metadata.bind = migrate_engine
 
         harvest_source_table = Table('harvest_source', metadata, autoload=True)

--- a/ckan/migration/versions/028_drop_harvest_source_status.py
+++ b/ckan/migration/versions/028_drop_harvest_source_status.py
@@ -2,12 +2,12 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import migrate.changeset
 
     
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     harvested_source_table = Table('harvest_source', metadata,
         Column('status', UnicodeText, nullable=False),
         )

--- a/ckan/migration/versions/028_drop_harvest_source_status.py
+++ b/ckan/migration/versions/028_drop_harvest_source_status.py
@@ -2,11 +2,12 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import migrate.changeset
 
     
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     harvested_source_table = Table('harvest_source', metadata,
         Column('status', UnicodeText, nullable=False),
         )

--- a/ckan/migration/versions/029_version_groups.py
+++ b/ckan/migration/versions/029_version_groups.py
@@ -5,7 +5,7 @@ import uuid
 from sqlalchemy import *
 from sqlalchemy import types
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 from datetime import datetime
 import migrate.changeset
 from migrate.changeset.constraint import ForeignKeyConstraint
@@ -39,7 +39,7 @@ def make_uuid():
 
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
 
     group_table = Table('group', metadata,

--- a/ckan/migration/versions/029_version_groups.py
+++ b/ckan/migration/versions/029_version_groups.py
@@ -5,6 +5,7 @@ import uuid
 from sqlalchemy import *
 from sqlalchemy import types
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 from datetime import datetime
 import migrate.changeset
 from migrate.changeset.constraint import ForeignKeyConstraint
@@ -38,7 +39,7 @@ def make_uuid():
 
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
 
     group_table = Table('group', metadata,

--- a/ckan/migration/versions/030_additional_user_attributes.py
+++ b/ckan/migration/versions/030_additional_user_attributes.py
@@ -3,14 +3,14 @@
 from sqlalchemy import *
 from sqlalchemy import types
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 from datetime import datetime
 import migrate.changeset
 import uuid
 
     
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
     user_sql = 'ALTER TABLE "user" ADD openid TEXT'
     migrate_engine.execute(user_sql)

--- a/ckan/migration/versions/030_additional_user_attributes.py
+++ b/ckan/migration/versions/030_additional_user_attributes.py
@@ -3,13 +3,14 @@
 from sqlalchemy import *
 from sqlalchemy import types
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 from datetime import datetime
 import migrate.changeset
 import uuid
 
     
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
     user_sql = 'ALTER TABLE "user" ADD openid TEXT'
     migrate_engine.execute(user_sql)

--- a/ckan/migration/versions/031_move_openid_to_new_field.py
+++ b/ckan/migration/versions/031_move_openid_to_new_field.py
@@ -3,6 +3,7 @@
 from sqlalchemy import *
 from sqlalchemy import types
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 from datetime import datetime
 import migrate.changeset
 import uuid
@@ -13,7 +14,7 @@ def make_uuid():
 
     
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     user_table = Table('user', metadata,
         Column('id', UnicodeText, primary_key=True, default=make_uuid),
         Column('name', UnicodeText),

--- a/ckan/migration/versions/031_move_openid_to_new_field.py
+++ b/ckan/migration/versions/031_move_openid_to_new_field.py
@@ -3,7 +3,7 @@
 from sqlalchemy import *
 from sqlalchemy import types
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 from datetime import datetime
 import migrate.changeset
 import uuid
@@ -14,7 +14,7 @@ def make_uuid():
 
     
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     user_table = Table('user', metadata,
         Column('id', UnicodeText, primary_key=True, default=make_uuid),
         Column('name', UnicodeText),

--- a/ckan/migration/versions/032_add_extra_info_field_to_resources.py
+++ b/ckan/migration/versions/032_add_extra_info_field_to_resources.py
@@ -3,13 +3,14 @@
 from sqlalchemy import *
 from sqlalchemy import types
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 from datetime import datetime
 import migrate.changeset
 import uuid
 
     
 def upgrade(migrate_engine):
-    metadata = MetaData(migrate_engine)
+    metadata = CkanMetaData(migrate_engine)
     user_sql = 'ALTER TABLE package_resource ADD COLUMN extras text'
     migrate_engine.execute(user_sql)
     user_sql = 'ALTER TABLE package_resource_revision ADD COLUMN extras text'

--- a/ckan/migration/versions/032_add_extra_info_field_to_resources.py
+++ b/ckan/migration/versions/032_add_extra_info_field_to_resources.py
@@ -3,14 +3,14 @@
 from sqlalchemy import *
 from sqlalchemy import types
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 from datetime import datetime
 import migrate.changeset
 import uuid
 
     
 def upgrade(migrate_engine):
-    metadata = CkanMetaData(migrate_engine)
+    metadata = CkanMigrationMetaData(migrate_engine)
     user_sql = 'ALTER TABLE package_resource ADD COLUMN extras text'
     migrate_engine.execute(user_sql)
     user_sql = 'ALTER TABLE package_resource_revision ADD COLUMN extras text'

--- a/ckan/migration/versions/033_auth_group_user_id_add_conditional.py
+++ b/ckan/migration/versions/033_auth_group_user_id_add_conditional.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import datetime
 import uuid
 from migrate.changeset.constraint import PrimaryKeyConstraint
@@ -11,7 +12,7 @@ def make_uuid():
     return unicode(uuid.uuid4())
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
     authorization_group_user_table = Table('authorization_group_user',
                                            metadata, autoload=True)

--- a/ckan/migration/versions/033_auth_group_user_id_add_conditional.py
+++ b/ckan/migration/versions/033_auth_group_user_id_add_conditional.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import datetime
 import uuid
 from migrate.changeset.constraint import PrimaryKeyConstraint
@@ -12,7 +12,7 @@ def make_uuid():
     return unicode(uuid.uuid4())
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
     authorization_group_user_table = Table('authorization_group_user',
                                            metadata, autoload=True)

--- a/ckan/migration/versions/034_resource_group_table.py
+++ b/ckan/migration/versions/034_resource_group_table.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import datetime
 import uuid
 import migrate.changeset
@@ -14,7 +14,7 @@ def make_uuid():
 
 def upgrade(migrate_engine):
 
-    metadata = CkanMetaData(migrate_engine)
+    metadata = CkanMigrationMetaData(migrate_engine)
 
     package = Table('package', metadata, autoload=True)
 

--- a/ckan/migration/versions/034_resource_group_table.py
+++ b/ckan/migration/versions/034_resource_group_table.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import datetime
 import uuid
 import migrate.changeset
@@ -13,7 +14,7 @@ def make_uuid():
 
 def upgrade(migrate_engine):
 
-    metadata = MetaData(migrate_engine)
+    metadata = CkanMetaData(migrate_engine)
 
     package = Table('package', metadata, autoload=True)
 

--- a/ckan/migration/versions/035_harvesting_doc_versioning.py
+++ b/ckan/migration/versions/035_harvesting_doc_versioning.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import datetime
 import uuid
 import migrate.changeset
@@ -9,7 +10,7 @@ from migrate.changeset.constraint import PrimaryKeyConstraint
 from ckan.model.types import JsonDictType
 
 def upgrade(migrate_engine):
-    metadata = MetaData(migrate_engine)
+    metadata = CkanMetaData(migrate_engine)
 
     migrate_engine.execute('''
 

--- a/ckan/migration/versions/035_harvesting_doc_versioning.py
+++ b/ckan/migration/versions/035_harvesting_doc_versioning.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import datetime
 import uuid
 import migrate.changeset
@@ -10,7 +10,7 @@ from migrate.changeset.constraint import PrimaryKeyConstraint
 from ckan.model.types import JsonDictType
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData(migrate_engine)
+    metadata = CkanMigrationMetaData(migrate_engine)
 
     migrate_engine.execute('''
 

--- a/ckan/migration/versions/036_lockdown_roles.py
+++ b/ckan/migration/versions/036_lockdown_roles.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import datetime
 import uuid
 from migrate.changeset.constraint import PrimaryKeyConstraint
@@ -11,7 +11,7 @@ def make_uuid():
     return unicode(uuid.uuid4())
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
     role_action = Table('role_action', metadata, autoload=True)
     q = role_action.insert(values={'id': make_uuid(), 'role': 'editor', 

--- a/ckan/migration/versions/036_lockdown_roles.py
+++ b/ckan/migration/versions/036_lockdown_roles.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import datetime
 import uuid
 from migrate.changeset.constraint import PrimaryKeyConstraint
@@ -10,7 +11,7 @@ def make_uuid():
     return unicode(uuid.uuid4())
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
     role_action = Table('role_action', metadata, autoload=True)
     q = role_action.insert(values={'id': make_uuid(), 'role': 'editor', 

--- a/ckan/migration/versions/037_role_anon_editor.py
+++ b/ckan/migration/versions/037_role_anon_editor.py
@@ -3,14 +3,14 @@
 from sqlalchemy import *
 from sqlalchemy.sql import select, and_
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import logging
 
 log = logging.getLogger(__name__)
 
 def upgrade(migrate_engine):
     '''#1066 Change Visitor role on System from "reader" to "anon_editor".'''
-    metadata = CkanMetaData(migrate_engine)
+    metadata = CkanMigrationMetaData(migrate_engine)
 
     # get visitor ID
     user = Table('user', metadata, autoload=True)

--- a/ckan/migration/versions/037_role_anon_editor.py
+++ b/ckan/migration/versions/037_role_anon_editor.py
@@ -3,13 +3,14 @@
 from sqlalchemy import *
 from sqlalchemy.sql import select, and_
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import logging
 
 log = logging.getLogger(__name__)
 
 def upgrade(migrate_engine):
     '''#1066 Change Visitor role on System from "reader" to "anon_editor".'''
-    metadata = MetaData(migrate_engine)
+    metadata = CkanMetaData(migrate_engine)
 
     # get visitor ID
     user = Table('user', metadata, autoload=True)

--- a/ckan/migration/versions/038_delete_migration_tables.py
+++ b/ckan/migration/versions/038_delete_migration_tables.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 
 def upgrade(migrate_engine):
 

--- a/ckan/migration/versions/038_delete_migration_tables.py
+++ b/ckan/migration/versions/038_delete_migration_tables.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 def upgrade(migrate_engine):
 

--- a/ckan/migration/versions/039_add_expired_id_and_dates.py
+++ b/ckan/migration/versions/039_add_expired_id_and_dates.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import uuid
 import datetime
 

--- a/ckan/migration/versions/039_add_expired_id_and_dates.py
+++ b/ckan/migration/versions/039_add_expired_id_and_dates.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import uuid
 import datetime
 

--- a/ckan/migration/versions/040_reset_key_on_user.py
+++ b/ckan/migration/versions/040_reset_key_on_user.py
@@ -2,9 +2,10 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
     user_table = Table('user', metadata, autoload=True)
     reset_key_col = Column('reset_key', UnicodeText)

--- a/ckan/migration/versions/040_reset_key_on_user.py
+++ b/ckan/migration/versions/040_reset_key_on_user.py
@@ -2,10 +2,10 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
     user_table = Table('user', metadata, autoload=True)
     reset_key_col = Column('reset_key', UnicodeText)

--- a/ckan/migration/versions/041_resource_new_fields.py
+++ b/ckan/migration/versions/041_resource_new_fields.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 def upgrade(migrate_engine):
     migrate_engine.execute(

--- a/ckan/migration/versions/041_resource_new_fields.py
+++ b/ckan/migration/versions/041_resource_new_fields.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 
 def upgrade(migrate_engine):
     migrate_engine.execute(

--- a/ckan/migration/versions/042_user_revision_indexes.py
+++ b/ckan/migration/versions/042_user_revision_indexes.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 def upgrade(migrate_engine):
     migrate_engine.execute('''

--- a/ckan/migration/versions/042_user_revision_indexes.py
+++ b/ckan/migration/versions/042_user_revision_indexes.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 
 def upgrade(migrate_engine):
     migrate_engine.execute('''

--- a/ckan/migration/versions/043_drop_postgres_search.py
+++ b/ckan/migration/versions/043_drop_postgres_search.py
@@ -2,10 +2,11 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import migrate.changeset
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
     package_search_table = Table('package_search', metadata, autoload=True)
     package_search_table.drop()

--- a/ckan/migration/versions/043_drop_postgres_search.py
+++ b/ckan/migration/versions/043_drop_postgres_search.py
@@ -2,11 +2,11 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import migrate.changeset
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
     package_search_table = Table('package_search', metadata, autoload=True)
     package_search_table.drop()

--- a/ckan/migration/versions/044_add_task_status.py
+++ b/ckan/migration/versions/044_add_task_status.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 def upgrade(migrate_engine):
     migrate_engine.execute('''

--- a/ckan/migration/versions/044_add_task_status.py
+++ b/ckan/migration/versions/044_add_task_status.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 
 def upgrade(migrate_engine):
     migrate_engine.execute('''

--- a/ckan/migration/versions/045_user_name_unique.py
+++ b/ckan/migration/versions/045_user_name_unique.py
@@ -5,14 +5,14 @@ import warnings
 from sqlalchemy import exc as sa_exc
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 from migrate.changeset.constraint import UniqueConstraint
 
 def upgrade(migrate_engine):
     # ignore reflection warnings
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=sa_exc.SAWarning)
-        metadata = CkanMetaData()
+        metadata = CkanMigrationMetaData()
         metadata.bind = migrate_engine
         user_table = Table('user', metadata, autoload=True)
     #    name_column = user_table.c.name

--- a/ckan/migration/versions/045_user_name_unique.py
+++ b/ckan/migration/versions/045_user_name_unique.py
@@ -5,13 +5,14 @@ import warnings
 from sqlalchemy import exc as sa_exc
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 from migrate.changeset.constraint import UniqueConstraint
 
 def upgrade(migrate_engine):
     # ignore reflection warnings
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=sa_exc.SAWarning)
-        metadata = MetaData()
+        metadata = CkanMetaData()
         metadata.bind = migrate_engine
         user_table = Table('user', metadata, autoload=True)
     #    name_column = user_table.c.name

--- a/ckan/migration/versions/046_drop_changesets.py
+++ b/ckan/migration/versions/046_drop_changesets.py
@@ -2,10 +2,11 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 import migrate.changeset
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
     for table_name in ['change', 'changemask', 'changeset']:
         table = Table(table_name, metadata, autoload=True)

--- a/ckan/migration/versions/046_drop_changesets.py
+++ b/ckan/migration/versions/046_drop_changesets.py
@@ -2,11 +2,11 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 import migrate.changeset
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
     for table_name in ['change', 'changemask', 'changeset']:
         table = Table(table_name, metadata, autoload=True)

--- a/ckan/migration/versions/047_rename_package_group_member.py
+++ b/ckan/migration/versions/047_rename_package_group_member.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 def upgrade(migrate_engine):
     migrate_engine.execute('''

--- a/ckan/migration/versions/047_rename_package_group_member.py
+++ b/ckan/migration/versions/047_rename_package_group_member.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 
 def upgrade(migrate_engine):
     migrate_engine.execute('''

--- a/ckan/migration/versions/048_add_activity_streams_tables.py
+++ b/ckan/migration/versions/048_add_activity_streams_tables.py
@@ -2,10 +2,10 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
     migrate_engine.execute('''
 CREATE TABLE activity (

--- a/ckan/migration/versions/048_add_activity_streams_tables.py
+++ b/ckan/migration/versions/048_add_activity_streams_tables.py
@@ -2,9 +2,10 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
     migrate_engine.execute('''
 CREATE TABLE activity (

--- a/ckan/migration/versions/049_add_group_approval_status.py
+++ b/ckan/migration/versions/049_add_group_approval_status.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 def upgrade(migrate_engine):
     migrate_engine.execute('''

--- a/ckan/migration/versions/049_add_group_approval_status.py
+++ b/ckan/migration/versions/049_add_group_approval_status.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 
 def upgrade(migrate_engine):
     migrate_engine.execute('''

--- a/ckan/migration/versions/050_term_translation_table.py
+++ b/ckan/migration/versions/050_term_translation_table.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 def upgrade(migrate_engine):
     migrate_engine.execute('''

--- a/ckan/migration/versions/050_term_translation_table.py
+++ b/ckan/migration/versions/050_term_translation_table.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 
 def upgrade(migrate_engine):
     migrate_engine.execute('''

--- a/ckan/migration/versions/051_add_tag_vocabulary.py
+++ b/ckan/migration/versions/051_add_tag_vocabulary.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 def upgrade(migrate_engine):
     migrate_engine.execute('''

--- a/ckan/migration/versions/051_add_tag_vocabulary.py
+++ b/ckan/migration/versions/051_add_tag_vocabulary.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 
 def upgrade(migrate_engine):
     migrate_engine.execute('''

--- a/ckan/migration/versions/052_update_member_capacities.py
+++ b/ckan/migration/versions/052_update_member_capacities.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 
 def upgrade(migrate_engine):
     migrate_engine.execute("""

--- a/ckan/migration/versions/052_update_member_capacities.py
+++ b/ckan/migration/versions/052_update_member_capacities.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 def upgrade(migrate_engine):
     migrate_engine.execute("""

--- a/ckan/migration/versions/053_add_group_logo.py
+++ b/ckan/migration/versions/053_add_group_logo.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 def upgrade(migrate_engine):
     migrate_engine.execute('''

--- a/ckan/migration/versions/053_add_group_logo.py
+++ b/ckan/migration/versions/053_add_group_logo.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 
 def upgrade(migrate_engine):
     migrate_engine.execute('''

--- a/ckan/migration/versions/056_add_related_table.py
+++ b/ckan/migration/versions/056_add_related_table.py
@@ -2,10 +2,10 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
     migrate_engine.execute('''
 BEGIN;

--- a/ckan/migration/versions/056_add_related_table.py
+++ b/ckan/migration/versions/056_add_related_table.py
@@ -2,9 +2,10 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
     migrate_engine.execute('''
 BEGIN;

--- a/ckan/migration/versions/057_tracking.py
+++ b/ckan/migration/versions/057_tracking.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 def upgrade(migrate_engine):
     migrate_engine.execute('''

--- a/ckan/migration/versions/057_tracking.py
+++ b/ckan/migration/versions/057_tracking.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 
 def upgrade(migrate_engine):
     migrate_engine.execute('''

--- a/ckan/migration/versions/058_add_follower_tables.py
+++ b/ckan/migration/versions/058_add_follower_tables.py
@@ -2,10 +2,10 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
     migrate_engine.execute('''
 CREATE TABLE user_following_dataset (

--- a/ckan/migration/versions/058_add_follower_tables.py
+++ b/ckan/migration/versions/058_add_follower_tables.py
@@ -2,9 +2,10 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
     migrate_engine.execute('''
 CREATE TABLE user_following_dataset (

--- a/ckan/migration/versions/059_add_related_count_and_flag.py
+++ b/ckan/migration/versions/059_add_related_count_and_flag.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 def upgrade(migrate_engine):
     migrate_engine.execute('''

--- a/ckan/migration/versions/059_add_related_count_and_flag.py
+++ b/ckan/migration/versions/059_add_related_count_and_flag.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 
 def upgrade(migrate_engine):
     migrate_engine.execute('''

--- a/ckan/migration/versions/060_add_system_info_table.py
+++ b/ckan/migration/versions/060_add_system_info_table.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 def upgrade(migrate_engine):
     meta = MetaData()

--- a/ckan/migration/versions/060_add_system_info_table.py
+++ b/ckan/migration/versions/060_add_system_info_table.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 
 def upgrade(migrate_engine):
     meta = MetaData()

--- a/ckan/migration/versions/061_add_follower__group_table.py
+++ b/ckan/migration/versions/061_add_follower__group_table.py
@@ -2,10 +2,10 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
     migrate_engine.execute('''
 CREATE TABLE user_following_group (

--- a/ckan/migration/versions/061_add_follower__group_table.py
+++ b/ckan/migration/versions/061_add_follower__group_table.py
@@ -2,9 +2,10 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
     migrate_engine.execute('''
 CREATE TABLE user_following_group (

--- a/ckan/migration/versions/062_add_dashboard_table.py
+++ b/ckan/migration/versions/062_add_dashboard_table.py
@@ -2,10 +2,10 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
     migrate_engine.execute('''
 CREATE TABLE dashboard (

--- a/ckan/migration/versions/062_add_dashboard_table.py
+++ b/ckan/migration/versions/062_add_dashboard_table.py
@@ -2,9 +2,10 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
     migrate_engine.execute('''
 CREATE TABLE dashboard (

--- a/ckan/migration/versions/063_org_changes.py
+++ b/ckan/migration/versions/063_org_changes.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 
 def upgrade(migrate_engine):
 

--- a/ckan/migration/versions/063_org_changes.py
+++ b/ckan/migration/versions/063_org_changes.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 def upgrade(migrate_engine):
 

--- a/ckan/migration/versions/064_add_email_last_sent_column.py
+++ b/ckan/migration/versions/064_add_email_last_sent_column.py
@@ -2,9 +2,10 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
     migrate_engine.execute('''
 ALTER TABLE dashboard

--- a/ckan/migration/versions/064_add_email_last_sent_column.py
+++ b/ckan/migration/versions/064_add_email_last_sent_column.py
@@ -2,10 +2,10 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
     migrate_engine.execute('''
 ALTER TABLE dashboard

--- a/ckan/migration/versions/065_add_email_notifications_preference.py
+++ b/ckan/migration/versions/065_add_email_notifications_preference.py
@@ -2,10 +2,10 @@
 
 from sqlalchemy import *
 from migrate import *
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
     migrate_engine.execute('''
 ALTER TABLE public.user

--- a/ckan/migration/versions/065_add_email_notifications_preference.py
+++ b/ckan/migration/versions/065_add_email_notifications_preference.py
@@ -2,9 +2,10 @@
 
 from sqlalchemy import *
 from migrate import *
+from ckan.model.metadata import CkanMetaData
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
     migrate_engine.execute('''
 ALTER TABLE public.user

--- a/ckan/migration/versions/086_drop_openid_column.py
+++ b/ckan/migration/versions/086_drop_openid_column.py
@@ -1,10 +1,10 @@
 # encoding: utf-8
 
-from sqlalchemy import MetaData
+from ckan.model.metadata import CkanMetaData
 
 
 def upgrade(migrate_engine):
-    metadata = MetaData()
+    metadata = CkanMetaData()
     metadata.bind = migrate_engine
     migrate_engine.execute('''
 ALTER TABLE "user"

--- a/ckan/migration/versions/086_drop_openid_column.py
+++ b/ckan/migration/versions/086_drop_openid_column.py
@@ -1,10 +1,10 @@
 # encoding: utf-8
 
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 
 
 def upgrade(migrate_engine):
-    metadata = CkanMetaData()
+    metadata = CkanMigrationMetaData()
     metadata.bind = migrate_engine
     migrate_engine.execute('''
 ALTER TABLE "user"

--- a/ckan/model/metadata.py
+++ b/ckan/model/metadata.py
@@ -9,7 +9,7 @@ from sqlalchemy import MetaData
 from ckan.common import config as ckan_config
 
 
-class CkanMetaData(MetaData):
+class CkanMigrationMetaData(MetaData):
     """CKAN custom metadata
 
     Allow for setting metadata from CKAN's own configuration.
@@ -21,4 +21,4 @@ class CkanMetaData(MetaData):
         if u'schema' not in kwargs and schema:
             kwargs[u'schema'] = schema
 
-        super(CkanMetaData, self).__init__(*args, **kwargs)
+        super(CkanMigrationMetaData, self).__init__(*args, **kwargs)

--- a/ckan/model/metadata.py
+++ b/ckan/model/metadata.py
@@ -1,7 +1,13 @@
 # encoding: utf-8
 
+"""Wrapper for SqlAchemy MetaData
+
+Keep a consistent set of metadata for CKAN.
+"""
+
 from sqlalchemy import MetaData
 from ckan.common import config as ckan_config
+
 
 class CkanMetaData(MetaData):
     """CKAN custom metadata

--- a/ckan/model/metadata.py
+++ b/ckan/model/metadata.py
@@ -1,0 +1,18 @@
+# encoding: utf-8
+
+from sqlalchemy import MetaData
+from ckan.common import config as ckan_config
+
+class CkanMetaData(MetaData):
+    """CKAN custom metadata
+
+    Allow for setting metadata from CKAN's own configuration.
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        schema = ckan_config.get('ckan.migrations.target_schema')
+        if 'schema' not in kwargs and schema:
+            kwargs['schema'] = schema
+
+        super(CkanMetaData, self).__init__(*args, **kwargs)

--- a/ckan/model/metadata.py
+++ b/ckan/model/metadata.py
@@ -17,8 +17,8 @@ class CkanMetaData(MetaData):
     """
 
     def __init__(self, *args, **kwargs):
-        schema = ckan_config.get('ckan.migrations.target_schema')
-        if 'schema' not in kwargs and schema:
-            kwargs['schema'] = schema
+        schema = ckan_config.get(u'ckan.migrations.target_schema')
+        if u'schema' not in kwargs and schema:
+            kwargs[u'schema'] = schema
 
         super(CkanMetaData, self).__init__(*args, **kwargs)

--- a/ckan/tests/config/test_environment.py
+++ b/ckan/tests/config/test_environment.py
@@ -22,7 +22,6 @@ class TestUpdateConfig(h.FunctionalTestBase):
 
     ENV_VAR_LIST = [
         ('CKAN_SQLALCHEMY_URL', 'postgresql://mynewsqlurl/'),
-        ('CKAN_MIGRATIONS_TARGET_SCHEMA', 'public2'),
         ('CKAN_DATASTORE_WRITE_URL', 'http://mynewdbwriteurl/'),
         ('CKAN_DATASTORE_READ_URL', 'http://mynewdbreadurl/'),
         ('CKAN_SOLR_URL', 'http://mynewsolrurl/solr'),
@@ -62,8 +61,6 @@ class TestUpdateConfig(h.FunctionalTestBase):
         nosetools.assert_equal(config['solr_url'], 'http://mynewsolrurl/solr')
         nosetools.assert_equal(config['sqlalchemy.url'],
                                'postgresql://mynewsqlurl/')
-        nosetools.assert_equal(config['ckan.migrations.target_schema'],
-                               'public2')
         nosetools.assert_equal(config['ckan.datastore.write_url'],
                                'http://mynewdbwriteurl/')
         nosetools.assert_equal(config['ckan.datastore.read_url'],

--- a/ckan/tests/config/test_environment.py
+++ b/ckan/tests/config/test_environment.py
@@ -84,8 +84,6 @@ class TestUpdateConfig(h.FunctionalTestBase):
 
         nosetools.assert_equal(config['sqlalchemy.url'],
                                'postgresql://mynewsqlurl/')
-        nosetools.assert_equal(config['ckan.migrations.target_schema'],
-                               'public2')
 
 
 class TestSiteUrlMandatory(object):

--- a/ckan/tests/config/test_environment.py
+++ b/ckan/tests/config/test_environment.py
@@ -22,6 +22,7 @@ class TestUpdateConfig(h.FunctionalTestBase):
 
     ENV_VAR_LIST = [
         ('CKAN_SQLALCHEMY_URL', 'postgresql://mynewsqlurl/'),
+        ('CKAN_MIGRATIONS_TARGET_SCHEMA', 'public2'),
         ('CKAN_DATASTORE_WRITE_URL', 'http://mynewdbwriteurl/'),
         ('CKAN_DATASTORE_READ_URL', 'http://mynewdbreadurl/'),
         ('CKAN_SOLR_URL', 'http://mynewsolrurl/solr'),
@@ -61,6 +62,8 @@ class TestUpdateConfig(h.FunctionalTestBase):
         nosetools.assert_equal(config['solr_url'], 'http://mynewsolrurl/solr')
         nosetools.assert_equal(config['sqlalchemy.url'],
                                'postgresql://mynewsqlurl/')
+        nosetools.assert_equal(config['ckan.migrations.target_schema'],
+                               'public2')
         nosetools.assert_equal(config['ckan.datastore.write_url'],
                                'http://mynewdbwriteurl/')
         nosetools.assert_equal(config['ckan.datastore.read_url'],
@@ -81,6 +84,8 @@ class TestUpdateConfig(h.FunctionalTestBase):
 
         nosetools.assert_equal(config['sqlalchemy.url'],
                                'postgresql://mynewsqlurl/')
+        nosetools.assert_equal(config['ckan.migrations.target_schema'],
+                               'public2')
 
 
 class TestSiteUrlMandatory(object):

--- a/ckan/tests/model/test_metadata.py
+++ b/ckan/tests/model/test_metadata.py
@@ -1,0 +1,23 @@
+# encoding: utf-8
+
+import nose.tools
+
+import ckan.tests.helpers as helpers
+import ckan.tests.factories as factories
+
+from ckan.model.metadata import CkanMetaData
+from ckan.common import config
+
+
+assert_equals = nose.tools.assert_equals
+
+
+class TestMetaData(object):
+
+    def test_set_schema(self):
+
+        config['ckan.migrations.target_schema'] = 'test_schema'
+
+        metadata = CkanMetaData()
+
+        assert_equals(metadata.schema, 'test_schema')

--- a/ckan/tests/model/test_metadata.py
+++ b/ckan/tests/model/test_metadata.py
@@ -16,8 +16,8 @@ class TestMetaData(object):
 
     def test_set_schema(self):
 
-        config['ckan.migrations.target_schema'] = 'test_schema'
+        config[u'ckan.migrations.target_schema'] = u'test_schema'
 
         metadata = CkanMetaData()
 
-        assert_equals(metadata.schema, 'test_schema')
+        assert_equals(metadata.schema, u'test_schema')

--- a/ckan/tests/model/test_metadata.py
+++ b/ckan/tests/model/test_metadata.py
@@ -5,7 +5,7 @@ import nose.tools
 import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
 
-from ckan.model.metadata import CkanMetaData
+from ckan.model.metadata import CkanMigrationMetaData
 from ckan.common import config
 
 
@@ -18,6 +18,6 @@ class TestMetaData(object):
 
         config[u'ckan.migrations.target_schema'] = u'test_schema'
 
-        metadata = CkanMetaData()
+        metadata = CkanMigrationMetaData()
 
         assert_equals(metadata.schema, u'test_schema')

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -270,6 +270,21 @@ Default value:  ``True``
 This option allows you to disable the datastore_search_sql action function, and
 corresponding API endpoint if you do not wish it to be activated.
 
+.. _ckan.migrations.target_schema:
+
+ckan.migrations.target_schema
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Example:
+
+ ckan.migrations.target_schema = ckan
+
+Default value:  ``public``
+
+This option allows you to define the target PostgreSQL schema to which the
+migrations should be pointed. In general, this should be ``public`` to fit with
+the standard default schema.
+
 Site Settings
 -------------
 

--- a/test-core.ini
+++ b/test-core.ini
@@ -18,6 +18,9 @@ testing = true
 # Specify the Postgres database for SQLAlchemy to use
 sqlalchemy.url = postgresql://ckan_default:pass@localhost/ckan_test
 
+## Migration Settings
+ckan.migrations.target_schema = public
+
 ## Datastore
 ckan.datastore.write_url = postgresql://ckan_default:pass@localhost/datastore_test
 ckan.datastore.read_url = postgresql://datastore_default:pass@localhost/datastore_test


### PR DESCRIPTION
When PostGIS starts up using the mdillon/postgis Docker image, the TIGER
target schema ends up with a table named "state", conflicting with CKAN's
state table.

This change makes the schema used by CKAN during migration explicit, and
configurable via an environment variable, CKAN_MIGRATIONS_TARGET_SCHEMA.

Fixes #

### Proposed fixes:

- Add a `CkanMetaData` class to provide a singly-settable default target schema
- Use this in migrations all migrations
- Use a `CKAN_MIGRATIONS_TARGET_SCHEMA` to make this settable via environment variables
- Update tests to ensure environment variable works
- Add environment variable into documentation

### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
