### PR TITLE
Don't crash when plugin `identify()` doesn't set `g.user`.

### DIFF
--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -98,8 +98,11 @@ def identify_user():
     if authenticators:
         for item in authenticators:
             item.identify()
-            if g.user:
-                break
+            try:
+                if g.user:
+                    break
+            except AttributeError:
+                continue
 
     # We haven't identified the user so try the default methods
     if not getattr(g, u'user', None):


### PR DESCRIPTION
Fixes #4247

### Proposed fixes:
Some authenticator plugins do not set `g.user` in `identify()`.
CKAN was then trying to read `g.user` and throwing an Attribute Error.
This fixes that.
No idea why this is needed now, it worked fine in 2.7.3.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
