### PR TITLE
Remove .wrapper margin below 768px

### DIFF
--- a/ckan/public/base/less/layout.less
+++ b/ckan/public/base/less/layout.less
@@ -91,7 +91,6 @@
 
 @media (max-width: @screen-xs-max) {
     .wrapper {
-        margin: 0 -20px;
         border-width: 0;
         .box-shadow(0);
         .border-radius(0);


### PR DESCRIPTION
Fixes #4104 

### Proposed fixes:

- Remove `.wrapper` margin below 768px


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
