### PR TITLE
[#4368] Fix broken CSS primer page

### DIFF
--- a/ckan/templates/development/primer.html
+++ b/ckan/templates/development/primer.html
@@ -70,10 +70,10 @@
   <h2>Datasets</h2>
   <hr>
   {% snippet 'snippets/package_list.html', packages=[
-  {'name': "test", 'title': 'Dataset #1', 'notes': lipsum(1), 'tracking_summary':{'recent': 10}},
-  {'name': "test", 'title': 'Dataset #2', 'notes': lipsum(0), 'tracking_summary':{'recent': 5}},
-  {'name': "test", 'title': 'Dataset #3', 'notes': lipsum(1), 'tracking_summary':{'recent': 10}},
-  {'name': "test", 'title': 'Dataset #4', 'notes': lipsum(1), 'tracking_summary':{'recent': 10}}
+  {'name': "test", 'title': 'Dataset #1', 'type': 'dataset', 'notes': lipsum(1), 'tracking_summary':{'recent': 10}},
+  {'name': "test", 'title': 'Dataset #2', 'type': 'dataset', 'notes': lipsum(0), 'tracking_summary':{'recent': 5}},
+  {'name': "test", 'title': 'Dataset #3', 'type': 'dataset', 'notes': lipsum(1), 'tracking_summary':{'recent': 10}},
+  {'name': "test", 'title': 'Dataset #4', 'type': 'dataset', 'notes': lipsum(1), 'tracking_summary':{'recent': 10}}
   ] %}
 </div>
 


### PR DESCRIPTION
Fixes #4368

### Proposed fixes:

Add a ``type`` key to the ``package`` dict to complete a dataset.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
