### PR TITLE
Update confirm-action.js Bootstrap 3 template

### DIFF
--- a/ckan/public/base/javascript/modules/confirm-action.js
+++ b/ckan/public/base/javascript/modules/confirm-action.js
@@ -28,11 +28,11 @@ this.ckan.module('confirm-action', function (jQuery) {
         '<div class="modal-content">',
         '<div class="modal-header">',
         '<button type="button" class="close" data-dismiss="modal">×</button>',
-        '<h3></h3>',
+        '<h3 class="modal-title"></h3>',
         '</div>',
         '<div class="modal-body"></div>',
         '<div class="modal-footer">',
-        '<button class="btn btn-cancel"></button>',
+        '<button class="btn btn-default btn-cancel"></button>',
         '<button class="btn btn-primary"></button>',
         '</div>',
         '</div>',
@@ -98,7 +98,7 @@ this.ckan.module('confirm-action', function (jQuery) {
         element.on('click', '.btn-cancel', this._onConfirmCancel);
         element.modal({show: false});
 
-        element.find('h3').text(this._('Please Confirm Action'));
+        element.find('.modal-title').text(this._('Please Confirm Action'));
         var content = this.options.content ||
                       this.options.i18n.content || /* Backwards-compatibility */
                       this._('Are you sure you want to perform this action?');


### PR DESCRIPTION
Fixes #4085 

### Proposed fixes:

- Add `modal-title` CSS class to the `<h3>` element
- Updated JS selector to target `modal-title` instead of just `h3`
- Add `btn-default` CSS class to the Cancel button

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
