### PR TITLE
DO NOT MERGE: Run flake8 on both Python 2 and 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,27 @@
-sudo: required
-
+group: travis_latest
 language: python
-
-services:
-  - docker
-
-cache:
-  directories:
-     - ~/docker
-
-before_install:
-  - docker build --rm=false -f contrib/docker/postgresql/Dockerfile -t postgresql .
-  - docker build --rm=false -f contrib/docker/solr/Dockerfile -t solr .
-  - docker pull redis:latest
-  - docker build --rm=false -t ckan .
-
+cache: pip
+python:
+    - 2.7
+    - 3.6
+    #- nightly
+    #- pypy
+    #- pypy3
+matrix:
+    allow_failures:
+        - python: nightly
+        - python: pypy
+        - python: pypy3
 install:
-  - docker run -d --name db postgresql
-  - docker run -d --name solr solr
-  - docker run -d --name redis redis:latest
-  - docker run -d --name ckan -p 5000:5000 --link db:db --link redis:redis --link solr:solr ckan
-
+    # - pip install -r requirements.txt
+    - pip install flake8  # pytest  # add another testing frameworks later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
-  - docker ps -a
+    - true  # pytest --capture=sys  # add other tests here
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
This is __ONLY A TEST__ and it should __NOT__ be merged...  I will close this PR with unmerged changes after a few hours.

A second attempt at #4054 now that many issues have been fixed.

I thought it would be useful for you to see the method behind [my madness](https://github.com/ckan/ckan/pulls?q=is%3Apr+author%3Acclauss+is%3Aclosed).

I run [flake8](https://gitlab.com/pycqa/flake8) __. --select=E901,E999,F821,F822,F823__ under both Python 2 and Python 3 to find syntax errors and undefined names.

This makes it quite easy to spot incompatibilities and recommend fixes.  Undefined names (like __unicode__ in Python 3) testing is a unique feature that I have not found in other Python linters.

### Output
https://travis-ci.org/ckan/ckan/builds/374409524