### PR TITLE
Ubuntu 16.04 should stop apache2 service first to install nginx

### DIFF
--- a/doc/maintaining/installing/install-from-package.rst
+++ b/doc/maintaining/installing/install-from-package.rst
@@ -47,7 +47,13 @@ CKAN:
 
 #. Install the Ubuntu packages that CKAN requires (and 'git', to enable you to install CKAN extensions)::
 
-    sudo apt-get install -y nginx apache2 libapache2-mod-wsgi libpq5 redis-server git-core
+    sudo apt-get install -y apache2 libapache2-mod-wsgi libpq5 redis-server git-core
+    
+#. Then stop apache2 service to install nginx
+    
+    sudo service apache2 stop
+    
+    sudo apt-get install -y nginx
 
 #. Download the CKAN package:
 


### PR DESCRIPTION
#. Install the Ubuntu packages that CKAN requires (and 'git', to enable you to install CKAN extensions)::

    sudo apt-get install -y apache2 libapache2-mod-wsgi libpq5 redis-server git-core
    
#. Then stop apache2 service to install nginx
    
    sudo service apache2 stop
    
    sudo apt-get install -y nginx

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
