### PR TITLE
Add yapf to dev requirements

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,7 @@
+[style]
+based_on_style = pep8
+coalesce_brackets = true
+dedent_closing_brackets = true
+allow_split_before_dict_value = false
+blank_line_before_nested_class_or_def = true
+split_complex_comprehension = true

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,5 +12,6 @@ pip-tools==2.0.2
 pyfakefs==3.2
 Sphinx==1.7.5
 sphinx-rtd-theme==0.3.1
+yapf==0.25.0
 
 # nose==1.3.0  # already in requirements.txt


### PR DESCRIPTION
I've been using [this awesome library](https://github.com/google/yapf) for a few years and think, that we can incorporate it for style consistency. The best thing here(two things) that it won't break anything(even PEP8 checks) and no one is forced to use this tool.

If there is anyone not familiar with yapf, it's a tool for autoformating your python code(like prettier in js, gofmt in go, codesniffer in php, etc.) It compatible with PEP8 and tries not only to format your code as requires PEP8, but to do it in nice, readable form. And it has pretty flexible configuration, so i suggest you to check link above. 

As for using this lib, you only need to `pip install -r dev-requirements.txt` and new command `yapf` will become available to you. Most used cases in my routine:
```bash
yapf path/to/file.py -d # show diff without actually changing anything
yapf path/to/file.py -i # update file in place
```

We can discuss it and change `.style.yapf` file for our needs(i just provided one, i'm using globally in my projects). 