### PR TITLE
Fix incremented follower-counter

### DIFF
--- a/ckan/public-bs2/base/javascript/modules/followers-counter.js
+++ b/ckan/public-bs2/base/javascript/modules/followers-counter.js
@@ -61,6 +61,8 @@ this.ckan.module('followers-counter', function($) {
       var action = options.action;
       var incrementedFollowers;
 
+      locale = locale ? locale.replace('_', '-') : locale;
+
       if (action === 'follow') {
         incrementedFollowers = (++this.options.num_followers).toLocaleString(locale);
       } else if (action === 'unfollow') {

--- a/ckan/public-bs2/base/javascript/modules/followers-counter.js
+++ b/ckan/public-bs2/base/javascript/modules/followers-counter.js
@@ -61,8 +61,6 @@ this.ckan.module('followers-counter', function($) {
       var action = options.action;
       var incrementedFollowers;
 
-      locale = locale ? locale.replace('_', '-') : locale;
-
       if (action === 'follow') {
         incrementedFollowers = (++this.options.num_followers).toLocaleString(locale);
       } else if (action === 'unfollow') {

--- a/ckan/public/base/javascript/modules/followers-counter.js
+++ b/ckan/public/base/javascript/modules/followers-counter.js
@@ -61,6 +61,8 @@ this.ckan.module('followers-counter', function($) {
       var action = options.action;
       var incrementedFollowers;
 
+      locale = locale ? locale.replace('_', '-') : locale;
+
       if (action === 'follow') {
         incrementedFollowers = (++this.options.num_followers).toLocaleString(locale);
       } else if (action === 'unfollow') {


### PR DESCRIPTION
Fixes #
If you change the language setting of ckan to a language that contains "_", the count does not increase when you click the follow button. 
(e.g.) ko_KR, pt_BR, cs_CZ

Uncaught RangeError: Invalid language tag: ko_kr
    at Number.toLocaleString (<anonymous>)
    at Module._updateCounter (followers-counter.js:65)
    at Module._onFollow (followers-counter.js:44)
    at Object.proxy (jquery.js:496)
    at Object.wrapper (pubsub.js:57)
    at Object.dispatch (jquery.js:5206)
    at Object.elemData.handle (jquery.js:5014)
    at Object.trigger (jquery.js:8201)
    at jQuery.fn.init.triggerHandler (jquery.js:8275)
    at Sandbox.publish (pubsub.js:36)

### Proposed fixes:
The toLocaleString function should use a locale code containing "-".
In follower-counter module, I modified ckan's locale code to use "-" instead of "_".

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
