### PR TITLE
Deleting a dataset now also deletes its resources

### DIFF
--- a/ckanext/example_iresourcecontroller/tests/test_example_iresourcecontroller.py
+++ b/ckanext/example_iresourcecontroller/tests/test_example_iresourcecontroller.py
@@ -89,6 +89,27 @@ class TestExampleIResourceController(object):
         assert plugin.counter['before_delete'] == 1, plugin.counter
         assert plugin.counter['after_delete'] == 1, plugin.counter
 
+    def test_resource_controller_plugin_delete_via_dataset_delete(self):
+        user = factories.Sysadmin()
+        dataset = factories.Dataset(user=user)
+        factories.Resource(user=user, package_id=dataset['id'])
+        factories.Resource(user=user, package_id=dataset['id'])
+
+        ckan.plugins.load('example_iresourcecontroller')
+        plugin = ckan.plugins.get_plugin('example_iresourcecontroller')
+
+        # Deleting the package deletes its resources too
+        res = helpers.call_action('package_delete',
+                                  id=dataset['id'],
+                                  apikey=user['apikey'])
+
+        assert plugin.counter['before_create'] == 0, plugin.counter
+        assert plugin.counter['after_create'] == 0, plugin.counter
+        assert plugin.counter['before_update'] == 0, plugin.counter
+        assert plugin.counter['after_update'] == 0, plugin.counter
+        assert plugin.counter['before_delete'] == 2, plugin.counter
+        assert plugin.counter['after_delete'] == 2, plugin.counter
+
     def test_resource_controller_plugin_show(self):
         """
         Before show gets called by the other methods but we test it


### PR DESCRIPTION
Fixes #4705

@dassolkim is concerned that IResourceController.before_delete event is
not firing at any point when a dataset is deleted and then purged
(either with package_purge or the admin.Trash page). PR #4867 seeks to
implement the event in the admin.Trash page. But this PR proposes the
alternative, which is to actually delete the resource when the dataset
is deleted and fire the event then.

It seems an anomaly that we don't delete resources with the dataset. It
makes sense that the dataset and resources are both state=deleted.
However there is an argument that we shouldn't, because a sysadmin can still
see the deleted dataset, but with this PR it will have no resources.

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
