### PR TITLE
Prevent group admins from changing their own role

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -604,7 +604,14 @@ def member_create(context, data_dict=None):
         filter(model.Member.table_id == obj.id).\
         filter(model.Member.group_id == group.id).\
         filter(model.Member.state == 'active').first()
-    if not member:
+    if member:
+        user_obj = model.User.get(user)
+        if member.table_name == u'user' and \
+                member.table_id == user_obj.id and \
+                member.capacity == u'admin' and \
+                capacity != u'admin':
+            raise Exception("Administrators cannot revoke their own admin status")
+    else:
         member = model.Member(table_name=obj_type,
                               table_id=obj.id,
                               group_id=group.id,

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -610,8 +610,8 @@ def member_create(context, data_dict=None):
                 member.table_id == user_obj.id and \
                 member.capacity == u'admin' and \
                 capacity != u'admin':
-            raise Exception(
-                    "Administrators cannot revoke their own admin status")
+            raise logic.NotAuthorized("Administrators cannot revoke their "
+                                      "own admin status")
     else:
         member = model.Member(table_name=obj_type,
                               table_id=obj.id,

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -610,7 +610,8 @@ def member_create(context, data_dict=None):
                 member.table_id == user_obj.id and \
                 member.capacity == u'admin' and \
                 capacity != u'admin':
-            raise Exception("Administrators cannot revoke their own admin status")
+            raise Exception(
+                    "Administrators cannot revoke their own admin status")
     else:
         member = model.Member(table_name=obj_type,
                               table_id=obj.id,

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1623,9 +1623,14 @@ def user_autocomplete(context, data_dict):
 
     q = data_dict['q']
     limit = data_dict.get('limit', 20)
+    ignore_self = data_dict.get('ignore_self', False)
 
     query = model.User.search(q)
     query = query.filter(model.User.state != model.State.DELETED)
+
+    if ignore_self:
+        query = query.filter(model.User.name != user)
+
     query = query.limit(limit)
 
     user_list = []

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -633,6 +633,7 @@ def default_autocomplete_schema(
         not_missing, unicode_safe, ignore_missing, natural_number_validator):
     return {
         'q': [not_missing, unicode_safe],
+        'ignore_self': [ignore_missing],
         'limit': [ignore_missing, natural_number_validator]
     }
 

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -393,9 +393,8 @@ content type, cookies, etc.
             route_name: {
                 'label': tab_label,
                 'icon': icon
-                }
             }
-        )
+        })
         # update the config with the updated admin_tabs dict
         config.update({config_var: admin_tabs_dict})
 

--- a/ckan/templates/group/member_new.html
+++ b/ckan/templates/group/member_new.html
@@ -30,7 +30,7 @@
             {% else %}
               <input id="username" type="text" name="username" placeholder="Username"
               value="" class="control-medium" data-module="autocomplete"
-              data-module-source="/api/2/util/user/autocomplete?q=?">
+              data-module-source="/api/2/util/user/autocomplete?ignore_self=true&q=?">
             {% endif %}
           </div>
         </div>
@@ -57,8 +57,15 @@
       {% endif %}
     </div>
 
-    {% set format_attrs = {'data-module': 'autocomplete'} %}
-    {{ form.select('role', label=_('Role'), options=roles, selected=user_role, error='', attrs=format_attrs) }}
+    {% if user and user.name == c.user and user_role == 'admin' %}
+      {% set format_attrs = {'data-module': 'autocomplete', 'disabled': 'disabled'} %}
+      {{ form.select('role', label=_('Role'), options=roles, selected=user_role, error='', attrs=format_attrs) }}
+      {{ form.hidden('role', value=user_role) }}
+    {% else %}
+      {% set format_attrs = {'data-module': 'autocomplete'} %}
+      {{ form.select('role', label=_('Role'), options=roles, selected=user_role, error='', attrs=format_attrs) }}
+    {% endif %}
+
     <div class="form-actions">
       {% if user %}
         <a href="{{ h.url_for(group_type + '.member_delete', id=group_dict.id, user=user.id) }}" class="btn btn-danger pull-left" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?') }}">{{ _('Delete') }}</a>

--- a/ckan/templates/organization/member_new.html
+++ b/ckan/templates/organization/member_new.html
@@ -31,8 +31,8 @@
               disabled="True" class="form-control">
             {% else %}
                 <input id="username" type="text" name="username" placeholder="{{ _('Username') }}"
-              value="" class="control-medium" data-module="autocomplete"
-              data-module-source="/api/2/util/user/autocomplete?q=?">
+                value="" class="control-medium" data-module="autocomplete"
+                data-module-source="/api/2/util/user/autocomplete?ignore_self=true&q=?">
             {% endif %}
           </div>
         </div>
@@ -59,8 +59,15 @@
       {% endif %}
     </div>
 
-    {% set format_attrs = {'data-module': 'autocomplete'} %}
-    {{ form.select('role', label=_('Role'), options=roles, selected=user_role, error='', attrs=format_attrs) }}
+    {% if user and user.name == c.user and user_role == 'admin' %}
+      {% set format_attrs = {'data-module': 'autocomplete', 'disabled': 'disabled'} %}
+      {{ form.select('role', label=_('Role'), options=roles, selected=user_role, error='', attrs=format_attrs) }}
+      {{ form.hidden('role', value=user_role) }}
+    {% else %}
+      {% set format_attrs = {'data-module': 'autocomplete'} %}
+      {{ form.select('role', label=_('Role'), options=roles, selected=user_role, error='', attrs=format_attrs) }}
+    {% endif %}
+
     <div class="form-actions">
       {% if user %}
         <a href="{{ h.url_for(group_type + '.member_delete', id=group_dict.id, user=user.id) }}" class="btn btn-danger pull-left" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?') }}">{{ _('Delete') }}</a>

--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -416,12 +416,13 @@ def format_autocomplete(ver=API_REST_DEFAULT_VERSION):
 def user_autocomplete(ver=API_REST_DEFAULT_VERSION):
     q = request.args.get(u'q', u'')
     limit = request.args.get(u'limit', 20)
+    ignore_self = request.args.get(u'ignore_self', False)
     user_list = []
     if q:
         context = {u'model': model, u'session': model.Session,
                    u'user': g.user, u'auth_user_obj': g.userobj}
 
-        data_dict = {u'q': q, u'limit': limit}
+        data_dict = {u'q': q, u'limit': limit, u'ignore_self': ignore_self}
 
         user_list = get_action(u'user_autocomplete')(context, data_dict)
     return _finish_ok(user_list)


### PR DESCRIPTION
Fixes #4560

This is one way to deal with the issue. I tried to make the changes as small as possible while still avoiding offering error-producing interaction paths to the user. I'm not entirely confident all the changes here have been implemented in the most elegant and style-preserving fashion, especially the `ignore_self` frontend part, but at the very least it works in our environment to counter the issue. 

### Proposed fixes:
- Prevent group admins from changing their own role
- Skip current user when autocompleting in new member view
- Disable role input when user is an admin editing their own membership

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
