### PR TITLE
Add support for base64 images for organization & group image

### DIFF
--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -388,7 +388,7 @@ def group_dictize(group, context,
 
     image_url = result_dict.get('image_url')
     result_dict['image_display_url'] = image_url
-    if image_url and not image_url.startswith('http'):
+    if image_url and not image_url.startswith('http') and not image_url.startswith('data:'):
         #munge here should not have an effect only doing it incase
         #of potential vulnerability of dodgy api input
         image_url = munge.munge_filename_legacy(image_url)


### PR DESCRIPTION
Fixes #

### Proposed fixes:
Add the possibility to enter the image for group or organization as base64 encoded data
(such data needs to be returned as-is to the templates, without pre-appending an url path)


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
