### PR TITLE
Replace webhelpers

### DIFF
--- a/ckan/controllers/feed.py
+++ b/ckan/controllers/feed.py
@@ -25,7 +25,7 @@ import logging
 import urlparse
 
 from six import text_type
-import webhelpers.feedgenerator
+from webhelpers import feedgenerator
 
 import ckan.lib.base as base
 import ckan.lib.helpers as h
@@ -410,7 +410,7 @@ class FeedController(base.BaseController):
                 author_name=pkg.get('author', ''),
                 author_email=pkg.get('author_email', ''),
                 categories=[t['name'] for t in pkg.get('tags', [])],
-                enclosure=webhelpers.feedgenerator.Enclosure(
+                enclosure=feedgenerator.Enclosure(
                     h.url_for(controller='api',
                               register='package',
                               action='show',
@@ -499,7 +499,7 @@ class FeedController(base.BaseController):
 
 
 # TODO paginated feed
-class _FixedAtom1Feed(webhelpers.feedgenerator.Atom1Feed):
+class _FixedAtom1Feed(feedgenerator.Atom1Feed):
     """
     The Atom1Feed defined in webhelpers doesn't provide all the fields we
     might want to publish.
@@ -545,7 +545,7 @@ class _FixedAtom1Feed(webhelpers.feedgenerator.Atom1Feed):
         """
         super(_FixedAtom1Feed, self).add_item_elements(handler, item)
 
-        dfunc = webhelpers.feedgenerator.rfc3339_date
+        dfunc = feedgenerator.rfc3339_date
 
         if(item['updated']):
             handler.addQuickElement(u'updated',

--- a/ckan/controllers/feed.py
+++ b/ckan/controllers/feed.py
@@ -25,7 +25,7 @@ import logging
 import urlparse
 
 from six import text_type
-from webhelpers import feedgenerator
+from django.utils import feedgenerator
 
 import ckan.lib.base as base
 import ckan.lib.helpers as h

--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -791,7 +791,7 @@ class GroupController(base.BaseController):
         format = request.params.get('format', '')
         if format == 'atom':
             # Generate and return Atom 1.0 document.
-            from webhelpers.feedgenerator import Atom1Feed
+            from django.utils.feedgenerator import Atom1Feed
             feed = Atom1Feed(
                 title=_(u'CKAN Group Revision History'),
                 link=h.url_for(

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -457,7 +457,7 @@ class PackageController(base.BaseController):
         format = request.params.get('format', '')
         if format == 'atom':
             # Generate and return Atom 1.0 document.
-            from webhelpers.feedgenerator import Atom1Feed
+            from django.utils.feedgenerator import Atom1Feed
             feed = Atom1Feed(
                 title=_(u'CKAN Dataset Revision History'),
                 link=h.url_for(controller='revision', action='read',

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -23,7 +23,6 @@ from paste.deploy import converters
 from webhelpers.html import HTML, literal, tags, tools
 from webhelpers import paginate
 import webhelpers.text as whtext
-import webhelpers.date as date
 from markdown import markdown
 from bleach import clean as bleach_clean, ALLOWED_TAGS, ALLOWED_ATTRIBUTES
 from pylons import url as _pylons_default_url
@@ -1578,19 +1577,6 @@ class _RFC2282TzInfo(datetime.tzinfo):
 
     def tzname(self, dt):
         return None
-
-
-@core_helper
-@maintain.deprecated('h.time_ago_in_words_from_str is deprecated in 2.2 '
-                     'and will be removed.  Please use '
-                     'h.time_ago_from_timestamp instead')
-def time_ago_in_words_from_str(date_str, granularity='month'):
-    '''Deprecated in 2.2 use time_ago_from_timestamp'''
-    if date_str:
-        return date.time_ago_in_words(date_str_to_datetime(date_str),
-                                      granularity=granularity)
-    else:
-        return _('Unknown')
 
 
 @core_helper

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -22,7 +22,6 @@ import uuid
 from paste.deploy import converters
 from webhelpers.html import HTML, literal, tags, tools
 from webhelpers import paginate
-import webhelpers.text as whtext
 from markdown import markdown
 from bleach import clean as bleach_clean, ALLOWED_TAGS, ALLOWED_ATTRIBUTES
 from pylons import url as _pylons_default_url
@@ -1223,6 +1222,11 @@ def group_name_to_title(name):
 
 
 @core_helper
+def truncate(text, limit):
+    return text[:limit] + '...' * (len(text) > limit)
+
+
+@core_helper
 def markdown_extract(text, extract_length=190):
     ''' return the plain text representation of markdown encoded text.  That
     is the texted without any html tags.  If extract_length is 0 then it
@@ -1235,12 +1239,7 @@ def markdown_extract(text, extract_length=190):
 
     return literal(
         text_type(
-            whtext.truncate(
-                plain,
-                length=extract_length,
-                indicator='...',
-                whole_word=True
-            )
+            truncate(plain, extract_length)
         )
     )
 
@@ -2644,7 +2643,6 @@ core_helper(tags.literal)
 core_helper(tags.link_to)
 core_helper(tags.file)
 core_helper(tags.submit)
-core_helper(whtext.truncate)
 # Useful additions from the paste library.
 core_helper(converters.asbool)
 # Useful additions from the stdlib.

--- a/ckan/tests/controllers/test_feed.py
+++ b/ckan/tests/controllers/test_feed.py
@@ -5,7 +5,7 @@ from ckan.lib.helpers import url_for
 import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
 import ckan.plugins as plugins
-from webhelpers.feedgenerator import GeoAtom1Feed
+from django.contrib.gis.feeds import GeoAtom1Feed
 
 
 class TestFeedNew(helpers.FunctionalTestBase):

--- a/ckan/tests/controllers/test_feed.py
+++ b/ckan/tests/controllers/test_feed.py
@@ -135,7 +135,7 @@ class TestFeedInterface(helpers.FunctionalTestBase):
         app = self._get_test_app()
         res = app.get(offset)
 
-        assert '<georss:box>-2373790.000000 2937940.000000 -1681290.000000 3567770.000000</georss:box>' in res.body, res.body
+        assert '<georss:box>2937940.000000 -2373790.000000 3567770.000000 -1681290.000000</georss:box>' in res.body, res.body
 
 
 class MockFeedPlugin(plugins.SingletonPlugin):

--- a/ckan/tests/legacy/functional/api/base.py
+++ b/ckan/tests/legacy/functional/api/base.py
@@ -9,7 +9,7 @@ import urllib
 
 from nose.tools import assert_equal
 from paste.fixture import TestRequest
-from webhelpers.html import url_escape
+from django.utils.encoding import escape_uri_path
 
 import ckan.model as model
 from ckan.tests.legacy import CreateTestData
@@ -41,7 +41,7 @@ class ApiTestCase(object):
         return response
 
     def post(self, offset, data, status=[200,201], *args, **kwds):
-        params = '%s=1' % url_escape(self.dumps(data))
+        params = '%s=1' % escape_uri_path(self.dumps(data))
         if 'extra_environ' in kwds:
             self.extra_environ = kwds['extra_environ']
         response = self.app.post(offset, params=params, status=status,

--- a/ckan/tests/legacy/functional/api/test_package_search.py
+++ b/ckan/tests/legacy/functional/api/test_package_search.py
@@ -2,7 +2,7 @@
 
 from urllib import quote
 
-import webhelpers
+from django.utils import html
 
 import ckan.lib.search as search
 from ckan.tests.legacy import setup_test_search_index
@@ -64,7 +64,7 @@ class PackageSearchApiTestCase(ApiTestCase, ControllerTestCase):
         assert res_dict['result']['count'] == 1, res_dict['result']['count']
 
     def test_06_uri_q_tags(self):
-        query = webhelpers.util.html_escape('annakarenina tags:russian tags:tolstoy')
+        query = html.escape('annakarenina tags:russian tags:tolstoy')
         offset = self.base_url + '?q=%s' % query
         res = self.app.get(offset, status=200)
         res_dict = self.data_from_res(res)

--- a/ckan/tests/legacy/lib/test_helpers.py
+++ b/ckan/tests/legacy/lib/test_helpers.py
@@ -60,12 +60,6 @@ class TestHelpers(TestController):
                       h.date_str_to_datetime,
                       '2008-04-13T20:40:20.500')
 
-    def test_time_ago_in_words_from_str(self):
-        two_months_ago = datetime.datetime.now() - datetime.timedelta(days=65)
-        two_months_ago_str = two_months_ago.isoformat()
-        res = h.time_ago_in_words_from_str(two_months_ago_str)
-        assert_equal(res, '2 months')
-
     def test_gravatar(self):
         email = 'zephod@gmail.com'
         expected = ['<a href="https://gravatar.com/"',

--- a/ckan/views/feed.py
+++ b/ckan/views/feed.py
@@ -5,7 +5,7 @@ import urlparse
 
 from flask import Blueprint, make_response
 from six import text_type
-import webhelpers.feedgenerator
+from webhelpers import feedgenerator
 from ckan.common import _, config, g, request, response
 import ckan.lib.helpers as h
 import ckan.lib.base as base
@@ -115,7 +115,7 @@ def output_feed(results, feed_title, feed_description, feed_link, feed_url,
             author_name=pkg.get(u'author', u''),
             author_email=pkg.get(u'author_email', u''),
             categories=[t['name'] for t in pkg.get(u'tags', [])],
-            enclosure=webhelpers.feedgenerator.Enclosure(
+            enclosure=feedgenerator.Enclosure(
                 h.url_for(
                     u'api.action',
                     logic_function=u'package_show',
@@ -500,7 +500,7 @@ def _create_atom_id(resource_path, authority_name=None, date_string=None):
     return u':'.join(['tag', tagging_entity, resource_path])
 
 
-class _FixedAtom1Feed(webhelpers.feedgenerator.Atom1Feed):
+class _FixedAtom1Feed(feedgenerator.Atom1Feed):
     """
     The Atom1Feed defined in webhelpers doesn't provide all the fields we
     might want to publish.
@@ -544,7 +544,7 @@ class _FixedAtom1Feed(webhelpers.feedgenerator.Atom1Feed):
         """
         super(_FixedAtom1Feed, self).add_item_elements(handler, item)
 
-        dfunc = webhelpers.feedgenerator.rfc3339_date
+        dfunc = feedgenerator.rfc3339_date
 
         if (item['updated']):
             handler.addQuickElement(u'updated',

--- a/ckan/views/feed.py
+++ b/ckan/views/feed.py
@@ -5,7 +5,7 @@ import urlparse
 
 from flask import Blueprint, make_response
 from six import text_type
-from webhelpers import feedgenerator
+from django.utils import feedgenerator
 from ckan.common import _, config, g, request, response
 import ckan.lib.helpers as h
 import ckan.lib.base as base

--- a/requirements.in
+++ b/requirements.in
@@ -4,6 +4,7 @@ alembic==1.0.0
 Babel==2.3.4
 bleach==3.0.2
 click==6.7
+Django==1.11.21
 fanstatic==0.12
 Flask==0.12.4
 Flask-Babel==0.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
 click==6.7
 decorator==4.4.0          # via pylons, sqlalchemy-migrate
+django==1.11.21
 fanstatic==0.12
 flask-babel==0.11.2
 flask==0.12.4


### PR DESCRIPTION
Fixes #4794

### Proposed fixes:

Rely on Django utils instead of webhelpers

### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [x] includes API changes
- [ ] includes bugfix for possible backport

### Backlog:

- [ ] Remove old code by `_FixedAtom1Feed`
- [ ] Update the documentation of `_FixedAtom1Feed`

### Important changes:

- The order of GeoRSS box coordinates is different
- Removed `test_time_ago_in_words_from_str` (deprecated since CKAN 2.2)
- Truncation is exact (like "I like CKAN bec...." instead of "I like CKAN...")