### PR TITLE
[ckan#5017] Fix facet search bug

### DIFF
--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -322,7 +322,7 @@ def _read(id, limit, group_type):
                     and len(value) and not param.startswith(u'_'):
                 if not param.startswith(u'ext_'):
                     fields.append((param, value))
-                    q += u' %s: "%s"' % (param, value)
+                    fq += u' %s: "%s"' % (param, value)
                     if param not in fields_grouped:
                         fields_grouped[param] = [value]
                     else:


### PR DESCRIPTION
Currently, when we enter the search term into the text field
and faceting upon a filter field, it's returns no results
After this change, results return accordingly to the expected amount

It's just a small fix, that allow us to add facet criteria on click to the fq rather than to q
CKAN back-end tests were passed

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
