### PR TITLE
Add simple email error logger to flask

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -117,7 +117,6 @@ def make_flask_stack(conf, **app_conf):
         log = logging.getLogger('werkzeug')
         log.setLevel(logging.DEBUG)
 
-
     # Use Beaker as the Flask session interface
     class BeakerSessionInterface(SessionInterface):
         def open_session(self, app, request):
@@ -462,6 +461,7 @@ def _register_error_handler(app):
         app.register_error_handler(Exception, error_handler)
         if config.get('email_to'):
             _setup_error_mail_handler(app)
+
 
 def _setup_error_mail_handler(app):
 

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -471,7 +471,6 @@ def _setup_error_mail_handler(app):
             log_record.method = request.method
             log_record.ip = request.environ.get("REMOTE_ADDR")
             log_record.headers = request.headers
-            log_record.exception = log_record.exc_info
             return True
 
     mailhost = tuple(config.get('smtp.server', 'localhost').split(":"))
@@ -486,6 +485,7 @@ def _setup_error_mail_handler(app):
 Time:               %(asctime)s
 URL:                %(url)s
 Method:             %(method)s
+IP:                 %(ip)s
 Headers:            %(headers)s
 
 '''))

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 import os
+import sys
 import re
 import time
 import inspect
@@ -41,6 +42,7 @@ from ckan.views import (identify_user,
 
 import ckan.lib.plugins as lib_plugins
 import logging
+from logging.handlers import SMTPHandler
 log = logging.getLogger(__name__)
 
 
@@ -114,6 +116,7 @@ def make_flask_stack(conf, **app_conf):
 
         log = logging.getLogger('werkzeug')
         log.setLevel(logging.DEBUG)
+
 
     # Use Beaker as the Flask session interface
     class BeakerSessionInterface(SessionInterface):
@@ -442,6 +445,7 @@ def _register_error_handler(app):
     u'''Register error handler'''
 
     def error_handler(e):
+        log.error(e, exc_info=sys.exc_info)
         if isinstance(e, HTTPException):
             extra_vars = {u'code': [e.code], u'content': e.description}
             # TODO: Remove
@@ -456,3 +460,36 @@ def _register_error_handler(app):
         app.register_error_handler(code, error_handler)
     if not app.debug and not app.testing:
         app.register_error_handler(Exception, error_handler)
+        if config.get('email_to'):
+            _setup_error_mail_handler(app)
+
+def _setup_error_mail_handler(app):
+
+    class ContextualFilter(logging.Filter):
+        def filter(self, log_record):
+            log_record.url = request.path
+            log_record.method = request.method
+            log_record.ip = request.environ.get("REMOTE_ADDR")
+            log_record.headers = request.headers
+            log_record.exception = log_record.exc_info
+            return True
+
+    mailhost = tuple(config.get('smtp.server', 'localhost').split(":"))
+    mail_handler = SMTPHandler(
+        mailhost=mailhost,
+        fromaddr=config.get('error_email_from'),
+        toaddrs=[config.get('email_to')],
+        subject='Application Error'
+    )
+
+    mail_handler.setFormatter(logging.Formatter('''
+Time:               %(asctime)s
+URL:                %(url)s
+Method:             %(method)s
+Headers:            %(headers)s
+
+'''))
+
+    context_provider = ContextualFilter()
+    app.logger.addFilter(context_provider)
+    app.logger.addHandler(mail_handler)


### PR DESCRIPTION
Fixes #4611

### Proposed fixes:
Adds simple email error logger to flask app. Uses the same config parameters as pylons did so no extra configuration is required.

In case of error, the email will contain the following example:


Time:               2019-01-17 13:06:18,548
URL:                /user/admin
Method:             GET
Headers:            Cookie: Drupal.toolbar.collapsed=0; SSESS6b28b91ad717e967d3986b15c6c3ee12=ceSUx4deo_M3r5tAKe3wBmixI452mrREzjq-64VWu2I; ckan=d75907f3c439157af44e103541f8dfdee32519a494aa1e2d1a514a2e85f00abf48160a98
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36
Connection: close
Host: 10.10.10.10
Upgrade-Insecure-Requests: 1
Cache-Control: max-age=0
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8
X-Url-Scheme: https
Accept-Language: fi-FI,fi;q=0.9,en-GB;q=0.8,en;q=0.7,en-US;q=0.6
Accept-Encoding: gzip, deflate, br



Traceback (most recent call last):
  File "/usr/lib/ckan/default/lib/python2.7/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib/ckan/default/lib/python2.7/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/lib/ckan/default/src/ckan/ckan/views/user.py", line 131, in read
    asd
NameError: global name 'asd' is not defined


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
