### PR TITLE
package_search fl parameter issues

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1869,6 +1869,8 @@ def package_search(context, data_dict):
 
         if result_fl:
             for package in query.results:
+                if isinstance(package, text_type):
+                    package = {result_fl[0]: package}
                 if package.get('extras'):
                     package.update(package['extras'] )
                     package.pop('extras')

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -626,10 +626,11 @@ def default_autocomplete_schema(
 @validator_args
 def default_package_search_schema(
         ignore_missing, unicode_safe, list_of_strings,
-        natural_number_validator, int_validator, convert_to_json_if_string):
+        natural_number_validator, int_validator, convert_to_json_if_string,
+        convert_to_list_if_string):
     return {
         'q': [ignore_missing, unicode_safe],
-        'fl': [ignore_missing, list_of_strings],
+        'fl': [ignore_missing, convert_to_list_if_string],
         'fq': [ignore_missing, unicode_safe],
         'rows': [ignore_missing, natural_number_validator],
         'sort': [ignore_missing, unicode_safe],

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -869,7 +869,6 @@ class TestPackageSearch(helpers.FunctionalTestBase):
         search_result = helpers.call_action('package_search', q='rivers', fl=['id'])
         eq(search_result['results'], [{'id': d1['id']}])
 
-
     def test_search_all(self):
         factories.Dataset(title='Rivers')
         factories.Dataset(title='Lakes')

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -857,12 +857,18 @@ class TestPackageSearch(helpers.FunctionalTestBase):
         eq(search_result['count'], 1)
 
     def test_search_fl(self):
-        factories.Dataset(title='Rivers', name='test_ri')
-        factories.Dataset(title='Lakes')
+        d1 = factories.Dataset(title='Rivers', name='test_ri')
+        d2 = factories.Dataset(title='Lakes')
 
         search_result = helpers.call_action('package_search', q='rivers', fl=['title', 'name'])
-
         eq(search_result['results'], [{'title': 'Rivers', 'name': 'test_ri'}])
+
+        search_result = helpers.call_action('package_search', q='rivers', fl='title,name')
+        eq(search_result['results'], [{'title': 'Rivers', 'name': 'test_ri'}])
+
+        search_result = helpers.call_action('package_search', q='rivers', fl=['id'])
+        eq(search_result['results'], [{'id': d1['id']}])
+
 
     def test_search_all(self):
         factories.Dataset(title='Rivers')


### PR DESCRIPTION
`fl` parameter to package_search should also accept a list-like strings to make it more consistent with other APIs, and should not cause 500 error when only one field is passed.