### PR TITLE
Allow dataset creation without adding any resources

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -667,9 +667,10 @@ class PackageController(base.BaseController):
                 except NotFound:
                     abort(404, _('The dataset {id} could not be found.'
                                  ).format(id=id))
-                if asbool(config.get('ckan.dataset.create_on_ui_requires_resources', 'True')) \
+                if asbool(config.get(
+                    'ckan.dataset.create_on_ui_requires_resources', 'True')) \
                     and not len(data_dict['resources']):
-                    # no data and configured to require resource so keep on page
+                    # no data and configured to require resource: stay on page
                     msg = _('You must add at least one data resource')
                     # On new templates do not use flash message
 

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -667,8 +667,8 @@ class PackageController(base.BaseController):
                 except NotFound:
                     abort(404, _('The dataset {id} could not be found.'
                                  ).format(id=id))
-                if not len(data_dict['resources']):
-                    # no data so keep on page
+                if asbool(config.get('ckan.dataset.create.require.resource', 'True')) and not len(data_dict['resources']):
+                    # no data and configured to require resource so keep on page
                     msg = _('You must add at least one data resource')
                     # On new templates do not use flash message
 

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -667,7 +667,8 @@ class PackageController(base.BaseController):
                 except NotFound:
                     abort(404, _('The dataset {id} could not be found.'
                                  ).format(id=id))
-                if asbool(config.get('ckan.dataset.create.require.resource', 'True')) and not len(data_dict['resources']):
+                if asbool(config.get('ckan.dataset.create_on_ui_requires_resources', 'True')) \
+                    and not len(data_dict['resources']):
                     # no data and configured to require resource so keep on page
                     msg = _('You must add at least one data resource')
                     # On new templates do not use flash message

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -1859,6 +1859,20 @@ example.
 Form Settings
 -------------
 
+.. ckan.dataset.create.require.resource
+
+ckan.dataset.create.require.resource
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+ckan.dataset.create.require.resource = False
+
+Default value: True
+
+If False, there is no need to add any resources when creating a new dataset.
+
+
 .. _package_new_return_url:
 
 package_new_return_url

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -1859,14 +1859,13 @@ example.
 Form Settings
 -------------
 
-.. ckan.dataset.create.require.resource
+.. ckan.dataset.create_on_ui_requires_resources
 
-ckan.dataset.create.require.resource
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ckan.dataset.create_on_ui_requires_resources
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Example::
-
-ckan.dataset.create.require.resource = False
+    ckan.dataset.create_on_ui_requires_resources = False
 
 Default value: True
 


### PR DESCRIPTION
# Fixes

Allows the user to create a dataset without adding a resource

### Proposed fixes:

See the following:
 https://github.com/ckan/ckan/issues/1090
 https://stackoverflow.com/questions/39496757/can-i-add-a-dataset-in-ckan-without-specifying-the-actual-data-link-or-file
 https://github.com/ckan/ckan/compare/master...smartlane:add-dataset-without-adding-data
 https://github.com/ckan/ckan/pull/2327
 https://github.com/ckan/ckan/pull/2316


### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
