### PR TITLE
Change basestring --> six.string_types for Python 3

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -5,6 +5,7 @@ import datetime
 from urllib import urlencode
 
 from pylons.i18n import get_lang
+from six import string_types
 
 import ckan.lib.base as base
 import ckan.lib.helpers as h
@@ -268,7 +269,7 @@ class GroupController(base.BaseController):
             controller = lookup_group_controller(group_type)
             action = 'bulk_process' if c.action == 'bulk_process' else 'read'
             url = h.url_for(controller=controller, action=action, id=id)
-            params = [(k, v.encode('utf-8') if isinstance(v, basestring)
+            params = [(k, v.encode('utf-8') if isinstance(v, string_types)
                        else str(v)) for k, v in params]
             return url + u'?' + urlencode(params)
 

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -9,6 +9,7 @@ import cgi
 from ckan.common import config
 from paste.deploy.converters import asbool
 import paste.fileapp
+from six import string_types
 
 import ckan.logic as logic
 import ckan.lib.base as base
@@ -45,7 +46,7 @@ lookup_package_plugin = ckan.lib.plugins.lookup_package_plugin
 
 
 def _encode_params(params):
-    return [(k, v.encode('utf-8') if isinstance(v, basestring) else str(v))
+    return [(k, v.encode('utf-8') if isinstance(v, string_types) else str(v))
             for k, v in params]
 
 

--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -5,6 +5,7 @@ import uuid
 import logging
 
 from sqlalchemy.orm import class_mapper
+from six import string_types
 
 import ckan.lib.dictization as d
 import ckan.lib.helpers as h
@@ -460,7 +461,7 @@ def package_api_to_dict(api1_dict, context):
     for key, value in api1_dict.iteritems():
         new_value = value
         if key == 'tags':
-            if isinstance(value, basestring):
+            if isinstance(value, string_types):
                 new_value = [{"name": item} for item in value.split()]
             else:
                 new_value = [{"name": item} for item in value]

--- a/ckan/lib/extract.py
+++ b/ckan/lib/extract.py
@@ -3,6 +3,7 @@
 import re
 from jinja2.ext import babel_extract as extract_jinja2
 import lib.jinja_extensions
+from six import string_types
 
 jinja_extensions = '''
                     jinja2.ext.do, jinja2.ext.with_,
@@ -24,7 +25,7 @@ def jinja2_cleaner(fileobj, *args, **kw):
 
     for lineno, func, message, finder in raw_extract:
 
-        if isinstance(message, basestring):
+        if isinstance(message, string_types):
             message = lib.jinja_extensions.regularise_html(message)
         elif message is not None:
             message = (lib.jinja_extensions.regularise_html(message[0])

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -35,6 +35,7 @@ from routes import url_for as _routes_default_url_for
 from flask import url_for as _flask_default_url_for
 from werkzeug.routing import BuildError as FlaskRouteBuildError
 import i18n
+from six import string_types
 
 import ckan.exceptions
 import ckan.model as model
@@ -111,7 +112,7 @@ def _datestamp_to_datetime(datetime_):
 
     :rtype: datetime
     '''
-    if isinstance(datetime_, basestring):
+    if isinstance(datetime_, string_types):
         try:
             datetime_ = date_str_to_datetime(datetime_)
         except TypeError:
@@ -171,7 +172,7 @@ def redirect_to(*args, **kw):
     _url = ''
     skip_url_parsing = False
     parse_url = kw.pop('parse_url', False)
-    if uargs and len(uargs) is 1 and isinstance(uargs[0], basestring) \
+    if uargs and len(uargs) is 1 and isinstance(uargs[0], string_types) \
             and (uargs[0].startswith('/') or is_url(uargs[0])) \
             and parse_url is False:
         skip_url_parsing = True
@@ -358,7 +359,7 @@ def _url_for_flask(*args, **kw):
     # The API routes used to require a slash on the version number, make sure
     # we remove it
     if (args and args[0].startswith('api.') and
-            isinstance(kw.get('ver'), basestring) and
+            isinstance(kw.get('ver'), string_types) and
             kw['ver'].startswith('/')):
         kw['ver'] = kw['ver'].replace('/', '')
 
@@ -1051,7 +1052,7 @@ def get_param_int(name, default=10):
 def _url_with_params(url, params):
     if not params:
         return url
-    params = [(k, v.encode('utf-8') if isinstance(v, basestring) else str(v))
+    params = [(k, v.encode('utf-8') if isinstance(v, string_types) else str(v))
               for k, v in params]
     return url + u'?' + urlencode(params)
 
@@ -1802,7 +1803,7 @@ def remove_url_param(key, value=None, replace=None, controller=None,
     instead.
 
     '''
-    if isinstance(key, basestring):
+    if isinstance(key, string_types):
         keys = [key]
     else:
         keys = key
@@ -2137,7 +2138,7 @@ def format_resource_items(items):
                 # Sometimes values that can't be converted to ints can sneak
                 # into the db. In this case, just leave them as they are.
                 pass
-        elif isinstance(value, basestring):
+        elif isinstance(value, string_types):
             # check if strings are actually datetime/number etc
             if re.search(reg_ex_datetime, value):
                 datetime_ = date_str_to_datetime(value)
@@ -2534,7 +2535,7 @@ def get_translated(data_dict, field):
         return data_dict[field + u'_translated'][language]
     except KeyError:
         val = data_dict.get(field, '')
-        return _(val) if val and isinstance(val, basestring) else val
+        return _(val) if val and isinstance(val, string_types) else val
 
 
 @core_helper

--- a/ckan/lib/search/common.py
+++ b/ckan/lib/search/common.py
@@ -5,6 +5,8 @@ import logging
 import re
 import pysolr
 import simplejson
+from six import string_types
+
 log = logging.getLogger(__name__)
 
 
@@ -72,7 +74,7 @@ def make_connection(decode_dates=True):
 
 def solr_datetime_decoder(d):
     for k, v in d.items():
-        if isinstance(v, basestring):
+        if isinstance(v, string_types):
             possible_datetime = re.search(pysolr.DATETIME_REGEX, v)
             if possible_datetime:
                 date_values = possible_datetime.groupdict()

--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -49,7 +49,7 @@ def convert_legacy_parameters_to_solr(legacy_params):
     non_solr_params = set(legacy_params.keys()) - VALID_SOLR_PARAMETERS
     for search_key in non_solr_params:
         value_obj = legacy_params[search_key]
-        value = value_obj.replace('+', ' ') if isinstance(value_obj, basestring) else value_obj
+        value = value_obj.replace('+', ' ') if isinstance(value_obj, six.string_types) else value_obj
         if search_key == 'all_fields':
             if value:
                 solr_params['fl'] = '*'
@@ -62,7 +62,7 @@ def convert_legacy_parameters_to_solr(legacy_params):
         elif search_key == 'tags':
             if isinstance(value_obj, list):
                 tag_list = value_obj
-            elif isinstance(value_obj, basestring):
+            elif isinstance(value_obj, six.string_types):
                 tag_list = [value_obj]
             else:
                 raise SearchQueryError('Was expecting either a string or JSON list for the tags parameter: %r' % value)
@@ -173,7 +173,7 @@ class TagSearchQuery(SearchQuery):
         else:
             options.update(kwargs)
 
-        if isinstance(query, basestring):
+        if isinstance(query, six.string_types):
             query = [query]
 
         query = query[:] # don't alter caller's query list.
@@ -220,7 +220,7 @@ class ResourceSearchQuery(SearchQuery):
         # action.
         query = []
         for field, terms in fields.items():
-            if isinstance(terms, basestring):
+            if isinstance(terms, six.string_types):
                 terms = terms.split()
             for term in terms:
                 query.append(':'.join([field, term]))

--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -7,6 +7,7 @@ import sys
 from collections import defaultdict
 
 import formencode.validators
+from six import string_types
 
 import ckan.model as model
 import ckan.authz as authz
@@ -175,7 +176,7 @@ def clean_dict(data_dict):
         if not isinstance(value, list):
             continue
         for inner_dict in value[:]:
-            if isinstance(inner_dict, basestring):
+            if isinstance(inner_dict, string_types):
                 break
             if not any(inner_dict.values()):
                 value.remove(inner_dict)
@@ -516,7 +517,7 @@ def get_or_bust(data_dict, keys):
         not in the given dictionary
 
     '''
-    if isinstance(keys, basestring):
+    if isinstance(keys, string_types):
         keys = [keys]
 
     import ckan.logic.schema as schema

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -11,6 +11,7 @@ import socket
 from ckan.common import config
 import sqlalchemy
 from paste.deploy.converters import asbool
+from six import string_types
 
 import ckan.lib.dictization
 import ckan.logic as logic
@@ -2109,7 +2110,7 @@ def resource_search(context, data_dict):
             {'fields': _('Do not specify if using "query" parameter')})
 
     elif query is not None:
-        if isinstance(query, basestring):
+        if isinstance(query, string_types):
             query = [query]
         try:
             fields = dict(pair.split(":", 1) for pair in query)
@@ -2125,7 +2126,7 @@ def resource_search(context, data_dict):
         # So maintain that behaviour
         split_terms = {}
         for field, terms in fields.items():
-            if isinstance(terms, basestring):
+            if isinstance(terms, string_types):
                 terms = terms.split()
             split_terms[field] = terms
         fields = split_terms
@@ -2143,7 +2144,7 @@ def resource_search(context, data_dict):
     resource_fields = model.Resource.get_columns()
     for field, terms in fields.items():
 
-        if isinstance(terms, basestring):
+        if isinstance(terms, string_types):
             terms = [terms]
 
         if field not in resource_fields:
@@ -2215,7 +2216,7 @@ def _tag_search(context, data_dict):
     model = context['model']
 
     terms = data_dict.get('query') or data_dict.get('q') or []
-    if isinstance(terms, basestring):
+    if isinstance(terms, string_types):
         terms = [terms]
     terms = [t.strip() for t in terms if t.strip()]
 
@@ -2402,7 +2403,7 @@ def term_translation_show(context, data_dict):
     # This action accepts `terms` as either a list of strings, or a single
     # string.
     terms = _get_or_bust(data_dict, 'terms')
-    if isinstance(terms, basestring):
+    if isinstance(terms, string_types):
         terms = [terms]
     if terms:
         q = q.where(trans_table.c.term.in_(terms))
@@ -2411,7 +2412,7 @@ def term_translation_show(context, data_dict):
     # string.
     if 'lang_codes' in data_dict:
         lang_codes = _get_or_bust(data_dict, 'lang_codes')
-        if isinstance(lang_codes, basestring):
+        if isinstance(lang_codes, string_types):
             lang_codes = [lang_codes]
         q = q.where(trans_table.c.lang_code.in_(lang_codes))
 

--- a/ckan/logic/converters.py
+++ b/ckan/logic/converters.py
@@ -2,6 +2,8 @@
 
 import json
 
+from six import string_types
+
 import ckan.model as model
 import ckan.lib.navl.dictization_functions as df
 import ckan.logic.validators as validators
@@ -60,7 +62,7 @@ def convert_to_tags(vocab):
         new_tags = data.get(key)
         if not new_tags:
             return
-        if isinstance(new_tags, basestring):
+        if isinstance(new_tags, string_types):
             new_tags = [new_tags]
 
         # get current number of tags
@@ -173,7 +175,7 @@ def convert_group_name_or_id_to_id(group_name_or_id, context):
 
 
 def convert_to_json_if_string(value, context):
-    if isinstance(value, basestring):
+    if isinstance(value, string_types):
         try:
             return json.loads(value)
         except ValueError:
@@ -183,13 +185,13 @@ def convert_to_json_if_string(value, context):
 
 
 def convert_to_list_if_string(value, context=None):
-    if isinstance(value, basestring):
+    if isinstance(value, string_types):
         return [value]
     else:
         return value
 
 
 def remove_whitespace(value, context):
-    if isinstance(value, basestring):
+    if isinstance(value, string_types):
         return value.strip()
     return value

--- a/ckan/model/types.py
+++ b/ckan/model/types.py
@@ -7,6 +7,7 @@ import uuid
 import simplejson as json
 
 from sqlalchemy import types
+from six import string_types
 
 import meta
 
@@ -74,7 +75,7 @@ class JsonDictType(JsonType):
         if value is None or value == {}: # ensure we stores nulls in db not json "null"
             return None
         else:
-            if isinstance(value, basestring):
+            if isinstance(value, string_types):
                 return unicode(value)
             else:
                 return unicode(json.dumps(value, ensure_ascii=False))
@@ -89,7 +90,7 @@ def iso_date_to_datetime_for_sqlite(datetime_or_iso_date_if_sqlite):
     # to call this to convert it into a datetime type. When running on
     # postgres then you have a datetime anyway, so this function doesn't
     # do anything.
-    if meta.engine_is_sqlite() and isinstance(datetime_or_iso_date_if_sqlite, basestring):
+    if meta.engine_is_sqlite() and isinstance(datetime_or_iso_date_if_sqlite, string_types):
         return datetime.datetime.strptime(datetime_or_iso_date_if_sqlite,
                                           '%Y-%m-%d %H:%M:%S.%f')
     else:

--- a/ckan/plugins/core.py
+++ b/ckan/plugins/core.py
@@ -12,6 +12,7 @@ from pyutilib.component.core import ExtensionPoint as PluginImplementations
 from pyutilib.component.core import SingletonPlugin as _pca_SingletonPlugin
 from pyutilib.component.core import Plugin as _pca_Plugin
 from paste.deploy.converters import asbool
+from six import string_types
 
 import interfaces
 
@@ -244,7 +245,7 @@ def _get_service(plugin_name):
     :return: the service object
     '''
 
-    if isinstance(plugin_name, basestring):
+    if isinstance(plugin_name, string_types):
         for group in GROUPS:
             iterator = iter_entry_points(
                 group=group,

--- a/ckan/tests/legacy/html_check.py
+++ b/ckan/tests/legacy/html_check.py
@@ -3,13 +3,15 @@
 import re
 import sgmllib
 
+from six import string_types
+
 import paste.fixture
 
 
 class HtmlCheckMethods(object):
     '''A collection of methods to check properties of a html page, usually
     in the form returned by paster.'''
-    
+
     def named_div(self, div_name, html):
         'strips html to just the <div id="DIV_NAME"> section'
         the_html = self._get_html_from_res(html)
@@ -31,15 +33,15 @@ class HtmlCheckMethods(object):
 
     def strip_tags(self, res):
         '''Call strip_tags on a TestResponse object to strip any and all HTML and normalise whitespace.'''
-        if not isinstance(res, basestring):
+        if not isinstance(res, string_types):
             res = res.body.decode('utf-8')
-        return Stripper().strip(res)    
+        return Stripper().strip(res)
 
     def check_named_element(self, html, tag_name, *html_to_find):
         '''Searches in the html and returns True if it can find a particular
         tag and all its subtags & data which contains all the of the
         html_to_find'''
-        named_element_re = re.compile('(<(%(tag)s\w*).*?(>.*?</%(tag)s)?>)' % {'tag':tag_name}) 
+        named_element_re = re.compile('(<(%(tag)s\w*).*?(>.*?</%(tag)s)?>)' % {'tag':tag_name})
         html_str = self._get_html_from_res(html)
         self._check_html(named_element_re, html_str.replace('\n', ''), html_to_find)
 

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -15,6 +15,8 @@ import hashlib
 import json
 from cStringIO import StringIO
 
+from six import string_types
+
 import ckan.lib.cli as cli
 import ckan.plugins as p
 import ckan.plugins.toolkit as toolkit
@@ -374,7 +376,7 @@ def _where_clauses(data_dict, fields_types):
     # add full-text search where clause
     q = data_dict.get('q')
     if q:
-        if isinstance(q, basestring):
+        if isinstance(q, string_types):
             ts_query_alias = _ts_query_alias()
             clause_str = u'_full_text @@ {0}'.format(ts_query_alias)
             clauses.append((clause_str,))
@@ -409,7 +411,7 @@ def _textsearch_query(data_dict):
     statements = []
     rank_columns = []
     plain = data_dict.get('plain', True)
-    if isinstance(q, basestring):
+    if isinstance(q, string_types):
         query, rank = _build_query_and_rank_statements(
             lang, q, plain)
         statements.append(query)
@@ -469,7 +471,7 @@ def _sort(data_dict, fields_types):
     if not sort:
         q = data_dict.get('q')
         if q:
-            if isinstance(q, basestring):
+            if isinstance(q, string_types):
                 return [_ts_rank_alias()]
             elif isinstance(q, dict):
                 return [_ts_rank_alias(field) for field in q
@@ -1196,7 +1198,7 @@ def validate(context, data_dict):
     for key, values in data_dict_copy.iteritems():
         if not values:
             continue
-        if isinstance(values, basestring):
+        if isinstance(values, string_types):
             value = values
         elif isinstance(values, (list, tuple)):
             value = values[0]

--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -6,6 +6,8 @@ import logging
 import paste.deploy.converters as converters
 import sqlparse
 
+from six import string_types
+
 from ckan.plugins.toolkit import get_action, ObjectNotFound, NotAuthorized
 
 log = logging.getLogger(__name__)
@@ -57,10 +59,10 @@ def validate_int(i, non_negative=False):
     return i >= 0 or not non_negative
 
 
-def _strip(input):
-    if isinstance(input, basestring) and len(input) and input[0] == input[-1]:
-        return input.strip().strip('"')
-    return input
+def _strip(s):
+    if isinstance(s, string_types) and len(s) and s[0] == s[-1]:
+        return s.strip().strip('"')
+    return s
 
 
 def should_fts_index_field_type(field_type):

--- a/ckanext/datastore/logic/schema.py
+++ b/ckanext/datastore/logic/schema.py
@@ -2,6 +2,8 @@
 
 import json
 
+from six import string_types
+
 import ckan.plugins as p
 import ckan.lib.navl.dictization_functions as df
 
@@ -48,13 +50,13 @@ def list_of_strings_or_lists(key, data, errors, context):
     if not isinstance(value, list):
         raise df.Invalid('Not a list')
     for x in value:
-        if not isinstance(x, basestring) and not isinstance(x, list):
+        if not isinstance(x, string_types) and not isinstance(x, list):
             raise df.Invalid('%s: %s' % ('Neither a string nor a list', x))
 
 
 def list_of_strings_or_string(key, data, errors, context):
     value = data.get(key)
-    if isinstance(value, basestring):
+    if isinstance(value, string_types):
         return
     list_of_strings_or_lists(key, data, errors, context)
 

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from six import string_types
 
 import ckan.plugins as p
 import ckan.logic as logic
@@ -213,16 +214,17 @@ class DatastorePlugin(p.SingletonPlugin):
 
         q = data_dict.get('q')
         if q:
-            if isinstance(q, basestring):
+            if isinstance(q, string_types):
                 del data_dict['q']
             elif isinstance(q, dict):
                 for key in q.keys():
-                    if key in fields_types and isinstance(q[key], basestring):
+                    if key in fields_types and isinstance(q[key],
+                                                          string_types):
                         del q[key]
 
         language = data_dict.get('language')
         if language:
-            if isinstance(language, basestring):
+            if isinstance(language, string_types):
                 del data_dict['language']
 
         plain = data_dict.get('plain')
@@ -249,7 +251,7 @@ class DatastorePlugin(p.SingletonPlugin):
         if limit:
             is_positive_int = datastore_helpers.validate_int(limit,
                                                              non_negative=True)
-            is_all = isinstance(limit, basestring) and limit.lower() == 'all'
+            is_all = isinstance(limit, string_types) and limit.lower() == 'all'
             if is_positive_int or is_all:
                 del data_dict['limit']
 

--- a/ckanext/multilingual/plugin.py
+++ b/ckanext/multilingual/plugin.py
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+from six import string_types
+
 import ckan
 from ckan.plugins import SingletonPlugin, implements, IPackageController
 from ckan.plugins import IGroupController, IOrganizationController, ITagController, IResourceController
@@ -31,7 +33,7 @@ def translate_data_dict(data_dict):
     for (key, value) in flattened.items():
         if value in (None, True, False):
             continue
-        elif isinstance(value, basestring):
+        elif isinstance(value, string_types):
             terms.add(value)
         elif isinstance(value, (int, long)):
             continue
@@ -79,7 +81,7 @@ def translate_data_dict(data_dict):
             # Don't try to translate values that aren't strings.
             translated_flattened[key] = value
 
-        elif isinstance(value, basestring):
+        elif isinstance(value, string_types):
             if value in desired_translations:
                 translated_flattened[key] = desired_translations[value]
             else:
@@ -127,7 +129,7 @@ def translate_resource_data_dict(data_dict):
     for (key, value) in flattened.items():
         if value in (None, True, False):
             continue
-        elif isinstance(value, basestring):
+        elif isinstance(value, string_types):
             terms.add(value)
         elif isinstance(value, (int, long)):
             continue
@@ -170,7 +172,7 @@ def translate_resource_data_dict(data_dict):
             # Don't try to translate values that aren't strings.
             translated_flattened[key] = value
 
-        elif isinstance(value, basestring):
+        elif isinstance(value, string_types):
             if value in desired_translations:
                 translated_flattened[key] = desired_translations[value]
             else:
@@ -229,7 +231,7 @@ class MultilingualDataset(SingletonPlugin):
             if not isinstance(value, list):
                 value = [value]
             for item in value:
-                if isinstance(item, basestring):
+                if isinstance(item, string_types):
                     all_terms.append(item)
 
         field_translations = get_action('term_translation_show')(


### PR DESCRIPTION
Related to #3309 (partial fix)

### Proposed fixes:

__basestring__ was removed in Python 3 so for each Python file that contains __basestring__, this PR adds __from six import string_types__ and replaces __basestring__ with __string_types__.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
