### PR TITLE
[#4121]Organization dropdown to full width fix 

### DIFF
--- a/ckan/public/base/less/forms.less
+++ b/ckan/public/base/less/forms.less
@@ -260,7 +260,8 @@ form .control-medium .info-block.info-inline {
     padding: 10px @gutterSmallX 0;
 }
 
-input[data-module="autocomplete"] {
+input[data-module="autocomplete"],
+select[data-module="autocomplete"] {
     width: 100%;
 }
 


### PR DESCRIPTION
Fixes #4121 

### Proposed fixes:

- Set explicit width to `<select>` elements with `data-module` attribute set to `autocomplete`. 

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
