### PR TITLE
move faceting criteria to fq parameter instead of part of the q param…

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -293,7 +293,7 @@ class GroupController(base.BaseController):
                         and len(value) and not param.startswith('_'):
                     if not param.startswith('ext_'):
                         c.fields.append((param, value))
-                        q += ' %s: "%s"' % (param, value)
+                        fq += '+%s:"%s"' % (param, value)
                         if param not in c.fields_grouped:
                             c.fields_grouped[param] = [value]
                         else:
@@ -334,7 +334,6 @@ class GroupController(base.BaseController):
             context_ = dict((k, v) for (k, v) in context.items()
                             if k != 'schema')
             query = get_action('package_search')(context_, data_dict)
-
             c.page = h.Page(
                 collection=query['results'],
                 page=page,


### PR DESCRIPTION
Fixes #4990 

### Proposed fixes:

in the original facet are concatenated to the search criteria, as part of the `q` argument. I propose to keep the original `q` from the user and pass multiple facets to the `fq` parameter for the action.- 

### Features:

- [x] includes bugfix for possible backport
