### PR TITLE
Flake8 can ignore 'rjsmin.py' imported code 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
       before_script:
         - flake8 --version
         # stop the build if there are Python syntax errors or undefined names
-        - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+        - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude ./ckan/include/rjsmin.py
         # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
         - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       script:


### PR DESCRIPTION
The release this week of [flake8 3.7.0](https://pypi.org/project/flake8/#history) caused it to flag this up:
```
$ flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
./ckan/include/rjsmin.py:91:9: F823 local variable 'xrange' {0} referenced before assignment
        xrange
        ^
1
```
However this breaks our build.

The import is in a try/except block so that it works with both python2 and python3. I guess there is another way to do this that doesn't trigger the linter. But we don't care about linting this file as it is imported code. 

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
