### PR TITLE
small ui fixes

### DIFF
--- a/ckan/templates/user/edit_user_form.html
+++ b/ckan/templates/user/edit_user_form.html
@@ -27,7 +27,7 @@
     {{ form.input('old_password',
                   type='password',
                   label=_('Sysadmin Password') if is_sysadmin else _('Old Password'),
-                  id='field-password',
+                  id='field-password-old',
                   value=data.oldpassword,
                   error=errors.oldpassword,
                   classes=['control-medium'],

--- a/ckan/templates/user/read_base.html
+++ b/ckan/templates/user/read_base.html
@@ -79,7 +79,7 @@
         </dl>
         {% if is_myself %}
           <dl>
-            <dt>{{ _('Email') }} <span class="label" title="{{ _('This means only you can see this') }}">{{ _('Private') }}</span></dt>
+            <dt>{{ _('Email') }} <span class="label label-default" title="{{ _('This means only you can see this') }}">{{ _('Private') }}</span></dt>
             <dd>{{ user.email }}</dd>
           </dl>
         {% endif %}


### PR DESCRIPTION
Fixes #
private label does not appear on the user page.
element id is duplicated in the edit_user_form page.

### Proposed fixes:
add default label class
changes the element ID value.



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
