### PR TITLE
fix remove_field in dateset page

### DIFF
--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -84,13 +84,15 @@ def drill_down_url(alternative_url=None, **by):
 
 
 def remove_field(package_type, key, value=None, replace=None):
+    if not package_type or package_type == u'dataset':
+        url = h.url_for(u'dataset.search')
+    else:
+        url = h.url_for(u'{0}_search'.format(package_type))
     return h.remove_url_param(
         key,
         value=value,
         replace=replace,
-        controller=u'dataset',
-        action=u'search',
-        alternative_url=package_type
+        alternative_url=url
     )
 
 


### PR DESCRIPTION
Fixes #4823
An error occurs when generating the url to delete the facet field.

![image](https://user-images.githubusercontent.com/7775824/58181710-40534780-7ce7-11e9-830c-71d957dad336.png)

### Proposed fixes:
fix remove_field function

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
