### PR TITLE
[#4671] Explicit validation error when group_id provided twice

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -151,8 +151,6 @@ def package_create(context, data_dict):
     else:
         schema = package_plugin.create_package_schema()
 
-    _check_access('package_create', context, data_dict)
-
     if 'api_version' not in context:
         # check_data_dict() is deprecated. If the package_plugin has a
         # check_data_dict() we'll call it, if it doesn't have the method we'll
@@ -171,6 +169,8 @@ def package_create(context, data_dict):
     log.debug('package_create validate_errs=%r user=%s package=%s data=%r',
               errors, context.get('user'),
               data.get('name'), data_dict)
+
+    _check_access('package_create', context, data_dict)
 
     if errors:
         model.Session.rollback()

--- a/ckan/logic/auth/create.py
+++ b/ckan/logic/auth/create.py
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-import six
-
 import ckan.logic as logic
 import ckan.authz as authz
 import ckan.logic.auth as logic_auth
@@ -186,14 +184,8 @@ def _check_group_auth(context, data_dict):
             id = group_blob.get('id') or group_blob.get('name')
             if not id:
                 continue
-        elif isinstance(group_blob, six.string_types):
-            id = group_blob
         else:
-            msg = _(
-                u'Only lists of dicts can be placed'
-                   u' against subschema %(schema)s, not %(type)s'
-            ) % ({'schema': 'group', 'type': type(group_blob)})
-            raise logic.ValidationError({'group': [msg]})
+            id = group_blob
         grp = model.Group.get(id)
         if grp is None:
             raise logic.NotFound(_('Group was not found.'))

--- a/ckan/logic/auth/create.py
+++ b/ckan/logic/auth/create.py
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+import six
+
 import ckan.logic as logic
 import ckan.authz as authz
 import ckan.logic.auth as logic_auth
@@ -184,8 +186,14 @@ def _check_group_auth(context, data_dict):
             id = group_blob.get('id') or group_blob.get('name')
             if not id:
                 continue
-        else:
+        elif isinstance(group_blob, six.string_types):
             id = group_blob
+        else:
+            msg = _(
+                u'Only lists of dicts can be placed'
+                   u' against subschema %(schema)s, not %(type)s'
+            ) % ({'schema': 'group', 'type': type(group_blob)})
+            raise logic.ValidationError({'group': [msg]})
         grp = model.Group.get(id)
         if grp is None:
             raise logic.NotFound(_('Group was not found.'))


### PR DESCRIPTION
Fixes #4671

When a user creates dataset after clicking **Add dataset** on the group page, form payload sometimes contains two group ids - one from the form itself and one from query string that was attempting to prefill package creation form. Such cases itself are out of CKAN core responsibility and should be handled by portal maintainers, but providing explicit validation error instead of 500 error should be nice.