### PR TITLE
Fix KeyError in package_create

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -227,7 +227,7 @@ def package_create(context, data_dict):
     return_id_only = context.get('return_id_only', False)
 
     if return_id_only:
-        return context['id']
+        pkg.id
 
     return _get_action('package_show')(
                 context.copy(), {'id': pkg.id}

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -804,6 +804,24 @@ class TestDatasetCreate(helpers.FunctionalTestBase):
         assert('id' not in context)
         assert('package' not in context)
 
+    def test_package_return_id_only(self):
+        user = factories.Sysadmin()
+        context = {
+            'user': user['name'],
+            'ignore_auth': False,
+            'return_id_only': True,
+        }
+        returned_id = helpers.call_action(
+            'package_create',
+            context=context,
+            id='1234',
+            name='test-dataset',
+        )
+        assert(returned_id, '1234')
+        # check against context pollution
+        assert('id' not in context)
+        assert('package' not in context)
+
     def test_id_cant_already_exist(self):
         dataset = factories.Dataset()
         user = factories.Sysadmin()


### PR DESCRIPTION
Fixes #4418

### Proposed fixes:
When `return_id_only` is set, don't rely on the context['id'], rather return the id directly from the model.


### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
