### PR TITLE
Check ValueError in url_validator

### DIFF
--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -697,11 +697,15 @@ def url_validator(key, data, errors, context):
     if not url:
         return
 
-    pieces = urlparse.urlparse(url)
-    if all([pieces.scheme, pieces.netloc]) and \
-       set(pieces.netloc) <= set(string.letters + string.digits + '-.') and \
-       pieces.scheme in ['http', 'https']:
-       return
+    try:
+        pieces = urlparse.urlparse(url)
+        if all([pieces.scheme, pieces.netloc]) and \
+           set(pieces.netloc) <= set(string.letters + string.digits + '-.') and \
+           pieces.scheme in ['http', 'https']:
+           return
+    except ValueError:
+        # url is invalid
+        pass
 
     errors[key].append(_('Please provide a valid URL'))
 

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -690,9 +690,6 @@ def url_validator(key, data, errors, context):
     import urlparse
     import string
 
-    model = context['model']
-    session = context['session']
-
     url = data.get(key, None)
     if not url:
         return

--- a/ckan/tests/logic/test_validators.py
+++ b/ckan/tests/logic/test_validators.py
@@ -611,4 +611,31 @@ class TestPasswordValidator(object):
         errors[key] = []
         call_validator(key, {key: password}, errors, None)
 
+
+class TestUrlValidator(object):
+
+    def test_ok(self):
+        urls = ['http://example.com', 'https://example.com', 'https://example.com/path?test=1&key=2']
+        key = ('url',)
+
+        @t.does_not_modify_errors_dict
+        def call_validator(*args, **kwargs):
+            return validators.url_validator(*args, **kwargs)
+        for url in urls:
+            errors = factories.validator_errors_dict()
+            errors[key] = []
+            call_validator(key, {key: url}, errors, None)
+
+    def test_invalid(self):
+        urls = ['ftp://example.com', 'test123', 'https://example.com]']
+        key = ('url',)
+
+        @adds_message_to_errors_dict('Please provide a valid URL')
+        def call_validator(*args, **kwargs):
+            return validators.url_validator(*args, **kwargs)
+        for url in urls:
+            errors = factories.validator_errors_dict()
+            errors[key] = []
+            call_validator(key, {key: url}, errors, None)
+
 # TODO: Need to test when you are not providing owner_org and the validator queries for the dataset with package_show


### PR DESCRIPTION
If an invalid URL is provided to urlparse (e.g. `https://example.com]`)
it might raise a ValueError. This breaks the url_validator.
This PR aims to fix that and simply add the error msg if a ValueError
occurs.

Fixes #4629

### Proposed fixes:

- Catch `ValueError` in `url_validator`

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
