### PR TITLE
Update datapusher api and paster docs

### DIFF
--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -207,8 +207,6 @@ alongside CKAN.
 
 To install this please look at the docs here: http://docs.ckan.org/projects/datapusher
 
-
-
 .. note:: The DataPusher only imports the first worksheet of a spreadsheet. It also does
    not support duplicate column headers. That includes blank column headings.
 

--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -207,10 +207,40 @@ alongside CKAN.
 
 To install this please look at the docs here: http://docs.ckan.org/projects/datapusher
 
+
+
 .. note:: The DataPusher only imports the first worksheet of a spreadsheet. It also does
    not support duplicate column headers. That includes blank column headings.
 
 .. _data_dictionary:
+
+
+Using datapusher from the command-line
+======================================
+
+To see all available datapusher paster commands run::
+    
+    paster datapusher
+    
+Resubmit all resources to datapusher, although it will skip files whose hash of the data file has not changed::
+
+    paster --plugin=ckan datapusher resubmit -c /etc/ckan/default/ckan.ini
+
+Resubmit a specific resource, whether or not the hash of the data file has changed::
+
+    paster --plugin=ckan datapusher submit <pkgname> -c /etc/ckan/default/ckan.ini
+    
+Submit every package to the datastore. This is useful if you're setting up datastore for a ckan that already has datasets::
+
+    paster --plugin=ckan datapusher submit_all -c /etc/ckan/default/ckan.ini
+
+
+API reference
+=============
+
+.. automodule:: ckanext.datapusher.logic.action
+   :members:
+
 
 ---------------
 Data Dictionary


### PR DESCRIPTION
Fixes https://github.com/ckan/datapusher/issues/37

### Proposed fixes:

As per https://github.com/ckan/datapusher/issues/37 comments, adding some clearer docs around the API and paster commands for DataPusher.

As per https://github.com/ckan/ckan/issues/4415, DataPusher will be phased out but until then it may be good to have this referenced. I ran into some issues that this helped for. I did find that with CKAN 2.8.1 the paster command `paster --plugin=ckan datapusher resubmit -c /etc/ckan/default/ckan.ini` failed and raised a `NotAuthorized` error tracing back to `if datapusher_submit({'user': user['name']}, data_dict)` - I'm thinking this is related to https://github.com/ckan/ckan/pull/4248 and https://github.com/ckan/datapusher/issues/171.  API works fine.

Also, adding reference to Issue https://github.com/ckan/datapusher/issues/18 to help link similar concerns.

### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
