### PR TITLE
DOCS Note for sql searches with UPPERCASE column names

### DIFF
--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -490,6 +490,10 @@ def datastore_search_sql(context, data_dict):
     .. note:: This action is only available when using PostgreSQL 9.X and
         using a read-only user on the database.
         It is not available in :ref:`legacy mode<legacy-mode>`.
+        
+    .. note:: When source data columns (i.e. CSV) heading names are provdied
+        in all UPPERCASE you need to double quote them in the SQL select 
+        statement to avoid returning null results.
 
     :param sql: a single SQL select statement
     :type sql: string


### PR DESCRIPTION
Something we found when using the datastore_search_sql API call was that in situations where the source data headings were all uppercase, the sql would return no results (even though we knew results should show). We eventually traced this to some postgres related config around uppercase identifiers. Solution is to double quote the column name. Adding here to document for future reference incase others get stumped by this. 

Tested in CKAN 2.6.0, 2.6.4 you may want to backport this note into some of the older docs.

Original ckan-dev list reference about this at: https://lists.okfn.org/pipermail/ckan-dev/2017-November/011201.html

CC/ @amercader 

### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
