### PR TITLE
[#4401] Fix for comparing the current with the chosen language

### DIFF
--- a/ckan/templates/snippets/language_selector.html
+++ b/ckan/templates/snippets/language_selector.html
@@ -3,7 +3,7 @@
   <label for="field-lang-select">{{ _('Language') }}</label>
   <select id="field-lang-select" name="url" data-module="autocomplete" data-module-dropdown-class="lang-dropdown" data-module-container-class="lang-container">
     {% for locale in h.get_available_locales() %}
-      <option value="{% url_for h.current_url(), locale=locale.short_name %}" {% if locale.identifier == current_lang %}selected="selected"{% endif %}>
+      <option value="{% url_for h.current_url(), locale=locale.short_name %}" {% if locale.short_name == current_lang %}selected="selected"{% endif %}>
         {{ locale.display_name or locale.english_name }}
       </option>
     {% endfor %}


### PR DESCRIPTION
Fixes #4401 

### Proposed fixes:
For some of the locales the locale identifier is different than the locale short_name and when the comparing is done between the locale.identifier and current_lang (which comes from the locale.short_name) the values for the same language are different. 


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
