### PR TITLE
Travis CI: Add flake8 jobs on both Python 2.7 and 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ group: travis_latest
 language: python
 
 matrix:
-  allow_failures:
-    - python: "3.7"  # pending #4357
   include:
     - python: "2.7"
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ matrix:
         - docker ps -a
 
     - python: "2.7"
+      env: FLAKE8=true
       cache: pip
       install:
         - pip install flake8
@@ -44,6 +45,7 @@ matrix:
         - true
 
     - python: "3.7"
+      env: FLAKE8=true
       dist: xenial    # required for Python 3.7
       sudo: required  # required for Python 3.7
       cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,59 @@
-sudo: required
-
+group: travis_latest
 language: python
 
-services:
-  - docker
+matrix:
+  allow_failures:
+    - python: "3.7"  # pending #4357
+  include:
+    - python: "2.7"
+      sudo: required
 
-cache:
-  directories:
-     - ~/docker
+      services:
+        - docker
 
-before_install:
-  - docker build --rm=false -f contrib/docker/postgresql/Dockerfile -t postgresql .
-  - docker build --rm=false -f contrib/docker/solr/Dockerfile -t solr .
-  - docker pull redis:latest
-  - docker build --rm=false -t ckan .
+      cache:
+        directories:
+          - ~/docker
 
-install:
-  - docker run -d --name db postgresql
-  - docker run -d --name solr solr
-  - docker run -d --name redis redis:latest
-  - docker run -d --name ckan -p 5000:5000 --link db:db --link redis:redis --link solr:solr ckan
+      before_install:
+        - docker build --rm=false -f contrib/docker/postgresql/Dockerfile -t postgresql .
+        - docker build --rm=false -f contrib/docker/solr/Dockerfile -t solr .
+        - docker pull redis:latest
+        - docker build --rm=false -t ckan .
 
-script:
-  - docker ps -a
+      install:
+        - docker run -d --name db postgresql
+        - docker run -d --name solr solr
+        - docker run -d --name redis redis:latest
+        - docker run -d --name ckan -p 5000:5000 --link db:db --link redis:redis --link solr:solr ckan
+
+      script:
+        - docker ps -a
+
+    - python: "2.7"
+      cache: pip
+      install:
+        - pip install flake8
+      before_script:
+        - flake8 --version
+        # stop the build if there are Python syntax errors or undefined names
+        - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+        # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+        - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      script:
+        - true
+
+    - python: "3.7"
+      dist: xenial    # required for Python 3.7
+      sudo: required  # required for Python 3.7
+      cache: pip
+      install:
+        - pip install flake8
+      before_script:
+        - flake8 --version
+        # stop the build if there are Python syntax errors or undefined names
+        - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+        # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+        - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      script:
+        - true


### PR DESCRIPTION
Run [flake8](https://gitlab.com/pycqa/flake8) __. --select=E901,E999,F821,F822,F823__ under both Python 2 and Python 3 to find syntax errors and undefined names.  This should help us catch Python incompatibilities in pull requests before they are reviewed.

This PR is an update to  #4227 which I closed because I thought that we could quickly move over to Circle CI but that is blocked by #4335 and then #4345, etc...

~The Python 3.7 job is run in __allow_failures__ mode until #4357 is fixed.~

__E901,E999,F821,F822,F823__ are the "showstopper" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc.  Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable `name` referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree

Fixes #

### Proposed fixes:



### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
