### PR TITLE
Fix name in example command to create sysadmin 

### DIFF
--- a/doc/maintaining/getting-started.rst
+++ b/doc/maintaining/getting-started.rst
@@ -36,7 +36,7 @@ example, to create a new user called ``seanh`` and make him a sysadmin:
 
 .. parsed-literal::
 
-   paster sysadmin add seanh email=seanh@localhost name=Seanh -c |production.ini|
+   paster sysadmin add seanh email=seanh@localhost name=seanh -c |production.ini|
    
 You'll be prompted to enter a password during account creation.
 


### PR DESCRIPTION
Fixes #

```
$ paster sysadmin add seanh email=seanh@localhost name=Seanh -c /etc/ckan/default/development.ini
User "seanh" not found
Create new user: seanh? [y/n]y
Password: 
Confirm password: 
Creating user: 'seanh'
Traceback (most recent call last):
  File "/vagrant/ckan/lib/cli.py", line 132, in user_add
    user_dict = logic.get_action('user_create')(context, data_dict)
  File "/vagrant/ckan/logic/__init__.py", line 457, in wrapped
    result = _action(context, data_dict, **kw)
  File "/vagrant/ckan/logic/action/create.py", line 961, in user_create
    raise ValidationError(errors)
ValidationError: {'name': ['Must be purely lowercase alphanumeric (ascii) characters and these symbols: -_']}
```

### Proposed fixes:

Add valid name as example.

### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport