### PR TITLE
Deleting a dataset sends IResourceController.before_delete

### DIFF
--- a/ckan/tests/logic/action/test_delete.py
+++ b/ckan/tests/logic/action/test_delete.py
@@ -49,11 +49,13 @@ class TestPackageDelete:
         dataset = helpers.call_action(
             'package_show', {'user': sysadmin['name']}, id=dataset['id'])
         assert_equals(dataset['state'], 'deleted')
-        # The resource is not shown though
-        assert_equals(dataset['resources'], [])
-        # The resource is still there but with state=deleted
+        # It's complete with resources
+        assert_equals([res['id'] for res in dataset['resources']],
+                      [resource['id']])
+        # The resource is still there, not deleted, otherwise it wouldn't have
+        # shown up as part of the deleted dataset
         res_obj = model.Resource.get(resource['id'])
-        assert_equals(res_obj.state, 'deleted')
+        assert_equals(res_obj.state, 'active')
 
 
 class TestResourceDelete:

--- a/ckanext/example_iresourcecontroller/tests/test_example_iresourcecontroller.py
+++ b/ckanext/example_iresourcecontroller/tests/test_example_iresourcecontroller.py
@@ -89,6 +89,27 @@ class TestExampleIResourceController(object):
         assert plugin.counter['before_delete'] == 1, plugin.counter
         assert plugin.counter['after_delete'] == 1, plugin.counter
 
+    def test_resource_controller_plugin_delete_via_dataset_delete(self):
+        user = factories.Sysadmin()
+        dataset = factories.Dataset(user=user)
+        factories.Resource(user=user, package_id=dataset['id'])
+        factories.Resource(user=user, package_id=dataset['id'])
+
+        ckan.plugins.load('example_iresourcecontroller')
+        plugin = ckan.plugins.get_plugin('example_iresourcecontroller')
+
+        # Deleting the package deletes its resources too
+        res = helpers.call_action('package_delete',
+                                  id=dataset['id'],
+                                  apikey=user['apikey'])
+
+        assert plugin.counter['before_create'] == 0, plugin.counter
+        assert plugin.counter['after_create'] == 0, plugin.counter
+        assert plugin.counter['before_update'] == 0, plugin.counter
+        assert plugin.counter['after_update'] == 0, plugin.counter
+        assert plugin.counter['before_delete'] == 2, plugin.counter
+        assert plugin.counter['after_delete'] == 2, plugin.counter
+
     def test_resource_controller_plugin_show(self):
         """
         Before show gets called by the other methods but we test it


### PR DESCRIPTION
Although it doesn't actually delete the resources, because when a
sysadmin views the deleted dataset it should show with those resource,
and they wouldn't show up if we set their state=deleted.

This fixes #4705 by sending the IResourceController.before_delete events
necessary for Datastore and FileStore to get rid of the associated data.

I think this is a better option compared to deleting the resources, which can be seen in alternate PR https://github.com/ckan/ckan/pull/4904

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
