### PR TITLE
[#4162] view filter: use plain queries when required

### DIFF
--- a/ckan/public-bs2/base/javascript/modules/resource-view-filters-form.js
+++ b/ckan/public-bs2/base/javascript/modules/resource-view-filters-form.js
@@ -19,7 +19,6 @@ ckan.module('resource-view-filters-form', function (jQuery) {
                 query;
 
             query = {
-              plain: false,
               resource_id: resourceId,
               limit: queryLimit,
               offset: offset,
@@ -30,7 +29,11 @@ ckan.module('resource-view-filters-form', function (jQuery) {
 
             if (term !== '') {
               var q = {};
-              q[filterName] = term + ':*';
+              if (!term.includes(' ')) {
+                term = term + ':*';
+                query.plain = false;
+              }
+              q[filterName] = term;
               query.q = JSON.stringify(q);
             }
 

--- a/ckan/public-bs2/base/javascript/modules/resource-view-filters.js
+++ b/ckan/public-bs2/base/javascript/modules/resource-view-filters.js
@@ -103,7 +103,6 @@ this.ckan.module('resource-view-filters', function (jQuery) {
                 query;
 
             query = {
-              plain: false,
               resource_id: resourceId,
               limit: queryLimit,
               offset: offset,
@@ -112,9 +111,14 @@ this.ckan.module('resource-view-filters', function (jQuery) {
               sort: filterName
             };
 
+
             if (term !== '') {
               var q = {};
-              q[filterName] = term + ':*';
+              if (!term.includes(' ')) {
+                term = term + ':*';
+                query.plain = false;
+              }
+              q[filterName] = term;
               query.q = JSON.stringify(q);
             }
 

--- a/ckan/public/base/javascript/modules/resource-view-filters-form.js
+++ b/ckan/public/base/javascript/modules/resource-view-filters-form.js
@@ -19,7 +19,6 @@ ckan.module('resource-view-filters-form', function (jQuery) {
                 query;
 
             query = {
-              plain: false,
               resource_id: resourceId,
               limit: queryLimit,
               offset: offset,
@@ -30,7 +29,11 @@ ckan.module('resource-view-filters-form', function (jQuery) {
 
             if (term !== '') {
               var q = {};
-              q[filterName] = term + ':*';
+              if (!term.includes(' ')) {
+                term = term + ':*';
+                query.plain = false;
+              }
+              q[filterName] = term;
               query.q = JSON.stringify(q);
             }
 

--- a/ckan/public/base/javascript/modules/resource-view-filters.js
+++ b/ckan/public/base/javascript/modules/resource-view-filters.js
@@ -103,7 +103,6 @@ this.ckan.module('resource-view-filters', function (jQuery) {
                 query;
 
             query = {
-              plain: false,
               resource_id: resourceId,
               limit: queryLimit,
               offset: offset,
@@ -114,7 +113,11 @@ this.ckan.module('resource-view-filters', function (jQuery) {
 
             if (term !== '') {
               var q = {};
-              q[filterName] = term + ':*';
+              if (!term.includes(' ')) {
+                term = term + ':*';
+                query.plain = false;
+              }
+              q[filterName] = term;
               query.q = JSON.stringify(q);
             }
 


### PR DESCRIPTION
Fixes #4162

### Proposed fixes:

Fix invalid queries sent when user types multiple words in view filter autocomplete box, allow disabling column autocomplete on specific columns via data dictionary interface

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport