### PR TITLE
Make reorder resources button translatable

### DIFF
--- a/ckan/public/base/javascript/modules/resource-reorder.js
+++ b/ckan/public/base/javascript/modules/resource-reorder.js
@@ -8,6 +8,7 @@ this.ckan.module('resource-reorder', function($) {
     },
     template: {
       title: '<h1></h1>',
+      help_text: '<p></p>',
       button: [
         '<a href="javascript:;" class="btn btn-default">',
         '<i class="fa fa-bars"></i>',
@@ -39,11 +40,19 @@ this.ckan.module('resource-reorder', function($) {
       jQuery.proxyAll(this, /_on/);
 
       var labelText = this._('Reorder resources');
+      var helpText = this._('You can rearrange the resources by dragging them using the arrow icon. Drag the resource ' +
+        'to the right and place it to the desired location on the list. When you are done, click the "Save order" -button.');
 
       this.html_title = $(this.template.title)
         .text(labelText)
         .insertBefore(this.el)
         .hide();
+
+      this.html_help_text = $(this.template.help_text)
+        .text(helpText)
+        .insertBefore(this.el)
+        .hide();
+
       var button = $(this.template.button)
         .on('click', this._onHandleStartReorder)
         .appendTo('.page_primary_action');
@@ -81,6 +90,7 @@ this.ckan.module('resource-reorder', function($) {
         this.html_form_actions
           .add(this.html_handles)
           .add(this.html_title)
+          .add(this.html_help_text)
           .show();
         this.el
           .addClass('reordering')
@@ -130,6 +140,7 @@ this.ckan.module('resource-reorder', function($) {
       this.html_form_actions
         .add(this.html_handles)
         .add(this.html_title)
+        .add(this.html_help_text)
         .hide();
       this.el
         .removeClass('reordering')

--- a/ckan/public/base/javascript/modules/resource-reorder.js
+++ b/ckan/public/base/javascript/modules/resource-reorder.js
@@ -4,8 +4,7 @@
 this.ckan.module('resource-reorder', function($) {
   return {
     options: {
-      id: false,
-      labelText: 'Reorder resources'
+      id: false
     },
     template: {
       title: '<h1></h1>',
@@ -39,7 +38,7 @@ this.ckan.module('resource-reorder', function($) {
     initialize: function() {
       jQuery.proxyAll(this, /_on/);
 
-      var labelText = this._(this.options.labelText);
+      var labelText = this._('Reorder resources');
 
       this.html_title = $(this.template.title)
         .text(labelText)


### PR DESCRIPTION
### Proposed fixes:
Reorder resources button has not been translatable since ckan 2.7 as message extraction does not pickup the javascript translation from variable. This PR also adds translatable help text to the module as its functionality is sometimes a little counter intuitive.

![image](https://user-images.githubusercontent.com/830663/59355494-bc154280-8d2f-11e9-84dd-202e9fa1f93c.png)

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
