### PR TITLE
Upgrade werkzeug

### DIFF
--- a/ckan/tests/controllers/test_home.py
+++ b/ckan/tests/controllers/test_home.py
@@ -44,7 +44,7 @@ class TestHome(helpers.FunctionalTestBase):
         response = app.get(url=url_for('home.index'), extra_environ=env)
 
         assert 'update your profile' in response.body
-        assert url_for('user.edit') in response.body
+        assert str(url_for('user.edit')) in response.body
         assert ' and add your email address.' in response.body
 
     def test_email_address_no_nag(self):

--- a/ckan/tests/helpers.py
+++ b/ckan/tests/helpers.py
@@ -155,6 +155,10 @@ class CKANTestApp(webtest.TestApp):
             self._flask_app = self.app.apps['flask_app']._wsgi_app
         return self._flask_app
 
+    def post(self, url, *args, **kwargs):
+        url = url.encode('utf8')  # or maybe it should be url_encoded?
+        return super(CKANTestApp, self).post(url, *args, **kwargs)
+
 
 def _get_test_app():
     '''Return a webtest.TestApp for CKAN, with legacy templates disabled.

--- a/ckan/tests/legacy/functional/test_preview_interface.py
+++ b/ckan/tests/legacy/functional/test_preview_interface.py
@@ -87,4 +87,4 @@ class TestPluggablePreviews(base.FunctionalTestCase):
 
     def test_iframe_url_is_correct(self):
         result = self.app.get(self.url)
-        assert self.preview_url in result.body, (self.preview_url, result.body)
+        assert str(self.preview_url) in result.body, (self.preview_url, result.body)

--- a/ckanext/datastore/tests/test_info.py
+++ b/ckanext/datastore/tests/test_info.py
@@ -66,11 +66,11 @@ class TestDatastoreInfo(DatastoreFunctionalTestBase):
             'http://test.ckan.net/api/3/action/datastore_upsert',
             '<code>http://test.ckan.net/api/3/action/datastore_search',
             'http://test.ckan.net/api/3/action/datastore_search_sql',
-            'http://test.ckan.net/api/3/action/datastore_search?resource_id=588dfa82-760c-45a2-b78a-e3bc314a4a9b&amp;limit=5',
+            'http://test.ckan.net/api/3/action/datastore_search?limit=5&amp;resource_id=588dfa82-760c-45a2-b78a-e3bc314a4a9b',
             'http://test.ckan.net/api/3/action/datastore_search?q=jones&amp;resource_id=588dfa82-760c-45a2-b78a-e3bc314a4a9b',
             'http://test.ckan.net/api/3/action/datastore_search_sql?sql=SELECT * from &#34;588dfa82-760c-45a2-b78a-e3bc314a4a9b&#34; WHERE title LIKE &#39;jones&#39;',
             "url: 'http://test.ckan.net/api/3/action/datastore_search'",
-            "http://test.ckan.net/api/3/action/datastore_search?resource_id=588dfa82-760c-45a2-b78a-e3bc314a4a9b&amp;limit=5&amp;q=title:jones",
+            "http://test.ckan.net/api/3/action/datastore_search?limit=5&amp;resource_id=588dfa82-760c-45a2-b78a-e3bc314a4a9b&amp;q=title:jones",
         )
         for url in expected_urls:
             assert url in page, url

--- a/ckanext/multilingual/tests/test_multilingual_plugin.py
+++ b/ckanext/multilingual/tests/test_multilingual_plugin.py
@@ -71,8 +71,8 @@ class TestDatasetTermTranslation(ckan.tests.legacy.html_check.HtmlCheckMethods):
         # It is testsysadmin who created the dataset, so testsysadmin whom
         # we'd expect to see the datasets for.
         for user_name in ('testsysadmin',):
-            offset = h.url_for(
-                'user.read', id=user_name)
+            offset = str(h.url_for(
+                'user.read', id=user_name))
             for (lang_code, translations) in (
                     ('de', _create_test_data.german_translations),
                     ('fr', _create_test_data.french_translations),

--- a/requirements.in
+++ b/requirements.in
@@ -37,5 +37,5 @@ webassets==0.12.1
 WebHelpers==1.3
 WebOb==1.0.8
 WebTest==1.4.3  # need to pin this so that Pylons does not install a newer version that conflicts with WebOb==1.0.8
-werkzeug==0.14.1
+werkzeug==0.15.5
 zope.interface==4.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,5 +63,5 @@ weberror==0.13.1          # via pylons
 webhelpers==1.3
 webob==1.0.8
 webtest==1.4.3
-werkzeug==0.14.1
+werkzeug==0.15.5
 zope.interface==4.3.2


### PR DESCRIPTION
### Proposed fixes:
Just a few subtle test changes needed:

With this upgrade of werkzeug, `url_for` now returns unicode, rather than a str. I'm not clear exactly where that happens, but flask uses lots of bits of werkzeug underneath. This caused test failures like this:

```
  File "/vagrant/src/ckan/ckan/tests/controllers/test_admin.py", line 34, in _reset_config
    app.post(
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webtest/app.py", line 838, in post
    content_type=content_type)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webtest/app.py", line 810, in _gen_request
    expect_errors=expect_errors)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webtest/app.py", line 1102, in do_request
    res = req.get_response(app, catch_exc_info=True)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webob/request.py", line 1049, in get_response
    application, catch_exc_info=True)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webob/request.py", line 1022, in call_application
    app_iter = application(self.environ, start_response)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webtest/lint.py", line 151, in lint_app
    check_environ(environ)
  File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/webtest/lint.py", line 335, in check_environ
    % (key, type(environ[key]), environ[key]))
AssertionError: Environmental variable PATH_INFO is not a string: <type 'unicode'> (value: u'/ckan-admin/reset_config')
```

This exception occurs because WSGI requires environ.PATH_INFO to be a string (bytes, not unicode). This is being checked by webtest.lint (the newest version does the same check). PATH_INFO is the part of the WSGI request storing the URL's path. WebOb is the thing that saves it, but our old version, it keeps it in whatever encoding we give it (rather than encoding it so it is a str). The upshot of all this is that when we pass a URL to our test app, it needs to be an (encoded) str.

I'm not 100% sure that UTF8 is the correct encoding - it might need url (percent) encoding, but for these tests it doesn't make any difference.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes sec fix for possible backport

Please [X] all the boxes above that apply
