### PR TITLE
Upgrade pyfakefs

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,7 @@ httpretty==0.8.3
 mock==2.0.0
 pycodestyle==2.2.0
 pip-tools==1.7.0
-pyfakefs==2.9
+pyfakefs==3.2
 Sphinx==1.7.5
 sphinx-rtd-theme==0.3.1
 


### PR DESCRIPTION
Fixes #4392 

### Proposed fixes:

Upgrade pyfakefs to avoid pbr conflict over mox3.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
