### PR TITLE
[4398] Trash batch-purging

### DIFF
--- a/ckan/controllers/admin.py
+++ b/ckan/controllers/admin.py
@@ -183,7 +183,7 @@ class AdminController(base.BaseController):
                     except Exception as inst:
                         msg = _('Problem purging revision %s: %s') % (id, inst)
                         msgs.append(msg)
-                h.flash_success(_('Purge %s complete') % (limit))
+                h.flash_success(_('Purge %s complete') % (index))
             else:
                 msgs.append(_('Action not implemented.'))
 

--- a/ckan/controllers/admin.py
+++ b/ckan/controllers/admin.py
@@ -144,7 +144,8 @@ class AdminController(base.BaseController):
                                                         request.params):
                 if 'purge-packages' in request.params:
                     revs_to_purge = []
-                    for pkg in c.deleted_packages:
+                    limit = 10
+                    for index, pkg in zip(range(limit), c.deleted_packages):
                         revisions = [x[0] for x in pkg.all_related_revisions]
                         # ensure no accidental purging of other(non-deleted)
                         # packages initially just avoided purging revisions
@@ -182,7 +183,7 @@ class AdminController(base.BaseController):
                     except Exception as inst:
                         msg = _('Problem purging revision %s: %s') % (id, inst)
                         msgs.append(msg)
-                h.flash_success(_('Purge complete'))
+                h.flash_success(_('Purge %s complete') % (limit))
             else:
                 msgs.append(_('Action not implemented.'))
 

--- a/ckan/controllers/admin.py
+++ b/ckan/controllers/admin.py
@@ -183,7 +183,7 @@ class AdminController(base.BaseController):
                     except Exception as inst:
                         msg = _('Problem purging revision %s: %s') % (id, inst)
                         msgs.append(msg)
-                h.flash_success(_('Purge %s complete') % (index))
+                h.flash_success(_('Purge %s complete') % (index + 1))
             else:
                 msgs.append(_('Action not implemented.'))
 

--- a/ckan/templates-bs2/admin/trash.html
+++ b/ckan/templates-bs2/admin/trash.html
@@ -6,7 +6,7 @@
   <ul class="user-list">
     {% for pkg in deleted_packages %}
       {% set title = pkg.title or pkg.name %}
-      <li>{{ h.link_to(h.truncate(title, truncate_title), h.url_for('dataset.read', id=pkg.name)) }}</li>
+      <li>{{ loop.index }} {{ h.link_to(h.truncate(title, truncate_title), h.url_for('dataset.read', id=pkg.name)) }}</li>
     {% endfor %}
 
   </ul>

--- a/ckan/templates/admin/trash.html
+++ b/ckan/templates/admin/trash.html
@@ -6,7 +6,7 @@
   <ul class="user-list">
     {% for pkg in deleted_packages %}
       {% set title = pkg.title or pkg.name %}
-      <li>{{ h.link_to(h.truncate(title, truncate_title), h.url_for('dataset.read', id=pkg.name)) }}</li>
+      <li>{{ loop.index }} {{ h.link_to(h.truncate(title, truncate_title), h.url_for('dataset.read', id=pkg.name)) }}</li>
     {% endfor %}
 
   </ul>

--- a/ckan/tests/controllers/test_admin.py
+++ b/ckan/tests/controllers/test_admin.py
@@ -347,7 +347,7 @@ class TestTrashView(helpers.FunctionalTestBase):
                                         status=302, extra_environ=env)
         purge_response = purge_response.follow(extra_environ=env)
         # redirected back to trash page
-        assert_true('Purge 3 complete' in purge_response)
+        assert_true('Purge 2 complete' in purge_response)
 
         # how many datasets after purge
         pkgs_before_purge = model.Session.query(model.Package).count()

--- a/ckan/tests/controllers/test_admin.py
+++ b/ckan/tests/controllers/test_admin.py
@@ -347,7 +347,7 @@ class TestTrashView(helpers.FunctionalTestBase):
                                         status=302, extra_environ=env)
         purge_response = purge_response.follow(extra_environ=env)
         # redirected back to trash page
-        assert_true('Purge complete' in purge_response)
+        assert_true('Purge 3 complete' in purge_response)
 
         # how many datasets after purge
         pkgs_before_purge = model.Session.query(model.Package).count()

--- a/ckan/views/admin.py
+++ b/ckan/views/admin.py
@@ -200,7 +200,7 @@ class TrashView(MethodView):
                 except Exception as inst:
                     msg = _(u'Problem purging revision %s: %s') % (id, inst)
                     msgs.append(msg)
-            h.flash_success(_(u'Purge %s complete') % (index))
+            h.flash_success(_(u'Purge %s complete') % (index + 1))
         else:
             msgs.append(_(u'Action not implemented.'))
 

--- a/ckan/views/admin.py
+++ b/ckan/views/admin.py
@@ -161,7 +161,8 @@ class TrashView(MethodView):
                 u'purge-revisions' in request.form):
             if u'purge-packages' in request.form:
                 revs_to_purge = []
-                for pkg in self.deleted_packages:
+                limit = 10
+                for index, pkg in zip(range(limit), self.deleted_packages):
                     revisions = [x[0] for x in pkg.all_related_revisions]
                     # ensure no accidental purging of other(non-deleted)
                     # packages initially just avoided purging revisions
@@ -199,7 +200,7 @@ class TrashView(MethodView):
                 except Exception as inst:
                     msg = _(u'Problem purging revision %s: %s') % (id, inst)
                     msgs.append(msg)
-            h.flash_success(_(u'Purge complete'))
+            h.flash_success(_(u'Purge %s complete') % (limit))
         else:
             msgs.append(_(u'Action not implemented.'))
 

--- a/ckan/views/admin.py
+++ b/ckan/views/admin.py
@@ -200,7 +200,7 @@ class TrashView(MethodView):
                 except Exception as inst:
                     msg = _(u'Problem purging revision %s: %s') % (id, inst)
                     msgs.append(msg)
-            h.flash_success(_(u'Purge %s complete') % (limit))
+            h.flash_success(_(u'Purge %s complete') % (index))
         else:
             msgs.append(_(u'Action not implemented.'))
 

--- a/doc/sysadmin-guide.rst
+++ b/doc/sysadmin-guide.rst
@@ -116,7 +116,8 @@ To permanently delete ("purge") a dataset:
 * Navigate to the dataset's "Edit" page, and delete it.
 * Visit ``http://<my-ckan-url>/ckan-admin/trash/``.
 
-This page shows all deleted datasets and allows you to delete them permanently.
+This page shows all deleted datasets and allows you to delete them permanently, 
+10 datasets at a time.
 
 .. warning::
 


### PR DESCRIPTION
Related to #4398 

### Proposed fixes:
Purge datasets 10 at a time to avoid timeouts when there are a lot of trash items.

Make the trash list a numbered list. Since the list does not do pagination, and the purge button is all the way in the bottom, the sysadmin needs to go to the bottom of the list to press "Purge."  Making it a numbered list, gives the sysadmin useful info when there a lot of datasets available for purging.

### Features:

- [x] includes tests covering changes
- [x] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
