### PR TITLE
[#3921] Change the header keys and values to string for the template controller

### DIFF
--- a/ckan/controllers/template.py
+++ b/ckan/controllers/template.py
@@ -30,7 +30,7 @@ class TemplateController(base.BaseController):
         Found)
         """
         if url.endswith(u'.txt'):
-            response.headers[u'Content-Type'] = u'text/plain; charset=utf-8'
+            response.headers[b'Content-Type'] = b'text/plain; charset=utf-8'
         # Default content-type is text/html
         try:
             return base.render(url)
@@ -38,7 +38,7 @@ class TemplateController(base.BaseController):
             if url.endswith(u'.html'):
                 base.abort(404)
             url += u'.html'
-            response.headers[u'Content-Type'] = u'text/html; charset=utf-8'
+            response.headers[b'Content-Type'] = b'text/html; charset=utf-8'
             try:
                 return base.render(url)
             except ckan.lib.render.TemplateNotFound:


### PR DESCRIPTION
Currently, after running/upgrading to CKAN 2.7 some links do not redirect as expected and fail with an internal server error.

After this change, all pages (default and additional) redirect as expected.

Fixes #

### Proposed fixes:
- Set header keys to string instead of unicode.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
