### PR TITLE
Fix assignment in obj_list_dictize

### DIFF
--- a/ckan/lib/dictization/__init__.py
+++ b/ckan/lib/dictization/__init__.py
@@ -79,7 +79,7 @@ def obj_list_dictize(obj_list, context, sort_key=lambda x:x):
 
     for obj in obj_list:
         if context.get('with_capacity'):
-            obj, capacity = obj
+            capacity = context.get('with_capacity')
             dictized = table_dictize(obj, context, capacity=capacity)
         else:
             dictized = table_dictize(obj, context)


### PR DESCRIPTION
with_capacity was incorrectly retrieved from its obj

Fixes https://github.com/ckan/ckan/issues/4813

### Proposed fixes:
Minimal fix to successfully retrieve the with_capacity value and pass it along


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
