### PR TITLE
Upgrade httpretty from 0.8.3 to 0.9.5

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@ coveralls   #Let Unpinned - Requires latest coveralls
 docutils==0.12
 factory-boy==2.1.1
 Flask-DebugToolbar==0.10.1
-httpretty==0.8.3
+httpretty==0.9.5
 mock==2.0.0
 pycodestyle==2.2.0
 pip-tools==2.0.2


### PR DESCRIPTION
Fixes #4537 

### Proposed fixes:

Upgrade httpretty to avoid conflicts.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
