### PR TITLE
Remove calls to deprecated _resource_preview

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -393,13 +393,12 @@ class PackageController(base.BaseController):
 
         # can the resources be previewed?
         for resource in c.pkg_dict['resources']:
-            # Backwards compatibility with preview interface
-            resource['can_be_previewed'] = self._resource_preview(
-                {'resource': resource, 'package': c.pkg_dict})
-
             resource_views = get_action('resource_view_list')(
                 context, {'id': resource['id']})
             resource['has_views'] = len(resource_views) > 0
+
+            # Backwards compatibility with preview interface
+            resource['can_be_previewed'] = bool(len(resource_views))
 
         package_type = c.pkg_dict['type'] or 'dataset'
         self._setup_template_variables(context, {'id': id},
@@ -1116,12 +1115,11 @@ class PackageController(base.BaseController):
         c.datastore_api = '%s/api/action' % \
             config.get('ckan.site_url', '').rstrip('/')
 
-        c.resource['can_be_previewed'] = self._resource_preview(
-            {'resource': c.resource, 'package': c.package})
-
         resource_views = get_action('resource_view_list')(
             context, {'id': resource_id})
         c.resource['has_views'] = len(resource_views) > 0
+
+        c.resource['can_be_previewed'] = bool(len(resource_views))
 
         current_resource_view = None
         view_id = request.GET.get('view_id')


### PR DESCRIPTION
Fixes #4472

### Proposed fixes:

Replaces calls to deprecated function with resource_view check as per comment https://github.com/ckan/ckan/issues/4472#issuecomment-424322127


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
