### PR TITLE
Host port and max upload file

### DIFF
--- a/contrib/docker/.env.template
+++ b/contrib/docker/.env.template
@@ -9,6 +9,10 @@
 # docker-compose up -d
 # docker-compose restart ckan # give the db service time to initialize the db cluster on first run
 
+# Host port
+# http://my-ckan.docs.org: {80 or 5000}
+HOST_PORT=5000
+
 # Image: ckan
 CKAN_SITE_ID=default
 #
@@ -43,3 +47,5 @@ POSTGRES_PORT=5432
 # Readonly user/pass will be datastore_ro:DATASTORE_READONLY_PASSWORD
 DATASTORE_READONLY_PASSWORD=datastore
 
+# Limit from upload file
+CKAN_MAX_UPLOAD_SIZE_MB=2

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - solr
       - redis
     ports:
-      - "0.0.0.0:${CKAN_PORT}:5000"
+      - "0.0.0.0:${CKAN_PORT}:${HOST_PORT}"
     environment:
       # Defaults work with linked containers, change to use own Postgres, SolR, Redis or Datapusher
       - CKAN_SQLALCHEMY_URL=postgresql://ckan:${POSTGRES_PASSWORD}@db/ckan


### PR DESCRIPTION
Fixes # In the `.env.template` file was adding the host port reference and the non-existent reference to the maximum file upload.
In the file `docker-compose.yml` we obtain the reference of the host port, informed in the file `.env.template`

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport
