### PR TITLE
Upgrade httpretty to 0.9.4 for Python 3 support

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -23,6 +23,7 @@ dependencies:
            && chmod +x ~/.local/bin/circleci-matrix"
 
     override:
+        - python --version ; pip --version
         - pip install -r requirement-setuptools.txt
         - pip install -r requirements.txt
         - pip install -r dev-requirements.txt

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@ coveralls   #Let Unpinned - Requires latest coveralls
 docutils==0.12
 factory-boy==2.1.1
 Flask-DebugToolbar==0.10.1
-httpretty==0.8.3
+httpretty==0.9.4
 mock==2.0.0
 pycodestyle==2.2.0
 pip-tools==1.7.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@ coveralls   #Let Unpinned - Requires latest coveralls
 docutils==0.12
 factory-boy==2.1.1
 Flask-DebugToolbar==0.10.1
-httpretty==0.9.4
+httpretty==0.9.5
 mock==2.0.0
 pycodestyle==2.2.0
 pip-tools==1.7.0


### PR DESCRIPTION
Helps with #3309

### Proposed fixes:
Upgrade development requirement [__httpretty__](https://github.com/gabrielfalcao/HTTPretty) from 0.8.3 to 0.9.4 for Python 3 support.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
