### PR TITLE
[#3949] Fix and test Solr index delete_package implementation

### DIFF
--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -314,12 +314,10 @@ class PackageSearchIndex(SearchIndex):
             log.exception(e)
             raise SearchIndexError(e)
 
-
     def delete_package(self, pkg_dict):
         conn = make_connection()
-        query = "+%s:%s (+id:\"%s\" OR +name:\"%s\") +site_id:\"%s\"" % (TYPE_FIELD, PACKAGE_TYPE,
-                                                       pkg_dict.get('id'), pkg_dict.get('id'),
-                                                       config.get('ckan.site_id'))
+        query = "+%s:%s AND +(id:\"%s\" OR name:\"%s\") AND +site_id:\"%s\"" % \
+                (TYPE_FIELD, PACKAGE_TYPE, pkg_dict.get('id'), pkg_dict.get('id'), config.get('ckan.site_id'))
         try:
             commit = asbool(config.get('ckan.search.solr_commit', 'true'))
             conn.delete(q=query, commit=commit)

--- a/ckan/tests/lib/search/test_index.py
+++ b/ckan/tests/lib/search/test_index.py
@@ -81,6 +81,28 @@ class TestSearchIndex(object):
         response = self.solr_client.search(q='name:monkey', fq=self.fq)
         assert_equal(len(response), 0)
 
+    def test_delete_package(self):
+        self.package_index.index_package(self.base_package_dict)
+
+        pkg_dict = self.base_package_dict.copy()
+        pkg_dict.update({
+            'id': 'test-index-2',
+            'name': 'monkey2'
+        })
+        self.package_index.index_package(pkg_dict)
+
+        response = self.solr_client.search(q='title:Monkey', fq=self.fq)
+        assert_equal(len(response), 2)
+        response_ids = sorted([x['id'] for x in response.docs])
+        assert_equal(response_ids, ['test-index', 'test-index-2'])
+
+        self.package_index.delete_package(pkg_dict)
+
+        response = self.solr_client.search(q='title:Monkey', fq=self.fq)
+        assert_equal(len(response), 1)
+        response_ids = sorted([x['id'] for x in response.docs])
+        assert_equal(response_ids, ['test-index'])
+
     def test_index_illegal_xml_chars(self):
 
         pkg_dict = self.base_package_dict.copy()


### PR DESCRIPTION
Fixes #3949

I have tested this with Solr 4.3.1 and Solr 7.2.0 and making the query more explicit does not seem to change the intent in 4.3.1. In any case, there is now a test for the expected behavior.

The query in the implementation of delete_package seems to have remained the same since 2011 so backporting this change is easy but not required if running an earlier version of Solr https://github.com/maxious/ckan/commit/eb88cbe74956960e50e80a11e042f3673bc984f2#diff-91ec3ea1f3b6d404c10bffb6161aee75R154

### Proposed fixes:
Use suggested solr delete query syntax from #3949 and test that deleting one package does not delete or otherwise affect queries for another similar package.

### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply