### PR TITLE
Add missing credentials and tls configuration to error email handler

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -474,11 +474,17 @@ def _setup_error_mail_handler(app):
             return True
 
     mailhost = tuple(config.get('smtp.server', 'localhost').split(":"))
+    credentials = None
+    if config.get('smtp.user'):
+        credentials = (config.get('smtp.user'), config.get('smtp.password'))
+    secure = () if asbool(config.get('smtp.starttls')) else None
     mail_handler = SMTPHandler(
         mailhost=mailhost,
         fromaddr=config.get('error_email_from'),
         toaddrs=[config.get('email_to')],
-        subject='Application Error'
+        subject='Application Error',
+        credentials=credentials,
+        secure=secure
     )
 
     mail_handler.setFormatter(logging.Formatter('''


### PR DESCRIPTION
Fixes #4611 

### Proposed fixes:
The previous fix #4623 did not include credentials or TLS attributes, so email sending failed if some email service was used. This remedies that oversight.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
