### PR TITLE
Reset .navbar-toggle right margin below 768px

### DIFF
--- a/ckan/public/base/less/masthead.less
+++ b/ckan/public/base/less/masthead.less
@@ -190,6 +190,9 @@
 }
 
 @media (max-width: @screen-sm-max) {
+    .navbar-toggle{
+      margin-right: 0;
+    }
     .account-masthead {
         margin-left: -@grid-gutter-width/2;
         margin-right: -@grid-gutter-width/2;


### PR DESCRIPTION
Fixes #4105 

### Proposed fixes:

- Reset right margin of `.navbar-toggle`, below 768px 

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
