### PR TITLE
[#3879] Remove authorization_group tables

### DIFF
--- a/ckan/migration/versions/087_remove_old_authz_grp_model.py
+++ b/ckan/migration/versions/087_remove_old_authz_grp_model.py
@@ -1,0 +1,12 @@
+# encoding: utf-8
+
+import ckan.model
+
+
+def upgrade(migrate_engine):
+    migrate_engine.execute(
+        '''
+        DROP TABLE IF EXISTS "authorization_group_user";
+	DROP TABLE IF EXISTS "authorization_group";
+        '''
+    )


### PR DESCRIPTION
Fixes #[#3879] Remove authorization_group tables
### Proposed fixes:

Drop the old tables that are still in the installation script.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
