### PR TITLE
Deletion of resource before purging

### DIFF
--- a/ckan/tests/views/test_admin.py
+++ b/ckan/tests/views/test_admin.py
@@ -1,10 +1,8 @@
+
 #encoding: utf-8
-
 from nose.tools import assert_true, assert_equal
-
 from ckan.lib.helpers import url_for
 from ckan.common import config
-
 import ckan.model as model
 import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
@@ -14,67 +12,47 @@ webtest_submit = helpers.webtest_submit
 
 class TestTrashPView(helpers.FunctionalTestBase):
 
-     def test_trash_purge_one_deleted_dataset(self):
-        '''Posting the trash view with 'deleted' dataset, purges the
+    def test_trash_purge_one_deleted_dataset(self):
+      '''Posting the trash view with 'deleted' dataset, purges the
         dataset.'''
-        user = factories.Sysadmin()
+      user = factories.Sysadmin()
+      dataset = factories.Dataset(state='deleted')
+      resource = factories.Resource(package_id=dataset['id'],
+                                    format='csv',
+                                    url="http://example.com/x.csv")
+      app = self._get_test_app()
+      resource_before_purge = model.Session.query(model.Resource).count()
+      assert_equal(resource_before_purge, 1)
+      env = {'REMOTE_USER': user['name'].encode('ascii')}
+      trash_url = url_for(controller='admin', action='trash')
+      trash_response = app.get(trash_url, extra_environ=env, status=200)
+      purge_form = trash_response.forms['form-purge-packages']
+      purge_response = webtest_submit(purge_form, 'purge-packages',
+                                      status=302, extra_environ=env)
+      purge_response = purge_response.follow(extra_environ=env)
+      assert_true('Purge complete' in purge_response)
+      resource_after_purge = model.Session.query(model.Resource).count()
+      assert_equal(resource_after_purge, 0)
 
-        dataset = factories.Dataset(state='deleted')
-	resource = factories.Resource(package_id = dataset['id'],
-                                  format = 'csv',
-                                  url = "http://example.com/x.csv")
-        app = self._get_test_app()
-
-        resource_before_purge = model.Session.query(model.Resource).count()
-        assert_equal(resource_before_purge, 1)
-
-        env = {'REMOTE_USER': user['name'].encode('ascii')}
-        trash_url = url_for(controller='admin', action='trash')
-        trash_response = app.get(trash_url, extra_environ=env, status=200)
-
-        # submit the purge form
-        purge_form = trash_response.forms['form-purge-packages']
-        purge_response = webtest_submit(purge_form, 'purge-packages',
-                                        status=302, extra_environ=env)
-        purge_response = purge_response.follow(extra_environ=env)
-		
-        # redirected back to trash page
-        assert_true('Purge complete' in purge_response)
-
-	resource_after_purge = model.Session.query(model.Resource).count()
-        # how many datasets after purge
-        #pkgs_before_purge = model.Session.query(model.Resource).count()
-        assert_equal(resource_after_purge, 0)
-
-     def test_trash_purge_delete_two_datasets(self):
-        '''Posting the trash view with 'deleted' datasets, purges the
-        datasets.'''
-        user = factories.Sysadmin()
-             
-        dataset = factories.Dataset(state='deleted')
-        resource1  = factories.Resource(package_id = dataset['id'],
-                                        format = 'csv',
-                                        url = "http://example.com/x.csv")
-        resource2  = factories.Resource(package_id = dataset['id'],
-                                        format = 'csv',
-                                        url = "http://example.com/x.csv")
-		app = self._get_test_app()
-		       
-        resource_before_purge = model.Session.query(model.Resource).count()
-        assert_equal(resource_before_purge, 2)
-
-        env = {'REMOTE_USER': user['name'].encode('ascii')}
-        trash_url = url_for(controller='admin', action='trash')
-        trash_response = app.get(trash_url, extra_environ=env, status=200)
-
-        # submit the purge form
-        purge_form = trash_response.forms['form-purge-packages']
-        purge_response = webtest_submit(purge_form, 'purge-packages',
-                                        status=302, extra_environ=env)
-        purge_response = purge_response.follow(extra_environ=env)
-        # redirected back to trash page
-        assert_true('Purge complete' in purge_response)
-
-        resource_after_purge = model.Session.query(model.Resource).count()
-        assert_equal(resource_after_purge, 0)
-        
+    def test_trash_purge_delete_two_datasets(self):
+      user = factories.Sysadmin()
+      dataset = factories.Dataset(state='deleted')
+      resource1  = factories.Resource(package_id=dataset['id'],
+                                      format='csv',
+                                      url="http://example.com/x.csv")
+      resource2  = factories.Resource(package_id=dataset['id'],
+                                      format='csv',
+                                      url="http://example.com/x.csv")
+      app = self._get_test_app()
+      resource_before_purge = model.Session.query(model.Resource).count()
+      assert_equal(resource_before_purge, 2)
+      env = {'REMOTE_USER': user['name'].encode('ascii')}
+      trash_url = url_for(controller='admin', action='trash')
+      trash_response = app.get(trash_url, extra_environ=env, status=200)
+      purge_form = trash_response.forms['form-purge-packages']
+      purge_response = webtest_submit(purge_form, 'purge-packages',
+                                      status=302, extra_environ=env)
+      purge_response = purge_response.follow(extra_environ=env)
+      assert_true('Purge complete' in purge_response)
+      resource_after_purge = model.Session.query(model.Resource).count()
+      assert_equal(resource_after_purge, 0)

--- a/ckan/tests/views/test_admin.py
+++ b/ckan/tests/views/test_admin.py
@@ -20,9 +20,9 @@ class TestTrashPView(helpers.FunctionalTestBase):
         user = factories.Sysadmin()
 
         dataset = factories.Dataset(state='deleted')
-		resource = factories.Resource(package_id=dataset['id'],
-                                      format='csv',
-                                      url="http://example.com/x.csv")
+	resource = factories.Resource(package_id = dataset['id'],
+                                  format = 'csv',
+                                  url = "http://example.com/x.csv")
         app = self._get_test_app()
 
         resource_before_purge = model.Session.query(model.Resource).count()
@@ -41,12 +41,10 @@ class TestTrashPView(helpers.FunctionalTestBase):
         # redirected back to trash page
         assert_true('Purge complete' in purge_response)
 
-		resource_after_purge = model.Session.query(model.Resource).count()
+	resource_after_purge = model.Session.query(model.Resource).count()
         # how many datasets after purge
         #pkgs_before_purge = model.Session.query(model.Resource).count()
         assert_equal(resource_after_purge, 0)
-
-
 
      def test_trash_purge_delete_two_datasets(self):
         '''Posting the trash view with 'deleted' datasets, purges the
@@ -54,15 +52,14 @@ class TestTrashPView(helpers.FunctionalTestBase):
         user = factories.Sysadmin()
              
         dataset = factories.Dataset(state='deleted')
-        resource1  = factories.Resource(package_id=dataset['id'],
-                                        format='csv',
-                                        url="http://example.com/x.csv")
-        resource2  = factories.Resource(package_id=dataset['id'],
-                                        format='csv',
-                                        url="http://example.com/x.csv")
+        resource1  = factories.Resource(package_id = dataset['id'],
+                                        format = 'csv',
+                                        url = "http://example.com/x.csv")
+        resource2  = factories.Resource(package_id = dataset['id'],
+                                        format = 'csv',
+                                        url = "http://example.com/x.csv")
 		app = self._get_test_app()
-		
-        
+		       
         resource_before_purge = model.Session.query(model.Resource).count()
         assert_equal(resource_before_purge, 2)
 
@@ -80,5 +77,4 @@ class TestTrashPView(helpers.FunctionalTestBase):
 
         resource_after_purge = model.Session.query(model.Resource).count()
         assert_equal(resource_after_purge, 0)
-
-
+        

--- a/ckan/tests/views/test_admin.py
+++ b/ckan/tests/views/test_admin.py
@@ -20,7 +20,9 @@ class TestTrashPView(helpers.FunctionalTestBase):
         user = factories.Sysadmin()
 
         dataset = factories.Dataset(state='deleted')
-		resource = factories.Resource(package_id=dataset['id'], format='csv', url="http://example.com/x.csv")
+		resource = factories.Resource(package_id=dataset['id'],
+                                      format='csv',
+                                      url="http://example.com/x.csv")
         app = self._get_test_app()
 
         resource_before_purge = model.Session.query(model.Resource).count()
@@ -52,8 +54,12 @@ class TestTrashPView(helpers.FunctionalTestBase):
         user = factories.Sysadmin()
              
         dataset = factories.Dataset(state='deleted')
-        resource1  = factories.Resource(package_id=dataset['id'], format='csv', url="http://example.com/x.csv")
-        resource2  = factories.Resource(package_id=dataset['id'], format='csv', url="http://example.com/x.csv")
+        resource1  = factories.Resource(package_id=dataset['id'],
+                                        format='csv',
+                                        url="http://example.com/x.csv")
+        resource2  = factories.Resource(package_id=dataset['id'],
+                                        format='csv',
+                                        url="http://example.com/x.csv")
 		app = self._get_test_app()
 		
         

--- a/ckan/tests/views/test_admin.py
+++ b/ckan/tests/views/test_admin.py
@@ -1,0 +1,78 @@
+#encoding: utf-8
+
+from nose.tools import assert_true, assert_equal
+
+from ckan.lib.helpers import url_for
+from ckan.common import config
+
+import ckan.model as model
+import ckan.tests.helpers as helpers
+import ckan.tests.factories as factories
+from ckan.model.system_info import get_system_info
+
+webtest_submit = helpers.webtest_submit
+
+class TestTrashPView(helpers.FunctionalTestBase):
+
+     def test_trash_purge_one_deleted_dataset(self):
+        '''Posting the trash view with 'deleted' dataset, purges the
+        dataset.'''
+        user = factories.Sysadmin()
+
+        dataset = factories.Dataset(state='deleted')
+		resource = factories.Resource(package_id=dataset['id'], format='csv', url="http://example.com/x.csv")
+        app = self._get_test_app()
+
+        resource_before_purge = model.Session.query(model.Resource).count()
+        assert_equal(resource_before_purge, 1)
+
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        trash_url = url_for(controller='admin', action='trash')
+        trash_response = app.get(trash_url, extra_environ=env, status=200)
+
+        # submit the purge form
+        purge_form = trash_response.forms['form-purge-packages']
+        purge_response = webtest_submit(purge_form, 'purge-packages',
+                                        status=302, extra_environ=env)
+        purge_response = purge_response.follow(extra_environ=env)
+		
+        # redirected back to trash page
+        assert_true('Purge complete' in purge_response)
+
+		resource_after_purge = model.Session.query(model.Resource).count()
+        # how many datasets after purge
+        #pkgs_before_purge = model.Session.query(model.Resource).count()
+        assert_equal(resource_after_purge, 0)
+
+
+
+     def test_trash_purge_delete_two_datasets(self):
+        '''Posting the trash view with 'deleted' datasets, purges the
+        datasets.'''
+        user = factories.Sysadmin()
+             
+        dataset = factories.Dataset(state='deleted')
+        resource1  = factories.Resource(package_id=dataset['id'], format='csv', url="http://example.com/x.csv")
+        resource2  = factories.Resource(package_id=dataset['id'], format='csv', url="http://example.com/x.csv")
+		app = self._get_test_app()
+		
+        
+        resource_before_purge = model.Session.query(model.Resource).count()
+        assert_equal(resource_before_purge, 2)
+
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        trash_url = url_for(controller='admin', action='trash')
+        trash_response = app.get(trash_url, extra_environ=env, status=200)
+
+        # submit the purge form
+        purge_form = trash_response.forms['form-purge-packages']
+        purge_response = webtest_submit(purge_form, 'purge-packages',
+                                        status=302, extra_environ=env)
+        purge_response = purge_response.follow(extra_environ=env)
+        # redirected back to trash page
+        assert_true('Purge complete' in purge_response)
+
+        resource_after_purge = model.Session.query(model.Resource).count()
+        assert_equal(resource_after_purge, 0)
+
+

--- a/ckan/views/admin.py
+++ b/ckan/views/admin.py
@@ -12,11 +12,15 @@ import ckan.lib.helpers as h
 import ckan.lib.navl.dictization_functions as dict_fns
 import ckan.logic as logic
 import ckan.model as model
+import ckan.plugins as plugins
 from ckan.common import g, _, config, request
 
 log = logging.getLogger(__name__)
 
 admin = Blueprint(u'admin', __name__, url_prefix=u'/ckan-admin')
+
+_get_or_bust = logic.get_or_bust
+_get_action = logic.get_action
 
 
 def _get_sysadmins():
@@ -156,7 +160,9 @@ class TrashView(MethodView):
         # but has to be done to avoid (odd) sqlalchemy errors (when doing
         # purge packages) of form: "this object already exists in the
         # session"
+        context = dict(model=model, user=g.user, auth_user_obj=g.userobj)
         msgs = []
+        data={}
         if (u'purge-packages' in request.form) or (
                 u'purge-revisions' in request.form):
             if u'purge-packages' in request.form:

--- a/ckan/views/admin.py
+++ b/ckan/views/admin.py
@@ -19,6 +19,7 @@ log = logging.getLogger(__name__)
 
 admin = Blueprint(u'admin', __name__, url_prefix=u'/ckan-admin')
 
+ValidationError = logic.ValidationError
 _get_or_bust = logic.get_or_bust
 _get_action = logic.get_action
 


### PR DESCRIPTION
Fixes #4705 

### Proposed fixes:
While purging of the dataset, the resources associated with them are deleted first and then the dataset. 

The procedure followed is as below:
a)We need to have/retrieve the package id.
b) Using the package id,we will then retrieve the list of resources associated the dataset.
c) Now, we will delete the resources associated with the datasets.
d)Now,when the resources are deleted, the flow of purging will resume its normal flow afterwards.

