### PR TITLE
Fix datastore dump > 25k records

### DIFF
--- a/ckanext/datastore/controller.py
+++ b/ckanext/datastore/controller.py
@@ -137,6 +137,7 @@ def dump_to(resource_id, output, fmt, offset, limit, options):
                 PAGINATE_BY if limit is None
                 else min(PAGINATE_BY, lim),
             'offset': offs,
+            'sort': '_id',
             'records_format': records_format,
             'include_total': 'false',  # XXX: default() is broken
         })


### PR DESCRIPTION
Fixes #4150 

### Proposed fixes:

dump is using an offset without a sort specified which isn't reliable. Sort on `_id` field.

A better fix would add this sort and use the id of the last record retrieved to fetch the next page, but that's a larger change for a future version.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport