### PR TITLE
[#4161] fix datastore info test, move to extension

### DIFF
--- a/ckan/tests/controllers/test_api.py
+++ b/ckan/tests/controllers/test_api.py
@@ -316,53 +316,6 @@ class TestApiController(helpers.FunctionalTestBase):
             sorted([dataset1['name'], dataset2['name']]))
 
 
-class TestApiControllerApiInfo(helpers.FunctionalTestBase):
-    """
-    As template loader initialized during setiing-up application
-    datastore(container of ajax_snippets/api_info.html) should be loaded before
-    any test
-    """
-    @classmethod
-    def _apply_config_changes(cls, config):
-        config['ckan.plugins'] = 'datastore'
-
-    @classmethod
-    def teardown_class(cls):
-        if p.plugin_loaded('datastore'):
-            p.unload('datastore')
-
-    def test_api_info(self):
-
-        dataset = factories.Dataset()
-        resource = factories.Resource(
-            id='588dfa82-760c-45a2-b78a-e3bc314a4a9b',
-            package_id=dataset['id'], datastore_active=True)
-
-        # the 'API info' is seen on the resource_read page, a snippet loaded by
-        # javascript via data_api_button.html
-        url = template_helpers.url_for(
-            controller='api', action='snippet', ver=1,
-            snippet_path='api_info.html', resource_id=resource['id'])
-
-        app = self._get_test_app()
-        page = app.get(url, status=200)
-
-        # check we built all the urls ok
-        expected_urls = (
-            'http://test.ckan.net/api/3/action/datastore_create',
-            'http://test.ckan.net/api/3/action/datastore_upsert',
-            '<code>http://test.ckan.net/api/3/action/datastore_search',
-            'http://test.ckan.net/api/3/action/datastore_search_sql',
-            'http://test.ckan.net/api/3/action/datastore_search?resource_id=588dfa82-760c-45a2-b78a-e3bc314a4a9b&amp;limit=5',
-            'http://test.ckan.net/api/3/action/datastore_search?q=jones&amp;resource_id=588dfa82-760c-45a2-b78a-e3bc314a4a9b',
-            'http://test.ckan.net/api/3/action/datastore_search_sql?sql=SELECT * from &#34;588dfa82-760c-45a2-b78a-e3bc314a4a9b&#34; WHERE title LIKE &#39;jones&#39;',
-            "url: 'http://test.ckan.net/api/3/action/datastore_search'",
-            "http://test.ckan.net/api/3/action/datastore_search?resource_id=588dfa82-760c-45a2-b78a-e3bc314a4a9b&amp;limit=5&amp;q=title:jones",
-        )
-        for url in expected_urls:
-            assert url in page, url
-
-
 class TestRevisionSearch(helpers.FunctionalTestBase):
 
     # Error cases

--- a/ckanext/datastore/tests/helpers.py
+++ b/ckanext/datastore/tests/helpers.py
@@ -4,9 +4,10 @@ from sqlalchemy import orm
 
 import ckan.model as model
 import ckan.lib.cli as cli
+from ckan.lib import search
 
 import ckan.plugins as p
-from ckan.tests.helpers import FunctionalTestBase
+from ckan.tests.helpers import FunctionalTestBase, reset_db
 import ckanext.datastore.backend.postgres as db
 
 
@@ -67,3 +68,21 @@ class DatastoreFunctionalTestBase(FunctionalTestBase):
         engine = db.get_write_engine()
         rebuild_all_dbs(orm.scoped_session(orm.sessionmaker(bind=engine)))
         super(DatastoreFunctionalTestBase, cls).setup_class()
+
+
+class DatastoreLegacyTestBase(object):
+    u"""
+    Tests that rely on data created in setup_class. No cleanup done between
+    each test method. Not recommended for new tests.
+    """
+    @classmethod
+    def setup_class(cls):
+        p.load(u'datastore')
+        reset_db()
+        search.clear_all()
+        engine = db.get_write_engine()
+        rebuild_all_dbs(orm.scoped_session(orm.sessionmaker(bind=engine)))
+
+    @classmethod
+    def teardown_class(cls):
+        p.unload(u'datastore')

--- a/ckanext/datastore/tests/test_chained_action.py
+++ b/ckanext/datastore/tests/test_chained_action.py
@@ -5,6 +5,8 @@ import ckan.plugins as p
 import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
 
+from ckanext.datastore.tests.helpers import DatastoreFunctionalTestBase
+
 assert_equals = nose.tools.assert_equals
 assert_raises = nose.tools.assert_raises
 
@@ -27,19 +29,10 @@ class ExampleDataStoreDeletedWithCountPlugin(p.SingletonPlugin):
         return ({u'datastore_delete': datastore_delete})
 
 
-class TestChainedAction(object):
-    @classmethod
-    def setup_class(cls):
-        p.load(u'datastore')
-        p.load(u'example_datastore_deleted_with_count_plugin')
-
-    @classmethod
-    def teardown_class(cls):
-        p.unload(u'example_datastore_deleted_with_count_plugin')
-        p.unload(u'datastore')
-
-    def setup(self):
-        helpers.reset_db()
+class TestChainedAction(DatastoreFunctionalTestBase):
+    _load_plugins = (
+        u'datastore',
+        u'example_datastore_deleted_with_count_plugin')
 
     def test_datastore_delete_filters(self):
         records = [

--- a/ckanext/datastore/tests/test_chained_auth_functions.py
+++ b/ckanext/datastore/tests/test_chained_auth_functions.py
@@ -5,6 +5,8 @@ from ckan.logic import check_access
 import ckan.lib.create_test_data as ctd
 import ckan.tests.helpers as helpers
 
+from ckanext.datastore.tests.helpers import DatastoreFunctionalTestBase
+
 assert_equals = nose.tools.assert_equals
 assert_raises = nose.tools.assert_raises
 
@@ -32,20 +34,13 @@ class ExampleDataStoreSearchSQLPlugin(p.SingletonPlugin):
         return {u'datastore_search_sql': datastore_search_sql_auth}
 
 
-class TestChainedAuth(object):
-    @classmethod
-    def setup_class(cls):
-        p.load(u'datastore')
-        p.load(u'example_data_store_search_sql_plugin')
-        ctd.CreateTestData.create()
-
-    @classmethod
-    def teardown_class(cls):
-        p.unload(u'example_data_store_search_sql_plugin')
-        p.unload(u'datastore')
-        helpers.reset_db()
+class TestChainedAuth(DatastoreFunctionalTestBase):
+    _load_plugins = (
+        u'datastore',
+        u'example_data_store_search_sql_plugin')
 
     def test_datastore_search_sql_auth(self):
+        ctd.CreateTestData.create()
         with assert_raises(TestAuthException) as raise_context:
             # checking access should call to our chained version defined above
             # first, thus this should throw an exception

--- a/ckanext/datastore/tests/test_db.py
+++ b/ckanext/datastore/tests/test_db.py
@@ -12,6 +12,7 @@ import ckan.tests.factories as factories
 
 import ckanext.datastore.backend.postgres as db
 import ckanext.datastore.backend as backend
+from ckanext.datastore.tests.helpers import DatastoreFunctionalTestBase
 
 assert_equal = nose.tools.assert_equal
 
@@ -173,16 +174,7 @@ def test_upsert_with_insert_method_and_invalid_data(
         backend.InvalidDataError, db.upsert_data, context, data_dict)
 
 
-class TestGetAllResourcesIdsInDatastore(object):
-    @classmethod
-    def setup_class(cls):
-        p.load('datastore')
-
-    @classmethod
-    def teardown_class(cls):
-        p.unload('datastore')
-        helpers.reset_db()
-
+class TestGetAllResourcesIdsInDatastore(DatastoreFunctionalTestBase):
     def test_get_all_resources_ids_in_datastore(self):
         resource_in_datastore = factories.Resource()
         resource_not_in_datastore = factories.Resource()
@@ -214,21 +206,10 @@ def datastore_job(res_id, value):
         helpers.call_action('datastore_upsert', **data)
 
 
-class TestBackgroundJobs(helpers.RQTestBase):
+class TestBackgroundJobs(helpers.RQTestBase, DatastoreFunctionalTestBase):
     '''
     Test correct interaction with the background jobs system.
     '''
-    @classmethod
-    def setup_class(cls):
-
-        cls.app = helpers._get_test_app()
-        p.load('datastore')
-
-    @classmethod
-    def teardown_class(cls):
-        p.unload('datastore')
-        helpers.reset_db()
-
     def test_worker_datastore_access(self):
         '''
         Test DataStore access from within a worker.
@@ -241,7 +222,7 @@ class TestBackgroundJobs(helpers.RQTestBase):
             'fields': [{'id': 'value', 'type': 'int'}],
         }
 
-        with self.app.flask_app.test_request_context():
+        with self._get_test_app().flask_app.test_request_context():
             table = helpers.call_action('datastore_create', **data)
         res_id = table['resource_id']
         for i in range(3):

--- a/ckanext/datastore/tests/test_delete.py
+++ b/ckanext/datastore/tests/test_delete.py
@@ -17,22 +17,21 @@ import ckan.tests.factories as factories
 from ckan.logic import NotFound
 import ckanext.datastore.backend.postgres as db
 from ckanext.datastore.tests.helpers import (
-    rebuild_all_dbs, set_url_type, DatastoreFunctionalTestBase)
+    rebuild_all_dbs, set_url_type,
+    DatastoreFunctionalTestBase, DatastoreLegacyTestBase)
 
 assert_raises = nose.tools.assert_raises
 
 
-class TestDatastoreDelete():
+class TestDatastoreDelete(DatastoreLegacyTestBase):
     sysadmin_user = None
     normal_user = None
     Session = None
 
     @classmethod
     def setup_class(cls):
-        if not tests.is_datastore_supported():
-            raise nose.SkipTest("Datastore not supported")
         cls.app = helpers._get_test_app()
-        p.load('datastore')
+        super(TestDatastoreDelete, cls).setup_class()
         ctd.CreateTestData.create()
         cls.sysadmin_user = model.User.get('testsysadmin')
         cls.normal_user = model.User.get('annafan')
@@ -54,11 +53,6 @@ class TestDatastoreDelete():
         cls.Session = orm.scoped_session(orm.sessionmaker(bind=engine))
         set_url_type(
             model.Package.get('annakarenina').resources, cls.sysadmin_user)
-
-    @classmethod
-    def teardown_class(cls):
-        rebuild_all_dbs(cls.Session)
-        p.unload('datastore')
 
     def _create(self):
         postparams = '%s=1' % json.dumps(self.data)

--- a/ckanext/datastore/tests/test_dump.py
+++ b/ckanext/datastore/tests/test_dump.py
@@ -7,23 +7,21 @@ import ckan.model as model
 import ckan.plugins as p
 import ckan.tests.legacy as tests
 import ckanext.datastore.backend.postgres as db
-import ckanext.datastore.tests.helpers as helpers
+from ckanext.datastore.tests.helpers import DatastoreLegacyTestBase
 import nose
 from ckan.tests.helpers import _get_test_app
 import sqlalchemy.orm as orm
 from nose.tools import assert_equals, assert_in
 
 
-class TestDatastoreDump(object):
+class TestDatastoreDump(DatastoreLegacyTestBase):
     sysadmin_user = None
     normal_user = None
 
     @classmethod
     def setup_class(cls):
         cls.app = _get_test_app()
-        if not tests.is_datastore_supported():
-            raise nose.SkipTest("Datastore not supported")
-        p.load('datastore')
+        super(TestDatastoreDump, cls).setup_class()
         ctd.CreateTestData.create()
         cls.sysadmin_user = model.User.get('testsysadmin')
         cls.normal_user = model.User.get('annafan')
@@ -89,11 +87,6 @@ class TestDatastoreDump(object):
 
         engine = db.get_write_engine()
         cls.Session = orm.scoped_session(orm.sessionmaker(bind=engine))
-
-    @classmethod
-    def teardown_class(cls):
-        helpers.rebuild_all_dbs(cls.Session)
-        p.unload('datastore')
 
     def test_dump_basic(self):
         auth = {'Authorization': str(self.normal_user.apikey)}

--- a/ckanext/datastore/tests/test_helpers.py
+++ b/ckanext/datastore/tests/test_helpers.py
@@ -5,6 +5,7 @@ import nose
 
 from ckan.common import config
 import ckanext.datastore.helpers as datastore_helpers
+from ckanext.datastore.tests.helpers import DatastoreLegacyTestBase
 import ckanext.datastore.backend.postgres as postgres_backend
 import ckanext.datastore.tests.helpers as datastore_test_helpers
 import ckanext.datastore.backend.postgres as db
@@ -63,11 +64,11 @@ class TestTypeGetters(object):
             assert datastore_helpers.should_fts_index_field_type(non_indexable) is False
 
 
-class TestGetTables(object):
+class TestGetTables(DatastoreLegacyTestBase):
 
     @classmethod
     def setup_class(cls):
-
+        super(TestGetTables, cls).setup_class()
         engine = db.get_write_engine()
         cls.Session = orm.scoped_session(orm.sessionmaker(bind=engine))
 
@@ -81,10 +82,6 @@ class TestGetTables(object):
         ]
         for create_table_sql in create_tables:
             cls.Session.execute(create_table_sql)
-
-    @classmethod
-    def teardown_class(cls):
-        datastore_test_helpers.clear_db(cls.Session)
 
     def test_get_table_names(self):
 

--- a/ckanext/datastore/tests/test_info.py
+++ b/ckanext/datastore/tests/test_info.py
@@ -11,6 +11,7 @@ import ckan.plugins as p
 import ckan.lib.create_test_data as ctd
 import ckan.model as model
 from ckan.tests.legacy import is_datastore_supported
+from ckan.lib import helpers as template_helpers
 
 import ckanext.datastore.backend.postgres as db
 from ckanext.datastore.tests.helpers import extract, rebuild_all_dbs
@@ -22,17 +23,8 @@ assert_equals = nose.tools.assert_equals
 assert_raises = nose.tools.assert_raises
 
 
-class TestDatastoreInfo(object):
-    @classmethod
-    def setup_class(cls):
-        if not is_datastore_supported():
-            raise nose.SkipTest("Datastore not supported")
-        plugin = p.load('datastore')
-
-    @classmethod
-    def teardown_class(cls):
-        p.unload('datastore')
-        helpers.reset_db()
+class TestDatastoreInfo(helpers.FunctionalTestBase):
+    _load_plugins = ['datastore']
 
     def test_info_success(self):
         resource = factories.Resource()
@@ -53,3 +45,33 @@ class TestDatastoreInfo(object):
         assert info['schema']['to'] == 'text'
         assert info['schema']['from'] == 'text'
         assert info['schema']['num'] == 'number', info['schema']
+
+    def test_api_info(self):
+        dataset = factories.Dataset()
+        resource = factories.Resource(
+            id='588dfa82-760c-45a2-b78a-e3bc314a4a9b',
+            package_id=dataset['id'], datastore_active=True)
+
+        # the 'API info' is seen on the resource_read page, a snippet loaded by
+        # javascript via data_api_button.html
+        url = template_helpers.url_for(
+            controller='api', action='snippet', ver=1,
+            snippet_path='api_info.html', resource_id=resource['id'])
+
+        app = self._get_test_app()
+        page = app.get(url, status=200)
+
+        # check we built all the urls ok
+        expected_urls = (
+            'http://test.ckan.net/api/3/action/datastore_create',
+            'http://test.ckan.net/api/3/action/datastore_upsert',
+            '<code>http://test.ckan.net/api/3/action/datastore_search',
+            'http://test.ckan.net/api/3/action/datastore_search_sql',
+            'http://test.ckan.net/api/3/action/datastore_search?resource_id=588dfa82-760c-45a2-b78a-e3bc314a4a9b&amp;limit=5',
+            'http://test.ckan.net/api/3/action/datastore_search?q=jones&amp;resource_id=588dfa82-760c-45a2-b78a-e3bc314a4a9b',
+            'http://test.ckan.net/api/3/action/datastore_search_sql?sql=SELECT * from &#34;588dfa82-760c-45a2-b78a-e3bc314a4a9b&#34; WHERE title LIKE &#39;jones&#39;',
+            "url: 'http://test.ckan.net/api/3/action/datastore_search'",
+            "http://test.ckan.net/api/3/action/datastore_search?resource_id=588dfa82-760c-45a2-b78a-e3bc314a4a9b&amp;limit=5&amp;q=title:jones",
+        )
+        for url in expected_urls:
+            assert url in page, url

--- a/ckanext/datastore/tests/test_info.py
+++ b/ckanext/datastore/tests/test_info.py
@@ -14,7 +14,7 @@ from ckan.tests.legacy import is_datastore_supported
 from ckan.lib import helpers as template_helpers
 
 import ckanext.datastore.backend.postgres as db
-from ckanext.datastore.tests.helpers import extract, rebuild_all_dbs
+from ckanext.datastore.tests.helpers import extract, DatastoreFunctionalTestBase
 
 import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
@@ -23,8 +23,7 @@ assert_equals = nose.tools.assert_equals
 assert_raises = nose.tools.assert_raises
 
 
-class TestDatastoreInfo(helpers.FunctionalTestBase):
-    _load_plugins = ['datastore']
+class TestDatastoreInfo(DatastoreFunctionalTestBase):
 
     def test_info_success(self):
         resource = factories.Resource()

--- a/ckanext/datastore/tests/test_interface.py
+++ b/ckanext/datastore/tests/test_interface.py
@@ -6,23 +6,16 @@ import ckan.plugins as p
 import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
 
+from ckanext.datastore.tests.helpers import DatastoreFunctionalTestBase
+
 assert_equals = nose.tools.assert_equals
 assert_raises = nose.tools.assert_raises
 
 
-class TestInterfaces(object):
-    @classmethod
-    def setup_class(cls):
-        p.load('datastore')
-        p.load('sample_datastore_plugin')
-
-    @classmethod
-    def teardown_class(cls):
-        p.unload('sample_datastore_plugin')
-        p.unload('datastore')
-
-    def setup(self):
-        helpers.reset_db()
+class TestInterfaces(DatastoreFunctionalTestBase):
+    _load_plugins = (
+        u'datastore',
+        u'sample_datastore_plugin')
 
     def test_datastore_search_can_create_custom_filters(self):
         records = [

--- a/ckanext/datastore/tests/test_plugin.py
+++ b/ckanext/datastore/tests/test_plugin.py
@@ -21,6 +21,12 @@ class TestPluginLoadingOrder(object):
         if p.plugin_loaded('sample_datastore_plugin'):
             p.unload('sample_datastore_plugin')
 
+    def teardown(self):
+        if p.plugin_loaded('sample_datastore_plugin'):
+            p.unload('sample_datastore_plugin')
+        if p.plugin_loaded('datastore'):
+            p.unload('datastore')
+
     def test_loading_datastore_first_works(self):
         p.load('datastore')
         p.load('sample_datastore_plugin')

--- a/ckanext/datastore/tests/test_upsert.py
+++ b/ckanext/datastore/tests/test_upsert.py
@@ -16,22 +16,13 @@ import ckan.tests.factories as factories
 from ckan.common import config
 
 import ckanext.datastore.backend.postgres as db
-from ckanext.datastore.tests.helpers import rebuild_all_dbs, set_url_type
+from ckanext.datastore.tests.helpers import (
+    set_url_type, DatastoreFunctionalTestBase, DatastoreLegacyTestBase)
 
 assert_equal = nose.tools.assert_equal
 
 
-class TestDatastoreUpsertNewTests(object):
-    @classmethod
-    def setup_class(cls):
-        if not p.plugin_loaded('datastore'):
-            p.load('datastore')
-
-    @classmethod
-    def teardown_class(cls):
-        p.unload('datastore')
-        helpers.reset_db()
-
+class TestDatastoreUpsertNewTests(DatastoreFunctionalTestBase):
     def test_upsert_doesnt_crash_with_json_field(self):
         resource = factories.Resource()
         data = {
@@ -77,16 +68,14 @@ class TestDatastoreUpsertNewTests(object):
         helpers.call_action('datastore_upsert', **data)
 
 
-class TestDatastoreUpsert():
+class TestDatastoreUpsert(DatastoreLegacyTestBase):
     sysadmin_user = None
     normal_user = None
 
     @classmethod
     def setup_class(cls):
-        if not tests.is_datastore_supported():
-            raise nose.SkipTest("Datastore not supported")
         cls.app = helpers._get_test_app()
-        p.load('datastore')
+        super(TestDatastoreUpsert, cls).setup_class()
         ctd.CreateTestData.create()
         cls.sysadmin_user = model.User.get('testsysadmin')
         cls.normal_user = model.User.get('annafan')
@@ -116,11 +105,6 @@ class TestDatastoreUpsert():
 
         engine = db.get_write_engine()
         cls.Session = orm.scoped_session(orm.sessionmaker(bind=engine))
-
-    @classmethod
-    def teardown_class(cls):
-        rebuild_all_dbs(cls.Session)
-        p.unload('datastore')
 
     def test_upsert_requires_auth(self):
         data = {
@@ -329,16 +313,14 @@ class TestDatastoreUpsert():
 
 
 
-class TestDatastoreInsert():
+class TestDatastoreInsert(DatastoreLegacyTestBase):
     sysadmin_user = None
     normal_user = None
 
     @classmethod
     def setup_class(cls):
-        if not tests.is_datastore_supported():
-            raise nose.SkipTest("Datastore not supported")
         cls.app = helpers._get_test_app()
-        p.load('datastore')
+        super(TestDatastoreInsert, cls).setup_class()
         ctd.CreateTestData.create()
         cls.sysadmin_user = model.User.get('testsysadmin')
         cls.normal_user = model.User.get('annafan')
@@ -368,11 +350,6 @@ class TestDatastoreInsert():
 
         engine = db.get_write_engine()
         cls.Session = orm.scoped_session(orm.sessionmaker(bind=engine))
-
-    @classmethod
-    def teardown_class(cls):
-        p.unload('datastore')
-        rebuild_all_dbs(cls.Session)
 
     def test_insert_non_existing_field(self):
         data = {
@@ -431,16 +408,14 @@ class TestDatastoreInsert():
         assert results.rowcount == 3
 
 
-class TestDatastoreUpdate():
+class TestDatastoreUpdate(DatastoreLegacyTestBase):
     sysadmin_user = None
     normal_user = None
 
     @classmethod
     def setup_class(cls):
-        if not tests.is_datastore_supported():
-            raise nose.SkipTest("Datastore not supported")
         cls.app = helpers._get_test_app()
-        p.load('datastore')
+        super(TestDatastoreUpdate, cls).setup_class()
         ctd.CreateTestData.create()
         cls.sysadmin_user = model.User.get('testsysadmin')
         cls.normal_user = model.User.get('annafan')
@@ -475,11 +450,6 @@ class TestDatastoreUpdate():
 
         engine = db.get_write_engine()
         cls.Session = orm.scoped_session(orm.sessionmaker(bind=engine))
-
-    @classmethod
-    def teardown_class(cls):
-        p.unload('datastore')
-        rebuild_all_dbs(cls.Session)
 
     def test_update_basic(self):
         c = self.Session.connection()


### PR DESCRIPTION
Fixes #4161 

### Proposed fixes:

earlier change to this test was not unloading plugin properly and test for datastore feature was mixed in with core tests.