### PR TITLE
[#3905] Added CKAN wrapper around flask Babel

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -30,7 +30,7 @@ from ckan.lib.render import CkanextTemplateLoader
 from ckan.common import config, g, request, ungettext
 import ckan.lib.app_globals as app_globals
 from ckan.plugins import PluginImplementations
-from ckan.plugins.interfaces import IBlueprint, IMiddleware
+from ckan.plugins.interfaces import IBlueprint, IMiddleware, ITranslation
 from ckan.views import (identify_user,
                         set_cors_headers_for_response,
                         check_session_cookie,
@@ -39,6 +39,31 @@ from ckan.views import (identify_user,
 
 import logging
 log = logging.getLogger(__name__)
+
+
+class CKANBabel(Babel):
+    def __init__(self, *pargs, **kwargs):
+        super(CKANBabel, self).__init__(*pargs, **kwargs)
+        self.__i18n_path_idx = 0
+
+    @property
+    def domain(self):
+        default = super(CKANBabel, self).domain
+        multiple = self.app.config.get('BABEL_MULTIPLE_DOMAINS')
+        if not multiple:
+            return default
+        domains = multiple.split(';')
+        try:
+            return domains[self.__i18n_path_idx]
+        except IndexError:
+            return default
+
+    @property
+    def translation_directories(self):
+        self.__i18n_path_idx = 0
+        for path in super(CKANBabel, self).translation_directories:
+            yield path
+            self.__i18n_path_idx += 1
 
 
 def make_flask_stack(conf, **app_conf):
@@ -139,10 +164,18 @@ def make_flask_stack(conf, **app_conf):
         return dict(ungettext=ungettext)
 
     # Babel
-    app.config[u'BABEL_TRANSLATION_DIRECTORIES'] = os.path.join(root, u'i18n')
-    app.config[u'BABEL_DOMAIN'] = 'ckan'
+    pairs = [(os.path.join(root, u'i18n'), 'ckan')] + [
+        (p.i18n_directory(), p.i18n_domain())
+        for p in PluginImplementations(ITranslation)
+    ]
 
-    babel = Babel(app)
+    i18n_dirs, i18n_domains = zip(*pairs)
+
+    app.config[u'BABEL_TRANSLATION_DIRECTORIES'] = ';'.join(i18n_dirs)
+    app.config[u'BABEL_DOMAIN'] = 'ckan'
+    app.config[u'BABEL_MULTIPLE_DOMAINS'] = ';'.join(i18n_domains)
+
+    babel = CKANBabel(app)
 
     babel.localeselector(get_locale)
 

--- a/ckanext/example_itranslation/tests/test_plugin.py
+++ b/ckanext/example_itranslation/tests/test_plugin.py
@@ -7,14 +7,20 @@ from nose.tools import assert_true, assert_false
 
 
 class TestExampleITranslationPlugin(helpers.FunctionalTestBase):
+
+    @classmethod
+    def _apply_config_changes(cls, config):
+        config['ckan.plugins'] = 'example_itranslation'
+
     @classmethod
     def setup_class(cls):
         super(TestExampleITranslationPlugin, cls).setup_class()
-        plugins.load('example_itranslation')
+        # plugins.load('example_itranslation')
 
     @classmethod
     def teardown_class(cls):
-        plugins.unload('example_itranslation')
+        if plugins.plugin_loaded('example_itranslation'):
+            plugins.unload('example_itranslation')
         super(TestExampleITranslationPlugin, cls).teardown_class()
 
     def test_translated_string_in_extensions_templates(self):


### PR DESCRIPTION
As mentioned in #3905, there are two ways of fixing this bug. I tried first one, with separate initialization of babel object for each translation domain, but it seems that there is no possibility to do this during the initialization process.

If you'll take a look at [babel init](https://github.com/python-babel/flask-babel/blob/master/flask_babel/__init__.py#L80), you may see, that latest call will replace single babel instance inside application so that any future calls will have only last initialized app. 

As making PR into flask-babel is a little bit longer way(and I am not sure, that I have enough time for this right now), I introduce CKANBabel class, that inherited from FlaskBabel and adds most simple and transparent support of multi-domains(this, I hope, allow to replace it with enhanced FlaskBabel in future):
- There is additional `BABEL_MULTIPLE_DOMAINS` config, that contains domain for each translation path, separated with semi-columns(just like translation path)
- Previous `BABEL_DOMAIN` is used as fallback and set to `ckan`
- Iteration over translation paths(it implemented as property), shifts pointer of `domain` property. 
- if there is a domain for the current offset of domain pointer - it will be returned instead of the default domain
- otherwise, default domain returned