### PR TITLE
[#3993] package_autocomplete use solr

### DIFF
--- a/ckan/config/solr/schema.xml
+++ b/ckan/config/solr/schema.xml
@@ -24,7 +24,7 @@
 <!-- We update the version when there is a backward-incompatible change to this
 schema. In this case the version should be set to the next CKAN version number.
 (x.y but not x.y.z since it needs to be a float) -->
-<schema name="ckan" version="2.81">
+<schema name="ckan" version="2.9">
 
 <types>
     <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>

--- a/ckan/config/solr/schema.xml
+++ b/ckan/config/solr/schema.xml
@@ -24,7 +24,7 @@
 <!-- We update the version when there is a backward-incompatible change to this
 schema. In this case the version should be set to the next CKAN version number.
 (x.y but not x.y.z since it needs to be a float) -->
-<schema name="ckan" version="2.8">
+<schema name="ckan" version="2.81">
 
 <types>
     <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
@@ -81,6 +81,18 @@ schema. In this case the version should be set to the next CKAN version number.
             <filter class="solr.LowerCaseFilterFactory"/>
         </analyzer>
     </fieldType>
+
+    <fieldType name="text_ngram" class="solr.TextField" positionIncrementGap="100">
+      <analyzer type="index">
+	<tokenizer class="solr.NGramTokenizerFactory" minGramSize="2" maxGramSize="10"/>
+	<filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+      <analyzer type="query">
+	<tokenizer class="solr.EdgeNGramTokenizerFactory" minGramSize="2" maxGramSize="10"/>
+	<filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
 </types>
 
 
@@ -89,10 +101,12 @@ schema. In this case the version should be set to the next CKAN version number.
     <field name="id" type="string" indexed="true" stored="true" required="true" />
     <field name="site_id" type="string" indexed="true" stored="true" required="true" />
     <field name="title" type="text" indexed="true" stored="true" />
+    <field name="title_ngram" type="text_ngram" indexed="true" stored="true" />
     <field name="entity_type" type="string" indexed="true" stored="true" omitNorms="true" />
     <field name="dataset_type" type="string" indexed="true" stored="true" />
     <field name="state" type="string" indexed="true" stored="true" omitNorms="true" />
     <field name="name" type="string" indexed="true" stored="true" omitNorms="true" />
+    <field name="name_ngram" type="text_ngram" indexed="true" stored="true" />
     <field name="revision_id" type="string" indexed="true" stored="true" omitNorms="true" />
     <field name="version" type="string" indexed="true" stored="true" />
     <field name="url" type="string" indexed="true" stored="true" omitNorms="true" />
@@ -165,6 +179,8 @@ schema. In this case the version should be set to the next CKAN version number.
 <solrQueryParser defaultOperator="AND"/>
 
 <copyField source="url" dest="urls"/>
+<copyField source="title" dest="title_ngram"/>
+<copyField source="name" dest="name_ngram"/>
 <copyField source="ckan_url" dest="urls"/>
 <copyField source="download_url" dest="urls"/>
 <copyField source="res_url" dest="urls"/>

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -31,7 +31,7 @@ def text_traceback():
     return res
 
 
-SUPPORTED_SCHEMA_VERSIONS = ['2.8']
+SUPPORTED_SCHEMA_VERSIONS = ['2.8' ,'2.81']
 
 DEFAULT_OPTIONS = {
     'limit': 20,

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -31,7 +31,7 @@ def text_traceback():
     return res
 
 
-SUPPORTED_SCHEMA_VERSIONS = ['2.8' ,'2.81']
+SUPPORTED_SCHEMA_VERSIONS = ['2.8', '2.9']
 
 DEFAULT_OPTIONS = {
     'limit': 20,

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1497,9 +1497,18 @@ def package_autocomplete(context, data_dict):
 
     '''
     _check_access('package_autocomplete', context, data_dict)
+    user = context.get('user')
 
     limit = data_dict.get('limit', 10)
     q = data_dict['q']
+
+    # enforce permission filter based on user
+    if context.get('ignore_auth') or (user and authz.is_sysadmin(user)):
+        labels = None
+    else:
+        labels = lib_plugins.get_permission_labels().get_user_dataset_labels(
+            context['auth_user_obj']
+        )
 
     data_dict = {
         'fq': '+capacity:public',
@@ -1513,7 +1522,8 @@ def package_autocomplete(context, data_dict):
         'rows': limit
     }
     query = search.query_for(model.Package)
-    results = query.run(data_dict)['results']
+
+    results = query.run(data_dict, permission_labels=labels)['results']
 
     q_lower = q.lower()
     pkg_list = []

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1511,7 +1511,6 @@ def package_autocomplete(context, data_dict):
         )
 
     data_dict = {
-        'fq': '+capacity:public',
         'q': ' OR '.join([
             'name_ngram:{0}',
             'title_ngram:{0}',


### PR DESCRIPTION
Alternative implementation of package_autocomplete. Contains schema chages -> requires rebuild of search index. 
I don't remember our strategy as for increasing solr version, so I updated it to 2.81. Everything else is pretty straightforward