### PR TITLE
Fix circleci error: openjdk-8-jdk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: python:2
+      - image: python:2-stretch
         environment:
           CKAN_DATASTORE_POSTGRES_DB: datastore_test
           CKAN_DATASTORE_POSTGRES_READ_USER: datastore_read
@@ -29,7 +29,7 @@ jobs:
       - checkout
 
       - run: |
-          # SO Dependencies
+          # OS Dependencies
           apt update
           case $CIRCLE_NODE_INDEX in
             $NODE_TESTS_CONTAINER)


### PR DESCRIPTION
CircleCI builds started failing this week:

    E: Unable to locate package openjdk-8-jdk

This occurred because the docker/python:2 image switched Debian version this week, from stretch to buster.

Buster uses openjdk 11 instead of 8, but even with this CKAN was unable to talk to Solr - maybe to do with AppArmor enabled in Buster. It was just easiest to pin back to stretch.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
