### PR TITLE
Fix Unicode Decode Error in error page

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -446,7 +446,7 @@ def _register_error_handler(app):
     def error_handler(e):
         log.error(e, exc_info=sys.exc_info)
         if isinstance(e, HTTPException):
-            extra_vars = {u'code': [e.code], u'content': e.description}
+            extra_vars = {u'code': [e.code], u'content': e.description.decode('utf-8')}
             # TODO: Remove
             g.code = [e.code]
 

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -446,7 +446,8 @@ def _register_error_handler(app):
     def error_handler(e):
         log.error(e, exc_info=sys.exc_info)
         if isinstance(e, HTTPException):
-            extra_vars = {u'code': [e.code], u'content': e.description.decode('utf-8')}
+            extra_vars = {u'code': [e.code],
+                          u'content': e.description.decode('utf-8')}
             # TODO: Remove
             g.code = [e.code]
 

--- a/ckan/templates-bs2/error_document_template.html
+++ b/ckan/templates-bs2/error_document_template.html
@@ -5,7 +5,7 @@
 {% block primary %}
   <article class="module">
     <div class="module-content">
-      {{ content.decode('utf-8') }}
+      {{ content }}
     </div>
   </article>
 {% endblock %}

--- a/ckan/templates-bs2/error_document_template.html
+++ b/ckan/templates-bs2/error_document_template.html
@@ -5,7 +5,7 @@
 {% block primary %}
   <article class="module">
     <div class="module-content">
-      {{ content}}
+      {{ content.decode('utf-8') }}
     </div>
   </article>
 {% endblock %}

--- a/ckan/templates/error_document_template.html
+++ b/ckan/templates/error_document_template.html
@@ -5,7 +5,7 @@
 {% block primary %}
   <article class="module">
     <div class="module-content">
-      {{ content.decode('utf-8') }}
+      {{ content }}
     </div>
   </article>
 {% endblock %}

--- a/ckan/templates/error_document_template.html
+++ b/ckan/templates/error_document_template.html
@@ -5,7 +5,7 @@
 {% block primary %}
   <article class="module">
     <div class="module-content">
-      {{ content}}
+      {{ content.decode('utf-8') }}
     </div>
   </article>
 {% endblock %}


### PR DESCRIPTION
### Proposed fixes:
If error messages have latin characters, there error template fails to render them with the following log output.

```
File "/usr/lib/ckan/default/src/ckan/ckan/templates/error_document_template.html", line 8, in block "primary"
{{ content}}
 UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 1: ordinal not in range(128)
```
This pr fixes the decoding of the variable.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
