### PR TITLE
Dockerfile: Upgrade from jessie to stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # See CKAN docs on installation from Docker Compose on usage
-FROM debian:jessie
+FROM debian:stretch
 MAINTAINER Open Knowledge
 
 # Install required system packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # See CKAN docs on installation from Docker Compose on usage
-FROM debian:stretch
+FROM debian:stretch 
 MAINTAINER Open Knowledge
 
 # Install required system packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # See CKAN docs on installation from Docker Compose on usage
-FROM debian:stretch 
+FROM debian:stretch
 MAINTAINER Open Knowledge
 
 # Install required system packages


### PR DESCRIPTION
* Debian jessie is now out of normal support and into LTS.  https://wiki.debian.org/LTS
* Debian stretch will be in normal support beyond the EOL of Python 2