### PR TITLE
long was renamed to int in Python 3 (en masse)

### DIFF
--- a/ckan/lib/dictization/__init__.py
+++ b/ckan/lib/dictization/__init__.py
@@ -11,6 +11,11 @@ try:
 except AttributeError:
     RowProxy = sqlalchemy.engine.base.RowProxy
 
+try:
+    long        # Python 2
+except NameError:
+    long = int  # Python 3
+
 
 # NOTE
 # The functions in this file contain very generic methods for dictizing objects

--- a/ckan/tests/logic/test_validators.py
+++ b/ckan/tests/logic/test_validators.py
@@ -151,7 +151,7 @@ class TestValidators(object):
             # Non-string names aren't allowed as names.
             13,
             23.7,
-            100L,
+            100,
             1.0j,
             None,
             True,
@@ -229,7 +229,7 @@ class TestValidators(object):
         non_string_values = [
             13,
             23.7,
-            100L,
+            100,
             1.0j,
             None,
             True,

--- a/ckanext/multilingual/plugin.py
+++ b/ckanext/multilingual/plugin.py
@@ -7,6 +7,11 @@ from ckan.plugins import IGroupController, IOrganizationController, ITagControll
 from ckan.common import request, config, c
 from ckan.logic import get_action
 
+try:
+    long        # Python 2
+except NameError:
+    long = int  # Python 3
+
 
 def translate_data_dict(data_dict):
     '''Return the given dict (e.g. a dataset dict) with as many of its fields

--- a/ckanext/stats/tests/test_stats_lib.py
+++ b/ckanext/stats/tests/test_stats_lib.py
@@ -92,7 +92,7 @@ class TestStatsPlugin(StatsFixture):
     def test_top_tags(self):
         tags = Stats.top_tags()
         tags = [(tag.name, count) for tag, count in tags]
-        assert_equal(tags, [('tag1', 1L)])
+        assert_equal(tags, [('tag1', 1)])
 
     def test_top_package_creators(self):
         creators = Stats.top_package_creators()


### PR DESCRIPTION
Related to #3309 (partial fix)

### Proposed fixes:
https://docs.python.org/3.0/whatsnew/3.0.html#integers
* define long in Python 3 using __try: / except NameError:__ blocks
* convert __100L__ --> __100__ in alignment with http://python-future.org/compatible_idioms.html#long-integers

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
