### PR TITLE
Add/beaker auth by default #4002

### DIFF
--- a/ckan/config/who.ini
+++ b/ckan/config/who.ini
@@ -1,7 +1,7 @@
-[plugin:auth_tkt]
-use = ckan.lib.auth_tkt:make_plugin
-# If no secret key is defined here, beaker.session.secret will be used
-#secret = somesecret
+[plugin:use_beaker]
+use = repoze.who.plugins.use_beaker:make_plugin
+key_name = ckan_session
+delete_on_logout = True
 
 [plugin:friendlyform]
 use = repoze.who.plugins.friendlyform:FriendlyFormPlugin
@@ -24,12 +24,12 @@ challenge_decider = repoze.who.classifiers:default_challenge_decider
 [identifiers]
 plugins =
     friendlyform;browser
-    auth_tkt
+    use_beaker
 
 [authenticators]
 plugins =
-    auth_tkt
     ckan.lib.authenticator:UsernamePasswordAuthenticator
+    ckanext.security.authenticator:BeakerRedisAuth
 
 [challengers]
 plugins =

--- a/ckan/config/who.ini
+++ b/ckan/config/who.ini
@@ -29,7 +29,7 @@ plugins =
 [authenticators]
 plugins =
     ckan.lib.authenticator:UsernamePasswordAuthenticator
-    ckanext.security.authenticator:BeakerRedisAuth
+    ckan.lib.authenticator:BeakerRedisAuth
 
 [challengers]
 plugins =

--- a/ckan/lib/authenticator.py
+++ b/ckan/lib/authenticator.py
@@ -30,3 +30,13 @@ class UsernamePasswordAuthenticator(object):
             return user.name
 
         return None
+
+class BeakerRedisAuth(object):
+    implements(IAuthenticator)
+
+    def authenticate(self, environ, identity):
+        # At this stage, the identity has already been validated from the cookie
+        # and redis (use_beaker middleware). We simply return the user id
+        # from the identity object if it's there, or None if the user's
+        # identity is not verified.
+        return identity.get('repoze.who.userid', None)

--- a/setup.py
+++ b/setup.py
@@ -221,6 +221,14 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['ez_setup']),
     namespace_packages=['ckanext', 'ckanext.stats'],
+    install_requires=[
+        'repoze.who-use-beaker',
+        'redis',
+        'beakeredis'
+    ],
+    dependency_links=[
+        'git+https://github.com/kaukas/repoze.who-use_beaker.git@8ec4cea#egg=repoze.who-use-beaker-0.4'
+    ],
     message_extractors={
         'ckan': [
             ('**.py', 'python', None),


### PR DESCRIPTION
Fixes #
This in-progress PR replaces auth_tkt with Beaker and Redis.
This is more secure by default, for example it invalidates sessions when users log out.
Discussion here:
https://github.com/ckan/ckan/issues/4002


### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
