### PR TITLE
Fix broken block / div nesting in the user/read_base template

### DIFF
--- a/ckan/templates/user/read_base.html
+++ b/ckan/templates/user/read_base.html
@@ -97,8 +97,8 @@
             <dd class="value"><code>{{ user.apikey }}</code></dd>
           </dl>
         {% endif %}
-        {% endblock %}
       </div>
+      {% endblock %}
     {% endblock %}
   </section>
 </div>


### PR DESCRIPTION
### Proposed fixes:
There is some wrong nesting of `{% block %}` / `<div>` elements in the user/read_base template. This minor change fixes it. 

### Features:
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
