### PR TITLE
Better message on non authorized errors

### DIFF
--- a/ckan/authz.py
+++ b/ckan/authz.py
@@ -197,10 +197,11 @@ def is_authorized(action, context, data_dict=None):
         # access straight away
         if not getattr(auth_function, 'auth_allow_anonymous_access', False) \
            and not context.get('auth_user_obj'):
-            return {'success': False,
-                    'msg': '{0} requires an authenticated user'
-                            .format(auth_function)
-                   }
+            return {
+                'success': False,
+                'msg': 'Action {0} requires an authenticated user'.format(
+                    auth_function.__name__)
+            }
 
         return auth_function(context, data_dict)
     else:


### PR DESCRIPTION
Display function name rather than the Python representation.

Changes this:

```
{
    "error": {
        "__type": "Authorization Error", 
        "message": "Access denied: <function package_search at 0x7f650af89578> requires an authenticated user"
    }, 
    "help": "http://ckan-dev:5000/api/3/action/help_show?name=package_search", 
    "success": false
}

```

To this:


```
{
    "error": {
        "__type": "Authorization Error", 
        "message": "Access denied: Action package_search requires an authenticated user"
    }, 
    "help": "http://ckan-dev:5000/api/3/action/help_show?name=package_search", 
    "success": false
}

```
