### PR TITLE
Changes to support Postgres 10+

### DIFF
--- a/ckanext/datastore/tests/test_unit.py
+++ b/ckanext/datastore/tests/test_unit.py
@@ -43,7 +43,7 @@ class TestTypeGetters(unittest.TestCase):
         engine = db._get_engine_from_url(config['sqlalchemy.url'])
         connection = engine.connect()
         assert db._pg_version_is_at_least(connection, '8.0')
-        assert not db._pg_version_is_at_least(connection, '10.0')
+        assert not db._pg_version_is_at_least(connection, '20.0')
 
 
 class TestLegacyModeSetting():

--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ Pairtree==0.7.1-T
 passlib==1.6.5
 paste==1.7.5.1
 polib==1.0.7
-psycopg2==2.4.5
+psycopg2==2.7.3.2
 python-magic==0.4.12
 pysolr==3.6.0
 Pylons==0.9.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ PasteDeploy==1.5.2        # via pastescript, pylons
 PasteScript==2.0.2        # via pylons
 pbr==1.10.0               # via sqlalchemy-migrate
 polib==1.0.7
-psycopg2==2.4.5
+psycopg2==2.7.3.2
 Pygments==2.1.3           # via weberror
 Pylons==0.9.7
 pysolr==3.6.0


### PR DESCRIPTION
Extends/fixes #3881 

### Proposed fixes:
- Upgrade Psycopg2 to a version supporting and compiled against libpq 10+
- Disable support in psycopg2 2.5+ for automatic conversion of native json types to python objects http://initd.org/psycopg/docs/extras.html#adapt-json
- Increase version number in postgres version check unit test of version that shouldn't exist from 10 to 20


### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
