### PR TITLE
#3968 Bleach/datapusher compatibility fix

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -25,7 +25,7 @@ from webhelpers import paginate
 import webhelpers.text as whtext
 import webhelpers.date as date
 from markdown import markdown
-from bleach import clean as clean_html, ALLOWED_TAGS, ALLOWED_ATTRIBUTES
+from bleach import clean as bleach_clean, ALLOWED_TAGS, ALLOWED_ATTRIBUTES
 from pylons import url as _pylons_default_url
 from ckan.common import config, is_flask_request
 from flask import redirect as _flask_redirect
@@ -2102,7 +2102,7 @@ def render_markdown(data, auto_link=True, allow_html=False):
         data = markdown(data.strip())
     else:
         data = RE_MD_HTML_TAGS.sub('', data.strip())
-        data = clean_html(
+        data = bleach_clean(
             markdown(data), strip=True,
             tags=MARKDOWN_TAGS, attributes=MARKDOWN_ATTRIBUTES)
     # tags can be added by tag:... or tag:"...." and a link will be made
@@ -2555,6 +2555,11 @@ def radio(selected, id, checked):
         value="%s" type="radio">') % (selected, id, selected, id))
 
 
+@core_helper
+def clean_html(html):
+    return bleach_clean(unicode(html))
+
+
 core_helper(flash, name='flash')
 core_helper(localised_number)
 core_helper(localised_SI_number)
@@ -2573,7 +2578,6 @@ core_helper(whtext.truncate)
 core_helper(converters.asbool)
 # Useful additions from the stdlib.
 core_helper(urlencode)
-core_helper(clean_html, name='clean_html')
 
 
 def load_plugin_helpers():

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+import datetime
+
 import nose
 import pytz
 import tzlocal
@@ -523,6 +525,17 @@ class TestGetDisplayTimezone(object):
     @helpers.change_config('ckan.display_timezone', 'America/New_York')
     def test_named_timezone(self):
         eq_(h.get_display_timezone(), pytz.timezone('America/New_York'))
+
+
+class TestCleanHtml(object):
+    def test_disallowed_tag(self):
+        eq_(h.clean_html('<b><bad-tag>Hello'),
+            u'<b>&lt;bad-tag&gt;Hello&lt;/bad-tag&gt;</b>')
+
+    def test_non_string(self):
+        # allow a datetime for compatibility with older ckanext-datapusher
+        eq_(h.clean_html(datetime.datetime(2018, 1, 5, 10, 48, 23, 463511)),
+            u'2018-01-05 10:48:23.463511')
 
 
 class TestHelperException(helpers.FunctionalTestBase):

--- a/ckanext/datapusher/templates/datapusher/resource_data.html
+++ b/ckanext/datapusher/templates/datapusher/resource_data.html
@@ -73,7 +73,7 @@
             {% endfor %}
             <span class="date" title="{{ h.render_datetime(item.timestamp, with_hours=True) }}">
               {{ h.time_ago_from_timestamp(item.timestamp) }}
-              <a href="#" data-target="popover" data-content="<dl>{% for key, value in item.iteritems() %}<dt>{{ key }}</dt><dd>{{ h.clean_html(value) }}</dd>{% endfor %}</dl>" data-html="true">{{ _('Details') }}</a>
+              <a href="#" data-target="popover" data-content="<dl>{% for key, value in item.iteritems() %}<dt>{{ key }}</dt><dd>{{ h.clean_html(value|string) }}</dd>{% endfor %}</dl>" data-html="true">{{ _('Details') }}</a>
             </span>
           </p>
         </li>


### PR DESCRIPTION
Cast avoids exception when ckanext-datapusher is used with the new bleach version (i.e. 2.1.2 rather than 1.5.0).

Fixes #3968

### Proposed fixes:



### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

No need to backport as there has not been a release since bleach was updated.
