### PR TITLE
[#4827] More robust auth functions for resource_view_show

### DIFF
--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -163,11 +163,29 @@ def resource_show(context, data_dict):
 
 
 def resource_view_show(context, data_dict):
-    return authz.is_authorized('resource_show', context, data_dict)
+
+    model = context['model']
+    resource = context.get('resource')
+    if not resource:
+        resource_view = model.ResourceView.get(data_dict['id'])
+        if not resource_view:
+            raise logic.NotFound(_('Resource view not found, cannot check auth.'))
+        resource = model.Resource.get(resource_view.resource_id)
+
+    return authz.is_authorized('resource_show', context, {'id': resource.id})
 
 
 def resource_view_list(context, data_dict):
-    return authz.is_authorized('resource_show', context, data_dict)
+
+    model = context['model']
+    resource = context.get('resource')
+    if not resource:
+        resource_view = model.ResourceView.get(data_dict['id'])
+        if not resource_view:
+            raise logic.NotFound(_('Resource view not found, cannot check auth.'))
+        resource = model.Resource.get(resource_view.resource_id)
+
+    return authz.is_authorized('resource_show', context, {'id': resource['id']})
 
 
 def revision_show(context, data_dict):

--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -165,12 +165,11 @@ def resource_show(context, data_dict):
 def resource_view_show(context, data_dict):
 
     model = context['model']
-    resource = context.get('resource')
-    if not resource:
-        resource_view = model.ResourceView.get(data_dict['id'])
-        if not resource_view:
-            raise logic.NotFound(_('Resource view not found, cannot check auth.'))
-        resource = model.Resource.get(resource_view.resource_id)
+
+    resource_view = model.ResourceView.get(data_dict['id'])
+    if not resource_view:
+        raise logic.NotFound(_('Resource view not found, cannot check auth.'))
+    resource = model.Resource.get(resource_view.resource_id)
 
     return authz.is_authorized('resource_show', context, {'id': resource.id})
 

--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -176,16 +176,7 @@ def resource_view_show(context, data_dict):
 
 
 def resource_view_list(context, data_dict):
-
-    model = context['model']
-    resource = context.get('resource')
-    if not resource:
-        resource_view = model.ResourceView.get(data_dict['id'])
-        if not resource_view:
-            raise logic.NotFound(_('Resource view not found, cannot check auth.'))
-        resource = model.Resource.get(resource_view.resource_id)
-
-    return authz.is_authorized('resource_show', context, {'id': resource['id']})
+    return authz.is_authorized('resource_show', context, data_dict)
 
 
 def revision_show(context, data_dict):

--- a/ckanext/datastore/tests/test_chained_auth_functions.py
+++ b/ckanext/datastore/tests/test_chained_auth_functions.py
@@ -96,4 +96,3 @@ class TestChainedAuthBuiltInFallback(DatastoreFunctionalTestBase):
         ctd.CreateTestData.create()
         # check if chained auth fallbacks to built-in user_create
         check_access(u'user_create', {u'user': u'annafan'}, {})
-


### PR DESCRIPTION
Fixes #4827.

Right now they rely on resource objects being present in the context. You should be able to call the auth function with the same parameters  as the action (ie just the resource view id). This is not an issue
 in core but it can be problematic when extending auth from extensions.

