### PR TITLE
[#4042] update extras only for deleted resource

### DIFF
--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -161,7 +161,7 @@ class DatastorePlugin(p.SingletonPlugin):
                 'resource_id': res.id,
             })
             res.extras['datastore_active'] = False
-            res_query.update(
+            res_query.filter_by(id=res.id).update(
                 {'extras': res.extras}, synchronize_session=False)
 
     # IDatastore


### PR DESCRIPTION
Improved PR for #4042, as there are no any activities there.

As for the script, that can revert the state of resource extras back. How about comparing latest resource revision with actual extras state? As we discussed, SOLR won't help much after index rebuild. And instead of blind rewriting all extras, we can show current and revisioned version of data and ask for confirmation. Here's code:
```python
from ConfigParser import ConfigParser
from argparse import ArgumentParser
from sqlalchemy import create_engine, exc
from sqlalchemy.sql import text

config = ConfigParser()
parser = ArgumentParser()
parser.add_argument('-c', '--config', help='Configuration file', required=True)

SIMPLE_Q = (
    "SELECT id, r.extras, rr.extras revision "
    "FROM resource r JOIN resource_revision rr "
    "USING(id, revision_id) WHERE r.extras != rr.extras"
)
IMPROVED_Q = (
    SIMPLE_Q + " AND  NOT (r.extras::JSON->>'datastore_active')::BOOLEAN"
)
UPDATE_Q = text("UPDATE resource SET extras = :extras WHERE id = :id")


def main():
    args = parser.parse_args()
    config.read(args.config)
    engine = create_engine(config.get('app:main', 'sqlalchemy.url'))
    try:
        records = engine.execute(IMPROVED_Q)
    except exc.ProgrammingError:
        records = engine.execute(SIMPLE_Q)

    total = records.rowcount
    print('Found {} datasets with inconsistent extras.'.format(total))
    print()

    skip_confirmation = False
    i = 0

    while True:
        row = records.fetchone()
        if row is None:
            break
        i += 1
        id, current, rev = row
        print('[{:{}}/{}] Resource <{}>'.format(i, len(str(total)), total, id))
        print('\tCurrent extras state in DB: {}'.format(current))
        print('\tAccording to the revision:  {}'.format(rev))
        if not skip_confirmation:
            choice = raw_input(
                '\tRequired action: '
                'y - rewrite; n - skip; ! - rewrite all; q - skip all: '
            ).strip()
            if choice == 'q':
                break
            elif choice == 'n':
                continue
            elif choice == '!':
                skip_confirmation = True
        engine.execute(UPDATE_Q, id=id, extras=rev)
        print('\tUpdated')


if __name__ == '__main__':
    main()

```

Folks, what do you think? 
PS should we actually commit this script or it would be better to link it inside mail notification?