### PR TITLE
Remove overly-specific .site-search input border

### DIFF
--- a/ckan/public/base/less/masthead.less
+++ b/ckan/public/base/less/masthead.less
@@ -119,9 +119,6 @@
     .section {
         float: left;
     }
-    input[type="text"] {
-        border-color: darken(@mastheadBackgroundColor, 5);
-    }
     .navigation {
         &.section {
             @media (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {


### PR DESCRIPTION
Fixes #4273 

### Proposed fixes:

- Remove extra styling rule in `masthead.less`

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
