### PR TITLE
3983 docker mac

### DIFF
--- a/contrib/docker/.env.template
+++ b/contrib/docker/.env.template
@@ -15,6 +15,8 @@ CKAN_SITE_ID=default
 # On AWS, your CKAN_SITE_URL is the output of:
 # curl -s http://169.254.169.254/latest/meta-data/public-hostname
 # CKAN_SITE_URL=http://ec2-xxx-xxx-xxx-xxx.ap-southeast-2.compute.amazonaws.com
+# On OSX with Docker for Mac, your CKAN_SITE_URL is
+# CKAN_SITE_URL=http://docker.for.mac.localhost:5000
 # When running locally, CKAN_SITE_URL must contain the port
 CKAN_SITE_URL=http://localhost:5000
 #

--- a/doc/maintaining/installing/install-from-docker-compose.rst
+++ b/doc/maintaining/installing/install-from-docker-compose.rst
@@ -83,7 +83,7 @@ a. Sensitive settings and environment variables
 
 Copy ``contrib/docker/.env.template`` to ``contrib/docker/.env`` and follow instructions
 within to set passwords and other sensitive or user-defined variables.
-The defaults will work fine in a development environment.
+The defaults will work fine in a development environment on Linux. For Windows and OSX, the `CKAN_SITE_URL` must be updated.
 
 .. note:: Related reading:
 


### PR DESCRIPTION
Fixes #3983.

### Proposed fixes:

Updates the template `.env` file for docker-compose and docs to highlight the changes needed for datapusher to run under Docker for Mac.

### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
