### PR TITLE
Retrieving the package after plugins run

### DIFF
--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -182,6 +182,8 @@ def resource_delete(context, data_dict):
         plugin.before_delete(context, data_dict,
                              pkg_dict.get('resources', []))
 
+    pkg_dict = _get_action('package_show')(context, {'id': package_id})
+
     if pkg_dict.get('resources'):
         pkg_dict['resources'] = [r for r in pkg_dict['resources'] if not
                 r['id'] == id]
@@ -193,7 +195,7 @@ def resource_delete(context, data_dict):
 
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.after_delete(context, pkg_dict.get('resources', []))
-
+    
     model.repo.commit()
 
 


### PR DESCRIPTION
### Proposed fixes:
Currently when a resource is deleted, the following process happens in `resource_delete`:

1. The package is retrieved
2. The resource and list of resources is passed to the `IResourceController.before_delete` function
3. The package is updated

Because the package is not retrieved or edited after the `before_delete` function runs in plugins, this causes any changes made to the package in the `before_delete` function to be overwritten.

By re-fetching the package after the plugins have run, any changes made to the package by plugins in `before_delete` are retained.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
