### PR TITLE
[#4031] More support for custom group types in templates

### DIFF
--- a/ckan/templates-bs2/group/snippets/group_form.html
+++ b/ckan/templates-bs2/group/snippets/group_form.html
@@ -9,13 +9,12 @@
     {% set attrs = {'data-module': 'slug-preview-target'} %}
     {{ form.input('title', label=_('Name'), id='field-name', placeholder=_('My Group'), value=data.title, error=errors.title, classes=['control-full'], attrs=attrs) }}
 
-    {# Perhaps these should be moved into the controller? #}
-    {% set prefix = h.url_for(controller='group', action='read', id='') %}
-    {% set domain = h.url_for(controller='group', action='read', id='', qualified=true) %}
+    {%- set prefix = h.url_for(group_type + '_read', id='') -%}
+    {%- set domain = h.url_for(group_type + '_read', id='', qualified=true) -%}
     {% set domain = domain|replace("http://", "")|replace("https://", "") %}
-    {% set attrs = {'data-module': 'slug-preview-slug', 'data-module-prefix': domain, 'data-module-placeholder': '<group>'} %}
+    {% set attrs = {'data-module': 'slug-preview-slug', 'data-module-prefix': domain, 'data-module-placeholder': '<' + group_type + '>'} %}
 
-    {{ form.prepend('name', label=_('URL'), prepend=prefix, id='field-url', placeholder=_('my-group'), value=data.name, error=errors.name, attrs=attrs, is_required=true) }}
+    {{ form.prepend('name', label=_('URL'), prepend=prefix, id='field-url', placeholder=_('my-' + group_type), value=data.name, error=errors.name, attrs=attrs, is_required=true) }}
 
     {{ form.markdown('description', label=_('Description'), id='field-description', placeholder=_('A little information about my group...'), value=data.description, error=errors.description) }}
 

--- a/ckan/templates-bs2/organization/snippets/organization_form.html
+++ b/ckan/templates-bs2/organization/snippets/organization_form.html
@@ -9,13 +9,12 @@
     {% set attrs = {'data-module': 'slug-preview-target'} %}
     {{ form.input('title', label=_('Name'), id='field-name', placeholder=_('My Organization'), value=data.title, error=errors.title, classes=['control-full'], attrs=attrs) }}
 
-    {# Perhaps these should be moved into the controller? #}
-    {% set prefix = h.url_for(controller='organization', action='read', id='') %}
-    {% set domain = h.url_for(controller='organization', action='read', id='', qualified=true) %}
+    {%- set prefix = h.url_for(group_type + '_read', id='') -%}
+    {%- set domain = h.url_for(group_type + '_read', id='', qualified=true) -%}
     {% set domain = domain|replace("http://", "")|replace("https://", "") %}
-    {% set attrs = {'data-module': 'slug-preview-slug', 'data-module-prefix': domain, 'data-module-placeholder': '<organization>'} %}
+    {% set attrs = {'data-module': 'slug-preview-slug', 'data-module-prefix': domain, 'data-module-placeholder': '<' + group_type + '>'} %}
 
-    {{ form.prepend('name', label=_('URL'), prepend=prefix, id='field-url', placeholder=_('my-organization'), value=data.name, error=errors.name, attrs=attrs, is_required=true) }}
+    {{ form.prepend('name', label=_('URL'), prepend=prefix, id='field-url', placeholder=_('my-' + group_type), value=data.name, error=errors.name, attrs=attrs, is_required=true) }}
 
     {{ form.markdown('description', label=_('Description'), id='field-description', placeholder=_('A little information about my organization...'), value=data.description, error=errors.description) }}
 

--- a/ckan/templates/group/snippets/group_form.html
+++ b/ckan/templates/group/snippets/group_form.html
@@ -10,12 +10,12 @@
     {{ form.input('title', label=_('Name'), id='field-name', placeholder=_('My Group'), value=data.title, error=errors.title, classes=['control-full'], attrs=attrs) }}
 
     {# Perhaps these should be moved into the controller? #}
-    {% set prefix = h.url_for(controller='group', action='read', id='') %}
-    {% set domain = h.url_for(controller='group', action='read', id='', qualified=true) %}
+    {%- set prefix = h.url_for(group_type + '_read', id='') -%}
+    {%- set domain = h.url_for(group_type + '_read', id='', qualified=true) -%}
     {% set domain = domain|replace("http://", "")|replace("https://", "") %}
-    {% set attrs = {'data-module': 'slug-preview-slug', 'class': 'form-control input-sm', 'data-module-prefix': domain, 'data-module-placeholder': '<group>'} %}
+    {% set attrs = {'data-module': 'slug-preview-slug', 'class': 'form-control input-sm', 'data-module-prefix': domain, 'data-module-placeholder': '<' + group_type + '>'} %}
 
-    {{ form.prepend('name', label=_('URL'), prepend=prefix, id='field-url', placeholder=_('my-group'), value=data.name, error=errors.name, attrs=attrs, is_required=true) }}
+    {{ form.prepend('name', label=_('URL'), prepend=prefix, id='field-url', placeholder=_('my-' + group_type), value=data.name, error=errors.name, attrs=attrs, is_required=true) }}
 
     {{ form.markdown('description', label=_('Description'), id='field-description', placeholder=_('A little information about my group...'), value=data.description, error=errors.description) }}
 

--- a/ckan/templates/group/snippets/group_form.html
+++ b/ckan/templates/group/snippets/group_form.html
@@ -9,7 +9,6 @@
     {% set attrs = {'data-module': 'slug-preview-target', 'class': 'form-control'} %}
     {{ form.input('title', label=_('Name'), id='field-name', placeholder=_('My Group'), value=data.title, error=errors.title, classes=['control-full'], attrs=attrs) }}
 
-    {# Perhaps these should be moved into the controller? #}
     {%- set prefix = h.url_for(group_type + '_read', id='') -%}
     {%- set domain = h.url_for(group_type + '_read', id='', qualified=true) -%}
     {% set domain = domain|replace("http://", "")|replace("https://", "") %}

--- a/ckan/templates/organization/snippets/organization_form.html
+++ b/ckan/templates/organization/snippets/organization_form.html
@@ -9,13 +9,12 @@
     {% set attrs = {'data-module': 'slug-preview-target', 'class': 'form-control'} %}
     {{ form.input('title', label=_('Name'), id='field-name', placeholder=_('My Organization'), value=data.title, error=errors.title, classes=['control-full'], attrs=attrs) }}
 
-    {# Perhaps these should be moved into the controller? #}
-    {% set prefix = h.url_for(controller='organization', action='read', id='') %}
-    {% set domain = h.url_for(controller='organization', action='read', id='', qualified=true) %}
+    {%- set prefix = h.url_for(group_type + '_read', id='') -%}
+    {%- set domain = h.url_for(group_type + '_read', id='', qualified=true) -%}
     {% set domain = domain|replace("http://", "")|replace("https://", "") %}
-    {% set attrs = {'data-module': 'slug-preview-slug', 'class': 'form-control input-sm', 'data-module-prefix': domain, 'data-module-placeholder': '<organization>'} %}
+    {% set attrs = {'data-module': 'slug-preview-slug', 'class': 'form-control input-sm', 'data-module-prefix': domain, 'data-module-placeholder': '<' + group_type + '>'} %}
 
-    {{ form.prepend('name', label=_('URL'), prepend=prefix, id='field-url', placeholder=_('my-organization'), value=data.name, error=errors.name, attrs=attrs, is_required=true) }}
+    {{ form.prepend('name', label=_('URL'), prepend=prefix, id='field-url', placeholder=_('my-' + group_type), value=data.name, error=errors.name, attrs=attrs, is_required=true) }}
 
     {{ form.markdown('description', label=_('Description'), id='field-description', placeholder=_('A little information about my organization...'), value=data.description, error=errors.description) }}
 

--- a/ckan/templates/package/base.html
+++ b/ckan/templates/package/base.html
@@ -11,8 +11,9 @@
     {% set dataset = h.dataset_display_name(pkg) %}
     {% if pkg.organization %}
       {% set organization = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
-      <li>{% link_for _('Organizations'), controller='organization', action='index' %}</li>
-      <li>{% link_for organization|truncate(30), controller='organization', action='read', id=pkg.organization.name %}</li>
+      {% set group_type = pkg.organization.type %}
+      <li>{% link_for _('Organizations'), controller='organization', action='index', named_route=group_type + '_index' %}</li>
+      <li>{% link_for organization|truncate(30), controller='organization', action='read', id=pkg.organization.name, named_route=group_type + '_read' %}</li>
     {% else %}
       <li>{% link_for _('Datasets'), controller='package', action='search' %}</li>
     {% endif %}

--- a/ckanext/example_igroupform/tests/test_controllers.py
+++ b/ckanext/example_igroupform/tests/test_controllers.py
@@ -141,6 +141,7 @@ class TestOrganizationController(helpers.FunctionalTestBase):
         assert 'data-module-placeholder="&lt;{}&gt;"'.format(
             custom_group_type) in response
 
+
 class TestGroupControllerNew(helpers.FunctionalTestBase):
     @classmethod
     def setup_class(cls):

--- a/ckanext/example_igroupform/tests/test_controllers.py
+++ b/ckanext/example_igroupform/tests/test_controllers.py
@@ -72,6 +72,19 @@ class TestGroupController(helpers.FunctionalTestBase):
                       id=group_name)
         response = app.get(url=url, extra_environ=env)
 
+    def test_custom_group_form_slug(self):
+        app = self._get_test_app()
+        env, response = _get_group_new_page(app, custom_group_type)
+
+        assert '<span class="input-group-addon">/{}/</span>'.format(
+            custom_group_type) in response
+        assert 'placeholder="my-{}"'.format(
+            custom_group_type) in response
+        assert 'data-module-prefix="test.ckan.net/{}/"'.format(
+            custom_group_type) in response
+        assert 'data-module-placeholder="&lt;{}&gt;"'.format(
+            custom_group_type) in response
+
 
 class TestOrganizationController(helpers.FunctionalTestBase):
     @classmethod
@@ -115,6 +128,18 @@ class TestOrganizationController(helpers.FunctionalTestBase):
                       id=group_name)
         response = app.get(url=url, extra_environ=env)
 
+    def test_custom_org_form_slug(self):
+        app = self._get_test_app()
+        env, response = _get_group_new_page(app, custom_group_type)
+
+        assert '<span class="input-group-addon">/{}/</span>'.format(
+            custom_group_type) in response
+        assert 'placeholder="my-{}"'.format(
+            custom_group_type) in response
+        assert 'data-module-prefix="test.ckan.net/{}/"'.format(
+            custom_group_type) in response
+        assert 'data-module-placeholder="&lt;{}&gt;"'.format(
+            custom_group_type) in response
 
 class TestGroupControllerNew(helpers.FunctionalTestBase):
     @classmethod


### PR DESCRIPTION
Some bits and bobs that were missed out in #4032 to properly display custom group types in templates. Fixed the breadcrumbs in the dataset pages and the slug widget to use the custom types.
