### PR TITLE
add_ckan_admin_tab function with icon

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -933,8 +933,11 @@ def build_extra_admin_nav():
     admin_tabs_dict = config.get('ckan.admin_tabs')
     output = ''
     if admin_tabs_dict:
-        for key in admin_tabs_dict:
-            output += build_nav_icon(key, admin_tabs_dict[key])
+        for k, v in admin_tabs_dict.iteritems():
+            if v['icon']:
+                output += build_nav_icon(k, v['label'], icon=v['icon'])
+            else:
+                output += build_nav(k, v['label'])
     return output
 
 

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -373,14 +373,20 @@ content type, cookies, etc.
 
     @classmethod
     def _add_ckan_admin_tabs(cls, config, route_name, tab_label,
-                             config_var='ckan.admin_tabs'):
+                             config_var='ckan.admin_tabs', icon=None):
         '''
         Update 'ckan.admin_tabs' dict the passed config dict.
         '''
         # get the admin_tabs dict from the config, or an empty dict.
         admin_tabs_dict = config.get(config_var, {})
         # update the admin_tabs dict with the new values
-        admin_tabs_dict.update({route_name: tab_label})
+        admin_tabs_dict.update({
+            route_name: {
+                'label': tab_label,
+                'icon': icon
+                }
+            }
+        )
         # update the config with the updated admin_tabs dict
         config.update({config_var: admin_tabs_dict})
 

--- a/ckanext/example_iconfigurer/tests/test_example_iconfigurer.py
+++ b/ckanext/example_iconfigurer/tests/test_example_iconfigurer.py
@@ -63,22 +63,22 @@ class TestExampleIConfigurerBuildExtraAdminTabsHelper(helpers.FunctionalTestBase
         response = app.get('/build_extra_admin_nav')
         nosetools.assert_equal(response.body, expected)
 
-    @helpers.change_config('ckan.admin_tabs', {'ckanext_myext_config_one': 'My Label'})
+    @helpers.change_config('ckan.admin_tabs', {'ckanext_myext_config_one': {'label': 'My Label', 'icon': None}})
     def test_build_extra_admin_nav_one_value_in_config(self):
         '''
         Correct string returned when ckan.admin_tabs option has single value in config.
         '''
         app = self._get_test_app()
-        expected = """<li><a href="/ckan-admin/myext_config_one"><i class="fa fa-picture-o"></i> My Label</a></li>"""
+        expected = """<li><a href="/ckan-admin/myext_config_one">My Label</a></li>"""
         response = app.get('/build_extra_admin_nav')
         nosetools.assert_equal(response.body, expected)
 
-    @helpers.change_config('ckan.admin_tabs', {'ckanext_myext_config_one': 'My Label', 'ckanext_myext_config_two': 'My Other Label'})
+    @helpers.change_config('ckan.admin_tabs', {'ckanext_myext_config_one': {'label': 'My Label', 'icon': 'picture-o'}, 'ckanext_myext_config_two': {'label': 'My Other Label', 'icon': None}})
     def test_build_extra_admin_nav_two_values_in_config(self):
         '''
         Correct string returned when ckan.admin_tabs option has two values in config.
         '''
         app = self._get_test_app()
-        expected = """<li><a href="/ckan-admin/myext_config_two"><i class="fa fa-picture-o"></i> My Other Label</a></li><li><a href="/ckan-admin/myext_config_one"><i class="fa fa-picture-o"></i> My Label</a></li>"""
+        expected = """<li><a href="/ckan-admin/myext_config_two">My Other Label</a></li><li><a href="/ckan-admin/myext_config_one"><i class="fa fa-picture-o"></i> My Label</a></li>"""
         response = app.get('/build_extra_admin_nav')
         nosetools.assert_equal(response.body, expected)

--- a/ckanext/example_iconfigurer/tests/test_iconfigurer_toolkit.py
+++ b/ckanext/example_iconfigurer/tests/test_iconfigurer_toolkit.py
@@ -18,7 +18,7 @@ class TestIConfigurerToolkitAddCkanAdminTab(helpers.FunctionalTestBase):
 
         toolkit.add_ckan_admin_tab(config, 'my_route_name', 'my_label')
 
-        nosetools.assert_equal({'ckan.admin_tabs': {'my_route_name': 'my_label'}}, config)
+        nosetools.assert_equal({'ckan.admin_tabs': {'my_route_name': {'label': 'my_label', 'icon': None}}}, config)
 
     def test_add_ckan_admin_tab_twice(self):
         '''
@@ -31,7 +31,7 @@ class TestIConfigurerToolkitAddCkanAdminTab(helpers.FunctionalTestBase):
         toolkit.add_ckan_admin_tab(config, 'my_route_name', 'my_label')
 
         expected_dict = {
-            'ckan.admin_tabs': {'my_route_name': 'my_label'}
+            'ckan.admin_tabs': {'my_route_name': {'label': 'my_label', 'icon': None}}
         }
 
         nosetools.assert_equal(expected_dict, config)
@@ -47,7 +47,7 @@ class TestIConfigurerToolkitAddCkanAdminTab(helpers.FunctionalTestBase):
         toolkit.add_ckan_admin_tab(config, 'my_route_name', 'my_replacement_label')
 
         expected_dict = {
-            'ckan.admin_tabs': {'my_route_name': 'my_replacement_label'}
+            'ckan.admin_tabs': {'my_route_name': {'label': 'my_replacement_label', 'icon': None}}
         }
 
         nosetools.assert_equal(expected_dict, config)
@@ -63,8 +63,8 @@ class TestIConfigurerToolkitAddCkanAdminTab(helpers.FunctionalTestBase):
 
         expected_dict = {
             'ckan.admin_tabs': {
-                'my_other_route_name': 'my_other_label',
-                'my_route_name': 'my_label'
+                'my_other_route_name': {'label': 'my_other_label', 'icon': None},
+                'my_route_name': {'label': 'my_label', 'icon': None}
             }
         }
 
@@ -75,7 +75,7 @@ class TestIConfigurerToolkitAddCkanAdminTab(helpers.FunctionalTestBase):
         Config already has a ckan.admin_tabs option.
         '''
         config = {
-            'ckan.admin_tabs': {'my_existing_route': 'my_existing_label'}
+            'ckan.admin_tabs': {'my_existing_route': {'label': 'my_existing_label', 'icon': None}}
         }
 
         toolkit.add_ckan_admin_tab(config, 'my_route_name', 'my_label')
@@ -83,9 +83,9 @@ class TestIConfigurerToolkitAddCkanAdminTab(helpers.FunctionalTestBase):
 
         expected_dict = {
             'ckan.admin_tabs': {
-                'my_existing_route': 'my_existing_label',
-                'my_other_route_name': 'my_other_label',
-                'my_route_name': 'my_label'
+                'my_existing_route': {'label': 'my_existing_label', 'icon': None},
+                'my_other_route_name': {'label': 'my_other_label', 'icon': None},
+                'my_route_name': {'label': 'my_label', 'icon': None}
             }
         }
 
@@ -105,8 +105,8 @@ class TestIConfigurerToolkitAddCkanAdminTab(helpers.FunctionalTestBase):
         expected_dict = {
             'ckan.my_option': 'This is my option',
             'ckan.admin_tabs': {
-                'my_other_route_name': 'my_other_label',
-                'my_route_name': 'my_label'
+                'my_other_route_name': {'label': 'my_other_label', 'icon': None},
+                'my_route_name': {'label': 'my_label', 'icon': None}
             }
         }
 


### PR DESCRIPTION
Fixes #
fix add_ckan_admin_tab function with icon

### Proposed fixes:
I tried to add the admin tab using the toolkit api.
But, I can not display tab label with icon.
I modified add_ckan_admin_tab function so that icon can be displayed together.

toolkit.add_ckan_admin_tab(config, 'admin.config', 'Test Menu') (ok)
toolkit.add_ckan_admin_tab(config, 'admin.config', 'Test Menu', icon='trash') (ok)

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
