### PR TITLE
Update install-from-docker-compose.rst

### DIFF
--- a/doc/maintaining/installing/install-from-docker-compose.rst
+++ b/doc/maintaining/installing/install-from-docker-compose.rst
@@ -66,7 +66,7 @@ d. CKAN source
 Clone CKAN into a directory of your choice::
 
     cd /path/to/my/projects
-    git clone git@github.com:ckan/ckan.git .
+    git clone https://github.com/ckan/ckan.git
 
 This will use the latest CKAN master, which may not be stable enough for production use.
 To use a stable version, checkout the respective tag, e.g.::


### PR DESCRIPTION
Modified git checkout example to go against https://github.com/ckan/ckan.git rather than git@github.com:ckan/ckan.git .

Fixes #
The original `git clone` example was failing when run as-is; this modification allows one to clone without needing to specify any credentials. 

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
