### PR TITLE
Fix fatal errors due to broken Russian and Dutch locales (related to #3327)

### DIFF
--- a/ckan/i18n/nl/LC_MESSAGES/ckan.po
+++ b/ckan/i18n/nl/LC_MESSAGES/ckan.po
@@ -1553,7 +1553,7 @@ msgstr[1] "meer dan {years} jaren geleden"
 
 #: ckan/lib/formatters.py:146
 msgid "{month} {day}, {year}, {hour:02}:{min:02} ({timezone})"
-msgstr "{maand} {dag}, {jaar}, {uur:02}:{min:02} ({tijdzone})"
+msgstr "{month} {day}, {year}, {hour:02}:{min:02} ({timezone})"
 
 #: ckan/lib/formatters.py:151
 msgid "{month} {day}, {year}"

--- a/ckan/i18n/ru/LC_MESSAGES/ckan.po
+++ b/ckan/i18n/ru/LC_MESSAGES/ckan.po
@@ -1572,11 +1572,11 @@ msgstr[3] "больше {years} лет назад"
 
 #: ckan/lib/formatters.py:146
 msgid "{month} {day}, {year}, {hour:02}:{min:02} ({timezone})"
-msgstr "{месяц} {день}, {год}, {часов:02}:{минут:02} ({timezone})"
+msgstr "{month} {day}, {year}, {hour:02}:{min:02} ({timezone})"
 
 #: ckan/lib/formatters.py:151
 msgid "{month} {day}, {year}"
-msgstr "{месяц} {день}, {год}"
+msgstr "{month} {day}, {year}"
 
 #: ckan/lib/formatters.py:167
 msgid "{bytes} bytes"


### PR DESCRIPTION
Fixes 500 Internal server error on dataset view pages with ru or nl locales.

### Proposed fixes:
Maybe this should be done on Transifex? And backported to supported branches?

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
