### PR TITLE
Update .btn-remove-url top and right positions

### DIFF
--- a/ckan/public/base/less/forms.less
+++ b/ckan/public/base/less/forms.less
@@ -748,8 +748,8 @@ input[data-module="autocomplete"] {
     .btn-remove-url {
         position: absolute;
         margin-right: 0;
-        top: 4px;
-        right: 5px;
+        top: @grid-gutter-width/5;
+        right: @grid-gutter-width/6;
         padding: 0 12px;
         .border-radius(100px);
         .icon-remove {


### PR DESCRIPTION
Fixes #4126

### Proposed fixes:

- Update `.btn-remove-url` top property
- Update `.btn-remove-url` right property - basically remains the same, just calculated through a LESS variable

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
