### PR TITLE
[#4346] Missing legacy routes

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -69,6 +69,7 @@ LEGACY_ROUTE_NAMES = {
     'home': 'home.index',
     'about': 'home.about',
     'search': 'dataset.search',
+    'group_index': 'group.index',
     'organizations_index': 'organization.index'
 }
 

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -532,6 +532,38 @@ class TestCleanHtml(object):
             u'2018-01-05 10:48:23.463511')
 
 
+class TestBuildNavMain(object):
+    def test_flask_routes(self):
+        menu = (
+            ('home.index', 'Home'),
+            ('dataset.search', 'Datasets'),
+            ('organization.index', 'Organizations'),
+            ('group.index', 'Groups'),
+            ('home.about', 'About')
+        )
+        eq_(h.build_nav_main(menu), (
+            '<li><a href="/">Home</a></li>'
+            '<li><a href="/dataset">Datasets</a></li>'
+            '<li><a href="/organization">Organizations</a></li>'
+            '<li><a href="/group">Groups</a></li>'
+            '<li><a href="/about">About</a></li>'))
+
+    def test_legacy_pylon_routes(self):
+        menu = (
+            ('home', 'Home'),
+            ('search', 'Datasets'),
+            ('organizations_index', 'Organizations'),
+            ('group_index', 'Groups'),
+            ('about', 'About')
+        )
+        eq_(h.build_nav_main(menu), (
+            '<li><a href="/">Home</a></li>'
+            '<li><a href="/dataset">Datasets</a></li>'
+            '<li><a href="/organization">Organizations</a></li>'
+            '<li><a href="/group">Groups</a></li>'
+            '<li><a href="/about">About</a></li>'))
+
+
 class TestHelperException(helpers.FunctionalTestBase):
 
     @raises(ckan.exceptions.HelperError)

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -541,7 +541,7 @@ class TestBuildNavMain(object):
             ('group.index', 'Groups'),
             ('home.about', 'About')
         )
-        eq_(h.build_nav_main(menu), (
+        eq_(h.build_nav_main(*menu), (
             '<li><a href="/">Home</a></li>'
             '<li><a href="/dataset">Datasets</a></li>'
             '<li><a href="/organization">Organizations</a></li>'
@@ -556,7 +556,7 @@ class TestBuildNavMain(object):
             ('group_index', 'Groups'),
             ('about', 'About')
         )
-        eq_(h.build_nav_main(menu), (
+        eq_(h.build_nav_main(*menu), (
             '<li><a href="/">Home</a></li>'
             '<li><a href="/dataset">Datasets</a></li>'
             '<li><a href="/organization">Organizations</a></li>'

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -543,9 +543,9 @@ class TestBuildNavMain(object):
         )
         eq_(h.build_nav_main(*menu), (
             '<li><a href="/">Home</a></li>'
-            '<li><a href="/dataset">Datasets</a></li>'
-            '<li><a href="/organization">Organizations</a></li>'
-            '<li><a href="/group">Groups</a></li>'
+            '<li><a href="/dataset/">Datasets</a></li>'
+            '<li><a href="/organization/">Organizations</a></li>'
+            '<li><a href="/group/">Groups</a></li>'
             '<li><a href="/about">About</a></li>'))
 
     def test_legacy_pylon_routes(self):
@@ -558,9 +558,9 @@ class TestBuildNavMain(object):
         )
         eq_(h.build_nav_main(*menu), (
             '<li><a href="/">Home</a></li>'
-            '<li><a href="/dataset">Datasets</a></li>'
-            '<li><a href="/organization">Organizations</a></li>'
-            '<li><a href="/group">Groups</a></li>'
+            '<li><a href="/dataset/">Datasets</a></li>'
+            '<li><a href="/organization/">Organizations</a></li>'
+            '<li><a href="/group/">Groups</a></li>'
             '<li><a href="/about">About</a></li>'))
 
 


### PR DESCRIPTION
Fixes #4346

### Proposed fixes:

Add missing `group_index` to `LEGACY_ROUTE_NAMES`.

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
