### PR TITLE
Facet filtering does not work in 'group.read' or 'organization.read' pages

### DIFF
--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -466,10 +466,12 @@ def read(group_type, is_organization, id=None, limit=20):
     # if the user specified a group id, redirect to the group name
     if data_dict['id'] == group_dict['id'] and \
             data_dict['id'] != group_dict['name']:
+
+        url_with_name = h.url_for(u'{}.read'.format(group_type),
+                                  id=group_dict['name'])
+
         return h.redirect_to(
-            h.add_url_param(
-                controller=group_type, action=u'read',
-                extras=dict(id=group_dict['name'])))
+            h.add_url_param(alternative_url=url_with_name))
 
     # TODO: Remove
     # ckan 2.9: Adding variables that were removed from c object for

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -466,8 +466,10 @@ def read(group_type, is_organization, id=None, limit=20):
     # if the user specified a group id, redirect to the group name
     if data_dict['id'] == group_dict['id'] and \
             data_dict['id'] != group_dict['name']:
-        return h.redirect_to(u'{}.read'.format(group_type),
-                             id=group_dict['name'])
+        return h.redirect_to(
+            h.add_url_param(
+                controller=group_type, action=u'read',
+                extras=dict(id=group_dict['name'])))
 
     # TODO: Remove
     # ckan 2.9: Adding variables that were removed from c object for


### PR DESCRIPTION
Fixes #
Facet filtering does not work in 'group.read' or 'organization.read' pages
I think this is a major issue.

e.g.)
facet filtering link is below in 'organization.read' page.
http://127.0.0.1:5000/organization/d89fa5bb-6886-4196-ae81-8f806f7f37d3 **?res_format=CSV**
 = > redirect to http://127.0.0.1:5000/organization/test
Parameter(res_format) is not included when redirecting

### Proposed fixes:
Make parameter included when redirecting

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
