### PR TITLE
[#4405] Fix breadcrumb on /datasets

### DIFF
--- a/ckan/templates/package/search.html
+++ b/ckan/templates/package/search.html
@@ -4,7 +4,7 @@
 {% block subtitle %}{{ _("Datasets") }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{{ h.nav_link(_(dataset_type.title() + 's'), controller='package', action='search', named_route=dataset_type + '_search', highlight_actions = 'new index') }}</li>
+  <li class="active">{{ h.nav_link(_(dataset_type.title() + 's'), controller='package', action='search', named_route='search') }}</li>
 {% endblock %}
 
 {% block primary_content %}


### PR DESCRIPTION
Fixes #4405 

This is a fix for CKAN 2.8 only, hence the PR targetting 2.8 branch. Hopefully this can get into 2.8.3 release.

This is based on https://github.com/ckan/ckan/pull/4816 which was the right fix but the PR targeted the wrong branch.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
