### PR TITLE
Fix exception email parameters

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -477,7 +477,9 @@ def _setup_error_mail_handler(app):
             log_record.headers = request.headers
             return True
 
-    mailhost = tuple(config.get('smtp.server', 'localhost').split(":"))
+    smtp_server = config.get('smtp.server', 'localhost')
+    mailhost = tuple(smtp_server.split(':')) \
+        if ':' in smtp_server else smtp_server
     credentials = None
     if config.get('smtp.user'):
         credentials = (config.get('smtp.user'), config.get('smtp.password'))


### PR DESCRIPTION
Fixes #4830

### Proposed fixes:
Fixes SMTPHandler "mailhost" parameter format. This is needed when you configure exception emails (and don't specify the SMTP port number).

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
