### PR TITLE
Fix cmp() for Python 3

### DIFF
--- a/ckan/model/group.py
+++ b/ckan/model/group.py
@@ -364,9 +364,7 @@ class Group(vdm.sqlalchemy.RevisionedObjectMixin,
                     results[obj_rev.revision] = []
                 results[obj_rev.revision].append(obj_rev)
         result_list = results.items()
-        ourcmp = lambda rev_tuple1, rev_tuple2: \
-            cmp(rev_tuple2[0].timestamp, rev_tuple1[0].timestamp)
-        return sorted(result_list, cmp=ourcmp)
+        return sorted(result_list, key=lambda x: x[0].timestamp, reverse=True)
 
     def __repr__(self):
         return '<Group %s>' % self.name
@@ -431,4 +429,3 @@ SELECT G.*, PT.depth FROM parenttree AS PT
     INNER JOIN public.group G ON G.id = PT.table_id
     WHERE G.type = :type AND G.state='active'
     ORDER BY PT.depth DESC;""".format(max_recurses=MAX_RECURSES)
-

--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -395,9 +395,7 @@ class Package(vdm.sqlalchemy.RevisionedObjectMixin,
                 results[obj_rev.revision].append(obj_rev)
 
         result_list = results.items()
-        ourcmp = lambda rev_tuple1, rev_tuple2: \
-                 cmp(rev_tuple2[0].timestamp, rev_tuple1[0].timestamp)
-        return sorted(result_list, cmp=ourcmp)
+        return sorted(result_list, key=lambda x: x[0].timestamp, reverse=True)
 
     @property
     def latest_related_revision(self):


### PR DESCRIPTION
Related to #3309 (partial fix)

### Proposed fixes:

The builtin __cmp()__ was removed in Python 3 so this PR follows the advise provided at https://docs.python.org/3.6/howto/sorting.html#key-functions for driving __sorted()__ with a key function for a class member.

The code is easier to understand and [might be a bit quicker](http://portingguide.readthedocs.io/en/latest/comparisons.html#the-cmp-argument).

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
