### PR TITLE
Escape sender and recipient in mailer.

### DIFF
--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -45,8 +45,8 @@ def _mail_recipient(recipient_name, recipient_email,
             msg.add_header(k, v)
     subject = Header(subject.encode('utf-8'), 'utf-8')
     msg['Subject'] = subject
-    msg['From'] = _("%s <%s>") % (sender_name, mail_from)
-    recipient = u"%s <%s>" % (recipient_name, recipient_email)
+    msg['From'] = _(""\%s"\ <%s>") % (sender_name, mail_from)
+    recipient = u""\%s\" <%s>" % (recipient_name, recipient_email)
     msg['To'] = Header(recipient, 'utf-8')
     msg['Date'] = Utils.formatdate(time())
     msg['X-Mailer'] = "CKAN %s" % ckan.__version__


### PR DESCRIPTION
Wrap the sender and recipient in double quotes to 
allow special characters and prevent issues with email headers.

Fixes #4343

### Proposed fixes:

Wrap sender and recipient in double quotes to avoid issues with special chars.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
