### PR TITLE
[#4420] Fix Solr query for non-private datasets

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1884,7 +1884,8 @@ def package_search(context, data_dict):
         include_drafts = asbool(data_dict.pop('include_drafts', False))
         data_dict.setdefault('fq', '')
         if not include_private:
-            data_dict['fq'] = '+capacity:public ' + data_dict['fq']
+            data_dict['fq'] = 'capacity:public' if not data_dict['fq'] \
+                else 'capacity:public +' + data_dict['fq']
         if include_drafts:
             data_dict['fq'] += ' +state:(active OR draft)'
 

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1888,6 +1888,8 @@ def package_search(context, data_dict):
                 else 'capacity:public +' + data_dict['fq']
         if include_drafts:
             data_dict['fq'] += ' +state:(active OR draft)'
+        if not include_drafts and not context.get('sysadmin'):
+            data_dict['fq'] += ' -state:draft'
 
         # Pop these ones as Solr does not need them
         extras = data_dict.pop('extras', None)

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1479,7 +1479,7 @@ def user_show(context, data_dict):
     if asbool(data_dict.get('include_datasets', False)):
         user_dict['datasets'] = []
 
-        fq = "+creator_user_id:{0}".format(user_dict['id'])
+        fq = "creator_user_id:{0}".format(user_dict['id'])
 
         search_dict = {'rows': 50}
 

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -1498,7 +1498,7 @@ class TestPackageSearch(helpers.FunctionalTestBase):
 
         fq = "(creator_user_id:{0} AND +state:draft)".format(user['id'])
         results = logic.get_action('package_search')(
-            {'user': sysadmin['name']},
+            {'user': sysadmin['name'], 'sysadmin': True},
             {'fq': fq})['results']
 
         names = [r['name'] for r in results]

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -1295,6 +1295,23 @@ class TestPackageSearch(helpers.FunctionalTestBase):
 
         eq(len(results), 0)
 
+    def test_package_search_with_fq_for_org_includes_only_org_datasets(self):
+        '''
+        Searching for datasets by organization returns only datasets from the
+        organization.
+        '''
+        user = factories.User()
+        org1 = factories.Organization(user=user)
+        org2 = factories.Organization(user=user)
+        dataset1 = factories.Dataset(user=user, owner_org=org1['name'], name="dataset1")
+        factories.Dataset(user=user, owner_org=org2['name'], name="dataset2")
+
+        fq = "owner_org:" + org1['id']
+        results = helpers.call_action('package_search', fq=fq)['results']
+
+        eq(len(results), 1)
+        nose.tools.assert_equal(results[0]['name'], dataset1['name'])
+
     def test_package_search_with_include_drafts_option_excludes_drafts_for_anon_user(self):
         '''
         An anon user can't user include_drafts to get draft datasets.


### PR DESCRIPTION
The assembled query was malformed, leading to Solr ignoring the main part of the query as passed in via the data_dict.

For instance, when searching for a group to display the number of datasets in it, the part of the query specifying the group was missed out. This meant that all groups displayed the total number of datasets, instead of the number in each group.

Fixes #4420 

### Proposed fixes:



### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
