### PR TITLE
Run CKAN container when db is ready

### DIFF
--- a/contrib/docker/ckan-entrypoint.sh
+++ b/contrib/docker/ckan-entrypoint.sh
@@ -40,6 +40,11 @@ write_config () {
   ckan-paster make-config --no-interactive ckan "$CONFIG"
 }
 
+# Wait for PostgreSQL
+while ! pg_isready -h db -U postgres; do
+  sleep 1;
+done
+
 # If we don't already have a config file, bootstrap
 if [ ! -e "$CONFIG" ]; then
   write_config

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -60,6 +60,8 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     volumes:
       - pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
 
   solr:
     container_name: solr

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       - db
       - solr
       - redis
+    depends_on:
+      - db
     ports:
       - "0.0.0.0:${CKAN_PORT}:5000"
     environment:


### PR DESCRIPTION
Fixes #3075
Fixes #3319

### Proposed fixes:

Docker allows to do health checks inside docker-compose.yml files since 2.1. This allows to specify when to run a container based on the health status of its dependencies. With this patch CKAN container is started only when the PostgreSQL database is ready.
Current docker-compose.yml version is 3.0, so there is no compatibility issue (docker-compose.yml 3.0 requires Docker Engine 1.13.0+, while 2.1 needs 1.12.0+).

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
