### PR TITLE
[#3592] Implement python-feedgen and deprecate webhelpers for Atom feeds.

### DIFF
--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -1121,7 +1121,7 @@ def history(package_type, id):
                 title=item_title,
                 link=item_link,
                 description=item_description,
-                author={'name': item_author_name},
+                author={u'name': item_author_name},
                 pubDate=item_pubdate,
             )
         response = make_response(feed.atom_str(encoding=u'utf-8'))

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -1084,13 +1084,13 @@ def history(package_type, id):
     format = request.args.get(u'format', u'')
     if format == u'atom':
         # Generate and return Atom 1.0 document.
-        from webhelpers.feedgenerator import Atom1Feed
-        feed = Atom1Feed(
+        from feedgen.feed import FeedGenerator
+        feed = FeedGenerator(
             title=_(u'CKAN Dataset Revision History'),
             link=h.url_for(
                 controller=u'revision', action=u'read', id=g.pkg_dict[u'name']
             ),
-            description=_(u'Recent changes to CKAN Dataset: ') +
+            subtitle=_(u'Recent changes to CKAN Dataset: ') +
             (g.pkg_dict[u'title'] or u''),
             language=text_type(i18n.get_lang()),
         )
@@ -1121,11 +1121,11 @@ def history(package_type, id):
                 title=item_title,
                 link=item_link,
                 description=item_description,
-                author_name=item_author_name,
-                pubdate=item_pubdate,
+                author={'name': item_author_name},
+                pubDate=item_pubdate,
             )
-        response = make_response(feed.writeString(u'utf-8'))
-        response.headers[u'Content-Type'] = u'application/atom+xml'
+        response = make_response(feed.atom_str(encoding=u'utf-8'))
+        response.heaatom_strders[u'Content-Type'] = u'application/atom+xml'
         return response
 
     package_type = g.pkg_dict[u'type'] or u'dataset'

--- a/ckan/views/feed.py
+++ b/ckan/views/feed.py
@@ -105,10 +105,10 @@ def output_feed(results, feed_title, feed_description, feed_link, feed_url,
         fe = feed.add_entry()
         fe.title(pkg.get(u'title', u''))
         fe.link(href=h.url_for(u'api.action',
-                          logic_function=u'package_read',
-                          id=pkg['id'],
-                          ver=3,
-                          _external=True))
+                logic_function=u'package_read',
+                id=pkg['id'],
+                ver=3,
+                _external=True))
         fe.description(pkg.get(u'notes', u''))
         fe.updated(iso8601.parse_date(pkg.get(u'metadata_modified')))
         fe.published(iso8601.parse_date(pkg.get(u'metadata_created')))
@@ -125,8 +125,8 @@ def output_feed(results, feed_title, feed_description, feed_link, feed_url,
                                id=pkg['name'],
                                ver=3,
                                _external=True),
-                               text_type(len(json.dumps(pkg))),
-                               u'application/json')
+                     text_type(len(json.dumps(pkg))),
+                     u'application/json')
         # TODO: webhelpers allowed **additional_fields because it was using
         # args instead of methods, a fix might be needed for this
 

--- a/ckan/views/feed.py
+++ b/ckan/views/feed.py
@@ -3,9 +3,7 @@
 import logging
 import urlparse
 
-from datetime import datetime
-import dateutil.parser
-import dateutil.tz
+import iso8601
 
 from flask import Blueprint, make_response
 from six import text_type
@@ -112,8 +110,8 @@ def output_feed(results, feed_title, feed_description, feed_link, feed_url,
                           ver=3,
                           _external=True))
         fe.description(pkg.get(u'notes', u''))
-        fe.updated()
-        fe.published() # TODO: fix published datetime using the datetime lib
+        fe.updated(iso8601.parse_date(pkg.get(u'metadata_modified')))
+        fe.published(iso8601.parse_date(pkg.get(u'metadata_created')))
         fe.id(_create_atom_id(u'/dataset/%s' % pkg['id']))
         fe.author({'name': pkg.get(u'author', u''),
                    'email': pkg.get(u'author_email', u'')})

--- a/ckan/views/feed.py
+++ b/ckan/views/feed.py
@@ -92,7 +92,7 @@ def output_feed(results, feed_title, feed_description, feed_link, feed_url,
         pass
     feed.subtitle(feed_description)
     feed.language(u'en')
-    feed.author({'name': author_name})
+    feed.author({u'name': author_name})
     feed.id(feed_guid)
 
     for pkg in results:
@@ -113,8 +113,8 @@ def output_feed(results, feed_title, feed_description, feed_link, feed_url,
         fe.updated(iso8601.parse_date(pkg.get(u'metadata_modified')))
         fe.published(iso8601.parse_date(pkg.get(u'metadata_created')))
         fe.id(_create_atom_id(u'/dataset/%s' % pkg['id']))
-        fe.author({'name': pkg.get(u'author', u''),
-                   'email': pkg.get(u'author_email', u'')})
+        fe.author({u'name': pkg.get(u'author', u''),
+                   u'email': pkg.get(u'author_email', u'')})
         # TODO: fix category, feedgen's ensure_format() requires dict/list
         try:
             fe.category(t['name'] for t in pkg.get(u'tags', []))

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -663,12 +663,12 @@ def history(id, group_type, is_organization):
     format = request.params.get(u'format', u'')
     if format == u'atom':
         # Generate and return Atom 1.0 document.
-        from webhelpers.feedgenerator import Atom1Feed
-        feed = Atom1Feed(
+        from feedgen.feed import FeedGenerator
+        feed = FeedGenerator(
             title=_(u'CKAN Group Revision History'),
             link=h.url_for(
                 group_type + u'.read', id=group_dict[u'name']),
-            description=_(u'Recent changes to CKAN Group: ') +
+            subtitle=_(u'Recent changes to CKAN Group: ') +
             group_dict['display_name'],
             language=text_type(get_lang()), )
         for revision_dict in group_revisions:
@@ -695,8 +695,9 @@ def history(id, group_type, is_organization):
                 title=item_title,
                 link=item_link,
                 description=item_description,
-                author_name=item_author_name,
-                pubdate=item_pubdate, )
+                author={'name': item_author_name},
+                pubDate=item_pubdate,
+            )
         feed.content_type = u'application/atom+xml'
         return feed.writeString(u'utf-8')
 

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -695,7 +695,7 @@ def history(id, group_type, is_organization):
                 title=item_title,
                 link=item_link,
                 description=item_description,
-                author={'name': item_author_name},
+                author={u'name': item_author_name},
                 pubDate=item_pubdate,
             )
         feed.content_type = u'application/atom+xml'

--- a/requirements.in
+++ b/requirements.in
@@ -33,6 +33,8 @@ tzlocal==1.3
 unicodecsv>=0.9
 vdm==0.14
 WebHelpers==1.3
+feedgen==0.7.0
+iso8601==0.1.12
 WebOb==1.0.8
 WebTest==1.4.3  # need to pin this so that Pylons does not install a newer version that conflicts with WebOb==1.0.8
 zope.interface==4.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,14 +13,17 @@ chardet==3.0.4            # via requests
 click==6.7
 decorator==4.3.0          # via pylons, sqlalchemy-migrate
 fanstatic==0.12
+feedgen==0.7.0
 flask-babel==0.11.2
 flask==0.12.4
 formencode==1.3.1         # via pylons
 funcsigs==1.0.2           # via beaker
 html5lib==1.0.1           # via bleach
 idna==2.7                 # via requests
+iso8601==0.1.12
 itsdangerous==0.24        # via flask
 jinja2==2.8
+lxml==4.2.5               # via feedgen
 mako==1.0.7               # via pylons
 markdown==2.6.7
 markupsafe==1.0           # via jinja2, mako, webhelpers
@@ -61,8 +64,6 @@ vdm==0.14
 webencodings==0.5.1       # via html5lib
 weberror==0.13.1          # via pylons
 webhelpers==1.3
-feedgen==0.7.0
-iso8601==0.1.12
 webob==1.0.8
 webtest==1.4.3
 werkzeug==0.14.1          # via flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,6 +62,7 @@ webencodings==0.5.1       # via html5lib
 weberror==0.13.1          # via pylons
 webhelpers==1.3
 feedgen==0.7.0
+iso8601==0.1.12
 webob==1.0.8
 webtest==1.4.3
 werkzeug==0.14.1          # via flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,6 +61,7 @@ vdm==0.14
 webencodings==0.5.1       # via html5lib
 weberror==0.13.1          # via pylons
 webhelpers==1.3
+feedgen==0.7.0
 webob==1.0.8
 webtest==1.4.3
 werkzeug==0.14.1          # via flask


### PR DESCRIPTION
Fixes #3592 

### Proposed fixes:

1. Implement python-feedgen as feed generator for Atom feeds. This module is maintained (the last update was in May 2018), unlike the current webhelpers module.
2. Remove the custom _FixedAtom1Feed class, because python-feedgen contains its features out-of-the-box.
3. Use the iso8601 module for simple ISO datetime format conversion, which makes the updated and published dates of datasets easier to maintain.

I had trouble with the link, categories and additional_fields features so I might need some help there. However, the weird thing with the link is that it gets generated even if that line is deleted, so I might be missing something. I have added comments in the code for these three too, so lets see if this fix fits the needs before anything else is done.
