### PR TITLE
[#4684] Add missing get_action calls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: python:2
+      - image: python:2-stretch
         environment:
           CKAN_DATASTORE_POSTGRES_DB: datastore_test
           CKAN_DATASTORE_POSTGRES_READ_USER: datastore_read
@@ -29,7 +29,7 @@ jobs:
       - checkout
 
       - run: |
-          # SO Dependencies
+          # OS Dependencies
           apt update
           case $CIRCLE_NODE_INDEX in
             $NODE_TESTS_CONTAINER)

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -2669,7 +2669,7 @@ def user_activity_list_html(context, data_dict):
     :rtype: string
 
     '''
-    activity_stream = user_activity_list(context, data_dict)
+    activity_stream = logic.get_action('user_activity_list')(context, data_dict)
     offset = int(data_dict.get('offset', 0))
     extra_vars = {
         'controller': 'user',
@@ -2755,7 +2755,7 @@ def organization_activity_list_html(context, data_dict):
     :rtype: string
 
     '''
-    activity_stream = organization_activity_list(context, data_dict)
+    activity_stream = logic.get_action('organization_activity_list')(context, data_dict)
     offset = int(data_dict.get('offset', 0))
     extra_vars = {
         'controller': 'organization',


### PR DESCRIPTION
In #4685 I missed these two calls for some reason and it has now come to bite me in a project.

This PR exceptionally targets `dev-v2.8` because this code is no longer present in master after the activity streams refactor.