### PR TITLE
Remove Jinja2 Bytecode cache

### DIFF
--- a/ckan/lib/jinja_extensions.py
+++ b/ckan/lib/jinja_extensions.py
@@ -35,7 +35,6 @@ def get_jinja_env_options():
                     ResourceExtension,
                     UrlForStaticExtension,
                     UrlForExtension],
-        bytecode_cache=FileSystemBytecodeCache()
     )
 
 


### PR DESCRIPTION
I'm getting random failures with the scheming extension:

```
File '/home/adria/dev/pyenvs/ckan/src/ckanext-scheming/ckanext/scheming/templates/scheming/package/read.html', line 3 in top-level template code
  {%- set schema = h.scheming_get_dataset_schema(dataset_type) -%}
File '/home/adria/dev/pyenvs/ckan/local/lib/python2.7/site-packages/jinja2/environment.py', line 434 in getattr
  return obj[attribute]
File '/home/adria/dev/pyenvs/ckan/src/ckan/ckan/lib/helpers.py', line 85 in __getitem__
  key=key
HelperError: Helper 'scheming_get_dataset_schema' has not been defined.
```
([Full stacktrace](https://gist.github.com/amercader/42ac78da709cd7a7fe7a7e99a9771e6a))

I'm not sure about the cause but removing the bytecode cache stops the failures entirely. I've also got exceptions at some point about core templates not being found (eg `package/read.html`). This might well be completely unrelated or caused by the fact that I jump between CKAN versions and branches during local development, but I was wondering if we should park this for now for at least 2.8.

WDYT?
