### PR TITLE
Fix import in license tests

### DIFF
--- a/ckan/tests/model/test_license.py
+++ b/ckan/tests/model/test_license.py
@@ -2,13 +2,12 @@
 
 import os
 
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_in
 from ckan.common import config
 
 from ckan.model.license import LicenseRegister
 from ckan.tests import helpers, factories
 
-assert_in = helpers.assert_in
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 


### PR DESCRIPTION
Fixes tests in master, failing after #4595 was merged, because of 0e1b600ef8165f2cf42c389f377f67640172907e

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
