### PR TITLE
Activity stream fixes

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -2633,7 +2633,7 @@ def organization_activity_list(context, data_dict):
     org_show = logic.get_action('organization_show')
     org_id = org_show(context, {'id': org_id})['id']
 
-    _activity_objects = model.activity.group_activity_list(
+    _activity_objects = model.activity.organization_activity_list(
         org_id, limit=limit, offset=offset)
     activity_objects = _filter_activity_by_user(
         _activity_objects, _activity_stream_get_filtered_users())

--- a/ckan/model/activity.py
+++ b/ckan/model/activity.py
@@ -211,7 +211,6 @@ def _group_activity_query(group_id):
         and_(
             model.Package.id == model.Member.table_id,
             model.Package.private == False,
-            model.Package.state == 'active'
         )
     ).filter(
         # We only care about activity either on the the group itself or on
@@ -222,6 +221,43 @@ def _group_activity_query(group_id):
         or_(
             model.Member.group_id == group_id,
             model.Activity.object_id == group_id
+        )
+    )
+
+    return q
+
+
+def _organization_activity_query(org_id):
+    '''Return an SQLAlchemy query for all activities about org_id.
+
+    Returns a query for all activities whose object is either the org itself
+    or one of the org's datasets.
+
+    '''
+    import ckan.model as model
+
+    org = model.Group.get(org_id)
+    if not org or not org.is_organization:
+        # Return a query with no results.
+        return model.Session.query(model.Activity).filter(text('0=1'))
+
+    q = model.Session.query(
+        model.Activity
+    ).outerjoin(
+        model.Package,
+        and_(
+            model.Package.id == model.Activity.object_id,
+            model.Package.private == False,
+        )
+    ).filter(
+        # We only care about activity either on the the org itself or on
+        # packages within that org.
+        # FIXME: This means that activity that occured while a package belonged
+        # to a org but was then removed will not show up. This may not be
+        # desired but is consistent with legacy behaviour.
+        or_(
+            model.Package.owner_org == org_id,
+            model.Activity.object_id == org_id
         )
     )
 
@@ -240,6 +276,21 @@ def group_activity_list(group_id, limit, offset):
 
     '''
     q = _group_activity_query(group_id)
+    return _activities_at_offset(q, limit, offset)
+
+
+def organization_activity_list(group_id, limit, offset):
+    '''Return the given org's public activity stream.
+
+    Returns activities where the given org or one of its datasets is the
+    object of the activity, e.g.:
+
+    "{USER} updated the organization {ORG}"
+    "{USER} updated the dataset {DATASET}"
+    etc.
+
+    '''
+    q = _organization_activity_query(group_id)
     return _activities_at_offset(q, limit, offset)
 
 

--- a/ckan/model/activity.py
+++ b/ckan/model/activity.py
@@ -204,7 +204,6 @@ def _group_activity_query(group_id):
         model.Member,
         and_(
             model.Activity.object_id == model.Member.table_id,
-            model.Member.state == 'active'
         )
     ).outerjoin(
         model.Package,
@@ -219,8 +218,18 @@ def _group_activity_query(group_id):
         # to a group but was then removed will not show up. This may not be
         # desired but is consistent with legacy behaviour.
         or_(
-            model.Member.group_id == group_id,
-            model.Activity.object_id == group_id
+            # active dataset in the group
+            and_(model.Member.group_id == group_id,
+                 model.Member.state == 'active',
+                 model.Package.state == 'active'),
+            # deleted dataset in the group
+            and_(model.Member.group_id == group_id,
+                 model.Member.state == 'deleted',
+                 model.Package.state == 'deleted'),
+                 # (we want to avoid showing changes to an active dataset that
+                 # was once in this group)
+            # activity the the group itself
+            model.Activity.object_id == group_id,
         )
     )
 

--- a/ckan/tests/controllers/test_group.py
+++ b/ckan/tests/controllers/test_group.py
@@ -758,3 +758,157 @@ class TestGroupIndex(helpers.FunctionalTestBase):
             assert_in('Test Group {0}'.format(i), response)
 
         assert 'Test Group 20' not in response
+
+
+class TestActivity(helpers.FunctionalTestBase):
+    def test_simple(self):
+        '''Checking the template shows the activity stream.'''
+        app = self._get_test_app()
+        user = factories.User()
+        group = factories.Group(user=user)
+
+        url = url_for('group.activity',
+                      id=group['id'])
+        response = app.get(url)
+        assert_in('Mr. Test User', response)
+        assert_in('created the group', response)
+
+    def test_create_group(self):
+        app = self._get_test_app()
+        user = factories.User()
+        group = factories.Group(user=user)
+
+        url = url_for('group.activity',
+                      id=group['id'])
+        response = app.get(url)
+        assert_in('<a href="/user/{}">Mr. Test User'.format(user['name']),
+                  response)
+        assert_in('created the group', response)
+        assert_in('<a href="/group/{}">Test Group'.format(
+                  group['name']), response)
+
+    def _clear_activities(self):
+        model.Session.query(model.ActivityDetail).delete()
+        model.Session.query(model.Activity).delete()
+        model.Session.flush()
+
+    def test_change_group(self):
+        app = self._get_test_app()
+        user = factories.User()
+        group = factories.Group(user=user)
+        self._clear_activities()
+        group['title'] = 'Group with changed title'
+        helpers.call_action(
+            'group_update', context={'user': user['name']}, **group)
+
+        url = url_for('group.activity',
+                      id=group['id'])
+        response = app.get(url)
+        assert_in('<a href="/user/{}">Mr. Test User'.format(user['name']),
+                  response)
+        assert_in('updated the group', response)
+        assert_in('<a href="/group/{}">Group with changed title'
+                  .format(group['name']), response)
+
+    def test_create_dataset(self):
+        app = self._get_test_app()
+        user = factories.User()
+        group = factories.Group(user=user)
+        dataset = factories.Dataset(groups=[{'id': group['id']}], user=user)
+
+        url = url_for('group.activity',
+                      id=group['id'])
+        response = app.get(url)
+        assert_in('<a href="/user/{}">Mr. Test User'.format(user['name']),
+                  response)
+        assert_in('created the dataset', response)
+        assert_in('<a href="/dataset/{}">Test Dataset'.format(dataset['name']),
+                  response)
+
+    def test_change_dataset(self):
+        app = self._get_test_app()
+        user = factories.User()
+        group = factories.Group(user=user)
+        dataset = factories.Dataset(groups=[{'id': group['id']}], user=user)
+        self._clear_activities()
+        dataset['title'] = 'Dataset with changed title'
+        helpers.call_action(
+            'package_update', context={'user': user['name']}, **dataset)
+
+        url = url_for('group.activity',
+                      id=group['id'])
+        response = app.get(url)
+        assert_in('<a href="/user/{}">Mr. Test User'.format(user['name']),
+                  response)
+        assert_in('updated the dataset', response)
+        assert_in('<a href="/dataset/{}">Dataset with changed title'
+                  .format(dataset['name']),
+                  response)
+
+    def test_delete_dataset(self):
+        app = self._get_test_app()
+        user = factories.User()
+        group = factories.Group(user=user)
+        dataset = factories.Dataset(groups=[{'id': group['id']}], user=user)
+        self._clear_activities()
+        helpers.call_action(
+            'package_delete', context={'user': user['name']}, **dataset)
+
+        url = url_for('group.activity',
+                      id=group['id'])
+        response = app.get(url)
+        assert_in('<a href="/user/{}">Mr. Test User'.format(user['name']),
+                  response)
+        assert_in('deleted the dataset', response)
+        assert_in('<a href="/dataset/{}">Test Dataset'
+                  .format(dataset['name']),
+                  response)
+
+    def test_change_dataset_that_used_to_be_in_the_group(self):
+        app = self._get_test_app()
+        user = factories.User()
+        group = factories.Group(user=user)
+        dataset = factories.Dataset(groups=[{'id': group['id']}], user=user)
+        # remove the dataset from the group
+        dataset['groups'] = []
+        helpers.call_action(
+            'package_update', context={'user': user['name']}, **dataset)
+        self._clear_activities()
+        # edit the dataset
+        dataset['title'] = 'Dataset with changed title'
+        helpers.call_action(
+            'package_update', context={'user': user['name']}, **dataset)
+
+        # dataset change should not show up in its former group
+        url = url_for('group.activity',
+                      id=group['id'])
+        response = app.get(url)
+        assert_in('No activities are within this activity stream', response)
+
+    def test_delete_dataset_that_used_to_be_in_the_group(self):
+        app = self._get_test_app()
+        user = factories.User()
+        group = factories.Group(user=user)
+        dataset = factories.Dataset(groups=[{'id': group['id']}], user=user)
+        # remove the dataset from the group
+        dataset['groups'] = []
+        helpers.call_action(
+            'package_update', context={'user': user['name']}, **dataset)
+        self._clear_activities()
+        dataset['title'] = 'Dataset with changed title'
+        helpers.call_action(
+            'package_delete', context={'user': user['name']}, **dataset)
+
+        # NOTE:
+        # ideally the dataset's deletion would not show up in its old group
+        # but it can't be helped without _group_activity_query getting v
+        # complicated
+        url = url_for('group.activity',
+                      id=group['id'])
+        response = app.get(url)
+        assert_in('<a href="/user/{}">Mr. Test User'.format(user['name']),
+                  response)
+        assert_in('deleted the dataset', response)
+        assert_in('<a href="/dataset/{}">Test Dataset'
+                  .format(dataset['name']),
+                  response)

--- a/ckan/tests/controllers/test_organization.py
+++ b/ckan/tests/controllers/test_organization.py
@@ -1,10 +1,12 @@
 # encoding: utf-8
 
-from ckan.common import config
-from bs4 import BeautifulSoup
 from nose.tools import assert_equal, assert_true, assert_in
-from ckan.lib.helpers import url_for
+from bs4 import BeautifulSoup
 from mock import patch
+
+from ckan.common import config
+from ckan.lib.helpers import url_for
+from ckan import model
 
 from ckan.tests import factories, helpers
 from ckan.tests.helpers import webtest_submit, submit_and_follow
@@ -569,3 +571,90 @@ class TestOrganizationMembership(helpers.FunctionalTestBase):
                     'role': 'test'
                 },
                 status=403, )
+
+
+class TestActivity(helpers.FunctionalTestBase):
+    def test_simple(self):
+        '''Checking the template shows the activity stream.'''
+        app = self._get_test_app()
+        user = factories.User()
+        org = factories.Organization(user=user)
+
+        url = url_for('organization.activity',
+                      id=org['id'])
+        response = app.get(url)
+        assert_in('Mr. Test User', response)
+        assert_in('created the organization', response)
+
+    def test_create_organization(self):
+        app = self._get_test_app()
+        user = factories.User()
+        org = factories.Organization(user=user)
+
+        url = url_for('organization.activity',
+                      id=org['id'])
+        response = app.get(url)
+        assert_in('<a href="/user/{}">Mr. Test User'.format(user['name']),
+                  response)
+        assert_in('created the organization', response)
+        assert_in('<a href="/organization/{}">Test Organization'.format(
+                  org['name']), response)
+
+    def test_create_dataset(self):
+        app = self._get_test_app()
+        user = factories.User()
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org=org['id'], user=user)
+
+        url = url_for('organization.activity',
+                      id=org['id'])
+        response = app.get(url)
+        assert_in('<a href="/user/{}">Mr. Test User'.format(user['name']),
+                  response)
+        assert_in('created the dataset', response)
+        assert_in('<a href="/dataset/{}">Test Dataset'.format(dataset['name']),
+                  response)
+
+    def _clear_activities(self):
+        model.Session.query(model.ActivityDetail).delete()
+        model.Session.query(model.Activity).delete()
+        model.Session.flush()
+
+    def test_change_dataset(self):
+        app = self._get_test_app()
+        user = factories.User()
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org=org['id'], user=user)
+        self._clear_activities()
+        dataset['title'] = 'Dataset with changed title'
+        helpers.call_action(
+            'package_update', context={'user': user['name']}, **dataset)
+
+        url = url_for('organization.activity',
+                      id=org['id'])
+        response = app.get(url)
+        assert_in('<a href="/user/{}">Mr. Test User'.format(user['name']),
+                  response)
+        assert_in('updated the dataset', response)
+        assert_in('<a href="/dataset/{}">Dataset with changed title'
+                  .format(dataset['name']),
+                  response)
+
+    def test_delete_dataset(self):
+        app = self._get_test_app()
+        user = factories.User()
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org=org['id'], user=user)
+        self._clear_activities()
+        helpers.call_action(
+            'package_delete', context={'user': user['name']}, **dataset)
+
+        url = url_for('organization.activity',
+                      id=org['id'])
+        response = app.get(url)
+        assert_in('<a href="/user/{}">Mr. Test User'.format(user['name']),
+                  response)
+        assert_in('deleted the dataset', response)
+        assert_in('<a href="/dataset/{}">Test Dataset'
+                  .format(dataset['name']),
+                  response)

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -14,6 +14,7 @@ from ckan.lib.helpers import url_for
 import ckan.model as model
 import ckan.plugins as p
 from ckan.logic import get_action
+import ckan.lib.dictization as dictization
 
 import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
@@ -1787,3 +1788,129 @@ class TestDatasetRead(helpers.FunctionalTestBase):
         app = helpers._get_test_app()
         app.get(url_for('dataset.read', id=dataset['id']),
                 status=200)  # ie no redirect
+
+
+class TestActivity(helpers.FunctionalTestBase):
+    def test_simple(self):
+        '''Checking the template shows the activity stream.'''
+        app = self._get_test_app()
+        user = factories.User()
+        dataset = factories.Dataset(user=user)
+
+        url = url_for('dataset.activity',
+                      id=dataset['id'])
+        response = app.get(url)
+        assert_in('Mr. Test User', response)
+        assert_in('created the dataset', response)
+
+    def test_create_dataset(self):
+        app = self._get_test_app()
+        user = factories.User()
+        dataset = factories.Dataset(user=user)
+
+        url = url_for('dataset.activity',
+                      id=dataset['id'])
+        response = app.get(url)
+        assert_in('<a href="/user/{}">Mr. Test User'.format(user['name']),
+                  response)
+        assert_in('created the dataset', response)
+        assert_in('<a href="/dataset/{}">Test Dataset'.format(dataset['name']),
+                  response)
+
+    def _clear_activities(self):
+        model.Session.query(model.ActivityDetail).delete()
+        model.Session.query(model.Activity).delete()
+        model.Session.flush()
+
+    def test_change_dataset(self):
+        app = self._get_test_app()
+        user = factories.User()
+        dataset = factories.Dataset(user=user)
+        self._clear_activities()
+        dataset['title'] = 'Dataset with changed title'
+        helpers.call_action(
+            'package_update', context={'user': user['name']}, **dataset)
+
+        url = url_for('dataset.activity',
+                      id=dataset['id'])
+        response = app.get(url)
+        assert_in('<a href="/user/{}">Mr. Test User'.format(user['name']),
+                  response)
+        assert_in('updated the dataset', response)
+        assert_in('<a href="/dataset/{}">Dataset with changed title'
+                  .format(dataset['name']),
+                  response)
+
+    def test_add_resource_to_dataset(self):
+        app = self._get_test_app()
+        user = factories.User()
+        dataset = factories.Dataset(user=user)
+        self._clear_activities()
+        resource = factories.Resource(package_id=dataset['id'], user=user)
+
+        url = url_for('dataset.activity',
+                      id=dataset['id'])
+        response = app.get(url)
+        assert_in('<a href="/user/{}">Mr. Test User'.format(user['name']),
+                  response)
+        assert_in('added the resource', response)
+        assert_in('<a href="/dataset/{}/resource/{}">test_resource_'.format(
+                  dataset['id'], resource['id']), response)
+        assert_in('to the dataset', response)
+        assert_in('<a href="/dataset/{}">Test Dataset'.format(dataset['name']),
+                  response)
+
+    def test_legacy_changed_package_activity(self):
+        '''Render a custom activity *** TODO ***
+        '''
+        app = self._get_test_app()
+
+        user = factories.User()
+        dataset = factories.Dataset(user=user)
+
+        # delete the modern Activity object that's been automatically created
+        modern_activity = model.Session.query(model.Activity) \
+            .filter_by(object_id=dataset['id']) \
+            .one()
+        revision_id = modern_activity.revision_id
+        modern_activity.delete()
+
+        # Create an Activity object as it was in earlier versions of CKAN.
+        # This code is based on:
+        # https://github.com/ckan/ckan/blob/b348bf2fe68db6704ea0a3e22d533ded3d8d4344/ckan/model/package.py#L508
+        activity_type = 'changed'
+        dataset_table_dict = dictization.table_dictize(
+            model.Package.get(dataset['id']), context={'model': model})
+        activity = model.Activity(
+            user_id=user['id'],
+            object_id=dataset['id'],
+            revision_id=revision_id,
+            activity_type="%s package" % activity_type,
+            data={
+                # "actor": a legacy activity had no "actor"
+                # "package": a legacy activity had just the package table,
+                # rather than the result of package_show
+                'package': dataset_table_dict,
+            }
+        )
+        model.Session.add(activity)
+        # a legacy activity had a ActivityDetail associated with the Activity
+        # This code is based on:
+        # https://github.com/ckan/ckan/blob/b348bf2fe68db6704ea0a3e22d533ded3d8d4344/ckan/model/package.py#L542
+        activity_detail = model.ActivityDetail(
+            activity_id=activity.id,
+            object_id=dataset['id'],
+            object_type=u"Package",
+            activity_type=activity_type,
+            data={u'package': dataset_table_dict})
+        model.Session.add(activity_detail)
+        model.Session.flush()
+
+        url = url_for('dataset.activity',
+                      id=dataset['id'])
+        response = app.get(url)
+        assert_in('<a href="/user/{}">Mr. Test User'.format(user['name']),
+                  response)
+        assert_in('updated the dataset', response)
+        assert_in('<a href="/dataset/{}">Test Dataset'.format(dataset['name']),
+                  response)

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -500,7 +500,9 @@ def activity(id, group_type, is_organization, offset=0):
         # template context for the group/read.html
         # template to retrieve later.
         extra_vars["group_activity_stream"] = \
-            _action(u'group_activity_list_html')(
+            _action(u'organization_activity_list_html'
+                    if group_dict.get('is_organization')
+                    else u'group_activity_list')(
             context, {
                 u'id': group_dict['id'],
                 u'offset': offset


### PR DESCRIPTION
Fixes #4625

### Proposed fixes:

* A deleted dataset's changes & deletion now show in its group & organization activity streams.
* Organization activity stream is produced with a more efficient db query, now it is not reusing the group one any more.
* Added a bunch of tests for the *display* of activity streams (in anticipation of mucking around with the templates)

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
