### PR TITLE
Allow to define legacy route mappings as a dict in config

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -907,10 +907,12 @@ def build_nav(menu_item, title, **kw):
 def map_pylons_to_flask_route_name(menu_item):
     '''returns flask routes for old fashioned route names'''
     # Pylons to Flask legacy route names mappings
-    if config.get('ckan.legacy_route_mappings'):
-        if isinstance(config.get('ckan.legacy_route_mappings'), string_types):
-            LEGACY_ROUTE_NAMES.update(json.loads(config.get(
-                'ckan.legacy_route_mappings')))
+    mappings = config.get('ckan.legacy_route_mappings')
+    if mappings:
+        if isinstance(mappings, string_types):
+            LEGACY_ROUTE_NAMES.update(json.loads(mappings))
+        elif isinstance(mappings, dict):
+            LEGACY_ROUTE_NAMES.update(mappings)
 
     if menu_item in LEGACY_ROUTE_NAMES:
         log.info('Route name "{}" is deprecated and will be removed.\

--- a/ckan/tests/controllers/test_home.py
+++ b/ckan/tests/controllers/test_home.py
@@ -66,6 +66,16 @@ class TestHome(helpers.FunctionalTestBase):
         response = app.get(url_for('home'))
         assert 'Welcome to CKAN' in response.body
 
+    @helpers.change_config('ckan.legacy_route_mappings',
+                           {'my_home_route': 'home.index'})
+    def test_map_pylons_to_flask_route_using_dict(self):
+        app = self._get_test_app()
+        response = app.get(url_for('my_home_route'))
+        assert 'Welcome to CKAN' in response.body
+
+        response = app.get(url_for('home'))
+        assert 'Welcome to CKAN' in response.body
+
 
 class TestI18nURLs(helpers.FunctionalTestBase):
 


### PR DESCRIPTION
The current code only updates the core default list if the `ckan.legacy_route_mappings` is a string (which is probably how it comes from the ini file). But this setting can also be set by extensions directly on the config object, and it makes more sense to do it as a dict.
