### PR TITLE
Travis CI: The sudo tag is deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,22 @@
 group: travis_latest
 language: python
 
+flake8-steps: &flake8-steps
+  env: FLAKE8=true
+  cache: pip
+  install: pip install flake8
+  before_script:
+    - flake8 --version
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude ./ckan/include/rjsmin.py
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  script:
+    - true
+
 matrix:
   include:
     - python: "2.7"
-      sudo: required
 
       services:
         - docker
@@ -29,31 +41,8 @@ matrix:
         - docker ps -a
 
     - python: "2.7"
-      env: FLAKE8=true
-      cache: pip
-      install:
-        - pip install flake8
-      before_script:
-        - flake8 --version
-        # stop the build if there are Python syntax errors or undefined names
-        - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude ./ckan/include/rjsmin.py
-        # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-        - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      script:
-        - true
+      <<: *flake8-steps
 
     - python: "3.7"
-      env: FLAKE8=true
       dist: xenial    # required for Python 3.7
-      sudo: required  # required for Python 3.7
-      cache: pip
-      install:
-        - pip install flake8
-      before_script:
-        - flake8 --version
-        # stop the build if there are Python syntax errors or undefined names
-        - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-        # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-        - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      script:
-        - true
+      <<: *flake8-steps


### PR DESCRIPTION
[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_"

Fixes #

### Proposed fixes:



### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
