### PR TITLE
bump tagged version recommended for docker install

### DIFF
--- a/doc/maintaining/installing/install-from-docker-compose.rst
+++ b/doc/maintaining/installing/install-from-docker-compose.rst
@@ -71,7 +71,7 @@ Clone CKAN into a directory of your choice::
 This will use the latest CKAN master, which may not be stable enough for production use.
 To use a stable version, checkout the respective tag, e.g.::
 
-    git checkout tags/ckan-2.6.2
+    git checkout tags/ckan-2.8.0
 
 ----------------------
 2. Build Docker images


### PR DESCRIPTION
Fixes #

### Proposed fixes:
The Docker installation document suggested installing stable tag/2.6.2, but then goes on to describe in detail how to work with artifacts only available in 2.8.0. Either link to the proper document, or bump the version (or both).


### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
