### PR TITLE
[#4872] Remove _external query param on Pylons generated URLs

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -409,7 +409,9 @@ def _url_for_pylons(*args, **kw):
 
     # We need to provide protocol and host to get full URLs, get them from
     # ckan.site_url
-    if kw.get('qualified', False) or kw.get('_external', False):
+    if kw.pop('_external', None):
+        kw['qualified'] = True
+    if kw.get('qualified'):
         kw['protocol'], kw['host'] = get_site_protocol_and_host()
 
     # The Pylons API routes require a slask on the version number for some

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -314,6 +314,23 @@ class TestHelpersUrlForFlaskandPylons(BaseUrlFor):
 
         p.unload('test_routing_plugin')
 
+    @helpers.change_config('ckan.site_url', 'http://example.com')
+    def test_url_for_pylons_request_external(self):
+
+        if not p.plugin_loaded('test_routing_plugin'):
+            p.load('test_routing_plugin')
+
+
+        url = 'http://example.com/from_pylons_extension_before_map'
+        generated_url = h.url_for(
+            controller='ckan.tests.config.test_middleware:MockPylonsController',
+            action='view',
+           _external=True,
+        )
+        eq_(generated_url, url)
+
+        p.unload('test_routing_plugin')
+
 
 class TestHelpersRenderMarkdown(object):
 

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -320,12 +320,11 @@ class TestHelpersUrlForFlaskandPylons(BaseUrlFor):
         if not p.plugin_loaded('test_routing_plugin'):
             p.load('test_routing_plugin')
 
-
         url = 'http://example.com/from_pylons_extension_before_map'
         generated_url = h.url_for(
             controller='ckan.tests.config.test_middleware:MockPylonsController',
             action='view',
-           _external=True,
+            _external=True,
         )
         eq_(generated_url, url)
 


### PR DESCRIPTION
Fixes #4872

The url_for wrapper for Pylons requests correctly handles Flask's `_external` parameter to generate fully qualified URLs, but fails to remove it, resulting in an extraneous param added to the URL,
 eg: http://example.com/dataset/test?_external=True

