### PR TITLE
[#4310] Add global properties `controller` and `action`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@
 Changelog
 ---------
 
+v.2.9.0 TBA
+==================
+
+Deprecations:
+ * `c.action` and `c.controller` variables should be avoided. Refer to either `request.enpoint`
+   (generally it will be string in format `BLUEPRINT_NAME.VIEW_NAME`, where blueprint is an
+   alternative of controller and view is an alternative of action) or `request.url_rule`(which is
+   object with additional information about current rule)
+
 v.2.8.0 2018-05-09
 ==================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ v.2.9.0 TBA
 
 Deprecations:
  * ``c.action`` and ``c.controller`` variables should be avoided.
-   Refer to either ``request.enpoint`` (generally it will be string in format
+   Refer to either ``request.endpoint`` (generally it will be string in format
    ``BLUEPRINT_NAME.VIEW_NAME``, where blueprint is an alternative of
    controller and view is an alternative of action) or ``request.url_rule``
    (which is object with additional information about current rule).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,10 +11,11 @@ v.2.9.0 TBA
 ==================
 
 Deprecations:
- * `c.action` and `c.controller` variables should be avoided. Refer to either `request.enpoint`
-   (generally it will be string in format `BLUEPRINT_NAME.VIEW_NAME`, where blueprint is an
-   alternative of controller and view is an alternative of action) or `request.url_rule`(which is
-   object with additional information about current rule)
+ * ``c.action`` and ``c.controller`` variables should be avoided.
+   Refer to either ``request.enpoint`` (generally it will be string in format
+   ``BLUEPRINT_NAME.VIEW_NAME``, where blueprint is an alternative of
+   controller and view is an alternative of action) or ``request.url_rule``
+   (which is object with additional information about current rule).
 
 v.2.8.0 2018-05-09
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,10 +12,22 @@ v.2.9.0 TBA
 
 Deprecations:
  * ``c.action`` and ``c.controller`` variables should be avoided.
-   Refer to either ``request.endpoint`` (generally it will be string in format
-   ``BLUEPRINT_NAME.VIEW_NAME``, where blueprint is an alternative of
-   controller and view is an alternative of action) or ``request.url_rule``
-   (which is object with additional information about current rule).
+   ``ckan.plugins.toolkit.get_endpoint`` can be used instead. This function
+   returns tuple of two items(depending on request handler):
+   1. Flask blueprint name / Pylons controller name
+   2. Flask view name / Pylons action name
+   In some cases, Flask blueprints have names that are differs from their
+   Pylons equivalents. For example, 'package' controller is divided between
+   'dataset' and 'resource' blueprints. For such cases you may need to perform
+   additional check of returned value:
+
+   >>> if toolkit.get_endpoint()[0] in ['dataset', 'package']:
+   >>>     do_something()
+
+   In this code snippet, will be called if current request is handled via Flask's
+   dataset blueprint in CKAN>=2.9, and, in the same time, it's still working for
+   Pylons package controller in CKAN<2.9
+
 
 v.2.8.0 2018-05-09
 ==================

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -32,6 +32,7 @@ from ckan.plugins.interfaces import IBlueprint, IMiddleware, ITranslation
 from ckan.views import (identify_user,
                         set_cors_headers_for_response,
                         check_session_cookie,
+                        set_controller_and_action
                         )
 
 
@@ -278,6 +279,10 @@ def ckan_before_request():
     # Identify the user from the repoze cookie or the API header
     # Sets g.user and g.userobj
     identify_user()
+
+    # Provide g.controller and g.action for backward compatibility
+    # with extensions
+    set_controller_and_action()
 
 
 def ckan_after_request(response):

--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -183,8 +183,8 @@ def _get_user_for_apikey():
 
 def set_controller_and_action():
     try:
-        controller, action = request.endpoint.split('.')
+        controller, action = request.endpoint.split(u'.')
     except ValueError:
-        log.debug('Endpoint does not contain dot: {}'.format(request.endpoint))
+        log.debug(u'Endpoint does not contain dot: {}'.format(request.endpoint))
         controller = action = request.endpoint
     g.controller, g.action = controller, action

--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -185,6 +185,8 @@ def set_controller_and_action():
     try:
         controller, action = request.endpoint.split(u'.')
     except ValueError:
-        log.debug(u'Endpoint does not contain dot: {}'.format(request.endpoint))
+        log.debug(
+            u'Endpoint does not contain dot: {}'.format(request.endpoint)
+        )
         controller = action = request.endpoint
     g.controller, g.action = controller, action

--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -179,3 +179,12 @@ def _get_user_for_apikey():
     query = model.Session.query(model.User)
     user = query.filter_by(apikey=apikey).first()
     return user
+
+
+def set_controller_and_action():
+    try:
+        controller, action = request.endpoint.split('.')
+    except ValueError:
+        log.debug('Endpoint does not contain dot: {}'.format(request.endpoint))
+        controller = action = request.endpoint
+    g.controller, g.action = controller, action


### PR DESCRIPTION
fixes #4310.

 There are a bunch of extensions that rely on this props. This PR
is attempting to add them inside `before_each_request` hook. If
url.endpoint contains a dot, then part before dot will be considered
as controller and part after the dot - as action. otherwise(routes
without the dot, like test /hello route), view name is used for both,
controller and action name
