### PR TITLE
Overhaul CKAN extension Travis template

### DIFF
--- a/ckan/pastertemplates/template/+dot+travis.yml_tmpl
+++ b/ckan/pastertemplates/template/+dot+travis.yml_tmpl
@@ -1,14 +1,44 @@
 language: python
 sudo: required
+
+# use an older trusty image, because the newer images cause build errors with
+# psycopg2 that comes with CKAN<2.8:
+#   "Error: could not determine PostgreSQL version from '10.1'"
+# see https://github.com/travis-ci/travis-ci/issues/8897
+dist: trusty
+group: deprecated-2017Q4
+
+# matrix
 python:
-    - "2.7"
+  - 2.7
+env:
+  - CKANVERSION=master
+  - CKANVERSION=2.7
+  - CKANVERSION=2.8
+
+# tests
 services:
-    - postgresql
-    - redis-server
+  - postgresql
+  - redis-server
 install:
-    - bash bin/travis-build.bash
-    - pip install coveralls
+  - bash bin/travis-build.bash
+  - pip install coveralls
 script: sh bin/travis-run.sh
 after_success:
-    - coveralls
+  - coveralls
 
+# additional jobs
+matrix:
+  include:
+    - name: "Flake8 on Python 3.7"
+      dist: xenial    # required for Python 3.7
+      cache: pip
+      install: pip install flake8
+      script:
+        - flake8 --version
+        - flake8 . --count --max-complexity=10 --max-line-length=127 --statistics --exclude ckan,{{ project }}
+      python: 3.7
+      # overwrite matrix
+      env:
+        - FLAKE8=true
+        - CKANVERSION=master

--- a/ckan/pastertemplates/template/bin/travis-build.bash_tmpl
+++ b/ckan/pastertemplates/template/bin/travis-build.bash_tmpl
@@ -10,22 +10,44 @@ sudo apt-get install solr-jetty
 echo "Installing CKAN and its Python dependencies..."
 git clone https://github.com/ckan/ckan
 cd ckan
-export latest_ckan_release_branch=`git branch --all | grep remotes/origin/release-v | sort -r | sed 's/remotes\/origin\///g' | head -n 1`
-echo "CKAN branch: $latest_ckan_release_branch"
-git checkout $latest_ckan_release_branch
+if [ $CKANVERSION == 'master' ]
+then
+    echo "CKAN version: master"
+else
+    CKAN_TAG=$(git tag | grep ^ckan-$CKANVERSION | sort --version-sort | tail -n 1)
+    git checkout $CKAN_TAG
+    echo "CKAN version: ${CKAN_TAG#ckan-}"
+fi
+
+# install the recommended version of setuptools
+if [ -f requirement-setuptools.txt ]
+then
+    echo "Updating setuptools..."
+    pip install -r requirement-setuptools.txt
+fi
+
+if [ $CKANVERSION == '2.7' ]
+then
+    echo "Installing setuptools"
+    pip install setuptools==39.0.1
+fi
+
 python setup.py develop
-pip install -r requirements.txt --allow-all-external
-pip install -r dev-requirements.txt --allow-all-external
+pip install -r requirements.txt
+pip install -r dev-requirements.txt
 cd -
 
 echo "Creating the PostgreSQL user and database..."
 sudo -u postgres psql -c "CREATE USER ckan_default WITH PASSWORD 'pass';"
 sudo -u postgres psql -c 'CREATE DATABASE ckan_test WITH OWNER ckan_default;'
 
-echo "SOLR config..."
+echo "Setting up Solr..."
 # Solr is multicore for tests on ckan master, but it's easier to run tests on
 # Travis single-core. See https://github.com/ckan/ckan/issues/2972
 sed -i -e 's/solr_url.*/solr_url = http:\/\/127.0.0.1:8983\/solr/' ckan/test-core.ini
+printf "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8983\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty
+sudo cp ckan/ckan/config/solr/schema.xml /etc/solr/conf/schema.xml
+sudo service jetty restart
 
 echo "Initialising the database..."
 cd ckan

--- a/ckan/pastertemplates/template/bin/travis-run.sh_tmpl
+++ b/ckan/pastertemplates/template/bin/travis-run.sh_tmpl
@@ -1,8 +1,9 @@
 #!/bin/sh -e
+set -ex
 
-echo "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8983\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty
-sudo cp ckan/ckan/config/solr/schema.xml /etc/solr/conf/schema.xml
-sudo service jetty restart
+flake8 --version
+# stop the build if there are Python syntax errors or undefined names
+flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude ckan,{{ project }}
 
 nosetests --ckan \
           --nologcapture \
@@ -13,3 +14,5 @@ nosetests --ckan \
           --cover-erase \
           --cover-tests
 
+# strict linting
+flake8 . --count --max-complexity=10 --max-line-length=127 --statistics --exclude ckan,{{ project }}

--- a/ckan/pastertemplates/template/dev-requirements.txt_tmpl
+++ b/ckan/pastertemplates/template/dev-requirements.txt_tmpl
@@ -1,0 +1,1 @@
+flake8    # for the travis build


### PR DESCRIPTION
This update to the Travis config is based on [ckanext-dcat](https://github.com/ckan/ckanext-dcat)'s config, with a few ideas of my own. I've tested it in [ckanext-downloadall](https://github.com/davidread/ckanext-downloadall)

* add tests for multiple CKAN versions
    * add fix for psycopg2 error with CKAN<2.8
    * add correct setuptools version for CKAN==2.7
* `--allow-all-external` option was deprecated and removed in pip 10
* SOLR's config sed command is moved, to travis-build.bash, with the other setup, and in line with ckanext-dcat
* flake8's simple checks for syntax is moved from a travis job to travis-run.sh, because it runs in 0.5s, but setting up the VM for the job takes 30-60s, so might as well just run it at the start of the test jobs. The point is to fail fast. This requires the addition of 'set -ex' in the .
* add strict flake8 linting - this is perhaps a matter of taste, but as a practice it's more popular than ever now, and it's always easiest to do it from the beginning of an extension's life. People can comment out that line if they prefer.
* flake8 added to dev-requirements.txt, since developers should probably be running it locally, as well as travis. I point my IDE (VS Code) at my virtualenv and it runs flake8 from there.
* adds *python3* flake8 linting - I'm not sure that adds much but you never know.

TBH I've not looked at using Travis' newer VMs / features, so more might be done in this area.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
