### PR TITLE
datastore_search: q/fields/records_format edge case tests and fixes

### DIFF
--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -167,8 +167,8 @@ def _get_fields_types(context, data_dict):
     return field_types
 
 
-def _get_type(context, oid):
-    _cache_types(context['connection'])
+def _get_type(connection, oid):
+    _cache_types(connection)
     return _pg_types[oid]
 
 
@@ -253,7 +253,7 @@ def _get_fields(context, data_dict):
         if not field[0].startswith('_'):
             fields.append({
                 'id': field[0].decode('utf-8'),
-                'type': _get_type(context, field[1])
+                'type': _get_type(context['connection'], field[1])
             })
     return fields
 
@@ -1317,7 +1317,7 @@ def format_results(context, results, data_dict):
     for field in results.cursor.description:
         result_fields.append({
             'id': field[0].decode('utf-8'),
-            'type': _get_type(context, field[1])
+            'type': _get_type(context['connection'], field[1])
         })
 
     records = []

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -168,7 +168,7 @@ def _get_fields_types(context, data_dict):
 
 
 def _get_type(context, oid):
-    _cache_types(context)
+    _cache_types(context['connection'])
     return _pg_types[oid]
 
 
@@ -258,9 +258,8 @@ def _get_fields(context, data_dict):
     return fields
 
 
-def _cache_types(context):
+def _cache_types(connection):
     if not _pg_types:
-        connection = context['connection']
         results = connection.execute(
             'SELECT oid, typname FROM pg_type;'
         )
@@ -282,7 +281,7 @@ def _cache_types(context):
             _pg_types.clear()
 
             # redo cache types with json now available.
-            return _cache_types(context)
+            return _cache_types(connection)
 
         register_composite('nested', connection.connection, True)
 
@@ -1454,7 +1453,7 @@ def search(context, data_dict):
     engine = backend._get_read_engine()
     context['connection'] = engine.connect()
     timeout = context.get('query_timeout', _TIMEOUT)
-    _cache_types(context)
+    _cache_types(context['connection'])
 
     try:
         context['connection'].execute(
@@ -1483,7 +1482,7 @@ def search_sql(context, data_dict):
 
     context['connection'] = engine.connect()
     timeout = context.get('query_timeout', _TIMEOUT)
-    _cache_types(context)
+    _cache_types(context['connection'])
 
     sql = data_dict['sql'].replace('%', '%%')
 
@@ -1708,7 +1707,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
     def delete(self, context, data_dict):
         engine = self._get_write_engine()
         context['connection'] = engine.connect()
-        _cache_types(context)
+        _cache_types(context['connection'])
 
         trans = context['connection'].begin()
         try:
@@ -1750,7 +1749,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
         engine = get_write_engine()
         context['connection'] = engine.connect()
         timeout = context.get('query_timeout', _TIMEOUT)
-        _cache_types(context)
+        _cache_types(context['connection'])
 
         _rename_json_field(data_dict)
 

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -160,8 +160,12 @@ def _rename_field(data_dict, term, replace):
     return data_dict
 
 
-def _get_fields_types(context, data_dict):
-    all_fields = _get_fields(context['connection'], data_dict['resource_id'])
+def _get_fields_types(connection, resource_id):
+    u'''
+    return a {column_name: column_type} dict for the passed resource_id
+    including '_id' but excluding other '_'-prefixed columns.
+    '''
+    all_fields = _get_fields(connection, resource_id)
     all_fields.insert(0, {'id': '_id', 'type': 'int'})
     field_types = OrderedDict([(f['id'], f['type']) for f in all_fields])
     return field_types
@@ -1142,7 +1146,8 @@ def upsert_data(context, data_dict):
 
 
 def validate(context, data_dict):
-    fields_types = _get_fields_types(context, data_dict)
+    fields_types = _get_fields_types(
+        context['connection'], data_dict['resource_id'])
     data_dict_copy = copy.deepcopy(data_dict)
 
     # TODO: Convert all attributes that can be a comma-separated string to
@@ -1188,7 +1193,8 @@ def validate(context, data_dict):
 
 def search_data(context, data_dict):
     validate(context, data_dict)
-    fields_types = _get_fields_types(context, data_dict)
+    fields_types = _get_fields_types(
+        context['connection'], data_dict['resource_id'])
 
     query_dict = {
         'select': [],
@@ -1340,7 +1346,8 @@ def format_results(context, results, data_dict):
 
 def delete_data(context, data_dict):
     validate(context, data_dict)
-    fields_types = _get_fields_types(context, data_dict)
+    fields_types = _get_fields_types(
+        context['connection'], data_dict['resource_id'])
 
     query_dict = {
         'where': []

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -1206,14 +1206,14 @@ class TestDatastoreSearchRecordsFormat(DatastoreFunctionalTestBase):
             'datastore_search',
             resource_id=r['resource_id'],
             records_format=u'csv',
-            q=u'aaab',
-            fields=u'num, dt, txt',
+            fields=u'dt, num, txt',
             )
         assert_equals(r['fields'], [
-            {u'id': u'num', u'type': u'numeric'},
             {u'id': u'dt', u'type': u'timestamp'},
+            {u'id': u'num', u'type': u'numeric'},
             {u'id': u'txt', u'type': u'text'}])
         assert_equals(
             r['records'],
-            u'9,2020-01-02T00:00:00,aaab\n',
+            u'2020-01-02T00:00:00,9,aaab\n'
+            u'2020-01-01T00:00:00,9,aaac\n'
             )

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -26,7 +26,7 @@ assert_raises = nose.tools.assert_raises
 assert_in = nose.tools.assert_in
 
 
-class TestDatastoreSearchNewTest(DatastoreFunctionalTestBase):
+class TestDatastoreSearch(DatastoreFunctionalTestBase):
     def test_fts_on_field_calculates_ranks_only_on_that_specific_field(self):
         resource = factories.Resource()
         data = {
@@ -119,7 +119,7 @@ class TestDatastoreSearchNewTest(DatastoreFunctionalTestBase):
         assert 'total' not in result
 
 
-class TestDatastoreSearch(DatastoreLegacyTestBase):
+class TestDatastoreSearchLegacyTests(DatastoreLegacyTestBase):
     sysadmin_user = None
     normal_user = None
 
@@ -652,7 +652,7 @@ class TestDatastoreSearch(DatastoreLegacyTestBase):
         assert res_dict['error'].get('fields') is not None, res_dict['error']
 
 
-class TestDatastoreFullTextSearch(DatastoreLegacyTestBase):
+class TestDatastoreFullTextSearchLegacyTests(DatastoreLegacyTestBase):
     @classmethod
     def setup_class(cls):
         cls.app = helpers._get_test_app()
@@ -773,7 +773,7 @@ class TestDatastoreFullTextSearch(DatastoreLegacyTestBase):
         assert res_dict['success'], pprint.pformat(res_dict)
 
 
-class TestDatastoreSQL(DatastoreLegacyTestBase):
+class TestDatastoreSQLLegacyTests(DatastoreLegacyTestBase):
     sysadmin_user = None
     normal_user = None
 
@@ -1188,4 +1188,32 @@ class TestDatastoreSearchRecordsFormat(DatastoreFunctionalTestBase):
             u'2,9,2020-01-02T00:00:00,aaab\n'
             u'1,10,2020-01-01T00:00:00,aaab\n'
             u'3,9,2020-01-01T00:00:00,aaac\n'
+            )
+
+    def test_fields_results_csv(self):
+        ds = factories.Dataset()
+        r = helpers.call_action(
+            u'datastore_create',
+            resource={u'package_id': ds['id']},
+            fields=[
+                {u'id': u'num', u'type': u'numeric'},
+                {u'id': u'dt', u'type': u'timestamp'},
+                {u'id': u'txt', u'type': u'text'}],
+            records=[
+                {u'num': 9, u'dt': u'2020-01-02', u'txt': u'aaab'},
+                {u'num': 9, u'dt': u'2020-01-01', u'txt': u'aaac'}])
+        r = helpers.call_action(
+            'datastore_search',
+            resource_id=r['resource_id'],
+            records_format=u'csv',
+            q=u'aaab',
+            fields=u'num, dt, txt',
+            )
+        assert_equals(r['fields'], [
+            {u'id': u'num', u'type': u'numeric'},
+            {u'id': u'dt', u'type': u'timestamp'},
+            {u'id': u'txt', u'type': u'text'}])
+        assert_equals(
+            r['records'],
+            u'9,2020-01-02T00:00:00,aaab\n',
             )

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -126,7 +126,7 @@ class TestDatastoreSearchLegacyTests(DatastoreLegacyTestBase):
     @classmethod
     def setup_class(cls):
         cls.app = helpers._get_test_app()
-        super(TestDatastoreSearch, cls).setup_class()
+        super(TestDatastoreSearchLegacyTests, cls).setup_class()
         ctd.CreateTestData.create()
         cls.sysadmin_user = model.User.get('testsysadmin')
         cls.normal_user = model.User.get('annafan')
@@ -656,7 +656,7 @@ class TestDatastoreFullTextSearchLegacyTests(DatastoreLegacyTestBase):
     @classmethod
     def setup_class(cls):
         cls.app = helpers._get_test_app()
-        super(TestDatastoreFullTextSearch, cls).setup_class()
+        super(TestDatastoreFullTextSearchLegacyTests, cls).setup_class()
         ctd.CreateTestData.create()
         cls.sysadmin_user = model.User.get('testsysadmin')
         cls.normal_user = model.User.get('annafan')
@@ -780,7 +780,7 @@ class TestDatastoreSQLLegacyTests(DatastoreLegacyTestBase):
     @classmethod
     def setup_class(cls):
         cls.app = helpers._get_test_app()
-        super(TestDatastoreSQL, cls).setup_class()
+        super(TestDatastoreSQLLegacyTests, cls).setup_class()
         ctd.CreateTestData.create()
         cls.sysadmin_user = model.User.get('testsysadmin')
         cls.normal_user = model.User.get('annafan')


### PR DESCRIPTION
The latest `datastore_search` code doesn't handle some combinations of parameters `q`, `fields` and `records_format`. Expand test coverage and fix issues found, including issues with `fields` list returned.

PR in progress