### PR TITLE
Remove instruction to create datastore db

### DIFF
--- a/doc/maintaining/installing/install-from-docker-compose.rst
+++ b/doc/maintaining/installing/install-from-docker-compose.rst
@@ -168,20 +168,17 @@ against the database and import / export files from ``$VOL_CKAN_HOME``.
 ---------------------------
 3. Datastore and datapusher
 ---------------------------
-To enable the datastore, the datastore database and database users have to be created before
-enabling the datastore and datapusher settings in the ``production.ini``.
+The datastore database and user are created when the `db` container is first started, however we need to do some additional configuration before enabling the datastore and datapusher settings in the ``production.ini``.
 
-a. Create and configure datastore database
+a. Configure datastore database
 
-With running CKAN containers, execute the built-in setup scripts against the ``db`` container::
+With running CKAN containers, execute the built-in setup script against the ``db`` container::
 
-    docker exec -it db sh /docker-entrypoint-initdb.d/00_create_datastore.sh
     docker exec ckan /usr/local/bin/ckan-paster --plugin=ckan datastore set-permissions -c /etc/ckan/production.ini | docker exec -i db psql -U ckan
 
-The first script will create the datastore database and the datastore readonly user in the ``db``
-container. The second script is the output of ``paster ckan set-permissions`` - however,
+The script pipes in the output of ``paster ckan set-permissions`` - however,
 as this output can change in future versions of CKAN, we set the permissions directly.
-The effect of these scripts is persisted in the named volume ``docker_pg_data``.
+The effect of this script is persisted in the named volume ``docker_pg_data``.
 
 .. note:: We re-use the already privileged default user of the CKAN database as read/write user
     for the datastore. The database user (``ckan``) is hard-coded, the password is supplied through


### PR DESCRIPTION
Fixes #4378

### Proposed fixes:

This PR removes the instruction to create the datastore db, as  the datastore creation script is run automatically when the Postgres `db` container first runs. See the [docker image docs](https://docs.docker.com/samples/library/postgres/#how-to-extend-this-image) for more information on automatic script execution in`/docker-entrypoint-initdb.d`.