### PR TITLE
Fix limited width of Order by select element

### DIFF
--- a/ckan/public/base/less/search.less
+++ b/ckan/public/base/less/search.less
@@ -57,9 +57,8 @@
         select {
             display: inline;
         }
-        select {
-            width: 160px;
-            margin: 0;
+        .form-control {
+            width: auto;
         }
     }
     // h2 {


### PR DESCRIPTION
Fixes #4172 

### Proposed fixes:

- Refactor `search.less` to allow the `<select>` element to extend in width, when `<option>` labels are long.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
