### PR TITLE
Replace direct calls to endpoint.split with convenient helper

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -731,7 +731,7 @@ def _link_active_pylons(kwargs):
 
 
 def _link_active_flask(kwargs):
-    blueprint, endpoint = request.url_rule.endpoint.split('.')
+    blueprint, endpoint = p.toolkit.get_endpoint()
     return(kwargs.get('controller') == blueprint and
            kwargs.get('action') == endpoint)
 
@@ -785,7 +785,7 @@ def nav_link(text, *args, **kwargs):
 def nav_link_flask(text, *args, **kwargs):
     if len(args) > 1:
         raise Exception('Too many unnamed parameters supplied')
-    blueprint, endpoint = request.url_rule.endpoint.split('.')
+    blueprint, endpoint = p.toolkit.get_endpoint()
     if args:
         kwargs['controller'] = blueprint or None
         kwargs['action'] = endpoint or None
@@ -1805,7 +1805,7 @@ def _create_url_with_params(params=None, controller=None, action=None,
     if not controller:
         controller = getattr(c, 'controller', False) or request.blueprint
     if not action:
-        action = getattr(c, 'action', False) or request.endpoint.split('.')[1]
+        action = getattr(c, 'action', False) or p.toolkit.get_endpoint()[1]
     if not extras:
         extras = {}
 

--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -204,11 +204,4 @@ def _get_user_for_apikey():
 
 
 def set_controller_and_action():
-    try:
-        controller, action = request.endpoint.split(u'.')
-    except ValueError:
-        log.debug(
-            u'Endpoint does not contain dot: {}'.format(request.endpoint)
-        )
-        controller = action = request.endpoint
-    g.controller, g.action = controller, action
+    g.controller, g.action = p.toolkit.get_endpoint()

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -78,7 +78,7 @@ def before_request():
         context = dict(model=model, user=g.user, auth_user_obj=g.userobj)
         logic.check_access(u'site_read', context)
     except logic.NotAuthorized:
-        _, action = request.url_rule.endpoint.split(u'.')
+        _, action = plugins.toolkit.get_endpoint()
         if action not in (
                 u'login',
                 u'request_reset',


### PR DESCRIPTION
Just noticed that we have such useful function inside toolkit. It has the sense to use it instead of direct manipulations with endpoint for rare cases that result in an error