### PR TITLE
3994 fix background job timeout

### DIFF
--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -191,6 +191,8 @@ ckan.hide_activity_from_users = %(ckan.site_id)s
 #smtp.password = your_password
 #smtp.mail_from =
 
+## RQ Job Settings
+rq.bg_job_timeout = 180
 
 ## Logging configuration
 [loggers]
@@ -226,6 +228,3 @@ formatter = generic
 
 [formatter_generic]
 format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s
-
-## RQ Job Settings
-rq.bg_job_timeout = 180

--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -192,7 +192,7 @@ ckan.hide_activity_from_users = %(ckan.site_id)s
 #smtp.mail_from =
 
 ## Background Job Settings
-bg_job_timeout = 180
+ckan.jobs.timeout = 180
 
 ## Logging configuration
 [loggers]

--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -226,3 +226,6 @@ formatter = generic
 
 [formatter_generic]
 format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s
+
+## RQ Job Settings
+rq.bg_job_timeout = 180

--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -191,8 +191,8 @@ ckan.hide_activity_from_users = %(ckan.site_id)s
 #smtp.password = your_password
 #smtp.mail_from =
 
-## RQ Job Settings
-rq.bg_job_timeout = 180
+## Background Job Settings
+bg_job_timeout = 180
 
 ## Logging configuration
 [loggers]

--- a/ckan/lib/jobs.py
+++ b/ckan/lib/jobs.py
@@ -36,7 +36,7 @@ import ckan.plugins as plugins
 log = logging.getLogger(__name__)
 
 DEFAULT_QUEUE_NAME = u'default'
-DEFAULT_JOB_TIMEOUT = config.get(u'bg_job_timeout', 180)
+DEFAULT_JOB_TIMEOUT = config.get(u'ckan.jobs.timeout', 180)
 
 # RQ job queues. Do not use this directly, use ``get_queue`` instead.
 _queues = {}

--- a/ckan/lib/jobs.py
+++ b/ckan/lib/jobs.py
@@ -36,7 +36,7 @@ import ckan.plugins as plugins
 log = logging.getLogger(__name__)
 
 DEFAULT_QUEUE_NAME = u'default'
-DEFAULT_JOB_TIMEOUT = config.get(u'rq.bg_job_timeout', 180)
+DEFAULT_JOB_TIMEOUT = config.get(u'bg_job_timeout', 180)
 
 # RQ job queues. Do not use this directly, use ``get_queue`` instead.
 _queues = {}

--- a/ckan/lib/jobs.py
+++ b/ckan/lib/jobs.py
@@ -154,7 +154,7 @@ def enqueue(fn, args=None, kwargs=None, title=None, queue=DEFAULT_QUEUE_NAME,
     if kwargs is None:
         kwargs = {}
     job = get_queue(queue).enqueue_call(func=fn, args=args, kwargs=kwargs,
-                                        timeout=None)
+                                        timeout=timeout)
     job.meta[u'title'] = title
     job.save()
     msg = u'Added background job {}'.format(job.id)

--- a/ckan/lib/jobs.py
+++ b/ckan/lib/jobs.py
@@ -36,6 +36,7 @@ import ckan.plugins as plugins
 log = logging.getLogger(__name__)
 
 DEFAULT_QUEUE_NAME = u'default'
+DEFAULT_JOB_TIMEOUT = config[u'rq.bg_job_timeout']
 
 # RQ job queues. Do not use this directly, use ``get_queue`` instead.
 _queues = {}
@@ -123,7 +124,8 @@ def get_queue(name=DEFAULT_QUEUE_NAME):
         return queue
 
 
-def enqueue(fn, args=None, kwargs=None, title=None, queue=DEFAULT_QUEUE_NAME):
+def enqueue(fn, args=None, kwargs=None, title=None, queue=DEFAULT_QUEUE_NAME,
+            timeout=DEFAULT_JOB_TIMEOUT):
     u'''
     Enqueue a job to be run in the background.
 
@@ -141,6 +143,9 @@ def enqueue(fn, args=None, kwargs=None, title=None, queue=DEFAULT_QUEUE_NAME):
     :param string queue: Name of the queue. If not given then the
         default queue is used.
 
+    :param integer timeout: The timeout, in seconds, to be passed
+        to the background job via rq.
+
     :returns: The enqueued job.
     :rtype: ``rq.job.Job``
     '''
@@ -148,7 +153,8 @@ def enqueue(fn, args=None, kwargs=None, title=None, queue=DEFAULT_QUEUE_NAME):
         args = []
     if kwargs is None:
         kwargs = {}
-    job = get_queue(queue).enqueue_call(func=fn, args=args, kwargs=kwargs)
+    job = get_queue(queue).enqueue_call(func=fn, args=args, kwargs=kwargs,
+                                        timeout=None)
     job.meta[u'title'] = title
     job.save()
     msg = u'Added background job {}'.format(job.id)

--- a/ckan/lib/jobs.py
+++ b/ckan/lib/jobs.py
@@ -36,7 +36,7 @@ import ckan.plugins as plugins
 log = logging.getLogger(__name__)
 
 DEFAULT_QUEUE_NAME = u'default'
-DEFAULT_JOB_TIMEOUT = config.get[u'rq.bg_job_timeout', 180]
+DEFAULT_JOB_TIMEOUT = config.get(u'rq.bg_job_timeout', 180)
 
 # RQ job queues. Do not use this directly, use ``get_queue`` instead.
 _queues = {}

--- a/ckan/lib/jobs.py
+++ b/ckan/lib/jobs.py
@@ -36,7 +36,7 @@ import ckan.plugins as plugins
 log = logging.getLogger(__name__)
 
 DEFAULT_QUEUE_NAME = u'default'
-DEFAULT_JOB_TIMEOUT = config[u'rq.bg_job_timeout']
+DEFAULT_JOB_TIMEOUT = config.get[u'rq.bg_job_timeout', 180]
 
 # RQ job queues. Do not use this directly, use ``get_queue`` instead.
 _queues = {}

--- a/ckan/tests/lib/test_jobs.py
+++ b/ckan/tests/lib/test_jobs.py
@@ -74,6 +74,18 @@ class TestEnqueue(RQTestBase):
         assert_equal(all_jobs[1].origin,
                      jobs.add_queue_name_prefix(u'my_queue'))
 
+    def test_enqueue_timeout(self):
+        self.enqueue()
+        self.enqueue(timeout=0)
+        self.enqueue(timeout=-1)
+        self.enqueue(timeout=3600)
+        all_jobs = self.all_jobs()
+        assert_equal(len(all_jobs), 4)
+        assert_equal(all_jobs[0].meta[u'timeout'], 180)
+        assert_equal(all_jobs[1].meta[u'timeout'], 180)
+        assert_equal(all_jobs[2].meta[u'timeout'], -1)
+        assert_equal(all_jobs[3].meta[u'timeout'], 3600)
+
 
 class TestGetAllQueues(RQTestBase):
 

--- a/ckan/tests/lib/test_jobs.py
+++ b/ckan/tests/lib/test_jobs.py
@@ -83,7 +83,7 @@ class TestEnqueue(RQTestBase):
         assert_equal(len(all_jobs), 4)
         assert_equal(all_jobs[0].timeout, 180)
         assert_equal(all_jobs[1].timeout, 180)
-        assert_equal(all_jobs[2].timeout, 180)
+        assert_equal(all_jobs[2].timeout, -1)
         assert_equal(all_jobs[3].timeout, 3600)
 
 

--- a/ckan/tests/lib/test_jobs.py
+++ b/ckan/tests/lib/test_jobs.py
@@ -81,10 +81,10 @@ class TestEnqueue(RQTestBase):
         self.enqueue(timeout=3600)
         all_jobs = self.all_jobs()
         assert_equal(len(all_jobs), 4)
-        assert_equal(all_jobs[0].meta[u'timeout'], 180)
-        assert_equal(all_jobs[1].meta[u'timeout'], 180)
-        assert_equal(all_jobs[2].meta[u'timeout'], -1)
-        assert_equal(all_jobs[3].meta[u'timeout'], 3600)
+        assert_equal(all_jobs[0].timeout, 180)
+        assert_equal(all_jobs[1].timeout, 180)
+        assert_equal(all_jobs[2].timeout, -1)
+        assert_equal(all_jobs[3].timeout, 3600)
 
 
 class TestGetAllQueues(RQTestBase):

--- a/ckan/tests/lib/test_jobs.py
+++ b/ckan/tests/lib/test_jobs.py
@@ -83,7 +83,7 @@ class TestEnqueue(RQTestBase):
         assert_equal(len(all_jobs), 4)
         assert_equal(all_jobs[0].timeout, 180)
         assert_equal(all_jobs[1].timeout, 180)
-        assert_equal(all_jobs[2].timeout, -1)
+        assert_equal(all_jobs[2].timeout, 180)
         assert_equal(all_jobs[3].timeout, 3600)
 
 

--- a/doc/maintaining/background-tasks.rst
+++ b/doc/maintaining/background-tasks.rst
@@ -104,7 +104,7 @@ A timeout can also be set on a job iwth the ``timeout`` keyword argument::
     jobs.enqueue(log_job, [u'My log message'], timeout=3600)
 
 The default background job timeout is 180 seconds. This is set in the
-ckan config ``.ini`` file under the ``bg_job_timeout`` item.
+ckan config ``.ini`` file under the ``ckan.jobs.timeout`` item.
 
 Accessing the database from background jobs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/maintaining/background-tasks.rst
+++ b/doc/maintaining/background-tasks.rst
@@ -104,7 +104,7 @@ A timeout can also be set on a job iwth the ``timeout`` keyword argument::
     jobs.enqueue(log_job, [u'My log message'], timeout=3600)
 
 The default background job timeout is 180 seconds. This is set in the
-ckan config ``.ini`` file under the ``rq.bg_job_timeout`` item.
+ckan config ``.ini`` file under the ``bg_job_timeout`` item.
 
 Accessing the database from background jobs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/maintaining/background-tasks.rst
+++ b/doc/maintaining/background-tasks.rst
@@ -99,6 +99,12 @@ You can also give the job a title which can be useful for identifying it when
 
     jobs.enqueue(log_job, [u'My log message'], title=u'My log job')
 
+A timeout can also be set on a job iwth the ``timeout`` keyword argument::
+
+    jobs.enqueue(log_job, [u'My log message'], timeout=3600)
+
+The default background job timeout is 180 seconds. This is set in the
+ckan config ``.ini`` file under the ``rq.bg_job_timeout`` item.
 
 Accessing the database from background jobs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test-core-circle-ci.ini
+++ b/test-core-circle-ci.ini
@@ -47,3 +47,6 @@ formatter = generic
 
 [formatter_generic]
 format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s
+
+[rq]
+rq.bg_job_timeout = 180

--- a/test-core-circle-ci.ini
+++ b/test-core-circle-ci.ini
@@ -13,6 +13,8 @@ sqlalchemy.url = postgresql://ckan_default:pass@ckan-postgres/ckan_test
 
 solr_url = http://localhost:8080/solr
 
+rq.bg_job_timeout = 180
+
 [loggers]
 keys = root, ckan, sqlalchemy
 
@@ -47,6 +49,3 @@ formatter = generic
 
 [formatter_generic]
 format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s
-
-[rq]
-rq.bg_job_timeout = 180

--- a/test-core-circle-ci.ini
+++ b/test-core-circle-ci.ini
@@ -13,8 +13,6 @@ sqlalchemy.url = postgresql://ckan_default:pass@ckan-postgres/ckan_test
 
 solr_url = http://localhost:8080/solr
 
-rq.bg_job_timeout = 180
-
 [loggers]
 keys = root, ckan, sqlalchemy
 

--- a/test-core.ini
+++ b/test-core.ini
@@ -101,6 +101,9 @@ who.config_file = %(here)s/who.ini
 who.log_level = warning
 who.log_file = %(cache_dir)s/who_log.ini
 
+## rq background jobs
+rq.bg_job_timeout = 180
+
 # Logging configuration
 [loggers]
 keys = root, ckan, sqlalchemy

--- a/test-core.ini
+++ b/test-core.ini
@@ -102,7 +102,7 @@ who.log_level = warning
 who.log_file = %(cache_dir)s/who_log.ini
 
 ## background jobs
-bg_job_timeout = 180
+ckan.jobs.timeout = 180
 
 # Logging configuration
 [loggers]

--- a/test-core.ini
+++ b/test-core.ini
@@ -101,8 +101,8 @@ who.config_file = %(here)s/who.ini
 who.log_level = warning
 who.log_file = %(cache_dir)s/who_log.ini
 
-## rq background jobs
-rq.bg_job_timeout = 180
+## background jobs
+bg_job_timeout = 180
 
 # Logging configuration
 [loggers]


### PR DESCRIPTION
Fixes #3994

### Proposed fixes:
Pass a timeout keyword from the `ckan.lib.jobs.equeue` method through to the rq `Job` object. 

Includes tests for cases where timeout is:
- None
- -1
- 0
- 3600


### Features:

- [x] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
