### PR TITLE
Fix return_id_only behaviour broken by #4315

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -227,7 +227,7 @@ def package_create(context, data_dict):
     return_id_only = context.get('return_id_only', False)
 
     if return_id_only:
-        return context['id']
+        return pkg.id
 
     return _get_action('package_show')(
                 context.copy(), {'id': pkg.id}

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -5,6 +5,8 @@
 '''
 import __builtin__ as builtins
 
+import six
+
 import ckan
 import ckan.logic as logic
 import ckan.model as model
@@ -981,6 +983,15 @@ class TestDatasetCreate(helpers.FunctionalTestBase):
         tag_names = sorted([tag_dict['name']
                             for tag_dict in dataset['tags']])
         assert_equals(tag_names, ['russian', 'tolstoy'])
+
+    def test_return_id_only(self):
+        dataset = helpers.call_action(
+            'package_create',
+            name='test-id',
+            context={'return_id_only': True},
+        )
+
+        assert isinstance(dataset, six.string_types)
 
 
 class TestGroupCreate(helpers.FunctionalTestBase):

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -652,6 +652,20 @@ class TestDatasetUpdate(helpers.FunctionalTestBase):
                             for tag_dict in dataset_['tags']])
         assert_equals(tag_names, ['russian', 'tolstoy'])
 
+    def test_return_id_only(self):
+        user = factories.User()
+        dataset = factories.Dataset(
+            user=user)
+
+        updated_dataset = helpers.call_action(
+            'package_update',
+            id=dataset['id'],
+            notes='Test',
+            context={'return_id_only': True},
+        )
+
+        assert_equals(updated_dataset, dataset['id'])
+
 
 class TestUpdateSendEmailNotifications(object):
     @classmethod


### PR DESCRIPTION
When calling `package_create` or `package_update` you can request to get just the id instead of the whole dict by passing `return_id_only` in the context. This was broken on #4315. Yes, I know people don't like it but it's current documented behaviour so it should be kept :)

For reference this was added as returning the full dict involves a call to `package_show`, with performance implications when doing massive harvestings/imports/

