### PR TITLE
fix xss in extra keys

### DIFF
--- a/ckan/templates/package/snippets/additional_info.html
+++ b/ckan/templates/package/snippets/additional_info.html
@@ -79,7 +79,7 @@
         {% for extra in h.sorted_extras(pkg_dict.extras) %}
           {% set key, value = extra %}
           <tr rel="dc:relation" resource="_:extra{{ i }}">
-            <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key) }}</th>
+            <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key|e) }}</th>
             <td class="dataset-details" property="rdf:value">{{ value }}</td>
           </tr>
         {% endfor %}

--- a/ckan/templates/snippets/additional_info.html
+++ b/ckan/templates/snippets/additional_info.html
@@ -16,7 +16,7 @@ extras is a list of tuples of the form (key, value)
       {% for extra in extras %}
         {% set key, value = extra %}
         <tr rel="dc:relation" resource="_:extra{{ i }}">
-          <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key) }}</th>
+          <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key|e) }}</th>
           <td class="dataset-details" property="rdf:value">{{ value }}</td>
         </tr>
       {% endfor %}


### PR DESCRIPTION
Fixes #
xss vulnerability in extra key field

![image](https://user-images.githubusercontent.com/7775824/68125589-42d3f180-ff55-11e9-891f-cb88e18a6c26.png)

![image](https://user-images.githubusercontent.com/7775824/68125485-17510700-ff55-11e9-92e1-447fdf763281.png)

### Proposed fixes:
html escape variables


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
