### PR TITLE
WIP: Catch ValueError from urlparse in resource_dictize

### DIFF
--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -122,7 +122,7 @@ def resource_dictize(res, context):
                 resource['url'] = u'http://' + url.lstrip('/')
         except ValueError:
             # leave value if urlparse can't parse it
-            pass
+            raise
     return resource
 
 

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -115,8 +115,14 @@ def resource_dictize(res, context):
                                     resource_id=res.id,
                                     filename=cleaned_name,
                                     qualified=True)
-    elif resource['url'] and not urlparse.urlsplit(url).scheme and not context.get('for_edit'):
-        resource['url'] = u'http://' + url.lstrip('/')
+    elif resource['url'] and not context.get('for_edit'):
+        try:
+            scheme = urlparse.urlsplit(url).scheme
+            if not scheme:
+                resource['url'] = u'http://' + url.lstrip('/')
+        except ValueError:
+            # leave value if urlparse can't parse it
+            pass
     return resource
 
 

--- a/ckan/tests/lib/dictization/test_model_dictize.py
+++ b/ckan/tests/lib/dictization/test_model_dictize.py
@@ -468,6 +468,21 @@ class TestPackageDictize:
         }
         assert expected_dict['url'] == result.url
 
+    def test_package_dictize_resource_upload_with_invalid_url(self):
+        dataset = factories.Dataset()
+        resource = factories.Resource(package=dataset['id'],
+                                      name='test_pkg_dictize',
+                                      url='http://<![CDATA[http://www.example.com]]')
+
+        context = {'model': model, 'session': model.Session}
+
+        result = model_save.resource_dict_save(resource, context)
+
+        expected_dict = {
+            u'url': u'http://<![CDATA[http://www.example.com]]',
+        }
+        assert expected_dict['url'] == result.url
+
     def test_package_dictize_tags(self):
         dataset = factories.Dataset(tags=[{'name': 'fish'}])
         dataset_obj = model.Package.get(dataset['id'])


### PR DESCRIPTION
Fixes #4632

### Proposed fixes:

- catch `ValueError` in `resource_dictize` to not crash when an invalid URL is entered

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
