### PR TITLE
Package migration message not needed on fresh ckan install

### DIFF
--- a/ckan/migration/versions/089_package_activity_migration_check.py
+++ b/ckan/migration/versions/089_package_activity_migration_check.py
@@ -16,17 +16,23 @@ def upgrade(migrate_engine):
     should run the package activity migration, so that the Activity Stream can
     display the detailed history of datasets:
 
-       python migrate_package_activity.py -c /etc/ckan/production.ini
+        python migrate_package_activity.py -c /etc/ckan/production.ini
 
     Once you've done that, the detailed history is visible in Activity Stream
     to *admins only*. However you are encouraged to make it available to the
     public, by setting this in production.ini:
 
-       ckan.auth.public_activity_stream_detail = true
+        ckan.auth.public_activity_stream_detail = true
 
     More information about all of this is here:
     https://github.com/ckan/ckan/wiki/Migrate-package-activity
                 '''.format(num_unmigrated=num_unmigrated_dataset_activities))
     else:
-        print(u'You have no unmigrated package activities - you do not need to'
-              'run migrate_package_activity.py.')
+        # there are no unmigrated package activities
+        are_any_datasets = bool(
+            migrate_engine.execute(u'SELECT id FROM PACKAGE LIMIT 1').rowcount)
+        # no need to tell the user if there are no datasets - this could just
+        # be a fresh CKAN install
+        if are_any_datasets:
+            print(u'You have no unmigrated package activities - you do not '
+                  'need to run migrate_package_activity.py.')


### PR DESCRIPTION
I was seeing seeing this in Travis:
```
Initialising the database...
You have no unmigrated package activities - you do not need torun migrate_package_activity.py.
Initialising DB: SUCCESS
```
and this PR gets rid of the middle line in this situation. This is simply a tidy up of something added in #3972.

Test with:
```
$ paster db clean
Cleaning DB: SUCCESS
$ paster db init
Initialising DB: SUCCESS
```

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
