### PR TITLE
Make parameters for wrapper() functions in ckan.logic generic args/kwargs

### DIFF
--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -577,12 +577,8 @@ def side_effect_free(action):
     your action function with CKAN.)
 
     '''
-    @functools.wraps(action)
-    def wrapper(*args, **kwargs):
-        return action(*args, **kwargs)
-    wrapper.side_effect_free = True
-
-    return wrapper
+    action.side_effect_free = True
+    return action
 
 
 def auth_sysadmins_check(action):
@@ -599,20 +595,14 @@ def auth_sysadmins_check(action):
     sysadmin.
 
     '''
-    @functools.wraps(action)
-    def wrapper(*args, **kwargs):
-        return action(*args, **kwargs)
-    wrapper.auth_sysadmins_check = True
-    return wrapper
+    action.auth_sysadmins_check = True
+    return action
 
 
 def auth_audit_exempt(action):
     ''' Dirty hack to stop auth audit being done '''
-    @functools.wraps(action)
-    def wrapper(*args, **kwargs):
-        return action(*args, **kwargs)
-    wrapper.auth_audit_exempt = True
-    return wrapper
+    action.auth_audit_exempt = True
+    return action
 
 
 def auth_allow_anonymous_access(action):
@@ -623,11 +613,8 @@ def auth_allow_anonymous_access(action):
     auth function can still return False if for some reason access is not
     granted).
     '''
-    @functools.wraps(action)
-    def wrapper(*args, **kwargs):
-        return action(*args, **kwargs)
-    wrapper.auth_allow_anonymous_access = True
-    return wrapper
+    action.auth_allow_anonymous_access = True
+    return action
 
 
 def auth_disallow_anonymous_access(action):
@@ -637,11 +624,8 @@ def auth_disallow_anonymous_access(action):
     exception if an authenticated user is not provided in the context, without
     calling the actual auth function.
     '''
-    @functools.wraps(action)
-    def wrapper(*args, **kwargs):
-        return action(*args, **kwargs)
-    wrapper.auth_allow_anonymous_access = False
-    return wrapper
+    action.auth_allow_anonymous_access = False
+    return action
 
 
 def chained_auth_function(func):

--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -578,8 +578,8 @@ def side_effect_free(action):
 
     '''
     @functools.wraps(action)
-    def wrapper(context, data_dict):
-        return action(context, data_dict)
+    def wrapper(*args, **kwargs):
+        return action(*args, **kwargs)
     wrapper.side_effect_free = True
 
     return wrapper
@@ -600,8 +600,8 @@ def auth_sysadmins_check(action):
 
     '''
     @functools.wraps(action)
-    def wrapper(context, data_dict):
-        return action(context, data_dict)
+    def wrapper(*args, **kwargs):
+        return action(*args, **kwargs)
     wrapper.auth_sysadmins_check = True
     return wrapper
 
@@ -609,8 +609,8 @@ def auth_sysadmins_check(action):
 def auth_audit_exempt(action):
     ''' Dirty hack to stop auth audit being done '''
     @functools.wraps(action)
-    def wrapper(context, data_dict):
-        return action(context, data_dict)
+    def wrapper(*args, **kwargs):
+        return action(*args, **kwargs)
     wrapper.auth_audit_exempt = True
     return wrapper
 
@@ -624,8 +624,8 @@ def auth_allow_anonymous_access(action):
     granted).
     '''
     @functools.wraps(action)
-    def wrapper(context, data_dict):
-        return action(context, data_dict)
+    def wrapper(*args, **kwargs):
+        return action(*args, **kwargs)
     wrapper.auth_allow_anonymous_access = True
     return wrapper
 
@@ -638,8 +638,8 @@ def auth_disallow_anonymous_access(action):
     calling the actual auth function.
     '''
     @functools.wraps(action)
-    def wrapper(context, data_dict):
-        return action(context, data_dict)
+    def wrapper(*args, **kwargs):
+        return action(*args, **kwargs)
     wrapper.auth_allow_anonymous_access = False
     return wrapper
 


### PR DESCRIPTION
### Proposed fixes:
Using both `@toolkit.chained_action` and one of the ckan.logic decorators (e.g. `@logic.side_effect_free`) caused an error as `chained_action` introduces a new parameter that the `wrapper` function in the decorator cannot handle. As the `wrapper` function doesn't actually use or modify the parameters, I've changed them to `*args, **kwargs` to allow for any number of parameters.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
