### PR TITLE
Speed up sphinx test

### DIFF
--- a/ckan/tests/test_coding_standards.py
+++ b/ckan/tests/test_coding_standards.py
@@ -62,9 +62,6 @@ def walk_python_files():
 def test_building_the_docs():
     u'''There should be no warnings or errors when building the Sphinx docs.
 
-    This test unfortunately does take quite a long time to run - rebuilding the
-    docs from scratch just takes a long time.
-
     This test will also fail is build_sphinx exits with non-zero status.
 
     '''
@@ -72,9 +69,7 @@ def test_building_the_docs():
         output = subprocess.check_output(
             [b'python',
              b'setup.py',
-             b'build_sphinx',
-             b'--all-files',
-             b'--fresh-env'],
+             b'build_sphinx'],
             stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as err:
         assert False, (

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,7 +10,7 @@ mock==2.0.0
 pycodestyle==2.2.0
 pip-tools==1.7.0
 pyfakefs==2.9
-Sphinx==1.7.1
+Sphinx==1.7.5
 sphinx-rtd-theme==0.3.1
 
 # nose==1.3.0  # already in requirements.txt


### PR DESCRIPTION
### Proposed fixes:

The `test_building_the_docs` test was rebuilding all of the
documentation from scratch as a test - on my computer, this took about
35 seconds.

There is no need to build the documentation from scratch, by removing
the all-files and fresh-env parameters only documentation for files that
have changed are rebuilt.

Removing these two parameters makes the test now take 7s, about 10s if
you change a file containing documentation.  For multiple full runs for
development this saved time adds up.

### To discuss:

Do we really need to rebuild the full docs on every test?

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
