### PR TITLE
Script that removes old git branches

### DIFF
--- a/bin/remove-old-git-branches.sh
+++ b/bin/remove-old-git-branches.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Change this variable if you are using another name for ckan/ckan's remote
+REMOTE=origin
+PR_ENDPOINT=https://api.github.com/repos/ckan/ckan/pulls
+
+prepare_branches() {
+  echo List existing branches
+  # awk filters out `master`, `release-something`, `dev-something` and `MAJOR.MINOR-something` branches
+  custom_branches=$(git fetch $REMOTE && git branch -r --list $REMOTE/* | awk '{ if ($2 !~ /^[0-9]\.[0-9]|^release|^dev-|^master$|HEAD/) print $2}' FS=/)
+
+  echo Calculate total amount of active PRs
+  # github adds Link header, that contains reference to last page with results. And that helps us to define total number of pages
+  last_page=$(curl -s -I $PR_ENDPOINT | grep '^Link' | sed -E 's/.*page=([[:digit:]]+).*rel="last".*/\1/')
+
+  echo Compute branches that are in use by active PRs
+  for ((i=1; i<=$last_page; i++))
+  do
+    # Take JSON, get name of branch with feature, leave only those ones, that starts with `ckan:`. I think, that jq is much more nice way to process json, but i'm not sure, that every one has it. But if you do,
+    # you can replace python's section with something like `| jq '.[] | .head.label' -r |`
+    next_portion=$(curl -s "$PR_ENDPOINT?page=$i" | python -c 'import json, sys; raw=sys.stdin.read(); labels=[str(item["head"]["label"]) for item in json.loads(raw)]; print("\n".join(labels))' | grep '^ckan' | sed 's/^ckan://')
+    used_branches="$used_branches\n$next_portion"
+    echo [$i of $last_page parts processed]
+  done;
+
+  echo Compute list of branches that can be safetely removed
+  tmp_file=$(mktemp)
+  diff <(echo -e "$used_branches" | sort) <(echo -e "$custom_branches" | sort) --unchanged-line-format="" >> $tmp_file
+
+  echo
+  echo List of all branches that can be removed stored into $tmp_file. Review it\'s content and run \'$0 --apply $tmp_file\'.
+  echo NOTE. This command requires write access to CKAN repository and will actually remove all branches that are listed in $tmp_file.
+}
+
+if [[ $# -gt 0 ]];
+then
+  case "$1" in
+    -h|--help)
+      echo Compute/remove unused branches
+      echo Usage: $0 [--apply FILE_WITH_BRANCHES]
+      ;;
+    --apply)
+      shift
+      if [[ -f $1 ]]
+      then
+        while read branch
+        do
+          git push $REMOTE --delete $branch
+        done < $1
+      else
+        echo File does not exist
+      fi
+      shift
+      ;;
+    *)
+      echo Check usage with: $0 --help
+      ;;
+  esac
+else
+  prepare_branches
+fi


### PR DESCRIPTION
Solution for #4585

We may face this problem in feature, so i've added [script](https://github.com/smotornyuk/ckan/blob/712f3adf74644116bfe5e439cf1d44e608641c72/bin/remove-old-git-branches.sh) to `bin` folder.

It should be executed in two stages. First, you run `bin/remove-old-git-branches.sh`. This command will take all branch names from your origin repo(you may use another remote name by changing `REMOTE` variable in script), fetch all branches that are used in open pull-request via github api and compare these two lists. Output will be stored to temporary file and you'll see something like 
```
List of all branches that can be removed stored into /tmp/xyz. Review it's content and run 'bin/remove-old-git-branches.sh --apply /tmp/xyz'
```

You need to review `/tmp/xyz` and maybe remove some lines if you want to preserve few branches. After this, run the command from first stage's output(it's the same script with --apply flag, that points to file with list of branches to remove). This will remove all branches that are still listed inside temporary file.

If you think, that some branches shouldn't be deleted, you may as well change 10th line of the script, `awk` segment. For now, i'm ignoring `master`, `release...`, `dev...`, `X.Y...` branches. 