### PR TITLE
from six.moves import input for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,46 @@
-sudo: required
-
 language: python
 
-services:
-  - docker
+matrix:
+  allow_failures:
+  - python: "3.6"
 
-cache:
-  directories:
-     - ~/docker
+  include:
+    - sudo: required
+      python: "2.7"
 
-before_install:
-  - docker build --rm=false -f contrib/docker/postgresql/Dockerfile -t postgresql .
-  - docker build --rm=false -f contrib/docker/solr/Dockerfile -t solr .
-  - docker pull redis:latest
-  - docker build --rm=false -t ckan .
+      services:
+        - docker
 
-install:
-  - docker run -d --name db postgresql
-  - docker run -d --name solr solr
-  - docker run -d --name redis redis:latest
-  - docker run -d --name ckan -p 5000:5000 --link db:db --link redis:redis --link solr:solr ckan
+      cache:
+        directories:
+          - ~/docker
 
-script:
-  - docker ps -a
+      before_install:
+        - docker build --rm=false -f contrib/docker/postgresql/Dockerfile -t postgresql .
+        - docker build --rm=false -f contrib/docker/solr/Dockerfile -t solr .
+        - docker pull redis:latest
+        - docker build --rm=false -t ckan .
+
+      install:
+        - docker run -d --name db postgresql
+        - docker run -d --name solr solr
+        - docker run -d --name redis redis:latest
+        - docker run -d --name ckan -p 5000:5000 --link db:db --link redis:redis --link solr:solr ckan
+
+      script:
+        - docker ps -a
+
+    - python: "3.6"
+      cache: pip
+
+      install:
+        - pip install flake8
+
+      before_script:
+        # stop the build if there are Python syntax errors or undefined names
+        - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+        # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+        - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+      script:
+        - true # pytest --capture=sys # add other tests here

--- a/scripts/4042_fix_resource_extras.py
+++ b/scripts/4042_fix_resource_extras.py
@@ -30,6 +30,7 @@ activated.
 import json
 from ConfigParser import ConfigParser
 from argparse import ArgumentParser
+from six.moves import input
 from sqlalchemy import create_engine
 from sqlalchemy.sql import text
 
@@ -76,10 +77,10 @@ def main():
         print(u'\tCurrent extras state in DB: {}'.format(current))
         print(u'\tAccording to the revision:  {}'.format(rev))
         if not skip_confirmation:
-            choice = raw_input(
+            choice = input(
                 u'\tRequired action: '
                 u'y - rewrite; n - skip; ! - rewrite all; q - skip all: '
-            ).strip()
+            ).strip().lower()
             if choice == u'q':
                 break
             elif choice == u'n':


### PR DESCRIPTION
Related to #4060 

### Proposed fixes:
* __from six.moves import input__ because __raw_input()__ was removed in Python 3
* Add Python 3.6 to the Travis CI testing in __allow_failures__ mode.

The __flake8__ undefined names should be identical in Python 2 and Python 3.

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
