### PR TITLE
Upgrade pip-tools

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,7 +8,7 @@ Flask-DebugToolbar==0.10.1
 httpretty==0.8.3
 mock==2.0.0
 pycodestyle==2.2.0
-pip-tools==1.7.0
+pip-tools==2.0.2
 pyfakefs==3.2
 Sphinx==1.7.5
 sphinx-rtd-theme==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,34 +5,34 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 argparse==1.4.0           # via ofs
-Babel==2.3.4              # via flask-babel
-Beaker==1.9.0             # via pylons
+babel==2.3.4
+beaker==1.9.0             # via pylons
 bleach==2.1.3
 click==6.7
 decorator==4.2.1          # via pylons, sqlalchemy-migrate
 fanstatic==0.12
-Flask-Babel==0.11.2
-Flask==0.12.2             # via flask-babel
-FormEncode==1.3.1         # via pylons
+flask-babel==0.11.2
+flask==0.12.2
+formencode==1.3.1         # via pylons
 funcsigs==1.0.2           # via beaker
 html5lib==1.0.1           # via bleach
 itsdangerous==0.24        # via flask
-Jinja2==2.8               # via flask, flask-babel
-Mako==1.0.7               # via pylons
-Markdown==2.6.7
-MarkupSafe==1.0           # via jinja2, mako, webhelpers
+jinja2==2.8
+mako==1.0.7               # via pylons
+markdown==2.6.7
+markupsafe==1.0           # via jinja2, mako, webhelpers
 nose==1.3.7               # via pylons
 ofs==0.4.2
-Pairtree==0.7.1-T
+pairtree==0.7.1-t
 passlib==1.6.5
 paste==1.7.5.1
-PasteDeploy==1.5.2        # via pastescript, pylons
-PasteScript==2.0.2        # via pylons
+pastedeploy==1.5.2        # via pastescript, pylons
+pastescript==2.0.2        # via pylons
 pbr==1.10.0               # via sqlalchemy-migrate
 polib==1.0.7
 psycopg2==2.7.3.2
-Pygments==2.2.0           # via weberror
-Pylons==0.9.7
+pygments==2.2.0           # via weberror
+pylons==0.9.7
 pysolr==3.6.0
 python-dateutil==1.5
 python-magic==0.4.15
@@ -43,25 +43,21 @@ repoze.lru==0.7           # via routes
 repoze.who-friendlyform==1.0.8
 repoze.who==2.3
 requests==2.11.1
-Routes==1.13              # via pylons
+routes==1.13
 rq==0.6.0
 simplejson==3.10.0
 six==1.11.0               # via bleach, html5lib, pastescript, pyutilib.component.core, sqlalchemy-migrate
 sqlalchemy-migrate==0.10.0
-SQLAlchemy==1.1.11        # via sqlalchemy-migrate
+sqlalchemy==1.1.11
 sqlparse==0.2.2
-Tempita==0.5.2            # via pylons, sqlalchemy-migrate, weberror
+tempita==0.5.2            # via pylons, sqlalchemy-migrate, weberror
 tzlocal==1.3
 unicodecsv==0.14.1
 vdm==0.14
 webencodings==0.5.1       # via html5lib
-WebError==0.13.1          # via pylons
-WebHelpers==1.3           # via pylons
-WebOb==1.0.8              # via fanstatic, pylons, repoze.who, repoze.who-friendlyform, weberror, webtest
-WebTest==1.4.3            # via pylons
-Werkzeug==0.14.1          # via flask
+weberror==0.13.1          # via pylons
+webhelpers==1.3
+webob==1.0.8
+webtest==1.4.3
+werkzeug==0.14.1          # via flask
 zope.interface==4.3.2
-
-# The following packages are commented out because they are
-# considered to be unsafe in a requirements file:
-# setuptools                # via repoze.who, zope.interface


### PR DESCRIPTION
Upgrade pip-tools so that pip-compile works with latest pip version (pip 18.0). Rerun pip-compile (cosmetic differences only in requirements.txt)

(btw I also looked into specifying requirements.in slightly looser, to allow patch updates to deps, but that assumes each dep agrees to do semantic versioning. Out of our deps I could only find 'bleach' and 'requests' stating they use semantic versioning, and pip-compile didn't seem to get newer versions so I left it for now.)

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
