### PR TITLE
Convert ur'strings' --> u'strings' in doc/conf.py

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -338,8 +338,8 @@ htmlhelp_basename = 'CKANdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class [howto/manual]).
 latex_documents = [
-  ('contents', 'CKAN.tex', ur'CKAN documentation',
-   ur'CKAN contributors', 'manual'),
+  ('contents', 'CKAN.tex', u'CKAN documentation',
+   u'CKAN contributors', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of


### PR DESCRIPTION
Related to #4039 (partial fix)  

### Proposed fixes:
See #4039 for details behind this proposed change.
```python
latex_documents = [
-  ('contents', 'CKAN.tex', ur'CKAN documentation',
-   ur'CKAN contributors', 'manual'),
+  ('contents', 'CKAN.tex', u'CKAN documentation',
+   u'CKAN contributors', 'manual'),
]
```
### Features:
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply

@torfsen @smotornyuk Please review