### PR TITLE
[#4336] Remove html5 shim from stats extension.

### DIFF
--- a/ckanext/stats/templates/ckanext/stats/index.html
+++ b/ckanext/stats/templates/ckanext/stats/index.html
@@ -189,11 +189,5 @@
 
 {% block scripts %}
   {{ super() }}
-{#
-Hellish hack to get excanvas to work in IE8. We disable html5shiv from
-overriding the createElement() method on this page.
-See: http://stackoverflow.com/questions/10208062/using-flot-with-bootstrap-ie8-incompatibility
-#}
-{% resource "vendor/block_html5_shim" %}
-{% resource "ckanext_stats/stats" %}
+  {% resource "ckanext_stats/stats" %}
 {% endblock %}


### PR DESCRIPTION
html5.js was removed in commit #3705 but still referenced in
the stats extension. Currently this causes an error when the page
loads in CKAN 2.8 installs.

Fixes #4336 

### Proposed fixes:

Removing references to html5.js.

This will remove support for older IE versions which
will only cause some issues for CKAN 2.8 users with the old
bootstrap 2 theme being used.

Leave references to `block_html5_shim` in the following files as 
they are for bootstrap 2 and docs which seems consitent with
other bs2 templates and the docs provided a helpful example.

* ckan/public-bs2/base/vendor/resource.config
* doc/contributing/frontend/resources.rst

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
