### PR TITLE
Cache paths of non-existing templates to reduce open() syscalls

### DIFF
--- a/ckan/lib/jinja_extensions.py
+++ b/ckan/lib/jinja_extensions.py
@@ -19,8 +19,12 @@ import ckan.lib.base as base
 import ckan.lib.helpers as h
 from ckan.common import config
 
+from werkzeug.local import Local
+
 
 log = logging.getLogger(__name__)
+local = Local()
+local.missing_templates = set()
 
 
 def get_jinja_env_options():
@@ -195,8 +199,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         pieces = loaders.split_template_path(template)
         for searchpath in searchpaths:
             filename = path.join(searchpath, *pieces)
+            if filename in local.missing_templates:
+                continue
             f = open_if_exists(filename)
             if f is None:
+                local.missing_templates.add(filename)
                 continue
             try:
                 contents = f.read().decode(self.encoding)


### PR DESCRIPTION
Fixes #4773 

### Proposed fixes:
- Cache template paths pointing to non-existing templates and skip trying to open them again
- Makes it impossible to add new template files on the fly, but is this a necessary feature?

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
