### PR TITLE
Failing autocomplete tests on master

### DIFF
--- a/ckan/config/solr/schema.xml
+++ b/ckan/config/solr/schema.xml
@@ -84,12 +84,12 @@ schema. In this case the version should be set to the next CKAN version number.
 
     <fieldType name="text_ngram" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
-	<tokenizer class="solr.NGramTokenizerFactory" minGramSize="2" maxGramSize="10"/>
-	<filter class="solr.LowerCaseFilterFactory"/>
+        <tokenizer class="solr.NGramTokenizerFactory" minGramSize="2" maxGramSize="10"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
       <analyzer type="query">
-	<tokenizer class="solr.EdgeNGramTokenizerFactory" minGramSize="2" maxGramSize="10"/>
-	<filter class="solr.LowerCaseFilterFactory"/>
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
     </fieldType>
 

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1536,7 +1536,7 @@ def package_autocomplete(context, data_dict):
             'name:{0}',
             'title:{0}',
         ]).format(search.query.solr_literal(q)),
-        'fl': ['name', 'title'],
+        'fl': 'name,title',
         'rows': limit
     }
     query = search.query_for(model.Package)

--- a/ckan/tests/legacy/logic/test_action.py
+++ b/ckan/tests/legacy/logic/test_action.py
@@ -130,7 +130,7 @@ class TestAction(WsgiAppCase):
         assert_equal(res_obj['result'][0]['match_displayed'], 'warandpeace')
 
     def test_02_package_autocomplete_match_title(self):
-        postparams = '%s=1' % json.dumps({'q':'a%20w', 'limit': 5})
+        postparams = '%s=1' % json.dumps({'q': 'won', 'limit': 5})
         res = self.app.post('/api/action/package_autocomplete', params=postparams)
         res_obj = json.loads(res.body)
         assert_equal(res_obj['success'], True)


### PR DESCRIPTION
Apparently, previously(circleV1) we were using SOLRv4 and now(circleV2) we use SOLRv3 instead. They have little bit different implementation of NGram tokenizer(that one, I'm using for autocomplete) and, in addition, newer SOLR is more adaptive in terms of search parameters. Actually, I was passing `fl` as a list and SOLRv4 was able to handle it, whereas SOLRv3 strictly requires string.. anyway, it seems that I've fixed the problem