### PR TITLE
[#4874] Allow to provide a custom DataProxy URL

### DIFF
--- a/ckanext/reclineview/plugin.py
+++ b/ckanext/reclineview/plugin.py
@@ -21,6 +21,12 @@ def get_mapview_config():
                  if k.startswith(namespace)])
 
 
+def get_dataproxy_url():
+    '''
+    Returns the value of the ckan.recline.dataproxy_url config option
+    '''
+    return config.get('ckan.recline.dataproxy_url', '//jsonpdataproxy.appspot.com')
+
 def in_list(list_possible_values):
     '''
     Validator that checks that the input value is one of the given
@@ -83,7 +89,8 @@ class ReclineViewBase(p.SingletonPlugin):
 
     def get_helpers(self):
         return {
-            'get_map_config': get_mapview_config
+            'get_map_config': get_mapview_config,
+            'get_dataproxy_url': get_dataproxy_url,
         }
 
 

--- a/ckanext/reclineview/plugin.py
+++ b/ckanext/reclineview/plugin.py
@@ -25,7 +25,9 @@ def get_dataproxy_url():
     '''
     Returns the value of the ckan.recline.dataproxy_url config option
     '''
-    return config.get('ckan.recline.dataproxy_url', '//jsonpdataproxy.appspot.com')
+    return config.get(
+        'ckan.recline.dataproxy_url', '//jsonpdataproxy.appspot.com')
+
 
 def in_list(list_possible_values):
     '''

--- a/ckanext/reclineview/theme/public/recline_view.js
+++ b/ckanext/reclineview/theme/public/recline_view.js
@@ -2,7 +2,8 @@ this.ckan.module('recline_view', function (jQuery) {
   return {
     options: {
       site_url: "",
-      controlsClassName: "controls"
+      controlsClassName: "controls",
+      dataproxyUrl: "//jsonpdataproxy.appspot.com"
     },
 
     initialize: function () {
@@ -44,6 +45,9 @@ this.ckan.module('recline_view', function (jQuery) {
 
       if (!resourceData.datastore_active) {
           recline.Backend.DataProxy.timeout = 10000;
+
+          recline.Backend.DataProxy.dataproxy_url = this.options.dataproxyUrl;
+
           resourceData.backend =  'dataproxy';
       } else {
           resourceData.backend =  'ckan';

--- a/ckanext/reclineview/theme/templates/recline_view.html
+++ b/ckanext/reclineview/theme/templates/recline_view.html
@@ -8,6 +8,7 @@
        data-module-resource = "{{ h.dump_json(resource_json) }}";
        data-module-resource-view = "{{ h.dump_json(resource_view_json) }}";
        data-module-map_config= "{{ h.dump_json(map_config) }}";
+       data-module-dataproxy-url= "{{ h.get_dataproxy_url() }}"
        >
     <h4 class="loading-dialog">
       <div class="loading-spinner"></div>

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -1329,6 +1329,23 @@ Default value: ``png jpeg jpg gif``
 
 Space-delimited list of image-based resource formats that will be rendered by the Image view plugin (``image_view``)
 
+
+.. _ckan.recline.dataproxy_url:
+
+ckan.recline.dataproxy_url
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+ ckan.recline.dataproxy_url = https://mydataproxy.example.com
+
+Default value: ``//jsonpdataproxy.appspot.com``
+
+Custom URL to a self-hosted DataProxy instance. The DataProxy is an external service currently used to stream data in 
+JSON format to the Recline-based views when data is not on the DataStore. The main instance is deprecated and will
+be eventually shut down, so users that require it can host an instance themselves and use this configuration option
+to point Recline to it.
+
 .. end_resource-views
 
 Theming Settings


### PR DESCRIPTION
Adds support for providing a custom DataProxy URL via config option. This will pave the way for deprecating it and completely removing it in the near future. If someone really wants to use it they can host it themselves and update the URL that Recline uses.

Fixes #4874 