### PR TITLE
add .ini path, jetty8 note, nose doc link

### DIFF
--- a/doc/contributing/test.rst
+++ b/doc/contributing/test.rst
@@ -56,7 +56,7 @@ Create test databases:
 
 Set the permissions::
 
-    paster datastore set-permissions -c test-core.ini | sudo -u postgres psql
+    paster datastore set-permissions -c |virtualenv|/src/ckan/test-core.ini | sudo -u postgres psql
 
 This database connection is specified in the ``test-core.ini`` file by the
 ``sqlalchemy.url`` parameter.
@@ -105,7 +105,7 @@ To enable multi-core:
          <core name="ckan" instanceDir="/etc/solr/ckan" />
        </cores>
 
-5. Restart Solr by restarting Jetty (or Tomcat)::
+5. Restart Solr by restarting Jetty (may also be called jetty8) (or Tomcat)::
 
        sudo service jetty restart
 
@@ -133,7 +133,8 @@ drop and reinitialize the database before the run you can use the ``reset-db``
 option::
 
      nosetests --ckan --reset-db --with-pylons=test-core.ini ckan
-
+     
+You can find details on how to run a subset of tests in the `Nose Documentation <https://nose.readthedocs.io/en/latest/usage.html#selecting-tests>`_.
 
 
 .. _migrationtesting:


### PR DESCRIPTION
While working through this document I got stuck in a couple of places, I've updated these parts so that others might find it easier in the future :).

### Proposed fixes:
* Explicit path for test-core.ini
* Note that `jetty` may be called `jetty8`
* Link to Nose documentation on running a subset of tests

### Features:
- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport