### PR TITLE
Upgrading to debian buster in order to use apt-get with the latest lo…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # See CKAN docs on installation from Docker Compose on usage
-FROM debian:stretch
+FROM debian:buster
 MAINTAINER Open Knowledge
 
 # Install required system packages


### PR DESCRIPTION
…ng term support release with latest version of python so it has security fixes.

Fixes #

### Proposed fixes:
Doing security scans there are a lot of vulnerabilities on the python version used.  Since our deployment is on AWS ECS, this is one of the major items that need fixing.  We have fixed it on our own fork, but submitting to upstream as well in case it is being used elsewhere as well.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
