### PR TITLE
Add back pkg.extras_list, which was just removed in #4691

### DIFF
--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -556,6 +556,19 @@ class Package(vdm.sqlalchemy.RevisionedObjectMixin,
                             rating=rating)
             meta.Session.add(rating)
 
+    @property
+    @maintain.deprecated()
+    def extras_list(self):
+        '''DEPRECATED in 2.9
+
+        Returns a list of the dataset's extras, as PackageExtra object
+        NB includes deleted ones too (state='deleted')
+        '''
+        from package_extra import PackageExtra
+        return meta.Session.query(PackageExtra) \
+            .filter_by(package_id=self.id) \
+            .all()
+
 
 class RatingValueException(Exception):
     pass

--- a/ckan/tests/model/test_package_extra.py
+++ b/ckan/tests/model/test_package_extra.py
@@ -52,3 +52,27 @@ class TestPackage(object):
             pkg.extras,
             {u'accuracy': u'metre'}
         )
+
+    def test_extras_list(self):
+        extras = [
+            {u'key': u'subject', u'value': u'science'},
+            {u'key': u'accuracy', u'value': u'metre'},
+            {u'key': u'sample_years', u'value': u'2012-2013'},
+        ]
+        dataset = factories.Dataset(extras=extras)
+        # delete the 'subject' extra
+        extras = extras[1:]
+        helpers.call_action(u'package_patch', id=dataset['id'], extras=extras)
+        # unrelated extra, to check it doesn't affect things
+        factories.Dataset(extras=[{u'key': u'foo', u'value': u'bar'}])
+
+        pkg = model.Package.by_name(dataset['name'])
+        assert isinstance(pkg.extras_list[0], model.PackageExtra)
+        assert_equal(
+            set([(pe.package_id, pe.key, pe.value, pe.state)
+                 for pe in pkg.extras_list]),
+            set([(dataset['id'], u'subject', u'science', u'deleted'),
+                 (dataset['id'], u'accuracy', u'metre', u'active'),
+                 (dataset['id'], u'sample_years', u'2012-2013', u'active'),
+                 ])
+        )


### PR DESCRIPTION
Fixes issue with #4691 raised by @frafra: https://github.com/ckan/ckan/commit/e0945313ab34aeb54602caa4046d630491f61252#commitcomment-33471741

I've checked this test also works with the previous code, as it was in CKAN 2.8.2.

No need to backport.

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
