### PR TITLE
Old style exceptions --> new style exceptions (en masse)

### DIFF
--- a/ckan/config/middleware/pylons_app.py
+++ b/ckan/config/middleware/pylons_app.py
@@ -155,7 +155,7 @@ def make_pylons_stack(conf, full_stack=True, static_files=True,
             path = os.path.join(storage_directory, 'storage')
             try:
                 os.makedirs(path)
-            except OSError, e:
+            except OSError as e:
                 # errno 17 is file already exists
                 if e.errno != 17:
                     raise

--- a/ckan/controllers/admin.py
+++ b/ckan/controllers/admin.py
@@ -100,7 +100,7 @@ class AdminController(base.BaseController):
 
                 data = logic.get_action('config_option_update')(
                     {'user': c.user}, data_dict)
-            except logic.ValidationError, e:
+            except logic.ValidationError as e:
                 errors = e.error_dict
                 error_summary = e.error_summary
                 vars = {'data': data, 'errors': errors,
@@ -179,7 +179,7 @@ class AdminController(base.BaseController):
                         # page Ensure that whatever 'head' pointer is used
                         # gets moved down to the next revision
                         model.repo.purge_revision(revision, leave_record=False)
-                    except Exception, inst:
+                    except Exception as inst:
                         msg = _('Problem purging revision %s: %s') % (id, inst)
                         msgs.append(msg)
                 h.flash_success(_('Purge complete'))

--- a/ckan/controllers/api.py
+++ b/ckan/controllers/api.py
@@ -144,7 +144,7 @@ class ApiController(base.BaseController):
     def _set_response_header(self, name, value):
         try:
             value = str(value)
-        except Exception, inst:
+        except Exception as inst:
             msg = "Couldn't convert '%s' header value '%s' to string: %s" % \
                 (name, value, inst)
             raise Exception(msg)
@@ -179,7 +179,7 @@ class ApiController(base.BaseController):
             side_effect_free = getattr(function, 'side_effect_free', False)
             request_data = self._get_request_data(
                 try_url_params=side_effect_free)
-        except ValueError, inst:
+        except ValueError as inst:
             log.info('Bad Action API request data: %s', inst)
             return self._finish_bad_request(
                 _('JSON Error: %s') % inst)
@@ -202,7 +202,7 @@ class ApiController(base.BaseController):
             result = function(context, request_data)
             return_dict['success'] = True
             return_dict['result'] = result
-        except DataError, e:
+        except DataError as e:
             log.info('Format incorrect (Action API): %s - %s',
                      e.error, request_data)
             return_dict['error'] = {'__type': 'Integrity Error',
@@ -210,7 +210,7 @@ class ApiController(base.BaseController):
                                     'data': request_data}
             return_dict['success'] = False
             return self._finish(400, return_dict, content_type='json')
-        except NotAuthorized, e:
+        except NotAuthorized as e:
             return_dict['error'] = {'__type': 'Authorization Error',
                                     'message': _('Access denied')}
             return_dict['success'] = False
@@ -219,14 +219,14 @@ class ApiController(base.BaseController):
                 return_dict['error']['message'] += u': %s' % e
 
             return self._finish(403, return_dict, content_type='json')
-        except NotFound, e:
+        except NotFound as e:
             return_dict['error'] = {'__type': 'Not Found Error',
                                     'message': _('Not found')}
             if unicode(e):
                 return_dict['error']['message'] += u': %s' % e
             return_dict['success'] = False
             return self._finish(404, return_dict, content_type='json')
-        except ValidationError, e:
+        except ValidationError as e:
             error_dict = e.error_dict
             error_dict['__type'] = 'Validation Error'
             return_dict['error'] = error_dict
@@ -234,18 +234,18 @@ class ApiController(base.BaseController):
             # CS nasty_string ignore
             log.info('Validation error (Action API): %r', str(e.error_dict))
             return self._finish(409, return_dict, content_type='json')
-        except search.SearchQueryError, e:
+        except search.SearchQueryError as e:
             return_dict['error'] = {'__type': 'Search Query Error',
                                     'message': 'Search Query is invalid: %r' %
                                     e.args}
             return_dict['success'] = False
             return self._finish(400, return_dict, content_type='json')
-        except search.SearchError, e:
+        except search.SearchError as e:
             return_dict['error'] = {'__type': 'Search Error',
                                     'message': 'Search error: %r' % e.args}
             return_dict['success'] = False
             return self._finish(409, return_dict, content_type='json')
-        except search.SearchIndexError, e:
+        except search.SearchIndexError as e:
             return_dict['error'] = {
                 '__type': 'Search Index Error',
                 'message': 'Unable to add package to search index: %s' %
@@ -294,9 +294,9 @@ class ApiController(base.BaseController):
                 _('Cannot list entity of this type: %s') % register)
         try:
             return self._finish_ok(action(context, {'id': id}))
-        except NotFound, e:
+        except NotFound as e:
             return self._finish_not_found(unicode(e))
-        except NotAuthorized, e:
+        except NotAuthorized as e:
             return self._finish_not_authz(unicode(e))
 
     def show(self, ver=None, register=None, subregister=None,
@@ -323,9 +323,9 @@ class ApiController(base.BaseController):
                 _('Cannot read entity of this type: %s') % register)
         try:
             return self._finish_ok(action(context, data_dict))
-        except NotFound, e:
+        except NotFound as e:
             return self._finish_not_found(unicode(e))
-        except NotAuthorized, e:
+        except NotAuthorized as e:
             return self._finish_not_authz(unicode(e))
 
     def create(self, ver=None, register=None, subregister=None,
@@ -347,7 +347,7 @@ class ApiController(base.BaseController):
             request_data = self._get_request_data()
             data_dict = {'id': id, 'id2': id2, 'rel': subregister}
             data_dict.update(request_data)
-        except ValueError, inst:
+        except ValueError as inst:
             return self._finish_bad_request(
                 _('JSON Error: %s') % inst)
 
@@ -366,15 +366,15 @@ class ApiController(base.BaseController):
                                           data_dict.get("id")))
             return self._finish_ok(response_data,
                                    resource_location=location)
-        except NotAuthorized, e:
+        except NotAuthorized as e:
             return self._finish_not_authz(unicode(e))
-        except NotFound, e:
+        except NotFound as e:
             return self._finish_not_found(unicode(e))
-        except ValidationError, e:
+        except ValidationError as e:
             # CS: nasty_string ignore
             log.info('Validation error (REST create): %r', str(e.error_dict))
             return self._finish(409, e.error_dict, content_type='json')
-        except DataError, e:
+        except DataError as e:
             log.info('Format incorrect (REST create): %s - %s',
                      e.error, request_data)
             error_dict = {
@@ -410,7 +410,7 @@ class ApiController(base.BaseController):
             request_data = self._get_request_data()
             data_dict = {'id': id, 'id2': id2, 'rel': subregister}
             data_dict.update(request_data)
-        except ValueError, inst:
+        except ValueError as inst:
             return self._finish_bad_request(
                 _('JSON Error: %s') % inst)
 
@@ -422,15 +422,15 @@ class ApiController(base.BaseController):
         try:
             response_data = action(context, data_dict)
             return self._finish_ok(response_data)
-        except NotAuthorized, e:
+        except NotAuthorized as e:
             return self._finish_not_authz(unicode(e))
-        except NotFound, e:
+        except NotFound as e:
             return self._finish_not_found(unicode(e))
-        except ValidationError, e:
+        except ValidationError as e:
             # CS: nasty_string ignore
             log.info('Validation error (REST update): %r', str(e.error_dict))
             return self._finish(409, e.error_dict, content_type='json')
-        except DataError, e:
+        except DataError as e:
             log.info('Format incorrect (REST update): %s - %s',
                      e.error, request_data)
             error_dict = {
@@ -469,11 +469,11 @@ class ApiController(base.BaseController):
         try:
             response_data = action(context, data_dict)
             return self._finish_ok(response_data)
-        except NotAuthorized, e:
+        except NotAuthorized as e:
             return self._finish_not_authz(unicode(e))
-        except NotFound, e:
+        except NotFound as e:
             return self._finish_not_found(unicode(e))
-        except ValidationError, e:
+        except ValidationError as e:
             # CS: nasty_string ignore
             log.info('Validation error (REST delete): %r', str(e.error_dict))
             return self._finish(409, e.error_dict, content_type='json')
@@ -497,7 +497,7 @@ class ApiController(base.BaseController):
                 since_time_str = request.params['since_time']
                 try:
                     since_time = h.date_str_to_datetime(since_time_str)
-                except ValueError, inst:
+                except ValueError as inst:
                     return self._finish_bad_request('ValueError: %s' % inst)
             else:
                 return self._finish_bad_request(
@@ -511,7 +511,7 @@ class ApiController(base.BaseController):
         elif register in ['dataset', 'package', 'resource']:
             try:
                 params = MultiDict(self._get_search_params(request.params))
-            except ValueError, e:
+            except ValueError as e:
                 return self._finish_bad_request(
                     _('Could not read parameters: %r' % e))
 
@@ -571,7 +571,7 @@ class ApiController(base.BaseController):
                         del params['callback']
                     results = query.run(params)
                 return self._finish_ok(results)
-            except search.SearchError, e:
+            except search.SearchError as e:
                 log.exception(e)
                 return self._finish_bad_request(
                     _('Bad search option: %s') % e)
@@ -585,7 +585,7 @@ class ApiController(base.BaseController):
             try:
                 qjson_param = request_params['qjson'].replace('\\\\u', '\\u')
                 params = h.json.loads(qjson_param, encoding='utf8')
-            except ValueError, e:
+            except ValueError as e:
                 raise ValueError(_('Malformed qjson value: %r')
                                  % e)
         elif len(request_params) == 1 and \
@@ -785,7 +785,7 @@ class ApiController(base.BaseController):
                     request_data = keys[0]
                 else:
                     request_data = urllib.unquote_plus(request.body)
-            except Exception, inst:
+            except Exception as inst:
                 msg = "Could not find the POST data: %r : %s" % \
                       (request.POST, inst)
                 raise ValueError(msg)
@@ -799,7 +799,7 @@ class ApiController(base.BaseController):
                     request_data = request.body
                 else:
                     request_data = None
-            except Exception, inst:
+            except Exception as inst:
                 msg = "Could not extract request body data: %s" % \
                       (inst)
                 raise ValueError(msg)
@@ -814,7 +814,7 @@ class ApiController(base.BaseController):
         if request_data and request.content_type != 'multipart/form-data':
             try:
                 request_data = h.json.loads(request_data, encoding='utf8')
-            except ValueError, e:
+            except ValueError as e:
                 raise ValueError('Error decoding JSON data. '
                                  'Error: %r '
                                  'JSON data extracted from the request: %r' %

--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -364,7 +364,7 @@ class GroupController(base.BaseController):
 
             c.sort_by_selected = sort_by
 
-        except search.SearchError, se:
+        except search.SearchError as se:
             log.error('Group search error: %r', se.args)
             c.query_error = True
             c.page = h.Page(collection=[])
@@ -542,11 +542,11 @@ class GroupController(base.BaseController):
 
             # Redirect to the appropriate _read route for the type of group
             h.redirect_to(group['type'] + '_read', id=group['name'])
-        except (NotFound, NotAuthorized), e:
+        except (NotFound, NotAuthorized) as e:
             abort(404, _('Group not found'))
         except dict_fns.DataError:
             abort(400, _(u'Integrity Error'))
-        except ValidationError, e:
+        except ValidationError as e:
             errors = e.error_dict
             error_summary = e.error_summary
             return self.new(data_dict, errors, error_summary)
@@ -572,11 +572,11 @@ class GroupController(base.BaseController):
                 self._force_reindex(group)
 
             h.redirect_to('%s_read' % group['type'], id=group['name'])
-        except (NotFound, NotAuthorized), e:
+        except (NotFound, NotAuthorized) as e:
             abort(404, _('Group not found'))
         except dict_fns.DataError:
             abort(400, _(u'Integrity Error'))
-        except ValidationError, e:
+        except ValidationError as e:
             errors = e.error_dict
             error_summary = e.error_summary
             return self.edit(id, data_dict, errors, error_summary)
@@ -721,7 +721,7 @@ class GroupController(base.BaseController):
             abort(403, _('Unauthorized to add member to group %s') % '')
         except NotFound:
             abort(404, _('Group not found'))
-        except ValidationError, e:
+        except ValidationError as e:
             h.flash_error(e.error_summary)
         return self._render_template('group/member_new.html', group_type)
 

--- a/ckan/controllers/home.py
+++ b/ckan/controllers/home.py
@@ -26,7 +26,7 @@ class HomeController(base.BaseController):
         except logic.NotAuthorized:
             base.abort(403, _('Not authorized to see this page'))
         except (sqlalchemy.exc.ProgrammingError,
-                sqlalchemy.exc.OperationalError), e:
+                sqlalchemy.exc.OperationalError) as e:
             # postgres and sqlite errors for missing tables
             msg = str(e)
             if ('relation' in msg and 'does not exist' in msg) or \

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -295,14 +295,14 @@ class PackageController(base.BaseController):
             )
             c.search_facets = query['search_facets']
             c.page.items = query['results']
-        except SearchQueryError, se:
+        except SearchQueryError as se:
             # User's search parameters are invalid, in such a way that is not
             # achievable with the web interface, so return a proper error to
             # discourage spiders which are the main cause of this.
             log.info('Dataset search query rejected: %r', se.args)
             abort(400, _('Invalid search query: {error_message}')
                   .format(error_message=str(se)))
-        except SearchError, se:
+        except SearchError as se:
             # May be bad input from the user, but may also be more serious like
             # bad code causing a SOLR syntax error, or a problem connecting to
             # SOLR
@@ -369,9 +369,9 @@ class PackageController(base.BaseController):
                 try:
                     date = h.date_str_to_datetime(revision_ref)
                     context['revision_date'] = date
-                except TypeError, e:
+                except TypeError as e:
                     abort(400, _('Invalid revision format: %r') % e.args)
-                except ValueError, e:
+                except ValueError as e:
                     abort(400, _('Invalid revision format: %r') % e.args)
         elif len(split) > 2:
             abort(400, _('Invalid revision format: %r') %
@@ -585,7 +585,7 @@ class PackageController(base.BaseController):
                     get_action('resource_update')(context, data)
                 else:
                     get_action('resource_create')(context, data)
-            except ValidationError, e:
+            except ValidationError as e:
                 errors = e.error_dict
                 error_summary = e.error_summary
                 return self.resource_edit(id, resource_id, data,
@@ -691,7 +691,7 @@ class PackageController(base.BaseController):
                     get_action('resource_update')(context, data)
                 else:
                     get_action('resource_create')(context, data)
-            except ValidationError, e:
+            except ValidationError as e:
                 errors = e.error_dict
                 error_summary = e.error_summary
                 return self.new_resource(id, data, errors, error_summary)
@@ -934,17 +934,17 @@ class PackageController(base.BaseController):
                                      package_type=package_type)
         except NotAuthorized:
             abort(403, _('Unauthorized to read package %s') % '')
-        except NotFound, e:
+        except NotFound as e:
             abort(404, _('Dataset not found'))
         except dict_fns.DataError:
             abort(400, _(u'Integrity Error'))
-        except SearchIndexError, e:
+        except SearchIndexError as e:
             try:
                 exc_str = unicode(repr(e.args))
             except Exception:  # We don't like bare excepts
                 exc_str = unicode(str(e))
             abort(500, _(u'Unable to add package to search index.') + exc_str)
-        except ValidationError, e:
+        except ValidationError as e:
             errors = e.error_dict
             error_summary = e.error_summary
             if is_an_update:
@@ -982,17 +982,17 @@ class PackageController(base.BaseController):
                                      package_type=package_type)
         except NotAuthorized:
             abort(403, _('Unauthorized to read package %s') % id)
-        except NotFound, e:
+        except NotFound as e:
             abort(404, _('Dataset not found'))
         except dict_fns.DataError:
             abort(400, _(u'Integrity Error'))
-        except SearchIndexError, e:
+        except SearchIndexError as e:
             try:
                 exc_str = unicode(repr(e.args))
             except Exception:  # We don't like bare excepts
                 exc_str = unicode(str(e))
             abort(500, _(u'Unable to update search index.') + exc_str)
-        except ValidationError, e:
+        except ValidationError as e:
             errors = e.error_dict
             error_summary = e.error_summary
             return self.edit(name_or_id, data_dict, errors, error_summary)
@@ -1435,7 +1435,7 @@ class PackageController(base.BaseController):
         # update resource should tell us early if the user has privilages.
         try:
             check_access('resource_update', context, {'id': resource_id})
-        except NotAuthorized, e:
+        except NotAuthorized as e:
             abort(403, _('User %r not authorized to edit %s') % (c.user, id))
 
         # get resource and package data
@@ -1475,7 +1475,7 @@ class PackageController(base.BaseController):
                     data = get_action('resource_view_update')(context, data)
                 else:
                     data = get_action('resource_view_create')(context, data)
-            except ValidationError, e:
+            except ValidationError as e:
                 # Could break preview if validation error
                 to_preview = False
                 errors = e.error_dict

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -243,7 +243,7 @@ class UserController(base.BaseController):
             user = get_action('user_create')(context, data_dict)
         except NotAuthorized:
             abort(403, _('Unauthorized to create user %s') % '')
-        except NotFound, e:
+        except NotFound as e:
             abort(404, _('User not found'))
         except DataError:
             abort(400, _(u'Integrity Error'))
@@ -251,7 +251,7 @@ class UserController(base.BaseController):
             error_msg = _(u'Bad Captcha. Please try again.')
             h.flash_error(error_msg)
             return self.new(data_dict)
-        except ValidationError, e:
+        except ValidationError as e:
             errors = e.error_dict
             error_summary = e.error_summary
             return self.new(data_dict, errors, error_summary)
@@ -373,11 +373,11 @@ class UserController(base.BaseController):
             h.redirect_to(controller='user', action='read', id=user['name'])
         except NotAuthorized:
             abort(403, _('Unauthorized to edit user %s') % id)
-        except NotFound, e:
+        except NotFound as e:
             abort(404, _('User not found'))
         except DataError:
             abort(400, _(u'Integrity Error'))
-        except ValidationError, e:
+        except ValidationError as e:
             errors = e.error_dict
             error_summary = e.error_summary
             return self.edit(id, data_dict, errors, error_summary)
@@ -497,7 +497,7 @@ class UserController(base.BaseController):
                     h.flash_success(_('Please check your inbox for '
                                     'a reset code.'))
                     h.redirect_to('/')
-                except mailer.MailerException, e:
+                except mailer.MailerException as e:
                     h.flash_error(_('Could not send reset link: %s') %
                                   unicode(e))
         return render('user/request_reset.html')
@@ -518,7 +518,7 @@ class UserController(base.BaseController):
             user_dict = get_action('user_show')(context, data_dict)
 
             user_obj = context['user_obj']
-        except NotFound, e:
+        except NotFound as e:
             abort(404, _('User not found'))
 
         c.reset_key = request.params.get('key')
@@ -544,13 +544,13 @@ class UserController(base.BaseController):
                 h.redirect_to('/')
             except NotAuthorized:
                 h.flash_error(_('Unauthorized to edit user %s') % id)
-            except NotFound, e:
+            except NotFound as e:
                 h.flash_error(_('User not found'))
             except DataError:
                 h.flash_error(_(u'Integrity Error'))
-            except ValidationError, e:
+            except ValidationError as e:
                 h.flash_error(u'%r' % e.error_dict)
-            except ValueError, ve:
+            except ValueError as ve:
                 h.flash_error(unicode(ve))
             user_dict['state'] = user_state
 

--- a/ckan/lib/celery_app.py
+++ b/ckan/lib/celery_app.py
@@ -56,7 +56,7 @@ for entry_point in iter_entry_points(group='ckan.celery_task'):
         default_config['CELERY_IMPORTS'].extend(
             entry_point.load()()
         )
-    except VersionConflict, e:
+    except VersionConflict as e:
         error = 'ERROR in entry point load: %s %s' % (entry_point, e)
         log.critical(error)
         pass

--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -140,7 +140,7 @@ def user_add(args):
         }
         user_dict = logic.get_action('user_create')(context, data_dict)
         pprint(user_dict)
-    except logic.ValidationError, e:
+    except logic.ValidationError as e:
         error(traceback.format_exc())
 
 ## from http://code.activestate.com/recipes/577058/ MIT licence.

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2461,7 +2461,7 @@ def resource_formats():
         with open(format_file_path) as format_file:
             try:
                 file_resource_formats = json.loads(format_file.read())
-            except ValueError, e:
+            except ValueError as e:
                 # includes simplejson.decoder.JSONDecodeError
                 raise ValueError('Invalid JSON syntax in %s: %s' %
                                  (format_file_path, e))

--- a/ckan/lib/jinja_extensions.py
+++ b/ckan/lib/jinja_extensions.py
@@ -178,7 +178,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 continue
             try:
                 contents = f.read().decode(self.encoding)
-            except UnicodeDecodeError, e:
+            except UnicodeDecodeError as e:
                 log.critical(
                     'Template corruption in `%s` unicode decode errors'
                     % filename

--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -62,7 +62,7 @@ def _mail_recipient(recipient_name, recipient_email,
 
     try:
         smtp_connection.connect(smtp_server)
-    except socket.error, e:
+    except socket.error as e:
         log.exception(e)
         raise MailerException('SMTP server could not be connected to: "%s" %s'
                               % (smtp_server, e))
@@ -89,7 +89,7 @@ def _mail_recipient(recipient_name, recipient_email,
         smtp_connection.sendmail(mail_from, [recipient_email], msg.as_string())
         log.info("Sent email to {0}".format(recipient_email))
 
-    except smtplib.SMTPException, e:
+    except smtplib.SMTPException as e:
         msg = '%r' % e
         log.exception(msg)
         raise MailerException(msg)

--- a/ckan/lib/navl/dictization_functions.py
+++ b/ckan/lib/navl/dictization_functions.py
@@ -218,7 +218,7 @@ def convert(converter, key, converted_data, errors, context):
         try:
             value = converted_data.get(key)
             value = converter().to_python(value, state=context)
-        except fe.Invalid, e:
+        except fe.Invalid as e:
             errors[key].append(e.msg)
         return
 
@@ -226,7 +226,7 @@ def convert(converter, key, converted_data, errors, context):
         try:
             value = converted_data.get(key)
             value = converter.to_python(value, state=context)
-        except fe.Invalid, e:
+        except fe.Invalid as e:
             errors[key].append(e.msg)
         return
 
@@ -234,22 +234,22 @@ def convert(converter, key, converted_data, errors, context):
         value = converter(converted_data.get(key))
         converted_data[key] = value
         return
-    except TypeError, e:
+    except TypeError as e:
         # hack to make sure the type error was caused by the wrong
         # number of arguments given.
         if converter.__name__ not in str(e):
             raise
-    except Invalid, e:
+    except Invalid as e:
         errors[key].append(e.error)
         return
 
     try:
         converter(key, converted_data, errors, context)
         return
-    except Invalid, e:
+    except Invalid as e:
         errors[key].append(e.error)
         return
-    except TypeError, e:
+    except TypeError as e:
         # hack to make sure the type error was caused by the wrong
         # number of arguments given.
         if converter.__name__ not in str(e):
@@ -259,7 +259,7 @@ def convert(converter, key, converted_data, errors, context):
         value = converter(converted_data.get(key), context)
         converted_data[key] = value
         return
-    except Invalid, e:
+    except Invalid as e:
         errors[key].append(e.error)
         return
 

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -72,7 +72,7 @@ def index_for(_type):
     try:
         _type_n = _normalize_type(_type)
         return _INDICES[_type_n]()
-    except KeyError, ke:
+    except KeyError as ke:
         log.warn("Unknown search type: %s" % _type)
         return NoopSearchIndex()
 
@@ -83,7 +83,7 @@ def query_for(_type):
     try:
         _type_n = _normalize_type(_type)
         return _QUERIES[_type_n]()
-    except KeyError, ke:
+    except KeyError as ke:
         raise SearchError("Unknown search type: %s" % _type)
 
 
@@ -99,7 +99,7 @@ def dispatch_by_operation(entity_type, entity, operation):
             index.remove_dict(entity)
         else:
             log.warn("Unknown operation: %s" % operation)
-    except Exception, ex:
+    except Exception as ex:
         log.exception(ex)
         # we really need to know about any exceptions, so reraise
         # (see #1172)
@@ -193,7 +193,7 @@ def rebuild(package_id=None, only_missing=False, force=False, refresh=False,
                     ),
                     defer_commit
                 )
-            except Exception, e:
+            except Exception as e:
                 log.error(u'Error while indexing dataset %s: %s' %
                           (pkg_id, repr(e)))
                 if force:

--- a/ckan/lib/search/common.py
+++ b/ckan/lib/search/common.py
@@ -55,7 +55,7 @@ def is_available():
     try:
         conn = make_connection()
         conn.search(q="*:*", rows=1)
-    except Exception, e:
+    except Exception as e:
         log.exception(e)
         return False
     return True

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -50,11 +50,11 @@ def clear_index():
     query = "+site_id:\"%s\"" % (config.get('ckan.site_id'))
     try:
         conn.delete(q=query)
-    except socket.error, e:
+    except socket.error as e:
         err = 'Could not connect to SOLR %r: %r' % (conn.url, e)
         log.error(err)
         raise SearchIndexError(err)
-    except pysolr.SolrError, e:
+    except pysolr.SolrError as e:
         err = 'SOLR %r exception: %r' % (conn.url, e)
         log.error(err)
         raise SearchIndexError(err)
@@ -293,12 +293,12 @@ class PackageSearchIndex(SearchIndex):
             if not asbool(config.get('ckan.search.solr_commit', 'true')):
                 commit = False
             conn.add(docs=[pkg_dict], commit=commit)
-        except pysolr.SolrError, e:
+        except pysolr.SolrError as e:
             msg = 'Solr returned an error: {0}'.format(
                 e[:1000] # limit huge responses
             )
             raise SearchIndexError(msg)
-        except socket.error, e:
+        except socket.error as e:
             err = 'Could not connect to Solr using {0}: {1}'.format(conn.url, str(e))
             log.error(err)
             raise SearchIndexError(err)
@@ -310,7 +310,7 @@ class PackageSearchIndex(SearchIndex):
         try:
             conn = make_connection()
             conn.commit(waitSearcher=False)
-        except Exception, e:
+        except Exception as e:
             log.exception(e)
             raise SearchIndexError(e)
 
@@ -323,6 +323,6 @@ class PackageSearchIndex(SearchIndex):
         try:
             commit = asbool(config.get('ckan.search.solr_commit', 'true'))
             conn.delete(q=query, commit=commit)
-        except Exception, e:
+        except Exception as e:
             log.exception(e)
             raise SearchIndexError(e)

--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -270,7 +270,7 @@ class PackageSearchQuery(SearchQuery):
         log.debug('Package query: %r' % query)
         try:
             solr_response = conn.search(**query)
-        except pysolr.SolrError, e:
+        except pysolr.SolrError as e:
             raise SearchError('SOLR returned an error running query: %r Error: %r' %
                               (query, e))
 
@@ -358,7 +358,7 @@ class PackageSearchQuery(SearchQuery):
         log.debug('Package query: %r' % query)
         try:
             solr_response = conn.search(**query)
-        except pysolr.SolrError, e:
+        except pysolr.SolrError as e:
             # Error with the sort parameter.  You see slightly different
             # error messages depending on whether the SOLR JSON comes back
             # or Jetty gets in the way converting it to HTML - not sure why

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -131,7 +131,7 @@ class Upload(object):
                                          'uploads', object_type)
         try:
             os.makedirs(self.storage_path)
-        except OSError, e:
+        except OSError as e:
             # errno 17 is file already exists
             if e.errno != 17:
                 raise
@@ -209,7 +209,7 @@ class ResourceUpload(object):
         self.storage_path = os.path.join(path, 'resources')
         try:
             os.makedirs(self.storage_path)
-        except OSError, e:
+        except OSError as e:
             # errno 17 is file already exists
             if e.errno != 17:
                 raise
@@ -247,7 +247,7 @@ class ResourceUpload(object):
                     self.mimetype = magic.from_buffer(self.upload_file.read(),
                                                       mime=True)
                     self.upload_file.seek(0, os.SEEK_SET)
-                except IOError, e:
+                except IOError as e:
                     # Not that important if call above fails
                     self.mimetype = None
 
@@ -289,7 +289,7 @@ class ResourceUpload(object):
         if self.filename:
             try:
                 os.makedirs(directory)
-            except OSError, e:
+            except OSError as e:
                 # errno 17 is file already exists
                 if e.errno != 17:
                     raise
@@ -313,5 +313,5 @@ class ResourceUpload(object):
         if self.clear:
             try:
                 os.remove(filepath)
-            except OSError, e:
+            except OSError as e:
                 pass

--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -303,7 +303,7 @@ def check_access(action, context, data_dict=None):
         if not logic_authorization['success']:
             msg = logic_authorization.get('msg', '')
             raise NotAuthorized(msg)
-    except NotAuthorized, e:
+    except NotAuthorized as e:
         log.debug(u'check access NotAuthorized - %s user=%s "%s"',
                   action, user, unicode(e))
         raise

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -315,7 +315,7 @@ def resource_create(context, data_dict):
         context['use_cache'] = False
         _get_action('package_update')(context, pkg_dict)
         context.pop('defer_commit')
-    except ValidationError, e:
+    except ValidationError as e:
         try:
             raise ValidationError(e.error_dict['resources'][-1])
         except (KeyError, IndexError):

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -186,7 +186,7 @@ def resource_delete(context, data_dict):
                 r['id'] == id]
     try:
         pkg_dict = _get_action('package_update')(context, pkg_dict)
-    except ValidationError, e:
+    except ValidationError as e:
         errors = e.error_dict['resources'][-1]
         raise ValidationError(errors)
 
@@ -357,7 +357,7 @@ def _group_or_org_delete(context, data_dict, is_org=False):
             if not authz.check_config_permission('ckan.auth.create_unowned_dataset'):
                 raise ValidationError(_('Organization cannot be deleted while it '
                                       'still has datasets'))
-            
+
             pkg_table = model.package_table
             # using Core SQLA instead of the ORM should be faster
             model.Session.execute(

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -114,7 +114,7 @@ def resource_update(context, data_dict):
         context['use_cache'] = False
         updated_pkg_dict = _get_action('package_update')(context, pkg_dict)
         context.pop('defer_commit')
-    except ValidationError, e:
+    except ValidationError as e:
         try:
             raise ValidationError(e.error_dict['resources'][-1])
         except (KeyError, IndexError):

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -126,7 +126,7 @@ def isodate(value, context):
         return None
     try:
         date = h.date_str_to_datetime(value)
-    except (TypeError, ValueError), e:
+    except (TypeError, ValueError) as e:
         raise Invalid(_('Date format incorrect'))
     return date
 

--- a/ckan/migration/versions/018_adjust_licenses.py
+++ b/ckan/migration/versions/018_adjust_licenses.py
@@ -6,82 +6,82 @@ import uuid
 
 
 map = {
-    u'OSI Approved::Mozilla Public License 1.1 (MPL)': 'mozilla1.1', 
-    u'OKD Compliant::Creative Commons Attribution-ShareAlike': 'cc-by-sa', 
-    u'OSI Approved::Nokia Open Source License': 'nokia', 
-    u'OSI Approved::Computer Associates Trusted Open Source License 1.1': 'ca-tosl1.1', 
-    u'OKD Compliant::Higher Education Statistics Agency Copyright with data.gov.uk rights': 'hesa-withrights', 
-    u'OSI Approved::Lucent Public License Version 1.02': 'lucent1.02', 
-    u'OSI Approved::Open Software License': 'osl-3.0', 
-    u'OSI Approved::Motosoto License': 'motosoto', 
-    u'OSI Approved::MIT license': 'mit-license', 
-    u'OSI Approved::Mozilla Public License 1.0 (MPL)': 'mozilla', 
-    u'OSI Approved::GNU General Public License v3 (GPLv3)': 'gpl-3.0', 
-    u'OKD Compliant::UK Click Use PSI': 'ukclickusepsi', 
-    u'OSI Approved::Eiffel Forum License': 'eiffel', 
-    u'OSI Approved::Jabber Open Source License': 'jabber-osl', 
-    u'OSI Approved::Open Group Test Suite License': 'opengroup', 
-    u'OSI Approved::Entessa Public License': 'entessa', 
-    u'OKD Compliant::Other': 'other-open', 
-    u'OSI Approved::EU DataGrid Software License': 'eudatagrid', 
-    u'OSI Approved::Zope Public License': 'zpl', 
-    u'OSI Approved::Naumen Public License': 'naumen', 
-    u'OSI Approved::wxWindows Library License': 'wxwindows', 
-    u'OKD Compliant::GNU Free Documentation License (GFDL)': 'gfdl', 
-    u'Non-OKD Compliant::Non-Commercial Other': 'other-nc', 
-    u'OKD Compliant::Open Data Commons Public Domain Dedication and License (PDDL)': 'odc-pddl', 
-    u'OSI Approved::NASA Open Source Agreement 1.3': 'nasa1.3', 
-    u'OSI Approved::X.Net License': 'xnet', 
-    u'OSI Approved::W3C License': 'W3C', 
-    u'OSI Approved::Academic Free License': 'afl-3.0', 
-    u'Non-OKD Compliant::Crown Copyright': 'ukcrown', 
-    u'OSI Approved::RealNetworks Public Source License V1.0': 'real', 
-    u'OSI Approved::Common Development and Distribution License': 'cddl1', 
-    u'OSI Approved::Intel Open Source License': 'intel-osl', 
-    u'OSI Approved::GNU General Public License (GPL)': 'gpl-2.0', 
-    u'Non-OKD Compliant::Creative Commons Non-Commercial (Any)': 'cc-nc', 
-    u'Non-OKD Compliant::Other': 'other-closed', 
-    u'Other::License Not Specified': 'notspecified', 
-    u'OSI Approved::Sybase Open Watcom Public License 1.0': 'sybase', 
-    u'OSI Approved::Educational Community License': 'ecl2', 
-    u'OSI Approved::Sun Industry Standards Source License (SISSL)': 'sun-issl', 
-    u'OKD Compliant::Other (Public Domain)': 'other-pd', 
-    u'OKD Compliant::Public Domain': 'other-pd', 
-    u'OKD Compliant::Creative Commons Attribution': 'cc-by', 
-    u'OSI Approved::OCLC Research Public License 2.0': 'oclc2', 
-    u'OSI Approved::Artistic license': 'artistic-license-2.0', 
-    u'OKD Compliant::Other (Attribution)': 'other-at', 
-    u'OSI Approved::Sleepycat License': 'sleepycat', 
-    u'OSI Approved::PHP License': 'php', 
-    u'OKD Compliant::Creative Commons CCZero': 'cc-zero', 
-    u'OSI Approved::University of Illinois/NCSA Open Source License': 'UoI-NCSA', 
-    u'OSI Approved::Adaptive Public License': 'apl1.0', 
-    u'OSI Approved::Ricoh Source Code Public License': 'ricohpl', 
-    u'OSI Approved::Eiffel Forum License V2.0': 'ver2_eiffel', 
-    u'OSI Approved::Python license (CNRI Python License)': 'pythonpl', 
-    u'OSI Approved::Frameworx License': 'frameworx', 
-    u'OSI Approved::IBM Public License': 'ibmpl', 
-    u'OSI Approved::Fair License': 'fair', 
-    u'OSI Approved::Lucent Public License (Plan9)': 'lucent-plan9', 
-    u'OSI Approved::Nethack General Public License': 'nethack', 
-    u'OSI Approved::Common Public License 1.0': 'cpal_1.0', 
-    u'OSI Approved::Attribution Assurance Licenses': 'attribution', 
-    u'OSI Approved::Reciprocal Public License': 'rpl1.5', 
-    u'OSI Approved::Eclipse Public License': 'eclipse-1.0', 
-    u'OSI Approved::CUA Office Public License Version 1.0': 'cuaoffice', 
-    u'OSI Approved::Vovida Software License v. 1.0': 'vovidapl', 
-    u'OSI Approved::Apple Public Source License': 'apsl-2.0', 
-    u'OKD Compliant::UK Crown Copyright with data.gov.uk rights': 'ukcrown-withrights', 
-    u'OKD Compliant::Local Authority Copyright with data.gov.uk rights': 'localauth-withrights', 
-    u'OKD Compliant::Open Data Commons Open Database License (ODbL)': 'odc-odbl', 
-    u'OSI Approved::New BSD license': 'bsd-license', 
-    u'OSI Approved::Qt Public License (QPL)': 'qtpl', 
-    u'OSI Approved::GNU Library or "Lesser" General Public License (LGPL)': 'lgpl-2.1', 
-    u'OSI Approved::MITRE Collaborative Virtual Workspace License (CVW License)': 'mitre', 
-    u'OSI Approved::Apache License, 2.0': 'apache2.0', 
-    u'OSI Approved::Apache Software License': 'apache', 
-    u'OSI Approved::Python Software Foundation License': 'PythonSoftFoundation', 
-    u'OSI Approved::Sun Public License': 'sunpublic', 
+    u'OSI Approved::Mozilla Public License 1.1 (MPL)': 'mozilla1.1',
+    u'OKD Compliant::Creative Commons Attribution-ShareAlike': 'cc-by-sa',
+    u'OSI Approved::Nokia Open Source License': 'nokia',
+    u'OSI Approved::Computer Associates Trusted Open Source License 1.1': 'ca-tosl1.1',
+    u'OKD Compliant::Higher Education Statistics Agency Copyright with data.gov.uk rights': 'hesa-withrights',
+    u'OSI Approved::Lucent Public License Version 1.02': 'lucent1.02',
+    u'OSI Approved::Open Software License': 'osl-3.0',
+    u'OSI Approved::Motosoto License': 'motosoto',
+    u'OSI Approved::MIT license': 'mit-license',
+    u'OSI Approved::Mozilla Public License 1.0 (MPL)': 'mozilla',
+    u'OSI Approved::GNU General Public License v3 (GPLv3)': 'gpl-3.0',
+    u'OKD Compliant::UK Click Use PSI': 'ukclickusepsi',
+    u'OSI Approved::Eiffel Forum License': 'eiffel',
+    u'OSI Approved::Jabber Open Source License': 'jabber-osl',
+    u'OSI Approved::Open Group Test Suite License': 'opengroup',
+    u'OSI Approved::Entessa Public License': 'entessa',
+    u'OKD Compliant::Other': 'other-open',
+    u'OSI Approved::EU DataGrid Software License': 'eudatagrid',
+    u'OSI Approved::Zope Public License': 'zpl',
+    u'OSI Approved::Naumen Public License': 'naumen',
+    u'OSI Approved::wxWindows Library License': 'wxwindows',
+    u'OKD Compliant::GNU Free Documentation License (GFDL)': 'gfdl',
+    u'Non-OKD Compliant::Non-Commercial Other': 'other-nc',
+    u'OKD Compliant::Open Data Commons Public Domain Dedication and License (PDDL)': 'odc-pddl',
+    u'OSI Approved::NASA Open Source Agreement 1.3': 'nasa1.3',
+    u'OSI Approved::X.Net License': 'xnet',
+    u'OSI Approved::W3C License': 'W3C',
+    u'OSI Approved::Academic Free License': 'afl-3.0',
+    u'Non-OKD Compliant::Crown Copyright': 'ukcrown',
+    u'OSI Approved::RealNetworks Public Source License V1.0': 'real',
+    u'OSI Approved::Common Development and Distribution License': 'cddl1',
+    u'OSI Approved::Intel Open Source License': 'intel-osl',
+    u'OSI Approved::GNU General Public License (GPL)': 'gpl-2.0',
+    u'Non-OKD Compliant::Creative Commons Non-Commercial (Any)': 'cc-nc',
+    u'Non-OKD Compliant::Other': 'other-closed',
+    u'Other::License Not Specified': 'notspecified',
+    u'OSI Approved::Sybase Open Watcom Public License 1.0': 'sybase',
+    u'OSI Approved::Educational Community License': 'ecl2',
+    u'OSI Approved::Sun Industry Standards Source License (SISSL)': 'sun-issl',
+    u'OKD Compliant::Other (Public Domain)': 'other-pd',
+    u'OKD Compliant::Public Domain': 'other-pd',
+    u'OKD Compliant::Creative Commons Attribution': 'cc-by',
+    u'OSI Approved::OCLC Research Public License 2.0': 'oclc2',
+    u'OSI Approved::Artistic license': 'artistic-license-2.0',
+    u'OKD Compliant::Other (Attribution)': 'other-at',
+    u'OSI Approved::Sleepycat License': 'sleepycat',
+    u'OSI Approved::PHP License': 'php',
+    u'OKD Compliant::Creative Commons CCZero': 'cc-zero',
+    u'OSI Approved::University of Illinois/NCSA Open Source License': 'UoI-NCSA',
+    u'OSI Approved::Adaptive Public License': 'apl1.0',
+    u'OSI Approved::Ricoh Source Code Public License': 'ricohpl',
+    u'OSI Approved::Eiffel Forum License V2.0': 'ver2_eiffel',
+    u'OSI Approved::Python license (CNRI Python License)': 'pythonpl',
+    u'OSI Approved::Frameworx License': 'frameworx',
+    u'OSI Approved::IBM Public License': 'ibmpl',
+    u'OSI Approved::Fair License': 'fair',
+    u'OSI Approved::Lucent Public License (Plan9)': 'lucent-plan9',
+    u'OSI Approved::Nethack General Public License': 'nethack',
+    u'OSI Approved::Common Public License 1.0': 'cpal_1.0',
+    u'OSI Approved::Attribution Assurance Licenses': 'attribution',
+    u'OSI Approved::Reciprocal Public License': 'rpl1.5',
+    u'OSI Approved::Eclipse Public License': 'eclipse-1.0',
+    u'OSI Approved::CUA Office Public License Version 1.0': 'cuaoffice',
+    u'OSI Approved::Vovida Software License v. 1.0': 'vovidapl',
+    u'OSI Approved::Apple Public Source License': 'apsl-2.0',
+    u'OKD Compliant::UK Crown Copyright with data.gov.uk rights': 'ukcrown-withrights',
+    u'OKD Compliant::Local Authority Copyright with data.gov.uk rights': 'localauth-withrights',
+    u'OKD Compliant::Open Data Commons Open Database License (ODbL)': 'odc-odbl',
+    u'OSI Approved::New BSD license': 'bsd-license',
+    u'OSI Approved::Qt Public License (QPL)': 'qtpl',
+    u'OSI Approved::GNU Library or "Lesser" General Public License (LGPL)': 'lgpl-2.1',
+    u'OSI Approved::MITRE Collaborative Virtual Workspace License (CVW License)': 'mitre',
+    u'OSI Approved::Apache License, 2.0': 'apache2.0',
+    u'OSI Approved::Apache Software License': 'apache',
+    u'OSI Approved::Python Software Foundation License': 'PythonSoftFoundation',
+    u'OSI Approved::Sun Public License': 'sunpublic',
     u'OSI Approved::zlib/libpng license': 'zlib-license'
 }
 
@@ -95,21 +95,21 @@ def upgrade(migrate_engine):
     old_package_license_ids = _get_old_package_license_ids(migrate_engine)
     old_package_revision_license_ids = _get_old_package_revision_license_ids(migrate_engine)
     _check_map_has_old_license_titles(old_license_titles, map)
-    
+
     # Upgrade database scheme.
     drop_fk_constraint_on_package_table = "ALTER TABLE package DROP CONSTRAINT package_license_id_fkey;"
     drop_fk_constraint_on_package_revision_table = "ALTER TABLE package_revision DROP CONSTRAINT package_revision_license_id_fkey;"
     change_license_id_type_on_package_table = "ALTER TABLE package ALTER COLUMN license_id TYPE text;"
     change_license_id_type_on_package_revision_table = "ALTER TABLE package_revision ALTER COLUMN license_id TYPE text;"
     drop_licenses_table = "DROP TABLE license CASCADE;"
-    
+
     migrate_engine.execute(drop_fk_constraint_on_package_table)
     migrate_engine.execute(drop_fk_constraint_on_package_revision_table)
     migrate_engine.execute(change_license_id_type_on_package_table)
     migrate_engine.execute(change_license_id_type_on_package_revision_table)
     migrate_engine.execute(drop_licenses_table)
 
-    # Set package license ids, and package revision license ids.    
+    # Set package license ids, and package revision license ids.
     new_package_license_ids = _switch_package_license_ids(
             old_package_license_ids, old_license_titles, map)
     new_package_revision_license_ids = _switch_package_license_ids(
@@ -123,7 +123,7 @@ def downgrade(migrate_engine):
 def _check_map_has_old_license_titles(old_license_titles, map):
     for title in old_license_titles.values():
         if title not in map:
-            raise Exception, "The old license title '%s' wasn't found in the upgrade map. Decide which new license id should be substituted for this license and add an entry to the map (in ckan/migration/versions/018_adjust_licenses.py)." % title
+            raise Exception("The old license title '%s' wasn't found in the upgrade map. Decide which new license id should be substituted for this license and add an entry to the map (in ckan/migration/versions/018_adjust_licenses.py)." % title)
 
 def _get_old_license_titles(migrate_engine):
     "Returns a dict of old license titles, keyed by old license id."
@@ -178,5 +178,3 @@ def _set_new_package_revision_license_ids(migrate_engine, new_ids):
 def _set_package_revision_license_id(migrate_engine, package_id, license_id):
     set_package_license_id = """UPDATE package_revision SET license_id ='%s' where id = '%s';""" % (license_id, package_id)
     migrate_engine.execute(set_package_license_id)
-
-

--- a/ckan/model/domain_object.py
+++ b/ckan/model/domain_object.py
@@ -107,7 +107,7 @@ class DomainObject(object):
         for col in table.c:
             try:
                 repr += u' %s=%s' % (col.name, getattr(self, col.name))
-            except Exception, inst:
+            except Exception as inst:
                 repr += u' %s=%s' % (col.name, inst)
 
         repr += '>'

--- a/ckan/model/license.py
+++ b/ckan/model/license.py
@@ -117,12 +117,12 @@ class LicenseRegister(object):
         try:
             response = urllib2.urlopen(license_url)
             response_body = response.read()
-        except Exception, inst:
+        except Exception as inst:
             msg = "Couldn't connect to licenses service %r: %s" % (license_url, inst)
             raise Exception(msg)
         try:
             license_data = json.loads(response_body)
-        except Exception, inst:
+        except Exception as inst:
             msg = "Couldn't read response from licenses service %r: %s" % (response_body, inst)
             raise Exception(inst)
         self._create_license_list(license_data, license_url)

--- a/ckan/model/modification.py
+++ b/ckan/model/modification.py
@@ -75,12 +75,12 @@ class DomainObjectModificationExtension(plugins.SingletonPlugin):
                 plugins.IDomainObjectModification):
             try:
                 observer.notify(entity, operation)
-            except SearchIndexError, search_error:
+            except SearchIndexError as search_error:
                 log.exception(search_error)
                 # Reraise, since it's pretty crucial to ckan if it can't index
                 # a dataset
                 raise
-            except Exception, ex:
+            except Exception as ex:
                 log.exception(ex)
                 # Don't reraise other exceptions since they are generally of
                 # secondary importance so shouldn't disrupt the commit.

--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -240,7 +240,7 @@ class Package(vdm.sqlalchemy.RevisionedObjectMixin,
             object_ = self
             direction = "reverse"
         else:
-            raise KeyError, 'Package relationship type: %r' % type_
+            raise KeyError('Package relationship type: %r' % type_)
 
         rels = self.get_relationships(with_package=related_package,
                                       type=type_, active=False, direction=direction)
@@ -364,7 +364,7 @@ class Package(vdm.sqlalchemy.RevisionedObjectMixin,
             self.license_id = license['id']
         else:
             msg = "Value not a license object or entity: %s" % repr(license)
-            raise Exception, msg
+            raise Exception(msg)
 
     license = property(get_license, set_license)
 

--- a/ckan/model/package_relationship.py
+++ b/ckan/model/package_relationship.py
@@ -40,7 +40,7 @@ class PackageRelationship(vdm.sqlalchemy.RevisionedObjectMixin,
     as "parent_of". However, the model functions provide the relationships
     from both packages in the relationship and the type is swapped from
     forward to reverse accordingly, for meaningful display to the user.'''
-    
+
     # List of (type, corresponding_reverse_type)
     # e.g. (A "depends_on" B, B has a "dependency_of" A)
     # don't forget to add specs to Solr's schema.xml
@@ -105,7 +105,7 @@ class PackageRelationship(vdm.sqlalchemy.RevisionedObjectMixin,
             raise Exception('Package %s is not in this relationship: %s' % \
                              (package, self))
         return (type_str, other_package)
-        
+
     @classmethod
     def by_subject(cls, package):
         return meta.Session.query(cls).filter(cls.subject_package_id==package.id)
@@ -113,7 +113,7 @@ class PackageRelationship(vdm.sqlalchemy.RevisionedObjectMixin,
     @classmethod
     def by_object(cls, package):
         return meta.Session.query(cls).filter(cls.object_package_id==package.id)
-    
+
     @classmethod
     def get_forward_types(cls):
         if not hasattr(cls, 'fwd_types'):
@@ -139,7 +139,7 @@ class PackageRelationship(vdm.sqlalchemy.RevisionedObjectMixin,
     def reverse_to_forward_type(cls, reverse_type):
         for fwd, rev in cls.types:
             if rev == reverse_type:
-                return fwd        
+                return fwd
 
     @classmethod
     def forward_to_reverse_type(cls, forward_type):
@@ -153,7 +153,7 @@ class PackageRelationship(vdm.sqlalchemy.RevisionedObjectMixin,
             if fwd == forward_or_reverse_type:
                 return rev
             if rev == forward_or_reverse_type:
-                return fwd        
+                return fwd
 
     @classmethod
     def make_type_printable(cls, type_):
@@ -161,7 +161,7 @@ class PackageRelationship(vdm.sqlalchemy.RevisionedObjectMixin,
             for j in range(2):
                 if type_ == types[j]:
                     return cls.types_printable[i][j]
-        raise TypeError, type_
+        raise TypeError(type_)
 
 meta.mapper(PackageRelationship, package_relationship_table, properties={
     'subject':orm.relation(_package.Package, primaryjoin=\

--- a/ckan/tests/legacy/__init__.py
+++ b/ckan/tests/legacy/__init__.py
@@ -86,7 +86,7 @@ class BaseCase(object):
         import commands
         (status, output) = commands.getstatusoutput(cmd)
         if status:
-            raise Exception, "Couldn't execute cmd: %s: %s" % (cmd, output)
+            raise Exception("Couldn't execute cmd: %s: %s" % (cmd, output))
 
     @classmethod
     def _paster(cls, cmd, config_path_rel):
@@ -279,7 +279,7 @@ class CkanServerCase(BaseCase):
         pid = process.pid
         pid = int(pid)
         if os.system("kill -9 %d" % pid):
-            raise Exception, "Can't kill foreign CKAN instance (pid: %d)." % pid
+            raise Exception("Can't kill foreign CKAN instance (pid: %d)." % pid)
 
 
 class TestController(CommonFixtureMethods, CkanServerCase, WsgiAppCase, BaseCase):

--- a/ckan/tests/legacy/functional/api/base.py
+++ b/ckan/tests/legacy/functional/api/base.py
@@ -186,8 +186,8 @@ class ApiTestCase(object):
     def loads(self, chars):
         try:
             return json.loads(chars)
-        except ValueError, inst:
-            raise Exception, "Couldn't loads string '%s': %s" % (chars, inst)
+        except ValueError as inst:
+            raise Exception("Couldn't loads string '%s': %s" % (chars, inst))
 
     def assert_json_response(self, res, expected_in_body=None):
         content_type = res.header_dict['Content-Type']

--- a/ckan/tests/legacy/lib/test_solr_schema_version.py
+++ b/ckan/tests/legacy/lib/test_solr_schema_version.py
@@ -39,7 +39,7 @@ class TestSolrSchemaVersionCheck(TestController):
 
             #Should not happen
             assert False
-        except SearchError,e:
+        except SearchError as e:
             assert 'Could not extract version info' in str(e)
 
         # An exception is thrown if the schema version is not supported
@@ -49,7 +49,5 @@ class TestSolrSchemaVersionCheck(TestController):
 
             #Should not happen
             assert False
-        except SearchError,e:
+        except SearchError as e:
             assert 'SOLR schema version not supported' in str(e)
-
-

--- a/ckan/tests/legacy/lib/test_solr_search_index.py
+++ b/ckan/tests/legacy/lib/test_solr_search_index.py
@@ -20,7 +20,7 @@ class TestSolrConfig(TestController):
             # solr.SolrConnection.query will throw a socket.error if it
             # can't connect to the SOLR instance
             q = conn.search(q="*:*", rows=1)
-        except pysolr.SolrError, e:
+        except pysolr.SolrError as e:
             if not config.get('solr_url'):
                 raise AssertionError("Config option 'solr_url' needs to be defined in this CKAN's development.ini. Default of %s didn't work: %s" % (search.DEFAULT_SOLR_URL, e))
             else:
@@ -55,4 +55,3 @@ class TestSolrSearch:
         result_names = [r['name'] for r in results]
         assert 'se-publications' in result_names
         assert 'se-opengov' in result_names
-

--- a/ckan/tests/legacy/misc/test_sync.py
+++ b/ckan/tests/legacy/misc/test_sync.py
@@ -30,7 +30,7 @@ class _TestSync(TestController):
         # (clean)
 
         self._last_synced_revision_id = {'http://localhost:5050':None}
-        
+
     @classmethod
     def teardown_class(self):
         self.sub_proc.kill()
@@ -41,7 +41,7 @@ class _TestSync(TestController):
         while True:
             try:
                 f = urllib2.urlopen('http://localhost:5050%s' % offset)
-            except urllib2.URLError, e:
+            except urllib2.URLError as e:
                 if hasattr(e, 'reason') and type(e.reason) == urllib2.socket.error:
                     # i.e. process not started up yet
                     count += 1
@@ -73,7 +73,7 @@ class _TestSync(TestController):
     def test_1_first_sync(self):
         server = self._last_synced_revision_id.keys()[0]
         assert server == 'http://localhost:5050'
-        
+
         # find id of last revision synced
         last_sync_rev_id = self._last_synced_revision_id[server]
         assert last_sync_rev_id == None # no syncs yet
@@ -86,10 +86,5 @@ class _TestSync(TestController):
         # get revision diffs
         diffs = self.sub_app_get_deserialized('%s/api/diff/revision?diff=%s&oldid=%s' % (server, remote_latest_rev_id, last_sync_rev_id))
         assert len(diffs) == 3
-                                      
+
         # apply diffs
-
-        
-        
-
-

--- a/ckan/tests/logic/action/test_delete.py
+++ b/ckan/tests/logic/action/test_delete.py
@@ -149,7 +149,7 @@ class TestDeleteTags(object):
         # through in NotFound as unicode.
         try:
             helpers.call_action('tag_delete', id=u'Delta symbol: \u0394')
-        except logic.NotFound, e:
+        except logic.NotFound as e:
             assert u'Delta symbol: \u0394' in unicode(e)
         else:
             assert 0, 'Should have raised NotFound'

--- a/ckan/views/admin.py
+++ b/ckan/views/admin.py
@@ -193,7 +193,7 @@ class TrashView(MethodView):
                     # page Ensure that whatever 'head' pointer is used
                     # gets moved down to the next revision
                     model.repo.purge_revision(revision, leave_record=False)
-                except Exception, inst:
+                except Exception as inst:
                     msg = _(u'Problem purging revision %s: %s') % (id, inst)
                     msgs.append(msg)
             h.flash_success(_(u'Purge complete'))

--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -95,7 +95,7 @@ def _finish_ok(response_data=None,
         status_int = 201
         try:
             resource_location = str(resource_location)
-        except Exception, inst:
+        except Exception as inst:
             msg = \
                 u"Couldn't convert '%s' header value '%s' to string: %s" % \
                 (u'Location', resource_location, inst)
@@ -171,7 +171,7 @@ def _get_request_data(try_url_params=False):
                 request.form.values()[0] in [u'1', u'']):
             try:
                 request_data = json.loads(request.form.keys()[0])
-            except ValueError, e:
+            except ValueError as e:
                 raise ValueError(
                     u'Error decoding JSON data. '
                     'Error: %r '
@@ -185,7 +185,7 @@ def _get_request_data(try_url_params=False):
           request.content_type != u'multipart/form-data'):
         try:
             request_data = request.get_json()
-        except BadRequest, e:
+        except BadRequest as e:
             raise ValueError(u'Error decoding JSON data. '
                              'Error: %r '
                              'JSON data extracted from the request: %r' %
@@ -259,7 +259,7 @@ def action(logic_function, ver=API_DEFAULT_VERSION):
 
         request_data = _get_request_data(
             try_url_params=side_effect_free)
-    except ValueError, inst:
+    except ValueError as inst:
         log.info(u'Bad Action API request data: %s', inst)
         return _finish_bad_request(
             _(u'JSON Error: %s') % inst)
@@ -283,7 +283,7 @@ def action(logic_function, ver=API_DEFAULT_VERSION):
         result = function(context, request_data)
         return_dict[u'success'] = True
         return_dict[u'result'] = result
-    except DataError, e:
+    except DataError as e:
         log.info(u'Format incorrect (Action API): %s - %s',
                  e.error, request_data)
         return_dict[u'error'] = {u'__type': u'Integrity Error',
@@ -291,7 +291,7 @@ def action(logic_function, ver=API_DEFAULT_VERSION):
                                  u'data': request_data}
         return_dict[u'success'] = False
         return _finish(400, return_dict, content_type=u'json')
-    except NotAuthorized, e:
+    except NotAuthorized as e:
         return_dict[u'error'] = {u'__type': u'Authorization Error',
                                  u'message': _(u'Access denied')}
         return_dict[u'success'] = False
@@ -300,14 +300,14 @@ def action(logic_function, ver=API_DEFAULT_VERSION):
             return_dict[u'error'][u'message'] += u': %s' % e
 
         return _finish(403, return_dict, content_type=u'json')
-    except NotFound, e:
+    except NotFound as e:
         return_dict[u'error'] = {u'__type': u'Not Found Error',
                                  u'message': _(u'Not found')}
         if unicode(e):
             return_dict[u'error'][u'message'] += u': %s' % e
         return_dict[u'success'] = False
         return _finish(404, return_dict, content_type=u'json')
-    except ValidationError, e:
+    except ValidationError as e:
         error_dict = e.error_dict
         error_dict[u'__type'] = u'Validation Error'
         return_dict[u'error'] = error_dict
@@ -315,18 +315,18 @@ def action(logic_function, ver=API_DEFAULT_VERSION):
         # CS nasty_string ignore
         log.info(u'Validation error (Action API): %r', str(e.error_dict))
         return _finish(409, return_dict, content_type=u'json')
-    except SearchQueryError, e:
+    except SearchQueryError as e:
         return_dict[u'error'] = {u'__type': u'Search Query Error',
                                  u'message': u'Search Query is invalid: %r' %
                                  e.args}
         return_dict[u'success'] = False
         return _finish(400, return_dict, content_type=u'json')
-    except SearchError, e:
+    except SearchError as e:
         return_dict[u'error'] = {u'__type': u'Search Error',
                                  u'message': u'Search error: %r' % e.args}
         return_dict[u'success'] = False
         return _finish(409, return_dict, content_type=u'json')
-    except SearchIndexError, e:
+    except SearchIndexError as e:
         return_dict[u'error'] = {
             u'__type': u'Search Index Error',
             u'message': u'Unable to add package to search index: %s' %

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -541,7 +541,7 @@ class RequestResetView(MethodView):
                     _(u'Please check your inbox for '
                       u'a reset code.'))
                 return h.redirect_to(u'/')
-            except mailer.MailerException, e:
+            except mailer.MailerException as e:
                 h.flash_error(_(u'Could not send reset link: %s') % unicode(e))
         return self.get()
 
@@ -616,7 +616,7 @@ class PerformResetView(MethodView):
             h.flash_error(_(u'User not found'))
         except dictization_functions.DataError:
             h.flash_error(_(u'Integrity Error'))
-        except logic.ValidationError, e:
+        except logic.ValidationError as e:
             h.flash_error(u'%r' % e.error_dict)
         except ValueError as e:
             h.flash_error(unicode(e))

--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -134,7 +134,7 @@ def datapusher_submit(context, data_dict):
                 }
             }))
         r.raise_for_status()
-    except requests.exceptions.ConnectionError, e:
+    except requests.exceptions.ConnectionError as e:
         error = {'message': 'Could not connect to DataPusher.',
                  'details': str(e)}
         task['error'] = json.dumps(error)
@@ -143,7 +143,7 @@ def datapusher_submit(context, data_dict):
         p.toolkit.get_action('task_status_update')(context, task)
         raise p.toolkit.ValidationError(error)
 
-    except requests.exceptions.HTTPError, e:
+    except requests.exceptions.HTTPError as e:
         m = 'An Error occurred while sending the job: {0}'.format(e.message)
         try:
             body = e.response.json()

--- a/ckanext/datapusher/plugin.py
+++ b/ckanext/datapusher/plugin.py
@@ -136,7 +136,7 @@ class DatapusherPlugin(p.SingletonPlugin):
                         p.toolkit.get_action('datapusher_submit')(context, {
                             'resource_id': entity.id
                         })
-                    except p.toolkit.ValidationError, e:
+                    except p.toolkit.ValidationError as e:
                         # If datapusher is offline want to catch error instead
                         # of raising otherwise resource save will fail with 500
                         log.critical(e)

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -320,7 +320,7 @@ def _change_privilege(context, data_dict, what):
         })
     try:
         context['connection'].execute(sql)
-    except ProgrammingError, e:
+    except ProgrammingError as e:
         log.critical("Error making resource private. {0!r}".format(e.message))
         raise ValidationError({
             'privileges': [
@@ -540,7 +540,7 @@ def create_alias(context, data_dict):
                     })
 
                 context['connection'].execute(sql_alias_string)
-        except DBAPIError, e:
+        except DBAPIError as e:
             if e.orig.pgcode in [_PG_ERR_CODE['duplicate_table'],
                                  _PG_ERR_CODE['duplicate_alias']]:
                 raise ValidationError({
@@ -644,7 +644,7 @@ def _is_valid_pg_type(context, type_name):
         connection = context['connection']
         try:
             connection.execute('SELECT %s::regtype', type_name)
-        except ProgrammingError, e:
+        except ProgrammingError as e:
             if e.orig.pgcode in [_PG_ERR_CODE['undefined_object'],
                                  _PG_ERR_CODE['syntax_error']]:
                 return False
@@ -1444,7 +1444,7 @@ def upsert(context, data_dict):
         upsert_data(context, data_dict)
         trans.commit()
         return _unrename_json_field(data_dict)
-    except IntegrityError, e:
+    except IntegrityError as e:
         if e.orig.pgcode == _PG_ERR_CODE['unique_violation']:
             raise ValidationError({
                 'constraints': ['Cannot insert records or create index because'
@@ -1455,19 +1455,19 @@ def upsert(context, data_dict):
                 }
             })
         raise
-    except DataError, e:
+    except DataError as e:
         raise ValidationError({
             'data': e.message,
             'info': {
                 'orig': [str(e.orig)]
             }})
-    except DBAPIError, e:
+    except DBAPIError as e:
         if e.orig.pgcode == _PG_ERR_CODE['query_canceled']:
             raise ValidationError({
                 'query': ['Query took too long']
             })
         raise
-    except Exception, e:
+    except Exception as e:
         trans.rollback()
         raise
     finally:
@@ -1485,7 +1485,7 @@ def search(context, data_dict):
         context['connection'].execute(
             u'SET LOCAL statement_timeout TO {0}'.format(timeout))
         return search_data(context, data_dict)
-    except DBAPIError, e:
+    except DBAPIError as e:
         if e.orig.pgcode == _PG_ERR_CODE['query_canceled']:
             raise ValidationError({
                 'query': ['Search took too long']
@@ -1530,7 +1530,7 @@ def search_sql(context, data_dict):
 
         return format_results(context, results, data_dict)
 
-    except ProgrammingError, e:
+    except ProgrammingError as e:
         if e.orig.pgcode == _PG_ERR_CODE['permission_denied']:
             raise toolkit.NotAuthorized({
                 'permissions': ['Not authorized to read resource.']
@@ -1548,7 +1548,7 @@ def search_sql(context, data_dict):
                 'orig': [_remove_explain(str(e.orig))]
             }
         })
-    except DBAPIError, e:
+    except DBAPIError as e:
         if e.orig.pgcode == _PG_ERR_CODE['query_canceled']:
             raise ValidationError({
                 'query': ['Query took too long']
@@ -1831,7 +1831,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
                 _change_privilege(context, data_dict, 'REVOKE')
             trans.commit()
             return _unrename_json_field(data_dict)
-        except IntegrityError, e:
+        except IntegrityError as e:
             if e.orig.pgcode == _PG_ERR_CODE['unique_violation']:
                 raise ValidationError({
                     'constraints': ['Cannot insert records or create index'
@@ -1842,19 +1842,19 @@ class DatastorePostgresqlBackend(DatastoreBackend):
                     }
                 })
             raise
-        except DataError, e:
+        except DataError as e:
             raise ValidationError({
                 'data': e.message,
                 'info': {
                     'orig': [str(e.orig)]
                 }})
-        except DBAPIError, e:
+        except DBAPIError as e:
             if e.orig.pgcode == _PG_ERR_CODE['query_canceled']:
                 raise ValidationError({
                     'query': ['Query took too long']
                 })
             raise
-        except Exception, e:
+        except Exception as e:
             trans.rollback()
             raise
         finally:

--- a/ckanext/resourceproxy/controller.py
+++ b/ckanext/resourceproxy/controller.py
@@ -70,15 +70,15 @@ def proxy_resource(context, data_dict):
                 base.abort(409, headers={'content-encoding': ''},
                            detail='Content is too large to be proxied.')
 
-    except requests.exceptions.HTTPError, error:
+    except requests.exceptions.HTTPError as error:
         details = 'Could not proxy resource. Server responded with %s %s' % (
             error.response.status_code, error.response.reason)
         base.abort(409, detail=details)
-    except requests.exceptions.ConnectionError, error:
+    except requests.exceptions.ConnectionError as error:
         details = '''Could not proxy resource because a
                             connection error occurred. %s''' % error
         base.abort(502, detail=details)
-    except requests.exceptions.Timeout, error:
+    except requests.exceptions.Timeout as error:
         details = 'Could not proxy resource because the connection timed out.'
         base.abort(504, detail=details)
 


### PR DESCRIPTION
Fixes #3309 (partial fix)

### Proposed fixes:
* Convert old style exceptions --> new style exceptions (en masse)
    * __except Exception, e__ --> __except Exception as e__
    * __raise Exception, msg__ --> __raise Exception(msg)__

As explained in [PEP 3109](https://www.python.org/dev/peps/pep-3109/), old style exceptions are ambiguous and are Syntax Errors in Python 3.  New style exceptions work in both Python 2 and 3.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
