### PR TITLE
Solr: expose default search field via config

### DIFF
--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -82,6 +82,9 @@ ckan.auth.public_activity_stream_detail = true
 ckan.site_id = default
 #solr_url = http://127.0.0.1:8983/solr
 
+# For Solr package searches, this specifies the fields that are searched and their relative weighting
+# search.default_fields = "name^4 title^4 tags^2 groups^2 text"
+
 
 ## Redis Settings
 

--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -26,10 +26,6 @@ VALID_SOLR_PARAMETERS = set([
     'extras', 'fq_list', 'tie', 'defType', 'mm', 'df'
 ])
 
-# for (solr) package searches, this specifies the fields that are searched
-# and their relative weighting
-QUERY_FIELDS = "name^4 title^4 tags^2 groups^2 text"
-
 solr_regex = re.compile(r'([\\+\-&|!(){}\[\]^"~*?:])')
 
 def escape_legacy_argument(val):
@@ -364,7 +360,7 @@ class PackageSearchQuery(SearchQuery):
             # this minimum match is explained
             # http://wiki.apache.org/solr/DisMaxQParserPlugin#mm_.28Minimum_.27Should.27_Match.29
             query['mm'] = query.get('mm', '2<-1 5<80%')
-            query['qf'] = query.get('qf', QUERY_FIELDS)
+            query['qf'] = query.get('qf', config.get('search.default_fields', 'name^4 title^4 tags^2 groups^2 text'))
 
         try:
             if query['q'].startswith('{!'):


### PR DESCRIPTION
# Features:
Expose the default search fields used in SOLR via a config