### PR TITLE
Beaker pin moved

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,6 @@
 # The file contains the direct ckan requirements.
 # Use pip-compile to create a requirements.txt file from this
 Babel==2.3.4
-Beaker==1.9.0 # Needs to be pinned to a more up to date version than the Pylons one
 bleach==2.1.2
 click==6.7
 fanstatic==0.12


### PR DESCRIPTION
The pin in requirements.in was added here: https://github.com/ckan/ckan/commit/c5e63c6a40456421c9e76ed16d9c60d5b664bf0f
However pylons' setup.py just requires `Beaker>=1.2.2`, so we can remove that pin and just rely on 'pip-compile --update' adding in the latest version to requirements.txt.

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
