### PR TITLE
Remove unhelpful docs

### DIFF
--- a/doc/contributing/documentation.rst
+++ b/doc/contributing/documentation.rst
@@ -67,10 +67,6 @@ install the dependencies necessary for building CKAN. In this example we'll
 create a virtualenv in a folder called ``pyenv``. Run these commands in a
 terminal:
 
-.. versionchanged:: 2.1
-   In CKAN 2.0 and earlier the requirements file was called
-   ``pip-requirements-docs.txt``, not ``dev-requirements.txt`` as below.
-
 ::
 
     virtualenv --no-site-packages pyenv

--- a/doc/contributing/test.rst
+++ b/doc/contributing/test.rst
@@ -32,10 +32,6 @@ virtual environment:
 Install nose and other test-specific CKAN dependencies into your virtual
 environment:
 
-.. versionchanged:: 2.1
-   In CKAN 2.0 and earlier the requirements file was called
-   ``pip-requirements-test.txt``, not ``dev-requirements.txt`` as below.
-
 .. parsed-literal::
 
     pip install -r |virtualenv|/src/ckan/dev-requirements.txt
@@ -45,10 +41,6 @@ environment:
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 Set up the test databases
 ~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionchanged:: 2.1
-   Previously |postgres| tests used the databases defined in your
-   ``development.ini`` file, instead of using their own test databases.
 
 Create test databases:
 

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -105,14 +105,6 @@ b. Install the recommended ``setuptools`` version:
        pip install setuptools==\ |min_setuptools_version|
 
 c. Install the CKAN source code into your virtualenv.
-   .. important::
-   
-       For the following commands, make sure you are in your CKAN default directory. E.g.
-    
-      .. parsed-literal::
-      
-         cd /usr/lib/ckan/default/
-   
    To install the latest stable release of CKAN (CKAN |latest_release_version|),
    run:
 
@@ -128,15 +120,6 @@ c. Install the CKAN source code into your virtualenv.
 
        pip install -e 'git+\ |git_url|\#egg=ckan'
 
-   .. tip::
-      
-      If you would like to work submit a pull request with your changes, be sure you are working from a cloned repository.
-      Use your personal repository URL instead of the CKAN repository. E.g.
-      
-      .. parsed-literal::
-         
-         pip install -e 'git=https://github.com/{your-username}/ckan.git#egg=ckan'
-   
    .. warning::
 
       The development version may contain bugs and should not be used for
@@ -144,10 +127,6 @@ c. Install the CKAN source code into your virtualenv.
       development.
 
 d. Install the Python modules that CKAN requires into your virtualenv:
-
-   .. versionchanged:: 2.1
-      In CKAN 2.0 and earlier the requirement file was called
-      ``pip-requirements.txt`` not ``requirements.txt`` as below.
 
    .. parsed-literal::
 
@@ -380,4 +359,3 @@ This is seen occasionally with Jetty and Ubuntu 14.04. It requires a solr-jetty 
     wget https://launchpad.net/~vshn/+archive/ubuntu/solr/+files/solr-jetty-jsp-fix_1.0.2_all.deb
     sudo dpkg -i solr-jetty-jsp-fix_1.0.2_all.deb
     sudo service jetty restart
-

--- a/doc/maintaining/upgrading/upgrade-source.rst
+++ b/doc/maintaining/upgrading/upgrade-source.rst
@@ -33,10 +33,6 @@ CKAN release you're upgrading to:
 
 #. Update CKAN's dependencies:
 
-   .. versionchanged:: 2.1
-      In CKAN 2.0 and earlier the requirements file was called
-      ``pip-requirements.txt``, not ``requirements.txt`` as below.
-
    ::
 
      pip install --upgrade -r requirements.txt
@@ -84,4 +80,3 @@ CKAN release you're upgrading to:
 
 You should now be able to visit your CKAN website in your web browser and see
 that it's running the new version of CKAN.
-


### PR DESCRIPTION
* 'pip install' is from the internet to your venv. Your current dir is irrelevant.
* personal repo tip is badly worded. Knowing how to submit a pull request involves a lot more than this and seems unhelpful to dilute these install instructions which are already really long.
* ckan 2.0 pip-requirements.txt - this is so old and unsupported, we should not be documenting it any more.

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
