### PR TITLE
4420 fix org and group dataset counts

### DIFF
--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -313,9 +313,9 @@ def group_dictize(group, context,
             }
 
             if group_.is_organization:
-                q['fq'] = 'owner_org:"{0}"'.format(group_.id)
+                q['fq'] = '+owner_org:"{0}"'.format(group_.id)
             else:
-                q['fq'] = 'groups:"{0}"'.format(group_.name)
+                q['fq'] = '+groups:"{0}"'.format(group_.name)
 
             # Allow members of organizations to see private datasets.
             if group_.is_organization:

--- a/ckan/tests/lib/dictization/test_model_dictize.py
+++ b/ckan/tests/lib/dictization/test_model_dictize.py
@@ -256,7 +256,9 @@ class TestGroupDictize:
     def test_group_dictize_with_package_count(self):
         # group_list_dictize calls it like this by default
         group_ = factories.Group()
+        other_group_ = factories.Group()
         factories.Dataset(groups=[{'name': group_['name']}])
+        factories.Dataset(groups=[{'name': other_group_['name']}])
         group_obj = model.Session.query(model.Group).filter_by().first()
         context = {'model': model, 'session': model.Session,
                    'dataset_counts': model_dictize.get_group_dataset_counts()
@@ -295,7 +297,9 @@ class TestGroupDictize:
     def test_group_dictize_for_org_with_package_count(self):
         # group_list_dictize calls it like this by default
         org_ = factories.Organization()
+        other_org_ = factories.Organization()
         factories.Dataset(owner_org=org_['id'])
+        factories.Dataset(owner_org=other_org_['id'])
         org_obj = model.Session.query(model.Group).filter_by().first()
         context = {'model': model, 'session': model.Session,
                    'dataset_counts': model_dictize.get_group_dataset_counts()


### PR DESCRIPTION
Fixes #4420 

### Proposed fixes:

When dictizing a group or organization and including the group's packages or package count, we need to search *only* for packages in that group. Otherwise the group/org index page shows that all groups/orgs have the total number of datasets for the whole CKAN instance.

### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
