### PR TITLE
Remove test.ckan.net

### DIFF
--- a/test-core.ini
+++ b/test-core.ini
@@ -54,7 +54,7 @@ package_form = standard
 licenses_group_url =
 # pyamqplib or queue
 carrot_messaging_library = queue
-ckan.site_url = http://test.ckan.net
+ckan.site_url = http://localhost
 package_new_return_url = http://localhost/dataset/<NAME>?test=new
 package_edit_return_url = http://localhost/dataset/<NAME>?test=edit
 ckan.extra_resource_fields = alt_url


### PR DESCRIPTION
Fixes #4540 (WIP)

### Proposed fixes:

Replace hard-coded values of `ckan.site_url` and remove references to `//test.ckan.net`.

### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

### Todo:

- [X] ./test-core.ini
- [ ] ./ckanext/example_igroupform/tests/test_controllers.py
- [ ] ./ckanext/datastore/tests/test_info.py
- [ ] ./ckan/tests/logic/action/test_get.py
- [ ] ./ckan/tests/legacy/logic/test_action.py
- [ ] ./ckan/tests/legacy/functional/test_pagination.py
- [ ] ./ckan/tests/legacy/functional/api/base.py
- [ ] ./ckan/tests/controllers/test_util.py

Checklist generated with:
```$ grep -rl '//test.ckan.net' . | xargs -n1 echo '- [ ]'```