### PR TITLE
Convert ur'strings' --> u'strings' for Python 3

### DIFF
--- a/ckan/lib/munge.py
+++ b/ckan/lib/munge.py
@@ -158,8 +158,8 @@ def munge_filename(filename):
     # Clean up
     filename = filename.lower().strip()
     filename = substitute_ascii_equivalents(filename)
-    filename = re.sub(ur'[^a-zA-Z0-9_. -]', '', filename).replace(u' ', u'-')
-    filename = re.sub(ur'-+', u'-', filename)
+    filename = re.sub(u'[^a-zA-Z0-9_. -]', '', filename).replace(u' ', u'-')
+    filename = re.sub(u'-+', u'-', filename)
 
     # Enforce length constraints
     name, ext = os.path.splitext(filename)

--- a/ckan/tests/test_coding_standards.py
+++ b/ckan/tests/test_coding_standards.py
@@ -18,6 +18,7 @@ import subprocess
 import sys
 
 from six import text_type
+from six.moves import xrange
 
 FILESYSTEM_ENCODING = text_type(
     sys.getfilesystemencoding() or sys.getdefaultencoding()
@@ -125,7 +126,7 @@ def test_source_files_specify_encoding():
 
     Empty files and files that only contain comments are ignored.
     '''
-    pattern = re.compile(ur'#.*?coding[:=][ \t]*utf-?8')
+    pattern = re.compile(u'#.*?coding[:=][ \\t]*utf-?8')
     decode_errors = []
     no_specification = []
     for abs_path, rel_path in walk_python_files():


### PR DESCRIPTION
Fixes #4039

This is an alternative to #4051 which proposes r'strings' instead of this PR's u'strings'.  Only one of the two PRs can be merged and the other must be closed with unmerged changes.

Related to #3309 in that once this PR lands, the ckan codebase should be clear of Python 3 Syntax Errors.  That is __NOT__ the same thing as being Python 3 compatible (see https://github.com/ckan/ckan/pulls/cclauss etc.) but a nice milestone for the project nevertheless.

Reviews please @wardi @torfsen @amercader @smotornyuk

### Proposed fixes:

Convert all the __ur'strings'__ of the current code base to __u'strings'__ as discussed at https://github.com/ckan/ckan/pull/4051#pullrequestreview-100242572

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
