### PR TITLE
support resource overrides in resources.config using fanstatic supersedes feature

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -206,6 +206,8 @@ def make_flask_stack(conf, **app_conf):
         app = plugin.make_middleware(app, config)
 
     # Fanstatic
+    fanstatic_enable_rollup = asbool(app_conf.get('fanstatic_enable_rollup',
+                                                  False))
     if debug:
         fanstatic_config = {
             'versioning': True,
@@ -213,6 +215,7 @@ def make_flask_stack(conf, **app_conf):
             'minified': False,
             'bottom': True,
             'bundle': False,
+            'rollup': fanstatic_enable_rollup,
         }
     else:
         fanstatic_config = {
@@ -221,6 +224,7 @@ def make_flask_stack(conf, **app_conf):
             'minified': True,
             'bottom': True,
             'bundle': True,
+            'rollup': fanstatic_enable_rollup,
         }
     root_path = config.get('ckan.root_path', None)
     if root_path:

--- a/ckan/config/middleware/pylons_app.py
+++ b/ckan/config/middleware/pylons_app.py
@@ -75,6 +75,8 @@ def make_pylons_stack(conf, full_stack=True, static_files=True,
                                     cleanup_pylons_response_string)
 
     # Fanstatic
+    fanstatic_enable_rollup = asbool(app_conf.get('fanstatic_enable_rollup',
+                                                  False))
     if asbool(config.get('debug', False)):
         fanstatic_config = {
             'versioning': True,
@@ -82,6 +84,7 @@ def make_pylons_stack(conf, full_stack=True, static_files=True,
             'minified': False,
             'bottom': True,
             'bundle': False,
+            'rollup': fanstatic_enable_rollup,
         }
     else:
         fanstatic_config = {
@@ -90,6 +93,7 @@ def make_pylons_stack(conf, full_stack=True, static_files=True,
             'minified': True,
             'bottom': True,
             'bundle': True,
+            'rollup': fanstatic_enable_rollup,
         }
     root_path = config.get('ckan.root_path', None)
     if root_path:

--- a/doc/contributing/frontend/resources.rst
+++ b/doc/contributing/frontend/resources.rst
@@ -111,6 +111,11 @@ the same as for the .ini config file.
         bootstrap/js/bootstrap-button.js
         font-awesome/css/font-awesome-ie7.css
 
+    [supersedes]
+
+    select2-upgraded.js = vendor/select2/select2.js
+
+
 
 [main]
 ~~~~~~
@@ -187,3 +192,9 @@ used.
 
 Groups can be referred to in many places in the
 resource.config file eg. [depends]
+
+[supersedes]
+~~~~~~~~~~~~
+
+Allows to override static files from other resources. Has to be enabled at the
+app config by setting fanstatic_enable_rollup = yes


### PR DESCRIPTION
Fanstatic resources support a [supersedes](http://www.fanstatic.org/en/0.12/api.html#fanstatic.Resource) argument which allows to override resources.

This PR exposes this functionality via the `resource.config` file. It also has to be enabled via the Fanstatic app config - which is done by setting `fanstatic_enable_rollup = yes` in the ckan config.

### Manual Testing Procedure
* Under an existing plugin directory, create a directory to hold the resources: `override_select2`
* Under the `override_select2` directory create the following files:
  * `upgraded-select.js`
    * Copy the contents of this file from `public/base/vendor/select2/select2.js`
    * Add a `foo: "bar",` attribute to the `Select2` object towards the end of the file
  * `resources.config`
```
[supersedes]

upgraded-select.js = vendor/select2/select2.js
```
* Edit the plugin's `plugin.py` and add the following line to the `update_config` method:
  * `p.toolkit.add_resource('override_select2', 'override_select2')`
* Edit the ckan app config, add the following line:
  * `fanstatic_enable_rollup = yes`
* Restart the app
* Open the browser console, type: `Select2.foo`
* Expected: `"bar"`
