### PR TITLE
Fix _load_plugins syntax to load extension templates

### DIFF
--- a/ckan/tests/helpers.py
+++ b/ckan/tests/helpers.py
@@ -198,9 +198,12 @@ class FunctionalTestBase(object):
         # Make a copy of the Pylons config, so we can restore it in teardown.
         cls._original_config = dict(config)
         cls._apply_config_changes(config)
+        try:
+            config['ckan.plugins'] = ' '.join(cls._load_plugins)
+            del cls._test_app  # reload with the new plugins
+        except AttributeError:
+            pass
         cls._get_test_app()
-        for plugin in getattr(cls, '_load_plugins', []):
-            p.load(plugin)
 
     @classmethod
     def _apply_config_changes(cls, cfg):

--- a/ckanext/datastore/tests/test_db.py
+++ b/ckanext/datastore/tests/test_db.py
@@ -195,7 +195,8 @@ def datastore_job(res_id, value):
     A background job that uses the Datastore.
     '''
     app = helpers._get_test_app()
-    p.load('datastore')
+    if not p.plugin_loaded(u'datastore'):
+        p.load('datastore')
     data = {
         'resource_id': res_id,
         'method': 'insert',

--- a/ckanext/example_iconfigurer/tests/test_example_iconfigurer.py
+++ b/ckanext/example_iconfigurer/tests/test_example_iconfigurer.py
@@ -8,15 +8,7 @@ import ckan.plugins as plugins
 
 class TestExampleIConfigurer(helpers.FunctionalTestBase):
 
-    @classmethod
-    def setup_class(cls):
-        super(TestExampleIConfigurer, cls).setup_class()
-        plugins.load('example_iconfigurer')
-
-    @classmethod
-    def teardown_class(cls):
-        plugins.unload('example_iconfigurer')
-        super(TestExampleIConfigurer, cls).teardown_class()
+    _load_plugins = ['example_iconfigurer']
 
     def test_template_renders(self):
         '''Our controller renders the extension's config template.'''

--- a/ckanext/example_idatasetform/tests/test_controllers.py
+++ b/ckanext/example_idatasetform/tests/test_controllers.py
@@ -22,19 +22,7 @@ def _get_package_edit_page(app, package_name):
 
 
 class TestPackageController(helpers.FunctionalTestBase):
-    @classmethod
-    def _apply_config_changes(cls, cfg):
-        cfg['ckan.plugins'] = 'example_idatasetform'
-
-    @classmethod
-    def setup_class(cls):
-        super(TestPackageController, cls).setup_class()
-
-    @classmethod
-    def teardown_class(cls):
-        if plugins.plugin_loaded('example_idatasetform'):
-            plugins.unload('example_idatasetform')
-        super(TestPackageController, cls).teardown_class()
+    _load_plugins = ['example_idatasetform']
 
     def test_edit_converted_extra_field(self):
         dataset = factories.Dataset(custom_text='foo')


### PR DESCRIPTION
Fixes #4941 - see for more info.

The key benefit is to be able to use in tests the _load_plugins syntax because with this PR the extension templates now work in that case.

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
