### PR TITLE
handle missing resources in case we have a race condition with the Da…

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2331,7 +2331,11 @@ def resource_view_get_fields(resource):
         'limit': 0,
         'include_total': False,
     }
-    result = logic.get_action('datastore_search')({}, data)
+    import ckan.plugins as p
+    try:
+        result = logic.get_action('datastore_search')({}, data)
+    except p.toolkit.ObjectNotFound:
+        return []
 
     fields = [field['id'] for field in result.get('fields', [])]
 


### PR DESCRIPTION
…taPusher, github #3980

It is possible for a resource to be deleted by the DataPusher at the point where we're trying to view it. This pull request handles the error and treats it like a non-datastore resource.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport
