### PR TITLE
PEP8 and tidy

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -55,7 +55,7 @@ _text = sqlalchemy.text
 
 def _filter_activity_by_user(activity_list, users=[]):
     '''
-    Return the given ``activity_list`` with activities from the specified
+    Return the given ``activity_list`` but with activities from the specified
     users removed. The users parameters should be a list of ids.
 
     A *new* filtered list is returned, the given ``activity_list`` itself is
@@ -1017,7 +1017,7 @@ def package_show(context, data_dict):
                 package_dict_validated = False
             metadata_modified = pkg.metadata_modified.isoformat()
             search_metadata_modified = search_result['metadata_modified']
-            # solr stores less precice datetime,
+            # solr stores less precise datetime,
             # truncate to 22 charactors to get good enough match
             if metadata_modified[:22] != search_metadata_modified[:22]:
                 package_dict = None
@@ -2511,10 +2511,10 @@ def user_activity_list(context, data_dict):
     offset = data_dict.get('offset', 0)
     limit = data_dict['limit']  # defaulted, limited & made an int by schema
 
-    _activity_objects = model.activity.user_activity_list(user.id, limit=limit,
-            offset=offset)
-    activity_objects = _filter_activity_by_user(_activity_objects,
-            _activity_stream_get_filtered_users())
+    _activity_objects = model.activity.user_activity_list(
+        user.id, limit=limit, offset=offset)
+    activity_objects = _filter_activity_by_user(
+        _activity_objects, _activity_stream_get_filtered_users())
 
     return model_dictize.activity_list_dictize(activity_objects, context)
 
@@ -2553,10 +2553,10 @@ def package_activity_list(context, data_dict):
     offset = int(data_dict.get('offset', 0))
     limit = data_dict['limit']  # defaulted, limited & made an int by schema
 
-    _activity_objects = model.activity.package_activity_list(package.id,
-            limit=limit, offset=offset)
-    activity_objects = _filter_activity_by_user(_activity_objects,
-            _activity_stream_get_filtered_users())
+    _activity_objects = model.activity.package_activity_list(
+        package.id, limit=limit, offset=offset)
+    activity_objects = _filter_activity_by_user(
+        _activity_objects, _activity_stream_get_filtered_users())
 
     return model_dictize.activity_list_dictize(activity_objects, context)
 
@@ -2594,10 +2594,10 @@ def group_activity_list(context, data_dict):
     group_show = logic.get_action('group_show')
     group_id = group_show(context, {'id': group_id})['id']
 
-    _activity_objects = model.activity.group_activity_list(group_id,
-            limit=limit, offset=offset)
-    activity_objects = _filter_activity_by_user(_activity_objects,
-            _activity_stream_get_filtered_users())
+    _activity_objects = model.activity.group_activity_list(
+        group_id, limit=limit, offset=offset)
+    activity_objects = _filter_activity_by_user(
+        _activity_objects, _activity_stream_get_filtered_users())
 
     return model_dictize.activity_list_dictize(activity_objects, context)
 
@@ -2633,10 +2633,10 @@ def organization_activity_list(context, data_dict):
     org_show = logic.get_action('organization_show')
     org_id = org_show(context, {'id': org_id})['id']
 
-    _activity_objects = model.activity.group_activity_list(org_id,
-            limit=limit, offset=offset)
-    activity_objects = _filter_activity_by_user(_activity_objects,
-            _activity_stream_get_filtered_users())
+    _activity_objects = model.activity.group_activity_list(
+        org_id, limit=limit, offset=offset)
+    activity_objects = _filter_activity_by_user(
+        _activity_objects, _activity_stream_get_filtered_users())
 
     return model_dictize.activity_list_dictize(activity_objects, context)
 
@@ -2664,9 +2664,9 @@ def recently_changed_packages_activity_list(context, data_dict):
     limit = data_dict['limit']  # defaulted, limited & made an int by schema
 
     _activity_objects = model.activity.recently_changed_packages_activity_list(
-            limit=limit, offset=offset)
-    activity_objects = _filter_activity_by_user(_activity_objects,
-            _activity_stream_get_filtered_users())
+        limit=limit, offset=offset)
+    activity_objects = _filter_activity_by_user(
+        _activity_objects, _activity_stream_get_filtered_users())
 
     return model_dictize.activity_list_dictize(activity_objects, context)
 
@@ -3354,11 +3354,11 @@ def dashboard_activity_list(context, data_dict):
 
     # FIXME: Filter out activities whose subject or object the user is not
     # authorized to read.
-    _activity_objects = model.activity.dashboard_activity_list(user_id,
-            limit=limit, offset=offset)
+    _activity_objects = model.activity.dashboard_activity_list(
+        user_id, limit=limit, offset=offset)
 
-    activity_objects = _filter_activity_by_user(_activity_objects,
-            _activity_stream_get_filtered_users())
+    activity_objects = _filter_activity_by_user(
+        _activity_objects, _activity_stream_get_filtered_users())
     activity_dicts = model_dictize.activity_list_dictize(
         activity_objects, context)
 

--- a/ckan/logic/auth/__init__.py
+++ b/ckan/logic/auth/__init__.py
@@ -9,8 +9,7 @@ import ckan.authz as authz
 
 
 def _get_object(context, data_dict, name, class_name):
-    # return the named item if in the data_dict, or get it from
-    # model.class_name
+    # return the named item if in the context, or get it from model.class_name
     try:
         return context[name]
     except KeyError:

--- a/ckan/model/activity.py
+++ b/ckan/model/activity.py
@@ -45,10 +45,11 @@ activity_detail_table = Table(
     Column('data', _types.JsonDictType),
     )
 
+
 class Activity(domain_object.DomainObject):
 
-    def __init__(self, user_id, object_id, revision_id, activity_type,
-            data=None):
+    def __init__(
+            self, user_id, object_id, revision_id, activity_type, data=None):
         self.id = _types.make_uuid()
         self.timestamp = datetime.datetime.utcnow()
         self.user_id = user_id
@@ -60,12 +61,14 @@ class Activity(domain_object.DomainObject):
         else:
             self.data = data
 
+
 meta.mapper(Activity, activity_table)
 
 
 class ActivityDetail(domain_object.DomainObject):
 
-    def __init__(self, activity_id, object_id, object_type, activity_type,
+    def __init__(
+            self, activity_id, object_id, object_type, activity_type,
             data=None):
         self.activity_id = activity_id
         self.object_id = object_id
@@ -79,11 +82,11 @@ class ActivityDetail(domain_object.DomainObject):
     @classmethod
     def by_activity_id(cls, activity_id):
         return ckan.model.Session.query(cls) \
-                .filter_by(activity_id = activity_id).all()
+            .filter_by(activity_id=activity_id).all()
 
 
-meta.mapper(ActivityDetail, activity_detail_table, properties = {
-    'activity':orm.relation ( Activity, backref=orm.backref('activity_detail'))
+meta.mapper(ActivityDetail, activity_detail_table, properties={
+    'activity': orm.relation(Activity, backref=orm.backref('activity_detail'))
     })
 
 
@@ -99,6 +102,7 @@ def _activities_limit(q, limit, offset=None):
         q = q.limit(limit)
     return q
 
+
 def _activities_union_all(*qlist):
     '''
     Return union of two or more queries sorted by timestamp,
@@ -109,11 +113,13 @@ def _activities_union_all(*qlist):
         union_all(*[q.subquery().select() for q in qlist])
         ).distinct(model.Activity.timestamp)
 
+
 def _activities_at_offset(q, limit, offset):
     '''
     Return a list of all activities at an offset with a limit.
     '''
     return _activities_limit(q, limit, offset).all()
+
 
 def _activities_from_user_query(user_id):
     '''Return an SQLAlchemy query for all activities from user_id.'''
@@ -158,15 +164,15 @@ def _package_activity_query(package_id):
 
     '''
     import ckan.model as model
-    q = model.Session.query(model.Activity)
-    q = q.filter_by(object_id=package_id)
+    q = model.Session.query(model.Activity) \
+        .filter_by(object_id=package_id)
     return q
 
 
 def package_activity_list(package_id, limit, offset):
     '''Return the given dataset (package)'s public activity stream.
 
-    Returns all activities  about the given dataset, i.e. where the given
+    Returns all activities about the given dataset, i.e. where the given
     dataset is the object of the activity, e.g.:
 
     "{USER} created the dataset {DATASET}"
@@ -216,7 +222,7 @@ def _group_activity_query(group_id):
         or_(
             model.Member.group_id == group_id,
             model.Activity.object_id == group_id
-        ),
+        )
     )
 
     return q
@@ -225,7 +231,7 @@ def _group_activity_query(group_id):
 def group_activity_list(group_id, limit, offset):
     '''Return the given group's public activity stream.
 
-    Returns all activities where the given group or one of its datasets is the
+    Returns activities where the given group or one of its datasets is the
     object of the activity, e.g.:
 
     "{USER} updated the group {GROUP}"
@@ -237,7 +243,7 @@ def group_activity_list(group_id, limit, offset):
     return _activities_at_offset(q, limit, offset)
 
 
-def _activites_from_users_followed_by_user_query(user_id, limit):
+def _activities_from_users_followed_by_user_query(user_id, limit):
     '''Return a query for all activities from users that user_id follows.'''
     import ckan.model as model
 
@@ -290,7 +296,7 @@ def _activities_from_groups_followed_by_user_query(user_id, limit):
 
 def _activities_from_everything_followed_by_user_query(user_id, limit):
     '''Return a query for all activities from everything user_id follows.'''
-    q1 = _activites_from_users_followed_by_user_query(user_id, limit)
+    q1 = _activities_from_users_followed_by_user_query(user_id, limit)
     q2 = _activities_from_datasets_followed_by_user_query(user_id, limit)
     q3 = _activities_from_groups_followed_by_user_query(user_id, limit)
     return _activities_union_all(q1, q2, q3)
@@ -330,7 +336,7 @@ def dashboard_activity_list(user_id, limit, offset):
     return _activities_at_offset(q, limit, offset)
 
 def _changed_packages_activity_query():
-    '''Return an SQLAlchemyu query for all changed package activities.
+    '''Return an SQLAlchemy query for all changed package activities.
 
     Return a query for all activities with activity_type '*package', e.g.
     'new_package', 'changed_package', 'deleted_package'.

--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -1,11 +1,9 @@
 # encoding: utf-8
 
 import datetime
-from calendar import timegm
 import logging
-logger = logging.getLogger(__name__)
 
-from sqlalchemy.sql import select, and_, union, or_
+from sqlalchemy.sql import and_, or_
 from sqlalchemy import orm
 from sqlalchemy import types, Column, Table
 from ckan.common import config
@@ -21,6 +19,8 @@ import extension
 
 import ckan.lib.maintain as maintain
 import ckan.lib.dictization as dictization
+
+logger = logging.getLogger(__name__)
 
 __all__ = ['Package', 'package_table', 'package_revision_table',
            'PACKAGE_NAME_MAX_LENGTH', 'PACKAGE_NAME_MIN_LENGTH',
@@ -508,6 +508,7 @@ class Package(vdm.sqlalchemy.RevisionedObjectMixin,
     def activity_stream_item(self, activity_type, revision, user_id):
         import ckan.model
         import ckan.logic
+
         assert activity_type in ("new", "changed"), (
             str(activity_type))
 

--- a/ckan/templates-bs2/group/activity_stream.html
+++ b/ckan/templates-bs2/group/activity_stream.html
@@ -3,7 +3,11 @@
 {% block subtitle %}{{ _('Activity Stream') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
-  <h2 class="hide-heading">{% block page_heading %}{{ _('Activity Stream') }}{% endblock %}</h2>
+  <h1 class="hide-heading">
+    {% block page_heading -%}
+      {{ _('Activity Stream') }}
+    {%- endblock %}
+  </h1>
   {% block activity_stream %}
     {{ group_activity_stream | safe }}
   {% endblock %}

--- a/ckan/templates-bs2/organization/activity_stream.html
+++ b/ckan/templates-bs2/organization/activity_stream.html
@@ -3,7 +3,11 @@
 {% block subtitle %}{{ _('Activity Stream') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
-  <h2 class="hide-heading">{% block page_heading %}{{ _('Activity Stream') }}{% endblock %}</h2>
+  <h1 class="hide-heading">
+    {% block page_heading -%}
+      {{ _('Activity Stream') }}
+    {%- endblock %}
+  </h1>
   {% block activity_stream %}
     {{ c.group_activity_stream | safe }}
   {% endblock %}

--- a/ckan/templates-bs2/package/snippets/resources.html
+++ b/ckan/templates-bs2/package/snippets/resources.html
@@ -1,10 +1,10 @@
 {#
-Displays a sidebard module with navigation containing the provided resources.
+Displays a sidebar module with navigation containing the provided resources.
 If no resources are provided then the module will not be displayed.
 
 pkg       - The package dict that owns the resources.
 active    - The id of the currently displayed resource.
-action    - The controller action to use (default: 'resource_read').
+action    - The resource action to use (default: 'read', meaning route 'resource.read').
 
 Example:
 

--- a/ckan/templates-bs2/user/activity_stream.html
+++ b/ckan/templates-bs2/user/activity_stream.html
@@ -3,7 +3,11 @@
 {% block subtitle %}{{ _('Activity Stream') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
-  <h2 class="hide-heading">{% block page_heading %}{{ _('Activity Stream') }}{% endblock %}</h2>
+  <h1 class="hide-heading">
+    {% block page_heading -%}
+      {{ _('Activity Stream') }}
+    {%- endblock %}
+  </h1>
   {% block activity_stream %}
     {{ g.user_activity_stream | safe }}
   {% endblock %}

--- a/ckan/templates/group/activity_stream.html
+++ b/ckan/templates/group/activity_stream.html
@@ -3,7 +3,11 @@
 {% block subtitle %}{{ _('Activity Stream') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
-  <h2 class="hide-heading">{% block page_heading %}{{ _('Activity Stream') }}{% endblock %}</h2>
+  <h1 class="hide-heading">
+    {% block page_heading -%}
+      {{ _('Activity Stream') }}
+    {%- endblock %}
+  </h1>
   {% block activity_stream %}
     {{ group_activity_stream | safe }}
   {% endblock %}

--- a/ckan/templates/organization/activity_stream.html
+++ b/ckan/templates/organization/activity_stream.html
@@ -3,7 +3,11 @@
 {% block subtitle %}{{ _('Activity Stream') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
-  <h2 class="hide-heading">{% block page_heading %}{{ _('Activity Stream') }}{% endblock %}</h2>
+  <h1 class="hide-heading">
+    {% block page_heading -%}
+      {{ _('Activity Stream') }}
+    {%- endblock %}
+  </h1>
   {% block activity_stream %}
     {{ group_activity_stream | safe }}
   {% endblock %}

--- a/ckan/templates/package/snippets/resources.html
+++ b/ckan/templates/package/snippets/resources.html
@@ -13,7 +13,7 @@ Example:
 #}
 {% set resources = pkg.resources or [] %}
 {% if resources %}
-	{% block resources %}
+  {% block resources %}
     <section class="module module-narrow resources">
       {% block resources_inner %}
         {% block resources_title %}

--- a/ckan/templates/package/snippets/resources.html
+++ b/ckan/templates/package/snippets/resources.html
@@ -1,10 +1,10 @@
 {#
-Displays a sidebard module with navigation containing the provided resources.
+Displays a sidebar module with navigation containing the provided resources.
 If no resources are provided then the module will not be displayed.
 
 pkg       - The package dict that owns the resources.
 active    - The id of the currently displayed resource.
-action    - The controller action to use (default: 'resource_read').
+action    - The resource action to use (default: 'read', meaning route 'resource.read').
 
 Example:
 
@@ -13,22 +13,22 @@ Example:
 #}
 {% set resources = pkg.resources or [] %}
 {% if resources %}
-    {% block resources %}
-	<section class="module module-narrow resources">
-	    {% block resources_inner %}
-		{% block resources_title %}
-		    <h2 class="module-heading"><i class="fa fa-files-o"></i> {{ _("Resources") }}</h2>
-		{% endblock %}
-		{% block resources_list %}
-		    <ul class="list-unstyled nav nav-simple">
-			{% for resource in resources %}
-			    <li class="nav-item{{ ' active' if active == resource.id }}">
-				{% link_for h.resource_display_name(resource)|truncate(25), named_route='resource.%s' % (action or 'read'), id=pkg.name, resource_id=resource.id, inner_span=true %}
-			    </li>
-			{% endfor %}
-		    </ul>
-		{% endblock %}
-	    {% endblock %}
-	</section>
-    {% endblock %}
+	{% block resources %}
+    <section class="module module-narrow resources">
+      {% block resources_inner %}
+        {% block resources_title %}
+          <h2 class="module-heading"><i class="fa fa-files-o"></i> {{ _("Resources") }}</h2>
+        {% endblock %}
+        {% block resources_list %}
+          <ul class="list-unstyled nav nav-simple">
+            {% for resource in resources %}
+              <li class="nav-item{{ ' active' if active == resource.id }}">
+                {% link_for h.resource_display_name(resource)|truncate(25), named_route='resource.%s' % (action or 'read'), id=pkg.name, resource_id=resource.id, inner_span=true %}
+              </li>
+            {% endfor %}
+          </ul>
+        {% endblock %}
+      {% endblock %}
+    </section>
+  {% endblock %}
 {% endif %}

--- a/ckan/templates/user/activity_stream.html
+++ b/ckan/templates/user/activity_stream.html
@@ -3,7 +3,11 @@
 {% block subtitle %}{{ _('Activity Stream') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
-  <h2 class="hide-heading">{% block page_heading %}{{ _('Activity Stream') }}{% endblock %}</h2>
+  <h1 class="hide-heading">
+    {% block page_heading -%}
+      {{ _('Activity Stream') }}
+    {%- endblock %}
+  </h1>
   {% block activity_stream %}
     {{ g.user_activity_stream | safe }}
   {% endblock %}

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -1009,7 +1009,7 @@ class TestResourceView(helpers.FunctionalTestBase):
 
     @classmethod
     def teardown_class(cls):
-            p.unload('image_view')
+        p.unload('image_view')
 
     def test_resource_view_create(self):
         user = factories.User()

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -1403,6 +1403,13 @@ class TestPackageSearch(helpers.FunctionalTestBase):
         '''
         logic.get_action('package_search')({}, dict(q='anything'))
 
+    def test_local_parameters_not_supported(self):
+        nose.tools.assert_raises(
+            SearchError,
+            helpers.call_action,
+            'package_search',
+            q='{!child of="content_type:parentDoc"}')
+
 
 class TestPackageAutocompleteWithDatasetForm(helpers.FunctionalTestBase):
     @classmethod
@@ -1435,14 +1442,6 @@ class TestPackageAutocompleteWithDatasetForm(helpers.FunctionalTestBase):
         assert 'custom_text' not in query['results'][0]
         eq(query['results'][0]['extras'][0]['key'], 'custom_text')
         eq(query['results'][0]['extras'][0]['value'], 'foo')
-
-    def test_local_parameters_not_supported(self):
-
-        nose.tools.assert_raises(
-            SearchError,
-            helpers.call_action,
-            'package_search',
-            q='{!child of="content_type:parentDoc"}')
 
 
 class TestBadLimitQueryParameters(helpers.FunctionalTestBase):

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -1014,11 +1014,9 @@ def activity(package_type, id):
     try:
         pkg_dict = get_action(u'package_show')(context, data_dict)
         pkg = context[u'package']
-        package_activity_stream = get_action(u'package_activity_list_html')(
-            context, {
-                u'id': pkg_dict[u'id']
-            }
-        )
+        package_activity_stream = get_action(
+            u'package_activity_list_html')(
+            context, {u'id': pkg_dict[u'id']})
         dataset_type = pkg_dict[u'type'] or u'dataset'
     except NotFound:
         return base.abort(404, _(u'Dataset not found'))


### PR DESCRIPTION
This is extracted from https://github.com/ckan/ckan/pull/3972

The only functional change is: `<h2>` -> `<h1>` which is for consistency with others of type: `{% block primary_content_inner %}`

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
