### PR TITLE
Upgrade bleach

### DIFF
--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -561,7 +561,7 @@ class TestHelpersRenderDatetime(object):
 class TestCleanHtml(object):
     def test_disallowed_tag(self):
         eq_(h.clean_html('<b><bad-tag>Hello'),
-            u'<b>&lt;bad-tag&gt;Hello&lt;/bad-tag&gt;</b>')
+            u'<b>&lt;bad-tag&gt;Hello</b>')
 
     def test_non_string(self):
         # allow a datetime for compatibility with older ckanext-datapusher

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 # The file contains the direct ckan requirements.
 # Use pip-compile to create a requirements.txt file from this
 Babel==2.3.4
-bleach==2.1.3
+bleach==3.0.2
 click==6.7
 fanstatic==0.12
 Flask==0.12.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 argparse==1.4.0           # via ofs
 babel==2.3.4
 beaker==1.10.0            # via pylons
-bleach==2.1.3
+bleach==3.0.2
 certifi==2018.10.15       # via requests
 chardet==3.0.4            # via requests
 click==6.7


### PR DESCRIPTION
I read the changelog and there's no advantage to this PR, apart from just being on the latest.

GitHub alerts falsely say we need to upgrade to 2.1.4 because of CVE-2018-7753, but actually that was fixed in 2.1.3, which this already uses. However I thought we should probably upgrade to latest while in there.

## Backport 

BUT we should backport an upgraded bleach version (to 2.1.3 is sufficient) for earlier CKAN versions that specify earlier ones:

e.g.
`
2.5 bleach==1.4.3
2.6 bleach==1.4.3
2.7 bleach==1.5.0
2.8 bleach==2.1.3 (ok)
`
Relevant PRs:
* https://github.com/ckan/ckan/pull/4120
* https://github.com/ckan/ckan/pull/3952 - looks like we should back port `html5lib==1.0.1` too for compatibility with bleach.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
