### PR TITLE
group_patch does not reset packages

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -525,8 +525,12 @@ def _group_or_org_update(context, data_dict, is_org=False):
     else:
         rev.message = _(u'REST API: Update object %s') % data.get("name")
 
-    group = model_save.group_dict_save(data, context,
-        prevent_packages_update=is_org)
+    contains_packages = 'packages' in data_dict
+
+    group = model_save.group_dict_save(
+        data, context,
+        prevent_packages_update=is_org or not contains_packages
+    )
 
     if is_org:
         plugin_type = plugins.IOrganizationController

--- a/ckan/tests/legacy/functional/api/test_activity.py
+++ b/ckan/tests/legacy/functional/api/test_activity.py
@@ -235,7 +235,7 @@ class TestActivity:
             extra_environ = {'Authorization': str(apikey)}
         else:
             extra_environ = None
-        params = {'id': group_id}
+        params = {'id': group_id, 'limit': 100}
         response = self.app.get("/api/action/group_activity_list",
                                 params=params, extra_environ=extra_environ)
         assert response.json['success'] is True
@@ -981,7 +981,10 @@ class TestActivity:
             user_id = 'not logged in'
             apikey = None
 
-        before = self.record_details(user_id, package['id'], apikey=apikey)
+        group_ids = [group['name'] for group in package['groups']]
+        before = self.record_details(
+            user_id, package['id'], apikey=apikey, group_ids=group_ids
+        )
 
         # Update the package.
         if package['title'] != 'edited':
@@ -991,7 +994,9 @@ class TestActivity:
             package['title'] = 'edited again'
         package_update(self.app, package, user)
 
-        after = self.record_details(user_id, package['id'], apikey=apikey)
+        after = self.record_details(
+            user_id, package['id'], apikey=apikey, group_ids=group_ids
+        )
 
         # Find the new activity in the user's activity stream.
         user_new_activities = (find_new_activities(
@@ -1132,9 +1137,11 @@ class TestActivity:
         item and detail are emitted.
 
         """
-        before = self.record_details(self.sysadmin_user['id'], package['id'],
-                apikey=self.sysadmin_user['apikey'])
-
+        group_ids = [group['name'] for group in package['groups']]
+        before = self.record_details(
+            self.sysadmin_user['id'], package['id'],
+            apikey=self.sysadmin_user['apikey'], group_ids=group_ids
+        )
         # Delete the package.
         package_dict = {'id': package['id']}
         response = self.app.post('/api/action/package_delete',
@@ -1143,8 +1150,10 @@ class TestActivity:
         response_dict = json.loads(response.body)
         assert response_dict['success'] is True
 
-        after = self.record_details(self.sysadmin_user['id'], package['id'],
-                apikey=self.sysadmin_user['apikey'])
+        after = self.record_details(
+            self.sysadmin_user['id'], package['id'],
+            apikey=self.sysadmin_user['apikey'], group_ids=group_ids
+        )
 
         # Find the new activity in the user's activity stream.
         user_new_activities = (find_new_activities(
@@ -1167,13 +1176,14 @@ class TestActivity:
                 after['recently changed datasets stream']) \
                         == user_new_activities
 
-        # If the package has any groups, the same new activity should appear
-        # in the activity stream of each group.
+        # If the package has any groups, there should be no new activities
+        # because package has been deleted == removed from group lifecycle
+
         for group_dict in package['groups']:
             grp_new_activities = find_new_activities(
                 before['group activity streams'][group_dict['name']],
                 after['group activity streams'][group_dict['name']])
-            assert grp_new_activities == [activity]
+            assert grp_new_activities == []
 
         # Check that the new activity has the right attributes.
         assert activity['object_id'] == package['id'], (
@@ -1522,15 +1532,21 @@ class TestActivity:
         pkg_dict = package_show(self.app, {'id': pkg_name})
 
         # Add one new tag to the package.
-        before = self.record_details(user['id'], pkg_dict['id'],
-                apikey=user['apikey'])
+        group_ids = [group['name'] for group in pkg_dict['groups']]
+
+        before = self.record_details(
+            user['id'], pkg_dict['id'],
+            apikey=user['apikey'], group_ids=group_ids
+        )
         new_tag_name = 'test tag'
         assert new_tag_name not in [tag['name'] for tag in pkg_dict['tags']]
 
         pkg_dict['tags'].append({'name': new_tag_name})
         package_update(self.app, pkg_dict, user)
-        after = self.record_details(user['id'], pkg_dict['id'],
-                apikey=user['apikey'])
+        after = self.record_details(
+            user['id'], pkg_dict['id'],
+            apikey=user['apikey'], group_ids=group_ids
+        )
 
         # Find the new activity in the user's activity stream.
         user_new_activities = (find_new_activities(

--- a/ckan/tests/logic/action/test_patch.py
+++ b/ckan/tests/logic/action/test_patch.py
@@ -75,6 +75,37 @@ class TestPatch(helpers.FunctionalTestBase):
         assert_equals(group2['name'], 'economy')
         assert_equals(group2['description'], 'somethingnew')
 
+    def test_group_patch_preserve_datasets(self):
+        user = factories.User()
+        group = factories.Group(
+            name='economy',
+            description='some test now',
+            user=user)
+        factories.Dataset(groups=[{'name': group['name']}])
+
+        group2 = helpers.call_action('group_show', id=group['id'])
+        assert_equals(1, group2['package_count'])
+
+        group = helpers.call_action(
+            'group_patch',
+            id=group['id'],
+            context={'user': user['name']})
+
+        group3 = helpers.call_action('group_show', id=group['id'])
+        assert_equals(1, group3['package_count'])
+
+        group = helpers.call_action(
+            'group_patch',
+            id=group['id'],
+            packages=[],
+            context={'user': user['name']})
+
+        group4 = helpers.call_action(
+            'group_show', id=group['id'], include_datasets=True
+        )
+        assert_equals(0, group4['package_count'])
+
+
     def test_organization_patch_updating_single_field(self):
         user = factories.User()
         organization = factories.Organization(

--- a/ckan/tests/logic/action/test_patch.py
+++ b/ckan/tests/logic/action/test_patch.py
@@ -105,7 +105,6 @@ class TestPatch(helpers.FunctionalTestBase):
         )
         assert_equals(0, group4['package_count'])
 
-
     def test_organization_patch_updating_single_field(self):
         user = factories.User()
         organization = factories.Organization(


### PR DESCRIPTION
I just accidentally noticed, that `group_patch`(rather, underlying `group_update`) drops all packages - and this happens because `group_dict_save` attempts to update all related packages during `group_update`. For `organization_update`, package update prevented by setting `prevent_packages_update` and i did the same for `group_update` if there is no `packages` key in request payload