### PR TITLE
Fix wrong _ function reference in user blueprint

### DIFF
--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -78,7 +78,7 @@ def before_request():
         context = dict(model=model, user=g.user, auth_user_obj=g.userobj)
         logic.check_access(u'site_read', context)
     except logic.NotAuthorized:
-        _, action = plugins.toolkit.get_endpoint()
+        blueprint, action = plugins.toolkit.get_endpoint()
         if action not in (
                 u'login',
                 u'request_reset',


### PR DESCRIPTION
This was causing an exception as it override the reference to the i18n `_` function below

```
  File "/srv/app/src/ckan/ckan/views/user.py", line 87, in before_request
    base.abort(403, _(u'Not authorized to see this page'))
TypeError: 'unicode' object is not callable
```
