### PR TITLE
Revert "Don't crash when plugin `identify()` doesn't set `g.user`."

### DIFF
--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -98,11 +98,8 @@ def identify_user():
     if authenticators:
         for item in authenticators:
             item.identify()
-            try:
-                if g.user:
-                    break
-            except AttributeError:
-                continue
+            if g.user:
+                break
 
     # We haven't identified the user so try the default methods
     if not getattr(g, u'user', None):


### PR DESCRIPTION
Reverts ckan/ckan#4249