### PR TITLE
Use TextField instead of StrField due to hardcoded size limit in solr 6

### DIFF
--- a/ckan/config/solr/schema.xml
+++ b/ckan/config/solr/schema.xml
@@ -27,7 +27,7 @@ schema. In this case the version should be set to the next CKAN version number.
 <schema name="ckan" version="2.9">
 
 <types>
-    <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
+    <fieldType name="string" class="solr.TextField" sortMissingLast="true" omitNorms="true"/>
     <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" omitNorms="true"/>
     <fieldtype name="binary" class="solr.BinaryField"/>
     <fieldType name="int" class="solr.TrieIntField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>


### PR DESCRIPTION
Using Solr6 indexing might fail with following log:

```
ckan.lib.search.common.SearchIndexError: Solr returned an error: (u'Solr responded with an error (HTTP 400): [Reason: Exception writing document id 4fb2245b8ebf2110d52eaf1899f72f8f to the index; possible analysis error: Document contains at least one immense term in field="coupled-resource" (whose UTF8 encoding is longer than the max length 32766), all of which were skipped.  Please correct the analyzer to not produce such terms.  The prefix of the first immense term is: \'[91, 123, 34, 104, 114, 101, 102, 34, 58, 32, 91, 34, 104, 116, 116, 112, 58, 47, 47, 119, 119, 119, 46, 112, 97, 105, 107, 107, 97, 116]...\', original message: bytes can be at most 32766 in length; got 35362. Perhaps the document has an indexed string field (solr.StrField) which is too large]',)
```
![image](https://user-images.githubusercontent.com/830663/58686946-eb6b9d00-8388-11e9-8b2e-fc26b156aba2.png)


### Proposed fixes:
Change StrField to TextField which does not have similar hardcoded limit.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
