### PR TITLE
Resolve issue with custom field delete icon not being rendered

### DIFF
--- a/ckan/public/base/javascript/modules/custom-fields.js
+++ b/ckan/public/base/javascript/modules/custom-fields.js
@@ -22,10 +22,6 @@ this.ckan.module('custom-fields', function (jQuery) {
       var delegated = this.options.fieldSelector + ':last input:first';
       this.el.on('change', delegated, this._onChange);
       this.el.on('change', ':checkbox', this._onRemove);
-
-      // Style the remove checkbox like a button.
-      // Not needed anymore. Included in the HTML markup
-      // this.$('.checkbox').addClass("btn btn-danger fa fa-trash");
     },
 
     /* Creates a new field and appends it to the list. This currently works by

--- a/ckan/public/base/javascript/modules/custom-fields.js
+++ b/ckan/public/base/javascript/modules/custom-fields.js
@@ -24,7 +24,8 @@ this.ckan.module('custom-fields', function (jQuery) {
       this.el.on('change', ':checkbox', this._onRemove);
 
       // Style the remove checkbox like a button.
-      this.$('.checkbox').addClass("btn btn-danger fa fa-times");
+      // Not needed anymore. Included in the HTML markup
+      // this.$('.checkbox').addClass("btn btn-danger fa fa-trash");
     },
 
     /* Creates a new field and appends it to the list. This currently works by

--- a/ckan/public/base/test/spec/modules/custom-fields.spec.js
+++ b/ckan/public/base/test/spec/modules/custom-fields.spec.js
@@ -50,13 +50,6 @@ describe('ckan.module.CustomFieldsModule()', function () {
 
       assert.calledOnce(target);
     });
-
-    it('should add "button" classes to the remove input', function () {
-      this.module.initialize();
-
-      assert.equal(this.module.$('.checkbox.btn').length, 1, 'each item should have the .btn class');
-      assert.equal(this.module.$('.checkbox.fa-times').length, 1, 'each item shoud have the .fa-times class');
-    });
   });
 
   describe('.newField(element)', function () {

--- a/ckan/templates-bs2/group/snippets/group_form.html
+++ b/ckan/templates-bs2/group/snippets/group_form.html
@@ -27,29 +27,7 @@
   {% endblock %}
 
   {% block custom_fields %}
-    {% for extra in data.extras %}
-      {% set prefix = 'extras__%d__' % loop.index0 %}
-      {{ form.custom(
-        names=(prefix ~ 'key', prefix ~ 'value', prefix ~ 'deleted'),
-        id='field-extras-%d' % loop.index,
-        label=_('Custom Field'),
-        values=(extra.key, extra.value, extra.deleted),
-        error=errors[prefix ~ 'key'] or errors[prefix ~ 'value']
-      ) }}
-    {% endfor %}
-
-    {# Add a max if 3 empty columns #}
-    {% for extra in range(data.extras|count, 3) %}
-      {% set index = (loop.index0 + data.extras|count) %}
-      {% set prefix = 'extras__%d__' % index %}
-      {{ form.custom(
-        names=(prefix ~ 'key', prefix ~ 'value', prefix ~ 'deleted'),
-        id='field-extras-%d' % index,
-        label=_('Custom Field'),
-        values=(extra.key, extra.value, extra.deleted),
-        error=errors[prefix ~ 'key'] or errors[prefix ~ 'value']
-      ) }}
-    {% endfor %}
+    {% snippet 'snippets/custom_form_fields.html', extras=data.extras, errors=errors, limit=3 %}
   {% endblock %}
 
   {{ form.required_message() }}

--- a/ckan/templates-bs2/organization/snippets/organization_form.html
+++ b/ckan/templates-bs2/organization/snippets/organization_form.html
@@ -27,29 +27,7 @@
   {% endblock %}
 
   {% block custom_fields %}
-    {% for extra in data.extras %}
-      {% set prefix = 'extras__%d__' % loop.index0 %}
-      {{ form.custom(
-        names=(prefix ~ 'key', prefix ~ 'value', prefix ~ 'deleted'),
-        id='field-extras-%d' % loop.index,
-        label=_('Custom Field'),
-        values=(extra.key, extra.value, extra.deleted),
-        error=errors[prefix ~ 'key'] or errors[prefix ~ 'value']
-      ) }}
-    {% endfor %}
-
-    {# Add a max if 3 empty columns #}
-    {% for extra in range(data.extras|count, 3) %}
-      {% set index = (loop.index0 + data.extras|count) %}
-      {% set prefix = 'extras__%d__' % index %}
-      {{ form.custom(
-        names=(prefix ~ 'key', prefix ~ 'value', prefix ~ 'deleted'),
-        id='field-extras-%d' % index,
-        label=_('Custom Field'),
-        values=(extra.key, extra.value, extra.deleted),
-        error=errors[prefix ~ 'key'] or errors[prefix ~ 'value']
-      ) }}
-    {% endfor %}
+    {% snippet 'snippets/custom_form_fields.html', extras=data.extras, errors=errors, limit=3 %}
   {% endblock %}
 
   {{ form.required_message() }}

--- a/ckan/templates/group/snippets/group_form.html
+++ b/ckan/templates/group/snippets/group_form.html
@@ -27,29 +27,7 @@
   {% endblock %}
 
   {% block custom_fields %}
-    {% for extra in data.extras %}
-      {% set prefix = 'extras__%d__' % loop.index0 %}
-      {{ form.custom(
-        names=(prefix ~ 'key', prefix ~ 'value', prefix ~ 'deleted'),
-        id='field-extras-%d' % loop.index,
-        label=_('Custom Field'),
-        values=(extra.key, extra.value, extra.deleted),
-        error=errors[prefix ~ 'key'] or errors[prefix ~ 'value']
-      ) }}
-    {% endfor %}
-
-    {# Add a max if 3 empty columns #}
-    {% for extra in range(data.extras|count, 3) %}
-      {% set index = (loop.index0 + data.extras|count) %}
-      {% set prefix = 'extras__%d__' % index %}
-      {{ form.custom(
-        names=(prefix ~ 'key', prefix ~ 'value', prefix ~ 'deleted'),
-        id='field-extras-%d' % index,
-        label=_('Custom Field'),
-        values=(extra.key, extra.value, extra.deleted),
-        error=errors[prefix ~ 'key'] or errors[prefix ~ 'value']
-      ) }}
-    {% endfor %}
+    {% snippet 'snippets/custom_form_fields.html', extras=data.extras, errors=errors, limit=3 %}
   {% endblock %}
 
   {{ form.required_message() }}

--- a/ckan/templates/organization/snippets/organization_form.html
+++ b/ckan/templates/organization/snippets/organization_form.html
@@ -27,29 +27,7 @@
   {% endblock %}
 
   {% block custom_fields %}
-    {% for extra in data.extras %}
-      {% set prefix = 'extras__%d__' % loop.index0 %}
-      {{ form.custom(
-        names=(prefix ~ 'key', prefix ~ 'value', prefix ~ 'deleted'),
-        id='field-extras-%d' % loop.index,
-        label=_('Custom Field'),
-        values=(extra.key, extra.value, extra.deleted),
-        error=errors[prefix ~ 'key'] or errors[prefix ~ 'value']
-      ) }}
-    {% endfor %}
-
-    {# Add a max if 3 empty columns #}
-    {% for extra in range(data.extras|count, 3) %}
-      {% set index = (loop.index0 + data.extras|count) %}
-      {% set prefix = 'extras__%d__' % index %}
-      {{ form.custom(
-        names=(prefix ~ 'key', prefix ~ 'value', prefix ~ 'deleted'),
-        id='field-extras-%d' % index,
-        label=_('Custom Field'),
-        values=(extra.key, extra.value, extra.deleted),
-        error=errors[prefix ~ 'key'] or errors[prefix ~ 'value']
-      ) }}
-    {% endfor %}
+    {% snippet 'snippets/custom_form_fields.html', extras=data.extras, errors=errors, limit=3 %}
   {% endblock %}
 
   {{ form.required_message() }}


### PR DESCRIPTION
Fixes #4075 

### Proposed fixes:

- Remove JS code for adding `.btn` and `.fa` classes to `.checkbox`
- Update `templates/group/snippets/group_form.html` to use `custom_form_fields.html` snippet
- Update `templates/organization/snippets/organization_form.html` to use `custom_form_fields.html` snippet


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
