### PR TITLE
Search by autocomplete dataset with 'like' (% searchTerm %)

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1576,7 +1576,7 @@ def package_autocomplete(context, data_dict):
     limit = data_dict.get('limit', 10)
     q = data_dict['q']
 
-    like_q = u"%s%%" % q
+    like_q = u'%' + q + u'%'
 
     query = model.Session.query(model.Package)
     query = query.filter(model.Package.state == 'active')


### PR DESCRIPTION
Modified:

like_q = u"%s%%" % q

by

like_q = u'%' + q + u'%'

In order to search as the format_autocomplete method. This way we can search terms as '%term%'

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
