### PR TITLE
Mark undefined name with # noqa

### DIFF
--- a/ckan/tests/legacy/functional/api/model/test_ratings.py
+++ b/ckan/tests/legacy/functional/api/model/test_ratings.py
@@ -47,7 +47,7 @@ class RatingsTestCase(BaseModelApiTestCase):
 
         offset = self.rating_offset(self.anna.name)
         res = self.app.get(offset, status=[200])
-        assert_equal(res, rating_opts['rating'])
+        assert_equal(res, rating_opts['rating'])  # noqa: test not implemented
 
     def test_register_post(self):
         # Test Rating Register Post 200.


### PR DESCRIPTION
Fixes #3823

This test is skipped because the underlying functionality is not implemented.  The __# noqa__ comment silences the linter... Flake8 testing of https://github.com/ckan/ckan on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./ckan/tests/legacy/functional/api/model/test_ratings.py:50:27: F821 undefined name 'rating_opts'
        assert_equal(res, rating_opts['rating'])
                          ^
1     F821 undefined name 'rating_opts'
1
```

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
