### PR TITLE
Document how to test code that relies on background jobs

### DIFF
--- a/doc/contributing/test.rst
+++ b/doc/contributing/test.rst
@@ -11,6 +11,11 @@ the front-end (JavaScript). In addition, the correct functionality of the
 complete front-end (HTML, CSS, JavaScript) on all supported browsers should be
 tested manually.
 
+.. seealso::
+
+   :doc:`CKAN coding standards for tests <testing>`
+     Conventions for writing tests for CKAN
+
 --------------
 Back-end tests
 --------------

--- a/doc/contributing/testing.rst
+++ b/doc/contributing/testing.rst
@@ -6,6 +6,14 @@ Testing coding standards
 before being merged into master**. This document gives some guidelines for
 developers who are writing tests or reviewing code for CKAN.
 
+.. seealso::
+
+   :doc:`Testing CKAN <test>`
+     How to set up your development environment to run CKAN's test suite
+
+   :ref:`background jobs testing`
+     How to handle asynchronous background jobs in your tests
+
 
 --------------------------------------
 Transitioning from legacy to new tests

--- a/doc/maintaining/background-tasks.rst
+++ b/doc/maintaining/background-tasks.rst
@@ -278,6 +278,51 @@ to use non-standard queues.
     so multiple parallel CKAN instances are not a problem.
 
 
+.. _background jobs testing:
+
+Testing code that uses background jobs
+======================================
+Due to the asynchronous nature of background jobs, code that uses them needs
+to be handled specially when writing tests.
+
+A common approach is to use the `mock package`_ to replace the
+``ckan.plugins.toolkit.enqueue_job`` function with a mock that executes jobs
+synchronously instead of asynchronously:
+
+.. code-block:: python
+
+    import mock
+
+    from ckan.tests import helpers
+
+
+    def synchronous_enqueue_job(job_func, args=None, kwargs=None, title=None):
+        '''
+        Synchronous mock for ``ckan.plugins.toolkit.enqueue_job``.
+        '''
+        args = args or []
+        kwargs = kwargs or {}
+        job_func(*args, **kwargs)
+
+
+    class TestSomethingWithBackgroundJobs(helpers.FunctionalTestBase):
+
+        @mock.patch('ckan.plugins.toolkit.enqueue_job',
+                    side_effect=synchronous_enqueue_job)
+        def test_something(self, enqueue_job_mock):
+            some_function_that_enqueues_a_background_job()
+            assert something
+
+
+Depending on how the function under test calls ``enqueue_job`` you might need
+to adapt where the mock is installed. See `mock's documentation`_ for details.
+
+
+.. _mock package: https://pypi.python.org/pypi/mock
+
+.. _mock's documentation: https://docs.python.org/dev/library/unittest.mock.html
+
+
 .. _background jobs migration:
 
 Migrating from CKAN's previous background job system


### PR DESCRIPTION
Adds a short explanation for how to test code which relies on asynchronous background jobs (as [asked recently](https://lists.okfn.org/pipermail/ckan-dev/2018-January/011311.html) on the mailing list).

I've taken the opportunity to also add links between `contributing/test` (setting up and running the tests) and `contributing/testing` (test coding conventions).