### PR TITLE
Don't re-register plugin helpers on flask_app, as it has been done on load_environment

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -308,7 +308,8 @@ def ckan_after_request(response):
 
 def helper_functions():
     u'''Make helper functions (`h`) available to Flask templates'''
-    helpers.load_plugin_helpers()
+    if not helpers.helper_functions:
+        helpers.load_plugin_helpers()
     return dict(h=helpers.helper_functions)
 
 


### PR DESCRIPTION
Otherwise this can cause issues like like ckan/ckanext-scheming#183