### PR TITLE
[#4346] Update missing legacy routes

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -68,6 +68,9 @@ MARKDOWN_ATTRIBUTES.setdefault('img', []).extend(['src', 'alt', 'title'])
 LEGACY_ROUTE_NAMES = {
     'home': 'home.index',
     'about': 'home.about',
+    'search': 'dataset.search',
+    'organizations_index': 'organization.index',
+    'group_index': 'group.index'
 }
 
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -69,8 +69,7 @@ LEGACY_ROUTE_NAMES = {
     'home': 'home.index',
     'about': 'home.about',
     'search': 'dataset.search',
-    'organizations_index': 'organization.index',
-    'group_index': 'group.index'
+    'organizations_index': 'organization.index'
 }
 
 


### PR DESCRIPTION
Fixes #4346

### Proposed fixes:
Update `LEGACY_ROUTE_NAMES` in the `helpers.py` with all default routes defined with navigation menu


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
