### PR TITLE
Explicitly set default search field in search query

### DIFF
--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -20,7 +20,7 @@ _open_licenses = None
 VALID_SOLR_PARAMETERS = set([
     'q', 'fl', 'fq', 'rows', 'sort', 'start', 'wt', 'qf', 'bf', 'boost',
     'facet', 'facet.mincount', 'facet.limit', 'facet.field',
-    'extras', 'fq_list', 'tie', 'defType', 'mm'
+    'extras', 'fq_list', 'tie', 'defType', 'mm', 'df'
 ])
 
 # for (solr) package searches, this specifies the fields that are searched
@@ -311,9 +311,6 @@ class PackageSearchQuery(SearchQuery):
         if not q or q == '""' or q == "''":
             query['q'] = "*:*"
 
-        # Set default search field
-        query['df'] = 'text'
-        
         # number of results
         rows_to_return = min(1000, int(query.get('rows', 10)))
         if rows_to_return > 0:

--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -311,6 +311,9 @@ class PackageSearchQuery(SearchQuery):
         if not q or q == '""' or q == "''":
             query['q'] = "*:*"
 
+        # Set default search field
+        query['df'] = 'text'
+        
         # number of results
         rows_to_return = min(1000, int(query.get('rows', 10)))
         if rows_to_return > 0:

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1814,6 +1814,9 @@ def package_search(context, data_dict):
     for key in [key for key in data_dict.keys() if key.startswith('ext_')]:
         data_dict['extras'][key] = data_dict.pop(key)
 
+    # set default search field
+    data_dict.setdefault('df', 'text')
+
     # check if some extension needs to modify the search params
     for item in plugins.PluginImplementations(plugins.IPackageController):
         data_dict = item.before_search(data_dict)

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1815,7 +1815,7 @@ def package_search(context, data_dict):
         data_dict['extras'][key] = data_dict.pop(key)
 
     # set default search field
-    data_dict.setdefault('df', 'text')
+    data_dict['df'] = 'text'
 
     # check if some extension needs to modify the search params
     for item in plugins.PluginImplementations(plugins.IPackageController):


### PR DESCRIPTION

Fixes #3510, #4235 

### Proposed fixes:
Sets default search field in queries as the schema based default search field is deprecated in solr4 and non functioning in solr 6.6.

This should not affect instances running solr3.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
