### PR TITLE
Upgrade node and less in docs

### DIFF
--- a/doc/contributing/frontend/index.rst
+++ b/doc/contributing/frontend/index.rst
@@ -25,7 +25,7 @@ Instructions for installing |nodejs| can be found on the |nodejs| `website
 On Ubuntu, run the following to install |nodejs| official repository and the node
 package::
 
-    curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
+    curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
     sudo apt-get install -y nodejs
 
 .. note:: If you use the package on the default Ubuntu repositories (eg ``sudo apt-get install nodejs``),
@@ -49,7 +49,7 @@ style script.
 
 ::
 
-    $ npm install less@1.7.5 nodewatch
+    $ npm install less@3.7.1 nodewatch
 
 
 You may need to use ``sudo`` depending on your CKAN install type.


### PR DESCRIPTION
I meant to do this in https://github.com/ckan/ckan/pull/4356
and used these versions to produce the CSS in that PR. However I [mistakenly reverted](https://github.com/ckan/ckan/pull/4356/commits/e1b6b7c086fe43757025c2ed7a544bc4ee612536) the change to the documentation page. So this updates the docs to match the CSS.

* Node 10 is the LTS version agreed on in #4356
* Less 3.6.1 was the latest when I did #4356

### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
