### PR TITLE
Ugrade flask version to 1.1.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ Babel==2.3.4
 bleach==3.0.2
 click==6.7
 fanstatic==0.12
-Flask==0.12.4
+Flask==1.1.1
 Flask-Babel==0.11.2
 Jinja2==2.10.1
 Markdown==2.6.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ click==6.7
 decorator==4.4.0          # via pylons, sqlalchemy-migrate
 fanstatic==0.12
 flask-babel==0.11.2
-flask==0.12.4
+Flask==1.1.1
 formencode==1.3.1         # via pylons
 funcsigs==1.0.2           # via beaker
 idna==2.8                 # via requests


### PR DESCRIPTION
Fix for recent security alert: https://github.com/ckan/ckan/network/alert/requirements.txt/flask/open

In addition, it better to upgrade major version now, while we don't have any code, that will be incompatible with newest flask version.