### PR TITLE
internal server error occurs when admin deletes its own account

### DIFF
--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -425,8 +425,12 @@ def delete(id):
     except logic.NotAuthorized:
         msg = _(u'Unauthorized to delete user with id "{user_id}".')
         base.abort(403, msg.format(user_id=id))
-    user_index = h.url_for(u'user.index')
-    return h.redirect_to(user_index)
+
+    if g.userobj.id == id:
+        return logout()
+    else:
+        user_index = h.url_for(u'user.index')
+        return h.redirect_to(user_index)
 
 
 def generate_apikey(id=None):


### PR DESCRIPTION
Fixes #
An internal server error occurs when admin deletes its own account
or if the extention allows users to "user_delete" for themselves.

### Proposed fixes:
When you move to user.index after own user delete, it seems that user information is left in session. 
If you do not delete session value, you can not access other page.

In my opinion, when you delete your own account, I think it is right to redirect to logout.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
