### PR TITLE
Allow chained auth functions to chain to built-in auth functions.

### DIFF
--- a/ckan/authz.py
+++ b/ckan/authz.py
@@ -102,13 +102,19 @@ class AuthFunctions:
                     fetched_auth_functions[name] = auth_function
 
         for name, func_list in chained_auth_functions.iteritems():
-            if name not in fetched_auth_functions:
+            if name not in fetched_auth_functions and\
+                    name not in self._functions:
                 raise Exception('The auth %r is not found for chained auth' % (
                     name))
             # create the chain of functions in the correct order
             for func in reversed(func_list):
-                prev_func = fetched_auth_functions[name]
-                fetched_auth_functions[name] = functools.partial(func, prev_func)
+                if name in fetched_auth_functions:
+                    prev_func = fetched_auth_functions[name]
+                else:
+                    # fallback to chaining off the builtin auth function
+                    prev_func = self._functions[name]
+                fetched_auth_functions[name] =\
+                    functools.partial(func, prev_func)
 
         # Use the updated ones in preference to the originals.
         self._functions.update(fetched_auth_functions)


### PR DESCRIPTION
### Proposed fixes:
Some authentication plugins implement chained auth functions on actions such as `user_create` and `user_update`. If no other plugins provide these functions, then CKAN raises the exception "The auth 'user_create' is not found for chained auth". The CKAN built-in auth system however does provide these functions. So it makes sense to fallback to having the chained auth function chain to the corresponding built-in function.

This is an example of one such plugin which attempts to chain off 'user_create' and 'user_update' and fails:
https://github.com/NaturalHistoryMuseum/ckanext-ldap/blob/6f9aec4edadaf792e347b4d20adad2c2322c167f/ckanext/ldap/logic/auth/create.py#L12

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
