### PR TITLE
Bug caused by updated to how Flask handles the file upload field

### DIFF
--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -144,8 +144,9 @@ class Upload(object):
         if not self.storage_path:
             return
 
-        if isinstance(self.upload_field_storage, (ALLOWED_UPLOAD_TYPES)):
-            if self.upload_field_storage:
+        if isinstance(self.upload_field_storage, (ALLOWED_UPLOAD_TYPES,)):
+            if self.upload_field_storage \
+               and self.upload_field_storage.filename:
                 self.filename = self.upload_field_storage.filename
                 self.filename = str(datetime.datetime.utcnow()) + self.filename
                 self.filename = munge.munge_filename_legacy(self.filename)

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -151,7 +151,8 @@ class Upload(object):
                 self.filename = munge.munge_filename_legacy(self.filename)
                 self.filepath = os.path.join(self.storage_path, self.filename)
                 data_dict[url_field] = self.filename
-                self.upload_file = _get_underlying_file(self.upload_field_storage)
+                self.upload_file = _get_underlying_file(
+                    self.upload_field_storage)
                 self.tmp_filepath = self.filepath + '~'
         # keep the file if there has been no change
         elif self.old_filename and not self.old_filename.startswith('http'):

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -145,8 +145,7 @@ class Upload(object):
             return
 
         if isinstance(self.upload_field_storage, (ALLOWED_UPLOAD_TYPES,)):
-            if self.upload_field_storage \
-               and self.upload_field_storage.filename:
+            if self.upload_field_storage.filename:
                 self.filename = self.upload_field_storage.filename
                 self.filename = str(datetime.datetime.utcnow()) + self.filename
                 self.filename = munge.munge_filename_legacy(self.filename)

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -145,13 +145,14 @@ class Upload(object):
             return
 
         if isinstance(self.upload_field_storage, (ALLOWED_UPLOAD_TYPES)):
-            self.filename = self.upload_field_storage.filename
-            self.filename = str(datetime.datetime.utcnow()) + self.filename
-            self.filename = munge.munge_filename_legacy(self.filename)
-            self.filepath = os.path.join(self.storage_path, self.filename)
-            data_dict[url_field] = self.filename
-            self.upload_file = _get_underlying_file(self.upload_field_storage)
-            self.tmp_filepath = self.filepath + '~'
+            if self.upload_field_storage:
+                self.filename = self.upload_field_storage.filename
+                self.filename = str(datetime.datetime.utcnow()) + self.filename
+                self.filename = munge.munge_filename_legacy(self.filename)
+                self.filepath = os.path.join(self.storage_path, self.filename)
+                data_dict[url_field] = self.filename
+                self.upload_file = _get_underlying_file(self.upload_field_storage)
+                self.tmp_filepath = self.filepath + '~'
         # keep the file if there has been no change
         elif self.old_filename and not self.old_filename.startswith('http'):
             if not self.clear:


### PR DESCRIPTION
… filename for the file_url field when I'm not actually uploading a new file, just changing other metadata (such as description).  This effectively kills kills the uploaded image link for the organization/groups.

Fixes #

### Proposed fixes:
Issue occurs only when I have an image for the organization/groups.  I need to be able to update other metadata but not uploading a new image.  It breaks due to the fact how old Pylons requests object not returning anything in the "image_upload" field when the user doesn't upload a new image.  Flask's FileStorage class has a boolean check instead where we can just do if "data_dict['image_upload']" or similar instead.  
I have kept the original if statement in place to be backwards compatible, additional check added in order to account for the Flask method.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
