### PR TITLE
Include requirement-setuptools.txt in manifest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ RUN apt-get -q -y update && apt-get -q -y upgrade && DEBIAN_FRONTEND=noninteract
 		python-dev \
         python-pip \
         python-virtualenv \
+        libffi-dev \
         libpq-dev \
+        libssl-dev \
         git-core \
 	&& apt-get -q clean
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,4 +19,4 @@ include CHANGELOG.txt
 include ckan/migration/migrate.cfg
 include ckan/migration/README
 recursive-include ckan/migration/versions *.sql
-recursive-include ckan_deb *
+include requirement-setuptools.txt


### PR DESCRIPTION
When attempting to `pip install ckan` it fails as the setup.py requires the requirement-setuptools.txt to be present, and it is not.  This change makes sure that the pip install will not fail due to the absence of this file.

This PR does not include the requirements.txt as this would likely require further discussion about how requirements are loaded.

This fixes issues #4271, #4946.

### Features:

- [x] includes bugfix for possible backport

