### PR TITLE
Major bug in datasotre plugin

### DIFF
--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -196,7 +196,7 @@ class DatastorePlugin(p.SingletonPlugin):
                 'resource_id': res.id,
             })
             res.extras['datastore_active'] = False
-            res_query.update(
+            res.update(
                 {'extras': res.extras}, synchronize_session=False)
 
     # IDatastore


### PR DESCRIPTION
Hi
I've just discovered this bug in the datastore plugin which set ALL the resources to datastore_active=False when any off the resources is deleted, just because the wrong query is used in the plugin to make the update. 
Thanks for taking this in consideration. I don't even understand how it hasn't been discovered before. 
Best regards

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
