### PR TITLE
Strip local path when uploading (IE fix)

### DIFF
--- a/ckan/public/base/javascript/modules/resource-upload-field.js
+++ b/ckan/public/base/javascript/modules/resource-upload-field.js
@@ -188,6 +188,9 @@ this.ckan.module('resource-upload-field', function (jQuery) {
     _onUploadAdd: function (event, data) {
       this.uploading(true);
       if (data.files && data.files.length) {
+        for (var i = 0; i < data.files.length; i++) {
+          data.files[i].name = data.files[i].name.split('/').pop();
+        }
         var key = this.generateKey(data.files[0].name);
 
         this.authenticate(key, data);


### PR DESCRIPTION
Fixes #4608 

### Proposed fixes:
Just strip the path from the filename when the jQuery file upload plugin receives a file.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport