### PR TITLE
Refactor Password Reset templates by adding missing Bootstrap 3 markup

### DIFF
--- a/ckan/templates/user/perform_reset.html
+++ b/ckan/templates/user/perform_reset.html
@@ -20,7 +20,7 @@
           {% if user_dict['state'] == 'pending' %}
             <p>{{ _('You can also change username. It can not be modified later.') }}</p>
             {{ form.input("name", id="field-name", label=_("Username"), type="text", value=user_dict["name"],
-               error='', attrs={'autocomplete': 'no'}, classes=["form-group"]) }}
+               error='', attrs={'autocomplete': 'no', 'class': 'form-control control-medium'}, classes=["form-group"]) }}
           {% endif %}
           {{ form.input("password1", id="field-password", label=_("Password"), type="password", value='', error='', attrs={'autocomplete': 'no', 'class': 'form-control control-medium'}, classes=["form-group"]) }}
           {{ form.input("password2", id="field-confirm-password", label=_("Confirm"), type="password", value='', error='', attrs={'autocomplete': 'no', 'class': 'form-control control-medium'}, classes=["form-group"]) }}

--- a/ckan/templates/user/perform_reset.html
+++ b/ckan/templates/user/perform_reset.html
@@ -10,20 +10,20 @@
 {% block primary_content %}
   <article class="module">
     {% block primary_content_inner %}
-    <h1 class="module-heading">
-      {% block page_heading %}{{ _('Reset Your Password') }}{% endblock %}
-    </h1>
     <div class="module-content">
+      <h1 class="page-heading">
+        {% block page_heading %}{{ _('Reset Your Password') }}{% endblock %}
+      </h1>
       {% block form %}
         <form action="" method="post">
           {{ form.errors(error_summary) }}
           {% if user_dict['state'] == 'pending' %}
             <p>{{ _('You can also change username. It can not be modified later.') }}</p>
             {{ form.input("name", id="field-name", label=_("Username"), type="text", value=user_dict["name"],
-               error='', attrs={'autocomplete': 'no'}, classes=["control-medium"]) }}
+               error='', attrs={'autocomplete': 'no'}, classes=["form-group"]) }}
           {% endif %}
-          {{ form.input("password1", id="field-password", label=_("Password"), type="password", value='', error='', attrs={'autocomplete': 'no'}, classes=["control-medium"]) }}
-          {{ form.input("password2", id="field-confirm-password", label=_("Confirm"), type="password", value='', error='', attrs={'autocomplete': 'no'}, classes=["control-medium"]) }}
+          {{ form.input("password1", id="field-password", label=_("Password"), type="password", value='', error='', attrs={'autocomplete': 'no', 'class': 'form-control control-medium'}, classes=["form-group"]) }}
+          {{ form.input("password2", id="field-confirm-password", label=_("Confirm"), type="password", value='', error='', attrs={'autocomplete': 'no', 'class': 'form-control control-medium'}, classes=["form-group"]) }}
           <div class="form-actions">
             {% block form_button %}
             <button class="btn btn-primary" type="submit" name="save">{{ _("Update Password") }}</button>

--- a/ckan/templates/user/request_reset.html
+++ b/ckan/templates/user/request_reset.html
@@ -12,12 +12,16 @@
       {% block primary_content_inner %}
       <h1 class="page-heading">{{ _('Reset your password') }}</h1>
       {% block form %}
-        <form action="" method="post" class="form-inline control-medium">
-          <label for="field-username">{{ _('Username') }}</label>
-          <input id="field-username" name="user" value="" type="text" />
-          {% block form_button %}
-          <button class="btn btn-primary" type="submit" name="reset">{{ _("Request reset") }}</button>
-          {% endblock %}
+        <form action="" method="post">
+          <div class="form-group">
+            <label for="field-username">{{ _('Username') }}</label>
+            <input id="field-username" class="control-medium form-control" name="user" value="" type="text" />
+          </div>
+          <div class="form-actions">
+            {% block form_button %}
+            <button class="btn btn-primary" type="submit" name="reset">{{ _("Request Reset") }}</button>
+            {% endblock %}
+          </div>
         </form>
       {% endblock %}
       {% endblock %}

--- a/ckan/templates/user/request_reset.html
+++ b/ckan/templates/user/request_reset.html
@@ -3,7 +3,7 @@
 {% block subtitle %}{{ _('Reset your password') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{% link_for _('Password reset'), named_route='user.request_reset' %}</li>
+  <li class="active">{% link_for _('Password Reset'), named_route='user.request_reset' %}</li>
 {% endblock %}
 
 {% block primary_content %}


### PR DESCRIPTION
Fixes #4165 

### Proposed fixes:

- Add missing Bootstrap 3 wrappers around form inputs
- Add missing `.form-control` CSS class to inputs
- Unify Update Password/Request Reset button markup and include `.form-actions` wrapper
- Match .page-heading position in DOM in `perform_reset.html` and `request_reset.html`
- Unify active breadcrumb item text
- Unify button labels


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
