### PR TITLE
Fix license test cleanup

### DIFF
--- a/ckan/tests/model/test_license.py
+++ b/ckan/tests/model/test_license.py
@@ -16,6 +16,13 @@ class TestLicenseRegister(object):
     def setup(self):
         helpers.reset_db()
 
+    def teardown(self):
+        # _license_register is cached, so clear it after tests that change the
+        # config['licenses_group_url']
+        from ckan import model
+        if hasattr(model.Package, '_license_register'):
+            del model.Package._license_register
+
     def test_default_register_has_basic_properties_of_a_license(self):
         config['licenses_group_url'] = None
         reg = LicenseRegister()


### PR DESCRIPTION
test_license.py (ckan/tests/model/test_license.py) doesn't clean up after itself properly, and in some circumstances causes other tests to fail.

e.g.
```
$ nosetests --ckan --with-pylons=test-core.ini  ckan/tests/model/test_license.py:TestLicenseRegister.test_import_v1_style_register_i18n ckan/tests/model/test_package.py:TestPackage.test_create
E
======================================================================
ERROR: ckan.tests.model.test_package.TestPackage.test_create
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/vagrant/src/ckan/ckan/tests/model/test_package.py", line 37, in test_create
    assert_equal(pkg.license.title,
AttributeError: 'NoneType' object has no attribute 'title'

----------------------------------------------------------------------
Ran 2 tests in 6.145s

FAILED (errors=1)
```

This is a fix that cleans up properly.

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
