### PR TITLE
Fix for test that didnt clean up properly, causing local error

### DIFF
--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -1275,6 +1275,7 @@ class TestPackageAutocompleteWithDatasetForm(helpers.FunctionalTestBase):
 
     @classmethod
     def teardown_class(cls):
+        super(TestPackageAutocompleteWithDatasetForm, cls).teardown_class()
         if p.plugin_loaded('example_idatasetform'):
             p.unload('example_idatasetform')
 


### PR DESCRIPTION
Fixes #4354

### Proposed fixes:
Fixes a test that was broken when run locally. As far as I can tell this didn't break on CircleCI because it runs them in parallel.

Affects master only - caused by [recent changes to this test](https://github.com/ckan/ckan/commit/a8b8548e895b#diff-c92cdbf4ff7391d90f31341452b90303L1277).

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
