### PR TITLE
Use g.template_title_delimiter wherever it possible

### DIFF
--- a/ckan/lib/app_globals.py
+++ b/ckan/lib/app_globals.py
@@ -42,7 +42,7 @@ app_globals_from_config_details = {
         # has been setup in load_environment():
     'ckan.site_id': {},
     'ckan.recaptcha.publickey': {'name': 'recaptcha_publickey'},
-    'ckan.template_title_deliminater': {'default': '-'},
+    'ckan.template_title_delimiter': {'default': '-'},
     'ckan.template_head_end': {},
     'ckan.template_footer_end': {},
     'ckan.dumps_url': {},

--- a/ckan/templates-bs2/base.html
+++ b/ckan/templates-bs2/base.html
@@ -42,7 +42,7 @@
     <title>
       {%- block title -%}
         {%- block subtitle %}{% endblock -%}
-        {%- if self.subtitle()|trim %} {{ g.template_title_deliminater }} {% endif -%}
+        {%- if self.subtitle()|trim %} {{ g.template_title_delimiter }} {% endif -%}
         {{ g.site_title }}
       {%- endblock -%}
     </title>

--- a/ckan/templates-bs2/dataviewer/base.html
+++ b/ckan/templates-bs2/dataviewer/base.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 
-{% block subtitle %}{{ h.dataset_display_name(package) }} - {{h.resource_display_name(resource) }}{% endblock %}
+{% block subtitle %}{{ h.dataset_display_name(package) }} {{ g.template_title_delimiter }} {{h.resource_display_name(resource) }}{% endblock %}
 
 {# remove any scripts #}
 {% block scripts %}

--- a/ckan/templates-bs2/group/about.html
+++ b/ckan/templates-bs2/group/about.html
@@ -1,6 +1,6 @@
 {% extends "group/read_base.html" %}
 
-{% block subtitle %}{{ _('About') }} - {{ super() }}{% endblock %}
+{% block subtitle %}{{ _('About') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1>

--- a/ckan/templates-bs2/group/activity_stream.html
+++ b/ckan/templates-bs2/group/activity_stream.html
@@ -1,6 +1,6 @@
 {% extends "group/read_base.html" %}
 
-{% block subtitle %}{{ _('Activity Stream') }} - {{ super() }}{% endblock %}
+{% block subtitle %}{{ _('Activity Stream') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
   <h2 class="hide-heading">{% block page_heading %}{{ _('Activity Stream') }}{% endblock %}</h2>

--- a/ckan/templates-bs2/group/admins.html
+++ b/ckan/templates-bs2/group/admins.html
@@ -1,6 +1,6 @@
 {% extends "group/read_base.html" %}
 
-{% block subtitle %}{{ _('Administrators') }} - {{ group_dict.title or group_dict.name }}{% endblock %}
+{% block subtitle %}{{ _('Administrators') }} {{ g.template_title_delimiter }} {{ group_dict.title or group_dict.name }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="hide-heading">{% block page_heading %}{{ _('Administrators') }}{% endblock %}</h1>

--- a/ckan/templates-bs2/group/followers.html
+++ b/ckan/templates-bs2/group/followers.html
@@ -1,6 +1,6 @@
 {% extends "group/read_base.html" %}
 
-{% block subtitle %}{{ _('Followers') }} - {{ group_dict.title or group_dict.name }}{% endblock %}
+{% block subtitle %}{{ _('Followers') }} {{ g.template_title_delimiter }} {{ group_dict.title or group_dict.name }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="hide-heading">{% block page_heading %}{{ _('Followers') }}{% endblock %}</h1>

--- a/ckan/templates-bs2/group/history.html
+++ b/ckan/templates-bs2/group/history.html
@@ -1,6 +1,6 @@
 {% extends "group/read_base.html" %}
 
-{% block subtitle %}{{ _('History') }} - {{ group_dict.display_name }}{% endblock %}
+{% block subtitle %}{{ _('History') }} {{ g.template_title_delimiter }} {{ group_dict.display_name }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="hide-heading">{{ _('History') }}</h1>

--- a/ckan/templates-bs2/group/members.html
+++ b/ckan/templates-bs2/group/members.html
@@ -1,6 +1,6 @@
 {% extends "group/edit_base.html" %}
 
-{% block subtitle %}{{ _('Members') }} - {{ group_dict.display_name }} - {{ _('Groups') }}{% endblock %}
+{% block subtitle %}{{ _('Members') }} {{ g.template_title_delimiter }} {{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ _('Groups') }}{% endblock %}
 
 {% block page_primary_action %}
   {% link_for _('Add Member'), named_route=group_type+'.member_new', id=group_dict.id, class_='btn btn-primary', icon='plus-square' %}

--- a/ckan/templates-bs2/group/read_base.html
+++ b/ckan/templates-bs2/group/read_base.html
@@ -1,6 +1,6 @@
 {% extends "page.html" %}
 
-{% block subtitle %}{{ h.get_translated(group_dict, 'title') or group_dict.display_name }} - {{ _('Groups') }}{% endblock %}
+{% block subtitle %}{{ h.get_translated(group_dict, 'title') or group_dict.display_name }} {{ g.template_title_delimiter }} {{ _('Groups') }}{% endblock %}
 
 {% block breadcrumb_content %}
   <li>{% link_for _('Groups'), named_route=group_type+'.index' %}</li>

--- a/ckan/templates-bs2/organization/about.html
+++ b/ckan/templates-bs2/organization/about.html
@@ -1,6 +1,6 @@
 {% extends "organization/read_base.html" %}
 
-{% block subtitle %}{{ _('About') }} - {{ super() }}{% endblock %}
+{% block subtitle %}{{ _('About') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1>{% block page_heading %}{{ c.group_dict.display_name }}{% endblock %}</h1>

--- a/ckan/templates-bs2/organization/activity_stream.html
+++ b/ckan/templates-bs2/organization/activity_stream.html
@@ -1,6 +1,6 @@
 {% extends "organization/read_base.html" %}
 
-{% block subtitle %}{{ _('Activity Stream') }} - {{ super() }}{% endblock %}
+{% block subtitle %}{{ _('Activity Stream') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
   <h2 class="hide-heading">{% block page_heading %}{{ _('Activity Stream') }}{% endblock %}</h2>

--- a/ckan/templates-bs2/organization/admins.html
+++ b/ckan/templates-bs2/organization/admins.html
@@ -1,6 +1,6 @@
 {% extends "organization/read_base.html" %}
 
-{% block subtitle %}{{ _('Administrators') }} - {{ c.group_dict.title or c.group_dict.name }}{% endblock %}
+{% block subtitle %}{{ _('Administrators') }} {{ g.template_title_delimiter }} {{ c.group_dict.title or c.group_dict.name }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="hide-heading">{% block page_heading %}{{ _('Administrators') }}{% endblock %}</h1>

--- a/ckan/templates-bs2/organization/bulk_process.html
+++ b/ckan/templates-bs2/organization/bulk_process.html
@@ -1,6 +1,6 @@
 {% extends "organization/edit_base.html" %}
 
-{% block subtitle %}{{ _('Edit datasets') }} - {{ super() }}{% endblock %}
+{% block subtitle %}{{ _('Edit datasets') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block page_primary_action %}
   {% link_for _('Add dataset'), named_route='dataset.new', group=c.group_dict.id, class_='btn btn-primary', icon='plus-square' %}

--- a/ckan/templates-bs2/organization/edit.html
+++ b/ckan/templates-bs2/organization/edit.html
@@ -1,6 +1,6 @@
 {% extends "organization/base_form_page.html" %}
 
-{% block subtitle %}{{ _('Edit') }} - {{ super() }}{% endblock %}
+{% block subtitle %}{{ _('Edit') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block page_heading_class %}hide-heading{% endblock %}
 {% block page_heading %}{{ _('Edit Organization') }}{% endblock %}

--- a/ckan/templates-bs2/organization/edit_base.html
+++ b/ckan/templates-bs2/organization/edit_base.html
@@ -2,7 +2,7 @@
 
 {% set organization = c.group_dict %}
 
-{% block subtitle %}{{ c.group_dict.display_name }} - {{ _('Organizations') }}{% endblock %}
+{% block subtitle %}{{ c.group_dict.display_name }} {{ g.template_title_delimiter }} {{ _('Organizations') }}{% endblock %}
 
 {% block breadcrumb_content %}
   <li>{% link_for _('Organizations'), named_route=group_type+'.index' %}</li>

--- a/ckan/templates-bs2/organization/member_new.html
+++ b/ckan/templates-bs2/organization/member_new.html
@@ -4,7 +4,7 @@
 
 {% set user = c.user_dict %}
 
-{% block subtitle %}{{ _('Edit Member') if user else _('Add Member') }} - {{ super() }}{% endblock %}
+{% block subtitle %}{{ _('Edit Member') if user else _('Add Member') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
   {% link_for _('Back to all members'), named_route=group_type+'.members', id=organization.name, class_='btn pull-right', icon='arrow-left' %}

--- a/ckan/templates-bs2/organization/members.html
+++ b/ckan/templates-bs2/organization/members.html
@@ -1,6 +1,6 @@
 {% extends "organization/edit_base.html" %}
 
-{% block subtitle %}{{ _('Members') }} - {{ super() }}{% endblock %}
+{% block subtitle %}{{ _('Members') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block page_primary_action %}
   {% if h.check_access('organization_update', {'id': organization.id}) %}

--- a/ckan/templates-bs2/organization/read_base.html
+++ b/ckan/templates-bs2/organization/read_base.html
@@ -1,6 +1,6 @@
 {% extends "page.html" %}
 
-{% block subtitle %}{{ c.group_dict.display_name }} - {{ _('Organizations') }}{% endblock %}
+{% block subtitle %}{{ c.group_dict.display_name }} {{ g.template_title_delimiter }} {{ _('Organizations') }}{% endblock %}
 
 {% block breadcrumb_content %}
   <li>{% link_for _('Organizations'), named_route=group_type+'.index' %}</li>

--- a/ckan/templates-bs2/package/activity.html
+++ b/ckan/templates-bs2/package/activity.html
@@ -1,6 +1,6 @@
 {% extends "package/read_base.html" %}
 
-{% block subtitle %}{{ _('Activity Stream') }} - {{ super() }}{% endblock %}
+{% block subtitle %}{{ _('Activity Stream') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="hide-heading">{% block page_heading %}{{ _('Activity Stream') }}{% endblock %}</h1>

--- a/ckan/templates-bs2/package/edit_view.html
+++ b/ckan/templates-bs2/package/edit_view.html
@@ -1,6 +1,6 @@
 {% extends "package/view_edit_base.html" %}
 
-{% block subtitle %}{{ _('Edit view') }} - {{ h.resource_display_name(resource) }}{% endblock %}
+{% block subtitle %}{{ _('Edit view') }} {{ g.template_title_delimiter }} {{ h.resource_display_name(resource) }}{% endblock %}
 {% block form_title %}{{ _('Edit view') }}{% endblock %}
 
 {% block breadcrumb_content %}

--- a/ckan/templates-bs2/package/followers.html
+++ b/ckan/templates-bs2/package/followers.html
@@ -1,6 +1,6 @@
 {% extends "package/read_base.html" %}
 
-{% block subtitle %}{{ _('Followers') }} - {{ h.dataset_display_name(pkg_dict) }}{% endblock %}
+{% block subtitle %}{{ _('Followers') }} {{ g.template_title_delimiter }} {{ h.dataset_display_name(pkg_dict) }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="hide-heading">{% block page_heading %}{{ _('Followers') }}{% endblock %}</h1>

--- a/ckan/templates-bs2/package/history.html
+++ b/ckan/templates-bs2/package/history.html
@@ -1,6 +1,6 @@
 {% extends "package/read_base.html" %}
 
-{% block subtitle %}{{ _('History') }} - {{ h.dataset_display_name(c.pkg_dict) }}{% endblock %}
+{% block subtitle %}{{ _('History') }} {{ g.template_title_delimiter }} {{ h.dataset_display_name(c.pkg_dict) }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="hide-heading">{{ _('History') }}</h1>

--- a/ckan/templates-bs2/package/new_resource_not_draft.html
+++ b/ckan/templates-bs2/package/new_resource_not_draft.html
@@ -1,6 +1,6 @@
 {% extends "package/resource_edit_base.html" %}
 
-{% block subtitle %}{{ _('Add resource') }} - {{ h.dataset_display_name(pkg) }}{% endblock %}
+{% block subtitle %}{{ _('Add resource') }} {{ g.template_title_delimiter }} {{ h.dataset_display_name(pkg) }}{% endblock %}
 {% block form_title %}{{ _('Add resource') }}{% endblock %}
 
 {% block breadcrumb_content %}

--- a/ckan/templates-bs2/package/new_view.html
+++ b/ckan/templates-bs2/package/new_view.html
@@ -1,6 +1,6 @@
 {% extends "package/view_edit_base.html" %}
 
-{% block subtitle %}{{ _('Add view') }} - {{ h.resource_display_name(resource) }}{% endblock %}
+{% block subtitle %}{{ _('Add view') }} {{ g.template_title_delimiter }} {{ h.resource_display_name(resource) }}{% endblock %}
 {% block form_title %}{{ _('Add view') }}{% endblock %}
 
 {% block breadcrumb_content %}

--- a/ckan/templates-bs2/package/read_base.html
+++ b/ckan/templates-bs2/package/read_base.html
@@ -1,6 +1,6 @@
 {% extends "package/base.html" %}
 
-{% block subtitle %}{{ h.dataset_display_name(pkg) }} - {{ super() }}{% endblock %}
+{% block subtitle %}{{ h.dataset_display_name(pkg) }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block head_extras -%}
   {{ super() }}

--- a/ckan/templates-bs2/package/resource_edit.html
+++ b/ckan/templates-bs2/package/resource_edit.html
@@ -1,6 +1,6 @@
 {% extends "package/resource_edit_base.html" %}
 
-{% block subtitle %}{{ _('Edit') }} - {{ h.resource_display_name(res) }} - {{ h.dataset_display_name(pkg) }}{% endblock %}
+{% block subtitle %}{{ _('Edit') }} {{ g.template_title_delimiter }} {{ h.resource_display_name(res) }} {{ g.template_title_delimiter }} {{ h.dataset_display_name(pkg) }}{% endblock %}
 
 {% block form %}
   {% snippet 'package/snippets/resource_edit_form.html',

--- a/ckan/templates-bs2/package/resource_read.html
+++ b/ckan/templates-bs2/package/resource_read.html
@@ -9,7 +9,7 @@
   <meta property="og:description" content="{{ description|forceescape }}">
 {% endblock -%}
 
-{% block subtitle %}{{ h.dataset_display_name(package) }} - {{ h.resource_display_name(res) }}{% endblock %}
+{% block subtitle %}{{ h.dataset_display_name(package) }} {{ g.template_title_delimiter }} {{ h.resource_display_name(res) }}{% endblock %}
 
 {% block breadcrumb_content_selected %}{% endblock %}
 

--- a/ckan/templates-bs2/package/resource_views.html
+++ b/ckan/templates-bs2/package/resource_views.html
@@ -1,7 +1,7 @@
 {% import 'macros/form.html' as form %}
 {% extends "package/resource_edit_base.html" %}
 
-{% block subtitle %}{{ _('View') }} - {{ h.resource_display_name(res) }}{% endblock %}
+{% block subtitle %}{{ _('View') }} {{ g.template_title_delimiter }} {{ h.resource_display_name(res) }}{% endblock %}
 
 {% block page_primary_action %}
   <div class="btn-group">

--- a/ckan/templates-bs2/package/resources.html
+++ b/ckan/templates-bs2/package/resources.html
@@ -2,7 +2,7 @@
 
 {% set has_reorder = pkg_dict and pkg_dict.resources and pkg_dict.resources|length > 0 %}
 
-{% block subtitle %}{{ _('Resources') }} - {{ h.dataset_display_name(pkg) }}{% endblock %}
+{% block subtitle %}{{ _('Resources') }} {{ g.template_title_delimiter }} {{ h.dataset_display_name(pkg) }}{% endblock %}
 
 {% block page_primary_action %}
   {% link_for _('Add new resource'), named_route='resource.new', id=pkg_dict.name, class_='btn btn-primary', icon='plus' %}

--- a/ckan/templates-bs2/user/activity_stream.html
+++ b/ckan/templates-bs2/user/activity_stream.html
@@ -1,6 +1,6 @@
 {% extends "user/read.html" %}
 
-{% block subtitle %}{{ _('Activity Stream') }} - {{ super() }}{% endblock %}
+{% block subtitle %}{{ _('Activity Stream') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
   <h2 class="hide-heading">{% block page_heading %}{{ _('Activity Stream') }}{% endblock %}</h2>

--- a/ckan/templates-bs2/user/edit_base.html
+++ b/ckan/templates-bs2/user/edit_base.html
@@ -1,6 +1,6 @@
 {% extends "page.html" %}
 
-{% block subtitle %}{{ _('Manage') }} - {{ user_dict.display_name }} - {{ _('Users') }}{% endblock %}
+{% block subtitle %}{{ _('Manage') }} {{ g.template_title_delimiter }} {{ user_dict.display_name }} {{ g.template_title_delimiter }} {{ _('Users') }}{% endblock %}
 
 {% block primary_content %}
   <article class="module">

--- a/ckan/templates-bs2/user/read_base.html
+++ b/ckan/templates-bs2/user/read_base.html
@@ -2,7 +2,7 @@
 
 {% set user = user_dict %}
 
-{% block subtitle %}{{ user.display_name }} - {{ _('Users') }}{% endblock %}
+{% block subtitle %}{{ user.display_name }} {{ g.template_title_delimiter }} {{ _('Users') }}{% endblock %}
 
 {% block breadcrumb_content %}
   {{ h.build_nav('user.index', _('Users')) }}

--- a/ckan/templates/base.html
+++ b/ckan/templates/base.html
@@ -40,7 +40,7 @@
     <title>
       {%- block title -%}
         {%- block subtitle %}{% endblock -%}
-        {%- if self.subtitle()|trim %} {{ g.template_title_deliminater }} {% endif -%}
+        {%- if self.subtitle()|trim %} {{ g.template_title_delimiter }} {% endif -%}
         {{ g.site_title }}
       {%- endblock -%}
     </title>

--- a/ckan/templates/dataviewer/base.html
+++ b/ckan/templates/dataviewer/base.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block subtitle %}{{ h.dataset_display_name(package) }} - {{h.resource_display_name(resource) }}{% endblock %}
+{% block subtitle %}{{ h.dataset_display_name(package) }} {{ g.template_title_delimiter }} {{h.resource_display_name(resource) }}{% endblock %}
 
 {# remove any scripts #}
 {% block scripts %}

--- a/ckan/templates/group/about.html
+++ b/ckan/templates/group/about.html
@@ -1,6 +1,6 @@
 {% extends "group/read_base.html" %}
 
-{% block subtitle %}{{ _('About') }} - {{ super() }}{% endblock %}
+{% block subtitle %}{{ _('About') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1>{% block page_heading %}{{ group_dict.display_name }}{% endblock %}</h1>

--- a/ckan/templates/group/activity_stream.html
+++ b/ckan/templates/group/activity_stream.html
@@ -1,6 +1,6 @@
 {% extends "group/read_base.html" %}
 
-{% block subtitle %}{{ _('Activity Stream') }} - {{ super() }}{% endblock %}
+{% block subtitle %}{{ _('Activity Stream') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
   <h2 class="hide-heading">{% block page_heading %}{{ _('Activity Stream') }}{% endblock %}</h2>

--- a/ckan/templates/group/admins.html
+++ b/ckan/templates/group/admins.html
@@ -1,6 +1,6 @@
 {% extends "group/read_base.html" %}
 
-{% block subtitle %}{{ _('Administrators') }} - {{ group_dict.title or group_dict.name }}{% endblock %}
+{% block subtitle %}{{ _('Administrators') }} {{ g.template_title_delimiter }} {{ group_dict.title or group_dict.name }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="hide-heading">{% block page_heading %}{{ _('Administrators') }}{% endblock %}</h1>

--- a/ckan/templates/group/edit_base.html
+++ b/ckan/templates/group/edit_base.html
@@ -1,6 +1,6 @@
 {% extends "page.html" %}
 
-{% block subtitle %}{{ _('Manage') }} - {{ group_dict.display_name }} - {{ _('Groups') }}{% endblock %}
+{% block subtitle %}{{ _('Manage') }} {{ g.template_title_delimiter }} {{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ _('Groups') }}{% endblock %}
 
 {% set group = group_dict %}
 

--- a/ckan/templates/group/followers.html
+++ b/ckan/templates/group/followers.html
@@ -1,6 +1,6 @@
 {% extends "group/read_base.html" %}
 
-{% block subtitle %}{{ _('Followers') }} - {{ group_dict.title or group_dict.name }}{% endblock %}
+{% block subtitle %}{{ _('Followers') }} {{ g.template_title_delimiter }} {{ group_dict.title or group_dict.name }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="hide-heading">{% block page_heading %}{{ _('Followers') }}{% endblock %}</h1>

--- a/ckan/templates/group/history.html
+++ b/ckan/templates/group/history.html
@@ -1,6 +1,6 @@
 {% extends "group/read_base.html" %}
 
-{% block subtitle %}{{ _('History') }} - {{ group_dict.display_name }}{% endblock %}
+{% block subtitle %}{{ _('History') }} {{ g.template_title_delimiter }} {{ group_dict.display_name }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="hide-heading">{{ _('History') }}</h1>

--- a/ckan/templates/group/members.html
+++ b/ckan/templates/group/members.html
@@ -1,6 +1,6 @@
 {% extends "group/edit_base.html" %}
 
-{% block subtitle %}{{ _('Members') }} - {{ group_dict.display_name }} - {{ _('Groups') }}{% endblock %}
+{% block subtitle %}{{ _('Members') }} {{ g.template_title_delimiter }} {{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ _('Groups') }}{% endblock %}
 
 {% block page_primary_action %}
   {% link_for _('Add Member'), named_route=group_type+'.member_new', id=group_dict.id, class_='btn btn-primary', icon='plus-square' %}

--- a/ckan/templates/group/read_base.html
+++ b/ckan/templates/group/read_base.html
@@ -1,6 +1,6 @@
 {% extends "page.html" %}
 
-{% block subtitle %}{{ group_dict.display_name }} - {{ _('Groups') }}{% endblock %}
+{% block subtitle %}{{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ _('Groups') }}{% endblock %}
 
 {% block breadcrumb_content %}
   <li>{% link_for _('Groups'), named_route=group_type+'.index' %}</li>

--- a/ckan/templates/organization/about.html
+++ b/ckan/templates/organization/about.html
@@ -1,6 +1,6 @@
 {% extends "organization/read_base.html" %}
 
-{% block subtitle %}{{ _('About') }} - {{ super() }}{% endblock %}
+{% block subtitle %}{{ _('About') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1>{% block page_heading %}{{ group_dict.display_name }}{% endblock %}</h1>

--- a/ckan/templates/organization/activity_stream.html
+++ b/ckan/templates/organization/activity_stream.html
@@ -1,6 +1,6 @@
 {% extends "organization/read_base.html" %}
 
-{% block subtitle %}{{ _('Activity Stream') }} - {{ super() }}{% endblock %}
+{% block subtitle %}{{ _('Activity Stream') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
   <h2 class="hide-heading">{% block page_heading %}{{ _('Activity Stream') }}{% endblock %}</h2>

--- a/ckan/templates/organization/admins.html
+++ b/ckan/templates/organization/admins.html
@@ -1,6 +1,6 @@
 {% extends "organization/read_base.html" %}
 
-{% block subtitle %}{{ _('Administrators') }} - {{ group_dict.title or group_dict.name }}{% endblock %}
+{% block subtitle %}{{ _('Administrators') }} {{ g.template_title_delimiter }} {{ group_dict.title or group_dict.name }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="hide-heading">{% block page_heading %}{{ _('Administrators') }}{% endblock %}</h1>

--- a/ckan/templates/organization/bulk_process.html
+++ b/ckan/templates/organization/bulk_process.html
@@ -1,6 +1,6 @@
 {% extends "organization/edit_base.html" %}
 
-{% block subtitle %}{{ _('Edit datasets') }} - {{ super() }}{% endblock %}
+{% block subtitle %}{{ _('Edit datasets') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block page_primary_action %}
   {% snippet 'snippets/add_dataset.html', group=group_dict.id %}

--- a/ckan/templates/organization/edit.html
+++ b/ckan/templates/organization/edit.html
@@ -1,6 +1,6 @@
 {% extends "organization/base_form_page.html" %}
 
-{% block subtitle %}{{ _('Edit') }} - {{ super() }}{% endblock %}
+{% block subtitle %}{{ _('Edit') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block page_heading_class %}hide-heading{% endblock %}
 {% block page_heading %}{{ _('Edit Organization') }}{% endblock %}

--- a/ckan/templates/organization/edit_base.html
+++ b/ckan/templates/organization/edit_base.html
@@ -2,7 +2,7 @@
 
 {% set organization = group_dict %}
 
-{% block subtitle %}{{ group_dict.display_name }} - {{ _('Organizations') }}{% endblock %}
+{% block subtitle %}{{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ _('Organizations') }}{% endblock %}
 
 {% block breadcrumb_content %}
   <li>{% link_for _('Organizations'), named_route=group_type+'.index' %}</li>

--- a/ckan/templates/organization/member_new.html
+++ b/ckan/templates/organization/member_new.html
@@ -4,7 +4,7 @@
 
 {% set user = user_dict %}
 
-{% block subtitle %}{{ _('Edit Member') if user else _('Add Member') }} - {{ super() }}{% endblock %}
+{% block subtitle %}{{ _('Edit Member') if user else _('Add Member') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
   {% link_for _('Back to all members'), named_route=group_type+'.members', id=organization.name, class_='btn btn-default pull-right', icon='arrow-left' %}

--- a/ckan/templates/organization/members.html
+++ b/ckan/templates/organization/members.html
@@ -1,6 +1,6 @@
 {% extends "organization/edit_base.html" %}
 
-{% block subtitle %}{{ _('Members') }} - {{ super() }}{% endblock %}
+{% block subtitle %}{{ _('Members') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block page_primary_action %}
   {% if h.check_access('organization_update', {'id': organization.id}) %}

--- a/ckan/templates/organization/read_base.html
+++ b/ckan/templates/organization/read_base.html
@@ -1,6 +1,6 @@
 {% extends "page.html" %}
 
-{% block subtitle %}{{ group_dict.display_name }} - {{ _('Organizations') }}{% endblock %}
+{% block subtitle %}{{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ _('Organizations') }}{% endblock %}
 
 {% block breadcrumb_content %}
   <li>{% link_for _('Organizations'), named_route=group_type+'.index' %}</li>

--- a/ckan/templates/package/activity.html
+++ b/ckan/templates/package/activity.html
@@ -1,6 +1,6 @@
 {% extends "package/read_base.html" %}
 
-{% block subtitle %}{{ _('Activity Stream') }} - {{ super() }}{% endblock %}
+{% block subtitle %}{{ _('Activity Stream') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="hide-heading">{% block page_heading %}{{ _('Activity Stream') }}{% endblock %}</h1>

--- a/ckan/templates/package/edit_view.html
+++ b/ckan/templates/package/edit_view.html
@@ -1,6 +1,6 @@
 {% extends "package/view_edit_base.html" %}
 
-{% block subtitle %}{{ _('Edit view') }} - {{ h.resource_display_name(resource) }}{% endblock %}
+{% block subtitle %}{{ _('Edit view') }} {{ g.template_title_delimiter }} {{ h.resource_display_name(resource) }}{% endblock %}
 {% block form_title %}{{ _('Edit view') }}{% endblock %}
 
 {% block breadcrumb_content %}

--- a/ckan/templates/package/followers.html
+++ b/ckan/templates/package/followers.html
@@ -1,6 +1,6 @@
 {% extends "package/read_base.html" %}
 
-{% block subtitle %}{{ _('Followers') }} - {{ h.dataset_display_name(pkg_dict) }}{% endblock %}
+{% block subtitle %}{{ _('Followers') }} {{ g.template_title_delimiter }} {{ h.dataset_display_name(pkg_dict) }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="hide-heading">{% block page_heading %}{{ _('Followers') }}{% endblock %}</h1>

--- a/ckan/templates/package/history.html
+++ b/ckan/templates/package/history.html
@@ -1,6 +1,6 @@
 {% extends "package/read_base.html" %}
 
-{% block subtitle %}{{ _('History') }} - {{ h.dataset_display_name(c.pkg_dict) }}{% endblock %}
+{% block subtitle %}{{ _('History') }} {{ g.template_title_delimiter }} {{ h.dataset_display_name(c.pkg_dict) }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="hide-heading">{{ _('History') }}</h1>

--- a/ckan/templates/package/new_resource_not_draft.html
+++ b/ckan/templates/package/new_resource_not_draft.html
@@ -1,6 +1,6 @@
 {% extends "package/resource_edit_base.html" %}
 
-{% block subtitle %}{{ _('Add resource') }} - {{ h.dataset_display_name(pkg) }}{% endblock %}
+{% block subtitle %}{{ _('Add resource') }} {{ g.template_title_delimiter }} {{ h.dataset_display_name(pkg) }}{% endblock %}
 {% block form_title %}{{ _('Add resource') }}{% endblock %}
 
 {% block breadcrumb_content %}

--- a/ckan/templates/package/new_view.html
+++ b/ckan/templates/package/new_view.html
@@ -1,6 +1,6 @@
 {% extends "package/view_edit_base.html" %}
 
-{% block subtitle %}{{ _('Add view') }} - {{ h.resource_display_name(resource) }}{% endblock %}
+{% block subtitle %}{{ _('Add view') }} {{ g.template_title_delimiter }} {{ h.resource_display_name(resource) }}{% endblock %}
 {% block form_title %}{{ _('Add view') }}{% endblock %}
 
 {% block breadcrumb_content %}

--- a/ckan/templates/package/read_base.html
+++ b/ckan/templates/package/read_base.html
@@ -1,6 +1,6 @@
 {% extends "package/base.html" %}
 
-{% block subtitle %}{{ h.dataset_display_name(pkg) }} - {{ super() }}{% endblock %}
+{% block subtitle %}{{ h.dataset_display_name(pkg) }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block head_extras -%}
   {{ super() }}

--- a/ckan/templates/package/resource_edit.html
+++ b/ckan/templates/package/resource_edit.html
@@ -1,6 +1,6 @@
 {% extends "package/resource_edit_base.html" %}
 
-{% block subtitle %}{{ _('Edit') }} - {{ h.resource_display_name(res) }} - {{ h.dataset_display_name(pkg) }}{% endblock %}
+{% block subtitle %}{{ _('Edit') }} {{ g.template_title_delimiter }} {{ h.resource_display_name(res) }} {{ g.template_title_delimiter }} {{ h.dataset_display_name(pkg) }}{% endblock %}
 
 {% block form %}
   {% snippet 'package/snippets/resource_edit_form.html',

--- a/ckan/templates/package/resource_read.html
+++ b/ckan/templates/package/resource_read.html
@@ -9,7 +9,7 @@
   <meta property="og:description" content="{{ description|forceescape }}">
 {% endblock -%}
 
-{% block subtitle %}{{ h.dataset_display_name(package) }} - {{ h.resource_display_name(res) }}{% endblock %}
+{% block subtitle %}{{ h.dataset_display_name(package) }} {{ g.template_title_delimiter }} {{ h.resource_display_name(res) }}{% endblock %}
 
 {% block breadcrumb_content_selected %}{% endblock %}
 

--- a/ckan/templates/package/resource_views.html
+++ b/ckan/templates/package/resource_views.html
@@ -1,7 +1,7 @@
 {% import 'macros/form.html' as form %}
 {% extends "package/resource_edit_base.html" %}
 
-{% block subtitle %}{{ _('View') }} - {{ h.resource_display_name(res) }}{% endblock %}
+{% block subtitle %}{{ _('View') }} {{ g.template_title_delimiter }} {{ h.resource_display_name(res) }}{% endblock %}
 
 {% block page_primary_action %}
   <div class="btn-group">

--- a/ckan/templates/package/resources.html
+++ b/ckan/templates/package/resources.html
@@ -2,7 +2,7 @@
 
 {% set has_reorder = pkg_dict and pkg_dict.resources and pkg_dict.resources|length > 0 %}
 
-{% block subtitle %}{{ _('Resources') }} - {{ h.dataset_display_name(pkg) }}{% endblock %}
+{% block subtitle %}{{ _('Resources') }} {{ g.template_title_delimiter }} {{ h.dataset_display_name(pkg) }}{% endblock %}
 
 {% block page_primary_action %}
   {% link_for _('Add new resource'), named_route='resource.new', id=pkg_dict.name, class_='btn btn-primary', icon='plus' %}

--- a/ckan/templates/user/activity_stream.html
+++ b/ckan/templates/user/activity_stream.html
@@ -1,6 +1,6 @@
 {% extends "user/read.html" %}
 
-{% block subtitle %}{{ _('Activity Stream') }} - {{ super() }}{% endblock %}
+{% block subtitle %}{{ _('Activity Stream') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
   <h2 class="hide-heading">{% block page_heading %}{{ _('Activity Stream') }}{% endblock %}</h2>

--- a/ckan/templates/user/edit_base.html
+++ b/ckan/templates/user/edit_base.html
@@ -1,6 +1,6 @@
 {% extends "page.html" %}
 
-{% block subtitle %}{{ _('Manage') }} - {{ user_dict.display_name }} - {{ _('Users') }}{% endblock %}
+{% block subtitle %}{{ _('Manage') }} {{ g.template_title_delimiter }} {{ user_dict.display_name }} {{ g.template_title_delimiter }} {{ _('Users') }}{% endblock %}
 
 {% block primary_content %}
   <article class="module">

--- a/ckan/templates/user/read_base.html
+++ b/ckan/templates/user/read_base.html
@@ -2,7 +2,7 @@
 
 {% set user = user_dict %}
 
-{% block subtitle %}{{ user.display_name }} - {{ _('Users') }}{% endblock %}
+{% block subtitle %}{{ user.display_name }} {{ g.template_title_delimiter }} {{ _('Users') }}{% endblock %}
 
 {% block breadcrumb_content %}
   {{ h.build_nav('user.index', _('Users')) }}

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -1285,14 +1285,14 @@ Example (showing insertion of Google Analytics code)::
 
 .. note:: This is only for legacy code, and shouldn't be used anymore.
 
-.. _ckan.template_title_deliminater:
+.. _ckan.template_title_delimiter:
 
-ckan.template_title_deliminater
+ckan.template_title_delimiter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Example::
 
- ckan.template_title_deliminater = |
+ ckan.template_title_delimiter = |
 
 Default value:  ``-``
 


### PR DESCRIPTION
Previously, `base.html` used **g.template_title_deliminater** for separating title segments, but almost all pages are using a hardcoded hyphen, so there is no easy way of changing title join-style. From now, one can just explicitly set `ckan.template_title_deliminater = |` and instead of having something like this(before PR):

![screenshot from 2018-11-16 11-39-57](https://user-images.githubusercontent.com/11091199/48614307-97720b80-e996-11e8-88a1-d51eb6040d90.png)

receive the correct result:
![screenshot from 2018-11-16 11-43-55](https://user-images.githubusercontent.com/11091199/48614356-b6709d80-e996-11e8-9420-f4b3a6e810f9.png)
