### PR TITLE
Fix reload() for Python 3

### DIFF
--- a/ckan/pastertemplates/__init__.py
+++ b/ckan/pastertemplates/__init__.py
@@ -55,8 +55,11 @@ class CkanextTemplate(Template):
 
         # workaround for a paster issue https://github.com/ckan/ckan/issues/2636
         # this is only used from a short-lived paster command
-        reload(sys)
-        sys.setdefaultencoding('utf-8')
+        try:
+            reload(sys)  # Python 2
+            sys.setdefaultencoding('utf-8')
+        except NameError:
+            pass         # Python 3
 
         if not vars['project'].startswith('ckanext-'):
             print("\nError: Project name must start with 'ckanext-'")


### PR DESCRIPTION
Related to #3309 (partial fix)

### Proposed fixes:

The builtin __reload()__ was moved into [importlib](https://docs.python.org/3/library/importlib.html#importlib.reload) in Python 3 because it was being overused and led to odd behavior that was often difficult to diagnose.  

In `__init__.py__` we are trying to __reload(sys)__ as a workaround to #2636  I suspect (but desire confirmation!) that this is about the lack of 'utf-8' and Unicode strs in Python 2 while both are the default in Python 3.  This PR therefor suggests that a __pass__ should be satisfactory in Python 3.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
