### PR TITLE
Add docker compose ckan dev settings

### DIFF
--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -38,6 +38,11 @@ services:
       - ckan_config:/etc/ckan
       - ckan_home:/usr/lib/ckan
       - ckan_storage:/var/lib/ckan
+    # Uncommenting the following 4 lines allows one to attach to the ckan container and interact with pdb sessions
+      #- ../../ckan/:/usr/lib/ckan/venv/src/ckan/ckan/
+    #stdin_open: true
+    #tty: true
+    #command: ["ckan-paster", "serve", "--reload", "/etc/ckan/production.ini"]
 
   datapusher:
     container_name: datapusher

--- a/doc/maintaining/installing/install-from-docker-compose.rst
+++ b/doc/maintaining/installing/install-from-docker-compose.rst
@@ -167,6 +167,7 @@ against the database and import / export files from ``$VOL_CKAN_HOME``.
 
 d. Using the containers for ckan development
 The ``docker-compose.yml`` file contains additional directives that are commented out by default.  Uncommenting the section that looks like the following, except for the actual comment, will allow one to interactively debug code using ``pdb``.::
+
     # Uncommenting the following 4 lines allows one to attach to the ckan container and interact with pdb sessions
     #- ../../ckan/:/usr/lib/ckan/venv/src/ckan/ckan/
     #stdin_open: true

--- a/doc/maintaining/installing/install-from-docker-compose.rst
+++ b/doc/maintaining/installing/install-from-docker-compose.rst
@@ -167,11 +167,11 @@ against the database and import / export files from ``$VOL_CKAN_HOME``.
 
 d. Using the containers for ckan development
 The ``docker-compose.yml`` file contains additional directives that are commented out by default.  Uncommenting the section that looks like the following, except for the actual comment, will allow one to interactively debug code using ``pdb``.::
-     # Uncommenting the following 4 lines allows one to attach to the ckan container and interact with pdb sessions
-       #- ../../ckan/:/usr/lib/ckan/venv/src/ckan/ckan/
-     #stdin_open: true
-     #tty: true
-     #command: ["ckan-paster", "serve", "--reload", "/etc/ckan/production.ini"]
+    # Uncommenting the following 4 lines allows one to attach to the ckan container and interact with pdb sessions
+    #- ../../ckan/:/usr/lib/ckan/venv/src/ckan/ckan/
+    #stdin_open: true
+    #tty: true
+    #command: ["ckan-paster", "serve", "--reload", "/etc/ckan/production.ini"]
 
 Once those lines are uncommented and the containders are running again one may then attach to the ckan container by executing a ``docker attach ckan`` command and using the standard ``import pdb; pdb.set_trace()`` anywhere in the ckan codebase from the host computer.  Navigating to the web page where the ``pdb.set_trace()`` code is placed will cause the attached ckan container to drop into the pdb debugger and allow one to interact with the debugger.  Any new ``pdb.set_trace()``
 statements will cause the server to restart so that the new debug code will be executed and drop the developer into the next breakpoint.

--- a/doc/maintaining/installing/install-from-docker-compose.rst
+++ b/doc/maintaining/installing/install-from-docker-compose.rst
@@ -165,6 +165,17 @@ We won't need to access files inside ``docker_pg_data`` directly, so we'll skip 
 As shown further below, we can use ``psql`` from inside the ``ckan`` container to run commands
 against the database and import / export files from ``$VOL_CKAN_HOME``.
 
+d. Using the containers for ckan development
+The ``docker-compose.yml`` file contains additional directives that are commented out by default.  Uncommenting the section that looks like the following, except for the actual comment, will allow one to interactively debug code using ``pdb``.::
+     # Uncommenting the following 4 lines allows one to attach to the ckan container and interact with pdb sessions
+       #- ../../ckan/:/usr/lib/ckan/venv/src/ckan/ckan/
+     #stdin_open: true
+     #tty: true
+     #command: ["ckan-paster", "serve", "--reload", "/etc/ckan/production.ini"]
+
+Once those lines are uncommented and the containders are running again one may then attach to the ckan container by executing a ``docker attach ckan`` command and using the standard ``import pdb; pdb.set_trace()`` anywhere in the ckan codebase from the host computer.  Navigating to the web page where the ``pdb.set_trace()`` code is placed will cause the attached ckan container to drop into the pdb debugger and allow one to interact with the debugger.  Any new ``pdb.set_trace()``
+statements will cause the server to restart so that the new debug code will be executed and drop the developer into the next breakpoint.
+
 ---------------------------
 3. Datastore and datapusher
 ---------------------------


### PR DESCRIPTION
Fixes #
N/A
### Proposed fixes:
N/A


### Features:
Adds functionality, commented out by default, that allows one to use the project `ckan` docker container as a development environment for interactive debugging with `pdb`.

Uncommenting the sections from the `docker-compose.yml` file as instructed in the update documentation, starting the containers, will then allow one to attach to the ckan container via a `docker attach ckan` command and interact with the code by using the `pdb` library and decorating any target code with `pdb.set_trace()` commands.  Additionally the mapping of the code from the ckan project directory into the target deployment volume on the container allows one to make changes to the code base and see the changes immediately in the running container after the service automatically restarts.

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
