### PR TITLE
fixing problem with reindex-fast on CKAN 2.7

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -602,7 +602,7 @@ Default is false.''')
 
     def rebuild_fast(self):
         ###  Get out config but without starting pylons environment ####
-        conf = self._get_config()
+        conf = _get_config(self.options.config)
 
         ### Get ids using own engine, otherwise multiprocess will balk
         db_url = conf['sqlalchemy.url']


### PR DESCRIPTION
Fixes problem with reindex-fast on CKAN 2.7

I didn't test this on 2.8 but it might be needed there as well from what i see in the code there


### Proposed fixes:
Replacing self._get_config() call (method that no longer exists in new CKAN version)


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
