### PR TITLE
Limit maximum height of site logo to scale down very large images

### DIFF
--- a/ckan/public-bs2/base/less/masthead.less
+++ b/ckan/public-bs2/base/less/masthead.less
@@ -24,13 +24,13 @@
           span.text {
             margin: 0 2px 0 4px;
           }
-          
+
           span.text {
             position: absolute;
             top: -9999px;
             left: -9999px;
           }
-          
+
           &:hover {
             color: mix(@mastheadBackgroundColor, @mastheadLinkColor, 15%);
             background-color: darken(@mastheadBackgroundColor, 15%);
@@ -118,7 +118,12 @@
       white-space: nowrap;
     }
   }
-
+  .logo{
+    display: inline-block;
+    img{
+      max-height: @logoMaxHeight;
+    }
+  }
   .nav-collapse {
     padding-top:10px;
   }

--- a/ckan/public-bs2/base/less/variables.less
+++ b/ckan/public-bs2/base/less/variables.less
@@ -12,6 +12,7 @@
 @layoutBackgroundColor: #eee;
 @layoutTrimBackgroundColor: #fff;
 @layoutTrimBorderColor: #ccc;
+@logoMaxHeight: 55px;
 
 @navLinkColor: #333;
 @navActiveBackgroundColor: #f6f6f6;

--- a/ckan/public/base/less/masthead.less
+++ b/ckan/public/base/less/masthead.less
@@ -113,6 +113,12 @@
             white-space: nowrap;
         }
     }
+    .logo{
+      display: inline-block;
+      img{
+        max-height: @logoMaxHeight;
+      }
+    }
     .navbar-collapse {
         padding: @grid-gutter-width/3 0;
     }

--- a/ckan/public/base/less/variables.less
+++ b/ckan/public/base/less/variables.less
@@ -12,6 +12,7 @@
 @layoutBackgroundColor: #eee;
 @layoutTrimBackgroundColor: #fff;
 @layoutTrimBorderColor: #ccc;
+@logoMaxHeight: 60px;
 
 @navLinkColor: #333;
 @navActiveBackgroundColor: #f6f6f6;


### PR DESCRIPTION
Fixes #4283 

### Proposed fixes:

- Limit logo height to 55px - Bootstrap 2
- Limit logo height to 60px - Bootstrap 3

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
