### PR TITLE
Drop instructions for Ubuntu 14.04 

### DIFF
--- a/doc/maintaining/installing/deployment.rst
+++ b/doc/maintaining/installing/deployment.rst
@@ -148,16 +148,6 @@ following contents:
 Replace ``default.ckanhosted.com`` and ``www.default.ckanhosted.com`` with the
 domain name for your site.
 
-.. note::
-
-    If you are running |apache| 2.2 or lower (eg on Ubuntu 12.04), remove this directive,
-    as it is not supported::
-
-        <Directory />
-            Require all granted
-        </Directory>
-
-
 This tells the Apache modwsgi module to redirect any requests to the web server
 to the WSGI script that you created above. Your WSGI script in turn directs the
 requests to your CKAN instance.
@@ -169,7 +159,7 @@ requests to your CKAN instance.
 Open ``/etc/apache2/ports.conf``. We need to replace the default port 80 with the 8080 one.
 
 
-   - On Apache 2.4 (eg Ubuntu 14.04 or RHEL 7):
+   - On Apache 2.4 (eg Ubuntu 18.04 or RHEL 7):
 
      Replace this line:
 
@@ -183,21 +173,6 @@ Open ``/etc/apache2/ports.conf``. We need to replace the default port 80 with th
 
             Listen 8080
 
-
-   - On Apache 2.2 (eg Ubuntu 12.04 or RHEL 6):
-
-     Replace these lines:
-
-        .. parsed-literal::
-
-            NameVirtualHost \*:80
-            Listen 80
-
-     With these ones:
-
-        .. parsed-literal::
-            NameVirtualHost \*:8080
-            Listen 8080
 
 -------------------------------
 8. Create the Nginx config file

--- a/doc/maintaining/installing/index.rst
+++ b/doc/maintaining/installing/index.rst
@@ -10,9 +10,9 @@ There are three ways to install CKAN:
 #. Install from Docker Compose
 
 From package is the quickest and easiest way to install CKAN, but it requires
-Ubuntu 16.04 64-bit or Ubuntu 14.04 64-bit. **You should install CKAN from package if**:
+Ubuntu 16.04 64-bit 64-bit. **You should install CKAN from package if**:
 
-* You want to install CKAN on an Ubuntu 16.04 or 14.04, 64-bit server, *and*
+* You want to install CKAN on an Ubuntu 16.04, 64-bit server, *and*
 * You only want to run one CKAN website per server
 
 See :doc:`install-from-package`.
@@ -20,7 +20,7 @@ See :doc:`install-from-package`.
 **You should install CKAN from source if**:
 
 * You want to install CKAN on a 32-bit computer, *or*
-* You want to install CKAN on a different version of Ubuntu, not 16.04 or 14.04, *or*
+* You want to install CKAN on a different version of Ubuntu, not 16.04, *or*
 * You want to install CKAN on another operating system (eg. RHEL, CentOS, OS X), *or*
 * You want to run multiple CKAN websites on the same server, *or*
 * You want to install CKAN for development

--- a/doc/maintaining/installing/install-from-docker-compose.rst
+++ b/doc/maintaining/installing/install-from-docker-compose.rst
@@ -22,7 +22,7 @@ taken to use this setup in production.
 --------------
 1. Environment
 --------------
-This tutorial was tested on Ubuntu 14.04 LTS and Ubuntu 16.04 LTS, respectively.
+This tutorial was tested on Ubuntu 16.04 LTS.
 The hosts can be local environments or cloud VMs. It is assumed that the user has direct access
 (via terminal / ssh) to the systems and root permissions.
 

--- a/doc/maintaining/installing/install-from-package.rst
+++ b/doc/maintaining/installing/install-from-package.rst
@@ -5,8 +5,8 @@ Installing CKAN from package
 ============================
 
 This section describes how to install CKAN from package. This is the quickest
-and easiest way to install CKAN, but it requires **Ubuntu 16.04 64-bit** or **Ubuntu 14.04 64-bit**. If
-you're not using Ubuntu 16.04 64-bit or Ubuntu 14.04 64-bit, or if you're installing CKAN for
+and easiest way to install CKAN, but it requires **Ubuntu 16.04 64-bit**. If
+you're not using Ubuntu 16.04 64-bit, or if you're installing CKAN for
 development, you should follow :doc:`install-from-source` instead.
 
 At the end of the installation process you will end up with two running web
@@ -48,11 +48,11 @@ CKAN:
 #. Install the Ubuntu packages that CKAN requires (and 'git', to enable you to install CKAN extensions)::
 
     sudo apt-get install -y apache2 libapache2-mod-wsgi libpq5 redis-server git-core
-    
+
 #. Then stop apache2 service to install nginx
-    
+
     sudo service apache2 stop
-    
+
     sudo apt-get install -y nginx
 
 #. Download the CKAN package:
@@ -63,12 +63,6 @@ CKAN:
 
            wget \http://packaging.ckan.org/|latest_package_name_xenial|
 
-   - On Ubuntu 14.04:
-
-       .. parsed-literal::
-
-           wget \http://packaging.ckan.org/|latest_package_name_trusty|
-
 
 #. Install the CKAN package:
 
@@ -77,12 +71,6 @@ CKAN:
        .. parsed-literal::
 
            sudo dpkg -i |latest_package_name_xenial|
-
-   - On Ubuntu 14.04:
-
-       .. parsed-literal::
-
-           sudo dpkg -i |latest_package_name_trusty|
 
     .. note:: If you get the following error it means that for some reason the
      Apache WSGI module was not enabled::
@@ -110,7 +98,7 @@ CKAN:
    |production.ini| file to reference your |postgres| server.
 
 .. note::
-     
+
    The commands mentioned below are tested for Ubuntu system
 
 Install |postgres|, running this command in a terminal::

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -5,8 +5,8 @@ Installing CKAN from source
 ===========================
 
 This section describes how to install CKAN from source. Although
-:doc:`install-from-package` is simpler, it requires Ubuntu 18.04 64-bit, Ubuntu
-16.04 64-bit, or Ubuntu 14.04 64-bit. Installing CKAN from source works with other
+:doc:`install-from-package` is simpler, it requires Ubuntu 18.04 64-bit or
+Ubuntu 16.04 64-bit. Installing CKAN from source works with other
 versions of Ubuntu and with other operating systems (e.g. RedHat, Fedora, CentOS, OS X).
 If you install CKAN from source on your own operating system, please share your
 experiences on our `How to Install CKAN <https://github.com/ckan/ckan/wiki/How-to-Install-CKAN>`_
@@ -20,13 +20,9 @@ work on CKAN.
 --------------------------------
 
 If you're using a Debian-based operating system (such as Ubuntu) install the
-required packages with this command for Ubuntu 18.04 and Ubuntu 16.04::
+required packages with this command::
 
     sudo apt-get install python-dev postgresql libpq-dev python-pip python-virtualenv git-core solr-jetty openjdk-8-jdk redis-server
-
-or for Ubuntu 14.04::
-
-    sudo apt-get install python-dev postgresql libpq-dev python-pip python-virtualenv git-core solr-jetty openjdk-6-jdk redis-server
 
 If you're not using a Debian-based operating system, find the best way to
 install the following packages on your operating system (see
@@ -79,11 +75,11 @@ a. Create a Python `virtual environment <http://www.virtualenv.org>`_
        sudo chown \`whoami\` |virtualenv|
        virtualenv --no-site-packages |virtualenv|
        |activate|
-    
+
 .. note::
 
     If your system uses Python3 by default (e.g. Ubuntu 18.04) make sure to create
-    the virtualenv using the Python2.7 executable with the ``--python`` option: 
+    the virtualenv using the Python2.7 executable with the ``--python`` option:
 
     .. parsed-literal::
 
@@ -334,17 +330,17 @@ Check by seeing if ``javac`` is installed::
 
 If ``javac`` isn't installed, do::
 
-     sudo apt-get install openjdk-6-jdk
+     sudo apt-get install openjdk-8-jdk
 
 and then restart Solr:
 
-For Ubuntu 16.04::
+For Ubuntu 18.04::
+
+     sudo service jetty9 restart
+
+or for Ubuntu 16.04::
 
      sudo service jetty8 restart
-
-or for Ubuntu 14.04::
-
-     sudo service jetty restart
 
 AttributeError: 'module' object has no attribute 'css/main.debug.css'
 ---------------------------------------------------------------------
@@ -360,16 +356,6 @@ main.debug.css to get CKAN running::
 
     cp /usr/lib/ckan/default/src/ckan/ckan/public/base/css/main.css \
     /usr/lib/ckan/default/src/ckan/ckan/public/base/css/main.debug.css
-
-JSP support not configured
---------------------------
-
-This is seen occasionally with Jetty and Ubuntu 14.04. It requires a solr-jetty fix::
-
-    cd /tmp
-    wget https://launchpad.net/~vshn/+archive/ubuntu/solr/+files/solr-jetty-jsp-fix_1.0.2_all.deb
-    sudo dpkg -i solr-jetty-jsp-fix_1.0.2_all.deb
-    sudo service jetty restart
 
 ImportError: No module named 'flask_debugtoolbar'
 -------------------------------------------------

--- a/doc/maintaining/installing/solr.rst
+++ b/doc/maintaining/installing/solr.rst
@@ -51,10 +51,6 @@ installed, we need to install and configure Solr.
 
     sudo service jetty8 restart
 
-   Or for Ubuntu 14.04::
-
-    sudo service jetty restart
-
    .. note::
 
     Ignore any warning that it wasn't already running - some Ubuntu
@@ -114,10 +110,6 @@ installed, we need to install and configure Solr.
    For Ubuntu 16.04::
 
     sudo service jetty8 restart
-
-   or for Ubuntu 14.04::
-
-    sudo service jetty restart
 
    Check that Solr is running by opening http://localhost:8983/solr/.
 


### PR DESCRIPTION
This is because this version is 5 years old, has hit End of Life (although it does have a *paid* support option - Extended Maintenance ESM). See https://itsfoss.com/ubuntu-14-04-end-of-life/

This PR elimenates a little bit of clutter in the docs, that no-one should be referring to any more.

### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
