### PR TITLE
Add missing closing div tag to template

### DIFF
--- a/ckan/templates/organization/member_new.html
+++ b/ckan/templates/organization/member_new.html
@@ -101,4 +101,5 @@
         datasets, but not add new datasets.</p>
     {% endtrans %}
   </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
Fixes odd page rendering problem where the content of the page sits under the secondary content.

For example:

![before](https://user-images.githubusercontent.com/4718259/65531836-b0bae100-def2-11e9-9eca-0344b60a467b.png)

and with this fix:

![after](https://user-images.githubusercontent.com/4718259/65531848-ba444900-def2-11e9-8891-d699928cb859.png)


### Proposed fixes:
Add closing `div` tag.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
