### PR TITLE
Fix db namespace clash in docker install

### DIFF
--- a/ckan/migration/versions/001_add_existing_tables.py
+++ b/ckan/migration/versions/001_add_existing_tables.py
@@ -5,6 +5,8 @@ from migrate import *
 
 
 def upgrade(migrate_engine):
+    # we specify the schema here, because of a clash with another 'state' table
+    # in the mdillon/postgis container
     meta = MetaData(schema='public')
 
     state = Table('state', meta,

--- a/ckan/migration/versions/001_add_existing_tables.py
+++ b/ckan/migration/versions/001_add_existing_tables.py
@@ -5,7 +5,7 @@ from migrate import *
 
 
 def upgrade(migrate_engine):
-    meta = MetaData()
+    meta = MetaData(schema='public')
 
     state = Table('state', meta,
       Column('id', Integer() ,  primary_key=True, nullable=False),


### PR DESCRIPTION
When asking sqlalchemy to create the "state" table, we now specify the "public" (default) namespace so that sqlalchemy doesnt wrongly skip it due to seeing the same named table (in the tiger namespace) already created by mdillon/postgis image.

Fixes #3929

This is a simpler version of PR #3965. Making the namespace configurable is not a requirement. Let's just fix the specific clash with this one-liner, and backport it to the last release, so that the docker install works again for people.
