### PR TITLE
[#4687] Allow to set the metadata_modified field through the

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -308,8 +308,12 @@ def package_update(context, data_dict):
         rev.message = _(u'REST API: Update object %s') % data.get("name")
 
     #avoid revisioning by updating directly
+    if data_dict['metadata_modified']:
+        metadata_modified = data_dict['metadata_modified']
+    else:
+        metadata_modified = datetime.datetime.utcnow()
     model.Session.query(model.Package).filter_by(id=pkg.id).update(
-        {"metadata_modified": datetime.datetime.utcnow()})
+        {"metadata_modified": metadata_modified})
     model.Session.refresh(pkg)
 
     pkg = model_save.package_dict_save(data, context)


### PR DESCRIPTION
package_update endpoint

When trying to set the metadata_modified field through the package_update endpoint it was ignoring the value informed in the data dictionary and setting it to now(). With this fix it will now check if this field exists in the data dictionary and then use it, otherwise it defaults to now().

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
