### PR TITLE
Fixed migrate_filestore by not feeding None to mimetypes.guess_type()

### DIFF
--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -221,7 +221,7 @@ class ResourceUpload(object):
         upload_field_storage = resource.pop('upload', None)
         self.clear = resource.pop('clear_upload', None)
 
-        if config_mimetype_guess == 'file_ext':
+        if url and config_mimetype_guess == 'file_ext':
             self.mimetype = mimetypes.guess_type(url)[0]
 
         if isinstance(upload_field_storage, ALLOWED_UPLOAD_TYPES):


### PR DESCRIPTION
The code here explicitly assumes that url can be None (by using .get() to get it). And it really happens when called from migrate_filestore with `ResourceUpload({'id': id})`.

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
