### PR TITLE
Make creating new tags in autocomplete module optional

### DIFF
--- a/ckan/public/base/javascript/modules/autocomplete.js
+++ b/ckan/public/base/javascript/modules/autocomplete.js
@@ -21,6 +21,7 @@ this.ckan.module('autocomplete', function (jQuery) {
     /* Options for the module */
     options: {
       tags: false,
+      createtags: true,
       key: false,
       label: false,
       items: 10,
@@ -61,6 +62,13 @@ this.ckan.module('autocomplete', function (jQuery) {
       if (!this.el.is('select')) {
         if (this.options.tags) {
           settings.tags = this._onQuery;
+
+          // Disable creating new tags
+          if (!this.options.createtags) {
+            settings.createSearchChoice = function(params) {
+              return undefined;
+            }
+          }
         } else {
           settings.query = this._onQuery;
           settings.createSearchChoice = this.formatTerm;


### PR DESCRIPTION
### Proposed fixes:
Autocomplete module creates new tags when inputting a tag which does not exist, this PR makes that optional. The default is still the same but developer can prevent creating new tags by adding data-module-createtags='false' to the template. This probably should be documented somewhere but javascript module documentation is pretty much non-existing currently anyway.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
