### PR TITLE
Remove unused RatingsTestCase.test_entity_get()

### DIFF
--- a/ckan/tests/legacy/functional/api/model/test_ratings.py
+++ b/ckan/tests/legacy/functional/api/model/test_ratings.py
@@ -23,20 +23,6 @@ class RatingsTestCase(BaseModelApiTestCase):
     def teardown_class(cls):
         model.repo.rebuild_db()
 
-    def test_register_get(self):
-        raise SkipTest('"Rating register get" functionality is not implemented')
-        rating1 = model.Rating(user_ip_address='1.2.3.4',
-                               package=self.anna,
-                               rating=4.0)
-        rating2 = model.Rating(user=model.User.by_name(u'annafan'),
-                               package=self.anna,
-                               rating=2.0)
-        model.Session.add_all((rating1, rating2))
-        model.repo.commit_and_remove()
-
-        offset = self.rating_offset()
-        res = self.app.get(offset, status=[200])
-
     def test_entity_get(self):
         raise SkipTest('"Rating entity get" functionality is not implemented')
         rating = model.Rating(user_ip_address='1.2.3.4',


### PR DESCRIPTION
Fixes #3823    The first line of this legacy test case is __raise SkipTest('"Rating register get" functionality is not implemented')__ so this PR recommends removing the method as discussed in #4211

### Proposed fixes:
* remove skipped legacy test case __RatingsTestCase.test_entity_get()__

### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport -- a flake8 undefined name

Please [X] all the boxes above that apply

Fixes: flake8 testing of https://github.com/ckan/ckan on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./ckan/tests/legacy/functional/api/model/test_ratings.py:50:27: F821 undefined name 'rating_opts'
        assert_equal(res, rating_opts['rating'])
                          ^
1     F821 undefined name 'rating_opts'
1
```
