### PR TITLE
Password reset request - generally tighten it up

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -834,9 +834,12 @@ def tag_list(context, data_dict):
 def user_list(context, data_dict):
     '''Return a list of the site's user accounts.
 
-    :param q: restrict the users returned to those whose names contain a string
+    :param q: filter the users returned to those whose names contain a string
       (optional)
     :type q: string
+    :param email: filter the users returned to those whose email match a
+      string (optional) (you must be a sysadmin to use this filter)
+    :type email: string
     :param order_by: which field to sort the list by (optional, default:
       ``'name'``). Can be any user field or ``edits`` (i.e. number_of_edits).
     :type order_by: string
@@ -855,6 +858,7 @@ def user_list(context, data_dict):
     _check_access('user_list', context, data_dict)
 
     q = data_dict.get('q', '')
+    email = data_dict.get('email')
     order_by = data_dict.get('order_by', 'name')
     all_fields = asbool(data_dict.get('all_fields', True))
 
@@ -882,6 +886,8 @@ def user_list(context, data_dict):
 
     if q:
         query = model.User.search(q, query, user_name=context.get('user'))
+    if email:
+        query = query.filter_by(email=email)
 
     if order_by == 'edits':
         query = query.order_by(_desc(

--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -96,6 +96,9 @@ def tag_list(context, data_dict):
 
 def user_list(context, data_dict):
     # Users list is visible by default
+    if data_dict.get('email'):
+        # only sysadmins can specify the 'email' parameter
+        return {'success': False}
     if not asbool(config.get('ckan.auth.public_user_details', True)):
         return restrict_anon(context)
     else:

--- a/ckan/templates/user/request_reset.html
+++ b/ckan/templates/user/request_reset.html
@@ -14,7 +14,7 @@
       {% block form %}
         <form action="" method="post">
           <div class="form-group">
-            <label for="field-username">{{ _('Username') }}</label>
+            <label for="field-username">{{ _('Email or username') }}</label>
             <input id="field-username" class="control-medium form-control" name="user" value="" type="text" />
           </div>
           <div class="form-actions">
@@ -35,8 +35,9 @@
     {% block help_inner %}
     <h2 class="module-heading">{{ _('How does this work?') }}</h2>
     <div class="module-content">
-      <p>{% trans %}Enter your username into the box and we will send you
-      an email with a link to enter a new password.{% endtrans %}</p>
+      <p>{% trans %}Enter your email address or username into the box and we
+        will send you an email with a link to enter a new password.
+        {% endtrans %}</p>
     </div>
     {% endblock %}
   </section>

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 from bs4 import BeautifulSoup
 from nose.tools import assert_true, assert_false, assert_equal, assert_in
+import mock
 
 import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
@@ -854,3 +855,68 @@ class TestActivity(helpers.FunctionalTestBase):
         assert_in('deleted the group', response)
         assert_in('<a href="/group/{}">Test Group'
                   .format(group['name']), response)
+
+
+class TestUserResetRequest(helpers.FunctionalTestBase):
+    @mock.patch('ckan.lib.mailer.send_reset_link')
+    def test_request_reset_by_email(self, send_reset_link):
+        user = factories.User()
+        app = self._get_test_app()
+        offset = url_for('user.request_reset')
+        response = app.post(offset, params=dict(user=user['email']),
+                            status=302).follow()
+
+        assert_in('A reset link has been emailed to you', response)
+        assert_equal(send_reset_link.call_args[0][0].id, user['id'])
+
+    @mock.patch('ckan.lib.mailer.send_reset_link')
+    def test_request_reset_by_name(self, send_reset_link):
+        user = factories.User()
+        app = self._get_test_app()
+        offset = url_for('user.request_reset')
+        response = app.post(offset, params=dict(user=user['name']),
+                            status=302).follow()
+
+        assert_in('A reset link has been emailed to you', response)
+        assert_equal(send_reset_link.call_args[0][0].id, user['id'])
+
+    @mock.patch('ckan.lib.mailer.send_reset_link')
+    def test_request_reset_when_duplicate_emails(self, send_reset_link):
+        user_a = factories.User(email='me@example.com')
+        user_b = factories.User(email='me@example.com')
+        app = self._get_test_app()
+        offset = url_for('user.request_reset')
+        response = app.post(offset, params=dict(user='me@example.com'),
+                            status=302).follow()
+
+        assert_in('A reset link has been emailed to you', response)
+        emailed_users = [call[0][0].name
+                         for call in send_reset_link.call_args_list]
+        assert_equal(emailed_users, [user_a['name'], user_b['name']])
+
+    def test_request_reset_without_param(self):
+        app = self._get_test_app()
+        offset = url_for('user.request_reset')
+        app.post(offset, params={}, status=400)
+
+    @mock.patch('ckan.lib.mailer.send_reset_link')
+    def test_request_reset_for_unknown_username(self, send_reset_link):
+        app = self._get_test_app()
+        offset = url_for('user.request_reset')
+        response = app.post(offset, params=dict(user='unknown'),
+                            status=302).follow()
+
+        # doesn't reveal account does or doesn't exist
+        assert_in('A reset link has been emailed to you', response)
+        send_reset_link.assert_not_called()
+
+    @mock.patch('ckan.lib.mailer.send_reset_link')
+    def test_request_reset_for_unknown_email(self, send_reset_link):
+        app = self._get_test_app()
+        offset = url_for('user.request_reset')
+        response = app.post(offset, params=dict(user='unknown@example.com'),
+                            status=302).follow()
+
+        # doesn't reveal account does or doesn't exist
+        assert_in('A reset link has been emailed to you', response)
+        send_reset_link.assert_not_called()

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -897,7 +897,9 @@ class TestUserResetRequest(helpers.FunctionalTestBase):
     def test_request_reset_without_param(self):
         app = self._get_test_app()
         offset = url_for('user.request_reset')
-        app.post(offset, params={}, status=400)
+        response = app.post(offset).follow()
+
+        assert_in('Email is required', response)
 
     @mock.patch('ckan.lib.mailer.send_reset_link')
     def test_request_reset_for_unknown_username(self, send_reset_link):

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -668,6 +668,18 @@ class TestUserList(helpers.FunctionalTestBase):
         got_user = got_users[0]
         assert got_user == user['name']
 
+    def test_user_list_filtered_by_email(self):
+
+        user_a = factories.User(email='a@example.com')
+        factories.User(email='b@example.com')
+
+        got_users = helpers.call_action('user_list', email='a@example.com',
+                                        all_fields=False)
+
+        assert len(got_users) == 1
+        got_user = got_users[0]
+        assert got_user == user_a['name']
+
 
 class TestUserShow(helpers.FunctionalTestBase):
 

--- a/ckan/tests/logic/auth/test_get.py
+++ b/ckan/tests/logic/auth/test_get.py
@@ -26,6 +26,13 @@ class TestUserListAuth(object):
                    'model': model}
         assert helpers.call_auth('user_list', context=context)
 
+    def test_user_list_email_parameter(self):
+        context = {'user': None,
+                   'model': model}
+        # using the 'email' parameter is not allowed (unless sysadmin)
+        assert_raises(logic.NotAuthorized, helpers.call_auth,
+                      'user_list', email='a@example.com', context=context)
+
 
 class TestUserShowAuth(object):
 

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -506,7 +506,8 @@ class RequestResetView(MethodView):
         self._prepare()
         id = request.form.get(u'user')
         if id in (None, u''):
-            base.abort(400, _(u'"user" parameter is required'))
+            h.flash_error(_(u'Email is required'))
+            return h.redirect_to(u'/user/reset')
         log.info(u'Password reset requested for user "{}"'.format(id))
 
         context = {u'model': model, u'user': g.user, u'ignore_auth': True}

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -513,6 +513,7 @@ class RequestResetView(MethodView):
         context = {u'model': model, u'user': g.user, u'ignore_auth': True}
         user_objs = []
 
+        # Usernames cannot contain '@' symbols
         if u'@' in id:
             # Search by email address
             # (You can forget a user id, but you don't tend to forget your

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -559,7 +559,7 @@ class RequestResetView(MethodView):
                 h.flash_error(_(u'Error sending the email. Try again later '
                                 'or contact an administrator for help'))
                 log.exception(e)
-                return
+                return h.redirect_to(u'/')
 
         # always tell the user it succeeded, because otherwise we reveal
         # which accounts exist or not

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -497,58 +497,79 @@ class RequestResetView(MethodView):
             u'user': g.user,
             u'auth_user_obj': g.userobj
         }
-        data_dict = {u'id': request.form.get(u'user')}
         try:
             logic.check_access(u'request_reset', context)
         except logic.NotAuthorized:
             base.abort(403, _(u'Unauthorized to request reset password.'))
-        return context, data_dict
 
     def post(self):
-        context, data_dict = self._prepare()
-        id = data_dict[u'id']
+        self._prepare()
+        id = request.form.get(u'user')
+        if id in (None, u''):
+            base.abort(400, _(u'"user" parameter is required'))
+        log.info(u'Password reset requested for user "{}"'.format(id))
 
-        context = {u'model': model, u'user': g.user}
-        user_obj = None
-        try:
-            logic.get_action(u'user_show')(context, data_dict)
-            user_obj = context[u'user_obj']
-        except logic.NotFound:
-            # Try searching the user
-            if id and len(id) > 2:
-                user_list = logic.get_action(u'user_list')(context, {
-                    u'id': id
-                })
-                if len(user_list) == 1:
-                    # This is ugly, but we need the user object for the
-                    # mailer,
+        context = {u'model': model, u'user': g.user, u'ignore_auth': True}
+        user_objs = []
+
+        if u'@' in id:
+            # Search by email address
+            # (You can forget a user id, but you don't tend to forget your
+            # email)
+            user_list = logic.get_action(u'user_list')(context, {
+                u'email': id
+            })
+            if user_list:
+                # send reset emails for *all* user accounts with this email
+                # (otherwise we'd have to silently fail - we can't tell the
+                # user, as that would reveal the existence of accounts with
+                # this email address)
+                for user_dict in user_list:
+                    # This is ugly, but we need the user object for the mailer,
                     # and user_list does not return them
-                    data_dict[u'id'] = user_list[0][u'id']
-                    logic.get_action(u'user_show')(context, data_dict)
-                    user_obj = context[u'user_obj']
-                elif len(user_list) > 1:
-                    h.flash_error(_(u'"%s" matched several users') % (id))
-                else:
-                    h.flash_error(_(u'No such user: %s') % id)
-            else:
-                h.flash_error(_(u'No such user: %s') % id)
+                    logic.get_action(u'user_show')(
+                        context, {u'id': user_dict[u'id']})
+                    user_objs.append(context[u'user_obj'])
 
-        if user_obj:
+        else:
+            # Search by user name
+            # (this is helpful as an option for a user who has multiple
+            # accounts with the same email address and they want to be
+            # specific)
+            try:
+                logic.get_action(u'user_show')(context, {u'id': id})
+                user_objs.append(context[u'user_obj'])
+            except logic.NotFound:
+                pass
+
+        if not user_objs:
+            log.info(u'User requested reset link for unknown user: {}'
+                     .format(id))
+
+        for user_obj in user_objs:
+            log.info(u'Emailing reset link to user: {}'
+                     .format(user_obj.name))
             try:
                 # FIXME: How about passing user.id instead? Mailer already
                 # uses model and it allow to simplify code above
                 mailer.send_reset_link(user_obj)
-                h.flash_success(
-                    _(u'Please check your inbox for '
-                      u'a reset code.'))
-                return h.redirect_to(u'/')
             except mailer.MailerException as e:
-                h.flash_error(_(u'Could not send reset link: %s') %
-                              text_type(e))
-        return self.get()
+                # SMTP is not configured correctly or the server is
+                # temporarily unavailable
+                h.flash_error(_(u'Error sending the email. Try again later '
+                                'or contact an administrator for help'))
+                log.exception(e)
+                return
+
+        # always tell the user it succeeded, because otherwise we reveal
+        # which accounts exist or not
+        h.flash_success(
+            _(u'A reset link has been emailed to you '
+              '(unless the account specified does not exist)'))
+        return h.redirect_to(u'/')
 
     def get(self):
-        context, data_dict = self._prepare()
+        self._prepare()
         return base.render(u'user/request_reset.html', {})
 
 


### PR DESCRIPTION
Fixes #

* To reset a password, the user can now only specify username or email - not the looser search done by model.User.search(), which allowed: partial name, partial fullname (and if sysadmin: partial email address) etc
  (This was originally loose to be helpful to users if they forgot their username, but it is more normal these days to only allow resets with your email address. I left in the username option, as explained in the code)
* Don't confirm whether a user exists or not - this is [recommended](https://www.owasp.org/index.php/Authentication_Cheat_Sheet#Authentication_and_Error_Messages)
* Logging added for audit purposes

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
