### PR TITLE
increase the strength of the password reset token

### DIFF
--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+import codecs
 import smtplib
 import socket
 import logging
@@ -192,7 +193,7 @@ def create_reset_key(user):
 
 
 def make_key():
-    return uuid.uuid4().hex[:10]
+    return codecs.encode(os.urandom(16), 'hex')
 
 
 def verify_reset_link(user, key):

--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 import codecs
+import os
 import smtplib
 import socket
 import logging


### PR DESCRIPTION
This is the first PR to merge features from the plugin:
https://github.com/data-govt-nz/ckanext-security/issues/2
into ckan core

### Fixes 
Having weak/predictable password reset tokens

### Proposed fixes:
Use a longer password reset token from a less predictable source. 

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
