### PR TITLE
default public access to false, restrict user list to sysadmins

### DIFF
--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -111,9 +111,8 @@ class UserController(base.BaseController):
         limit = int(
             request.params.get('limit', config.get('ckan.user_list_limit', 20))
         )
-        try:
-            check_access('user_list', context, data_dict)
-        except NotAuthorized:
+
+        if (not asbool(config.get('ckan.auth.public_user_details', False))):
             abort(403, _('Not authorized to see this page'))
 
         users_list = get_action('user_list')(context, data_dict)


### PR DESCRIPTION
Fixes #
Hides the user listing page from all users except Sysadmins by default.
Swaps the default of the  `ckan.auth.public_user_details` flag so that user details are restricted to logged-in users by default, and can be made public by setting this flag to `true` (`true` was the previous default.

I'm still working on this PR, opening early for discussion.
Currently password reset is broken by these changes, currently investigating.

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
