### PR TITLE
Security dont confirm if user exists 2

### DIFF
--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -732,7 +732,9 @@ class TestUserResetRequest(helpers.FunctionalTestBase):
     def test_request_reset_without_param(self):
         app = self._get_test_app()
         offset = url_for('user.request_reset')
-        app.post(offset, params={}, status=400)
+        response = app.post(offset).follow()
+
+        assert_in('Email is required', response)
 
     @mock.patch('ckan.lib.mailer.send_reset_link')
     def test_request_reset_for_unknown_username(self, send_reset_link):

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -506,7 +506,8 @@ class RequestResetView(MethodView):
         self._prepare()
         id = request.form.get(u'user')
         if id in (None, u''):
-            base.abort(400, _(u'"user" parameter is required'))
+            h.flash_error(_(u'Email is required'))
+            return h.redirect_to(u'/user/reset')
         log.info(u'Password reset requested for user "{}"'.format(id))
 
         context = {u'model': model, u'user': g.user, u'ignore_auth': True}

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -513,6 +513,7 @@ class RequestResetView(MethodView):
         context = {u'model': model, u'user': g.user, u'ignore_auth': True}
         user_objs = []
 
+        # Usernames cannot contain '@' symbols
         if u'@' in id:
             # Search by email address
             # (You can forget a user id, but you don't tend to forget your

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -559,7 +559,7 @@ class RequestResetView(MethodView):
                 h.flash_error(_(u'Error sending the email. Try again later '
                                 'or contact an administrator for help'))
                 log.exception(e)
-                return
+                return h.redirect_to(u'/')
 
         # always tell the user it succeeded, because otherwise we reveal
         # which accounts exist or not


### PR DESCRIPTION
This is a copy of: https://github.com/ckan/ckan/pull/4636 , with the requested changes.

Fixes #

* To reset a password, the user can now only specify username or email - not the looser search done by model.User.search(), which allowed: partial name, partial fullname (and if sysadmin: partial email address) etc
  (This was originally loose to be helpful to users if they forgot their username, but it is more normal these days to only allow resets with your email address. I left in the username option, as explained in the code)
* Don't confirm whether a user exists or not - this is [recommended](https://www.owasp.org/index.php/Authentication_Cheat_Sheet#Authentication_and_Error_Messages)
* Logging added for audit purposes

### Features:
* [x]  includes tests covering changes
* [ ]  includes updated documentation
* [x]  includes user-visible changes
* [ ]  includes API changes
* [ ]  includes bugfix for possible backport

Please [X] all the boxes above that apply
