### PR TITLE
Provide example of requirements installation without source CKAN installation.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -39,6 +39,7 @@ rst_epilog = '''
 .. |production.ini| replace:: |config_dir|/production.ini
 .. |development.ini| replace:: |config_dir|/development.ini
 .. |git_url| replace:: \https://github.com/ckan/ckan.git
+.. |raw_git_url| replace:: \https://raw.githubusercontent.com/ckan/ckan
 .. |postgres| replace:: PostgreSQL
 .. |database| replace:: ckan_default
 .. |database_user| replace:: ckan_default

--- a/doc/extensions/tutorial.rst
+++ b/doc/extensions/tutorial.rst
@@ -1,3 +1,5 @@
+.. include:: /_substitutions.rst
+
 ---------------------------
 Writing extensions tutorial
 ---------------------------
@@ -17,6 +19,19 @@ Before you can start developing a CKAN extension, you'll need a working source
 install of CKAN on your system. If you don't have a CKAN source install
 already, follow the instructions in
 :doc:`/maintaining/installing/install-from-source` before continuing.
+
+.. note::
+
+   If you are developing extension without actual source installation
+   of CKAN(i.e. if you have installed CKAN as package via `pip install
+   ckan`), you can install all main and dev dependencies with the
+   following commands:
+
+   .. parsed-literal::
+
+      pip install -r |raw_git_url|/|latest_release_tag|/requirements.txt
+      pip install -r |raw_git_url|/|latest_release_tag|/dev-requirements.txt
+
 
 
 Creating a new extension


### PR DESCRIPTION
Came from #4689

Add a note to `Writing extension tutorial` for developers who are going
to make some contributions to the existing extension and don't want to complete
the whole installation of CKAN from source, but prefers simple `pip install ckan`
