### PR TITLE
[#4081] Return a 403 if not authorized on the search page

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -311,6 +311,9 @@ class PackageController(base.BaseController):
             c.query_error = True
             c.search_facets = {}
             c.page = h.Page(collection=[])
+        except NotAuthorized:
+            abort(403, _('Not authorized to see this page'))
+
         c.search_facets_limits = {}
         for facet in c.search_facets.keys():
             try:


### PR DESCRIPTION
Fixes #4081 

If someone customized the package_search auth function to restrict access the frontend returns an uncaught exception as this case is not handled in the controller