### PR TITLE
fix preload bootstrap

### DIFF
--- a/ckan/public/base/css/webassets.yml
+++ b/ckan/public/base/css/webassets.yml
@@ -1,18 +1,24 @@
 fuchsia:
+  filters: cssrewrite
   output: base/%(version)s_fuchsia.css
   contents: fuchsia.css
 green:
+  filters: cssrewrite
   output: base/%(version)s_green.css
   contents: green.css
 main:
+  filters: cssrewrite
   output: base/%(version)s_main.css
   contents: main.css
 main-rtl:
+  filters: cssrewrite
   output: base/%(version)s_main-rtl.css
   contents: main-rtl.css
 maroon:
+  filters: cssrewrite
   output: base/%(version)s_maroon.css
   contents: maroon.css
 red:
+  filters: cssrewrite
   output: base/%(version)s_red.css
   contents: red.css

--- a/ckan/public/base/javascript/webassets.yml
+++ b/ckan/public/base/javascript/webassets.yml
@@ -4,6 +4,7 @@ main:
   extra:
     preload:
       - vendor/vendor
+      - vendor/bootstrap
   contents:
     - apply-html-class.js
     - plugins/jquery.inherit.js


### PR DESCRIPTION
cannot read property of boostrap in main.js

Fixes #
Close button of flash message does not work.
`
cffbc237_main.js:204 Uncaught TypeError: element.append(...).alert is not a function
    at Function.notify.initialize (cffbc237_main.js:204)
    at HTMLDivElement.<anonymous> (cffbc237_main.js:204)
    at Function.each (86894786_jquery.js:15)
    at jQuery.fn.init.each (86894786_jquery.js:5)
    at cffbc237_main.js:204
    at cffbc237_main.js:204
`


![image](https://user-images.githubusercontent.com/7775824/59933942-59394f00-9485-11e9-87a3-c7ae8a1db737.png)


### Proposed fixes:
preload bootstrap in main.js


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
