### PR TITLE
Add Python 3.6 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,47 @@
-sudo: required
-
+group: travis_latest
 language: python
 
-services:
-  - docker
+matrix:
+  allow_failures:
+  - python: "3.6"
 
-cache:
-  directories:
-     - ~/docker
+  include:
+    - sudo: required
+      python: "2.7"
 
-before_install:
-  - docker build --rm=false -f contrib/docker/postgresql/Dockerfile -t postgresql .
-  - docker build --rm=false -f contrib/docker/solr/Dockerfile -t solr .
-  - docker pull redis:latest
-  - docker build --rm=false -t ckan .
+      services:
+        - docker
 
-install:
-  - docker run -d --name db postgresql
-  - docker run -d --name solr solr
-  - docker run -d --name redis redis:latest
-  - docker run -d --name ckan -p 5000:5000 --link db:db --link redis:redis --link solr:solr ckan
+      cache:
+        directories:
+          - ~/docker
 
-script:
-  - docker ps -a
+      before_install:
+        - docker build --rm=false -f contrib/docker/postgresql/Dockerfile -t postgresql .
+        - docker build --rm=false -f contrib/docker/solr/Dockerfile -t solr .
+        - docker pull redis:latest
+        - docker build --rm=false -t ckan .
+
+      install:
+        - docker run -d --name db postgresql
+        - docker run -d --name solr solr
+        - docker run -d --name redis redis:latest
+        - docker run -d --name ckan -p 5000:5000 --link db:db --link redis:redis --link solr:solr ckan
+
+      script:
+        - docker ps -a
+
+    - python: "3.6"
+      cache: pip
+
+      install:
+        - pip install flake8
+
+      before_script:
+        # stop the build if there are Python syntax errors or undefined names
+        - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+        # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+        - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+      script:
+        - true # pytest --capture=sys # add other tests here

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ group: travis_latest
 language: python
 
 matrix:
-  allow_failures:
-  - python: "3.6"
-
   include:
     - sudo: required
       python: "2.7"


### PR DESCRIPTION
Helps with #4060

### Proposed fixes:
Add Python 3.6 to Travis CI ~in allow_failures mode~ while keeping all Python 2.7 processing in tact.

### Features:
- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
