### PR TITLE
Fix .form-actions overflow

### DIFF
--- a/ckan/public/base/less/forms.less
+++ b/ckan/public/base/less/forms.less
@@ -123,11 +123,7 @@ textarea {
 }
 
 .form-actions {
-    // background: none;
-    // overflow: auto; // margin-left: -@gutterX;
-    // margin-right: -@gutterX;
-    // margin-bottom: 0; // Prevents reduces the padding when included in a module.
-    // padding-bottom: 0;
+  overflow: auto;
 }
 
 @media (min-width: @screen-sm-min) {
@@ -147,6 +143,7 @@ textarea {
     .form-actions .action-info {
         float: left;
         width: 50%;
+        margin-right: @grid-gutter-width/2;
     }
 }
 


### PR DESCRIPTION
Fixes #4111 

### Proposed fixes:

- Set `.form-actions` `overflow` to `auto`
- Set `.form-actions .action-info` right margin

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
