### PR TITLE
[#4022] use javascript content-type for jsonp responses

### DIFF
--- a/ckan/controllers/api.py
+++ b/ckan/controllers/api.py
@@ -38,6 +38,7 @@ CONTENT_TYPES = {
     'text': 'text/plain;charset=utf-8',
     'html': 'text/html;charset=utf-8',
     'json': 'application/json;charset=utf-8',
+    'javascript': 'application/javascript;charset=utf-8',
 }
 
 
@@ -99,6 +100,7 @@ class ApiController(base.BaseController):
                 # escape callback to remove '<', '&', '>' chars
                 callback = cgi.escape(request.params['callback'])
                 response_msg = self._wrap_jsonp(callback, response_msg)
+                response.headers['Content-Type'] = CONTENT_TYPES['javascript']
         return response_msg
 
     def _finish_ok(self, response_data=None,

--- a/ckan/tests/controllers/test_api.py
+++ b/ckan/tests/controllers/test_api.py
@@ -278,6 +278,19 @@ class TestApiController(helpers.FunctionalTestBase):
         eq_(sorted(res_dict['result']),
             sorted([dataset1['name'], dataset2['name']]))
 
+    def test_jsonp_returns_javascript_content_type(self):
+        url = url_for(
+            controller='api',
+            action='action',
+            logic_function='status_show',
+            ver='/3')
+        app = self._get_test_app()
+        res = app.get(
+            url=url,
+            params={'callback': 'my_callback'},
+        )
+        assert_in('application/javascript', res.headers.get('Content-Type'))
+
     def test_jsonp_does_not_work_on_post_requests(self):
 
         dataset1 = factories.Dataset()

--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -23,6 +23,7 @@ CONTENT_TYPES = {
     u'text': u'text/plain;charset=utf-8',
     u'html': u'text/html;charset=utf-8',
     u'json': u'application/json;charset=utf-8',
+    u'javascript': u'application/javascript;charset=utf-8',
 }
 
 API_REST_DEFAULT_VERSION = 1
@@ -69,6 +70,7 @@ def _finish(status_int, response_data=None,
             # escape callback to remove '<', '&', '>' chars
             callback = cgi.escape(request.args[u'callback'])
             response_msg = _wrap_jsonp(callback, response_msg)
+            headers[u'Content-Type'] = CONTENT_TYPES[u'javascript']
     return make_response((response_msg, status_int, headers))
 
 


### PR DESCRIPTION
Fixes #4022 

### Proposed fixes:

Applying fix to both new API view and old API controller, just for backporting.


### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X] includes API changes
- [X] includes bugfix for possible backport