### PR TITLE
Add basic auth support for Solr

### DIFF
--- a/ckan/lib/search/common.py
+++ b/ckan/lib/search/common.py
@@ -6,6 +6,7 @@ import re
 import pysolr
 import simplejson
 from six import string_types
+import urllib
 
 log = logging.getLogger(__name__)
 
@@ -71,8 +72,8 @@ def make_connection(decode_dates=True):
         protocol = re.search('(http(?:s)?)://', solr_url).group()
         solr_url = re.sub(protocol, '', solr_url)
         solr_url = "{}{}:{}@{}".format(protocol,
-                                       solr_user,
-                                       solr_password,
+                                       urllib.quote_plus(solr_user),
+                                       urllib.quote_plus(solr_password),
                                        solr_url)
 
     if decode_dates:

--- a/ckan/lib/search/common.py
+++ b/ckan/lib/search/common.py
@@ -65,6 +65,13 @@ def is_available():
 
 def make_connection(decode_dates=True):
     solr_url, solr_user, solr_password = SolrSettings.get()
+
+    if solr_url and solr_user:
+        # Rebuild the URL with the username/password
+        protocol = re.search('(http(?:s)?)://', solr_url).group()
+        solr_url = re.sub(protocol, '', solr_url)
+        solr_url = "{}{}:{}@{}".format(protocol, solr_user, solr_password, solr_url)
+
     if decode_dates:
         decoder = simplejson.JSONDecoder(object_hook=solr_datetime_decoder)
         return pysolr.Solr(solr_url, decoder=decoder)

--- a/ckan/lib/search/common.py
+++ b/ckan/lib/search/common.py
@@ -70,7 +70,10 @@ def make_connection(decode_dates=True):
         # Rebuild the URL with the username/password
         protocol = re.search('(http(?:s)?)://', solr_url).group()
         solr_url = re.sub(protocol, '', solr_url)
-        solr_url = "{}{}:{}@{}".format(protocol, solr_user, solr_password, solr_url)
+        solr_url = "{}{}:{}@{}".format(protocol,
+                                       solr_user,
+                                       solr_password,
+                                       solr_url)
 
     if decode_dates:
         decoder = simplejson.JSONDecoder(object_hook=solr_datetime_decoder)

--- a/ckan/lib/search/common.py
+++ b/ckan/lib/search/common.py
@@ -69,7 +69,7 @@ def make_connection(decode_dates=True):
 
     if solr_url and solr_user:
         # Rebuild the URL with the username/password
-        protocol = re.search('(http(?:s)?)://', solr_url).group()
+        protocol = re.search('http(?:s)?://', solr_url).group()
         solr_url = re.sub(protocol, '', solr_url)
         solr_url = "{}{}:{}@{}".format(protocol,
                                        urllib.quote_plus(solr_user),


### PR DESCRIPTION
Fixes #4089 

This PR rebuilds the URL used to create the Solr connection with the `solr_user` and `solr_password` settings from `ckan.ini`.