### PR TITLE
Changing Open Knowledge International to Open Knowledge Foundation

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,7 +2,7 @@ License
 +++++++
 
 CKAN - Data Catalogue Software
-Copyright (c) 2006-2018 Open Knowledge International and contributors
+Copyright (c) 2006-2018 Open Knowledge Foundation and contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ ckan-dev mailing list or on Gitter.
 Copying and License
 -------------------
 
-This material is copyright (c) 2006-2018 Open Knowledge International and contributors.
+This material is copyright (c) 2006-2018 Open Knowledge Foundation and contributors.
 
 It is open and licensed under the GNU Affero General Public License (AGPL) v3.0
 whose full text may be found at:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -99,7 +99,7 @@ master_doc = 'contents'
 # General information about the project.
 project = u'CKAN'
 project_short_name = u'CKAN'
-copyright = u'''&copy; 2009-2018 <a href="https://okfn.org/">Open Knowledge International</a> and <a href="https://github.com/ckan/ckan/graphs/contributors">contributors</a>.
+copyright = u'''&copy; 2009-2018 <a href="https://okfn.org/">Open Knowledge Foundation</a> and <a href="https://github.com/ckan/ckan/graphs/contributors">contributors</a>.
     Licensed under <a
     href="https://creativecommons.org/licenses/by-sa/3.0/">Creative Commons
     Attribution ShareAlike (Unported) v3.0 License</a>.<br />


### PR DESCRIPTION
Following the [announcement](https://blog.okfn.org/2019/05/20/for-a-fair-free-and-open-future-celebrating-15-years-of-the-open-knowledge-foundation/) that Open Knowledge International is rebranding to Open Knowledge Foundation as of Monday 20th May 2019, I'd like to request these small text changes.