### PR TITLE
Add missing CSS class to modal title in resource_view.html

### DIFF
--- a/ckan/templates/package/snippets/resource_view.html
+++ b/ckan/templates/package/snippets/resource_view.html
@@ -3,7 +3,7 @@
 {% block resource_view %}
   <div id="view-{{ resource_view['id'] }}" class="resource-view" data-id="{{ resource_view['id'] }}" data-title="{{ resource_view['title'] }}" data-description="{{ resource_view['descripion'] }}">
   <div class="actions">
-    <a class="btn" 
+    <a class="btn"
        target="_blank"
        href="{{ h.url_for('resource_view', id=package['name'], resource_id=resource['id'], view_id=resource_view['id'], qualified=True) }}">
       <i class="fa fa-arrows-alt"></i>
@@ -17,7 +17,7 @@
       <i class="fa fa-code"></i>
       {{ _("Embed") }}
     </a>
-  </div>  
+  </div>
   <p class="desc">{{ h.render_markdown(resource_view['description']) }}</p>
     <div class="m-top ckanext-datapreview">
       {% if not to_preview and h.resource_view_is_filterable(resource_view) %}
@@ -71,7 +71,7 @@
 
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal">&times;</button>
-        <h3>{{ _("Embed resource view") }}</h3>
+        <h3 class="modal-title">{{ _("Embed resource view") }}</h3>
       </div>
       <div class="modal-body">
         <p class="embed-content">{{ _("You can copy and paste the embed code into a CMS or blog software that supports raw HTML") }}</p>


### PR DESCRIPTION
Fixes #4240 

### Proposed fixes:

- Add missing CSS class to modal title in `resource_view.html` snippet


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
