### PR TITLE
Upgrade sqlalchemy-migrate and pbr

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -26,7 +26,7 @@ requests==2.21.0
 Routes==1.13
 rq==0.6.0
 simplejson==3.10.0
-sqlalchemy-migrate==0.10.0
+sqlalchemy-migrate==0.12.0
 SQLAlchemy==1.1.11
 sqlparse==0.2.2
 tzlocal==1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ flask-babel==0.11.2
 flask==0.12.4
 formencode==1.3.1         # via pylons
 funcsigs==1.0.2           # via beaker
-html5lib==1.0.1           # via bleach
 idna==2.7                 # via requests
 itsdangerous==0.24        # via flask
 jinja2==2.10.1
@@ -49,8 +48,8 @@ requests==2.21.0
 routes==1.13
 rq==0.6.0
 simplejson==3.10.0
-six==1.11.0               # via bleach, html5lib, pastescript, python-dateutil, pyutilib.component.core, sqlalchemy-migrate
-sqlalchemy-migrate==0.10.0
+six==1.11.0               # via bleach, pastescript, python-dateutil, pyutilib.component.core, sqlalchemy-migrate
+sqlalchemy-migrate==0.12.0
 sqlalchemy==1.1.11
 sqlparse==0.2.2
 tempita==0.5.2            # via pylons, sqlalchemy-migrate, weberror
@@ -58,7 +57,7 @@ tzlocal==1.3
 unicodecsv==0.14.1
 urllib3==1.24             # via requests
 vdm==0.14
-webencodings==0.5.1       # via html5lib
+webencodings==0.5.1       # via bleach
 weberror==0.13.1          # via pylons
 webhelpers==1.3
 webob==1.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ passlib==1.6.5
 paste==1.7.5.1
 pastedeploy==1.5.2        # via pastescript, pylons
 pastescript==2.0.2        # via pylons
-pbr==1.10.0               # via sqlalchemy-migrate
+pbr==5.1.3                # via sqlalchemy-migrate
 polib==1.0.7
 psycopg2==2.7.3.2
 pygments==2.2.0           # via weberror


### PR DESCRIPTION
Upgrades:
* sqlalchemy-migrate 0.10.0->0.12.0 (latest)
* pbr 1.10.0->5.1.3 (latest)

These are upgraded for the sake of being up to date.

sqlalchemy-migrate [releases](https://github.com/openstack/sqlalchemy-migrate/releases). There doesn't seem to be an up-to-date changelog, but 0.11 is mentioned [here](https://allmychanges.com/p/python/sqlalchemy-migrate/). This sort of annoyance is another reason to move to Alembic - work started [here](https://github.com/ckan/ckan/pull/4450).

pbr was quite out of date. It "manages setuptools packaging", and I think it is only used by sqlalchemy-migrate.

I've tested this like this:
* tests pass, including with `--ckan-migration` option
* with a database from CKAN 2.3, upgrading to this version of CKAN, running `paster db upgrade`  and then manually clicking around web interface ok.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
