### PR TITLE
Bugfix: Allow empty arrays and objects in json type fields when inserting data into datastore

### DIFF
--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1042,7 +1042,7 @@ def upsert_data(context, data_dict):
             row = []
             for field in fields:
                 value = record.get(field['id'])
-                if value and field['type'].lower() == 'nested':
+                if value is not None and field['type'].lower() == 'nested':
                     # a tuple with an empty second value
                     value = (json.dumps(value), '')
                 row.append(value)

--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -21,6 +21,32 @@ from ckan.plugins.toolkit import ValidationError
 
 
 class TestDatastoreCreateNewTests(DatastoreFunctionalTestBase):
+    def test_create_works_with_empty_array_in_json_field(self):
+        package = factories.Dataset()
+        data = {
+            'resource': {
+                'package_id': package['id']
+            },
+            'fields': [{'id': 'movie', 'type': 'text'},
+                       {'id': 'directors', 'type': 'json'}],
+            'records': [{'movie': 'sideways', 'directors': []}]
+        }
+        result = helpers.call_action('datastore_create', **data)
+        assert result['resource_id'] is not None
+
+    def test_create_works_with_empty_object_in_json_field(self):
+        package = factories.Dataset()
+        data = {
+            'resource': {
+                'package_id': package['id']
+            },
+            'fields': [{'id': 'movie', 'type': 'text'},
+                       {'id': 'director', 'type': 'json'}],
+            'records': [{'movie': 'sideways', 'director': {}}]
+        }
+        result = helpers.call_action('datastore_create', **data)
+        assert result['resource_id'] is not None     
+
     def test_create_creates_index_on_primary_key(self):
         package = factories.Dataset()
         data = {


### PR DESCRIPTION
Fixes #4766

### Proposed fixes:
Add bugfix from #1776 to INSERT method in upsert_data. This allows empty json arrays or json objects to be inserted into json type fields when creating new data in the datastore.


### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
