### PR TITLE
Don't set a default argument as a mutable type

### DIFF
--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -28,7 +28,11 @@ class MailerException(Exception):
 
 def _mail_recipient(recipient_name, recipient_email,
                     sender_name, sender_url, subject,
-                    body, headers={}):
+                    body, headers=None):
+    
+    if not headers:
+        headers = {}
+    
     mail_from = config.get('smtp.mail_from')
     msg = MIMEText(body.encode('utf-8'), 'plain', 'utf-8')
     for k, v in headers.items():

--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -29,10 +29,10 @@ class MailerException(Exception):
 def _mail_recipient(recipient_name, recipient_email,
                     sender_name, sender_url, subject,
                     body, headers=None):
-    
+
     if not headers:
         headers = {}
-    
+
     mail_from = config.get('smtp.mail_from')
     msg = MIMEText(body.encode('utf-8'), 'plain', 'utf-8')
     for k, v in headers.items():


### PR DESCRIPTION
When you run this a second time, `headers` will be the value they were last time you ran it. That seems bad.

http://docs.python-guide.org/en/latest/writing/gotchas/

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
