### PR TITLE
Fix display of org title in organization stream

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1613,7 +1613,7 @@ def group_link(group):
 def organization_link(organization):
     url = url_for(controller='organization', action='read',
                   id=organization['name'])
-    return tags.link_to(organization['name'], url)
+    return tags.link_to(organization['title'], url)
 
 
 @core_helper


### PR DESCRIPTION
This fixes the display of the organization in the organization activity stream. It was displaying the name.

URL: /organization/activity/cabinet-office/0

Before:
<img width="437" alt="screen shot 2018-05-04 at 11 13 45" src="https://user-images.githubusercontent.com/307612/39623148-999216ac-4f8c-11e8-9123-59526d2eb943.png">

After:
<img width="453" alt="screen shot 2018-05-04 at 11 13 57" src="https://user-images.githubusercontent.com/307612/39623156-9eead8aa-4f8c-11e8-910b-e84d47a70651.png">


### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
