### PR TITLE
Add missing empty space between "Add to group" button

### DIFF
--- a/ckan/public/base/less/forms.less
+++ b/ckan/public/base/less/forms.less
@@ -657,6 +657,7 @@ select[data-module="autocomplete"] {
 
 .select2-container {
     margin-top: 1px;
+    margin-bottom: @grid-gutter-width/4;
 }
 
 .select2-container-multi {

--- a/ckan/public/base/less/module.less
+++ b/ckan/public/base/less/module.less
@@ -23,6 +23,12 @@
 
 .module-content {
     padding: @grid-gutter-width;
+
+    form[method=post]{
+      .btn-primary{
+        margin-bottom: @grid-gutter-width;
+      }
+    }
 }
 
 // @media (min-width: @screen-sm-min) {


### PR DESCRIPTION
Fixes #4154 

### Proposed fixes:

- Add bottom margin to `.select2-container`
- Add bottom margin to `.btn-primary` within `.module-content form[method=post]`


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
