### PR TITLE
Use group.read instead group_read in h.url_for

### DIFF
--- a/ckan/templates-bs2/group/snippets/group_item.html
+++ b/ckan/templates-bs2/group/snippets/group_item.html
@@ -12,7 +12,7 @@ Example:
     </ul>
 #}
 {% set type = group.type or 'group' %}
-{% set url = h.url_for(type ~ '_read', action='read', id=group.name) %}
+{% set url = h.url_for(type ~ '.read', id=group.name) %}
 {% block item %}
 <li class="media-item">
   {% block item_inner %}

--- a/ckan/templates-bs2/snippets/organization.html
+++ b/ckan/templates-bs2/snippets/organization.html
@@ -15,7 +15,7 @@ Example:
 #}
 
 {% set truncate = truncate or 0 %}
-{% set url = h.url_for(organization.type + '_read', id=organization.name, ) %}
+{% set url = h.url_for(organization.type + '.read', id=organization.name, ) %}
 
   {% block info %}
   <div class="module module-narrow module-shallow context-info">

--- a/ckan/templates/group/snippets/group_item.html
+++ b/ckan/templates/group/snippets/group_item.html
@@ -12,7 +12,7 @@ Example:
     </ul>
 #}
 {% set type = group.type or 'group' %}
-{% set url = h.url_for(type ~ '_read', action='read', id=group.name) %}
+{% set url = h.url_for(type ~ '.read', id=group.name) %}
 {% block item %}
 <li class="media-item">
   {% block item_inner %}

--- a/ckan/templates/snippets/organization.html
+++ b/ckan/templates/snippets/organization.html
@@ -15,7 +15,7 @@ Example:
 #}
 
 {% set truncate = truncate or 0 %}
-{% set url = h.url_for(organization.type + '_read', id=organization.name, ) %}
+{% set url = h.url_for(organization.type + '.read', id=organization.name, ) %}
 
   {% block info %}
   <div class="module module-narrow module-shallow context-info">


### PR DESCRIPTION
Update templates to use `controller.action` url names. Fixes:
* Get rid of deprecation messages in console
* Group listing builds correct url to group details page. Previously, `action='read'` argument to `h.url_for` was treated as facet( e.g. http://localhost:5000/group/david?action=read)