### PR TITLE
Improve error message when running "paster less" but npm is not installed

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -2007,6 +2007,9 @@ class LessCommand(CkanCommand):
         process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         output = process.communicate()
         directory = output[0].strip()
+        if not directory:
+            raise error('Command "{}" returned nothing. Check that npm is '
+                        'installed.'.format(command))
         less_bin = os.path.join(directory, 'lessc')
 
         public = config.get(u'ckan.base_public_folder')


### PR DESCRIPTION
Before this PR, the error message if you run "paster less" without doing the [nodejs & npm install](http://docs.ckan.org/en/ckan-2.7.3/contributing/frontend/#install-frontend-dependencies) is misleading:
```
$ paster less
compile green.css
('', '/bin/sh: 1: lessc: not found\n')
compile fuchsia.css
('', '/bin/sh: 1: lessc: not found\n')
compile maroon.css
('', '/bin/sh: 1: lessc: not found\n')
compile red.css
('', '/bin/sh: 1: lessc: not found\n')
compile main.css
('', '/bin/sh: 1: lessc: not found\n')
```

With this PR, the error message is clear:
```
$ paster less
Command "npm bin" returned nothing. Check that npm is installed.
```

I came across this when helping a CKAN newbie.

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
