### PR TITLE
Upgrade jinja2 to 2.10.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ click==6.7
 fanstatic==0.12
 Flask==0.12.4
 Flask-Babel==0.11.2
-Jinja2==2.8.1
+Jinja2==2.10.1
 Markdown==2.6.7
 ofs==0.4.2
 Pairtree==0.7.1-T

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ funcsigs==1.0.2           # via beaker
 html5lib==1.0.1           # via bleach
 idna==2.7                 # via requests
 itsdangerous==0.24        # via flask
-jinja2==2.8.1
+jinja2==2.10.1
 mako==1.0.7               # via pylons
 markdown==2.6.7
 markupsafe==1.0           # via jinja2, mako, webhelpers


### PR DESCRIPTION
[2.10.1](https://github.com/pallets/jinja/blob/master/CHANGES.rst#version-2101) adds protection to `format_map`. We don't use this, but Github is nagging.

(We [upgraded jinja2](https://github.com/ckan/ckan/pull/4725) only a few days ago but this wasn't sufficient to stop the nagging)

The changelog is purely fixes and new new features - nothing backwards incompatible. I've clicked around in the web interface and it all seems fine to me.

This version is compatible with our version of flask - it [requires](https://github.com/pallets/flask/blob/0.12.4/setup.py#L75) `Jinja2>=2.4`

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
