### PR TITLE
Upgrade PyYaml

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -20,6 +20,7 @@ Pylons==0.9.7
 python-dateutil>=1.5.0
 pytz==2016.7
 pyutilib.component.core==4.6.4
+pyyaml  # needed by webassets. latest should be fine.
 repoze.who-friendlyform==1.0.8
 repoze.who==2.3
 requests==2.22.0
@@ -32,6 +33,7 @@ sqlparse==0.2.2
 tzlocal==1.3
 unicodecsv>=0.9
 vdm==0.14
+webassets==0.12.1
 WebHelpers==1.3
 WebOb==1.0.8
 WebTest==1.4.3  # need to pin this so that Pylons does not install a newer version that conflicts with WebOb==1.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ funcsigs==1.0.2           # via beaker
 idna==2.8                 # via requests
 itsdangerous==1.1.0       # via flask
 jinja2==2.10.1
-mako==1.0.9               # via pylons
+mako==1.0.9               # via alembic, pylons
 markdown==2.6.7
 markupsafe==1.1.1         # via jinja2, mako, webhelpers
 nose==1.3.7               # via pylons
@@ -35,9 +35,11 @@ pygments==2.3.1           # via weberror
 pylons==0.9.7
 pysolr==3.6.0
 python-dateutil==2.8.0
+python-editor==1.0.4      # via alembic
 python-magic==0.4.15
 pytz==2016.7
 pyutilib.component.core==4.6.4
+pyyaml==5.1
 redis==3.2.1              # via rq
 repoze.lru==0.7           # via routes
 repoze.who-friendlyform==1.0.8
@@ -55,6 +57,7 @@ tzlocal==1.3
 unicodecsv==0.14.1
 urllib3==1.25.2           # via requests
 vdm==0.14
+webassets==0.12.1
 webencodings==0.5.1       # via bleach
 weberror==0.13.1          # via pylons
 webhelpers==1.3
@@ -62,5 +65,3 @@ webob==1.0.8
 webtest==1.4.3
 werkzeug==0.14.1
 zope.interface==4.3.2
-PyYAML==3.13
-webassets==0.12.1


### PR DESCRIPTION
* PyYaml needed upgrading due to GitHub's security nag.
* PyYaml is used by webassets and it seems fine with the latest version, according to:
  https://github.com/miracle2k/webassets/blob/e3e82114324ffd6cf1a2877976a1de08c515eb10/requirements-dev.pip
* PyYaml was only just introduced to CKAN in webassets PR https://github.com/ckan/ckan/pull/4614
  However it was added to requirements.txt not requirements.in, so I fixed that too.
* Regenerating requirements.in adds a few minor things along the way.

CC @smotornyuk 

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
