### PR TITLE
unicode() --> six.text_type() for Python 3

### DIFF
--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -528,9 +528,9 @@ class CreateView(MethodView):
             return base.abort(404, _(u'Dataset not found'))
         except SearchIndexError as e:
             try:
-                exc_str = unicode(repr(e.args))
+                exc_str = text_type(repr(e.args))
             except Exception:  # We don't like bare excepts
-                exc_str = unicode(str(e))
+                exc_str = text_type(str(e))
             return base.abort(
                 500,
                 _(u'Unable to add package to search index.') + exc_str
@@ -660,9 +660,9 @@ class EditView(MethodView):
             return base.abort(404, _(u'Dataset not found'))
         except SearchIndexError as e:
             try:
-                exc_str = unicode(repr(e.args))
+                exc_str = text_type(repr(e.args))
             except Exception:  # We don't like bare excepts
-                exc_str = unicode(str(e))
+                exc_str = text_type(str(e))
             return base.abort(
                 500,
                 _(u'Unable to update search index.') + exc_str


### PR DESCRIPTION
@amercader flake8 testing of https://github.com/ckan/ckan on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./ckan/views/dataset.py:531:27: F821 undefined name 'unicode'
                exc_str = unicode(repr(e.args))
                          ^
./ckan/views/dataset.py:533:27: F821 undefined name 'unicode'
                exc_str = unicode(str(e))
                          ^
./ckan/views/dataset.py:663:27: F821 undefined name 'unicode'
                exc_str = unicode(repr(e.args))
                          ^
./ckan/views/dataset.py:665:27: F821 undefined name 'unicode'
                exc_str = unicode(str(e))
                          ^
./ckan/views/resource.py:575:20: F821 undefined name 'bgase'
            return bgase.abort(
                   ^
5     F821 undefined name 'unicode'
5
```

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
