### PR TITLE
autocomplete tagsep - fix

### DIFF
--- a/ckan/public/base/javascript/modules/autocomplete.js
+++ b/ckan/public/base/javascript/modules/autocomplete.js
@@ -2,14 +2,16 @@
  * a list of terms from an API endpoint (provided using data-module-source).
  *
  * source   - A url pointing to an API autocomplete endpoint.
- * interval - The interval between requests in milliseconds (default: 1000).
+ * interval - The interval between requests in milliseconds (default: 300).
  * items    - The max number of items to display (default: 10)
  * tags     - Boolean attribute if true will create a tag input.
  * key      - A string of the key you want to be the form value to end up on
  *            from the ajax returned results
  * label    - A string of the label you want to appear within the dropdown for
  *            returned results
- *
+ * tokensep - An array (passed as string) that contains characters which will
+              be interpreted as separators for tags when typed or pasted
+              (default "[',']").
  * Examples
  *
  *   // <input name="tags" data-module="autocomplete" data-module-source="http://" />
@@ -24,6 +26,7 @@ this.ckan.module('autocomplete', function (jQuery) {
       label: false,
       items: 10,
       source: null,
+      tokensep: [','],
       interval: 300,
       dropdownClass: '',
       containerClass: ''
@@ -50,7 +53,8 @@ this.ckan.module('autocomplete', function (jQuery) {
         formatNoMatches: this.formatNoMatches,
         formatInputTooShort: this.formatInputTooShort,
         dropdownCssClass: this.options.dropdownClass,
-        containerCssClass: this.options.containerClass
+        containerCssClass: this.options.containerClass,
+        tokenSeparators: eval(this.options.tokensep)
       };
 
       // Different keys are required depending on whether the select is


### PR DESCRIPTION
### Proposed fixes:

Input of tags automatically separates tags (starts a new tag) when a comma is typed. However this doesn't work if a string containing commas is pasted. This severely slows down dataset submission for use-cases where tags or keywords are already available from another source.

This PR fixes that by making use of the [tokenSeparators option](http://select2.github.io/select2/#doc-tokenSeparators) of select2. It should work back to CKAN v2.3 and not break earlier versions. Additonally, other separators can be specified by passing `data-module-tagsep="[',', ';', '|']"`, for example.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
