### PR TITLE
CI - IMPORTANT BUG

### DIFF
--- a/.circleci-matrix.yml
+++ b/.circleci-matrix.yml
@@ -1,9 +1,0 @@
-env:
-- SEGMENTS="01234"
-- SEGMENTS="567"
-- SEGMENTS="89ab"
-- SEGMENTS="cdef"
-
-command:
-- mkdir -p $CIRCLE_TEST_REPORTS/nose
-- nosetests --ckan --reset-db --with-pylons=test-core.ini --nologcapture --with-coverage --cover-package=ckan --cover-package=ckanext --with-xunit --xunit-file=$CIRCLE_TEST_REPORTS/nose/junit.xml --segments=$SEGMENTS ckan ckanext

--- a/circle.yml
+++ b/circle.yml
@@ -58,8 +58,8 @@ database:
 test:
 
     override:
-        - circleci-matrix:
-            parallel: true
+        - mkdir -p $CIRCLE_TEST_REPORTS/nose
+        - nosetests --ckan --reset-db --with-pylons=test-core.ini --nologcapture --with-coverage --cover-package=ckan --cover-package=ckanext --with-xunit --xunit-file=$CIRCLE_TEST_REPORTS/nose/junit.xml ckan ckanext
 
     post:
         - paster serve test-core.ini:


### PR DESCRIPTION
Segmentation of Test have lead to don't trigger some tests.
This PR "fixes" the problem.

So, this PR would not pass the PR checks cause it is triggering tests that are now executed and not before this.

In order to fix this, we must do the following:
- Disable CircleCI parallelization.
- Skiping or fixing the 13 new tests that fail.

Even with this, this should be merged