### PR TITLE
[Docs] Update bootstrap reference.

### DIFF
--- a/doc/theming/templates.rst
+++ b/doc/theming/templates.rst
@@ -679,7 +679,7 @@ use the right HTML tags and CSS classes.
 
 There are two places to look for CSS classes available in CKAN:
 
-1. The `Bootstrap 2.3.2 docs <http://getbootstrap.com/2.3.2/components.html>`_. All of the HTML, CSS and JavaScript
+1. The `Bootstrap 3.3.7 docs <https://getbootstrap.com/docs/3.3/components/>`_. All of the HTML, CSS and JavaScript
    provided by Bootstrap is available to use in CKAN.
 
 2. CKAN's development primer page, which can be found on any CKAN site at


### PR DESCRIPTION
Change bootstrap from version 2.3.2 to 3.3.7.
This was changed in CKAN 2.8.0.

Fixes #

### Proposed fixes:

Update documentation to current bootstrap version.

### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
