### PR TITLE
Add missing CSS class to Fullscreen and Embed buttons

### DIFF
--- a/ckan/public/base/less/resource-view.less
+++ b/ckan/public/base/less/resource-view.less
@@ -1,3 +1,9 @@
+.resource-view {
+  .actions {
+    right: 0;
+  }
+}
+
 .resource-view-filters {
     margin-bottom: 1em;
     .resource-view-filter {
@@ -15,4 +21,13 @@
             left: auto;
         }
     }
+}
+
+.view-preview-container {
+  .module-content {
+    position: relative;
+  }
+  .actions {
+    right: @grid-gutter-width/2;
+  }
 }

--- a/ckan/templates/package/snippets/resource_view.html
+++ b/ckan/templates/package/snippets/resource_view.html
@@ -3,13 +3,13 @@
 {% block resource_view %}
   <div id="view-{{ resource_view['id'] }}" class="resource-view" data-id="{{ resource_view['id'] }}" data-title="{{ resource_view['title'] }}" data-description="{{ resource_view['descripion'] }}">
   <div class="actions">
-    <a class="btn" 
+    <a class="btn btn-default"
        target="_blank"
        href="{{ h.url_for('resource_view', id=package['name'], resource_id=resource['id'], view_id=resource_view['id'], qualified=True) }}">
       <i class="fa fa-arrows-alt"></i>
       {{ _("Fullscreen") }}
     </a>
-    <a class="btn"
+    <a class="btn btn-default"
        href="#embed-{{ resource_view['id'] }}"
        data-module="resource-view-embed"
        data-module-id="{{ resource_view['id'] }}"
@@ -17,7 +17,7 @@
       <i class="fa fa-code"></i>
       {{ _("Embed") }}
     </a>
-  </div>  
+  </div>
   <p class="desc">{{ h.render_markdown(resource_view['description']) }}</p>
     <div class="m-top ckanext-datapreview">
       {% if not to_preview and h.resource_view_is_filterable(resource_view) %}


### PR DESCRIPTION
Fixes #4239 

### Proposed fixes:

- Add missing `.btn-default` CSS class to Fullscreen and Embed button in `ckan/templates/package/snippets/resource_view.html`
- Add additional CSS styling

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
