### PR TITLE
Improvement: Remove legacy documentation about non-existant block.

### DIFF
--- a/doc/contributing/frontend/template-blocks.rst
+++ b/doc/contributing/frontend/template-blocks.rst
@@ -64,15 +64,6 @@ Add a breadcrumb to the page by extending this element::
     {% include "breadcrumb.html" %}
   {% endblock %}
 
-actions
--------
-
-Add actions to the page by extending this element::
-
-  {% block actions %}
-    <a class="btn" href="{{ save_url }}">Save</a>
-  {% endblock %}
-
 primary
 -------
 


### PR DESCRIPTION
Fixes #4743 

### Proposed fixes:

Remove legacy documentation that references an [`actions` block](https://docs.ckan.org/en/2.8/contributing/frontend/template-blocks.html#actions) that no longer exists in the page.html template. It was [removed in 2013](https://github.com/ckan/ckan/commit/25cdea387018486791b66fad9bce282b2dd2a65f#diff-3a3c92fefd91654892ad323c0935035c).

### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
