### PR TITLE
Fixing API Examples

### DIFF
--- a/doc/maintaining/filestore.rst
+++ b/doc/maintaining/filestore.rst
@@ -81,7 +81,7 @@ For example, to create a new CKAN resource and upload a file to it using
 
 .. parsed-literal::
 
- curl -H'Authorization: your-api-key' 'http://yourhost/api/action/resource_create' --form upload=@filetoupload --form package_id=my_dataset
+ curl -H'Authorization: your-api-key' 'http://yourhost/api/action/resource_create' --form upload=@filetoupload --form package_id=my_dataset --form url=url --form name="resource name"
 
 (Curl automatically sends a ``multipart-form-data`` heading with you use the
 ``--form`` option.)
@@ -93,7 +93,7 @@ To create a new resource and upload a file to it using the Python library
 
  import requests
  requests.post('http://0.0.0.0:5000/api/action/resource_create',
-               data={"package_id":"my_dataset"},
+               data={"package_id":"my_dataset", "name": "resource name", "url": ""},
                headers={"X-CKAN-API-Key": "21a47217-6d7b-49c5-88f9-72ebd5a4d4bb"},
                files=[('upload', file('/path/to/file/to/upload.csv'))])
 


### PR DESCRIPTION
From working with a CKAN instance for the first time (2.5.2) it looks like the examples given here regarding file upload do not work. The request is rejected if the "url" key is not set and it needs to be set to an empty string for the file upload to work. If not, the following error is returned:

```
{"help": "http://.../api/3/action/help_show?name=resource_create", "success": false, "error": {"url": ["Missing value"], "__type": "Validation Error"}}
```

Setting the "url" key to anything other than an empty string seems to be accepted but the file contents are ignored and the resources is treated as an external link.

This commit updates the curl and requests examples to set the "url" and "name" keys appropriately.

### Fixes
Documentation fix for file upload API example.

### Proposed fixes:
N/A


### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
