### PR TITLE
Build correct urls to relatively reffered files

### DIFF
--- a/ckan/lib/webassets_tools.py
+++ b/ckan/lib/webassets_tools.py
@@ -58,7 +58,7 @@ def webassets_init():
     env.debug = config.get(u'debug', False)
     env.url = u'/webassets/'
 
-    env.append_path(base_path, u'/base/')
+    add_public_path(base_path, u'/base/')
 
     logger.debug(u'Base path {0}'.format(base_path))
     create_library(u'vendor', os.path.join(
@@ -159,3 +159,7 @@ def get_webassets_path():
             u'must be specified'
         )
     return webassets_path
+
+
+def add_public_path(path, url):
+    env.append_path(path, url)

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -325,8 +325,19 @@ content type, cookies, etc.
 
         The path is relative to the file calling this function.
 
+        Webassets addition: append directory to webassets load paths
+        in order to correctly rewrite relative css paths and resolve
+        public urls.
+
         '''
-        cls._add_served_directory(config, relative_path, 'extra_public_paths')
+        import ckan.lib.helpers as h
+        from ckan.lib.webassets_tools import add_public_path
+        path = cls._add_served_directory(
+            config,
+            relative_path,
+            'extra_public_paths'
+        )
+        add_public_path(path, h.url_for_static('/'))
 
     @classmethod
     def _add_served_directory(cls, config, relative_path, config_var):
@@ -349,6 +360,7 @@ content type, cookies, etc.
                 config[config_var] += ',' + absolute_path
             else:
                 config[config_var] = absolute_path
+        return absolute_path
 
     @classmethod
     def _add_resource(cls, path, name):

--- a/ckanext/reclineview/theme/public/webassets.yml
+++ b/ckanext/reclineview/theme/public/webassets.yml
@@ -1,5 +1,7 @@
 main-css:
   output: ckanext-reclineview/%(version)s_reclineview.css
+  filters: cssrewrite
+
   contents:
     - vendor/bootstrap/3.2.0/css/bootstrap.css
     - vendor/leaflet/0.7.7/leaflet.css


### PR DESCRIPTION
Fixes #4844

When CSS file contains relative links to static files(eg. `background: url(../x.png)`), those paths are computed from webasset's path(`/webassets/...`) and(as webassets doesn't handle any files except for css/js) in UI we have a bunch of 404s. The most obvious solution here - applying `cssrewrite` filter so that your `webassets.yaml` looks like (attention to the third line)
```yaml
main-css:
  output: ckanext-reclineview/%(version)s_reclineview.css
  filters: cssrewrite
  contents:
    - vendor/bootstrap/3.2.0/css/bootstrap.css
    # ....
```
And it's exactly how one should fix such issues in future. For initial case i had to slightly update workflow for public paths registration. One of `Webassets`' CSS rewriter's rules - file that if referred by rewrote URL must exist in the filesystem and it MUST be available via public URL. So, we need to register all CKAN public URLs inside `webassets` environment so that it can verify existence of our files.