### PR TITLE
Fix PostGIS base image tag

### DIFF
--- a/contrib/docker/postgresql/Dockerfile
+++ b/contrib/docker/postgresql/Dockerfile
@@ -1,5 +1,5 @@
 #FROM postgres:9.6
-FROM mdillon/postgis
+FROM mdillon/postgis:11
 MAINTAINER Open Knowledge
 
 # Allow connections; we don't map out any ports so only linked docker containers can connect


### PR DESCRIPTION
Using `:latest` as tag (the default) is a bad idea, especially for a database like Postgres, where a manual upgrade of the database is required when moving to a major release. People sticking to a specific CKAN version could get a non-working database just because they rebuilt the Docker images (for security reasons) and they will end up with a different Postgres version. This should be avoided.

This patch fixes future problem by blocking automatic upgrades to new major releases of Postgres.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport