### PR TITLE
Remove link to unavailable page

### DIFF
--- a/doc/contributing/test.rst
+++ b/doc/contributing/test.rst
@@ -261,9 +261,6 @@ following browsers:
 * Firefox: Latest + previous version
 * Chrome: Latest + previous version
 
-These browsers are determined by whatever has >= 1% share with the
-latest months data from: http://data.gov.uk/data/site-usage
-
 Install browser virtual machines
 ================================
 


### PR DESCRIPTION
Fixes #
https://data.gov.uk/data/site-usage is no longer available.

### Proposed fixes:
Remove the link and accompanying text


### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
