### PR TITLE
add nav icon

### DIFF
--- a/ckan/templates/group/edit_base.html
+++ b/ckan/templates/group/edit_base.html
@@ -17,8 +17,8 @@
 {% endblock %}
 
 {% block content_primary_nav %}
-  {{ h.build_nav_icon(group_type + '.edit', _('Edit'), id=group_dict.name) }}
-  {{ h.build_nav_icon(group_type + '.members', _('Members'), id=group_dict.name) }}
+  {{ h.build_nav_icon(group_type + '.edit', _('Edit'), id=group_dict.name, icon='pencil-square-o') }}
+  {{ h.build_nav_icon(group_type + '.members', _('Members'), id=group_dict.name, icon='users') }}
 {% endblock %}
 
 {% block secondary_content %}

--- a/ckan/templates/group/read_base.html
+++ b/ckan/templates/group/read_base.html
@@ -14,9 +14,9 @@
 {% endblock %}
 
 {% block content_primary_nav %}
-  {{ h.build_nav_icon(group_type + '.read', _('Datasets'), id=group_dict.name) }}
-  {{ h.build_nav_icon(group_type + '.activity', _('Activity Stream'), id=group_dict.name, offset=0) }}
-  {{ h.build_nav_icon(group_type + '.about', _('About'), id=group_dict.name) }}
+  {{ h.build_nav_icon(group_type + '.read', _('Datasets'), id=group_dict.name, icon='sitemap') }}
+  {{ h.build_nav_icon(group_type + '.activity', _('Activity Stream'), id=group_dict.name, offset=0, icon='clock-o') }}
+  {{ h.build_nav_icon(group_type + '.about', _('About'), id=group_dict.name, icon='info-circle') }}
 {% endblock %}
 
 {% block secondary_content %}

--- a/ckan/templates/organization/edit_base.html
+++ b/ckan/templates/organization/edit_base.html
@@ -19,9 +19,9 @@
 {% endblock %}
 
 {% block content_primary_nav %}
-  {{ h.build_nav_icon(group_type + '.edit', _('Edit'), id=group_dict.name) }}
-  {{ h.build_nav_icon(group_type + '.bulk_process', _('Datasets'), id=group_dict.name) }}
-  {{ h.build_nav_icon(group_type + '.members', _('Members'), id=group_dict.name) }}
+  {{ h.build_nav_icon(group_type + '.edit', _('Edit'), id=group_dict.name, icon='pencil-square-o') }}
+  {{ h.build_nav_icon(group_type + '.bulk_process', _('Datasets'), id=group_dict.name, icon='sitemap') }}
+  {{ h.build_nav_icon(group_type + '.members', _('Members'), id=group_dict.name, icon='users') }}
 {% endblock %}
 
 {% block secondary_content %}

--- a/ckan/templates/organization/read_base.html
+++ b/ckan/templates/organization/read_base.html
@@ -14,9 +14,9 @@
 {% endblock %}
 
 {% block content_primary_nav %}
-  {{ h.build_nav_icon(group_type + '.read', _('Datasets'), id=group_dict.name) }}
-  {{ h.build_nav_icon(group_type + '.activity', _('Activity Stream'), id=group_dict.name, offset=0) }}
-  {{ h.build_nav_icon(group_type + '.about', _('About'), id=group_dict.name) }}
+  {{ h.build_nav_icon(group_type + '.read', _('Datasets'), id=group_dict.name, icon='sitemap') }}
+  {{ h.build_nav_icon(group_type + '.activity', _('Activity Stream'), id=group_dict.name, offset=0, icon='clock-o') }}
+  {{ h.build_nav_icon(group_type + '.about', _('About'), id=group_dict.name, icon='info-circle') }}
 {% endblock %}
 
 {% block secondary_content %}

--- a/ckan/templates/package/edit_base.html
+++ b/ckan/templates/package/edit_base.html
@@ -14,8 +14,8 @@
 {% endblock %}
 
 {% block content_primary_nav %}
-    {{ h.build_nav_icon('dataset.edit', _('Edit metadata'), id=pkg.name) }}
-    {{ h.build_nav_icon('dataset.resources', _('Resources'), id=pkg.name) }}
+    {{ h.build_nav_icon('dataset.edit', _('Edit metadata'), id=pkg.name, icon='pencil-square-o') }}
+    {{ h.build_nav_icon('dataset.resources', _('Resources'), id=pkg.name, icon='bars') }}
 {% endblock %}
 
 {% block secondary_content %}

--- a/ckan/templates/package/read_base.html
+++ b/ckan/templates/package/read_base.html
@@ -18,9 +18,9 @@
 {% endblock %}
 
 {% block content_primary_nav %}
-  {{ h.build_nav_icon('dataset.read', _('Dataset'), id=pkg.id if is_activity_archive else pkg.name) }}
-  {{ h.build_nav_icon('dataset.groups', _('Groups'), id=pkg.id if is_activity_archive else pkg.name) }}
-  {{ h.build_nav_icon('dataset.activity', _('Activity Stream'), id=pkg.id if is_activity_archive else pkg.name) }}
+  {{ h.build_nav_icon('dataset.read', _('Dataset'), id=pkg.id if is_activity_archive else pkg.name, icon='sitemap') }}
+  {{ h.build_nav_icon('dataset.groups', _('Groups'), id=pkg.id if is_activity_archive else pkg.name, icon='users') }}
+  {{ h.build_nav_icon('dataset.activity', _('Activity Stream'), id=pkg.id if is_activity_archive else pkg.name, icon='clock-o') }}
 {% endblock %}
 
 {% block secondary_content %}

--- a/ckan/templates/package/resource_edit_base.html
+++ b/ckan/templates/package/resource_edit_base.html
@@ -21,9 +21,9 @@
 {% endblock %}
 
 {% block content_primary_nav %}
-  {{ h.build_nav_icon('resource.edit', _('Edit resource'), id=pkg.name, resource_id=res.id) }}
+  {{ h.build_nav_icon('resource.edit', _('Edit resource'), id=pkg.name, resource_id=res.id, icon='pencil-square-o') }}
   {% block inner_primary_nav %}{% endblock %}
-  {{ h.build_nav_icon('resource.views', _('Views'), id=pkg.name, resource_id=res.id) }}
+  {{ h.build_nav_icon('resource.views', _('Views'), id=pkg.name, resource_id=res.id, icon='bars') }}
 {% endblock %}
 
 {% block primary_content_inner %}

--- a/ckan/templates/user/dashboard.html
+++ b/ckan/templates/user/dashboard.html
@@ -16,10 +16,10 @@
           {% link_for _('Edit settings'), named_route='user.edit', id=user.name, class_='btn btn-default', icon='cog' %}
         </div>
         <ul class="nav nav-tabs">
-          {{ h.build_nav_icon('dashboard.index', _('News feed')) }}
-          {{ h.build_nav_icon('dashboard.datasets', _('My Datasets')) }}
-          {{ h.build_nav_icon('dashboard.organizations', _('My Organizations')) }}
-          {{ h.build_nav_icon('dashboard.groups', _('My Groups')) }}
+          {{ h.build_nav_icon('dashboard.index', _('News feed'), icon='list') }}
+          {{ h.build_nav_icon('dashboard.datasets', _('My Datasets'), icon='sitemap') }}
+          {{ h.build_nav_icon('dashboard.organizations', _('My Organizations'), icon='building-o') }}
+          {{ h.build_nav_icon('dashboard.groups', _('My Groups'), icon='users') }}
         </ul>
       </header>
     {% endblock %}

--- a/ckan/templates/user/read_base.html
+++ b/ckan/templates/user/read_base.html
@@ -16,8 +16,8 @@
 {% endblock %}
 
 {% block content_primary_nav %}
-  {{ h.build_nav_icon('user.read', _('Datasets'), id=user.name) }}
-  {{ h.build_nav_icon('user.activity', _('Activity Stream'), id=user.name) }}
+  {{ h.build_nav_icon('user.read', _('Datasets'), id=user.name, icon='sitemap') }}
+  {{ h.build_nav_icon('user.activity', _('Activity Stream'), id=user.name, icon='clock-o') }}
 {% endblock %}
 
 {% block secondary_content %}


### PR DESCRIPTION
Fixes #
There is no nav icon because the mapper's ckan_icon attribute is not used.
(flask migration)

### Proposed fixes:

build_nav_icon function with the icon attribute.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
