### PR TITLE
[#4878] Allow custom CKAN callback URL for the DataPusher

### DIFF
--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -62,7 +62,14 @@ def datapusher_submit(context, data_dict):
     datapusher_url = config.get('ckan.datapusher.url')
 
     site_url = h.url_for('/', qualified=True)
-    callback_url = h.url_for('/api/3/action/datapusher_hook', qualified=True)
+
+    callback_url_base = config.get('ckan.datapusher.callback_url_base')
+    if callback_url_base:
+        callback_url = urlparse.urljoin(
+            callback_url_base.rstrip('/'), '/api/3/action/datapusher_hook')
+    else:
+        callback_url = h.url_for(
+            '/api/3/action/datapusher_hook', qualified=True)
 
     user = p.toolkit.get_action('user_show')(context, {'id': context['user']})
 

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -1524,6 +1524,22 @@ running on port 8800. If you want to manually install the DataPusher, follow
 the installation `instructions <http://docs.ckan.org/projects/datapusher>`_.
 
 
+.. _ckan.datapusher.callback_url_base:
+
+ckan.datapusher.url
+^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+  ckan.datapusher.callback_url_base = http://ckan:5000/
+
+Default value: Value of ``ckan.site_url``
+
+Alternative callback URL for DataPusher when performing a request to CKAN. This is
+useful on scenarios where the host where DataPusher is running can not access the
+public CKAN site URL.
+
+
 .. _ckan.datapusher.assume_task_stale_after:
 
 ckan.datapusher.assume_task_stale_after

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -1526,8 +1526,8 @@ the installation `instructions <http://docs.ckan.org/projects/datapusher>`_.
 
 .. _ckan.datapusher.callback_url_base:
 
-ckan.datapusher.url
-^^^^^^^^^^^^^^^^^^^
+ckan.datapusher.callback_url_base
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Example::
 


### PR DESCRIPTION
Fixes #4878 
Fixes #3987
Fixes #4013
Fixes #4515
Fixes ckan/datapusher#83

The DataPusher pings back CKAN when performing or finishing a job (calling the datapusher_hook action), and it does so via an HTTP request to the host defined in `ckan.site_url`.

There are a number of scenarios where this does not work, eg:

* CKAN and DataPusher sitting behind a Firewall that doesn't allow external requests
* Standard Docker compose setup for development where the `ckan.site_url` is http://localhost:5000 or similar

This change adds a new config option that allows to define an alternative internal URL that DataPusher can reach.

As shown by the number of issues, this has been raised several times in the past.



