### PR TITLE
Update psycopg2 dependecy to 2.7.3.2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ Pairtree==0.7.1-T
 passlib==1.6.5
 paste==1.7.5.1
 polib==1.0.7
-psycopg2==2.4.5
+psycopg2==2.7.3.2
 python-magic==0.4.12
 pysolr==3.6.0
 Pylons==0.9.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ PasteDeploy==1.5.2        # via pastescript, pylons
 PasteScript==2.0.2        # via pylons
 pbr==1.10.0               # via sqlalchemy-migrate
 polib==1.0.7
-psycopg2==2.4.5
+psycopg2==2.7.3.2
 Pygments==2.1.3           # via weberror
 Pylons==0.9.7
 pysolr==3.6.0


### PR DESCRIPTION
Old versions of psycopg2 have [a problem when encountering newer versions of PostgreSQL](https://github.com/psycopg/psycopg2/issues/594). This causes the installation of psycopg2 (and therefore CKAN) to fail, for example [on Travis](https://github.com/ckan/ckanext-pages/pull/74). This commit updates CKAN's psycopg2 dependency to the latest version, which includes a fix for the issue.

The [release notes](http://initd.org/psycopg/docs/news.html) for psycopg2 list a wide range of changes since CKAN's current version (2.4.5). Most of them seem harmless, however there is the following:

> Dropped support for client library older than PostgreSQL 9.1 (but older server versions are still supported).

As far as I can see, this should not be a problem, since version 9.1 of [libpq5](https://launchpad.net/ubuntu/precise/amd64/libpq5) and [libpq-dev](https://launchpad.net/ubuntu/precise/+package/libpq-dev) is available for all versions of Ubuntu that CKAN supports (at least 12.04 and later).