### PR TITLE
Don't explode when a non-logged in user visits /dashboard

### DIFF
--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -192,6 +192,15 @@ class TestLogout(helpers.FunctionalTestBase):
 
 class TestUser(helpers.FunctionalTestBase):
 
+    def test_not_logged_in_dashboard(self):
+        app = self._get_test_app()
+
+        for route in ['index', 'organizations', 'datasets', 'groups']:
+            app.get(
+                url=url_for(u'dashboard.{}'.format(route)),
+                status=403
+            )
+
     def test_own_datasets_show_up_on_user_dashboard(self):
         user = factories.User()
         dataset_title = 'My very own dataset'

--- a/ckan/views/dashboard.py
+++ b/ckan/views/dashboard.py
@@ -18,6 +18,9 @@ dashboard = Blueprint(u'dashboard', __name__, url_prefix=u'/dashboard')
 @dashboard.before_request
 def before_request():
     try:
+        if not g.userobj:
+            raise logic.NotAuthorized()
+
         context = dict(model=model, user=g.user, auth_user_obj=g.userobj)
         logic.check_access(u'site_read', context)
     except logic.NotAuthorized:


### PR DESCRIPTION
Fixes #4305

### Proposed fixes:

When a non-logged-in user visits /dashboard, errors happen.  This PR
stops those errors happening by ensuring at the start of the request
to the dashboard view that there is a logged in user.

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
