### PR TITLE
Remove vdm from PackageExtra and GroupExtra

### DIFF
--- a/ckan/controllers/revision.py
+++ b/ckan/controllers/revision.py
@@ -65,7 +65,6 @@ class RevisionController(base.BaseController):
                 package_indications = []
                 revision_changes = model.repo.list_changes(revision)
                 resource_revisions = revision_changes[model.Resource]
-                package_extra_revisions = revision_changes[model.PackageExtra]
                 for package in revision.packages:
                     if not package:
                         # package is None sometimes - I don't know why,
@@ -93,13 +92,6 @@ class RevisionController(base.BaseController):
                             if resource_revision.package_id == package.id:
                                 transition += ':resources'
                                 break
-                        for package_extra_revision in package_extra_revisions:
-                            if package_extra_revision.package_id == \
-                                    package.id:
-                                if package_extra_revision.key == \
-                                        'date_updated':
-                                    transition += ':date_updated'
-                                    break
                     indication = "%s:%s" % (package.name, transition)
                     package_indications.append(indication)
                 pkgs = u'[%s]' % ' '.join(package_indications)

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -225,11 +225,8 @@ def package_dictize(pkg, context):
         assert not 'display_name' in tag
         tag['display_name'] = tag['name']
 
-    #extras
-    if is_latest_revision:
-        extra = model.package_extra_table
-    else:
-        extra = model.extra_revision_table
+    #extras - no longer revisioned, so always provide latest
+    extra = model.package_extra_table
     q = select([extra]).where(extra.c.package_id == pkg.id)
     result = execute(q, extra, context)
     result_dict["extras"] = extras_list_dictize(result, context)

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -228,7 +228,7 @@ def package_dictize(pkg, context):
     #extras - no longer revisioned, so always provide latest
     extra = model.package_extra_table
     q = select([extra]).where(extra.c.package_id == pkg.id)
-    result = execute(q, extra, context)
+    result = _execute(q, extra, context)
     result_dict["extras"] = extras_list_dictize(result, context)
 
     #groups

--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -96,16 +96,14 @@ def package_resource_list_save(res_dicts, package, context):
         resource_list.append(resource)
 
 
-def package_extras_save(extra_dicts, obj, context):
+def package_extras_save(extra_dicts, pkg, context):
     allow_partial_update = context.get("allow_partial_update", False)
     if extra_dicts is None and allow_partial_update:
         return
 
-    model = context["model"]
     session = context["session"]
 
-    extras_list = obj.extras_list
-    old_extras = dict((extra.key, extra) for extra in extras_list)
+    old_extras = pkg._extras
 
     new_extras = {}
     for extra_dict in extra_dicts or []:
@@ -116,28 +114,22 @@ def package_extras_save(extra_dicts, obj, context):
             pass
         else:
             new_extras[extra_dict["key"]] = extra_dict["value"]
+
     #new
     for key in set(new_extras.keys()) - set(old_extras.keys()):
-        state = 'active'
-        extra = model.PackageExtra(state=state, key=key, value=new_extras[key])
-        session.add(extra)
-        extras_list.append(extra)
+        pkg.extras[key] = new_extras[key]
     #changed
     for key in set(new_extras.keys()) & set(old_extras.keys()):
         extra = old_extras[key]
-        if new_extras[key] == extra.value and extra.state != 'deleted':
+        if new_extras[key] == extra.value:
             continue
-        state = 'active'
         extra.value = new_extras[key]
-        extra.state = state
         session.add(extra)
     #deleted
     for key in set(old_extras.keys()) - set(new_extras.keys()):
         extra = old_extras[key]
-        if extra.state == 'deleted':
-            continue
-        state = 'deleted'
-        extra.state = state
+        extra.delete()
+
 
 def package_tag_list_save(tag_dicts, package, context):
     allow_partial_update = context.get("allow_partial_update", False)
@@ -305,7 +297,7 @@ def package_dict_save(pkg_dict, context):
         objects = pkg_dict.get('relationships_as_object')
         relationship_list_save(objects, pkg, 'relationships_as_object', context)
 
-    extras = package_extras_save(pkg_dict.get("extras"), pkg, context)
+    package_extras_save(pkg_dict.get("extras"), pkg, context)
 
     return pkg
 

--- a/ckan/migration/versions/077_add_revisions_to_system_info.py
+++ b/ckan/migration/versions/077_add_revisions_to_system_info.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-import vdm.sqlalchemy
+from ckan import model
 
 
 def upgrade(migrate_engine):
@@ -21,5 +21,5 @@ def upgrade(migrate_engine):
         ALTER TABLE system_info_revision
             DROP CONSTRAINT "system_info_revision_key_key";
 
-        '''.format(state=vdm.sqlalchemy.State.ACTIVE)
+        '''.format(state=model.State.ACTIVE)
     )

--- a/ckan/migration/versions/088_delete_extras_which_are_deleted_state.py
+++ b/ckan/migration/versions/088_delete_extras_which_are_deleted_state.py
@@ -1,0 +1,11 @@
+# encoding: utf-8
+
+
+def upgrade(migrate_engine):
+    migrate_engine.execute(
+        '''
+            ALTER TABLE "package_extra_revision"
+              DROP CONSTRAINT package_extra_revision_continuity_id_fkey;
+            DELETE FROM "package_extra" WHERE state='deleted';
+        '''
+    )

--- a/ckan/migration/versions/088_delete_extras_which_are_deleted_state.py
+++ b/ckan/migration/versions/088_delete_extras_which_are_deleted_state.py
@@ -6,6 +6,9 @@ def upgrade(migrate_engine):
         '''
             ALTER TABLE "package_extra_revision"
               DROP CONSTRAINT package_extra_revision_continuity_id_fkey;
+            ALTER TABLE "group_extra_revision"
+              DROP CONSTRAINT group_extra_revision_continuity_id_fkey;
             DELETE FROM "package_extra" WHERE state='deleted';
+            DELETE FROM "group_extra" WHERE state='deleted';
         '''
     )

--- a/ckan/migration/versions/088_delete_extras_which_are_deleted_state.py
+++ b/ckan/migration/versions/088_delete_extras_which_are_deleted_state.py
@@ -4,11 +4,11 @@
 def upgrade(migrate_engine):
     migrate_engine.execute(
         '''
-            ALTER TABLE "package_extra_revision"
-              DROP CONSTRAINT package_extra_revision_continuity_id_fkey;
-            ALTER TABLE "group_extra_revision"
-              DROP CONSTRAINT group_extra_revision_continuity_id_fkey;
-            DELETE FROM "package_extra" WHERE state='deleted';
-            DELETE FROM "group_extra" WHERE state='deleted';
+ALTER TABLE "package_extra_revision"
+    DROP CONSTRAINT IF EXISTS package_extra_revision_continuity_id_fkey;
+ALTER TABLE "group_extra_revision"
+    DROP CONSTRAINT IF EXISTS group_extra_revision_continuity_id_fkey;
+DELETE FROM "package_extra" WHERE state='deleted';
+DELETE FROM "group_extra" WHERE state='deleted';
         '''
     )

--- a/ckan/model/__init__.py
+++ b/ckan/model/__init__.py
@@ -351,7 +351,7 @@ class Repository(vdm.sqlalchemy.Repository):
 
 repo = Repository(meta.metadata, meta.Session,
                   versioned_objects=[Package, PackageTag, Resource,
-                                     PackageExtra, Member,
+                                     Member,
                                      Group, SystemInfo]
         )
 

--- a/ckan/model/__init__.py
+++ b/ckan/model/__init__.py
@@ -64,9 +64,7 @@ from group_extra import (
 )
 from package_extra import (
     PackageExtra,
-    PackageExtraRevision,
     package_extra_table,
-    extra_revision_table,
 )
 from resource import (
     Resource,

--- a/ckan/model/__init__.py
+++ b/ckan/model/__init__.py
@@ -60,7 +60,6 @@ from group import (
 from group_extra import (
     GroupExtra,
     group_extra_table,
-    GroupExtraRevision,
 )
 from package_extra import (
     PackageExtra,

--- a/ckan/model/core.py
+++ b/ckan/model/core.py
@@ -2,10 +2,12 @@
 
 import datetime
 
+from sqlalchemy import Column, DateTime, Text, Boolean
+import vdm.sqlalchemy
+
 import domain_object
 import meta
-import vdm.sqlalchemy
-from sqlalchemy import Column, DateTime, Text, Boolean
+import revision
 
 
 __all__ = ['System', 'Revision', 'State', 'StatefulObjectMixin',
@@ -57,8 +59,8 @@ class StatefulObjectMixin(object):
 Revision = vdm.sqlalchemy.make_Revision(meta.mapper, revision_table)
 
 
-def make_revisioned_table(table):
-    revision_table = vdm.sqlalchemy.make_revisioned_table(table)
+def make_revisioned_table(table, frozen=False):
+    revision_table = revision.make_revisioned_table(table, frozen)
     revision_table.append_column(Column('expired_id',
                                  Text))
     revision_table.append_column(Column('revision_timestamp', DateTime))

--- a/ckan/model/domain_object.py
+++ b/ckan/model/domain_object.py
@@ -79,7 +79,7 @@ class DomainObject(object):
 
     def delete(self):
         # stateful objects have this method overridden - see
-        # vmd.base.StatefulObjectMixin
+        # core.StatefulObjectMixin
         self.Session.delete(self)
 
     def purge(self):

--- a/ckan/model/group.py
+++ b/ckan/model/group.py
@@ -27,9 +27,11 @@ member_table = Table('member', meta.metadata,
                      Column('capacity', types.UnicodeText,
                             nullable=False),
                      Column('group_id', types.UnicodeText,
-                            ForeignKey('group.id')),)
+                            ForeignKey('group.id')),
+                     Column('state', types.UnicodeText,
+                            default=core.State.ACTIVE),
+                     )
 
-vdm.sqlalchemy.make_table_stateful(member_table)
 member_revision_table = core.make_revisioned_table(member_table)
 
 group_table = Table('group', meta.metadata,
@@ -47,14 +49,17 @@ group_table = Table('group', meta.metadata,
                            default=datetime.datetime.now),
                     Column('is_organization', types.Boolean, default=False),
                     Column('approval_status', types.UnicodeText,
-                           default=u"approved"))
+                           default=u"approved"),
+                    Column('state', types.UnicodeText,
+                           default=core.State.ACTIVE),
+                    )
 
-vdm.sqlalchemy.make_table_stateful(group_table)
+
 group_revision_table = core.make_revisioned_table(group_table)
 
 
 class Member(vdm.sqlalchemy.RevisionedObjectMixin,
-             vdm.sqlalchemy.StatefulObjectMixin,
+             core.StatefulObjectMixin,
              domain_object.DomainObject):
     '''A Member object represents any other object being a 'member' of a
     particular Group.
@@ -112,7 +117,7 @@ class Member(vdm.sqlalchemy.RevisionedObjectMixin,
 
 
 class Group(vdm.sqlalchemy.RevisionedObjectMixin,
-            vdm.sqlalchemy.StatefulObjectMixin,
+            core.StatefulObjectMixin,
             domain_object.DomainObject):
 
     def __init__(self, name=u'', title=u'', description=u'', image_url=u'',

--- a/ckan/model/group.py
+++ b/ckan/model/group.py
@@ -357,12 +357,11 @@ class Group(vdm.sqlalchemy.RevisionedObjectMixin,
         this group. Ordered by most recent first.
         '''
         results = {}
-        from group_extra import GroupExtra
         for grp_rev in self.all_revisions:
             if not grp_rev.revision in results:
                 results[grp_rev.revision] = []
             results[grp_rev.revision].append(grp_rev)
-        for class_ in [Member, GroupExtra]:
+        for class_ in [Member]:  # GroupExtra is not revisioned any more
             rev_class = class_.__revision_class__
             obj_revisions = meta.Session.query(rev_class).\
                 filter_by(group_id=self.id).all()

--- a/ckan/model/group_extra.py
+++ b/ckan/model/group_extra.py
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 import vdm.sqlalchemy
-import vdm.sqlalchemy.stateful
 from sqlalchemy import orm, types, Column, Table, ForeignKey
 from six import text_type
 
@@ -19,15 +18,15 @@ group_extra_table = Table('group_extra', meta.metadata,
     Column('group_id', types.UnicodeText, ForeignKey('group.id')),
     Column('key', types.UnicodeText),
     Column('value', types.UnicodeText),
+    Column('state', types.UnicodeText, default=core.State.ACTIVE),
 )
 
-vdm.sqlalchemy.make_table_stateful(group_extra_table)
 group_extra_revision_table = core.make_revisioned_table(group_extra_table)
 
 
 class GroupExtra(vdm.sqlalchemy.RevisionedObjectMixin,
-        vdm.sqlalchemy.StatefulObjectMixin,
-        domain_object.DomainObject):
+                 core.StatefulObjectMixin,
+                 domain_object.DomainObject):
     pass
 
 meta.mapper(GroupExtra, group_extra_table, properties={

--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -412,8 +412,9 @@ class Package(vdm.sqlalchemy.RevisionedObjectMixin,
 
         results = {} # field_name:diffs
         results.update(super(Package, self).diff(to_revision, from_revision))
-        # Iterate over PackageTag, PackageExtra, Resources etc.
-        for obj_class in [Resource, PackageExtra, PackageTag]:
+        # Iterate over PackageTag, Resources etc. (NB PackageExtra is not
+        # revisioned any more, so the diff is incomplete)
+        for obj_class in [Resource, PackageTag]:
             obj_rev_class = obj_class.__revision_class__
             # Query for object revisions related to this package
             obj_rev_query = meta.Session.query(obj_rev_class).\

--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -52,18 +52,18 @@ package_table = Table('package', meta.metadata,
         Column('metadata_created', types.DateTime, default=datetime.datetime.utcnow),
         Column('metadata_modified', types.DateTime, default=datetime.datetime.utcnow),
         Column('private', types.Boolean, default=False),
+        Column('state', types.UnicodeText, default=core.State.ACTIVE),
 )
 
 
-vdm.sqlalchemy.make_table_stateful(package_table)
 package_revision_table = core.make_revisioned_table(package_table)
 
 ## -------------------
 ## Mapped classes
 
 class Package(vdm.sqlalchemy.RevisionedObjectMixin,
-        vdm.sqlalchemy.StatefulObjectMixin,
-        domain_object.DomainObject):
+              core.StatefulObjectMixin,
+              domain_object.DomainObject):
 
     text_search_fields = ['name', 'title']
 

--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -371,22 +371,21 @@ class Package(vdm.sqlalchemy.RevisionedObjectMixin,
     @property
     def all_related_revisions(self):
         '''Returns chronological list of all object revisions related to
-        this package. Includes PackageRevisions, PackageTagRevisions,
-        PackageExtraRevisions and ResourceRevisions.
+        this package. Includes PackageRevisions, PackageTagRevisions
+        and ResourceRevisions.
         @return List of tuples (revision, [list of object revisions of this
                                            revision])
                 Ordered by most recent first.
         '''
         from tag import PackageTag
         from resource import Resource
-        from package_extra import PackageExtra
 
         results = {} # revision:[PackageRevision1, PackageTagRevision1, etc.]
         for pkg_rev in self.all_revisions:
             if not results.has_key(pkg_rev.revision):
                 results[pkg_rev.revision] = []
             results[pkg_rev.revision].append(pkg_rev)
-        for class_ in [Resource, PackageExtra, PackageTag]:
+        for class_ in [Resource, PackageTag]:
             rev_class = class_.__revision_class__
             obj_revisions = meta.Session.query(rev_class).filter_by(package_id=self.id).all()
             for obj_rev in obj_revisions:

--- a/ckan/model/package_extra.py
+++ b/ckan/model/package_extra.py
@@ -2,7 +2,6 @@
 
 from six import text_type
 import vdm.sqlalchemy
-import vdm.sqlalchemy.stateful
 from sqlalchemy import orm, types, Column, Table, ForeignKey
 from sqlalchemy.ext.associationproxy import association_proxy
 

--- a/ckan/model/package_extra.py
+++ b/ckan/model/package_extra.py
@@ -15,8 +15,7 @@ import types as _types
 import ckan.lib.dictization
 import activity
 
-__all__ = ['PackageExtra', 'package_extra_table', 'PackageExtraRevision',
-           'extra_revision_table']
+__all__ = ['PackageExtra', 'package_extra_table']
 
 package_extra_table = Table('package_extra', meta.metadata,
     Column('id', types.UnicodeText, primary_key=True, default=_types.make_uuid),
@@ -27,8 +26,10 @@ package_extra_table = Table('package_extra', meta.metadata,
     Column('state', types.UnicodeText, default=core.State.ACTIVE),
 )
 
-
-extra_revision_table = core.make_revisioned_table(package_extra_table)
+# Define the package_extra_revision table, but no need to map it, as it is only
+# used by migrate_package_activity.py
+extra_revision_table = \
+    core.make_revisioned_table(package_extra_table, frozen=True)
 
 
 class PackageExtra(
@@ -65,10 +66,6 @@ meta.mapper(PackageExtra, package_extra_table, properties={
     extension=[extension.PluginMapperExtension()],
 )
 
-# Keep the PackageExtraRevision table for now, but it no longer has .continuity
-# foreign key constraint to PackageExtra (modify_base_object_mapper did that)
-PackageExtraRevision = vdm.sqlalchemy.create_object_version(meta.mapper, PackageExtra,
-        extra_revision_table)
 
 def _create_extra(key, value):
     return PackageExtra(key=text_type(key), value=value)

--- a/ckan/model/package_extra.py
+++ b/ckan/model/package_extra.py
@@ -4,6 +4,7 @@ from six import text_type
 import vdm.sqlalchemy
 import vdm.sqlalchemy.stateful
 from sqlalchemy import orm, types, Column, Table, ForeignKey
+from sqlalchemy.ext.associationproxy import association_proxy
 
 import meta
 import core
@@ -58,11 +59,6 @@ meta.mapper(PackageExtra, package_extra_table, properties={
             cascade='all, delete, delete-orphan',
             ),
         ),
-    'package_no_state': orm.relation(_package.Package,
-        backref=orm.backref('extras_list',
-            cascade='all, delete, delete-orphan',
-            ),
-        )
     },
     order_by=[package_extra_table.c.package_id, package_extra_table.c.key],
     extension=[vdm.sqlalchemy.Revisioner(extra_revision_table),
@@ -79,8 +75,5 @@ PackageExtraRevision.related_packages = lambda self: [self.continuity.package]
 def _create_extra(key, value):
     return PackageExtra(key=text_type(key), value=value)
 
-_extras_active = vdm.sqlalchemy.stateful.DeferredProperty('_extras',
-        vdm.sqlalchemy.stateful.StatefulDict, base_modifier=lambda x: x.get_as_of())
-setattr(_package.Package, 'extras_active', _extras_active)
-_package.Package.extras = vdm.sqlalchemy.stateful.OurAssociationProxy('extras_active', 'value',
-            creator=_create_extra)
+_package.Package.extras = association_proxy(
+    '_extras', 'value', creator=_create_extra)

--- a/ckan/model/package_extra.py
+++ b/ckan/model/package_extra.py
@@ -28,9 +28,10 @@ package_extra_table = Table('package_extra', meta.metadata,
 )
 
 
-extra_revision_table= core.make_revisioned_table(package_extra_table)
+extra_revision_table = core.make_revisioned_table(package_extra_table)
 
-class PackageExtra(vdm.sqlalchemy.RevisionedObjectMixin,
+
+class PackageExtra(
         core.StatefulObjectMixin,
         domain_object.DomainObject):
 
@@ -61,16 +62,13 @@ meta.mapper(PackageExtra, package_extra_table, properties={
         ),
     },
     order_by=[package_extra_table.c.package_id, package_extra_table.c.key],
-    extension=[vdm.sqlalchemy.Revisioner(extra_revision_table),
-               extension.PluginMapperExtension(),
-               ],
+    extension=[extension.PluginMapperExtension()],
 )
 
-vdm.sqlalchemy.modify_base_object_mapper(PackageExtra, core.Revision, core.State)
-PackageExtraRevision= vdm.sqlalchemy.create_object_version(meta.mapper, PackageExtra,
+# Keep the PackageExtraRevision table for now, but it no longer has .continuity
+# foreign key constraint to PackageExtra (modify_base_object_mapper did that)
+PackageExtraRevision = vdm.sqlalchemy.create_object_version(meta.mapper, PackageExtra,
         extra_revision_table)
-
-PackageExtraRevision.related_packages = lambda self: [self.continuity.package]
 
 def _create_extra(key, value):
     return PackageExtra(key=text_type(key), value=value)

--- a/ckan/model/package_extra.py
+++ b/ckan/model/package_extra.py
@@ -23,13 +23,14 @@ package_extra_table = Table('package_extra', meta.metadata,
     Column('package_id', types.UnicodeText, ForeignKey('package.id')),
     Column('key', types.UnicodeText),
     Column('value', types.UnicodeText),
+    Column('state', types.UnicodeText, default=core.State.ACTIVE),
 )
 
-vdm.sqlalchemy.make_table_stateful(package_extra_table)
+
 extra_revision_table= core.make_revisioned_table(package_extra_table)
 
 class PackageExtra(vdm.sqlalchemy.RevisionedObjectMixin,
-        vdm.sqlalchemy.StatefulObjectMixin,
+        core.StatefulObjectMixin,
         domain_object.DomainObject):
 
     def related_packages(self):

--- a/ckan/model/package_relationship.py
+++ b/ckan/model/package_relationship.py
@@ -27,13 +27,14 @@ package_relationship_table = Table('package_relationship', meta.metadata,
      Column('object_package_id', types.UnicodeText, ForeignKey('package.id')),
      Column('type', types.UnicodeText),
      Column('comment', types.UnicodeText),
+     Column('state', types.UnicodeText, default=core.State.ACTIVE),
      )
 
-vdm.sqlalchemy.make_table_stateful(package_relationship_table)
+
 package_relationship_revision_table = core.make_revisioned_table(package_relationship_table)
 
 class PackageRelationship(vdm.sqlalchemy.RevisionedObjectMixin,
-                          vdm.sqlalchemy.StatefulObjectMixin,
+                          core.StatefulObjectMixin,
                           domain_object.DomainObject):
     '''The rule with PackageRelationships is that they are stored in the model
     always as the "forward" relationship - i.e. "child_of" but never

--- a/ckan/model/resource.py
+++ b/ckan/model/resource.py
@@ -8,7 +8,6 @@ from sqlalchemy.ext.orderinglist import ordering_list
 from sqlalchemy import orm
 from ckan.common import config
 import vdm.sqlalchemy
-import vdm.sqlalchemy.stateful
 from sqlalchemy import types, func, Column, Table, ForeignKey, and_
 
 import meta

--- a/ckan/model/resource.py
+++ b/ckan/model/resource.py
@@ -55,14 +55,15 @@ resource_table = Table(
     Column('cache_last_updated', types.DateTime),
     Column('url_type', types.UnicodeText),
     Column('extras', _types.JsonDictType),
+    Column('state', types.UnicodeText, default=core.State.ACTIVE),
 )
 
-vdm.sqlalchemy.make_table_stateful(resource_table)
+
 resource_revision_table = core.make_revisioned_table(resource_table)
 
 
 class Resource(vdm.sqlalchemy.RevisionedObjectMixin,
-               vdm.sqlalchemy.StatefulObjectMixin,
+               core.StatefulObjectMixin,
                domain_object.DomainObject):
     extra_columns = None
 

--- a/ckan/model/revision.py
+++ b/ckan/model/revision.py
@@ -15,9 +15,9 @@ def make_revisioned_table(base_table, frozen=False):
     @return revision table.
     '''
     base_table.append_column(
-            Column('revision_id', UnicodeText, ForeignKey('revision.id'))
+            Column(u'revision_id', UnicodeText, ForeignKey(u'revision.id'))
             )
-    newtable = Table(base_table.name + '_revision', base_table.metadata)
+    newtable = Table(base_table.name + u'_revision', base_table.metadata)
     copy_table(base_table, newtable)
 
     # create foreign key 'continuity' constraint
@@ -28,17 +28,17 @@ def make_revisioned_table(base_table, frozen=False):
         if col.primary_key:
             pkcols.append(col)
     assert len(pkcols) <= 1,\
-        'Do not support versioning objects with multiple primary keys'
-    fk_name = base_table.name + '.' + pkcols[0].name
+        u'Do not support versioning objects with multiple primary keys'
+    fk_name = base_table.name + u'.' + pkcols[0].name
     newtable.append_column(
-        Column('continuity_id', pkcols[0].type,
+        Column(u'continuity_id', pkcols[0].type,
                None if frozen else ForeignKey(fk_name))
         )
 
     # TODO: why do we iterate all the way through rather than just using dict
     # functionality ...? Surely we always have a revision here ...
     for col in newtable.c:
-        if col.name == 'revision_id':
+        if col.name == u'revision_id':
             col.primary_key = True
             newtable.primary_key.columns.add(col)
     return newtable

--- a/ckan/model/revision.py
+++ b/ckan/model/revision.py
@@ -1,0 +1,44 @@
+# encoding: utf-8
+
+from sqlalchemy import Table, Column, UnicodeText, ForeignKey
+
+from vdm.sqlalchemy.sqla import copy_table
+
+
+# This function is copied from vdm, but with the addition of the 'frozen' param
+def make_revisioned_table(base_table, frozen=False):
+    '''Modify base_table and create correponding revision table.
+
+    A 'frozen' revision table is not written to any more - it's just there
+    as a record. It doesn't have the continuity foreign key relation.
+
+    @return revision table.
+    '''
+    base_table.append_column(
+            Column('revision_id', UnicodeText, ForeignKey('revision.id'))
+            )
+    newtable = Table(base_table.name + '_revision', base_table.metadata)
+    copy_table(base_table, newtable)
+
+    # create foreign key 'continuity' constraint
+    # remember base table primary cols have been exactly duplicated onto our
+    # table
+    pkcols = []
+    for col in base_table.c:
+        if col.primary_key:
+            pkcols.append(col)
+    assert len(pkcols) <= 1,\
+        'Do not support versioning objects with multiple primary keys'
+    fk_name = base_table.name + '.' + pkcols[0].name
+    newtable.append_column(
+        Column('continuity_id', pkcols[0].type,
+               None if frozen else ForeignKey(fk_name))
+        )
+
+    # TODO: why do we iterate all the way through rather than just using dict
+    # functionality ...? Surely we always have a revision here ...
+    for col in newtable.c:
+        if col.name == 'revision_id':
+            col.primary_key = True
+            newtable.primary_key.columns.add(col)
+    return newtable

--- a/ckan/model/system_info.py
+++ b/ckan/model/system_info.py
@@ -23,14 +23,14 @@ system_info_table = Table(
     Column('id', types.Integer(),  primary_key=True, nullable=False),
     Column('key', types.Unicode(100), unique=True, nullable=False),
     Column('value', types.UnicodeText),
+    Column('state', types.UnicodeText, default=core.State.ACTIVE),
 )
 
-vdm.sqlalchemy.make_table_stateful(system_info_table)
 system_info_revision_table = core.make_revisioned_table(system_info_table)
 
 
 class SystemInfo(vdm.sqlalchemy.RevisionedObjectMixin,
-                 vdm.sqlalchemy.StatefulObjectMixin,
+                 core.StatefulObjectMixin,
                  domain_object.DomainObject):
 
     def __init__(self, key, value):

--- a/ckan/model/tag.py
+++ b/ckan/model/tag.py
@@ -35,9 +35,9 @@ package_tag_table = Table('package_tag', meta.metadata,
         Column('id', types.UnicodeText, primary_key=True, default=_types.make_uuid),
         Column('package_id', types.UnicodeText, ForeignKey('package.id')),
         Column('tag_id', types.UnicodeText, ForeignKey('tag.id')),
+        Column('state', types.UnicodeText, default=core.State.ACTIVE),
         )
 
-vdm.sqlalchemy.make_table_stateful(package_tag_table)
 # TODO: this has a composite primary key ...
 package_tag_revision_table = core.make_revisioned_table(package_tag_table)
 
@@ -218,8 +218,8 @@ class Tag(domain_object.DomainObject):
         return '<Tag %s>' % self.name
 
 class PackageTag(vdm.sqlalchemy.RevisionedObjectMixin,
-        vdm.sqlalchemy.StatefulObjectMixin,
-        domain_object.DomainObject):
+                 core.StatefulObjectMixin,
+                 domain_object.DomainObject):
     def __init__(self, package=None, tag=None, state=None, **kwargs):
         self.package = package
         self.tag = tag

--- a/ckan/model/user.py
+++ b/ckan/model/user.py
@@ -11,7 +11,6 @@ from sqlalchemy.sql.expression import or_
 from sqlalchemy.orm import synonym
 from sqlalchemy import types, Column, Table, func
 from six import text_type
-import vdm.sqlalchemy
 
 import meta
 import core
@@ -33,12 +32,11 @@ user_table = Table('user', meta.metadata,
         Column('activity_streams_email_notifications', types.Boolean,
             default=False),
         Column('sysadmin', types.Boolean, default=False),
+        Column('state', types.UnicodeText, default=core.State.ACTIVE),
         )
 
-vdm.sqlalchemy.make_table_stateful(user_table)
 
-
-class User(vdm.sqlalchemy.StatefulObjectMixin,
+class User(core.StatefulObjectMixin,
            domain_object.DomainObject):
 
     VALID_NAME = re.compile(r"^[a-zA-Z0-9_\-]{3,255}$")

--- a/ckan/tests/legacy/functional/test_revision.py
+++ b/ckan/tests/legacy/functional/test_revision.py
@@ -149,6 +149,5 @@ class TestRevisionController(TestController):
         # Tests for indications about what happened.
         assert 'warandpeace:created' in res, res
         assert 'annakarenina:created' in res, res
-        assert 'warandpeace:updated:date_updated' in res, res
         assert 'annakarenina:updated:resources' in res, res
         assert 'annakarenina:deleted' in res, res

--- a/ckan/tests/legacy/lib/test_dictization.py
+++ b/ckan/tests/legacy/lib/test_dictization.py
@@ -41,10 +41,12 @@ class TestBasicDictize:
             u'author_email': None,
             u'creator_user_id': None,
             'extras': [
-               {u'key': u'genre',
-                u'state': u'active',
-                u'value': 'romantic novel'},
-               {u'key': u'original media', u'state': u'active', u'value': u'book'}],
+            # extras are no longer revisioned
+            #    {u'key': u'genre',
+            #     u'state': u'active',
+            #     u'value': 'romantic novel'},
+            #    {u'key': u'original media', u'state': u'active', u'value': u'book'}
+               ],
             'groups': [{
                         u'name': u'david',
                         u'capacity': u'public',
@@ -410,7 +412,6 @@ class TestBasicDictize:
         second_dictized['resources'][0]['url'] = u'http://new_url2'
         second_dictized['tags'][0]['name'] = u'new_tag'
         second_dictized['tags'][0]['display_name'] = u'new_tag'
-        second_dictized['extras'][0]['value'] = u'new_value'
         second_dictized['state'] = 'active'
 
         print('\n'.join(unified_diff(pformat(second_dictized).split('\n'), pformat(third_dictized).split('\n'))))
@@ -440,9 +441,7 @@ class TestBasicDictize:
 
         third_dictized['tags'].insert(1, {'name': u'newnew_tag', 'display_name': u'newnew_tag', 'state': 'active'})
         third_dictized['num_tags'] = third_dictized['num_tags'] + 1
-        third_dictized['extras'].insert(0, {'key': 'david',
-                                         'value': u'new_value',
-                                         'state': u'active'})
+        third_dictized['extras'] = []  # extras are no longer revisioned
         third_dictized['state'] = 'active'
         third_dictized['state'] = 'active'
 

--- a/ckan/tests/legacy/lib/test_dictization.py
+++ b/ckan/tests/legacy/lib/test_dictization.py
@@ -41,11 +41,11 @@ class TestBasicDictize:
             u'author_email': None,
             u'creator_user_id': None,
             'extras': [
-            # extras are no longer revisioned
-            #    {u'key': u'genre',
-            #     u'state': u'active',
-            #     u'value': 'romantic novel'},
-            #    {u'key': u'original media', u'state': u'active', u'value': u'book'}
+                # extras are no longer revisioned so we get the latest version
+                {'key': u'david', 'state': u'active', 'value': u'new_value'},
+                {'key': u'genre', 'state': u'active', 'value': u'new_value'},
+                {'key': u'original media', 'state': u'active',
+                 'value': u'book'}
                ],
             'groups': [{
                         u'name': u'david',
@@ -441,7 +441,6 @@ class TestBasicDictize:
 
         third_dictized['tags'].insert(1, {'name': u'newnew_tag', 'display_name': u'newnew_tag', 'state': 'active'})
         third_dictized['num_tags'] = third_dictized['num_tags'] + 1
-        third_dictized['extras'] = []  # extras are no longer revisioned
         third_dictized['state'] = 'active'
         third_dictized['state'] = 'active'
 

--- a/ckan/tests/legacy/models/test_extras.py
+++ b/ckan/tests/legacy/models/test_extras.py
@@ -5,11 +5,11 @@ from ckan.tests.legacy import *
 import ckan.model as model
 
 class TestExtras:
-    @classmethod 
+    @classmethod
     def setup_class(self):
         CreateTestData.create()
 
-    @classmethod 
+    @classmethod
     def teardown_class(self):
         model.repo.rebuild_db()
 
@@ -20,7 +20,7 @@ class TestExtras:
 
         rev = model.repo.new_revision()
         pkg._extras[u'country'] = model.PackageExtra(key=u'country', value='us')
-        pkg.extras_active[u'xxx'] = model.PackageExtra(key=u'xxx', value='yyy')
+        pkg.extras[u'xxx'] = u'yyy'
         pkg.extras[u'format'] = u'rdf'
         model.repo.commit_and_remove()
 
@@ -28,37 +28,19 @@ class TestExtras:
         rev1 = model.repo.youngest_revision().id
         samepkg = model.Package.by_name(u'warandpeace')
         assert len(samepkg._extras) == 3, samepkg._extras
-        assert samepkg.extras_active[u'country'].value == 'us', samepkg.extras_active
         assert samepkg.extras[u'country'] == 'us'
         assert samepkg.extras[u'format'] == 'rdf'
         model.Session.remove()
 
-        # now delete and extras
+        # now delete an extra
         samepkg = model.Package.by_name(u'warandpeace')
         model.repo.new_revision()
         del samepkg.extras[u'country']
         model.repo.commit_and_remove()
 
         samepkg = model.Package.by_name(u'warandpeace')
-        assert len(samepkg._extras) == 3
+        assert len(samepkg._extras) == 2
         assert len(samepkg.extras) == 2
         extra = model.Session.query(model.PackageExtra).filter_by(key=u'country').first()
-        assert extra and extra.state == model.State.DELETED, extra
+        assert not extra, extra
         model.Session.remove()
-        
-        samepkg = model.Package.by_name(u'warandpeace')
-        samepkg.get_as_of(model.Session.query(model.Revision).get(rev1))
-        assert len(samepkg.extras) == 3, len(samepkg.extras)
-        model.Session.remove()
-
-        # now restore it ...
-        model.repo.new_revision()
-        samepkg = model.Package.by_name(u'warandpeace')
-        samepkg.extras[u'country'] = 'uk'
-        model.repo.commit_and_remove()
-
-        samepkg = model.Package.by_name(u'warandpeace')
-        assert len(samepkg.extras) == 3
-        assert len(samepkg._extras) == 3
-        assert samepkg.extras[u'country'] == 'uk'
-        

--- a/ckan/tests/legacy/models/test_package.py
+++ b/ckan/tests/legacy/models/test_package.py
@@ -353,7 +353,7 @@ class TestRelatedRevisions:
 
     def test_1_all_revisions(self):
         assert len(self.pkg1.all_revisions) == 3, self.pkg1.all_revisions
-        assert len(self.pkg1.all_related_revisions) == 7, self.pkg1.all_related_revisions
+        assert len(self.pkg1.all_related_revisions) == 6, self.pkg1.all_related_revisions
 
     def test_2_diff(self):
         rev_q = model.repo.history()
@@ -365,10 +365,6 @@ class TestRelatedRevisions:
         assert diff['notes'] == '- None\n+ Changed notes', diff['notes']
         assert diff.get('PackageTag-geo-state') == u'- \n+ active', diff
         assert diff.get('PackageTag-scientific-state') == u'- \n+ active', diff
-        assert diff.get('PackageExtra-a-value') == u'- \n+ b', diff
-        assert diff.get('PackageExtra-a-state') == u'- \n+ active', diff
-        assert diff.get('PackageExtra-c-value') == u'- \n+ d', diff
-        assert diff.get('PackageExtra-c-state') == u'- \n+ active', diff
         def test_res(diff, res, field, expected_value):
             key = 'Resource-%s-%s' % (res.id[:4], field)
             got_value = diff.get(key)

--- a/ckan/tests/logic/action/test_delete.py
+++ b/ckan/tests/logic/action/test_delete.py
@@ -242,8 +242,7 @@ class TestGroupPurge(object):
         assert_equals(sorted(
             [gr.name for gr in model.Session.query(model.GroupRevision)]),
             ['child', 'parent'])
-        assert_equals(model.Session.query(model.GroupExtraRevision).all(),
-                      [])
+        # GroupExtra is not revisioned
         # Member is not revisioned
 
         # No Revision objects were purged, in fact 1 is created for the purge
@@ -345,8 +344,7 @@ class TestOrganizationPurge(object):
         assert_equals(sorted(
             [gr.name for gr in model.Session.query(model.GroupRevision)]),
             ['child', 'parent'])
-        assert_equals(model.Session.query(model.GroupExtraRevision).all(),
-                      [])
+        # GroupExtra is not revisioned
         # Member is not revisioned
 
         # No Revision objects were purged, in fact 1 is created for the purge

--- a/ckan/tests/logic/action/test_delete.py
+++ b/ckan/tests/logic/action/test_delete.py
@@ -452,8 +452,7 @@ class TestDatasetPurge(object):
         assert_equals(model.Session.query(model.PackageRevision).all(), [])
         assert_equals(model.Session.query(model.ResourceRevision).all(), [])
         assert_equals(model.Session.query(model.PackageTagRevision).all(), [])
-        assert_equals(model.Session.query(model.PackageExtraRevision).all(),
-                      [])
+        # PackageExtraRevision is not revisioned
         # Member is not revisioned
 
         # No Revision objects were purged or created


### PR DESCRIPTION
Fixes #4690

* [x] PackageExtra no longer revisioned, but its revision table is kept (frozen) for the benefit of a future migration: [migrate_package_activity.py](#3972)
* [x] PackageExtra no longer stateful
* [x] GroupExtra no longer revisions, but its revision table is kept (frozen)
* [x] GroupExtra no longer stateful
* [x] State enum and StatefulObjectMixin are moved from vdm into ckan

Note: We're agreed that revisioning can go as soon as #3972 is merged and that should be soon, but maybe we want to confirm that that's going into this release of ckan before this one can be merged.

-- 

The original aim of this was to simply move the few lines of vdm.sqlalchemy.StatefulObjectMixin into CKAN, because I think we still want a package to be stateful - i.e. when you delete it, it only changes state=deleted. This allows an admin to still see it and look at its activity stream, see who deleted it etc.

However I didn't want to move into CKAN a whole load of vdm stateful stuff like the complicated vdm bits that are used by PackageExtras and GroupExtras:
* vdm.sqlalchemy.stateful.DeferredProperty
* vdm.sqlalchemy.stateful.StatefulDict
* vdm.sqlalchemy.stateful.OurAssociationProxy

So I figured that by making PackageExtra and GroupExtra not stateful, we don't need those vdm things at all. We don't need PackageExtra and GroupExtra to be stateful, because when we delete an extra, unlike with packages there's no benefit of it hanging around still - an admin can still see the history of it in the activity stream (as soon as #3972 is merged).

And when you remove the statefulness, you need a migration to delete the PackageExtra & GroupExtra objects which are state=deleted, otherwise they will suddenly appear to users. And to delete these objects, we need to delete the ForeignKey relation from PackageExtraRevision and GroupExtraRevision (continuity_id). So I needed to remove the revisioning from these objects too.

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
