### PR TITLE
pool_pre_ping defaults to True

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -289,6 +289,7 @@ def update_config():
 
     # CONFIGURATION OPTIONS HERE (note: all config options will override
     # any Pylons config options)
+    config.setdefault('pool_pre_ping', True)
 
     # Initialize SQLAlchemy
     engine = sqlalchemy.engine_from_config(config)

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -115,6 +115,7 @@ def _get_engine_from_url(connection_url):
     engine = _engines.get(connection_url)
     if not engine:
         extras = {'url': connection_url}
+        config.setdefault('pool_pre_ping', True)
         engine = sqlalchemy.engine_from_config(config,
                                                'ckan.datastore.sqlalchemy.',
                                                **extras)


### PR DESCRIPTION
Fixes #4734

### Proposed fixes:
Set `pool_pre_ping = True` as default for sqlalchemy connections. This should make connections to the database more reliable.