### PR TITLE
from six.moves import xrange for Python 3 (en masse)

### DIFF
--- a/ckan/lib/jinja_extensions.py
+++ b/ckan/lib/jinja_extensions.py
@@ -11,6 +11,8 @@ from jinja2.exceptions import TemplateNotFound
 from jinja2.utils import open_if_exists, escape
 from jinja2 import Environment
 
+from six.moves import xrange
+
 import ckan.lib.base as base
 import ckan.lib.helpers as h
 

--- a/ckan/tests/controllers/test_api.py
+++ b/ckan/tests/controllers/test_api.py
@@ -13,6 +13,8 @@ from StringIO import StringIO
 from nose.tools import assert_equal, assert_in, eq_
 from pyfakefs import fake_filesystem
 
+from six.moves import xrange
+
 from ckan.lib.helpers import url_for
 import ckan.tests.helpers as helpers
 from ckan.tests import factories

--- a/ckan/tests/controllers/test_group.py
+++ b/ckan/tests/controllers/test_group.py
@@ -3,6 +3,8 @@
 from bs4 import BeautifulSoup
 from nose.tools import assert_equal, assert_true, assert_in
 
+from six.moves import xrange
+
 from ckan.lib.helpers import url_for
 
 import ckan.tests.helpers as helpers

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -4,6 +4,8 @@ import datetime
 
 import nose.tools
 
+from six.moves import xrange
+
 from ckan import __version__
 import ckan.logic as logic
 import ckan.plugins as p


### PR DESCRIPTION
Related to #3309 (partial fix)

### Proposed fixes:
__xrange()__ was removed in Python 3 in favor of __range()__ so for each Python file that contains a call to __xrange()__, this PR adds __from six.moves import xrange__.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
