### PR TITLE
Override .module-content h1 top margin

### DIFF
--- a/ckan/public/base/less/module.less
+++ b/ckan/public/base/less/module.less
@@ -63,7 +63,7 @@
 .pagination-wrapper{
     text-align: center;
     border-top: 1px solid @hr-border;
-    padding-top: @grid-gutter-width/3; 
+    padding-top: @grid-gutter-width/3;
 }
 
 // .module-content .pagination {
@@ -99,6 +99,7 @@
 // }
 
 .module h1 {
+    margin-top: 0;
     margin-bottom: 20px;
 }
 


### PR DESCRIPTION
Fixes #4079 

### Proposed fixes:

- Explicitly override top margin of .module-content h1


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
