### PR TITLE
Do not reuse connection if invalidated on usage

### DIFF
--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -266,7 +266,6 @@ class BaseController(WSGIController):
             if not error.connection_invalidated:
                 raise
             log.info('DBAPIError: %s' % error.message.rstrip())
-            model.Session.connection().should_close_with_result = True
             start_response(503, {})
             return ""
         finally:


### PR DESCRIPTION
This exception handler ensures that a connection that's invalidated as a result of using it (for example, the connection may no longer be alive), is correctly closed and removed from the connection pool.

Previously, a defunct connection would be left in the pool and reused indiscriminately.

### Features:
 [ ] includes tests covering changes