### PR TITLE
[#4303] Update error handler

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -415,6 +415,9 @@ def _register_error_handler(app):
     def error_handler(e):
         if isinstance(e, HTTPException):
             extra_vars = {u'code': [e.code], u'content': e.description}
+            # TODO: Remove
+            g.code = [e.code]
+
             return base.render(
                 u'error_document_template.html', extra_vars), e.code
         extra_vars = {u'code': [500], u'content': u'Internal server error'}


### PR DESCRIPTION
Fixes #4303

### Proposed fixes:
Set `g.code` in the error handler for cases when `error_document_template.html` is extended not to crush

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
