### PR TITLE
update the 'debug' warning to better match the documentation, github #4871

### DIFF
--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -13,7 +13,8 @@
 
 [DEFAULT]
 
-# WARNING: *THIS SETTING MUST BE SET TO FALSE ON A PRODUCTION ENVIRONMENT*
+# WARNING: *THIS SETTING MUST BE SET TO FALSE ON A PUBLIC ENVIRONMENT*
+# With debug mode enabled, a visitor to your site could execute malicious commands.
 debug = false
 
 [server:main]


### PR DESCRIPTION
- it's not just production environments that are at risk, any publicly visible site must not use debug mode

Fixes #

### Proposed fixes:

Improve the warning on the `debug` flag.

### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
