### PR TITLE
Fix TypeError in recline view

### DIFF
--- a/ckanext/reclineview/theme/public/vendor/ckan.js/ckan.js
+++ b/ckanext/reclineview/theme/public/vendor/ckan.js/ckan.js
@@ -43,6 +43,11 @@ if (isNodeModule) {
   my.Client.prototype.datastoreQuery = function(queryObj, cb) {
     var actualQuery = my._normalizeQuery(queryObj);
     this.action('datastore_search', actualQuery, function(err, results) {
+      if(err || !results){
+        cb(err);
+        return;
+      }
+
       // map ckan types to our usual types ...
       var fields = _.map(results.result.fields, function(field) {
         field.type = field.type in my.ckan2JsonTableSchemaTypes ? my.ckan2JsonTableSchemaTypes[field.type] : field.type;


### PR DESCRIPTION
Fixes #

error occurs if you put a character or a blank value in a non-text filter such as numeric.
No error message and loading does not disappear.
![image](https://user-images.githubusercontent.com/7775824/61380962-4af41c80-a8e5-11e9-8b7a-b38fe22b2e0b.png)


### Proposed fixes:
add error handling.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
