### PR TITLE
[#4379] Fix edit slug button

### DIFF
--- a/ckan/public/base/javascript/plugins/jquery.slug-preview.js
+++ b/ckan/public/base/javascript/plugins/jquery.slug-preview.js
@@ -70,7 +70,7 @@
       '<div class="slug-preview">',
       '<strong></strong>',
       '<span class="slug-preview-prefix"></span><span class="slug-preview-value"></span>',
-      '<button class="btn btn-xs"></button>',
+      '<button class="btn btn-default btn-xs"></button>',
       '</div>'
     ].join('\n')
   };


### PR DESCRIPTION
Fixes #4379

### Proposed fixes:

Add the ``.btn-default`` CSS class to the button according to bs3's spec.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
