### PR TITLE
[#4684] Use get_action to call activity actions

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -2698,7 +2698,7 @@ def package_activity_list_html(context, data_dict):
     :rtype: string
 
     '''
-    activity_stream = package_activity_list(context, data_dict)
+    activity_stream = logic.get_action('package_activity_list')(context, data_dict)
     offset = int(data_dict.get('offset', 0))
     extra_vars = {
         'controller': 'package',
@@ -2729,7 +2729,7 @@ def group_activity_list_html(context, data_dict):
     :rtype: string
 
     '''
-    activity_stream = group_activity_list(context, data_dict)
+    activity_stream = logic.get_action('group_activity_list')(context, data_dict)
     offset = int(data_dict.get('offset', 0))
     extra_vars = {
         'controller': 'group',
@@ -2784,8 +2784,8 @@ def recently_changed_packages_activity_list_html(context, data_dict):
     :rtype: string
 
     '''
-    activity_stream = recently_changed_packages_activity_list(
-        context, data_dict)
+    activity_stream = logic.get_action(
+                'recently_changed_packages_activity_list')(context, data_dict)
     offset = int(data_dict.get('offset', 0))
     extra_vars = {
         'controller': 'package',
@@ -3344,7 +3344,7 @@ def dashboard_activity_list_html(context, data_dict):
     :rtype: string
 
     '''
-    activity_stream = dashboard_activity_list(context, data_dict)
+    activity_stream = logic.get_action('dashboard_activity_list')(context, data_dict)
     model = context['model']
     user_id = context['user']
     offset = data_dict.get('offset', 0)


### PR DESCRIPTION
Fixes #4684 

Otherwise they can not be overridden.

This targets the next 2.8 patch release as it's no longer relevant in master after #4627
