### PR TITLE
Travis CI: Add more flake8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ flake8-steps: &flake8-steps
   before_script:
     - flake8 --version
     # stop the build if there are Python syntax errors or undefined names
-    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude ./ckan/include/rjsmin.py
+    - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics --exclude ./ckan/include/rjsmin.py
     # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
     - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
   script:


### PR DESCRIPTION
As requested in #4752

[__flake8 --select=E9,F63,F72,F82__](http://flake8.pycqa.org/en/latest/user/error-codes.html) will run all E9xx tests + all F63x tests + all F72x tests + all F82x tests.

Fixes #

### Proposed fixes:



### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
