### PR TITLE
Add support for user/pass for Solr as ENV var

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -135,6 +135,8 @@ CONFIG_FROM_ENV_VARS = {
     'ckan.datastore.read_url': 'CKAN_DATASTORE_READ_URL',
     'ckan.redis.url': 'CKAN_REDIS_URL',
     'solr_url': 'CKAN_SOLR_URL',
+    'solr_user': 'CKAN_SOLR_USER',
+    'solr_password': 'CKAN_SOLR_PASSWORD',
     'ckan.site_id': 'CKAN_SITE_ID',
     'ckan.site_url': 'CKAN_SITE_URL',
     'ckan.storage_path': 'CKAN_STORAGE_PATH',


### PR DESCRIPTION
Fixes #4091

### Proposed fixes:

This PR adds support for the `CKAN_SOLR_USER` and `CKAN_SOLR_PASSWORD` environment variables alongside `CKAN_SOLR_URL`.