### PR TITLE
Fixes iuploader test, running locally

### DIFF
--- a/ckanext/example_iuploader/test/test_plugin.py
+++ b/ckanext/example_iuploader/test/test_plugin.py
@@ -45,12 +45,6 @@ def _get_package_new_page(app):
 
 
 class TestExampleIUploaderPlugin(helpers.FunctionalTestBase):
-    def __init__(self):
-        super(TestExampleIUploaderPlugin, self).__init__()
-        self.fs = None
-        self.fake_open = None
-        self.fake_os = None
-
     @classmethod
     def setup_class(cls):
         super(TestExampleIUploaderPlugin, cls).setup_class()
@@ -65,10 +59,15 @@ class TestExampleIUploaderPlugin(helpers.FunctionalTestBase):
     def _apply_config_changes(cls, cfg):
         cfg['ckan.storage_path'] = '/doesnt_exist'
 
+        # webassets needs somewhere on disk to cache assets, however it is
+        # really hard to patch it to use the fake disk, so we simply let it
+        # write files to the real disk. Therefore /tmp must exist.
+        cfg['ckan.webassets.path'] = '/tmp/webassets'
+
     def setup(self):
-        # Set up a fake filesystem for the uploads to be stored
         super(TestExampleIUploaderPlugin, self).setup()
 
+    # Uses a fake filesystem for the uploads to be stored.
     # Set up a mock open which tries the real filesystem first then falls
     # back to the mock filesystem.
     # Would be nicer if we could mock open on a specific module, but because


### PR DESCRIPTION
I was getting this:

    $ nosetests --nologcapture --with-pylons=test-core.ini -v ckanext/example_iuploader/test/test_plugin.py:TestExampleIUploaderPlugin.test_resource_download_iuploader_called
    ...
    OSError: [Errno 13] Permission denied: '/doesnt_exist'

I'm not sure how this test passes on circleci.

This test changes the storage_path to '/doesnt_exist' and patches lots of places that CKAN accesses the disk during upload, so that it uses the ram disk (implemented with pyfakefs). However we recently added webassets, which kicks in during this test when it renders a page. The problem is that webassets also relies on the storage_path and tries to set up a cache directory and puts tempfiles in it etc. So this requires more patching:
```
    @patch.object(webassets.cache, 'os', fake_os)
    @patch.object(webassets.bundle, 'os', fake_os)
    @patch.object(webassets.merge, 'open', fake_open)
    @patch.object(tempfile, '_os', fake_os)
```
but I couldn't make it work because after all that it tries something pyfakefs can't handle:
```
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webassets/merge.py", line 77, in data
    f = open(self.filename, 'r', encoding='utf-8')
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/pyfakefs/fake_filesystem.py", line 3842, in __call__
    return self._call_ver2(*args, **kwargs)
TypeError: _call_ver2() got an unexpected keyword argument 'encoding'
```

I tried another way to tackle this by trying to patch h.include_assets() to not do anything, so webassets was avoided. However I couldn't work out how to patch it successfully.

So I figure that it was easiest to simply let webassets write to the real disk, and assume that /tmp is available.

Full error:
```
$ nosetests --nologcapture --with-pylons=test-core.ini -v ckanext/example_iuploader/test/test_plugin.py:TestExampleIUploaderPlugin.test_resource_download_iuploader_called
/usr/lib/ckan/default/local/lib/python2.7/site-packages/webassets/loaders.py:162: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  obj = self.yaml.load(f) or {}
No handlers could be found for logger "ckan.lib.uploader"
ckanext.example_iuploader.test.test_plugin.TestExampleIUploaderPlugin.test_resource_download_iuploader_called ... ERROR

======================================================================
ERROR: ckanext.example_iuploader.test.test_plugin.TestExampleIUploaderPlugin.test_resource_download_iuploader_called
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/mock/mock.py", line 1305, in patched
    return func(*args, **keywargs)
  File "/vagrant/src/ckan/ckanext/example_iuploader/test/test_plugin.py", line 87, in test_resource_download_iuploader_called
    env, response = _get_package_new_page(app)
  File "/vagrant/src/ckan/ckanext/example_iuploader/test/test_plugin.py", line 42, in _get_package_new_page
    extra_environ=env,
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webtest/app.py", line 759, in get
    expect_errors=expect_errors)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webtest/app.py", line 1102, in do_request
    res = req.get_response(app, catch_exc_info=True)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webob/request.py", line 1049, in get_response
    application, catch_exc_info=True)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webob/request.py", line 1022, in call_application
    app_iter = application(self.environ, start_response)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webtest/lint.py", line 179, in lint_app
    iterator = application(environ, start_response_wrapper)
  File "/vagrant/src/ckan/ckan/config/middleware/__init__.py", line 203, in __call__
    return self.apps[app_name](environ, start_response)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/repoze/who/middleware.py", line 64, in __call__
    return self.app(environ, start_response)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webob/dec.py", line 147, in __call__
    resp = self.call_func(req, *args, **self.kwargs)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webob/dec.py", line 208, in call_func
    return self.func(req, *args, **kwargs)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/fanstatic/publisher.py", line 234, in __call__
    return request.get_response(self.app)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webob/request.py", line 1053, in get_response
    application, catch_exc_info=False)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webob/request.py", line 1022, in call_application
    app_iter = application(self.environ, start_response)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webob/dec.py", line 147, in __call__
    resp = self.call_func(req, *args, **self.kwargs)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webob/dec.py", line 208, in call_func
    return self.func(req, *args, **kwargs)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/fanstatic/injector.py", line 54, in __call__
    response = request.get_response(self.app)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webob/request.py", line 1053, in get_response
    application, catch_exc_info=False)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webob/request.py", line 1022, in call_application
    app_iter = application(self.environ, start_response)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/flask/app.py", line 1997, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/beaker/middleware.py", line 156, in __call__
    return self.wrap_app(environ, session_start_response)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/flask/app.py", line 1985, in wsgi_app
    response = self.handle_exception(e)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/flask/app.py", line 1540, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/flask/views.py", line 84, in view
    return self.dispatch_request(*args, **kwargs)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/flask/views.py", line 149, in dispatch_request
    return meth(*args, **kwargs)
  File "/vagrant/src/ckan/ckan/views/dataset.py", line 661, in get
    u'errors_json': errors_json
  File "/vagrant/src/ckan/ckan/lib/base.py", line 150, in render
    return flask_render_template(template_name, **extra_vars)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/flask/templating.py", line 134, in render_template
    context, ctx.app)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/flask/templating.py", line 116, in _render
    rv = template.render(context)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/vagrant/src/ckan/ckan/templates/package/new.html", line 9, in top-level template code
    {% block subtitle %}{{ _('Create Dataset') }}{% endblock %}
  File "/vagrant/src/ckan/ckan/templates/package/base_form_page.html", line 1, in top-level template code
    {% extends "package/edit_base.html" %}
  File "/vagrant/src/ckan/ckan/templates/package/edit_base.html", line 1, in top-level template code
    {% extends 'package/base.html' %}
  File "/vagrant/src/ckan/ckan/templates/package/base.html", line 3, in top-level template code
    {% set pkg = pkg_dict %}
  File "/vagrant/src/ckan/ckan/templates/page.html", line 1, in top-level template code
    {% extends "base.html" %}
  File "/vagrant/src/ckan/ckan/templates/base.html", line 68, in top-level template code
    {%- block styles %}
  File "/vagrant/src/ckan/ckan/templates/base.html", line 72, in block "styles"
    {% asset main_css[6:-4] %}
  File "/vagrant/src/ckan/ckan/lib/jinja_extensions.py", line 347, in _call
    h.include_asset(args[0])
  File "/vagrant/src/ckan/ckan/lib/webassets_tools.py", line 106, in include_asset
    urls = [url_for_static_or_external(url) for url in bundle.urls()]
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webassets/bundle.py", line 806, in urls
    urls.extend(bundle._urls(new_ctx, extra_filters, *args, **kwargs))
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webassets/bundle.py", line 765, in _urls
    *args, **kwargs)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webassets/bundle.py", line 609, in _build
    if ctx.updater else True
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webassets/updater.py", line 173, in needs_rebuild
    super(TimestampUpdater, self).needs_rebuild(bundle, ctx) or \
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webassets/updater.py", line 103, in needs_rebuild
    return self.check_bundle_definition(bundle, ctx)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webassets/updater.py", line 82, in check_bundle_definition
    if not ctx.cache:
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webassets/bundle.py", line 50, in __getattr__
    return self.getattr(self._parent, item)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webassets/bundle.py", line 58, in getattr
    return getattr(object, item)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webassets/env.py", line 461, in _get_cache
    cache = get_cache(self._storage['cache'], self)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webassets/cache.py", line 236, in get_cache
    os.makedirs(directory)
  File "/usr/lib/ckan/default/lib/python2.7/os.py", line 150, in makedirs
    makedirs(head, mode)
  File "/usr/lib/ckan/default/lib/python2.7/os.py", line 150, in makedirs
    makedirs(head, mode)
  File "/usr/lib/ckan/default/lib/python2.7/os.py", line 157, in makedirs
    mkdir(name, mode)
OSError: [Errno 13] Permission denied: '/doesnt_exist'

----------------------------------------------------------------------
Ran 1 test in 5.245s

FAILED (errors=1)
```
### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
