### PR TITLE
Fix to allow multiple tags in a single dataset search

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1834,7 +1834,7 @@ def add_url_param(alternative_url=None, controller=None, action=None,
     '''
 
     params_nopage = [
-        (k, v)for k, v in request.params.items(multi=True) 
+        (k, v)for k, v in request.params.items(multi=True)
         if k != 'page'
     ]
     params = set(params_nopage)
@@ -1873,7 +1873,7 @@ def remove_url_param(key, value=None, replace=None, controller=None,
 
     params_nopage = [
         (k, v) for k, v in request.params.items(multi=True)
-         if k != 'page'
+        if k != 'page'
     ]
     params = list(params_nopage)
     if value:

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1833,7 +1833,10 @@ def add_url_param(alternative_url=None, controller=None, action=None,
     instead.
     '''
 
-    params_nopage = [(k, v) for k, v in request.params.items(multi=True) if k != 'page']
+    params_nopage = [
+        (k, v)for k, v in request.params.items(multi=True) 
+        if k != 'page'
+    ]
     params = set(params_nopage)
     if new_params:
         params |= set(new_params.items())
@@ -1868,7 +1871,10 @@ def remove_url_param(key, value=None, replace=None, controller=None,
     else:
         keys = key
 
-    params_nopage = [(k, v) for k, v in request.params.items(multi=True) if k != 'page']
+    params_nopage = [
+        (k, v) for k, v in request.params.items(multi=True)
+         if k != 'page'
+    ]
     params = list(params_nopage)
     if value:
         params.remove((keys[0], value))

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1009,7 +1009,7 @@ def get_facet_items_dict(
     for facet_item in search_facets.get(facet)['items']:
         if not len(facet_item['name'].strip()):
             continue
-        if not (facet, facet_item['name']) in request.params.items():
+        if not (facet, facet_item['name']) in request.params.items(multi=True):
             facets.append(dict(active=False, **facet_item))
         elif not exclude_active:
             facets.append(dict(active=True, **facet_item))
@@ -1045,7 +1045,7 @@ def has_more_facets(facet, search_facets, limit=None, exclude_active=False):
     for facet_item in search_facets.get(facet)['items']:
         if not len(facet_item['name'].strip()):
             continue
-        if not (facet, facet_item['name']) in request.params.items():
+        if not (facet, facet_item['name']) in request.params.items(multi=True):
             facets.append(dict(active=False, **facet_item))
         elif not exclude_active:
             facets.append(dict(active=True, **facet_item))
@@ -1833,7 +1833,7 @@ def add_url_param(alternative_url=None, controller=None, action=None,
     instead.
     '''
 
-    params_nopage = [(k, v) for k, v in request.params.items() if k != 'page']
+    params_nopage = [(k, v) for k, v in request.params.items(multi=True) if k != 'page']
     params = set(params_nopage)
     if new_params:
         params |= set(new_params.items())
@@ -1868,7 +1868,7 @@ def remove_url_param(key, value=None, replace=None, controller=None,
     else:
         keys = key
 
-    params_nopage = [(k, v) for k, v in request.params.items() if k != 'page']
+    params_nopage = [(k, v) for k, v in request.params.items(multi=True) if k != 'page']
     params = list(params_nopage)
     if value:
         params.remove((keys[0], value))

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -1531,6 +1531,36 @@ class TestSearch(helpers.FunctionalTestBase):
 
         assert_equal(len(ds_titles), 1)
         assert_true('Dataset One' in ds_titles)
+    
+    def test_search_page_results_tags(self):
+        '''Searching with a tag returns expected results.'''
+        app = self._get_test_app()
+        factories.Dataset(name="dataset-one", title='Dataset One',
+                          tags=[
+                              {'name': 'my-tag-1'},
+                              {'name': 'my-tag-2'},
+                              {'name': 'my-tag-3'},
+                          ])
+        factories.Dataset(name="dataset-two", title='Dataset Two')
+        factories.Dataset(name="dataset-three", title='Dataset Three')
+
+        search_url = url_for('dataset.search')
+        search_response = app.get(search_url)
+        params = '/dataset/?tags=my-tag-1&tags=my-tag-2&tags=my-tag-3'
+        assert_true(params in search_response)
+
+        tag_search_response = app.get(params)
+
+        assert_true('1 dataset found' in tag_search_response)
+
+        search_response_html = BeautifulSoup(tag_search_response.body)
+        ds_titles = search_response_html.select('.dataset-list '
+                                                '.dataset-item '
+                                                '.dataset-heading a')
+        ds_titles = [n.string for n in ds_titles]
+
+        assert_equal(len(ds_titles), 3)
+        assert_true('Dataset One' in ds_titles)
 
     def test_search_page_results_private(self):
         '''Private datasets don't show up in dataset search results.'''

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -1534,6 +1534,7 @@ class TestSearch(helpers.FunctionalTestBase):
 
     def test_search_page_results_tags(self):
         '''Searching with a tag returns expected results with multiple tags'''
+
         app = self._get_test_app()
         factories.Dataset(name="dataset-one", title='Dataset One',
                           tags=[

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -1531,9 +1531,9 @@ class TestSearch(helpers.FunctionalTestBase):
 
         assert_equal(len(ds_titles), 1)
         assert_true('Dataset One' in ds_titles)
-    
+
     def test_search_page_results_tags(self):
-        '''Searching with a tag returns expected results.'''
+        '''Searching with a tag returns expected results with multiple tags'''
         app = self._get_test_app()
         factories.Dataset(name="dataset-one", title='Dataset One',
                           tags=[
@@ -1544,11 +1544,7 @@ class TestSearch(helpers.FunctionalTestBase):
         factories.Dataset(name="dataset-two", title='Dataset Two')
         factories.Dataset(name="dataset-three", title='Dataset Three')
 
-        search_url = url_for('dataset.search')
-        search_response = app.get(search_url)
         params = '/dataset/?tags=my-tag-1&tags=my-tag-2&tags=my-tag-3'
-        assert_true(params in search_response)
-
         tag_search_response = app.get(params)
 
         assert_true('1 dataset found' in tag_search_response)

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -1550,7 +1550,7 @@ class TestSearch(helpers.FunctionalTestBase):
         assert_true('1 dataset found' in tag_search_response)
 
         search_response_html = BeautifulSoup(tag_search_response.body)
-        ds_titles = search_response_html.select('.filtered pill')
+        ds_titles = search_response_html.select('.filtered')
         assert_equal(len(ds_titles), 3)
 
     def test_search_page_results_private(self):

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -1550,13 +1550,8 @@ class TestSearch(helpers.FunctionalTestBase):
         assert_true('1 dataset found' in tag_search_response)
 
         search_response_html = BeautifulSoup(tag_search_response.body)
-        ds_titles = search_response_html.select('.dataset-list '
-                                                '.dataset-item '
-                                                '.dataset-heading a')
-        ds_titles = [n.string for n in ds_titles]
-
+        ds_titles = search_response_html.select('.filtered pill')
         assert_equal(len(ds_titles), 3)
-        assert_true('Dataset One' in ds_titles)
 
     def test_search_page_results_private(self):
         '''Private datasets don't show up in dataset search results.'''

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -209,7 +209,7 @@ def search(package_type):
         extra_vars[u'fields_grouped'] = fields_grouped = {}
         search_extras = {}
         fq = u''
-        for (param, value) in request.args.items():
+        for (param, value) in request.args.items(multi=True):
             if param not in [u'q', u'page', u'sort'] \
                     and len(value) and not param.startswith(u'_'):
                 if not param.startswith(u'ext_'):
@@ -297,7 +297,6 @@ def search(package_type):
         )
         extra_vars[u'search_facets'] = query[u'search_facets']
         extra_vars[u'page'].items = query[u'results']
-
     except SearchQueryError as se:
         # User's search parameters are invalid, in such a way that is not
         # achievable with the web interface, so return a proper error to
@@ -319,7 +318,6 @@ def search(package_type):
 
     # FIXME: try to avoid using global variables
     g.search_facets_limits = {}
-
     for facet in extra_vars[u'search_facets'].keys():
         try:
             limit = int(

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -41,16 +41,6 @@ services:
       - ckan_config:/etc/ckan
       - ckan_home:/usr/lib/ckan
       - ckan_storage:/var/lib/ckan
-      - '../../ckanext/:/usr/lib/ckan/venv/src/ckan/ckanext/'
-      - '../../production.ini:/etc/ckan/production.ini'
-    # Uncommenting the following 4 lines allows one to attach to the ckan container and interact with pdb sessions
-      - ../../ckan/:/usr/lib/ckan/venv/src/ckan/ckan/
-    stdin_open: true
-    tty: true
-    command: ["ckan-paster", "serve", "--reload", "/etc/ckan/production.ini"]
-
-
-
 
   datapusher:
     container_name: datapusher

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -41,6 +41,16 @@ services:
       - ckan_config:/etc/ckan
       - ckan_home:/usr/lib/ckan
       - ckan_storage:/var/lib/ckan
+      - '../../ckanext/:/usr/lib/ckan/venv/src/ckan/ckanext/'
+      - '../../production.ini:/etc/ckan/production.ini'
+    # Uncommenting the following 4 lines allows one to attach to the ckan container and interact with pdb sessions
+      - ../../ckan/:/usr/lib/ckan/venv/src/ckan/ckan/
+    stdin_open: true
+    tty: true
+    command: ["ckan-paster", "serve", "--reload", "/etc/ckan/production.ini"]
+
+
+
 
   datapusher:
     container_name: datapusher


### PR DESCRIPTION
Fixes #
In the current version of the dataset search screen, applied tag facets are not displayed past the first facet applied.

This is because the params/args present on the request are `MultiDict`, and they are being accessed using `items()`, which only returns the first value for each key. Passing in the `multi=True` arg to `items()` allows for multiple series for a given key, which solves this problem.

Previous Behavior (check URL)
![Screen Shot 2019-04-30 at 2 39 33 PM](https://user-images.githubusercontent.com/5278388/57039161-e13f6d00-6c29-11e9-9346-9c285f7e7da4.png)

Fixed behavior:
<img width="1792" alt="Screen Shot 2019-05-01 at 2 40 14 PM" src="https://user-images.githubusercontent.com/5278388/57039173-e997a800-6c29-11e9-8f49-3f5d178eff40.png">


### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
