### PR TITLE
Show input field after select2 focus

### DIFF
--- a/ckan/public/base/vendor/select2/select2.js
+++ b/ckan/public/base/vendor/select2/select2.js
@@ -1989,7 +1989,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 if (data.results.length === 0 && checkFormatter(opts.formatNoMatches, "formatNoMatches")) {
                     render("<li class='select2-no-results'>" + evaluate(opts.formatNoMatches, opts.element, search.val()) + "</li>");
                     if(this.showSearch){
-                        this.showSearch(search.val());
+                        this.showSearch(true);
                     }
                     return;
                 }


### PR DESCRIPTION
After select2 upgrade input field not always shown when autocomplete
field receives focus. This PR contains changes to the source of select2.
It isn't the best solution, but otherwise, we need either to
update major version of select2(a lot of incompatibility issues for
extension) or monkey-patch select2.

Partially solves #4907
