### PR TITLE
Fix hardcoded root paths

### DIFF
--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -497,7 +497,7 @@ class UserController(base.BaseController):
                     mailer.send_reset_link(user_obj)
                     h.flash_success(_('Please check your inbox for '
                                     'a reset code.'))
-                    h.redirect_to('/')
+                    h.redirect_to(u'home.index')
                 except mailer.MailerException as e:
                     h.flash_error(_('Could not send reset link: %s') %
                                   text_type(e))
@@ -542,7 +542,7 @@ class UserController(base.BaseController):
                 mailer.create_reset_key(user_obj)
 
                 h.flash_success(_("Your password has been reset."))
-                h.redirect_to('/')
+                h.redirect_to(u'home.index')
             except NotAuthorized:
                 h.flash_error(_('Unauthorized to edit user %s') % id)
             except NotFound as e:

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -563,14 +563,14 @@ class RequestResetView(MethodView):
                 h.flash_error(_(u'Error sending the email. Try again later '
                                 'or contact an administrator for help'))
                 log.exception(e)
-                return h.redirect_to(u'/')
+                return h.redirect_to(u'home.index')
 
         # always tell the user it succeeded, because otherwise we reveal
         # which accounts exist or not
         h.flash_success(
             _(u'A reset link has been emailed to you '
               '(unless the account specified does not exist)'))
-        return h.redirect_to(u'/')
+        return h.redirect_to(u'home.index')
 
     def get(self):
         self._prepare()
@@ -636,7 +636,7 @@ class PerformResetView(MethodView):
             mailer.create_reset_key(context[u'user_obj'])
 
             h.flash_success(_(u'Your password has been reset.'))
-            return h.redirect_to(u'/')
+            return h.redirect_to(u'home.index')
         except logic.NotAuthorized:
             h.flash_error(_(u'Unauthorized to edit user %s') % id)
         except logic.NotFound:


### PR DESCRIPTION
On a CKAN mounted on a path different than '/', the redirect made after requesting a password reset is not taking into account the path where it is mounted. We've solved it by replacing this paths.

### Proposed fixes:

Replace hardcoded '/' paths per the corresponding controller & action

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
