### PR TITLE
4673 allow reply to emails

### DIFF
--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -194,6 +194,7 @@ ckan.hide_activity_from_users = %(ckan.site_id)s
 #smtp.user = username@example.com
 #smtp.password = your_password
 #smtp.mail_from =
+#smtp.reply_to =
 
 ## Background Job Settings
 ckan.jobs.timeout = 180

--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -37,6 +37,7 @@ def _mail_recipient(recipient_name, recipient_email,
         headers = {}
 
     mail_from = config.get('smtp.mail_from')
+    reply_to = config.get('smtp.reply_to')
     msg = MIMEText(body.encode('utf-8'), 'plain', 'utf-8')
     for k, v in headers.items():
         if k in msg.keys():
@@ -50,6 +51,8 @@ def _mail_recipient(recipient_name, recipient_email,
     msg['To'] = Header(recipient, 'utf-8')
     msg['Date'] = Utils.formatdate(time())
     msg['X-Mailer'] = "CKAN %s" % ckan.__version__
+    if reply_to and reply_to != '':
+        msg['Reply-to'] = reply_to
 
     # Send the email using Python's smtplib.
     smtp_connection = smtplib.SMTP()

--- a/ckan/tests/lib/test_mailer.py
+++ b/ckan/tests/lib/test_mailer.py
@@ -233,3 +233,26 @@ class TestMailer(MailerBase):
                       'headers': {'header1': 'value1'}}
         assert_raises(mailer.MailerException,
                       mailer.mail_recipient, **test_email)
+
+    @helpers.change_config('smtp.reply_to', 'norply@ckan.org')
+    def test_reply_to(self):
+
+        msgs = self.get_smtp_messages()
+        assert_equal(msgs, [])
+
+        # send email
+        test_email = {'recipient_name': 'Bob',
+                      'recipient_email': 'Bob@bob.com',
+                      'subject': 'Meeting',
+                      'body': 'The meeting is cancelled.',
+                      'headers': {'header1': 'value1'}}
+        mailer.mail_recipient(**test_email)
+
+        # check it went to the mock smtp server
+        msgs = self.get_smtp_messages()
+        msg = msgs[0]
+
+        expected_from_header = "Reply-to: {}".format(
+            config.get('smtp.reply_to'))
+
+        assert_in(expected_from_header, msg[3])

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -1341,7 +1341,7 @@ Example::
 
 Default value: ``//jsonpdataproxy.appspot.com``
 
-Custom URL to a self-hosted DataProxy instance. The DataProxy is an external service currently used to stream data in 
+Custom URL to a self-hosted DataProxy instance. The DataProxy is an external service currently used to stream data in
 JSON format to the Recline-based views when data is not on the DataStore. The main instance is deprecated and will
 be eventually shut down, so users that require it can host an instance themselves and use this configuration option
 to point Recline to it.
@@ -2086,6 +2086,21 @@ Default value: ``None``
 
 The email address that emails sent by CKAN will come from. Note that, if left blank, the
 SMTP server may insert its own.
+
+.. _smtp.reply_to:
+
+smtp.reply_to
+^^^^^^^^^^^^^
+
+Example::
+
+  smtp.mail_from = noreply.example.com
+
+Default value: ``None``
+
+The email address that will be used if someone attempts to reply to a system email.
+If left blank, no ``Reply-to`` will be added to the email and the value of
+``smtp.mail_from`` will be used.
 
 .. _email_to:
 

--- a/doc/maintaining/email-notifications.rst
+++ b/doc/maintaining/email-notifications.rst
@@ -66,6 +66,11 @@ notifications for a CKAN site, a sysadmin must:
 
     From: PublicData.eu <mailmain@publicdata.eu>
 
+   If you would like to use an alternate reply address, such as a "no-reply"
+   address, set :ref:`smtp.reply_to` in the ``[app:main]``
+   section of your CKAN configuration file. For example::
+
+    smtp.reply_to = noreply@example.com
 
 5. If you do not have an SMTP server running locally on the machine that hosts
    your CKAN instance, you can change the :ref:`email-settings` to send email via an


### PR DESCRIPTION
Fixes #4673

### Proposed fixes:

Add ability to set a 'Reply-to' value for out going system emails/notifications.

Update to the creation of the CKAN configuration file, `deployment.ini_tmpl`, which adds the option `smtp.reply_to`. By default it's empty and commented out like `smtp.mail_from`.

The value is used in `mailer.py`'s `_mail_recipient` function to set a `Reply-to`, if there is a non-blank value. Otherwise, no `Reply-to` is added and everything functions as it has been.

### Features:

- [X] includes tests covering changes
- [X] includes updated documentation


