### PR TITLE
setup.py: add include_package_data=True

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -216,6 +216,7 @@ setup(
     keywords='data packaging component tool server',
     long_description=__long_description__,
     zip_safe=False,
+    include_package_data=True,
     packages=find_packages(exclude=['ez_setup']),
     namespace_packages=['ckanext', 'ckanext.stats'],
     message_extractors={


### PR DESCRIPTION
Respects MANIFEST.in and makes template loader working
when installed as package in site-packages.

I'm trying to package CKAN for NixOS and this seems required as I don't (can't) run from ckan directory directly.