### PR TITLE
Upgrade Sphinx to avoid large number of warnings when building

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,7 +10,7 @@ mock==2.0.0
 pycodestyle==2.2.0
 pip-tools==1.7.0
 pyfakefs==2.9
-Sphinx==1.2.3
-sphinx-rtd-theme==0.1.9
+Sphinx==1.7.1
+sphinx-rtd-theme==0.2.4
 
 # nose==1.3.0  # already in requirements.txt

--- a/doc/theming/jinja-tags.rst
+++ b/doc/theming/jinja-tags.rst
@@ -2,4 +2,4 @@
 Custom Jinja2 tags reference
 ============================
 
-.. todo::
+.. todo:: TODO


### PR DESCRIPTION
Upgrade Sphinx version to avoid multiple warnings when building the docs:

```
python setup.py build_sphinx
/home/adria/dev/pyenvs/ckan/local/lib/python2.7/site-packages/setuptools/dist.py:351: UserWarning: Normalizing '2.8.0a' to '2.8.0a0'
  normalized_version,
running build_sphinx
Running Sphinx v1.2.3
loading pickled environment... done
WARNING: unsupported build info format in u'/home/adria/dev/pyenvs/ckan/src/ckan/build/sphinx/html/.buildinfo', building all
building [html]: targets for 92 source files that are out of date
updating environment: 1 added, 92 changed, 0 removed
deprecation warning: io.FileInput() argument `handle_io_errors` is ignored since "Docutils 0.10 (2012-12-16)" and will soon be removed.reading sources... [  2%] api/index

```