### PR TITLE
[#4179] retry DB connection for an extra 45s

### DIFF
--- a/ckan/model/__init__.py
+++ b/ckan/model/__init__.py
@@ -4,6 +4,7 @@ import warnings
 import logging
 import re
 from datetime import datetime
+from time import sleep
 
 from six import text_type
 import vdm.sqlalchemy
@@ -138,6 +139,7 @@ import ckan.migration
 log = logging.getLogger(__name__)
 
 
+DB_CONNECT_RETRIES = 10
 
 # set up in init_model after metadata is bound
 version_table = None
@@ -152,11 +154,18 @@ def init_model(engine):
     meta.metadata.bind = engine
     # sqlalchemy migrate version table
     import sqlalchemy.exc
-    try:
-        global version_table
-        version_table = Table('migrate_version', meta.metadata, autoload=True)
-    except sqlalchemy.exc.NoSuchTableError:
-        pass
+    for i in reversed(range(DB_CONNECT_RETRIES)):
+        try:
+            global version_table
+            version_table = Table('migrate_version', meta.metadata, autoload=True)
+            break
+        except sqlalchemy.exc.NoSuchTableError:
+            break
+        except sqlalchemy.exc.OperationalError as e:
+            if 'database system is starting up' in repr(e.orig) and i:
+                sleep(DB_CONNECT_RETRIES - i)
+                continue
+            raise
 
 
 class Repository(vdm.sqlalchemy.Repository):


### PR DESCRIPTION
Fixes #4179 

### Proposed fixes:
retry connection after 1s, 2s, 3s, .. 9s to give postgres more time to finish cleaning up

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport