### PR TITLE
Convert ur'strings' --> r'strings' for Python 3

### DIFF
--- a/ckan/lib/munge.py
+++ b/ckan/lib/munge.py
@@ -8,6 +8,8 @@
 import os.path
 import re
 
+from six import text_type
+
 from ckan import model
 from ckan.lib.io import decode_path
 
@@ -24,7 +26,7 @@ MIN_FILENAME_TOTAL_LENGTH = 3
 def munge_name(name):
     '''Munges the package name field in case it is not to spec.'''
     # substitute non-ascii characters
-    if isinstance(name, unicode):
+    if isinstance(name, text_type):
         name = substitute_ascii_equivalents(name)
     # separators become dashes
     name = re.sub('[ .:/]', '-', name)
@@ -39,7 +41,7 @@ def munge_name(name):
 def munge_title_to_name(name):
     '''Munge a package title into a package name.'''
     # substitute non-ascii characters
-    if isinstance(name, unicode):
+    if isinstance(name, text_type):
         name = substitute_ascii_equivalents(name)
     # convert spaces and separators
     name = re.sub('[ .:/]', '-', name)
@@ -147,7 +149,7 @@ def munge_filename(filename):
 
     Returns a Unicode string.
     '''
-    if not isinstance(filename, unicode):
+    if not isinstance(filename, text_type):
         filename = decode_path(filename)
 
     # Ignore path
@@ -156,8 +158,8 @@ def munge_filename(filename):
     # Clean up
     filename = filename.lower().strip()
     filename = substitute_ascii_equivalents(filename)
-    filename = re.sub(ur'[^a-zA-Z0-9_. -]', '', filename).replace(u' ', u'-')
-    filename = re.sub(ur'-+', u'-', filename)
+    filename = re.sub(r'[^a-zA-Z0-9_. -]', '', filename).replace(u' ', u'-')
+    filename = re.sub(r'-+', u'-', filename)
 
     # Enforce length constraints
     name, ext = os.path.splitext(filename)

--- a/ckan/tests/test_coding_standards.py
+++ b/ckan/tests/test_coding_standards.py
@@ -17,8 +17,10 @@ import re
 import subprocess
 import sys
 
+from six import text_type
+from six.moves import xrange
 
-FILESYSTEM_ENCODING = unicode(
+FILESYSTEM_ENCODING = text_type(
     sys.getfilesystemencoding() or sys.getdefaultencoding()
 )
 
@@ -124,7 +126,7 @@ def test_source_files_specify_encoding():
 
     Empty files and files that only contain comments are ignored.
     '''
-    pattern = re.compile(ur'#.*?coding[:=][ \t]*utf-?8')
+    pattern = re.compile(r'#.*?coding[:=][ \t]*utf-?8')
     decode_errors = []
     no_specification = []
     for abs_path, rel_path in walk_python_files():
@@ -572,6 +574,7 @@ _STRING_LITERALS_WHITELIST = [
     u'ckan/tests/plugins/__init__.py',
     u'ckan/tests/plugins/test_toolkit.py',
     u'ckan/tests/test_authz.py',
+    u'ckan/tests/test_coding_standards.py',
     u'ckan/tests/test_factories.py',
     u'ckan/websetup.py',
     u'ckanext/datapusher/cli.py',


### PR DESCRIPTION
Fixes #4039

Related to #3309 in that once this PR lands, the ckan codebase should be clear of Python 3 Syntax Errors.  That is __NOT__ the same thing as being Python 3 compatible (see https://github.com/ckan/ckan/pulls/cclauss etc.) but a nice milestone for the project nevertheless.

__NOTE:__ This PR [breaks this rule](https://github.com/ckan/ckan/blob/master/ckan/tests/test_coding_standards.py#L235-L238)!!  I tried several alternatives but this seemed the best approach to me.

### Proposed fixes:

Convert all the __ur'strings'__ of the current code base to __r'strings'__ as discussed at https://github.com/ckan/ckan/issues/4039#issuecomment-369227934

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
