### PR TITLE
Allow chaining off core actions

### DIFF
--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -430,11 +430,13 @@ def get_action(action):
                 auth_function.auth_audit_exempt = True
                 fetched_actions[name] = auth_function
     for name, func_list in chained_actions.iteritems():
-        if name not in fetched_actions:
+        if name not in fetched_actions and name not in _actions:
+            # nothing to override from plugins or core
             raise NotFound('The action %r is not found for chained action' % (
                 name))
         for func in reversed(func_list):
-            prev_func = fetched_actions[name]
+            # try other plugins first, fall back to core
+            prev_func = fetched_actions.get(name, _actions.get(name))
             fetched_actions[name] = functools.partial(func, prev_func)
 
     # Use the updated ones in preference to the originals.

--- a/ckanext/datastore/tests/test_chained_action.py
+++ b/ckanext/datastore/tests/test_chained_action.py
@@ -4,11 +4,17 @@ import nose
 import ckan.plugins as p
 import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
+from ckan.logic.action.get import package_list as core_package_list
 
 from ckanext.datastore.tests.helpers import DatastoreFunctionalTestBase
 
 assert_equals = nose.tools.assert_equals
 assert_raises = nose.tools.assert_raises
+
+package_list_message = u'The content of this message is largely irrelevant'
+
+class TestActionException(Exception):
+    pass
 
 
 @p.toolkit.chained_action
@@ -22,11 +28,19 @@ def datastore_delete(up_func, context, data_dict):
     return result
 
 
+@p.toolkit.chained_action
+def package_list(next_func, context, data_dict):
+    # check it's received the core function as the first arg
+    assert_equals(next_func, core_package_list)
+    raise TestActionException(package_list_message)
+
+
 class ExampleDataStoreDeletedWithCountPlugin(p.SingletonPlugin):
     p.implements(p.IActions)
 
     def get_actions(self):
-        return ({u'datastore_delete': datastore_delete})
+        return ({u'datastore_delete': datastore_delete,
+                 u'package_list': package_list})
 
 
 class TestChainedAction(DatastoreFunctionalTestBase):
@@ -67,3 +81,8 @@ class TestChainedAction(DatastoreFunctionalTestBase):
         helpers.call_action(u'datastore_create', **data)
 
         return resource
+
+    def test_chain_core_action(self):
+        with assert_raises(TestActionException) as raise_context:
+            helpers.call_action(u'package_list', {})
+        assert_equals(raise_context.exception.message, package_list_message)

--- a/ckanext/datastore/tests/test_chained_action.py
+++ b/ckanext/datastore/tests/test_chained_action.py
@@ -13,6 +13,7 @@ assert_raises = nose.tools.assert_raises
 
 package_list_message = u'The content of this message is largely irrelevant'
 
+
 class TestActionException(Exception):
     pass
 


### PR DESCRIPTION
Attempt to find an action from another plugin first, but failing that, override from the core actions.

### Proposed fixes:
Similar to #4491, but for actions rather than auth functions. Allows plugins to override actions defined in the core CKAN logic.

I've added a small test in the `test_chained_action.py` file in the datastore tests just because it seemed like the most relevant place to put it without creating a new file; let me know if I should move it!


### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
