### PR TITLE
[#4194] Fix the "From" field with UTF-8 name and ASCII address in mail

### DIFF
--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -45,7 +45,8 @@ def _mail_recipient(recipient_name, recipient_email,
             msg.add_header(k, v)
     subject = Header(subject.encode('utf-8'), 'utf-8')
     msg['Subject'] = subject
-    msg['From'] = _("%s <%s>") % (sender_name, mail_from)
+    msg['From'] = Header(_("%s") % sender_name, 'utf-8')
+    msg['From'].append("<%s>" % mail_from, 'ascii')
     recipient = u"%s <%s>" % (recipient_name, recipient_email)
     msg['To'] = Header(recipient, 'utf-8')
     msg['Date'] = Utils.formatdate(time())

--- a/ckan/tests/lib/test_mailer.py
+++ b/ckan/tests/lib/test_mailer.py
@@ -3,6 +3,7 @@
 from nose.tools import assert_equal, assert_raises, assert_in, assert_raises
 from email.mime.text import MIMEText
 from email.parser import Parser
+from email.header import Header
 from email.header import decode_header
 import hashlib
 import base64
@@ -143,9 +144,12 @@ class TestMailer(MailerBase):
         msgs = self.get_smtp_messages()
         msg = msgs[0]
 
+        sender_name = config.get('ckan.site_title')
+        mail_from = config.get('smtp.mail_from')
+
         expected_from_header = '{0} <{1}>'.format(
-            config.get('ckan.site_title'),
-            config.get('smtp.mail_from')
+            Header(sender_name, 'utf-8'),
+            Header(mail_from, 'ascii')
         )
 
         assert_in(expected_from_header, msg[3])


### PR DESCRIPTION
Fixes #4194

### Proposed fixes:

According the discussion in [this thread](https://stackoverflow.com/questions/41908883/how-to-add-an-utf-8-from-address-to-a-mail-mesage), we should assign the encoding to the name part and the address part respectively.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
