### PR TITLE
I should add `|safe` to escape html

### DIFF
--- a/ckanext/example_theme_docs/v07_helper_function/templates/home/layout1.html
+++ b/ckanext/example_theme_docs/v07_helper_function/templates/home/layout1.html
@@ -1,5 +1,5 @@
 {% ckan_extends %}
 
 {% block featured_group %}
-  {{ h.recently_changed_packages_activity_stream(limit=4) }}
+  {{ h.recently_changed_packages_activity_stream(limit=4) | safe }}
 {% endblock %}


### PR DESCRIPTION
Just change
```
{{ h.recently_changed_packages_activity_stream(limit=4)  }} 
```
to
```
{{ h.recently_changed_packages_activity_stream(limit=4) |safe }} 
```

When automatic escaping is enabled everything is escaped by default except for values explicitly marked as safe. Those can either be marked by the application or in the template by using the |safe filter.

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
