### PR TITLE
`default` validator replaces all falsey values

### DIFF
--- a/ckan/lib/navl/validators.py
+++ b/ckan/lib/navl/validators.py
@@ -74,11 +74,12 @@ def ignore(key, data, errors, context):
     raise StopOnError
 
 def default(default_value):
-
+    '''
+    Return default_value if key is missing or None.
+    '''
     def callable(key, data, errors, context):
-
         value = data.get(key)
-        if not value or value is missing:
+        if value is None or value is missing:
             data[key] = default_value
 
     return callable


### PR DESCRIPTION
Change the current behaviour of the core `default` validator:

| default(42) | current return value | new return value |
| - | - | - |
| (missing) | 42 | 42 |
| None | 42 | 42 |
| 100 | 100 | 100 |
| 0 | 42 | **0** |
| False | 42 | **False** |
| [] | 42 | **[]** |
| '' | 42 | **''** |
