### PR TITLE
Validation Error on datastore_search when sorting timestamp fields

### DIFF
--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1672,7 +1672,6 @@ class DatastorePostgresqlBackend(DatastoreBackend):
 
         select_cols = []
         records_format = data_dict.get(u'records_format')
-        json_values = records_format in (u'objects', u'lists')
         for field_id in field_ids:
             fmt = u'to_json({0})' if records_format == u'lists' else u'{0}'
             typ = fields_types.get(field_id)
@@ -1680,7 +1679,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
                 fmt = u'({0}).json'
             elif typ == u'timestamp':
                 fmt = u"to_char({0}, 'YYYY-MM-DD\"T\"HH24:MI:SS')"
-                if json_values:
+                if records_format == u'lists':
                     fmt = u"to_json({0})".format(fmt)
             elif typ.startswith(u'_') or typ.endswith(u'[]'):
                 fmt = u'array_to_json({0})'


### PR DESCRIPTION
### CKAN Version if known (or site URL)
2.7+

### Please describe the expected behaviour
The datastore_search API should be able to perform a distinct or sort on fields with a timestamp data type. A data table or data explorer resource view should be able to reorder rows based on a timestamp field.

### Please describe the actual behaviour
A validation error is returned from the datastore_search API when performing a distinct or sort on fields with a timestamp data type. The data table and data explorer view can't reorder rows based on a timestamp field.

The problem seems to be that timestamps are converted to char than to json before sorting.
https://github.com/ckan/ckan/blob/ckan-2.7.3/ckanext/datastore/backend/postgres.py#L1726-L1729

### What steps can be taken to reproduce the issue?
Call the datastore_search endpoint with distinct=true and sorting on a timestamp field. `/api/3/action/datastore_search?resource_id={resource_id}&fields="DateOpened"&sort="DateOpened"&distinct=true`

Returned Statement

```
SELECT array_to_json(array_agg(j))::text FROM (
  SELECT DISTINCT to_json(to_char("DateOpened", 'YYYY-MM-DD"T"HH24:MI:SS')) as "DateOpened"
  FROM "resource_id" 
  ORDER BY "DateOpened" asc LIMIT 100 OFFSET 0
) AS j"
```

Returned Validation Error

```
Could not identify an ordering operator for type json
LINE 5:  ORDER BY "DateOpened" asc LIMIT 100 OFFSET...
HINT:  Use an explicit ordering operator or modify the query.
```