### PR TITLE
Datastore/datapusher render fix

### DIFF
--- a/ckanext/datapusher/plugin.py
+++ b/ckanext/datapusher/plugin.py
@@ -68,7 +68,11 @@ class ResourceDataController(base.BaseController):
             base.abort(403, _('Not authorized to see this page'))
 
         return base.render('datapusher/resource_data.html',
-                           extra_vars={'status': datapusher_status})
+                           extra_vars={
+                               'status': datapusher_status,
+                               'pkg_dict': toolkit.c.pkg_dict,
+                               'resource': toolkit.c.resource,
+                           })
 
 
 class DatapusherPlugin(p.SingletonPlugin):

--- a/ckanext/datapusher/tests/test_controller.py
+++ b/ckanext/datapusher/tests/test_controller.py
@@ -1,34 +1,22 @@
 import nose
-import sqlalchemy.orm as orm
 
-import ckan.plugins as p
 import ckan.tests.legacy as tests
-from ckan.tests import helpers
+from ckan.tests.helpers import FunctionalTestBase
 import ckan.tests.factories as factories
 
-import ckanext.datastore.backend.postgres as db
-from ckanext.datastore.tests.helpers import rebuild_all_dbs, set_url_type
 
-
-class TestController():
+class TestController(FunctionalTestBase):
     sysadmin_user = None
     normal_user = None
 
-    @classmethod
-    def setup_class(cls):
-        cls.app = helpers._get_test_app()
-        if not tests.is_datastore_supported():
-            raise nose.SkipTest("Datastore not supported")
-        p.load('datastore')
-        p.load('datapusher')
-        engine = db.get_write_engine()
-        cls.Session = orm.scoped_session(orm.sessionmaker(bind=engine))
+    _load_plugins = ['datastore', 'datapusher']
 
     @classmethod
-    def teardown_class(cls):
-        rebuild_all_dbs(cls.Session)
-        p.unload('datastore')
-        p.unload('datapusher')
+    def setup_class(cls):
+        cls.app = cls._get_test_app()
+        if not tests.is_datastore_supported():
+            raise nose.SkipTest("Datastore not supported")
+        super(TestController, cls).setup_class()
 
     def test_resource_data(self):
         user = factories.User()

--- a/ckanext/datapusher/tests/test_controller.py
+++ b/ckanext/datapusher/tests/test_controller.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import nose
 
 import ckan.tests.legacy as tests
@@ -9,13 +11,13 @@ class TestController(FunctionalTestBase):
     sysadmin_user = None
     normal_user = None
 
-    _load_plugins = ['datastore', 'datapusher']
+    _load_plugins = [u'datastore', u'datapusher']
 
     @classmethod
     def setup_class(cls):
         cls.app = cls._get_test_app()
         if not tests.is_datastore_supported():
-            raise nose.SkipTest("Datastore not supported")
+            raise nose.SkipTest(u'Datastore not supported')
         super(TestController, cls).setup_class()
 
     def test_resource_data(self):
@@ -23,10 +25,10 @@ class TestController(FunctionalTestBase):
         dataset = factories.Dataset(creator_user_id=user['id'])
         resource = factories.Resource(package_id=dataset['id'],
                                       creator_user_id=user['id'])
-        auth = {'Authorization': str(user['apikey'])}
+        auth = {u'Authorization': str(user['apikey'])}
 
         self.app.get(
-            url='/dataset/{id}/resource_data/{resource_id}'
+            url=u'/dataset/{id}/resource_data/{resource_id}'
             .format(id=str(dataset['name']),
                     resource_id=str(resource['id'])),
             extra_environ=auth)

--- a/ckanext/datapusher/tests/test_controller.py
+++ b/ckanext/datapusher/tests/test_controller.py
@@ -1,0 +1,44 @@
+import nose
+import sqlalchemy.orm as orm
+
+import ckan.plugins as p
+import ckan.tests.legacy as tests
+from ckan.tests import helpers
+import ckan.tests.factories as factories
+
+import ckanext.datastore.backend.postgres as db
+from ckanext.datastore.tests.helpers import rebuild_all_dbs, set_url_type
+
+
+class TestController():
+    sysadmin_user = None
+    normal_user = None
+
+    @classmethod
+    def setup_class(cls):
+        cls.app = helpers._get_test_app()
+        if not tests.is_datastore_supported():
+            raise nose.SkipTest("Datastore not supported")
+        p.load('datastore')
+        p.load('datapusher')
+        engine = db.get_write_engine()
+        cls.Session = orm.scoped_session(orm.sessionmaker(bind=engine))
+
+    @classmethod
+    def teardown_class(cls):
+        rebuild_all_dbs(cls.Session)
+        p.unload('datastore')
+        p.unload('datapusher')
+
+    def test_resource_data(self):
+        user = factories.User()
+        dataset = factories.Dataset(creator_user_id=user['id'])
+        resource = factories.Resource(package_id=dataset['id'],
+                                      creator_user_id=user['id'])
+        auth = {'Authorization': str(user['apikey'])}
+
+        self.app.get(
+            url='/dataset/{id}/resource_data/{resource_id}'
+            .format(id=str(dataset['name']),
+                    resource_id=str(resource['id'])),
+            extra_environ=auth)

--- a/ckanext/datastore/controller.py
+++ b/ckanext/datastore/controller.py
@@ -109,7 +109,10 @@ class DatastoreController(BaseController):
 
         return render(
             'datastore/dictionary.html',
-            extra_vars={'fields': fields})
+            extra_vars={
+                'fields': fields,
+                'resource': c.resource,
+            })
 
 
 def dump_to(resource_id, output, fmt, offset, limit, options):

--- a/ckanext/datastore/controller.py
+++ b/ckanext/datastore/controller.py
@@ -111,6 +111,7 @@ class DatastoreController(BaseController):
             'datastore/dictionary.html',
             extra_vars={
                 'fields': fields,
+                'pkg_dict': c.pkg_dict,
                 'resource': c.resource,
             })
 

--- a/ckanext/datastore/tests/test_dictionary.py
+++ b/ckanext/datastore/tests/test_dictionary.py
@@ -26,9 +26,6 @@ class TestDatastoreDictionary(DatastoreLegacyTestBase):
         helpers.call_action('datastore_create', **data)
         auth = {'Authorization': str(user['apikey'])}
         self.app.get(
-            # url='resource_dictionary',
-            # params=dict(id=str(dataset['name']),
-            #             resource_id=str(resource['id'])),
             url='/dataset/{id}/dictionary/{resource_id}'
             .format(id=str(dataset['name']),
                     resource_id=str(resource['id'])),

--- a/ckanext/datastore/tests/test_dictionary.py
+++ b/ckanext/datastore/tests/test_dictionary.py
@@ -1,0 +1,35 @@
+from ckanext.datastore.tests.helpers import DatastoreFunctionalTestBase, DatastoreLegacyTestBase
+import ckan.tests.factories as factories
+import ckan.tests.helpers as helpers
+
+
+class TestDatastoreDictionary(DatastoreLegacyTestBase):
+
+    @classmethod
+    def setup_class(cls):
+        cls.app = helpers._get_test_app()
+        super(TestDatastoreDictionary, cls).setup_class()
+
+    def test_read(self):
+        user = factories.User()
+        dataset = factories.Dataset(creator_user_id=user['id'])
+        resource = factories.Resource(package_id=dataset['id'],
+                                      creator_user_id=user['id'])
+        data = {
+            'resource_id': resource['id'],
+            'force': True,
+            'records': [
+                {'from': 'Brazil', 'to': 'Brazil', 'num': 2},
+                {'from': 'Brazil', 'to': 'Italy', 'num': 22}
+            ],
+        }
+        helpers.call_action('datastore_create', **data)
+        auth = {'Authorization': str(user['apikey'])}
+        self.app.get(
+            # url='resource_dictionary',
+            # params=dict(id=str(dataset['name']),
+            #             resource_id=str(resource['id'])),
+            url='/dataset/{id}/dictionary/{resource_id}'
+            .format(id=str(dataset['name']),
+                    resource_id=str(resource['id'])),
+            extra_environ=auth)

--- a/ckanext/datastore/tests/test_dictionary.py
+++ b/ckanext/datastore/tests/test_dictionary.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from ckanext.datastore.tests.helpers import DatastoreFunctionalTestBase, DatastoreLegacyTestBase
 import ckan.tests.factories as factories
 import ckan.tests.helpers as helpers
@@ -16,17 +18,17 @@ class TestDatastoreDictionary(DatastoreLegacyTestBase):
         resource = factories.Resource(package_id=dataset['id'],
                                       creator_user_id=user['id'])
         data = {
-            'resource_id': resource['id'],
-            'force': True,
-            'records': [
-                {'from': 'Brazil', 'to': 'Brazil', 'num': 2},
-                {'from': 'Brazil', 'to': 'Italy', 'num': 22}
+            u'resource_id': resource['id'],
+            u'force': True,
+            u'records': [
+                {u'from': u'Brazil', u'to': u'Brazil', u'num': 2},
+                {u'from': u'Brazil', u'to': u'Italy', u'num': 22}
             ],
         }
-        helpers.call_action('datastore_create', **data)
-        auth = {'Authorization': str(user['apikey'])}
+        helpers.call_action(u'datastore_create', **data)
+        auth = {u'Authorization': str(user['apikey'])}
         self.app.get(
-            url='/dataset/{id}/dictionary/{resource_id}'
+            url=u'/dataset/{id}/dictionary/{resource_id}'
             .format(id=str(dataset['name']),
                     resource_id=str(resource['id'])),
             extra_environ=auth)


### PR DESCRIPTION
Fixes #4332 

### Proposed fixes:
This was an exception caused by changes in templates like this:

https://github.com/ckan/ckan/pull/4062/files#diff-6e66e2fde5c1f5c9fa488ccccd6dfeabL4

(c.resource -> resource)
which broke these couple of renders which didn't have tests.

The problem only affects master.

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport - NO, it only affects master, not any releases
