### PR TITLE
[#2293] Replace httpie doc examples with CURL examples

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -79,7 +79,7 @@ of all the datasets in the ``data-explorer`` group on demo.ckan.org, install
 curl and then call the ``group_list`` API function by running this command
 in a terminal::
 
-    curl http://demo.ckan.org/api/3/action/group_list
+    curl https://demo.ckan.org/api/3/action/group_list
 
 The response from CKAN will look like this::
 

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -73,13 +73,13 @@ To call the CKAN API, post a JSON dictionary in an HTTP POST request to one of
 CKAN's API URLs. The parameters for the API function should be given in the
 JSON dictionary. CKAN will also return its response in a JSON dictionary.
 
-One way to post a JSON dictionary to a URL is using the command-line HTTP
-client `HTTPie <http://httpie.org/>`_.  For example, to get a list of the names
+One way to post a JSON dictionary to a URL is using the command-line 
+client `Curl <https://curl.haxx.se/>`_.  For example, to get a list of the names
 of all the datasets in the ``data-explorer`` group on demo.ckan.org, install
-HTTPie and then call the ``group_list`` API function by running this command
+curl and then call the ``group_list`` API function by running this command
 in a terminal::
 
-    http http://demo.ckan.org/api/3/action/group_list
+    curl http://demo.ckan.org/api/3/action/group_list
 
 The response from CKAN will look like this::
 
@@ -262,16 +262,16 @@ can be configured with the ``apikey_header_name`` option in your CKAN
 configuration file.)
 
 For example, to ask whether or not you're currently following the user
-``markw`` on demo.ckan.org using HTTPie, run this command::
+``markw`` on demo.ckan.org using curl, run this command::
 
-    http http://demo.ckan.org/api/3/action/am_following_user id=markw Authorization:XXX
+    curl -H "Authorization: XXX"  https://demo.ckan.org/api/3/action/am_following_user?id=markw 
 
 (Replacing ``XXX`` with your API key.)
 
 Or, to get the list of activities from your user dashboard on demo.ckan.org,
 run this Python code::
 
-    request = urllib2.Request('http://demo.ckan.org/api/3/action/dashboard_activity_list')
+    request = urllib2.Request('https://demo.ckan.org/api/3/action/dashboard_activity_list')
     request.add_header('Authorization', 'XXX')
     response_dict = json.loads(urllib2.urlopen(request, '{}').read())
 
@@ -374,9 +374,9 @@ Uploading a new version of a resource file
 You can use the ``upload`` parameter of the
 :py:func:`~ckan.logic.action.update.resource_update` function to upload a
 new version of a resource file. This requires a ``multipart/form-data``
-request, with httpie you can do this using the ``@file.csv``::
+request, with curl you can do this using the ``@file.csv``::
 
-    http --json POST http://demo.ckan.org/api/3/action/resource_update id=<resource id> upload=@updated_file.csv Authorization:<api key>
+    curl -X POST  -H "Content-Type: multipart/form-data"  -H "Authorization: XXXX"  -F "id=<resource_id>" -F "upload=@updated_file.csv" https://demo.ckan.org/api/3/action/resource_update  
 
 
 .. _api-reference:

--- a/doc/contributing/documentation.rst
+++ b/doc/contributing/documentation.rst
@@ -492,7 +492,7 @@ is a nice way to include a list of related links::
        :doc:`The DataStore extension <datastore>`
          A CKAN extension for storing data.
 
-       CKAN's `demo site <http://demo.ckan.org/>`_
+       CKAN's `demo site <https://demo.ckan.org/>`_
          A demo site running the latest CKAN beta version.
 
 Seealso boxes are particularly useful when two pages are related, but don't

--- a/doc/maintaining/linked-data-and-rdf.rst
+++ b/doc/maintaining/linked-data-and-rdf.rst
@@ -9,10 +9,10 @@ https://github.com/ckan/ckanext-dcat
 These features include the RDF serializations of CKAN datasets based on `DCAT`_, that used to be generated
 using templates hosted on the main CKAN repo, eg:
 
-* http://demo.ckan.org/dataset/newcastle-city-council-payments-over-500.xml
-* http://demo.ckan.org/dataset/newcastle-city-council-payments-over-500.ttl
-* http://demo.ckan.org/dataset/newcastle-city-council-payments-over-500.n3
-* http://demo.ckan.org/dataset/newcastle-city-council-payments-over-500.jsonld
+* https://demo.ckan.org/dataset/newcastle-city-council-payments-over-500.xml
+* https://demo.ckan.org/dataset/newcastle-city-council-payments-over-500.ttl
+* https://demo.ckan.org/dataset/newcastle-city-council-payments-over-500.n3
+* https://demo.ckan.org/dataset/newcastle-city-council-payments-over-500.jsonld
 
 ckanext-dcat offers many more `features <https://github.com/ckan/ckanext-dcat#overview>`_,
 including catalog-wide endpoints and harvesters to import RDF data into CKAN. Please check

--- a/doc/maintaining/stats.rst
+++ b/doc/maintaining/stats.rst
@@ -42,4 +42,4 @@ Viewing the Statistics
 ======================
 
 To view the statistics reported by the stats extension, visit the ``/stats``
-page, for example: http://demo.ckan.org/stats
+page, for example: https://demo.ckan.org/stats

--- a/doc/user-guide.rst
+++ b/doc/user-guide.rst
@@ -140,7 +140,7 @@ Adding a new dataset
 
     You may need to be a member of an organization in order to add and edit
     datsets. See the section :ref:`creating_an_organization` below. On
-    http://demo.ckan.org, you can add a dataset without being in an organization,
+    https://demo.ckan.org, you can add a dataset without being in an organization,
     but dataset features relating to authorization and organizations will not be
     available.
 


### PR DESCRIPTION
As per #2293 we replace the httpie examples with the equivalent in curl.
It appears that the examples were using http and therefore were getting
a 302 to the https url, and as we all know to our pain, POST data
doesn't follow redirects and so the examples weren't always working.
Have changes some occurrences of http://demo.ckan.org to
https://demo.ckan.org

Fixes #2293
