### PR TITLE
Bump python-magic to 0.4.15 to add Alpine Linux support (#4098)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ passlib==1.6.5
 paste==1.7.5.1
 polib==1.0.7
 psycopg2==2.7.3.2
-python-magic==0.4.12
+python-magic==0.4.15
 pysolr==3.6.0
 Pylons==0.9.7
 python-dateutil>=1.5.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ Pygments==2.2.0           # via weberror
 Pylons==0.9.7
 pysolr==3.6.0
 python-dateutil==1.5
-python-magic==0.4.12
+python-magic==0.4.15
 pytz==2016.7
 pyutilib.component.core==4.6.4
 redis==2.10.6             # via rq


### PR DESCRIPTION
Fixes #4098

### Proposed fixes:

This PR bumps python-magic to 0.4.15 to add support for Alpine Linux.