### PR TITLE
stop apache and nginx, then install solr

### DIFF
--- a/doc/maintaining/installing/install-from-package.rst
+++ b/doc/maintaining/installing/install-from-package.rst
@@ -123,6 +123,12 @@ set the correct password, database and database user.
    change the :ref:`solr_url` setting in your
    |production.ini| file to reference your |solr| server.
 
+Before install |solr|, stop apache2 and nginx service firstly:
+
+    sudo service nginx stop
+    
+    sudo service apache2 stop
+
 Install |solr|, running this command in a terminal::
 
     sudo apt-get install -y solr-jetty


### PR DESCRIPTION
Before install |solr|, stop apache2 and nginx service firstly:

    sudo service nginx stop
    
    sudo service apache2 stop

Install |solr|, running this command in a terminal::

    sudo apt-get install -y solr-jetty

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
