### PR TITLE
[Security] Don't confirm whether a user exists or not

### DIFF
--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -485,12 +485,7 @@ class UserController(base.BaseController):
                         data_dict['id'] = user_list[0]['id']
                         user_dict = get_action('user_show')(context, data_dict)
                         user_obj = context['user_obj']
-                    elif len(user_list) > 1:
-                        h.flash_error(_('"%s" matched several users') % (id))
-                    else:
-                        h.flash_error(_('No such user: %s') % id)
-                else:
-                    h.flash_error(_('No such user: %s') % id)
+            helpers.flash_success(_('A reset token has been sent.'))
 
             if user_obj:
                 try:

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -485,7 +485,7 @@ class UserController(base.BaseController):
                         data_dict['id'] = user_list[0]['id']
                         user_dict = get_action('user_show')(context, data_dict)
                         user_obj = context['user_obj']
-            helpers.flash_success(_('A reset token has been sent.'))
+            h.flash_success(_('A reset token has been sent.'))
 
             if user_obj:
                 try:


### PR DESCRIPTION
Being able to enumerate users allows attackers to find valid username
which they can then try to guess/brute force the passwords for. This PR
makes the reset token request always return a "A reset token has been sent"
so attackers are unable to find out whether a user exists or not.

Attackers could also enumerate users through the users list, but upon
investigation it seems that the UK/US data portals either have this
disabled or behind a login. The NZ portal will soon be disabling this
listing page as well.

https://www.owasp.org/index.php/Authentication_Cheat_Sheet#Authentication_and_Error_Messages

Fixes #
* Don't confirm whether a user exists or not on the reset form

### Proposed fixes:
* Remove any other places in the system where users can be enumerated from 

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
