### PR TITLE
Fix wrong config path

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -35,7 +35,7 @@ rst_epilog = '''
 .. |virtualenv| replace:: |virtualenv_parent_dir|/default
 .. |activate| replace:: . |virtualenv|/bin/activate
 .. |config_parent_dir| replace:: /etc/ckan
-.. |config_dir| replace:: |config_parent_dir|/default
+.. |config_dir| replace:: |config_parent_dir|
 .. |production.ini| replace:: |config_dir|/production.ini
 .. |development.ini| replace:: |config_dir|/development.ini
 .. |git_url| replace:: \https://github.com/ckan/ckan.git


### PR DESCRIPTION
### Proposed fixes:

getting-started.html refers to a configuration directory which does not exist (checked while building 2.8.1 using docker-compose).


### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
