### PR TITLE
Change unicode() --> six.text_type() for Python 3

### DIFF
--- a/ckan/controllers/api.py
+++ b/ckan/controllers/api.py
@@ -9,6 +9,7 @@ import urllib
 
 from webob.multidict import UnicodeMultiDict
 from paste.util.multidict import MultiDict
+from six import text_type
 
 import ckan.model as model
 import ckan.logic as logic
@@ -217,14 +218,14 @@ class ApiController(base.BaseController):
                                     'message': _('Access denied')}
             return_dict['success'] = False
 
-            if unicode(e):
+            if text_type(e):
                 return_dict['error']['message'] += u': %s' % e
 
             return self._finish(403, return_dict, content_type='json')
         except NotFound as e:
             return_dict['error'] = {'__type': 'Not Found Error',
                                     'message': _('Not found')}
-            if unicode(e):
+            if text_type(e):
                 return_dict['error']['message'] += u': %s' % e
             return_dict['success'] = False
             return self._finish(404, return_dict, content_type='json')
@@ -297,9 +298,9 @@ class ApiController(base.BaseController):
         try:
             return self._finish_ok(action(context, {'id': id}))
         except NotFound as e:
-            return self._finish_not_found(unicode(e))
+            return self._finish_not_found(text_type(e))
         except NotAuthorized as e:
-            return self._finish_not_authz(unicode(e))
+            return self._finish_not_authz(text_type(e))
 
     def show(self, ver=None, register=None, subregister=None,
              id=None, id2=None):
@@ -326,9 +327,9 @@ class ApiController(base.BaseController):
         try:
             return self._finish_ok(action(context, data_dict))
         except NotFound as e:
-            return self._finish_not_found(unicode(e))
+            return self._finish_not_found(text_type(e))
         except NotAuthorized as e:
-            return self._finish_not_authz(unicode(e))
+            return self._finish_not_authz(text_type(e))
 
     def create(self, ver=None, register=None, subregister=None,
                id=None, id2=None):
@@ -369,9 +370,9 @@ class ApiController(base.BaseController):
             return self._finish_ok(response_data,
                                    resource_location=location)
         except NotAuthorized as e:
-            return self._finish_not_authz(unicode(e))
+            return self._finish_not_authz(text_type(e))
         except NotFound as e:
-            return self._finish_not_found(unicode(e))
+            return self._finish_not_found(text_type(e))
         except ValidationError as e:
             # CS: nasty_string ignore
             log.info('Validation error (REST create): %r', str(e.error_dict))
@@ -425,9 +426,9 @@ class ApiController(base.BaseController):
             response_data = action(context, data_dict)
             return self._finish_ok(response_data)
         except NotAuthorized as e:
-            return self._finish_not_authz(unicode(e))
+            return self._finish_not_authz(text_type(e))
         except NotFound as e:
-            return self._finish_not_found(unicode(e))
+            return self._finish_not_found(text_type(e))
         except ValidationError as e:
             # CS: nasty_string ignore
             log.info('Validation error (REST update): %r', str(e.error_dict))
@@ -472,9 +473,9 @@ class ApiController(base.BaseController):
             response_data = action(context, data_dict)
             return self._finish_ok(response_data)
         except NotAuthorized as e:
-            return self._finish_not_authz(unicode(e))
+            return self._finish_not_authz(text_type(e))
         except NotFound as e:
-            return self._finish_not_found(unicode(e))
+            return self._finish_not_found(text_type(e))
         except ValidationError as e:
             # CS: nasty_string ignore
             log.info('Validation error (REST delete): %r', str(e.error_dict))
@@ -671,7 +672,7 @@ class ApiController(base.BaseController):
 
     def tag_autocomplete(self):
         q = request.str_params.get('incomplete', '')
-        q = unicode(urllib.unquote(q), 'utf-8')
+        q = text_type(urllib.unquote(q), 'utf-8')
         limit = request.params.get('limit', 10)
         tag_names = []
         if q:
@@ -758,7 +759,7 @@ class ApiController(base.BaseController):
         def make_unicode(entity):
             '''Cast bare strings and strings in lists or dicts to Unicode. '''
             if isinstance(entity, str):
-                return unicode(entity)
+                return text_type(entity)
             elif isinstance(entity, list):
                 new_items = []
                 for item in entity:

--- a/ckan/controllers/feed.py
+++ b/ckan/controllers/feed.py
@@ -24,6 +24,7 @@ of the revision history, rather than a feed of datasets.
 import logging
 import urlparse
 
+from six import text_type
 import webhelpers.feedgenerator
 
 import ckan.lib.base as base
@@ -417,7 +418,7 @@ class FeedController(base.BaseController):
                               id=pkg['name'],
                               ver='3',
                               qualified=True),
-                    unicode(len(json.dumps(pkg))),   # TODO fix this
+                    text_type(len(json.dumps(pkg))),   # TODO fix this
                     u'application/json'),
                 **additional_fields
             )

--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -5,7 +5,7 @@ import datetime
 from urllib import urlencode
 
 from pylons.i18n import get_lang
-from six import string_types
+from six import string_types, text_type
 
 import ckan.lib.base as base
 import ckan.lib.helpers as h
@@ -789,7 +789,7 @@ class GroupController(base.BaseController):
                     id=c.group_dict['name']),
                 description=_(u'Recent changes to CKAN Group: ') +
                 c.group_dict['display_name'],
-                language=unicode(get_lang()),
+                language=text_type(get_lang()),
             )
             for revision_dict in c.group_revisions:
                 revision_date = h.date_str_to_datetime(

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -9,7 +9,7 @@ import cgi
 from ckan.common import config
 from paste.deploy.converters import asbool
 import paste.fileapp
-from six import string_types
+from six import string_types, text_type
 
 import ckan.logic as logic
 import ckan.lib.base as base
@@ -462,7 +462,7 @@ class PackageController(base.BaseController):
                                id=c.pkg_dict['name']),
                 description=_(u'Recent changes to CKAN Dataset: ') +
                 (c.pkg_dict['title'] or ''),
-                language=unicode(i18n.get_lang()),
+                language=text_type(i18n.get_lang()),
             )
             for revision_dict in c.pkg_revisions:
                 revision_date = h.date_str_to_datetime(
@@ -941,9 +941,9 @@ class PackageController(base.BaseController):
             abort(400, _(u'Integrity Error'))
         except SearchIndexError as e:
             try:
-                exc_str = unicode(repr(e.args))
+                exc_str = text_type(repr(e.args))
             except Exception:  # We don't like bare excepts
-                exc_str = unicode(str(e))
+                exc_str = text_type(str(e))
             abort(500, _(u'Unable to add package to search index.') + exc_str)
         except ValidationError as e:
             errors = e.error_dict
@@ -989,9 +989,9 @@ class PackageController(base.BaseController):
             abort(400, _(u'Integrity Error'))
         except SearchIndexError as e:
             try:
-                exc_str = unicode(repr(e.args))
+                exc_str = text_type(repr(e.args))
             except Exception:  # We don't like bare excepts
-                exc_str = unicode(str(e))
+                exc_str = text_type(str(e))
             abort(500, _(u'Unable to update search index.') + exc_str)
         except ValidationError as e:
             errors = e.error_dict

--- a/ckan/controllers/revision.py
+++ b/ckan/controllers/revision.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timedelta
 
 from pylons.i18n import get_lang
+from six import text_type
 
 import ckan.logic as logic
 import ckan.lib.base as base
@@ -44,7 +45,7 @@ class RevisionController(base.BaseController):
                 title=_(u'CKAN Repository Revision History'),
                 link=h.url_for(controller='revision', action='list', id=''),
                 description=_(u'Recent changes to the CKAN repository.'),
-                language=unicode(get_lang()),
+                language=text_type(get_lang()),
             )
             # TODO: make this configurable?
             # we do not want the system to fall over!

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -4,6 +4,7 @@ import logging
 
 from ckan.common import config
 from paste.deploy.converters import asbool
+from six import text_type
 
 import ckan.lib.base as base
 import ckan.model as model
@@ -499,7 +500,7 @@ class UserController(base.BaseController):
                     h.redirect_to('/')
                 except mailer.MailerException as e:
                     h.flash_error(_('Could not send reset link: %s') %
-                                  unicode(e))
+                                  text_type(e))
         return render('user/request_reset.html')
 
     def perform_reset(self, id):
@@ -551,7 +552,7 @@ class UserController(base.BaseController):
             except ValidationError as e:
                 h.flash_error(u'%r' % e.error_dict)
             except ValueError as ve:
-                h.flash_error(unicode(ve))
+                h.flash_error(text_type(ve))
             user_dict['state'] = user_state
 
         c.user_dict = user_dict

--- a/ckan/lib/alphabet_paginate.py
+++ b/ckan/lib/alphabet_paginate.py
@@ -18,6 +18,7 @@ Based on webhelpers.paginator, but:
 from itertools import dropwhile
 import re
 
+from six import text_type
 from sqlalchemy import  __version__ as sqav
 from sqlalchemy.orm.query import Query
 from webhelpers.html.builder import HTML
@@ -54,7 +55,7 @@ class AlphaPage(object):
         # because we grey-out those which aren't.
         self.available = dict( (c,0,) for c in self.letters )
         for c in self.collection:
-            if isinstance(c, unicode):
+            if isinstance(c, text_type):
                 x = c[0]
             elif isinstance(c, dict):
                 x = c[self.alpha_attribute][0]
@@ -131,7 +132,7 @@ class AlphaPage(object):
                 if self.page != self.other_text:
                     if isinstance(self.collection[0], dict):
                         items = [x for x in self.collection if x[self.alpha_attribute][0:1].lower() == self.page.lower()]
-                    elif isinstance(self.collection[0], unicode):
+                    elif isinstance(self.collection[0], text_type):
                         items = [x for x in self.collection if x[0:1].lower() == self.page.lower()]
                     else:
                         items = [x for x in self.collection if getattr(x,self.alpha_attribute)[0:1].lower() == self.page.lower()]

--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -16,10 +16,12 @@ import logging
 from optparse import OptionConflictError
 import traceback
 
+from six import text_type
 from six.moves import input, xrange
 from six.moves.urllib.error import HTTPError
 from six.moves.urllib.parse import urljoin, urlparse
 from six.moves.urllib.request import urlopen
+
 import sqlalchemy as sa
 import routes
 import paste.script
@@ -810,13 +812,13 @@ class Sysadmin(CkanCommand):
             return
         username = self.args[1]
 
-        user = model.User.by_name(unicode(username))
+        user = model.User.by_name(text_type(username))
         if not user:
             print('User "%s" not found' % username)
             makeuser = input('Create new user: %s? [y/n]' % username)
             if makeuser == 'y':
                 user_add(self.args[1:])
-                user = model.User.by_name(unicode(username))
+                user = model.User.by_name(text_type(username))
             else:
                 print('Exiting ...')
                 return
@@ -834,7 +836,7 @@ class Sysadmin(CkanCommand):
             return
         username = self.args[1]
 
-        user = model.User.by_name(unicode(username))
+        user = model.User.by_name(text_type(username))
         if not user:
             print('Error: user "%s" not found!' % username)
             return
@@ -902,7 +904,7 @@ class UserCmd(CkanCommand):
         import ckan.model as model
 
         username = self.args[0]
-        user = model.User.get(unicode(username))
+        user = model.User.get(text_type(username))
         print('User: \n', user)
 
     def setpass(self):
@@ -1005,7 +1007,7 @@ class DatasetCmd(CkanCommand):
 
     def _get_dataset(self, dataset_ref):
         import ckan.model as model
-        dataset = model.Package.get(unicode(dataset_ref))
+        dataset = model.Package.get(text_type(dataset_ref))
         assert dataset, 'Could not find dataset matching reference: %r' % dataset_ref
         return dataset
 

--- a/ckan/lib/create_test_data.py
+++ b/ckan/lib/create_test_data.py
@@ -4,6 +4,8 @@ import logging
 from collections import defaultdict
 import datetime
 
+from six import string_types, text_type
+
 import ckan.model as model
 
 log = logging.getLogger(__name__)
@@ -162,7 +164,7 @@ class CreateTestData(object):
                 pkg_dict = {}
                 for field in cls.pkg_core_fields:
                     if item.has_key(field):
-                        pkg_dict[field] = unicode(item[field])
+                        pkg_dict[field] = text_type(item[field])
                 if model.Package.by_name(pkg_dict['name']):
                     log.warning('Cannot create package "%s" as it already exists.' % \
                                     (pkg_dict['name']))
@@ -171,13 +173,13 @@ class CreateTestData(object):
                 model.Session.add(pkg)
                 for attr, val in item.items():
                     if isinstance(val, str):
-                        val = unicode(val)
+                        val = text_type(val)
                     if attr=='name':
                         continue
                     if attr in cls.pkg_core_fields:
                         pass
                     elif attr == 'download_url':
-                        pkg.add_resource(unicode(val))
+                        pkg.add_resource(text_type(val))
                     elif attr == 'resources':
                         assert isinstance(val, (list, tuple))
                         for res_dict in val:
@@ -185,19 +187,19 @@ class CreateTestData(object):
                             for k, v in res_dict.items():
                                 if k != 'extras':
                                     if not isinstance(v, datetime.datetime):
-                                        v = unicode(v)
+                                        v = text_type(v)
                                     non_extras[str(k)] = v
-                            extras = {str(k): unicode(v) for k, v in res_dict.get('extras', {}).items()}
+                            extras = {str(k): text_type(v) for k, v in res_dict.get('extras', {}).items()}
                             pkg.add_resource(extras=extras, **non_extras)
                     elif attr == 'tags':
-                        if isinstance(val, (str, unicode)):
+                        if isinstance(val, string_types):
                             tags = val.split()
                         elif isinstance(val, list):
                             tags = val
                         else:
                             raise NotImplementedError
                         for tag_name in tags:
-                            tag_name = unicode(tag_name)
+                            tag_name = text_type(tag_name)
                             tag = model.Tag.by_name(tag_name)
                             if not tag:
                                 tag = model.Tag(name=tag_name)
@@ -207,18 +209,18 @@ class CreateTestData(object):
                             model.Session.flush()
                     elif attr == 'groups':
                         model.Session.flush()
-                        if isinstance(val, (str, unicode)):
+                        if isinstance(val, string_types):
                             group_names = val.split()
                         elif isinstance(val, list):
                             group_names = val
                         else:
                             raise NotImplementedError
                         for group_name in group_names:
-                            group = model.Group.by_name(unicode(group_name))
+                            group = model.Group.by_name(text_type(group_name))
                             if not group:
                                 if not group_name in new_groups:
                                     group = model.Group(name=
-                                                        unicode(group_name))
+                                                        text_type(group_name))
                                     model.Session.add(group)
                                     new_group_names.add(group_name)
                                     new_groups[group_name] = group
@@ -254,7 +256,7 @@ class CreateTestData(object):
 
         rev = model.repo.new_revision()
         for group_name in extra_group_names:
-            group = model.Group(name=unicode(group_name))
+            group = model.Group(name=text_type(group_name))
             model.Session.add(group)
             new_group_names.add(group_name)
             needs_commit = True
@@ -265,8 +267,8 @@ class CreateTestData(object):
 
         # create users that have been identified as being needed
         for user_name in new_user_names:
-            if not model.User.by_name(unicode(user_name)):
-                user = model.User(name=unicode(user_name))
+            if not model.User.by_name(text_type(user_name)):
+                user = model.User(name=text_type(user_name))
                 model.Session.add(user)
                 cls.user_refs.append(user_name)
                 needs_commit = True
@@ -277,7 +279,7 @@ class CreateTestData(object):
 
         # setup authz for groups just created
         for group_name in new_group_names:
-            group = model.Group.by_name(unicode(group_name))
+            group = model.Group.by_name(text_type(group_name))
             cls.group_names.add(group_name)
             needs_commit = True
 
@@ -291,10 +293,10 @@ class CreateTestData(object):
             rev.message = u'Creating package relationships.'
 
             def pkg(pkg_name):
-                return model.Package.by_name(unicode(pkg_name))
+                return model.Package.by_name(text_type(pkg_name))
             for subject_name, relationship, object_name in relationships:
                 pkg(subject_name).add_relationship(
-                    unicode(relationship), pkg(object_name))
+                    text_type(relationship), pkg(object_name))
                 needs_commit = True
 
             model.repo.commit_and_remove()
@@ -315,12 +317,12 @@ class CreateTestData(object):
         group_attributes = set(('name', 'title', 'description', 'parent_id',
                                 'type', 'is_organization'))
         for group_dict in group_dicts:
-            if model.Group.by_name(unicode(group_dict['name'])):
+            if model.Group.by_name(text_type(group_dict['name'])):
                 log.warning('Cannot create group "%s" as it already exists.' %
                             group_dict['name'])
                 continue
             pkg_names = group_dict.pop('packages', [])
-            group = model.Group(name=unicode(group_dict['name']))
+            group = model.Group(name=text_type(group_dict['name']))
             group.type = auth_profile or 'group'
             for key in group_dict:
                 if key in group_attributes:
@@ -329,7 +331,7 @@ class CreateTestData(object):
                     group.extras[key] = group_dict[key]
             assert isinstance(pkg_names, (list, tuple))
             for pkg_name in pkg_names:
-                pkg = model.Package.by_name(unicode(pkg_name))
+                pkg = model.Package.by_name(text_type(pkg_name))
                 assert pkg, pkg_name
                 member = model.Member(group=group, table_id=pkg.id,
                                       table_name='package')
@@ -358,7 +360,7 @@ class CreateTestData(object):
             rev.author = cls.author
             # add it to a parent's group
             if 'parent' in group_dict:
-                parent = model.Group.by_name(unicode(group_dict['parent']))
+                parent = model.Group.by_name(text_type(group_dict['parent']))
                 assert parent, group_dict['parent']
                 member = model.Member(group=group, table_id=parent.id,
                                       table_name='group', capacity='parent')
@@ -512,8 +514,8 @@ left arrow <
         for k, v in user_dict.items():
             if v:
                 # avoid unicode warnings
-                user_dict[k] = unicode(v)
-        user = model.User(name=unicode(name), **user_dict)
+                user_dict[k] = text_type(v)
+        user = model.User(name=text_type(name), **user_dict)
         model.Session.add(user)
         cls.user_refs.append(user_ref)
         return user
@@ -542,15 +544,15 @@ left arrow <
         '''Purges packages etc. that were created by this class.'''
         for pkg_name in cls.pkg_names:
             model.Session().autoflush = False
-            pkg = model.Package.by_name(unicode(pkg_name))
+            pkg = model.Package.by_name(text_type(pkg_name))
             if pkg:
                 pkg.purge()
         for tag_name in cls.tag_names:
-            tag = model.Tag.by_name(unicode(tag_name))
+            tag = model.Tag.by_name(text_type(tag_name))
             if tag:
                 tag.purge()
         for group_name in cls.group_names:
-            group = model.Group.by_name(unicode(group_name))
+            group = model.Group.by_name(text_type(group_name))
             if group:
                 model.Session.delete(group)
         revs = model.Session.query(model.Revision).filter_by(author=cls.author)
@@ -562,7 +564,7 @@ left arrow <
             model.Session.commit()
             model.Session.delete(rev)
         for user_name in cls.user_refs:
-            user = model.User.get(unicode(user_name))
+            user = model.User.get(text_type(user_name))
             if user:
                 user.purge()
         model.Session.commit()

--- a/ckan/lib/dictization/__init__.py
+++ b/ckan/lib/dictization/__init__.py
@@ -3,6 +3,7 @@
 import datetime
 from sqlalchemy.orm import class_mapper
 import sqlalchemy
+from six import text_type
 from ckan.common import config
 from ckan.model.core import State
 
@@ -58,7 +59,7 @@ def table_dictize(obj, context, **kw):
         elif isinstance(value, list):
             result_dict[name] = value
         else:
-            result_dict[name] = unicode(value)
+            result_dict[name] = text_type(value)
 
     result_dict.update(kw)
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -35,7 +35,7 @@ from routes import url_for as _routes_default_url_for
 from flask import url_for as _flask_default_url_for
 from werkzeug.routing import BuildError as FlaskRouteBuildError
 import i18n
-from six import string_types
+from six import string_types, text_type
 
 import ckan.exceptions
 import ckan.model as model
@@ -166,7 +166,7 @@ def redirect_to(*args, **kw):
         kw['__no_cache__'] = True
 
     # Routes router doesn't like unicode args
-    uargs = map(lambda arg: str(arg) if isinstance(arg, unicode) else arg,
+    uargs = map(lambda arg: str(arg) if isinstance(arg, text_type) else arg,
                 args)
 
     _url = ''
@@ -1091,7 +1091,7 @@ def sorted_extras(package_extras, auto_clean=False, subs=None, exclude=None):
         elif auto_clean:
             k = k.replace('_', ' ').replace('-', ' ').title()
         if isinstance(v, (list, tuple)):
-            v = ", ".join(map(unicode, v))
+            v = ", ".join(map(text_type, v))
         output.append((k, v))
     return output
 
@@ -1126,7 +1126,7 @@ def get_action(action_name, data_dict=None):
 @core_helper
 def linked_user(user, maxlength=0, avatar=20):
     if not isinstance(user, model.User):
-        user_name = unicode(user)
+        user_name = text_type(user)
         user = model.User.get(user_name)
         if not user:
             return user_name
@@ -1169,7 +1169,7 @@ def markdown_extract(text, extract_length=190):
         return literal(plain)
 
     return literal(
-        unicode(
+        text_type(
             whtext.truncate(
                 plain,
                 length=extract_length,
@@ -2296,7 +2296,7 @@ def resource_view_full_page(resource_view):
 @core_helper
 def remove_linebreaks(string):
     '''Remove linebreaks from string to make it usable in JavaScript'''
-    return unicode(string).replace('\n', '')
+    return text_type(string).replace('\n', '')
 
 
 @core_helper
@@ -2563,7 +2563,7 @@ def radio(selected, id, checked):
 
 @core_helper
 def clean_html(html):
-    return bleach_clean(unicode(html))
+    return bleach_clean(text_type(html))
 
 
 core_helper(flash, name='flash')

--- a/ckan/lib/io.py
+++ b/ckan/lib/io.py
@@ -6,9 +6,10 @@ Utility functions for I/O.
 
 import sys
 
+from six import text_type
 
-_FILESYSTEM_ENCODING = unicode(sys.getfilesystemencoding()
-                               or sys.getdefaultencoding())
+_FILESYSTEM_ENCODING = text_type(sys.getfilesystemencoding()
+                                 or sys.getdefaultencoding())
 
 
 def encode_path(p):
@@ -28,7 +29,7 @@ def encode_path(p):
 
     Raises a ``TypeError`` is the input is not a Unicode string.
     '''
-    if not isinstance(p, unicode):
+    if not isinstance(p, text_type):
         raise TypeError(u'Can only encode unicode, not {}'.format(type(p)))
     return p.encode(_FILESYSTEM_ENCODING)
 

--- a/ckan/lib/jinja_extensions.py
+++ b/ckan/lib/jinja_extensions.py
@@ -12,6 +12,7 @@ from jinja2.utils import open_if_exists, escape
 from jinja2 import Environment
 from jinja2 import FileSystemBytecodeCache
 
+from six import text_type
 from six.moves import xrange
 
 import ckan.lib.base as base
@@ -80,7 +81,7 @@ class CkanInternationalizationExtension(ext.InternationalizationExtension):
             for arg in args:
                 if isinstance(arg, nodes.Const):
                     value = arg.value
-                    if isinstance(value, unicode):
+                    if isinstance(value, text_type):
                         arg.value = regularise_html(value)
         return node
 

--- a/ckan/lib/lazyjson.py
+++ b/ckan/lib/lazyjson.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
-
 from simplejson import loads, RawJSON, dumps
+from six import text_type
 
 
 class LazyJSONObject(RawJSON):
@@ -12,7 +12,7 @@ class LazyJSONObject(RawJSON):
     unicode strings containing a single JSON object.
     '''
     def __init__(self, json_string):
-        assert isinstance(json_string, unicode), json_string
+        assert isinstance(json_string, text_type), json_string
         self._json_string = json_string
         self._json_dict = None
 

--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -11,6 +11,7 @@ from email import Utils
 
 from ckan.common import config
 import paste.deploy.converters
+from six import text_type
 
 import ckan
 import ckan.model as model
@@ -186,7 +187,7 @@ def send_invite(user, group_dict=None, role=None):
 
 
 def create_reset_key(user):
-    user.reset_key = unicode(make_key())
+    user.reset_key = text_type(make_key())
     model.repo.commit_and_remove()
 
 

--- a/ckan/lib/munge.py
+++ b/ckan/lib/munge.py
@@ -8,6 +8,8 @@
 import os.path
 import re
 
+from six import text_type
+
 from ckan import model
 from ckan.lib.io import decode_path
 
@@ -24,7 +26,7 @@ MIN_FILENAME_TOTAL_LENGTH = 3
 def munge_name(name):
     '''Munges the package name field in case it is not to spec.'''
     # substitute non-ascii characters
-    if isinstance(name, unicode):
+    if isinstance(name, text_type):
         name = substitute_ascii_equivalents(name)
     # separators become dashes
     name = re.sub('[ .:/]', '-', name)
@@ -39,7 +41,7 @@ def munge_name(name):
 def munge_title_to_name(name):
     '''Munge a package title into a package name.'''
     # substitute non-ascii characters
-    if isinstance(name, unicode):
+    if isinstance(name, text_type):
         name = substitute_ascii_equivalents(name)
     # convert spaces and separators
     name = re.sub('[ .:/]', '-', name)
@@ -147,7 +149,7 @@ def munge_filename(filename):
 
     Returns a Unicode string.
     '''
-    if not isinstance(filename, unicode):
+    if not isinstance(filename, text_type):
         filename = decode_path(filename)
 
     # Ignore path

--- a/ckan/lib/navl/dictization_functions.py
+++ b/ckan/lib/navl/dictization_functions.py
@@ -4,6 +4,8 @@ import copy
 import formencode as fe
 import inspect
 import json
+
+from six import text_type
 from ckan.common import config
 
 from ckan.common import _
@@ -47,7 +49,7 @@ class State(object):
 
 class DictizationError(Exception):
     def __str__(self):
-        return unicode(self).encode('utf8')
+        return text_type(self).encode('utf8')
 
     def __unicode__(self):
         if hasattr(self, 'error') and self.error:

--- a/ckan/lib/navl/validators.py
+++ b/ckan/lib/navl/validators.py
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+from six import text_type
+
 import ckan.lib.navl.dictization_functions as df
 
 from ckan.common import _, json
@@ -120,7 +122,7 @@ def convert_int(value, context):
 def unicode_only(value):
     '''Accept only unicode values'''
 
-    if not isinstance(value, unicode):
+    if not isinstance(value, text_type):
         raise Invalid(_('Must be a Unicode string value'))
     return value
 
@@ -137,7 +139,7 @@ def unicode_safe(value):
     converts binary strings assuming either UTF-8 or CP1252
     encodings (not ASCII, with occasional decoding errors)
     '''
-    if isinstance(value, unicode):
+    if isinstance(value, text_type):
         return value
     if hasattr(value, 'filename'):
         # cgi.FieldStorage instance for uploaded files, show the name
@@ -156,6 +158,6 @@ def unicode_safe(value):
     except Exception:
         # at this point we have given up. Just don't error out
         try:
-            return unicode(value)
+            return text_type(value)
         except Exception:
             return u'\N{REPLACEMENT CHARACTER}'

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -13,6 +13,7 @@ import re
 import pysolr
 from ckan.common import config
 from paste.deploy.converters import asbool
+from six import text_type
 
 from common import SearchIndexError, make_connection
 from ckan.model import PackageRelationship
@@ -140,7 +141,7 @@ class PackageSearchIndex(SearchIndex):
         for extra in extras:
             key, value = extra['key'], extra['value']
             if isinstance(value, (tuple, list)):
-                value = " ".join(map(unicode, value))
+                value = " ".join(map(text_type, value))
             key = ''.join([c for c in key if c in KEY_CHARS])
             pkg_dict['extras_' + key] = value
             if key not in index_fields:

--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -7,7 +7,7 @@ import sys
 from collections import defaultdict
 
 import formencode.validators
-from six import string_types
+from six import string_types, text_type
 
 import ckan.model as model
 import ckan.authz as authz
@@ -306,7 +306,7 @@ def check_access(action, context, data_dict=None):
             raise NotAuthorized(msg)
     except NotAuthorized as e:
         log.debug(u'check access NotAuthorized - %s user=%s "%s"',
-                  action, user, unicode(e))
+                  action, user, text_type(e))
         raise
 
     log.debug('check access OK - %s user=%s', action, user)

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -11,7 +11,7 @@ import socket
 from ckan.common import config
 import sqlalchemy
 from paste.deploy.converters import asbool
-from six import string_types
+from six import string_types, text_type
 
 import ckan.lib.dictization
 import ckan.logic as logic
@@ -2168,7 +2168,7 @@ def resource_search(context, data_dict):
 
             # Treat the has field separately, see docstring.
             if field == 'hash':
-                q = q.filter(model_attr.ilike(unicode(term) + '%'))
+                q = q.filter(model_attr.ilike(text_type(term) + '%'))
 
             # Resource extras are stored in a json blob.  So searching for
             # matching fields is a bit trickier.  See the docstring.
@@ -2185,7 +2185,7 @@ def resource_search(context, data_dict):
 
             # Just a regular field
             else:
-                q = q.filter(model_attr.ilike('%' + unicode(term) + '%'))
+                q = q.filter(model_attr.ilike('%' + text_type(term) + '%'))
 
     if order_by is not None:
         if hasattr(model.Resource, order_by):

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -11,6 +11,7 @@ import os
 
 from ckan.common import config
 import paste.deploy.converters as converters
+from six import text_type
 
 import ckan.lib.helpers as h
 import ckan.plugins as plugins
@@ -822,9 +823,9 @@ def term_translation_update(context, data_dict):
 
     _check_access('term_translation_update', context, data_dict)
 
-    schema = {'term': [validators.not_empty, unicode],
-              'term_translation': [validators.not_empty, unicode],
-              'lang_code': [validators.not_empty, unicode]}
+    schema = {'term': [validators.not_empty, text_type],
+              'term_translation': [validators.not_empty, text_type],
+              'lang_code': [validators.not_empty, text_type]}
 
     data, errors = _validate(data_dict, schema, context)
     if errors:

--- a/ckan/logic/converters.py
+++ b/ckan/logic/converters.py
@@ -2,7 +2,7 @@
 
 import json
 
-from six import string_types
+from six import string_types, text_type
 
 import ckan.model as model
 import ckan.lib.navl.dictization_functions as df
@@ -46,7 +46,7 @@ def convert_from_extras(key, data, errors, context):
 
 def extras_unicode_convert(extras, context):
     for extra in extras:
-        extras[extra] = unicode(extras[extra])
+        extras[extra] = text_type(extras[extra])
     return extras
 
 def free_tags_only(key, data, errors, context):

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -3,6 +3,7 @@
 from functools import wraps
 import inspect
 
+from six import text_type
 import ckan.model
 import ckan.plugins as plugins
 from ckan.logic import get_validator
@@ -419,9 +420,9 @@ def user_new_form_schema(
         user_password_validator, user_passwords_match):
     schema = default_user_schema()
 
-    schema['password1'] = [unicode, user_both_passwords_entered,
+    schema['password1'] = [text_type, user_both_passwords_entered,
                            user_password_validator, user_passwords_match]
-    schema['password2'] = [unicode]
+    schema['password2'] = [text_type]
 
     return schema
 
@@ -467,7 +468,7 @@ def default_generate_apikey_user_schema(
 def default_user_invite_schema(
         not_empty, unicode_safe):
     return {
-        'email': [not_empty, unicode],
+        'email': [not_empty, text_type],
         'group_id': [not_empty],
         'role': [not_empty],
     }

--- a/ckan/model/__init__.py
+++ b/ckan/model/__init__.py
@@ -5,6 +5,7 @@ import logging
 import re
 from datetime import datetime
 
+from six import text_type
 import vdm.sqlalchemy
 from vdm.sqlalchemy.base import SQLAlchemySession
 from sqlalchemy import MetaData, __version__ as sqav, Table
@@ -392,7 +393,7 @@ def _get_groups(self):
 
 # could set this up directly on the mapper?
 def _get_revision_user(self):
-    username = unicode(self.author)
+    username = text_type(self.author)
     user = meta.Session.query(User).filter_by(name=username).first()
     return user
 

--- a/ckan/model/group_extra.py
+++ b/ckan/model/group_extra.py
@@ -3,6 +3,7 @@
 import vdm.sqlalchemy
 import vdm.sqlalchemy.stateful
 from sqlalchemy import orm, types, Column, Table, ForeignKey
+from six import text_type
 
 import group
 import meta
@@ -46,10 +47,10 @@ GroupExtraRevision = vdm.sqlalchemy.create_object_version(meta.mapper, GroupExtr
     group_extra_revision_table)
 
 def _create_extra(key, value):
-    return GroupExtra(key=unicode(key), value=value)
+    return GroupExtra(key=text_type(key), value=value)
 
 _extras_active = vdm.sqlalchemy.stateful.DeferredProperty('_extras',
-        vdm.sqlalchemy.stateful.StatefulDict, base_modifier=lambda x: x.get_as_of()) 
+        vdm.sqlalchemy.stateful.StatefulDict, base_modifier=lambda x: x.get_as_of())
 setattr(group.Group, 'extras_active', _extras_active)
 group.Group.extras = vdm.sqlalchemy.stateful.OurAssociationProxy('extras_active', 'value',
             creator=_create_extra)

--- a/ckan/model/license.py
+++ b/ckan/model/license.py
@@ -6,6 +6,7 @@ import re
 
 from ckan.common import config
 from paste.deploy.converters import asbool
+from six import text_type
 
 from ckan.common import _, json
 import ckan.lib.maintain as maintain
@@ -200,7 +201,7 @@ class DefaultLicense(dict):
         if key in self.keys:
             value = getattr(self, key)
             if isinstance(value, str):
-                return unicode(value)
+                return text_type(value)
             else:
                 return value
         else:
@@ -210,7 +211,7 @@ class DefaultLicense(dict):
         ''' create a dict of the license used by the licenses api '''
         out = {}
         for key in self.keys:
-            out[key] = unicode(getattr(self, key))
+            out[key] = text_type(getattr(self, key))
         return out
 
 class LicenseNotSpecified(DefaultLicense):

--- a/ckan/model/package_extra.py
+++ b/ckan/model/package_extra.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from six import text_type
 import vdm.sqlalchemy
 import vdm.sqlalchemy.stateful
 from sqlalchemy import orm, types, Column, Table, ForeignKey
@@ -75,11 +76,10 @@ PackageExtraRevision= vdm.sqlalchemy.create_object_version(meta.mapper, PackageE
 PackageExtraRevision.related_packages = lambda self: [self.continuity.package]
 
 def _create_extra(key, value):
-    return PackageExtra(key=unicode(key), value=value)
+    return PackageExtra(key=text_type(key), value=value)
 
 _extras_active = vdm.sqlalchemy.stateful.DeferredProperty('_extras',
-        vdm.sqlalchemy.stateful.StatefulDict, base_modifier=lambda x: x.get_as_of()) 
+        vdm.sqlalchemy.stateful.StatefulDict, base_modifier=lambda x: x.get_as_of())
 setattr(_package.Package, 'extras_active', _extras_active)
 _package.Package.extras = vdm.sqlalchemy.stateful.OurAssociationProxy('extras_active', 'value',
             creator=_create_extra)
-

--- a/ckan/model/resource.py
+++ b/ckan/model/resource.py
@@ -2,6 +2,7 @@
 
 import datetime
 
+from six import text_type
 from sqlalchemy.util import OrderedDict
 from sqlalchemy.ext.orderinglist import ordering_list
 from sqlalchemy import orm
@@ -212,7 +213,7 @@ def resource_identifier(obj):
 
 class DictProxy(object):
 
-    def __init__(self, target_key, target_dict, data_type=unicode):
+    def __init__(self, target_key, target_dict, data_type=text_type):
         self.target_key = target_key
         self.target_dict = target_dict
         self.data_type = data_type

--- a/ckan/model/system_info.py
+++ b/ckan/model/system_info.py
@@ -8,6 +8,7 @@ For more details, check :doc:`maintaining/configuration`.
 '''
 
 from sqlalchemy import types, Column, Table
+from six import text_type
 
 import vdm.sqlalchemy
 import meta
@@ -37,7 +38,7 @@ class SystemInfo(vdm.sqlalchemy.RevisionedObjectMixin,
         super(SystemInfo, self).__init__()
 
         self.key = key
-        self.value = unicode(value)
+        self.value = text_type(value)
 
 
 meta.mapper(SystemInfo, system_info_table,
@@ -76,12 +77,12 @@ def set_system_info(key, value):
     ''' save data in the system_info table '''
     obj = None
     obj = meta.Session.query(SystemInfo).filter_by(key=key).first()
-    if obj and obj.value == unicode(value):
+    if obj and obj.value == text_type(value):
         return
     if not obj:
         obj = SystemInfo(key, value)
     else:
-        obj.value = unicode(value)
+        obj.value = text_type(value)
 
     from ckan.model import repo
     rev = repo.new_revision()

--- a/ckan/model/types.py
+++ b/ckan/model/types.py
@@ -7,7 +7,7 @@ import uuid
 import simplejson as json
 
 from sqlalchemy import types
-from six import string_types
+from six import string_types, text_type
 
 import meta
 
@@ -15,13 +15,13 @@ __all__ = ['iso_date_to_datetime_for_sqlite', 'make_uuid', 'UuidType',
            'JsonType', 'JsonDictType']
 
 def make_uuid():
-    return unicode(uuid.uuid4())
+    return text_type(uuid.uuid4())
 
 class UuidType(types.TypeDecorator):
     impl = types.Unicode
 
     def process_bind_param(self, value, engine):
-        return unicode(value)
+        return text_type(value)
 
     def process_result_value(self, value, engine):
         # return uuid.UUID(value)
@@ -33,7 +33,7 @@ class UuidType(types.TypeDecorator):
     @classmethod
     def default(cls):
         # return uuid.uuid4()
-        return unicode(uuid.uuid4())
+        return text_type(uuid.uuid4())
 
 
 class JsonType(types.TypeDecorator):
@@ -50,7 +50,7 @@ class JsonType(types.TypeDecorator):
             return None
         else:
             # ensure_ascii=False => allow unicode but still need to convert
-            return unicode(json.dumps(value, ensure_ascii=False))
+            return text_type(json.dumps(value, ensure_ascii=False))
 
     def process_result_value(self, value, engine):
         if value is None:
@@ -76,9 +76,9 @@ class JsonDictType(JsonType):
             return None
         else:
             if isinstance(value, string_types):
-                return unicode(value)
+                return text_type(value)
             else:
-                return unicode(json.dumps(value, ensure_ascii=False))
+                return text_type(json.dumps(value, ensure_ascii=False))
 
     def copy(self):
         return JsonDictType(self.impl.length)

--- a/ckan/model/user.py
+++ b/ckan/model/user.py
@@ -10,6 +10,7 @@ from passlib.hash import pbkdf2_sha512
 from sqlalchemy.sql.expression import or_
 from sqlalchemy.orm import synonym
 from sqlalchemy import types, Column, Table, func
+from six import text_type
 import vdm.sqlalchemy
 
 import meta
@@ -101,7 +102,7 @@ class User(vdm.sqlalchemy.StatefulObjectMixin,
         '''
         hashed_password = pbkdf2_sha512.encrypt(password)
 
-        if not isinstance(hashed_password, unicode):
+        if not isinstance(hashed_password, text_type):
             hashed_password = hashed_password.decode('utf-8')
         self._password = hashed_password
 
@@ -109,7 +110,7 @@ class User(vdm.sqlalchemy.StatefulObjectMixin,
         return self._password
 
     def _verify_and_upgrade_from_sha1(self, password):
-        if isinstance(password, unicode):
+        if isinstance(password, text_type):
             password_8bit = password.encode('ascii', 'ignore')
         else:
             password_8bit = password

--- a/ckan/tests/controllers/test_api.py
+++ b/ckan/tests/controllers/test_api.py
@@ -13,6 +13,7 @@ from StringIO import StringIO
 from nose.tools import assert_equal, assert_in, eq_
 from pyfakefs import fake_filesystem
 
+from six import text_type
 from six.moves import xrange
 
 from ckan.lib.helpers import url_for
@@ -411,7 +412,7 @@ class TestRevisionSearch(helpers.FunctionalTestBase):
         rev_ids = []
         for i in xrange(num_revisions):
             rev = model.repo.new_revision()
-            rev.id = unicode(i)
+            rev.id = text_type(i)
             model.Session.commit()
             rev_ids.append(rev.id)
         return rev_ids

--- a/ckan/tests/legacy/__init__.py
+++ b/ckan/tests/legacy/__init__.py
@@ -21,6 +21,7 @@ import time
 from ckan.common import config
 from pylons.test import pylonsapp
 from paste.script.appinstall import SetupCommand
+from six import text_type
 
 import pkg_resources
 import paste.fixture
@@ -134,7 +135,7 @@ class CommonFixtureMethods(BaseCase):
     @classmethod
     def purge_packages(cls, pkg_names):
         for pkg_name in pkg_names:
-            pkg = model.Package.by_name(unicode(pkg_name))
+            pkg = model.Package.by_name(text_type(pkg_name))
             if pkg:
                 pkg.purge()
         model.repo.commit_and_remove()

--- a/ckan/tests/legacy/html_check.py
+++ b/ckan/tests/legacy/html_check.py
@@ -3,7 +3,8 @@
 import re
 import sgmllib
 
-from six import string_types
+from six import string_types, text_type
+
 
 import paste.fixture
 
@@ -64,23 +65,23 @@ class HtmlCheckMethods(object):
     def _get_html_from_res(self, html):
         if isinstance(html, paste.fixture.TestResponse):
             html_str = html.body.decode('utf8')
-        elif isinstance(html, unicode):
+        elif isinstance(html, text_type):
             html_str = html
         elif isinstance(html, str):
             html_str = html.decode('utf8')
         else:
             raise TypeError
-        return html_str # always unicode
+        return html_str  # always unicode
 
     def _check_html(self, regex_compiled, html, html_to_find):
-        html_to_find = [unicode(html_bit) for html_bit in html_to_find]
+        html_to_find = [text_type(html_bit) for html_bit in html_to_find]
         partly_matching_tags = []
         html_str = self._get_html_from_res(html)
         for tag in regex_compiled.finditer(html_str):
             found_all=True
             for i, html_bit_to_find in enumerate(html_to_find):
-                assert isinstance(html_bit_to_find, (str, unicode)), html_bit_to_find
-                html_bit_to_find = unicode(html_bit_to_find)
+                assert isinstance(html_bit_to_find, string_types), html_bit_to_find
+                html_bit_to_find = text_type(html_bit_to_find)
                 find_inverse = html_bit_to_find.startswith('!')
                 if (find_inverse and html_bit_to_find[1:] in tag.group()) or \
                    (not find_inverse and html_bit_to_find not in tag.group()):

--- a/ckan/tests/legacy/lib/__init__.py
+++ b/ckan/tests/legacy/lib/__init__.py
@@ -1,13 +1,14 @@
 # encoding: utf-8
 
 from nose.tools import assert_equal
+from six import text_type
 
 from ckan import model
 import ckan.lib.search as search
 
 def check_search_results(terms, expected_count, expected_packages=[]):
     query = {
-        'q': unicode(terms),
+        'q': text_type(terms),
     }
     result = search.query_for(model.Package).run(query)
     pkgs = result['results']

--- a/ckan/tests/legacy/lib/test_navl.py
+++ b/ckan/tests/legacy/lib/test_navl.py
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+from six import text_type
+
 from ckan.lib.navl.dictization_functions import (flatten_schema,
                                    get_all_key_combinations,
                                    make_full_schema,
@@ -301,7 +303,7 @@ def test_simple():
 
 def test_simple_converter_types():
     schema = {
-        "name": [not_empty, unicode],
+        "name": [not_empty, text_type],
         "age": [ignore_missing, int],
         "gender": [default("female")],
     }
@@ -315,13 +317,13 @@ def test_simple_converter_types():
     assert not errors
     assert converted_data == {'gender': 'female', 'age': 32, 'name': u'fred'}, converted_data
 
-    assert isinstance(converted_data["name"], unicode)
-    assert not isinstance(converted_data["gender"], unicode)
+    assert isinstance(converted_data["name"], text_type)
+    assert isinstance(converted_data["gender"], str)
 
 
 def test_formencode_compat():
     schema = {
-        "name": [not_empty, unicode],
+        "name": [not_empty, text_type],
         "email": [validators.Email],
         "email2": [validators.Email],
     }
@@ -338,7 +340,7 @@ def test_formencode_compat():
 def test_range_validator():
 
     schema = {
-        "name": [not_empty, unicode],
+        "name": [not_empty, text_type],
         "email": [validators.Int(min=1, max=10)],
         "email2": [validators.Email],
     }

--- a/ckan/tests/lib/navl/test_dictization_functions.py
+++ b/ckan/tests/lib/navl/test_dictization_functions.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 import nose
+from six import text_type
 from ckan.lib.navl.dictization_functions import validate, Invalid
 
 
@@ -59,7 +60,7 @@ class TestDictizationError(object):
 
     def test_unicode_error(self):
         err_obj = Invalid('Some ascii error')
-        eq_(unicode(err_obj), u"Invalid: 'Some ascii error'")
+        eq_(text_type(err_obj), u"Invalid: 'Some ascii error'")
 
     def test_repr_error(self):
         err_obj = Invalid('Some ascii error')
@@ -73,7 +74,7 @@ class TestDictizationError(object):
 
     def test_unicode_unicode_error(self):
         err_obj = Invalid(u'Some unicode \xa3 error')
-        eq_(unicode(err_obj), "Invalid: u'Some unicode \\xa3 error'")
+        eq_(text_type(err_obj), "Invalid: u'Some unicode \\xa3 error'")
 
     def test_repr_unicode_error(self):
         err_obj = Invalid(u'Some unicode \xa3 error')
@@ -85,7 +86,7 @@ class TestDictizationError(object):
 
     def test_unicode_blank(self):
         err_obj = Invalid('')
-        eq_(unicode(err_obj), u"Invalid")
+        eq_(text_type(err_obj), u"Invalid")
 
     def test_repr_blank(self):
         err_obj = Invalid('')

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -6,6 +6,7 @@ import nose
 import pytz
 import tzlocal
 from babel import Locale
+from six import text_type
 
 from ckan.common import config
 import ckan.lib.helpers as h
@@ -469,7 +470,7 @@ class TestHelpersRemoveLineBreaks(object):
             '"remove_linebreaks" should remove line breaks'
 
     def test_remove_linebreaks_casts_into_unicode(self):
-        class UnicodeLike(unicode):
+        class UnicodeLike(text_type):
             pass
 
         test_string = UnicodeLike('foo')

--- a/ckan/tests/lib/test_io.py
+++ b/ckan/tests/lib/test_io.py
@@ -6,6 +6,7 @@ import shutil
 import tempfile
 
 from nose.tools import eq_, ok_, raises
+from six import text_type
 
 import ckan.lib.io as ckan_io
 
@@ -21,7 +22,7 @@ class TestDecodeEncodePath(object):
         ckan_io.encode_path(b'just_a_str')
 
     def test_decode_path_returns_unicode(self):
-        ok_(isinstance(ckan_io.decode_path(b'just_a_str'), unicode))
+        ok_(isinstance(ckan_io.decode_path(b'just_a_str'), text_type))
 
     def test_encode_path_returns_str(self):
         ok_(isinstance(ckan_io.encode_path(u'just_a_unicode'), str))

--- a/ckan/tests/lib/test_munge.py
+++ b/ckan/tests/lib/test_munge.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 from nose.tools import assert_equal, ok_
+from six import text_type
 
 from ckan.lib.munge import (munge_filename_legacy, munge_filename, munge_name,
                             munge_title_to_name, munge_tag)
@@ -66,7 +67,7 @@ class TestMungeFilename(object):
         for org, exp in self.munge_list:
             munge = munge_filename(org)
             assert_equal(munge, exp)
-            ok_(isinstance(munge, unicode))
+            ok_(isinstance(munge, text_type))
 
     def test_munge_filename_multiple_pass(self):
         '''Munging filename multiple times produces same result.'''

--- a/ckan/tests/lib/test_navl.py
+++ b/ckan/tests/lib/test_navl.py
@@ -2,6 +2,7 @@
 
 import nose
 import pylons
+from six import text_type
 
 from ckan.tests import helpers
 from ckan.config import environment
@@ -17,7 +18,7 @@ class TestFormencdoeLanguage(object):
         from ckan.lib.navl.validators import not_empty
         from formencode import validators
         schema = {
-            "name": [not_empty, unicode],
+            "name": [not_empty, text_type],
             "email": [validators.Email],
             "email2": [validators.Email],
         }

--- a/ckan/tests/logic/action/test_delete.py
+++ b/ckan/tests/logic/action/test_delete.py
@@ -3,6 +3,7 @@
 import re
 
 import nose.tools
+from six import text_type
 
 import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
@@ -150,7 +151,7 @@ class TestDeleteTags(object):
         try:
             helpers.call_action('tag_delete', id=u'Delta symbol: \u0394')
         except logic.NotFound as e:
-            assert u'Delta symbol: \u0394' in unicode(e)
+            assert u'Delta symbol: \u0394' in text_type(e)
         else:
             assert 0, 'Should have raised NotFound'
 

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -4,6 +4,7 @@ import datetime
 
 import nose.tools
 
+from six import text_type
 from six.moves import xrange
 
 from ckan import __version__
@@ -1948,7 +1949,7 @@ class TestRevisionList(helpers.FunctionalTestBase):
         rev_ids = []
         for i in xrange(num_revisions):
             rev = model.repo.new_revision()
-            rev.id = unicode(i)
+            rev.id = text_type(i)
             model.Session.commit()
             rev_ids.append(rev.id)
         return rev_ids

--- a/ckan/tests/model/test_user.py
+++ b/ckan/tests/model/test_user.py
@@ -6,6 +6,7 @@ import unittest
 
 import nose.tools as nt
 from passlib.hash import pbkdf2_sha512
+from six import text_type
 
 import ckan.tests.factories as factories
 import ckan.tests.helpers as helpers
@@ -28,7 +29,7 @@ class TestPassword(unittest.TestCase):
 
         This is needed to create old password hashes in the tests
         '''
-        if isinstance(password, unicode):
+        if isinstance(password, text_type):
             password_8bit = password.encode('ascii', 'ignore')
         else:
             password_8bit = password
@@ -37,7 +38,7 @@ class TestPassword(unittest.TestCase):
         hash = hashlib.sha1(password_8bit + salt.hexdigest())
         hashed_password = salt.hexdigest() + hash.hexdigest()
 
-        if not isinstance(hashed_password, unicode):
+        if not isinstance(hashed_password, text_type):
             hashed_password = hashed_password.decode('utf-8')
         return hashed_password
 

--- a/ckan/tests/test_coding_standards.py
+++ b/ckan/tests/test_coding_standards.py
@@ -17,8 +17,9 @@ import re
 import subprocess
 import sys
 
+from six import text_type
 
-FILESYSTEM_ENCODING = unicode(
+FILESYSTEM_ENCODING = text_type(
     sys.getfilesystemencoding() or sys.getdefaultencoding()
 )
 

--- a/ckan/tests/test_common.py
+++ b/ckan/tests/test_common.py
@@ -4,6 +4,7 @@ import flask
 import pylons
 
 from nose.tools import eq_, assert_not_equal as neq_, assert_raises
+from six import text_type
 
 from ckan.tests import helpers
 from ckan.common import (CKANConfig, config as ckan_config,
@@ -243,7 +244,7 @@ class TestCommonG(object):
 
         with app.flask_app.test_request_context():
 
-            assert u'flask.g' in unicode(ckan_g)
+            assert u'flask.g' in text_type(ckan_g)
 
             flask.g.user = u'example'
 

--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 from paste.deploy.converters import asbool
+from six import text_type
 
 import ckan.model as model
 from ckan.common import g, request, config, session
@@ -115,7 +116,7 @@ def identify_user():
         g.author = g.user
     else:
         g.author = g.remote_addr
-    g.author = unicode(g.author)
+    g.author = text_type(g.author)
 
 
 def _identify_user_default():

--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -5,6 +5,7 @@ import cgi
 import logging
 
 from flask import Blueprint, make_response
+from six import text_type
 from werkzeug.exceptions import BadRequest
 
 import ckan.model as model
@@ -298,14 +299,14 @@ def action(logic_function, ver=API_DEFAULT_VERSION):
                                  u'message': _(u'Access denied')}
         return_dict[u'success'] = False
 
-        if unicode(e):
+        if text_type(e):
             return_dict[u'error'][u'message'] += u': %s' % e
 
         return _finish(403, return_dict, content_type=u'json')
     except NotFound as e:
         return_dict[u'error'] = {u'__type': u'Not Found Error',
                                  u'message': _(u'Not found')}
-        if unicode(e):
+        if text_type(e):
             return_dict[u'error'][u'message'] += u': %s' % e
         return_dict[u'success'] = False
         return _finish(404, return_dict, content_type=u'json')

--- a/ckan/views/feed.py
+++ b/ckan/views/feed.py
@@ -4,6 +4,7 @@ import logging
 import urlparse
 
 from flask import Blueprint, make_response
+from six import text_type
 import webhelpers.feedgenerator
 from ckan.common import _, config, g, request, response
 import ckan.lib.helpers as h
@@ -53,7 +54,7 @@ def _enclosure(pkg):
         u'href': h.url(u'api.action', logic_function=u'package_show',
                        ver=3, id=pkg['id'], _external=True),
         u'rel': u'',
-        u'length': unicode(len(json.dumps(pkg))),
+        u'length': text_type(len(json.dumps(pkg))),
         u'type': u'application/json'})
     return links
 
@@ -121,7 +122,7 @@ def output_feed(results, feed_title, feed_description, feed_link, feed_url,
                     id=pkg['name'],
                     ver=3,
                     _external=True),
-                unicode(len(json.dumps(pkg))), u'application/json'),
+                text_type(len(json.dumps(pkg))), u'application/json'),
             **additional_fields)
 
     resp = make_response(feed.writeString(u'utf-8'), 200)

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -4,6 +4,7 @@ import logging
 from flask import Blueprint
 from flask.views import MethodView
 from paste.deploy.converters import asbool
+from six import text_type
 
 import ckan.lib.authenticator as authenticator
 import ckan.lib.base as base
@@ -542,7 +543,8 @@ class RequestResetView(MethodView):
                       u'a reset code.'))
                 return h.redirect_to(u'/')
             except mailer.MailerException as e:
-                h.flash_error(_(u'Could not send reset link: %s') % unicode(e))
+                h.flash_error(_(u'Could not send reset link: %s') %
+                              text_type(e))
         return self.get()
 
     def get(self):
@@ -619,7 +621,7 @@ class PerformResetView(MethodView):
         except logic.ValidationError as e:
             h.flash_error(u'%r' % e.error_dict)
         except ValueError as e:
-            h.flash_error(unicode(e))
+            h.flash_error(text_type(e))
         user_dict[u'state'] = user_state
         return base.render(u'user/perform_reset.html', {
             u'user_dict': user_dict

--- a/ckanext/datapusher/logic/schema.py
+++ b/ckanext/datapusher/logic/schema.py
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+from six import text_type
+
 import ckan.plugins as p
 import ckanext.datastore.logic.schema as dsschema
 
@@ -18,7 +20,7 @@ OneOf = get_validator('OneOf')
 
 def datapusher_submit_schema():
     schema = {
-        'resource_id': [not_missing, not_empty, unicode],
+        'resource_id': [not_missing, not_empty, text_type],
         'id': [ignore_missing],
         'set_url_type': [ignore_missing, boolean_validator],
         'ignore_hash': [ignore_missing, boolean_validator],

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -15,7 +15,7 @@ import hashlib
 import json
 from cStringIO import StringIO
 
-from six import string_types
+from six import string_types, text_type
 
 import ckan.lib.cli as cli
 import ckan.plugins as p
@@ -707,12 +707,12 @@ def convert(data, type_name):
         sub_type = type_name[1:]
         return [convert(item, sub_type) for item in data]
     if type_name == 'tsvector':
-        return unicode(data, 'utf-8')
+        return text_type(data, 'utf-8')
     if isinstance(data, datetime.datetime):
         return data.isoformat()
     if isinstance(data, (int, float)):
         return data
-    return unicode(data)
+    return text_type(data)
 
 
 def check_fields(context, fields):

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -4,6 +4,7 @@ import logging
 import json
 
 import sqlalchemy
+from six import text_type
 
 import ckan.lib.search as search
 import ckan.lib.navl.dictization_functions
@@ -149,7 +150,7 @@ def datastore_create(context, data_dict):
     try:
         result = backend.create(context, data_dict)
     except InvalidDataError as err:
-        raise p.toolkit.ValidationError(unicode(err))
+        raise p.toolkit.ValidationError(text_type(err))
 
     # Set the datastore_active flag on the resource if necessary
     model = _get_or_bust(context, 'model')

--- a/ckanext/datastore/logic/schema.py
+++ b/ckanext/datastore/logic/schema.py
@@ -2,7 +2,8 @@
 
 import json
 
-from six import string_types
+from six import string_types, text_type
+
 
 import ckan.plugins as p
 import ckan.lib.navl.dictization_functions as df
@@ -90,21 +91,21 @@ def unicode_or_json_validator(value, context):
         v = json_validator(value, context)
         # json.loads will parse literals; however we want literals as unicode.
         if not isinstance(v, dict):
-            return unicode(value)
+            return text_type(value)
         else:
             return v
     except df.Invalid:
-        return unicode(value)
+        return text_type(value)
 
 
 def datastore_create_schema():
     schema = {
-        'resource_id': [ignore_missing, unicode, resource_id_exists],
+        'resource_id': [ignore_missing, text_type, resource_id_exists],
         'force': [ignore_missing, boolean_validator],
         'id': [ignore_missing],
         'aliases': [ignore_missing, list_of_strings_or_string],
         'fields': {
-            'id': [not_empty, unicode],
+            'id': [not_empty, text_type],
             'type': [ignore_missing],
             'info': [ignore_missing],
         },
@@ -129,10 +130,10 @@ def datastore_create_schema():
 
 def datastore_upsert_schema():
     schema = {
-        'resource_id': [not_missing, not_empty, unicode],
+        'resource_id': [not_missing, not_empty, text_type],
         'force': [ignore_missing, boolean_validator],
         'id': [ignore_missing],
-        'method': [ignore_missing, unicode, OneOf(
+        'method': [ignore_missing, text_type, OneOf(
             ['upsert', 'insert', 'update'])],
         '__junk': [empty],
         '__before': [rename('id', 'resource_id')]
@@ -142,7 +143,7 @@ def datastore_upsert_schema():
 
 def datastore_delete_schema():
     schema = {
-        'resource_id': [not_missing, not_empty, unicode],
+        'resource_id': [not_missing, not_empty, text_type],
         'force': [ignore_missing, boolean_validator],
         'id': [ignore_missing],
         '__junk': [empty],
@@ -153,12 +154,12 @@ def datastore_delete_schema():
 
 def datastore_search_schema():
     schema = {
-        'resource_id': [not_missing, not_empty, unicode],
+        'resource_id': [not_missing, not_empty, text_type],
         'id': [ignore_missing],
         'q': [ignore_missing, unicode_or_json_validator],
         'plain': [ignore_missing, boolean_validator],
         'filters': [ignore_missing, json_validator],
-        'language': [ignore_missing, unicode],
+        'language': [ignore_missing, text_type],
         'limit': [ignore_missing, int_validator],
         'offset': [ignore_missing, int_validator],
         'fields': [ignore_missing, list_of_strings_or_string],

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -3,6 +3,7 @@
 from contextlib import contextmanager
 from email.utils import encode_rfc2231
 from simplejson import dumps
+from six import text_type
 from xml.etree.cElementTree import Element, SubElement, ElementTree
 
 import unicodecsv
@@ -156,7 +157,7 @@ class XMLWriter(object):
         if v is None:
             element.attrib[u'xsi:nil'] = u'true'
         elif not isinstance(v, (list, dict)):
-            element.text = unicode(v)
+            element.text = text_type(v)
         else:
             if isinstance(v, list):
                 it = enumerate(v)
@@ -166,13 +167,13 @@ class XMLWriter(object):
                 self._insert_node(element, self._value_tag, value, key)
 
         if key_attr is not None:
-            element.attrib[self._key_attr] = unicode(key_attr)
+            element.attrib[self._key_attr] = text_type(key_attr)
 
     def write_records(self, records):
         for r in records:
             root = Element(u'row')
             if self.id_col:
-                root.attrib[u'_id'] = unicode(r[u'_id'])
+                root.attrib[u'_id'] = text_type(r[u'_id'])
             for c in self.columns:
                 self._insert_node(root, c, r[c])
             ElementTree(root).write(self.response, encoding=u'utf-8')

--- a/ckanext/datatablesview/controller.py
+++ b/ckanext/datatablesview/controller.py
@@ -2,7 +2,9 @@
 
 import json
 
-from ckan.plugins.toolkit import BaseController, request, get_action
+from six import text_type
+
+from ckan.plugins.toolkit import BaseController, get_action, request
 
 
 class DataTablesController(BaseController):
@@ -11,11 +13,11 @@ class DataTablesController(BaseController):
             None, {u'id': resource_view_id})
 
         draw = int(request.params['draw'])
-        search_text = unicode(request.params['search[value]'])
+        search_text = text_type(request.params['search[value]'])
         offset = int(request.params['start'])
         limit = int(request.params['length'])
         view_filters = resource_view.get(u'filters', {})
-        user_filters = unicode(request.params['filters'])
+        user_filters = text_type(request.params['filters'])
         filters = merge_filters(view_filters, user_filters)
 
         datastore_search = get_action(u'datastore_search')
@@ -55,7 +57,7 @@ class DataTablesController(BaseController):
             u'iTotalRecords': unfiltered_response.get(u'total', 0),
             u'iTotalDisplayRecords': response.get(u'total', 0),
             u'aaData': [
-                [unicode(row.get(colname, u'')) for colname in cols]
+                [text_type(row.get(colname, u'')) for colname in cols]
                 for row in response['records']
             ],
         })

--- a/ckanext/example_iconfigurer/plugin.py
+++ b/ckanext/example_iconfigurer/plugin.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 from routes.mapper import SubMapper
+from six import text_type
 
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
@@ -44,7 +45,8 @@ class ExampleIConfigurerPlugin(plugins.SingletonPlugin):
             'ckan.datasets_per_page': [ignore_missing, is_positive_integer],
 
             # This is a custom configuration option
-            'ckanext.example_iconfigurer.test_conf': [ignore_missing, unicode],
+            'ckanext.example_iconfigurer.test_conf': [ignore_missing,
+                                                      text_type],
         })
 
         return schema

--- a/ckanext/example_iconfigurer/plugin_v1.py
+++ b/ckanext/example_iconfigurer/plugin_v1.py
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+from six import text_type
+
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 
@@ -21,7 +23,8 @@ class ExampleIConfigurerPlugin(plugins.SingletonPlugin):
             'ckan.datasets_per_page': [ignore_missing, is_positive_integer],
 
             # This is a custom configuration option
-            'ckanext.example_iconfigurer.test_conf': [ignore_missing, unicode],
+            'ckanext.example_iconfigurer.test_conf': [ignore_missing,
+                                                      text_type],
         })
 
         return schema

--- a/ckanext/example_iconfigurer/plugin_v2.py
+++ b/ckanext/example_iconfigurer/plugin_v2.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+from six import text_type
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 
@@ -25,7 +26,8 @@ class ExampleIConfigurerPlugin(plugins.SingletonPlugin):
             'ckan.datasets_per_page': [ignore_missing, is_positive_integer],
 
             # This is a custom configuration option
-            'ckanext.example_iconfigurer.test_conf': [ignore_missing, unicode],
+            'ckanext.example_iconfigurer.test_conf': [ignore_missing,
+                                                      text_type],
         })
 
         return schema

--- a/ckanext/example_iconfigurer/tests/test_iconfigurer_update_config.py
+++ b/ckanext/example_iconfigurer/tests/test_iconfigurer_update_config.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 import nose.tools
+from six import text_type
 
 from ckan.common import config
 
@@ -81,7 +82,7 @@ class TestConfigOptionUpdatePluginEnabled(object):
 
         # db
         obj = model.Session.query(model.SystemInfo).filter_by(key=key).first()
-        assert_equals(obj.value, unicode(value))  # all values stored as string
+        assert_equals(obj.value, text_type(value))  # all values stored as string
 
     def test_update_registered_external_value(self):
 

--- a/ckanext/example_ivalidators/plugin.py
+++ b/ckanext/example_ivalidators/plugin.py
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+from six import text_type
+
 from ckan.plugins.toolkit import Invalid
 from ckan import plugins
 
@@ -31,4 +33,4 @@ def unicode_please(value):
             return value.decode(u'utf8')
         except UnicodeDecodeError:
             return value.decode(u'cp1252')
-    return unicode(value)
+    return text_type(value)

--- a/ckanext/imageview/plugin.py
+++ b/ckanext/imageview/plugin.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 import logging
+from six import text_type
 import ckan.plugins as p
 
 log = logging.getLogger(__name__)
@@ -25,7 +26,7 @@ class ImageView(p.SingletonPlugin):
         return {'name': 'image_view',
                 'title': p.toolkit._('Image'),
                 'icon': 'picture-o',
-                'schema': {'image_url': [ignore_empty, unicode]},
+                'schema': {'image_url': [ignore_empty, text_type]},
                 'iframed': False,
                 'always_available': True,
                 'default_title': p.toolkit._('Image'),

--- a/ckanext/stats/stats.py
+++ b/ckanext/stats/stats.py
@@ -3,6 +3,7 @@
 import datetime
 
 from ckan.common import config
+from six import text_type
 from sqlalchemy import Table, select, join, func, and_
 
 import ckan.plugins as p
@@ -36,7 +37,7 @@ class Stats(object):
               order_by(func.avg(rating.c.rating).desc(), func.count(rating.c.rating).desc()).\
               limit(limit)
         res_ids = model.Session.execute(sql).fetchall()
-        res_pkgs = [(model.Session.query(model.Package).get(unicode(pkg_id)), avg, num) for pkg_id, avg, num in res_ids]
+        res_pkgs = [(model.Session.query(model.Package).get(text_type(pkg_id)), avg, num) for pkg_id, avg, num in res_ids]
         return res_pkgs
 
     @classmethod
@@ -50,7 +51,7 @@ class Stats(object):
             order_by(func.count(package_revision.c.revision_id).desc()).\
             limit(limit)
         res_ids = model.Session.execute(s).fetchall()
-        res_pkgs = [(model.Session.query(model.Package).get(unicode(pkg_id)), val) for pkg_id, val in res_ids]
+        res_pkgs = [(model.Session.query(model.Package).get(text_type(pkg_id)), val) for pkg_id, val in res_ids]
         return res_pkgs
 
     @classmethod
@@ -69,7 +70,7 @@ class Stats(object):
             limit(limit)
 
         res_ids = model.Session.execute(s).fetchall()
-        res_groups = [(model.Session.query(model.Group).get(unicode(group_id)), val) for group_id, val in res_ids]
+        res_groups = [(model.Session.query(model.Group).get(text_type(group_id)), val) for group_id, val in res_ids]
         return res_groups
 
     @classmethod
@@ -97,7 +98,7 @@ class Stats(object):
         if returned_tag_info in ('id', 'name'):
             return res_col
         elif returned_tag_info == 'object':
-            res_tags = [(model.Session.query(model.Tag).get(unicode(tag_id)), val) for tag_id, val in res_col]
+            res_tags = [(model.Session.query(model.Tag).get(text_type(tag_id)), val) for tag_id, val in res_col]
             return res_tags
 
     @classmethod
@@ -111,7 +112,7 @@ class Stats(object):
                  .order_by(func.count(model.Package.creator_user_id).desc())\
                  .limit(limit).all()
         user_count = [
-            (model.Session.query(model.User).get(unicode(user_id)), count)
+            (model.Session.query(model.User).get(text_type(user_id)), count)
             for user_id, count in userid_count
             if user_id]
         return user_count

--- a/ckanext/webpageview/plugin.py
+++ b/ckanext/webpageview/plugin.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 import logging
+from six import text_type
 import ckan.plugins as p
 
 log = logging.getLogger(__name__)
@@ -19,7 +20,7 @@ class WebPageView(p.SingletonPlugin):
     def info(self):
         return {'name': 'webpage_view',
                 'title': p.toolkit._('Website'),
-                'schema': {'page_url': [ignore_empty, unicode]},
+                'schema': {'page_url': [ignore_empty, text_type]},
                 'iframed': False,
                 'icon': 'link',
                 'always_available': True,

--- a/doc/contributing/unicode.rst
+++ b/doc/contributing/unicode.rst
@@ -10,6 +10,22 @@ between Python 2 and Python 3 you might also be interested in the
 .. _Python 2 Unicode HOWTO: https://docs.python.org/2/howto/unicode.html
 .. _Python 3 Unicode HOWTO: https://docs.python.org/3/howto/unicode.html
 
+CKAN uses the `six`_ module to provide simultaneous compatibility with
+Python 2 and Python 3.  All **strs** are Unicode in Python 3 so the builtins
+``unicode`` and ``basestring`` have been removed so there are a few general
+rules to follow:
+
+.. _six: http://six.readthedocs.io
+
+#. Change all calls to ``basestring()`` into calls to ``six.string_types()``
+#. Change remaining instances of ``basestring`` to ``six.string_types``
+#. Change all instances of ``(str, unicode)`` to ``six.string_types``
+#. Change all calls to ``unicode()`` into calls to ``six.text_type()``
+#. Change remaining instances of ``unicode`` to ``six.text_type``
+
+These rules do not apply in every instance so some thought needs to be
+given about the context around these changes.
+
 .. note::
 
     This document describes the intended future state of Unicode handling in
@@ -22,8 +38,9 @@ between Python 2 and Python 3 you might also be interested in the
 
 Overall Strategy
 ----------------
-CKAN only uses Unicode internally (``unicode`` on Python 2). Conversion to/from
-ASCII strings happens on the boundary to other systems/libaries if necessary.
+CKAN only uses Unicode internally (``six.text_type`` on both Python 2 and
+Python 3). Conversion to/from ASCII strings happens on the boundary to other
+systems/libraries if necessary.
 
 
 Encoding of Python files
@@ -50,6 +67,13 @@ to explicitly mark a literal as ``str``::
     x = "I'm a str literal"
     y = u"I'm a unicode literal"
     z = b"I'm also a str literal"
+
+In Python 3, all ``str`` are Unicode and ``str`` and ``bytes`` are explicitly
+different data types so::
+
+    x = "I'm a str literal"
+    y = u"I'm also a str literal"
+    z = b"I'm a bytes literal"
 
 In CKAN, every string literal must carry either a ``u`` or a ``b`` prefix.
 While the latter is redundant in Python 2, it makes the developer's intention
@@ -79,13 +103,13 @@ Use ``io.open`` to open text files
 ```````````````````````````````````
 When opening text (not binary) files you should use `io.open`_ instead of
 ``open``. This allows you to specify the file's encoding and reads will return
-``unicode`` instead of ``str``::
+Unicode instead of ASCII::
 
     import io
 
     with io.open(u'my_file.txt', u'r', encoding=u'utf-8') as f:
         text = f.read()  # contents is automatically decoded
-                         # to unicode using UTF-8
+                         # to Unicode using UTF-8
 
 .. _io.open: https://docs.python.org/2/library/io.html#io.open
 
@@ -237,4 +261,3 @@ represented using the filesystem's encoding use
 .. _os.walk: https://docs.python.org/2/library/os.html#os.walk
 .. _os.getcwd: https://docs.python.org/2/library/os.html#os.getcwd
 .. _os.getcwdu: https://docs.python.org/2/library/os.html#os.getcwdu
-


### PR DESCRIPTION
Related to #3309  (partial fix)

__unicode()__ was removed in Python 3 because all str are Unicode so this PR:
* Changes all calls to __unicode()__ into calls to [__six.text_type()__](https://pythonhosted.org/six/#six.text_type)
* Change all instances of __(str, unicode)__ to [__six.string_types__](https://pythonhosted.org/six/#six.string_types)
* Change remaining instances of __unicode__ to [__six.text_type__](https://pythonhosted.org/six/#six.text_type)