### PR TITLE
[#4260] 'New view' button fix

### DIFF
--- a/ckan/templates-bs2/package/resource_views.html
+++ b/ckan/templates-bs2/package/resource_views.html
@@ -5,7 +5,7 @@
 
 {% block page_primary_action %}
   <div class="btn-group">
-    <a class="btn btn-primary dropdown-toggle" data-toggle="dropdown" href="#">
+    <a class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
       <i class="fa fa-plus-square"></i>
       {{ _('New view') }}
       <span class="caret"></span>


### PR DESCRIPTION
Fixes #4260 

### Proposed fixes:
Removed `href="#"` to the issues of incomatibility between jquery3 and bootstrap2


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
