### PR TITLE
Do not crash on unsuccessfull CLI results

### DIFF
--- a/ckan/cli/__init__.py
+++ b/ckan/cli/__init__.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 
 def error_shout(exception):
-    click.secho(str(exception), fg='red', err=True)
+    click.secho(str(exception), fg=u'red', err=True)
 
 
 click_config_option = click.option(

--- a/ckan/cli/__init__.py
+++ b/ckan/cli/__init__.py
@@ -9,12 +9,17 @@ from logging.config import fileConfig as loggingFileConfig
 log = logging.getLogger(__name__)
 
 
+def error_shout(exception):
+    click.secho(str(exception), fg='red', err=True)
+
+
 click_config_option = click.option(
     u'-c',
     u'--config',
     default=None,
     metavar=u'CONFIG',
-    help=u'Config file to use (default: development.ini)')
+    help=u'Config file to use (default: development.ini)'
+)
 
 
 def load_config(config=None):

--- a/ckan/cli/db.py
+++ b/ckan/cli/db.py
@@ -3,7 +3,8 @@
 import logging
 
 import click
-from werkzeug.serving import run_simple
+
+from ckan.cli import error_shout
 
 log = logging.getLogger(__name__)
 
@@ -13,7 +14,7 @@ def db():
     pass
 
 
-@db.command(u'init', short_help=u'Initialaze the database')
+@db.command(u'init', short_help=u'Initialize the database')
 def initdb():
     u'''Initialising the database'''
     log.info(u"Initialize the Database")
@@ -21,8 +22,9 @@ def initdb():
         import ckan.model as model
         model.repo.init_db()
     except Exception as e:
-        click.secho(e, err=True)
-    print(u'Initialising DB: SUCCESS')
+        error_shout(e)
+    else:
+        click.secho(u'Initialising DB: SUCCESS', fg=u'green', bold=True)
 
 
 PROMPT_MSG = u'This will delete all of your data!\nDo you want to continue?'
@@ -36,8 +38,9 @@ def cleandb():
         import ckan.model as model
         model.repo.clean_db()
     except Exception as e:
-        click.secho(e, err=True)
-    click.secho(u'Cleaning DB: SUCCESS', color=u"green", bold=True)
+        error_shout(e)
+    else:
+        click.secho(u'Cleaning DB: SUCCESS', fg=u'green', bold=True)
 
 
 @db.command(u'upgrade', short_help=u'Upgrade the database')
@@ -48,8 +51,9 @@ def updatedb(version=None):
         import ckan.model as model
         model.repo.upgrade_db(version)
     except Exception as e:
-        click.secho(e, err=True)
-    click.secho(u'Upgrading DB: SUCCESS', fg=u'green', bold=True)
+        error_shout(e)
+    else:
+        click.secho(u'Upgrading DB: SUCCESS', fg=u'green', bold=True)
 
 
 @db.command(u'version', short_help=u'Returns current version of data schema')
@@ -60,7 +64,9 @@ def version():
         from ckan.model import Session
         ver = Session.execute(u'select version from '
                               u'migrate_version;').fetchall()
-        click.secho(u"Latest data schema version: {0}".format(ver[0][0]),
-                    fg=u"green", bold=True)
+        click.secho(
+            u"Latest data schema version: {0}".format(ver[0][0]),
+            bold=True
+        )
     except Exception as e:
-        click.secho(e, err=True)
+        error_shout(e)

--- a/ckan/cli/search_index.py
+++ b/ckan/cli/search_index.py
@@ -4,7 +4,8 @@ import multiprocessing as mp
 
 import click
 import sqlalchemy as sa
-from werkzeug.serving import run_simple
+
+from ckan.cli import error_shout
 
 
 @click.group(name=u'search-index', short_help=u'Search index commands')
@@ -40,7 +41,7 @@ def rebuild(ctx, verbose, force, refresh, only_missing, quiet, commit_each):
                     defer_commit=(not commit_each),
                     quiet=quiet)
     except Exception as e:
-        click.echo(e, err=True)
+        error_shout(e)
     if not commit_each:
         commit()
 


### PR DESCRIPTION
* DB commands use `click.secho\fg=green' in case of success(previously `init` was using `print`, `clean` was using `color` argument instead of `fg` for specifying output color and only `upgrade` had no issues:) ) 
* DB commands use the colored output in case of error. Furthermore, I've added `error_shout` function, that can be used for consistency of styles(name can be changed)
* `click.secho(err_object, err=True)` will raise error, because first argument is expected to be a string. Conversion to string done in previously mentioned `error_shout`
