### PR TITLE
datastore dump: add datastore_search-like parameters

### DIFF
--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -306,8 +306,8 @@ def _cache_types(connection):
 
             backend = DatastorePostgresqlBackend.get_active_backend()
             engine = backend._get_write_engine()
-            with engine.begin() as connection:
-                connection.execute(
+            with engine.begin() as write_connection:
+                write_connection.execute(
                     'CREATE TYPE "nested" AS (json {0}, extra text)'.format(
                         'json' if native_json else 'text'))
             _pg_types.clear()

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -167,8 +167,8 @@ def _get_fields_types(context, data_dict):
     return field_types
 
 
-def _get_type(context, oid):
-    _cache_types(context['connection'])
+def _get_type(connection, oid):
+    _cache_types(connection)
     return _pg_types[oid]
 
 
@@ -253,7 +253,7 @@ def _get_fields(context, data_dict):
         if not field[0].startswith('_'):
             fields.append({
                 'id': field[0].decode('utf-8'),
-                'type': _get_type(context, field[1])
+                'type': _get_type(context['connection'], field[1])
             })
     return fields
 
@@ -1317,7 +1317,7 @@ def format_results(context, results, data_dict):
     for field in results.cursor.description:
         result_fields.append({
             'id': field[0].decode('utf-8'),
-            'type': _get_type(context, field[1])
+            'type': _get_type(context['connection'], field[1])
         })
 
     records = []

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -168,7 +168,7 @@ def _get_fields_types(context, data_dict):
 
 
 def _get_type(context, oid):
-    _cache_types(context)
+    _cache_types(context['connection'])
     return _pg_types[oid]
 
 
@@ -258,9 +258,8 @@ def _get_fields(context, data_dict):
     return fields
 
 
-def _cache_types(context):
+def _cache_types(connection):
     if not _pg_types:
-        connection = context['connection']
         results = connection.execute(
             'SELECT oid, typname FROM pg_type;'
         )
@@ -282,7 +281,7 @@ def _cache_types(context):
             _pg_types.clear()
 
             # redo cache types with json now available.
-            return _cache_types(context)
+            return _cache_types(connection)
 
         register_composite('nested', connection.connection, True)
 
@@ -1454,7 +1453,7 @@ def search(context, data_dict):
     engine = backend._get_read_engine()
     context['connection'] = engine.connect()
     timeout = context.get('query_timeout', _TIMEOUT)
-    _cache_types(context)
+    _cache_types(context['connection'])
 
     try:
         context['connection'].execute(
@@ -1483,7 +1482,7 @@ def search_sql(context, data_dict):
 
     context['connection'] = engine.connect()
     timeout = context.get('query_timeout', _TIMEOUT)
-    _cache_types(context)
+    _cache_types(context['connection'])
 
     sql = data_dict['sql'].replace('%', '%%')
 
@@ -1708,7 +1707,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
     def delete(self, context, data_dict):
         engine = self._get_write_engine()
         context['connection'] = engine.connect()
-        _cache_types(context)
+        _cache_types(context['connection'])
 
         trans = context['connection'].begin()
         try:
@@ -1750,7 +1749,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
         engine = get_write_engine()
         context['connection'] = engine.connect()
         timeout = context.get('query_timeout', _TIMEOUT)
-        _cache_types(context)
+        _cache_types(context['connection'])
 
         _rename_json_field(data_dict)
 

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -171,7 +171,7 @@ def _get_fields_types(connection, resource_id):
     return field_types
 
 
-def _result_fields(fields_types, field_info, fields, q):
+def _result_fields(fields_types, field_info, fields):
     u'''
     return a list of field information based on the fields present,
     passed and query passed.
@@ -181,7 +181,6 @@ def _result_fields(fields_types, field_info, fields, q):
     :param field_info: dict returned from _get_field_info(..)
     :param fields: list of field names passed to datastore_search
         or None for all
-    :param q: dict or string q parameter passed to datastore_search
     '''
     result_fields = []
 
@@ -1306,8 +1305,7 @@ def search_data(context, data_dict):
     data_dict['fields'] = _result_fields(
         fields_types,
         _get_field_info(context['connection'], data_dict['resource_id']),
-        datastore_helpers.get_list(data_dict.get('fields')),
-        data_dict.get('q'))
+        datastore_helpers.get_list(data_dict.get('fields')))
 
     _unrename_json_field(data_dict)
 

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -400,16 +400,12 @@ def _where_clauses(data_dict, fields_types):
     return clauses
 
 
-def _textsearch_query(data_dict):
-    q = data_dict.get('q')
-    lang = _fts_lang(data_dict.get('lang'))
-
+def _textsearch_query(lang, q, plain):
     if not q:
         return '', ''
 
     statements = []
     rank_columns = []
-    plain = data_dict.get('plain', True)
     if isinstance(q, string_types):
         query, rank = _build_query_and_rank_statements(
             lang, q, plain)
@@ -1700,7 +1696,10 @@ class DatastorePostgresqlBackend(DatastoreBackend):
         else:
             field_ids = fields_types.keys()
 
-        ts_query, rank_column = _textsearch_query(data_dict)
+        ts_query, rank_column = _textsearch_query(
+            _fts_lang(data_dict.get('lang')),
+            data_dict.get('q'),
+            data_dict.get('plain', True))
         limit = data_dict.get('limit', 100)
         offset = data_dict.get('offset', 0)
 

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -160,8 +160,12 @@ def _rename_field(data_dict, term, replace):
     return data_dict
 
 
-def _get_fields_types(context, data_dict):
-    all_fields = _get_fields(context['connection'], data_dict['resource_id'])
+def _get_fields_types(connection, resource_id):
+    u'''
+    return a {column_name: column_type} dict for the passed resource_id
+    including '_id' but excluding other '_'-prefixed columns.
+    '''
+    all_fields = _get_fields(connection, resource_id)
     all_fields.insert(0, {'id': '_id', 'type': 'int'})
     field_types = OrderedDict([(f['id'], f['type']) for f in all_fields])
     return field_types
@@ -1142,7 +1146,8 @@ def upsert_data(context, data_dict):
 
 
 def validate(context, data_dict):
-    fields_types = _get_fields_types(context, data_dict)
+    fields_types = _get_fields_types(
+        context['connection'], data_dict['resource_id'])
     data_dict_copy = copy.deepcopy(data_dict)
 
     # TODO: Convert all attributes that can be a comma-separated string to
@@ -1188,7 +1193,8 @@ def validate(context, data_dict):
 
 def search_data(context, data_dict):
     validate(context, data_dict)
-    fields_types = _get_fields_types(context, data_dict)
+    fields_types = _get_fields_types(
+        context['connection'], data_dict['resource_id'])
 
     query_dict = {
         'select': [],
@@ -1340,7 +1346,8 @@ def format_results(context, results, data_dict):
 
 def delete_data(context, data_dict):
     validate(context, data_dict)
-    fields_types = _get_fields_types(context, data_dict)
+    fields_types = _get_fields_types(
+        context['connection'], data_dict['resource_id'])
 
     query_dict = {
         'where': []

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -177,6 +177,7 @@ def _result_fields(fields_types, field_info, fields, q):
     passed and query passed.
 
     :param fields_types: OrderedDict returned from _get_fields_types(..)
+        with rank column types added by plugins' datastore_search
     :param field_info: dict returned from _get_field_info(..)
     :param fields: list of field names passed to datastore_search
         or None for all
@@ -190,7 +191,7 @@ def _result_fields(fields_types, field_info, fields, q):
     for field_id in fields:
         f = {u'id': field_id, u'type': fields_types[field_id]}
         if field_id in field_info:
-            f['info'] = field_info[f['id']]
+            f[u'info'] = field_info[f['id']]
         result_fields.append(f)
     return result_fields
 
@@ -391,41 +392,49 @@ def _where_clauses(data_dict, fields_types):
                     clause_str = u'_full_text @@ {0}'.format(query_field)
                     clauses.append((clause_str,))
 
-                clause_str = (u'to_tsvector({0}, cast("{1}" as text)) '
-                              u'@@ {2}').format(
-                                  literal_string(lang),
-                                  field, query_field)
+                clause_str = (
+                    u'to_tsvector({0}, cast({1} as text)) @@ {2}').format(
+                        literal_string(lang),
+                        identifier(field),
+                        query_field)
                 clauses.append((clause_str,))
 
     return clauses
 
 
 def _textsearch_query(lang, q, plain):
+    u'''
+    :param lang: language for to_tsvector
+    :param q: string to search _full_text or dict to search columns
+    :param plain: True to use plainto_tsquery, False for to_tsquery
+
+    return (query, rank_columns) based on passed text/dict query
+    rank_columns is a {alias: statement} dict where alias is "rank" for
+    _full_text queries, and "rank <column-name>" for column search
+    '''
     if not q:
-        return '', ''
+        return '', {}
 
     statements = []
-    rank_columns = []
+    rank_columns = {}
     if isinstance(q, string_types):
         query, rank = _build_query_and_rank_statements(
             lang, q, plain)
         statements.append(query)
-        rank_columns.append(rank)
+        rank_columns[u'rank'] = rank
     elif isinstance(q, dict):
         for field, value in q.iteritems():
             query, rank = _build_query_and_rank_statements(
                 lang, value, plain, field)
             statements.append(query)
-            rank_columns.append(rank)
+            rank_columns[u'rank ' + field] = rank
 
     statements_str = ', ' + ', '.join(statements)
-    rank_columns_str = ', '.join(rank_columns)
-    return statements_str, rank_columns_str
+    return statements_str, rank_columns
 
 
 def _build_query_and_rank_statements(lang, query, plain, field=None):
     query_alias = _ts_query_alias(field)
-    rank_alias = _ts_rank_alias(field)
     lang_literal = literal_string(lang)
     query_literal = literal_string(query)
     if plain:
@@ -436,14 +445,12 @@ def _build_query_and_rank_statements(lang, query, plain, field=None):
         lang_literal=lang_literal,
         literal=query_literal, alias=query_alias)
     if field is None:
-        rank_field = '_full_text'
+        rank_field = u'_full_text'
     else:
-        rank_field = u'to_tsvector({lang_literal}, cast("{field}" as text))'
-        rank_field = rank_field.format(lang_literal=lang_literal, field=field)
-    rank_statement = u'ts_rank({rank_field}, {query_alias}, 32) AS {alias}'
-    rank_statement = rank_statement.format(rank_field=rank_field,
-                                           query_alias=query_alias,
-                                           alias=rank_alias)
+        rank_field = u'to_tsvector({0}, cast({1} as text))'.format(
+            lang_literal, identifier(field))
+    rank_statement = u'ts_rank({0}, {1}, 32)'.format(
+        rank_field, query_alias)
     return statement, rank_statement
 
 
@@ -454,25 +461,18 @@ def _fts_lang(lang=None):
     return lang or default_fts_lang
 
 
-def _ts_rank_alias(field=None):
-    rank_alias = u'rank'
-    if field:
-        rank_alias += u' ' + field
-    return u'"{0}"'.format(rank_alias)
+def _sort(sort, fields_types, rank_columns):
+    u'''
+    :param sort: string or list sort parameter passed to datastore_search,
+        use None if not given
+    :param fields_types: OrderedDict returned from _get_fields_types(..)
+    :param rank_columns: rank_columns returned from _ts_query(..)
 
-
-def _sort(data_dict, fields_types):
-    sort = data_dict.get('sort')
+    returns sort expression as a string. When sort is None use rank_columns
+    to order by best text search match
+    '''
     if not sort:
-        q = data_dict.get('q')
-        if q:
-            if isinstance(q, string_types):
-                return [_ts_rank_alias()]
-            elif isinstance(q, dict):
-                return [_ts_rank_alias(field) for field in q
-                        if field not in fields_types]
-        else:
-            return []
+        return rank_columns.values()
 
     clauses = datastore_helpers.get_list(sort, False)
 
@@ -490,7 +490,7 @@ def _ts_query_alias(field=None):
     query_alias = u'query'
     if field:
         query_alias += u' ' + field
-    return u'"{0}"'.format(query_alias)
+    return identifier(query_alias)
 
 
 def _get_aliases(context, data_dict):
@@ -1691,19 +1691,26 @@ class DatastorePostgresqlBackend(DatastoreBackend):
 
         fields = data_dict.get('fields')
 
+        ts_query, rank_columns = _textsearch_query(
+            _fts_lang(data_dict.get('lang')),
+            data_dict.get('q'),
+            data_dict.get('plain', True))
+        # mutate parameter to add rank columns for _result_fields
+        for rank_alias in rank_columns:
+            fields_types[rank_alias] = u'float'
+
         if fields:
             field_ids = datastore_helpers.get_list(fields)
         else:
             field_ids = fields_types.keys()
 
-        ts_query, rank_column = _textsearch_query(
-            _fts_lang(data_dict.get('lang')),
-            data_dict.get('q'),
-            data_dict.get('plain', True))
         limit = data_dict.get('limit', 100)
         offset = data_dict.get('offset', 0)
 
-        sort = _sort(data_dict, fields_types)
+        sort = _sort(
+            data_dict.get('sort'),
+            fields_types,
+            rank_columns)
         where = _where_clauses(data_dict, fields_types)
 
         select_cols = []
@@ -1719,12 +1726,15 @@ class DatastorePostgresqlBackend(DatastoreBackend):
                     fmt = u"to_json({0})".format(fmt)
             elif typ.startswith(u'_') or typ.endswith(u'[]'):
                 fmt = u'array_to_json({0})'
+
+            if field_id in rank_columns:
+                select_cols.append((fmt + ' as {1}').format(
+                    rank_columns[field_id], identifier(field_id)))
+                continue
+
             if records_format == u'objects':
                 fmt += u' as {0}'
-            select_cols.append(fmt.format(
-                identifier(field_id)))
-        if rank_column:
-            select_cols.append(rank_column)
+            select_cols.append(fmt.format(identifier(field_id)))
 
         query_dict['distinct'] = data_dict.get('distinct', False)
         query_dict['select'] += select_cols

--- a/ckanext/datastore/commands.py
+++ b/ckanext/datastore/commands.py
@@ -86,4 +86,6 @@ def dump(ctx, resource_id, output_file, config, format, offset, limit, bom):
         fmt=format,
         offset=offset,
         limit=limit,
-        options={u'bom': bom})
+        options={u'bom': bom},
+        sort='_id',
+        search_params={})

--- a/ckanext/datastore/commands.py
+++ b/ckanext/datastore/commands.py
@@ -87,5 +87,5 @@ def dump(ctx, resource_id, output_file, config, format, offset, limit, bom):
         offset=offset,
         limit=limit,
         options={u'bom': bom},
-        sort='_id',
+        sort=u'_id',
         search_params={})

--- a/ckanext/datastore/controller.py
+++ b/ckanext/datastore/controller.py
@@ -66,8 +66,8 @@ class DatastoreController(BaseController):
     def dump(self, resource_id):
         data, errors = dict_fns.validate(dict(request.GET), dump_schema())
         if errors:
-            abort(400, u'\n'.join(u'{0}: {1}'.format(k, ' '.join(e))
-                for k, e in errors.items()))
+            abort(400, u'\n'.join(
+                u'{0}: {1}'.format(k, ' '.join(e)) for k, e in errors.items()))
 
         try:
             dump_to(
@@ -142,7 +142,8 @@ class DatastoreController(BaseController):
             })
 
 
-def dump_to(resource_id, output, fmt, offset, limit, options, sort, search_params):
+def dump_to(
+        resource_id, output, fmt, offset, limit, options, sort, search_params):
     if fmt == 'csv':
         writer_factory = csv_writer
         records_format = 'csv'

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -168,9 +168,6 @@ class DatastorePlugin(p.SingletonPlugin):
 
     def datastore_validate(self, context, data_dict, fields_types):
         column_names = fields_types.keys()
-        fields = data_dict.get('fields')
-        if fields:
-            data_dict['fields'] = list(set(fields) - set(column_names))
 
         filters = data_dict.get('filters', {})
         for key in filters.keys():
@@ -181,11 +178,17 @@ class DatastorePlugin(p.SingletonPlugin):
         if q:
             if isinstance(q, string_types):
                 del data_dict['q']
+                column_names.append(u'rank')
             elif isinstance(q, dict):
                 for key in q.keys():
                     if key in fields_types and isinstance(q[key],
                                                           string_types):
+                        column_names.append(u'rank ' + key)
                         del q[key]
+
+        fields = data_dict.get('fields')
+        if fields:
+            data_dict['fields'] = list(set(fields) - set(column_names))
 
         language = data_dict.get('language')
         if language:

--- a/ckanext/datastore/tests/test_dump.py
+++ b/ckanext/datastore/tests/test_dump.py
@@ -125,13 +125,14 @@ class TestDatastoreDump(DatastoreLegacyTestBase):
 
     def test_dump_q_and_fields(self):
         auth = {'Authorization': str(self.normal_user.apikey)}
-        res = self.app.get('/datastore/dump/{0}?q=warandpeace&fields=nested,author&format=json'.format(str(
-            self.data['resource_id'])), extra_environ=auth)
+        res = self.app.get(
+            u'/datastore/dump/{0}?q=warandpeace&fields=nested,author'
+            .format(str(self.data['resource_id'])), extra_environ=auth)
         content = res.body.decode('utf-8')
 
         expected_content = (
             u'nested,author\r\n'
-            u'"{""a"": ""b""}",tolstoy\r\n')
+            u'"{""a"": ""b""}",tolstoy\n')
         assert_equals(content, expected_content)
 
     def test_dump_tsv(self):

--- a/ckanext/datastore/tests/test_dump.py
+++ b/ckanext/datastore/tests/test_dump.py
@@ -123,6 +123,17 @@ class TestDatastoreDump(DatastoreLegacyTestBase):
             u'{""moo"": ""moo""}]"\n')
         assert_equals(content, expected_content)
 
+    def test_dump_q_and_fields(self):
+        auth = {'Authorization': str(self.normal_user.apikey)}
+        res = self.app.get('/datastore/dump/{0}?q=warandpeace&fields=nested,author&format=json'.format(str(
+            self.data['resource_id'])), extra_environ=auth)
+        content = res.body.decode('utf-8')
+
+        expected_content = (
+            u'nested,author\r\n'
+            u'"{""a"": ""b""}",tolstoy\r\n')
+        assert_equals(content, expected_content)
+
     def test_dump_tsv(self):
         auth = {'Authorization': str(self.normal_user.apikey)}
         res = self.app.get('/datastore/dump/{0}?limit=1&format=tsv'.format(str(

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -1206,14 +1206,14 @@ class TestDatastoreSearchRecordsFormat(DatastoreFunctionalTestBase):
             'datastore_search',
             resource_id=r['resource_id'],
             records_format=u'csv',
-            q=u'aaab',
-            fields=u'num, dt, txt',
+            fields=u'dt, num, txt',
             )
         assert_equals(r['fields'], [
-            {u'id': u'num', u'type': u'numeric'},
             {u'id': u'dt', u'type': u'timestamp'},
+            {u'id': u'num', u'type': u'numeric'},
             {u'id': u'txt', u'type': u'text'}])
         assert_equals(
             r['records'],
-            u'9,2020-01-02T00:00:00,aaab\n',
+            u'2020-01-02T00:00:00,9,aaab\n'
+            u'2020-01-01T00:00:00,9,aaac\n'
             )

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -26,7 +26,7 @@ assert_raises = nose.tools.assert_raises
 assert_in = nose.tools.assert_in
 
 
-class TestDatastoreSearchNewTest(DatastoreFunctionalTestBase):
+class TestDatastoreSearch(DatastoreFunctionalTestBase):
     def test_fts_on_field_calculates_ranks_only_on_that_specific_field(self):
         resource = factories.Resource()
         data = {
@@ -119,7 +119,7 @@ class TestDatastoreSearchNewTest(DatastoreFunctionalTestBase):
         assert 'total' not in result
 
 
-class TestDatastoreSearch(DatastoreLegacyTestBase):
+class TestDatastoreSearchLegacyTests(DatastoreLegacyTestBase):
     sysadmin_user = None
     normal_user = None
 
@@ -652,7 +652,7 @@ class TestDatastoreSearch(DatastoreLegacyTestBase):
         assert res_dict['error'].get('fields') is not None, res_dict['error']
 
 
-class TestDatastoreFullTextSearch(DatastoreLegacyTestBase):
+class TestDatastoreFullTextSearchLegacyTests(DatastoreLegacyTestBase):
     @classmethod
     def setup_class(cls):
         cls.app = helpers._get_test_app()
@@ -773,7 +773,7 @@ class TestDatastoreFullTextSearch(DatastoreLegacyTestBase):
         assert res_dict['success'], pprint.pformat(res_dict)
 
 
-class TestDatastoreSQL(DatastoreLegacyTestBase):
+class TestDatastoreSQLLegacyTests(DatastoreLegacyTestBase):
     sysadmin_user = None
     normal_user = None
 
@@ -1188,4 +1188,32 @@ class TestDatastoreSearchRecordsFormat(DatastoreFunctionalTestBase):
             u'2,9,2020-01-02T00:00:00,aaab\n'
             u'1,10,2020-01-01T00:00:00,aaab\n'
             u'3,9,2020-01-01T00:00:00,aaac\n'
+            )
+
+    def test_fields_results_csv(self):
+        ds = factories.Dataset()
+        r = helpers.call_action(
+            u'datastore_create',
+            resource={u'package_id': ds['id']},
+            fields=[
+                {u'id': u'num', u'type': u'numeric'},
+                {u'id': u'dt', u'type': u'timestamp'},
+                {u'id': u'txt', u'type': u'text'}],
+            records=[
+                {u'num': 9, u'dt': u'2020-01-02', u'txt': u'aaab'},
+                {u'num': 9, u'dt': u'2020-01-01', u'txt': u'aaac'}])
+        r = helpers.call_action(
+            'datastore_search',
+            resource_id=r['resource_id'],
+            records_format=u'csv',
+            q=u'aaab',
+            fields=u'num, dt, txt',
+            )
+        assert_equals(r['fields'], [
+            {u'id': u'num', u'type': u'numeric'},
+            {u'id': u'dt', u'type': u'timestamp'},
+            {u'id': u'txt', u'type': u'text'}])
+        assert_equals(
+            r['records'],
+            u'9,2020-01-02T00:00:00,aaab\n',
             )

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -1221,14 +1221,28 @@ class TestDatastoreSearchRecordsFormat(DatastoreFunctionalTestBase):
             'datastore_search',
             resource_id=r['resource_id'],
             records_format=u'csv',
-            fields=u'dt, num, txt',
+            fields=u'dt',
             q=u'aaac',
             )
         assert_equals(r['fields'], [
             {u'id': u'dt', u'type': u'timestamp'},
-            {u'id': u'num', u'type': u'numeric'},
-            {u'id': u'txt', u'type': u'text'}])
+            ])
         assert_equals(
             r['records'],
-            u'2020-01-01T00:00:00,9,aaac\n'
+            u'2020-01-01T00:00:00\n'
+            )
+        r = helpers.call_action(
+            'datastore_search',
+            resource_id=r['resource_id'],
+            records_format=u'csv',
+            fields=u'txt, rank txt',
+            q={u'txt': u'aaac'},
+            )
+        assert_equals(r['fields'], [
+            {u'id': u'txt', u'type': u'text'},
+            {u'id': u'rank txt', u'type': u'float'},
+            ])
+        assert_equals(
+            r['records'][:7],
+            u'aaac,0.'
             )

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -126,7 +126,7 @@ class TestDatastoreSearchLegacyTests(DatastoreLegacyTestBase):
     @classmethod
     def setup_class(cls):
         cls.app = helpers._get_test_app()
-        super(TestDatastoreSearch, cls).setup_class()
+        super(TestDatastoreSearchLegacyTests, cls).setup_class()
         ctd.CreateTestData.create()
         cls.sysadmin_user = model.User.get('testsysadmin')
         cls.normal_user = model.User.get('annafan')
@@ -656,7 +656,7 @@ class TestDatastoreFullTextSearchLegacyTests(DatastoreLegacyTestBase):
     @classmethod
     def setup_class(cls):
         cls.app = helpers._get_test_app()
-        super(TestDatastoreFullTextSearch, cls).setup_class()
+        super(TestDatastoreFullTextSearchLegacyTests, cls).setup_class()
         ctd.CreateTestData.create()
         cls.sysadmin_user = model.User.get('testsysadmin')
         cls.normal_user = model.User.get('annafan')
@@ -780,7 +780,7 @@ class TestDatastoreSQLLegacyTests(DatastoreLegacyTestBase):
     @classmethod
     def setup_class(cls):
         cls.app = helpers._get_test_app()
-        super(TestDatastoreSQL, cls).setup_class()
+        super(TestDatastoreSQLLegacyTests, cls).setup_class()
         ctd.CreateTestData.create()
         cls.sysadmin_user = model.User.get('testsysadmin')
         cls.normal_user = model.User.get('annafan')

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -40,7 +40,7 @@ class TestDatastoreSearch(DatastoreFunctionalTestBase):
         result = helpers.call_action('datastore_create', **data)
         search_data = {
             'resource_id': resource['id'],
-            'fields': 'from',
+            'fields': 'from, rank from',
             'q': {
                 'from': 'Brazil'
             },
@@ -1215,5 +1215,20 @@ class TestDatastoreSearchRecordsFormat(DatastoreFunctionalTestBase):
         assert_equals(
             r['records'],
             u'2020-01-02T00:00:00,9,aaab\n'
+            u'2020-01-01T00:00:00,9,aaac\n'
+            )
+        r = helpers.call_action(
+            'datastore_search',
+            resource_id=r['resource_id'],
+            records_format=u'csv',
+            fields=u'dt, num, txt',
+            q=u'aaac',
+            )
+        assert_equals(r['fields'], [
+            {u'id': u'dt', u'type': u'timestamp'},
+            {u'id': u'num', u'type': u'numeric'},
+            {u'id': u'txt', u'type': u'text'}])
+        assert_equals(
+            r['records'],
             u'2020-01-01T00:00:00,9,aaac\n'
             )


### PR DESCRIPTION
This is a small change that accepts new parameters to datastore dump and passes them through to the underlying datastore_search call(s):

**NOTE** this depends on #4462, please review that one first

| parameter | description | new | exists in datastore_search |
| - | - | - | - |
| filters | e.g. `{"key1": "a", "key2": "b"}` | :heavy_check_mark: | :heavy_check_mark: |
| q | full-text query | :heavy_check_mark: | :heavy_check_mark: |
| distinct | return only distinct rows (default: false) | :heavy_check_mark: | :heavy_check_mark: |
| plain | treat as plain text query (default: false) | :heavy_check_mark: | :heavy_check_mark: |
| language | language of the full text query | :heavy_check_mark: | :heavy_check_mark: |
| fields | fields to return | :heavy_check_mark: | :heavy_check_mark: |
| sort | e.g. `"fieldname1, fieldname2 desc"` | :heavy_check_mark: | :heavy_check_mark: |
| limit | maximum number of rows to return (default all rows) | | :heavy_check_mark: |
| offset | offset this number of rows | | :heavy_check_mark: |
| format | `"csv"`, `"tsv"`, `"json"`, or `"xml"` | | |
| bom | byte order mark (default: False) | | |

