### PR TITLE
[2317] If no ordering specified for datastore, use _id

### DIFF
--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1202,7 +1202,7 @@ def search_data(context, data_dict):
     select_columns = ', '.join(query_dict['select']).replace('%', '%%')
     ts_query = query_dict['ts_query'].replace('%', '%%')
     resource_id = data_dict['resource_id'].replace('%', '%%')
-    sort = query_dict['sort']
+    sort = query_dict('sort', '_id')
     limit = query_dict['limit']
     offset = query_dict['offset']
 

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -187,6 +187,9 @@ class TestDatastoreSearch(DatastoreLegacyTestBase):
         assert result['total'] == len(self.data['records'])
         assert result['records'] == self.expected_records, result['records']
 
+    def test_default_sort_order(self):
+        pass
+
     def test_search_private_dataset(self):
         group = self.dataset.get_groups()[0]
         context = {

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -124,12 +124,12 @@ class TestDatastoreSearch(DatastoreLegacyTestBase):
                        {'id': 'published'},
                        {'id': u'characters', u'type': u'_text'},
                        {'id': 'rating with %'}],
-            'records': [{u'b\xfck': 'annakarenina', 'author': 'tolstoy',
+            'records': [{u'b\xfck': 'warandpeace', 'author': 'tolstoy',
+                        'nested': {'a': 'b'}, 'rating with %': '99%'},
+                        {u'b\xfck': 'annakarenina', 'author': 'tolstoy',
                         'published': '2005-03-01', 'nested': ['b', {'moo': 'moo'}],
                         u'characters': [u'Princess Anna', u'Sergius'],
-                        'rating with %': '60%'},
-                        {u'b\xfck': 'warandpeace', 'author': 'tolstoy',
-                        'nested': {'a': 'b'}, 'rating with %': '99%'}
+                        'rating with %': '60%'}
                        ]
         }
         postparams = '%s=1' % json.dumps(cls.data)
@@ -186,9 +186,6 @@ class TestDatastoreSearch(DatastoreLegacyTestBase):
         result = res_dict['result']
         assert result['total'] == len(self.data['records'])
         assert result['records'] == self.expected_records, result['records']
-
-    def test_default_sort_order(self):
-        pass
 
     def test_search_private_dataset(self):
         group = self.dataset.get_groups()[0]


### PR DESCRIPTION
Fixes #2317

Default to ordering on the indexed _id if no other sort order is
specified.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
