### PR TITLE
Remove unnecessary tables

### DIFF
--- a/ckan/migration/versions/087_remove_old_authorization_tables.py
+++ b/ckan/migration/versions/087_remove_old_authorization_tables.py
@@ -1,0 +1,10 @@
+# encoding: utf-8
+
+
+def upgrade(migrate_engine):
+    migrate_engine.execute(
+        '''
+            DROP TABLE IF EXISTS "authorization_group_user";
+            DROP TABLE IF EXISTS "authorization_group";
+        '''
+    )


### PR DESCRIPTION
Fixes #3879

### Proposed fixes:

In previous work the need for these tables was removed, however
migrations were not provided.  authorization_group_role was removed in a
later PR, but authorization_group and authorization_group_user were not.

This PR just deletes the tables if they still exist.


