### PR TITLE
Add doc language around patching resources.

### DIFF
--- a/ckan/logic/action/patch.py
+++ b/ckan/logic/action/patch.py
@@ -19,14 +19,14 @@ def package_patch(context, data_dict):
     The difference between the update and patch methods is that the patch will
     perform an update of the provided parameters, while leaving all other
     parameters unchanged, whereas the update methods deletes all parameters
-    not explicitly provided in the data_dict. 
-    
-    You are able to partially update and/or create resources with package_patch.
-    If you are updating existing resources be sure to provide the resource id. 
-    Existing resources excluded from the package_patch data_dict will be removed. 
-    Resources in the package data_dict without an id will be treated as new 
-    resources and will be added. New resources added with the patch method do 
-    not create the default views. 
+    not explicitly provided in the data_dict.
+
+    You are able to partially update and/or create resources with
+    package_patch. If you are updating existing resources be sure to provide
+    the resource id. Existing resources excluded from the package_patch
+    data_dict will be removed. Resources in the package data_dict without
+    an id will be treated as new resources and will be added. New resources
+    added with the patch method do not create the default views.
 
     You must be authorized to edit the dataset and the groups that it belongs
     to.

--- a/ckan/logic/action/patch.py
+++ b/ckan/logic/action/patch.py
@@ -19,7 +19,14 @@ def package_patch(context, data_dict):
     The difference between the update and patch methods is that the patch will
     perform an update of the provided parameters, while leaving all other
     parameters unchanged, whereas the update methods deletes all parameters
-    not explicitly provided in the data_dict
+    not explicitly provided in the data_dict. 
+    
+    You are able to partially update and/or create resources with package_patch.
+    If you are updating existing resources be sure to provide the resource id. 
+    Existing resources excluded from the package_patch data_dict will be removed. 
+    Resources in the package data_dict without an id will be treated as new 
+    resources and will be added. New resources added with the patch method do 
+    not create the default views. 
 
     You must be authorized to edit the dataset and the groups that it belongs
     to.


### PR DESCRIPTION
Fixes #

### Proposed fixes:

Some of the functionality with `package_patch` was unclear to me. I thought others may experience the same at some point so I've updated the documentation.

- **No default views for new resources:** As per PR #3061 update methods are not supposed to create the default views for resources, even if the update method creates a resource, but this was not referenced in the docs.
- **Handling resources:** I've added language around expected behaviour of `package_patch` when updating, creating or deleting resources. Although it now makes sense, I originally expected a resource name to be used to verify if the resource exists and update it before removing and creating a new one and to leave existing resources not referenced in the list of resource dicts.

### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
