### PR TITLE
Update datapusher dockerfile

### DIFF
--- a/contrib/docker/.env.template
+++ b/contrib/docker/.env.template
@@ -42,4 +42,6 @@ POSTGRES_PORT=5432
 # Readwrite user/pass will be ckan:POSTGRES_PASSWORD
 # Readonly user/pass will be datastore_ro:DATASTORE_READONLY_PASSWORD
 DATASTORE_READONLY_PASSWORD=datastore
-
+#
+# Image: datapusher
+DATAPUSHER_VERSION=0.0.15

--- a/contrib/docker/datapusher/Dockerfile
+++ b/contrib/docker/datapusher/Dockerfile
@@ -1,0 +1,30 @@
+FROM python:2.7-stretch
+
+WORKDIR /usr/src
+
+ARG DATAPUSHER_VERSION
+
+# Download datapusher
+RUN wget https://github.com/ckan/datapusher/archive/${DATAPUSHER_VERSION}.zip
+RUN unzip ${DATAPUSHER_VERSION}.zip && rm ${DATAPUSHER_VERSION}.zip
+
+# Adding Requirements
+RUN pip install -r datapusher-${DATAPUSHER_VERSION}/requirements.txt
+RUN pip install -e datapusher-${DATAPUSHER_VERSION}/
+
+WORKDIR /usr/src/datapusher-${DATAPUSHER_VERSION}
+
+# Adding SSl Verify
+# RUN echo "SSL_VERIFY = False" >> /usr/src/datapusher/deployment/datapusher_settings.py
+
+# Export LC_ALL
+ENV LC_ALL=C
+
+# USER
+USER root
+
+# EXPOSE
+EXPOSE 8800
+
+# COMMAND
+CMD ["python", "datapusher/main.py", "deployment/datapusher_settings.py"]

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - db
       - solr
       - redis
+      - datapusher
     depends_on:
       - db
     ports:
@@ -43,9 +44,11 @@ services:
 
   datapusher:
     container_name: datapusher
-    image: clementmouchet/datapusher
-    ports:
-      - "8800:8800"
+    build:
+      context: ../../
+      dockerfile: contrib/docker/datapusher/Dockerfile
+      args:
+        - DATAPUSHER_VERSION=${DATAPUSHER_VERSION}
 
   db:
     container_name: db


### PR DESCRIPTION
Fixes #
Update datapusher dockerfile

### Proposed fixes:
The docker image of the currently guided datapusher is not being updated.
I have experienced the following issue (https://github.com/ckan/ckan-service-provider/issues/36)
and it seems to have been fixed in 0.0.8 of ckan-service-provider.
So I suggest building a datapusher docker image via git.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
