### PR TITLE
Wrong parameters in pg_dump

### DIFF
--- a/doc/maintaining/database-management.rst
+++ b/doc/maintaining/database-management.rst
@@ -64,7 +64,7 @@ and restoring a database and its content to/from a file.
 
 For example, first dump your CKAN database::
 
-    sudo -u postgres pg_dump --format=custom -d ckan_default > ckan.dump
+    sudo pg_dump -U postgres --format=custom --file=ckan.dump ckan_default
 
 .. warning::
 


### PR DESCRIPTION
I have seen documentation https://www.postgresql.org/docs/current/static/app-pgdump.html and "-u" and "-d" do not exist

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
