### PR TITLE
Added database index migrations for group_extra and resource

### DIFF
--- a/ckan/migration/versions/091_0ffc0b277141_group_extra_group_id_index.py
+++ b/ckan/migration/versions/091_0ffc0b277141_group_extra_group_id_index.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """group_extra group_id index
 
 Revision ID: 0ffc0b277141
@@ -6,19 +8,18 @@ Create Date: 2019-09-11 12:16:42.792661
 
 """
 from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = '0ffc0b277141'
+revision = u'0ffc0b277141'
 down_revision = u'980dcd44de4b'
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    op.create_index('idx_group_extra_group_id', 'group_extra', ['group_id'])
+    op.create_index(u'idx_group_extra_group_id', u'group_extra', [u'group_id'])
 
 
 def downgrade():
-    op.drop_index('idx_group_extra_group_id')
+    op.drop_index(u'idx_group_extra_group_id')

--- a/ckan/migration/versions/091_0ffc0b277141_group_extra_group_id_index.py
+++ b/ckan/migration/versions/091_0ffc0b277141_group_extra_group_id_index.py
@@ -1,0 +1,24 @@
+"""group_extra group_id index
+
+Revision ID: 0ffc0b277141
+Revises: 980dcd44de4b
+Create Date: 2019-09-11 12:16:42.792661
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '0ffc0b277141'
+down_revision = u'980dcd44de4b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index('idx_group_extra_group_id', 'group_extra', ['group_id'])
+
+
+def downgrade():
+    op.drop_index('idx_group_extra_group_id')

--- a/ckan/migration/versions/092_01afcadbd8c0_resource_package_id_index.py
+++ b/ckan/migration/versions/092_01afcadbd8c0_resource_package_id_index.py
@@ -1,0 +1,24 @@
+"""resource package_id index
+
+Revision ID: 01afcadbd8c0
+Revises: 0ffc0b277141
+Create Date: 2019-09-11 12:16:53.937813
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '01afcadbd8c0'
+down_revision = '0ffc0b277141'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index('idx_package_resource_package_id', 'resource', ['package_id'])
+
+
+def downgrade():
+    op.drop_index('idx_package_resource_package_id')

--- a/ckan/migration/versions/092_01afcadbd8c0_resource_package_id_index.py
+++ b/ckan/migration/versions/092_01afcadbd8c0_resource_package_id_index.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """resource package_id index
 
 Revision ID: 01afcadbd8c0
@@ -6,19 +8,19 @@ Create Date: 2019-09-11 12:16:53.937813
 
 """
 from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = '01afcadbd8c0'
-down_revision = '0ffc0b277141'
+revision = u'01afcadbd8c0'
+down_revision = u'0ffc0b277141'
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    op.create_index('idx_package_resource_package_id', 'resource', ['package_id'])
+    op.create_index(u'idx_package_resource_package_id', u'resource',
+                    [u'package_id'])
 
 
 def downgrade():
-    op.drop_index('idx_package_resource_package_id')
+    op.drop_index(u'idx_package_resource_package_id')


### PR DESCRIPTION
Fixes #4974 

### Proposed fixes:
- Added database migration for `group_extra (group_id)` index
- Added database migration for `resource (package_id)` index

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply

Financed by Finland's open data portal opendata.fi. Find all Finnish open data at https://www.opendata.fi/en.
The Service is provided by the Population Register Centre (https://vrk.fi/en/).