### PR TITLE
Allows external database host with docker containers

### DIFF
--- a/contrib/docker/ckan-entrypoint.sh
+++ b/contrib/docker/ckan-entrypoint.sh
@@ -70,5 +70,5 @@ while ! pg_isready -h $CKAN_DB_HOST -U postgres; do
   sleep 1;
 done
 
-ckan-paster --plugin=ckan $CKAN_DB_HOST init -c "${CKAN_CONFIG}/production.ini"
+ckan-paster --plugin=ckan db init -c "${CKAN_CONFIG}/production.ini"
 exec "$@"


### PR DESCRIPTION
Fixes #
This allows one to use an external PostgreSQL database rather than requiring the docker ckan container to point to the `db` service within the compose file. In our case this allows us to point our containers to an AWS RDS instance. This change programmatically determines the database host based on the required `CKAN_SQLALCHEMY_URL` environment variable rather than leaving it hard coded to the compose service name.

This change also allows the system to fail fast if required environment variables are not set rather than waiting for the database to be available before testing the environment variables.
### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
