### PR TITLE
Blueprint name is 'feeds' not 'feed'

### DIFF
--- a/ckan/templates/organization/snippets/feeds.html
+++ b/ckan/templates/organization/snippets/feeds.html
@@ -1,4 +1,4 @@
-{%- set dataset_feed = h.url_for('feed.organization', id=group_dict.name) -%}
+{%- set dataset_feed = h.url_for('feeds.organization', id=group_dict.name) -%}
 {%- set history_feed = h.url_for(controller='revision', action='list', format='atom', days=1) -%}
 <link rel="alternate" type="application/atom+xml" title="{{ g.site_title }} - {{ _('Datasets in organization: {group}').format(group=group_dict.display_name) }}" href="{{ dataset_feed }}" />
 <link rel="alternate" type="application/atom+xml" title="{{ g.site_title }} - {{ _('Recent Revision History') }}" href="{{ history_feed }}" />


### PR DESCRIPTION
### Proposed fixes:
I think the Blueprint name is wrong in the html snippet. Double-checked on beta.ckan.org and the url that is generated is wrong:

![image](https://user-images.githubusercontent.com/6586348/59772338-41f73780-92b4-11e9-9854-fae8b4569130.png)


