### PR TITLE
In Python identity is not the same thing as equality

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -189,7 +189,7 @@ def redirect_to(*args, **kw):
     _url = ''
     skip_url_parsing = False
     parse_url = kw.pop('parse_url', False)
-    if uargs and len(uargs) is 1 and isinstance(uargs[0], string_types) \
+    if uargs and len(uargs) == 1 and isinstance(uargs[0], string_types) \
             and (uargs[0].startswith('/') or is_url(uargs[0])) \
             and parse_url is False:
         skip_url_parsing = True

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -475,7 +475,7 @@ content type, cookies, etc.
         # there are some routes('hello_world') that are not using blueprint
         # For such case, let's assume that view function is a controller
         # itself and action is None.
-        if len(endpoint) is 1:
+        if len(endpoint) == 1:
             return endpoint + (None,)
         return endpoint
 

--- a/ckan/tests/legacy/functional/test_pagination.py
+++ b/ckan/tests/legacy/functional/test_pagination.py
@@ -10,7 +10,7 @@ from ckan.tests.legacy import TestController, url_for, setup_test_search_index
 
 def scrape_search_results(response, object_type):
     assert object_type in ('dataset', 'group_dataset', 'group', 'user')
-    if object_type is not 'group_dataset':
+    if object_type != 'group_dataset':
         results = re.findall('a href="/%s/%s_(\d\d)' % (object_type, object_type),
                              str(response))
     else:

--- a/ckan/tests/legacy/logic/test_action.py
+++ b/ckan/tests/legacy/logic/test_action.py
@@ -702,7 +702,7 @@ class TestAction(WsgiAppCase):
         # There shouldn't be any results.  If the '%' character wasn't
         # escaped correctly, then the search would match because of the
         # unescaped wildcard.
-        assert count is 0
+        assert count == 0
 
     def test_42_resource_search_fields_parameter_still_accepted(self):
         '''The fields parameter is deprecated, but check it still works.


### PR DESCRIPTION
Fixes #4674

### Proposed fixes:
__is__ --> ==
__is not__ --> !=


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
