### PR TITLE
Add unified(dot) name for webassets endpoint(`webassets.index`)

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -512,6 +512,6 @@ def _setup_webassets(app):
 
     webassets_folder = get_webassets_path()
 
-    @app.route('/webassets/<path:path>')
+    @app.route('/webassets/<path:path>', endpoint='webassets.index')
     def webassets(path):
         return send_from_directory(webassets_folder, path)

--- a/ckan/tests/config/test_middleware.py
+++ b/ckan/tests/config/test_middleware.py
@@ -106,10 +106,17 @@ class TestAppDispatcher(helpers.FunctionalTestBase):
             return 'This was served from Flask'
 
         # This endpoint is defined both in Flask and in Pylons core
-        flask_app.add_url_rule('/flask_core', view_func=test_view)
+        flask_app.add_url_rule(
+            '/flask_core',
+            view_func=test_view,
+            endpoint='flask_core.index')
 
         # This endpoint is defined both in Flask and a Pylons extension
-        flask_app.add_url_rule('/pylons_and_flask', view_func=test_view)
+        flask_app.add_url_rule(
+            '/pylons_and_flask',
+            view_func=test_view,
+            endpoint='pylons_and_flask.index'
+        )
 
     def test_ask_around_is_called(self):
 


### PR DESCRIPTION
Otherwise, it would be different from our convention `blueprint.action` and will produce numerous problems in the future. For example, `toolkit.get_endpoint` takes endpoint's name, splits it by dot and returns two items as a tuple. In case of the default naming for flask routes, it would return `('webassets', )` for current webassets definition.