### PR TITLE
[#4247] Allow extensions not to set a c.user (regression fix)

### DIFF
--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -122,7 +122,6 @@ def identify_user():
                     break
             except AttributeError:
                 continue
-            
 
     # We haven't identified the user so try the default methods
     if not getattr(g, u'user', None):

--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -117,8 +117,12 @@ def identify_user():
     if authenticators:
         for item in authenticators:
             item.identify()
-            if g.user:
-                break
+            try:
+                if g.user:
+                    break
+            except AttributeError:
+                continue
+            
 
     # We haven't identified the user so try the default methods
     if not getattr(g, u'user', None):


### PR DESCRIPTION
credits @ashleysommer

Fixes #4247


@amercader I went ahead and did the exact same pull request @ashleysommer had done.
If you remember, PR #4249 was merge into _branch 2.8_ but not _master_. You asked for a new PR to master so here it is.