### PR TITLE
[#4031] Improve IGroupForm support (2.7 version)

### DIFF
--- a/ckan/config/routing.py
+++ b/ckan/config/routing.py
@@ -292,19 +292,23 @@ def make_map():
                   highlight_actions='index search')
         m.connect('group_list', '/group/list', action='list')
         m.connect('group_new', '/group/new', action='new')
-        m.connect('group_action', '/group/{action}/{id}',
-                  requirements=dict(action='|'.join([
-                      'edit',
-                      'delete',
-                      'member_new',
-                      'member_delete',
-                      'history',
-                      'followers',
-                      'follow',
-                      'unfollow',
-                      'admins',
-                      'activity',
-                  ])))
+
+        for action in [
+              'edit',
+              'delete',
+              'member_new',
+              'member_delete',
+              'history',
+              'followers',
+              'follow',
+              'unfollow',
+              'admins',
+              'activity',
+          ]:
+            m.connect('group_' + action,
+                      '/group/' + action + '/{id}',
+                      action=action)
+
         m.connect('group_about', '/group/about/{id}', action='about',
                   ckan_icon='info-circle'),
         m.connect('group_edit', '/group/edit/{id}', action='edit',
@@ -327,7 +331,9 @@ def make_map():
           'member_new',
           'member_delete',
           'history']:
-            m.connect('organization_' + action, '/organization/' + action + '/{id}', action=action)
+            m.connect('organization_' + action,
+                      '/organization/' + action + '/{id}',
+                      action=action)
 
         m.connect('organization_activity', '/organization/activity/{id}/{offset}',
                   action='activity', ckan_icon='clock-o')

--- a/ckan/config/routing.py
+++ b/ckan/config/routing.py
@@ -319,16 +319,16 @@ def make_map():
     # organizations these basically end up being the same as groups
     with SubMapper(map, controller='organization') as m:
         m.connect('organizations_index', '/organization', action='index')
-        m.connect('/organization/list', action='list')
-        m.connect('/organization/new', action='new')
-        m.connect('/organization/{action}/{id}',
-                  requirements=dict(action='|'.join([
-                      'delete',
-                      'admins',
-                      'member_new',
-                      'member_delete',
-                      'history'
-                  ])))
+        m.connect('organization_index', '/organization', action='index')
+        m.connect('organization_new', '/organization/new', action='new')
+        for action in [
+          'delete',
+          'admins',
+          'member_new',
+          'member_delete',
+          'history']:
+            m.connect('organization_' + action, '/organization/' + action + '/{id}', action=action)
+
         m.connect('organization_activity', '/organization/activity/{id}/{offset}',
                   action='activity', ckan_icon='clock-o')
         m.connect('organization_read', '/organization/{id}', action='read')

--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -53,6 +53,8 @@ class GroupController(base.BaseController):
         return lookup_group_plugin(group_type).db_to_form_schema()
 
     def _setup_template_variables(self, context, data_dict, group_type=None):
+        if 'type' not in data_dict:
+            data_dict['type'] = group_type
         return lookup_group_plugin(group_type).\
             setup_template_variables(context, data_dict)
 

--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -238,9 +238,9 @@ class GroupController(base.BaseController):
         q = c.q = request.params.get('q', '')
         # Search within group
         if c.group_dict.get('is_organization'):
-            q += ' owner_org:"%s"' % c.group_dict.get('id')
+            fq = 'owner_org:"%s"' % c.group_dict.get('id')
         else:
-            q += ' groups:"%s"' % c.group_dict.get('name')
+            fq = 'groups:"%s"' % c.group_dict.get('name')
 
         c.description_formatted = \
             h.render_markdown(c.group_dict.get('description'))
@@ -321,7 +321,7 @@ class GroupController(base.BaseController):
 
             data_dict = {
                 'q': q,
-                'fq': '',
+                'fq': fq,
                 'include_private': True,
                 'facet.field': facets.keys(),
                 'rows': limit,

--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -103,18 +103,6 @@ class GroupController(base.BaseController):
         return render(self._replace_group_org(template_name),
                       extra_vars={'group_type': group_type})
 
-    def _redirect_to_this_controller(self, *args, **kw):
-        ''' wrapper around redirect_to but it adds in this request's controller
-        (so that it works for Organization or other derived controllers)'''
-        kw['controller'] = request.environ['pylons.routes_dict']['controller']
-        return h.redirect_to(*args, **kw)
-
-    def _url_for_this_controller(self, *args, **kw):
-        ''' wrapper around url_for but it adds in this request's controller
-        (so that it works for Organization or other derived controllers)'''
-        kw['controller'] = request.environ['pylons.routes_dict']['controller']
-        return h.url_for(*args, **kw)
-
     def _guess_group_type(self, expecting_name=False):
         """
             Guess the type of group from the URL.
@@ -452,7 +440,7 @@ class GroupController(base.BaseController):
             get_action(action_functions[action])(context, data_dict)
         except NotAuthorized:
             abort(403, _('Not authorized to perform bulk update'))
-        self._redirect_to_this_controller(action='bulk_process', id=id)
+        h.redirect_to(group_type + '_bulk_process', id=id)
 
     def new(self, data=None, errors=None, error_summary=None):
         if data and 'type' in data:
@@ -615,7 +603,7 @@ class GroupController(base.BaseController):
         group_type = self._ensure_controller_matches_group_type(id)
 
         if 'cancel' in request.params:
-            self._redirect_to_this_controller(action='edit', id=id)
+            h.redirect_to(group_type + '_edit', id=id)
 
         context = {'model': model, 'session': model.Session,
                    'user': c.user}
@@ -635,7 +623,7 @@ class GroupController(base.BaseController):
                 else:
                     h.flash_notice(_('%s has been deleted.')
                                    % _(group_type.capitalize()))
-                self._redirect_to_this_controller(action='index')
+                h.redirect_to(group_type + '_index')
             c.group_dict = self._action('group_show')(context, {'id': id})
         except NotAuthorized:
             abort(403, _('Unauthorized to delete group %s') % '')
@@ -706,7 +694,7 @@ class GroupController(base.BaseController):
                 c.group_dict = self._action('group_member_create')(
                     context, data_dict)
 
-                self._redirect_to_this_controller(action='members', id=id)
+                h.redirect_to(group_type + '_members', id=id)
             else:
                 user = request.params.get('user')
                 if user:
@@ -728,7 +716,7 @@ class GroupController(base.BaseController):
         group_type = self._ensure_controller_matches_group_type(id)
 
         if 'cancel' in request.params:
-            self._redirect_to_this_controller(action='members', id=id)
+            h.redirect_to(group_type + '_members', id=id)
 
         context = {'model': model, 'session': model.Session,
                    'user': c.user}
@@ -744,7 +732,7 @@ class GroupController(base.BaseController):
                 self._action('group_member_delete')(
                     context, {'id': id, 'user_id': user_id})
                 h.flash_notice(_('Group member has been deleted.'))
-                self._redirect_to_this_controller(action='members', id=id)
+                h.redirect_to(group_type + '_members', id=id)
             c.user_dict = self._action('user_show')(context, {'id': user_id})
             c.user_id = user_id
             c.group_id = id
@@ -792,8 +780,8 @@ class GroupController(base.BaseController):
             from webhelpers.feedgenerator import Atom1Feed
             feed = Atom1Feed(
                 title=_(u'CKAN Group Revision History'),
-                link=self._url_for_this_controller(
-                    action='read',
+                link=h.url_for(
+                    group_type + '_read',
                     id=c.group_dict['name']),
                 description=_(u'Recent changes to CKAN Group: ') +
                 c.group_dict['display_name'],

--- a/ckan/controllers/organization.py
+++ b/ckan/controllers/organization.py
@@ -20,9 +20,6 @@ class OrganizationController(group.GroupController):
 
     group_types = ['organization']
 
-    def _guess_group_type(self, expecting_name=False):
-        return 'organization'
-
     def _replace_group_org(self, string):
         ''' substitute organization for group if this is an org'''
         return re.sub('^group', 'organization', string)

--- a/ckan/lib/plugins.py
+++ b/ckan/lib/plugins.py
@@ -23,6 +23,7 @@ _default_package_plugin = None
 _group_plugins = {}
 # The fallback behaviour
 _default_group_plugin = None
+_default_organization_plugin = None
 # Mapping from group-type strings to controllers
 _group_controllers = {}
 
@@ -34,6 +35,8 @@ def reset_package_plugins():
     _package_plugins = {}
     global _default_group_plugin
     _default_group_plugin = None
+    global _default_organization_plugin
+    _default_organization_plugin = None
     global _group_plugins
     _group_plugins = {}
     global _group_controllers
@@ -133,22 +136,21 @@ def register_group_plugins(map):
     This method will setup the mappings between group types and the
     registered IGroupForm instances. If it's called more than once an
     exception will be raised.
+
+    It will register IGroupForm instances for both groups and organizations
     """
     global _default_group_plugin
+    global _default_organization_plugin
 
     # This function should have not effect if called more than once.
     # This should not occur in normal deployment, but it may happen when
     # running unit tests.
-    if _default_group_plugin is not None:
+    if (_default_group_plugin is not None or
+            _default_organization_plugin is not None):
         return
 
     # Create the mappings and register the fallback behaviour if one is found.
     for plugin in plugins.PluginImplementations(plugins.IGroupForm):
-        if plugin.is_fallback():
-            if _default_group_plugin is not None:
-                raise ValueError("More than one fallback IGroupForm has been "
-                                 "registered")
-            _default_group_plugin = plugin
 
         # Get group_controller from plugin if there is one,
         # otherwise use 'group'
@@ -156,6 +158,24 @@ def register_group_plugins(map):
             group_controller = plugin.group_controller()
         except AttributeError:
             group_controller = 'group'
+
+        if plugin.is_fallback():
+            if hasattr(plugin, 'is_organization'):
+                is_organization = plugin.is_organization
+            else:
+                is_organization = group_controller == 'organization'
+
+            if is_organization:
+                if _default_organization_plugin is not None:
+                    raise ValueError("More than one fallback IGroupForm for "
+                                     "organizations has been registered")
+                _default_organization_plugin = plugin
+
+            else:
+                if _default_group_plugin is not None:
+                    raise ValueError("More than one fallback IGroupForm for "
+                                     "groups has been registered")
+                _default_group_plugin = plugin
 
         for group_type in plugin.group_types():
             # Create the routes based on group_type here, this will
@@ -231,6 +251,8 @@ def register_group_plugins(map):
     # Setup the fallback behaviour if one hasn't been defined.
     if _default_group_plugin is None:
         _default_group_plugin = DefaultGroupForm()
+    if _default_organization_plugin is None:
+        _default_organization_plugin = DefaultOrganizationForm()
     if 'group' not in _group_controllers:
         _group_controllers['group'] = 'group'
     if 'organization' not in _group_controllers:
@@ -548,8 +570,6 @@ class DefaultOrganizationForm(DefaultGroupForm):
 
     def activity_template(self):
         return 'organization/activity_stream.html'
-
-_default_organization_plugin = DefaultOrganizationForm()
 
 
 class DefaultTranslation(object):

--- a/ckan/lib/plugins.py
+++ b/ckan/lib/plugins.py
@@ -190,6 +190,14 @@ def register_group_plugins(map):
                         controller=group_controller,
                         action='members',
                         ckan_icon='users')
+            map.connect('%s_member_new' % group_type,
+                        '/%s/member_new/{id}' % group_type,
+                        controller=group_controller,
+                        action='member_new')
+            map.connect('%s_member_delete' % group_type,
+                        '/%s/member_delete/{id}' % group_type,
+                        controller=group_controller,
+                        action='member_delete')
             map.connect('%s_activity' % group_type,
                         '/%s/activity/{id}/{offset}' % group_type,
                         controller=group_controller,

--- a/ckan/templates/group/edit_base.html
+++ b/ckan/templates/group/edit_base.html
@@ -7,20 +7,20 @@
 {% set group = c.group_dict %}
 
 {% block breadcrumb_content %}
-  <li>{% link_for _('Groups'), controller='group', action='index' %}</li>
+  <li>{% link_for _('Groups'), controller='group', action='index', named_route=group_type + '_index' %}</li>
   {% block breadcrumb_content_inner %}
-    <li>{% link_for h.get_translated(group, 'title') or group.display_name |truncate(35), controller='group', action='read', id=group.name %}</li>
-    <li class="active">{% link_for _('Manage'), controller='group', action='edit', id=group.name %}</li>
+    <li>{% link_for h.get_translated(group, 'title') or group.display_name |truncate(35), controller='group', action='read', id=group.name, named_route=group_type + '_read' %}</li>
+    <li class="active">{% link_for _('Manage'), controller='group', action='edit', id=group.name, named_route=group_type + '_edit' %}</li>
   {% endblock %}
 {% endblock %}
 
 {% block content_action %}
-  {% link_for _('View'), controller='group', action='read', id=c.group_dict.name, class_='btn', icon='eye' %}
+  {% link_for _('View'), controller='group', action='read', id=c.group_dict.name, class_='btn', icon='eye', named_route=group_type + '_read' %}
 {% endblock %}
 
 {% block content_primary_nav %}
-  {{ h.build_nav_icon('group_edit', _('Edit'), id=c.group_dict.name) }}
-  {{ h.build_nav_icon('group_members', _('Members'), id=c.group_dict.name) }}
+  {{ h.build_nav_icon(group_type + '_edit', _('Edit'), id=c.group_dict.name) }}
+  {{ h.build_nav_icon(group_type + '_members', _('Members'), id=c.group_dict.name) }}
 {% endblock %}
 
 {% block secondary_content %}

--- a/ckan/templates/group/index.html
+++ b/ckan/templates/group/index.html
@@ -3,14 +3,14 @@
 {% block subtitle %}{{ _('Groups') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{% link_for _('Groups'), controller='group', action='index' %}</li>
+  <li class="active">{% link_for _('Groups'), controller='group', action='index', named_route=group_type + '_index' %}</li>
 {% endblock %}
 
 {% block page_header %}{% endblock %}
 
 {% block page_primary_action %}
   {% if h.check_access('group_create') %}
-    {% link_for _('Add Group'), controller='group', action='new', class_='btn btn-primary', icon='plus-square' %}
+    {% link_for _('Add Group'), controller='group', action='new', class_='btn btn-primary', icon='plus-square', named_route=group_type + '_new' %}
   {% endif %}
 {% endblock %}
 

--- a/ckan/templates/group/member_new.html
+++ b/ckan/templates/group/member_new.html
@@ -5,7 +5,7 @@
 {% set user = c.user_dict %}
 
 {% block primary_content_inner %}
-  {% link_for _('Back to all members'), controller='group', action='members', id=group.name, class_='btn pull-right', icon='arrow-left' %}
+  {% link_for _('Back to all members'), controller='group', action='members', id=group.name, class_='btn pull-right', icon='arrow-left', named_route=group_type + '_members' %}
   <h1 class="page-heading">
     {% block page_heading %}{{ _('Edit Member') if user else _('Add Member') }}{% endblock %}
   </h1>
@@ -55,7 +55,7 @@
     {{ form.select('role', label=_('Role'), options=c.roles, selected=c.user_role, error='', attrs=format_attrs) }}
     <div class="form-actions">
       {% if user %}
-        <a href="{% url_for controller='group', action='member_delete', id=c.group_dict.id, user=user.id %}" class="btn btn-danger pull-left" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?') }}">{{ _('Delete') }}</a>
+        <a href="{{ h.url_for(group_type + '_member_delete', id=c.group_dict.id, user=user_id) }}" class="btn btn-danger pull-left" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?') }}">{{ _('Delete') }}</a>
         <button class="btn btn-primary" type="submit" name="submit" >
           {{ _('Save') }}
         </button>

--- a/ckan/templates/group/members.html
+++ b/ckan/templates/group/members.html
@@ -3,7 +3,7 @@
 {% block subtitle %}{{ _('Members') }} - {{ c.group_dict.display_name }} - {{ _('Groups') }}{% endblock %}
 
 {% block page_primary_action %}
-  {% link_for _('Add Member'), controller='group', action='member_new', id=c.group_dict.id, class_='btn btn-primary', icon='plus-square' %}
+  {% link_for _('Add Member'), controller='group', action='member_new', id=c.group_dict.id, class_='btn btn-primary', icon='plus-square', named_route=group_type + '_member_new' %}
 {% endblock %}
 
 {% block primary_content_inner %}
@@ -25,10 +25,10 @@
         <td>{{ role }}</td>
         <td>
           <div class="btn-group pull-right">
-            <a class="btn btn-small" href="{% url_for controller='group', action='member_new', id=c.group_dict.id, user=user_id %}" title="{{ _('Edit') }}">
+            <a class="btn btn-small" href="{% url_for controller='group', action='member_delete', id=c.group_dict.id, user=user_id %}" title="{{ _('Edit') }}">
               <i class="fa fa-wrench"></i>
             </a>
-            <a class="btn btn-danger btn-small" href="{% url_for controller='group', action='member_delete', id=c.group_dict.id, user=user_id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?') }}" title="{{ _('Delete') }}">{% block delete_button_text %}<i class="fa fa-times"></i>{% endblock %}</a>
+            <a class="btn btn-danger btn-small" href="{{ h.url_for(group_type + '_member_delete', id=c.group_dict.id, user=user_id) }}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?') }}" title="{{ _('Delete') }}">{% block delete_button_text %}<i class="fa fa-times"></i>{% endblock %}</a>
           </div>
         </td>
       </tr>

--- a/ckan/templates/group/read_base.html
+++ b/ckan/templates/group/read_base.html
@@ -3,20 +3,20 @@
 {% block subtitle %}{{ h.get_translated(c.group_dict, 'title') or c.group_dict.display_name }} - {{ _('Groups') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li>{% link_for _('Groups'), controller='group', action='index' %}</li>
-  <li class="active">{% link_for h.get_translated(c.group_dict, 'title') or c.group_dict.display_name |truncate(35), controller='group', action='read', id=c.group_dict.name %}</li>
+  <li>{% link_for _('Groups'), controller='group', action='index', named_route=group_type + '_index' %}</li>
+  <li class="active">{% link_for h.get_translated(c.group_dict, 'title') or c.group_dict.display_name |truncate(35), controller='group', action='read', id=c.group_dict.name, named_route=group_type + '_read' %}</li>
 {% endblock %}
 
 {% block content_action %}
   {% if h.check_access('group_update', {'id': c.group_dict.id}) %}
-    {% link_for _('Manage'), controller='group', action='edit', id=c.group_dict.name, class_='btn', icon='wrench' %}
+    {% link_for _('Manage'), controller='group', action='edit', id=c.group_dict.name, class_='btn', icon='wrench', named_route=group_type + '_edit' %}
   {% endif %}
 {% endblock %}
 
 {% block content_primary_nav %}
-  {{ h.build_nav_icon('group_read', _('Datasets'), id=c.group_dict.name) }}
-  {{ h.build_nav_icon('group_activity', _('Activity Stream'), id=c.group_dict.name, offset=0) }}
-  {{ h.build_nav_icon('group_about', _('About'), id=c.group_dict.name) }}
+  {{ h.build_nav_icon(group_type + '_read', _('Datasets'), id=c.group_dict.name) }}
+  {{ h.build_nav_icon(group_type + '_activity', _('Activity Stream'), id=c.group_dict.name, offset=0) }}
+  {{ h.build_nav_icon(group_type + '_about', _('About'), id=c.group_dict.name) }}
 {% endblock %}
 
 {% block secondary_content %}

--- a/ckan/templates/organization/edit_base.html
+++ b/ckan/templates/organization/edit_base.html
@@ -5,23 +5,23 @@
 {% block subtitle %}{{ c.group_dict.display_name }} - {{ _('Organizations') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li>{% link_for _('Organizations'), controller='organization', action='index' %}</li>
+  <li>{% link_for _('Organizations'), controller='organization', action='index', named_route=group_type + '_index' %}</li>
   {% block breadcrumb_content_inner %}
-    <li>{% link_for organization.display_name|truncate(35), controller='organization', action='read', id=organization.name %}</li>
-    <li class="active">{% link_for _('Manage'), controller='organization', action='edit', id=organization.name %}</li>
+    <li>{% link_for organization.display_name|truncate(35), controller='organization', action='read', id=organization.name, named_route=group_type + '_read' %}</li>
+    <li class="active">{% link_for _('Manage'), controller='organization', action='edit', id=organization.name, named_route=group_type + '_edit' %}</li>
   {% endblock %}
 {% endblock %}
 
 {% block content_action %}
   {% if organization and h.check_access('organization_update', {'id': organization.id}) %}
-    {% link_for _('View'), controller='organization', action='read', id=organization.name, class_='btn', icon='eye' %}
+    {% link_for _('View'), controller='organization', action='read', id=organization.name, class_='btn', icon='eye', named_route=group_type + '_read' %}
   {% endif %}
 {% endblock %}
 
 {% block content_primary_nav %}
-  {{ h.build_nav_icon('organization_edit', _('Edit'), id=c.group_dict.name) }}
-  {{ h.build_nav_icon('organization_bulk_process', _('Datasets'), id=c.group_dict.name) }}
-  {{ h.build_nav_icon('organization_members', _('Members'), id=c.group_dict.name) }}
+  {{ h.build_nav_icon(group_type + '_edit', _('Edit'), id=c.group_dict.name) }}
+  {{ h.build_nav_icon(group_type + '_bulk_process', _('Datasets'), id=c.group_dict.name) }}
+  {{ h.build_nav_icon(group_type + '_members', _('Members'), id=c.group_dict.name) }}
 {% endblock %}
 
 {% block secondary_content %}

--- a/ckan/templates/organization/index.html
+++ b/ckan/templates/organization/index.html
@@ -3,14 +3,14 @@
 {% block subtitle %}{{ _('Organizations') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{% link_for _('Organizations'), controller='organization', action='index' %}</li>
+  <li class="active">{% link_for _('Organizations'), controller='organization', action='index', named_route=group_type + '_index' %}</li>
 {% endblock %}
 
 {% block page_header %}{% endblock %}
 
 {% block page_primary_action %}
   {% if h.check_access('organization_create') %}
-    {% link_for _('Add Organization'), controller='organization', action='new', class_='btn btn-primary', icon='plus-square' %}
+    {% link_for _('Add Organization'), controller='organization', action='new', class_='btn btn-primary', icon='plus-square', named_route=group_type + '_new' %}
   {% endif %}
 {% endblock %}
 

--- a/ckan/templates/organization/member_new.html
+++ b/ckan/templates/organization/member_new.html
@@ -7,7 +7,7 @@
 {% block subtitle %}{{ _('Edit Member') if user else _('Add Member') }} - {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
-  {% link_for _('Back to all members'), controller='organization', action='members', id=organization.name, class_='btn pull-right', icon='arrow-left' %}
+  {% link_for _('Back to all members'), controller='organization', action='members', id=organization.name, class_='btn pull-right', icon='arrow-left', named_route=group_type + '_members' %}
   <h1 class="page-heading">
     {% block page_heading %}{{ _('Edit Member') if user else _('Add Member') }}{% endblock %}
   </h1>
@@ -56,7 +56,7 @@
     {{ form.select('role', label=_('Role'), options=c.roles, selected=c.user_role, error='', attrs=format_attrs) }}
     <div class="form-actions">
       {% if user %}
-        <a href="{% url_for controller='organization', action='member_delete', id=c.group_dict.id, user=user.id %}" class="btn btn-danger pull-left" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?') }}">{{ _('Delete') }}</a>
+        <a href="{{ h.url_for(group_type + '_member_delete', id=c.group_dict.id, user=user_id) }}" class="btn btn-danger pull-left" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?') }}">{{ _('Delete') }}</a>
         <button class="btn btn-primary" type="submit" name="submit" >
           {{ _('Update Member') }}
         </button>

--- a/ckan/templates/organization/members.html
+++ b/ckan/templates/organization/members.html
@@ -5,7 +5,7 @@
 {% block page_primary_action %}
   {% if h.check_access('organization_update', {'id': organization.id}) %}
 
-    {% link_for _('Add Member'), controller='organization', action='member_new', id=c.group_dict.id, class_='btn btn-primary', icon='plus-square' %}
+    {% link_for _('Add Member'), controller='organization', action='member_new', id=c.group_dict.id, class_='btn btn-primary', icon='plus-square', named_route=group_type + '_member_new' %}
   {% endif %}
 {% endblock %}
 
@@ -30,10 +30,10 @@
           <td>{{ role }}</td>
           <td>
             <div class="btn-group pull-right">
-              <a class="btn btn-small" href="{% url_for controller='organization', action='member_new', id=c.group_dict.id, user=user_id %}" title="{{ _('Edit') }}">
+              <a class="btn btn-small" href="{{ h.url_for(group_type + '_member_new', id=c.group_dict.id, user=user_id) }}" title="{{ _('Edit') }}">
                 <i class="fa fa-wrench"></i>
               </a>
-              <a class="btn btn-danger btn-small" href="{% url_for controller='organization', action='member_delete', id=c.group_dict.id, user=user_id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?') }}" title="{{ _('Delete') }}">{% block delete_button_text %}<i class="fa fa-times"></i>{% endblock %}</a>
+              <a class="btn btn-danger btn-small" href="{{ h.url_for(group_type + '_member_delete', id=c.group_dict.id, user=user_id) }}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?') }}" title="{{ _('Delete') }}">{% block delete_button_text %}<i class="fa fa-times"></i>{% endblock %}</a>
             </div>
           </td>
         </tr>

--- a/ckan/templates/organization/read_base.html
+++ b/ckan/templates/organization/read_base.html
@@ -3,24 +3,24 @@
 {% block subtitle %}{{ c.group_dict.display_name }} - {{ _('Organizations') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li>{% link_for _('Organizations'), controller='organization', action='index' %}</li>
-  <li class="active">{% link_for c.group_dict.display_name|truncate(35), controller='organization', action='read', id=c.group_dict.name %}</li>
+  <li>{% link_for _('Organizations'), controller='organization', action='index', named_route=group_type + '_index' %}</li>
+  <li class="active">{% link_for c.group_dict.display_name|truncate(35), controller='organization', action='read', id=c.group_dict.name, named_route=group_type + '_read' %}</li>
 {% endblock %}
 
 {% block content_action %}
   {% if h.check_access('organization_update', {'id': c.group_dict.id}) %}
-    {% link_for _('Manage'), controller='organization', action='edit', id=c.group_dict.name, class_='btn', icon='wrench' %}
+    {% link_for _('Manage'), controller='organization', action='edit', id=c.group_dict.name, class_='btn', icon='wrench', named_route=group_type + '_edit' %}
   {% endif %}
 {% endblock %}
 
 {% block content_primary_nav %}
-  {{ h.build_nav_icon('organization_read', _('Datasets'), id=c.group_dict.name) }}
-  {{ h.build_nav_icon('organization_activity', _('Activity Stream'), id=c.group_dict.name, offset=0) }}
-  {{ h.build_nav_icon('organization_about', _('About'), id=c.group_dict.name) }}
+  {{ h.build_nav_icon(group_type + '_read', _('Datasets'), id=c.group_dict.name) }}
+  {{ h.build_nav_icon(group_type + '_activity', _('Activity Stream'), id=c.group_dict.name, offset=0) }}
+  {{ h.build_nav_icon(group_type + '_about', _('About'), id=c.group_dict.name) }}
 {% endblock %}
 
 {% block secondary_content %}
-  {% snippet 'snippets/organization.html', organization=c.group_dict, show_nums=true %}
+  {% snippet 'snippets/organization.html', organization=c.group_dict, show_nums=true, group_type=group_type %}
   {% block organization_facets %}{% endblock %}
 {% endblock %}
 

--- a/ckan/templates/snippets/organization.html
+++ b/ckan/templates/snippets/organization.html
@@ -15,7 +15,7 @@ Example:
 #}
 
 {% set truncate = truncate or 0 %}
-{% set url = h.url_for(controller='organization', action='read', id=organization.name) %}
+{% set url = h.url_for(organization.type + '_read', id=organization.name, ) %}
 
   {% block info %}
   <div class="module module-narrow module-shallow context-info">


### PR DESCRIPTION
These are the same changes as in #4032 but targeting 2.7, so it's easier to decide what is safe to backport.

Although there are a lot of changes in templates IMO they are all safe, as they don't touch any template structure or markup, just the way that URLs are generated.

Adding names to routes should not affect any existing generation or resolution.

https://github.com/ckan/ckan/commit/8ec960bcc0b5940bd497bbabb65cdcff1546db0f is the one that touches more critical code, but it's basically fixing a bug and I can't see how it could break any existing plugin (more than they already are)

@wardi let me know what you think after you've reviewed #4032 