### PR TITLE
"paster db init" (or upgrade) now prints the version number

### DIFF
--- a/ckan/model/__init__.py
+++ b/ckan/model/__init__.py
@@ -275,9 +275,10 @@ class Repository(vdm.sqlalchemy.Repository):
         mig.upgrade(self.metadata.bind, self.migrate_repository, version=version)
         version_after = mig.db_version(self.metadata.bind, self.migrate_repository)
         if version_after != version_before:
-            log.info('CKAN database version upgraded: %s -> %s', version_before, version_after)
+            print('CKAN database version upgraded: {} -> {}'
+                  .format(version_before, version_after))
         else:
-            log.info('CKAN database version remains as: %s', version_after)
+            print('CKAN database version remains as: {}'.format(version_after))
 
         ##this prints the diffs in a readable format
         ##import pprint


### PR DESCRIPTION
With this PR, the version number is printed when migrating the database:
```
$ paster db clean
Cleaning DB: SUCCESS
$ paster db init
CKAN database version upgraded: 0 -> 89
Initialising DB: SUCCESS
$ paster db init
CKAN database version remains as: 89
Initialising DB: SUCCESS
```

Before:
```
$ paster db clean
Cleaning DB: SUCCESS
$ paster db init
Initialising DB: SUCCESS
$ paster db init
Initialising DB: SUCCESS
```
(and the same for `paster db upgrade`)

## Discussion

The logger doesn't work for CLI commands, because it gets disabled. This is because when importing cli.py, it imports ckan.model, which tries to use the logger. Because _load_config() hasn't been called yet, which would configure the loggers, using the logger at this moment disables the logger. The solution I hoped for many years ago is to not have any ckan imports at the root level of cli.py, but despite a warning against it, this has happened, and logging got swallowed.

I could get rid of the ckan imports in cli.py, but people might add them in again - clearly the warning message wasn't understood or missed.

The simple solution is to use print, and I don't see the harm in having stuff written to stdout. There's already print statements for `paster db init`. So it's just `paster db upgrade` that now has stdout when there was none.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
