### PR TITLE
Upgrade psycopg2, fixes ckan/ckan#4837

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -286,7 +286,7 @@ General notes:
    This is due to a bug in the psycopg2 version pinned to the release. To solve
    it, upgrade psycopg2 with the following command::
 
-     pip install --upgrade psycopg2==2.7.3.2
+     pip install --upgrade psycopg2==2.8.2
 
  * This release does not require a Solr schema upgrade, but if you are having the
    issues described in #3863 (datasets wrongly indexed in multilingual setups),

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -315,7 +315,7 @@ def _cache_types(connection):
             # redo cache types with json now available.
             return _cache_types(connection)
 
-        register_composite('nested', connection.connection, True)
+        register_composite('nested', connection.connection.connection, True)
 
 
 def _pg_version_is_at_least(connection, version):

--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,7 @@ passlib==1.6.5
 paste==1.7.5.1
 PasteScript==2.0.2
 polib==1.0.7
-psycopg2==2.7.3.2
+psycopg2==2.8.2
 python-magic==0.4.15
 pysolr==3.6.0
 Pylons==0.9.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ pastedeploy==2.0.1        # via pastescript, pylons
 pastescript==2.0.2
 pbr==5.2.0                # via sqlalchemy-migrate
 polib==1.0.7
-psycopg2==2.7.3.2
+psycopg2==2.8.2
 pygments==2.3.1           # via weberror
 pylons==0.9.7
 pysolr==3.6.0


### PR DESCRIPTION
Fixes #4837 

### Proposed fixes:
Upgrade psycopg2 to version 2.8.2


### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
