### PR TITLE
Remove unnecessary label on search form

### DIFF
--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -8315,9 +8315,6 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
 .search-form .search-input-group {
   margin-bottom: 12px;
 }
-.search-form .search-input-group .input-group-btn .btn {
-  margin-top: 25px;
-}
 .tertiary .control-order-by {
   float: none;
   margin: 0;

--- a/ckan/public/base/less/search.less
+++ b/ckan/public/base/less/search.less
@@ -89,11 +89,6 @@
     }
     .search-input-group {
         margin-bottom: 12px;
-        .input-group-btn {
-            .btn {
-                margin-top: 25px;
-            }
-        }
     }
 }
 

--- a/ckan/templates-bs2/snippets/search_form.html
+++ b/ckan/templates-bs2/snippets/search_form.html
@@ -10,7 +10,6 @@
 
   {% block search_input %}
     <div class="search-input control-group {{ search_class }}">
-      <label for="field-giant-search">{% block header_site_search_label %}{{ _('Search Datasets') }}{% endblock %}</label>
       <input id="field-giant-search" type="text" class="search" name="q" value="{{ query }}" autocomplete="off" placeholder="{{ placeholder }}">
       {% block search_input_button %}
       <button type="submit" value="search">

--- a/ckan/templates/snippets/search_form.html
+++ b/ckan/templates/snippets/search_form.html
@@ -10,7 +10,6 @@
 
   {% block search_input %}
     <div class="input-group search-input-group">
-      <label for="field-giant-search">{% block header_site_search_label %}{{ _('Search Datasets') }}{% endblock %}</label>
       <input id="field-giant-search" type="text" class="form-control" name="q" value="{{ query }}" autocomplete="off" placeholder="{{ placeholder }}">
       {% block search_input_button %}
       <span class="input-group-btn">


### PR DESCRIPTION
Fixes  Search form snippet

On search_form snippet, we have unnecessary label "Search Datasets..." that is displayed on search organizations, search group pages. This PR is removing this label and align search input field with search button
