### PR TITLE
fix preview button error in EditResouceView page

### DIFF
--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -691,26 +691,33 @@ class EditResourceViewView(MethodView):
             extra_vars.update(post_extra)
 
         package_type = _get_package_type(id)
-        data = extra_vars[u'data']
-        view_type = None
+        data = extra_vars[u'data'] if u'data' in extra_vars else None
+        if data and u'view_type' in data:
+            view_type = data.get(u'view_type')
+        else:
+            view_type = request.args.get(u'view_type')
+
         # view_id exists only when updating
         if view_id:
-            if not data:
+            if not data or not view_type:
                 try:
-                    data = get_action(u'resource_view_show')(
+                    view_data = get_action(u'resource_view_show')(
                         context, {
                             u'id': view_id
                         }
                     )
+                    view_type = view_data[u'view_type']
+                    if data:
+                        data.update(view_data)
+                    else:
+                        data = view_data
                 except (NotFound, NotAuthorized):
                     return base.abort(404, _(u'View not found'))
 
-            view_type = data.get(u'view_type')
             # might as well preview when loading good existing view
             if not extra_vars[u'errors']:
                 to_preview = True
 
-        view_type = view_type or request.args.get(u'view_type')
         data[u'view_type'] = view_type
         view_plugin = lib_datapreview.get_view_plugin(view_type)
         if not view_plugin:


### PR DESCRIPTION
Fixes #

Error occurs when preview button is clicked on EditResourceVIew (reclineview)

### Proposed fixes:
Check if view_type is valid

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
