### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are offered for the **3 most recent** minor CKAN releases. They are included in patch releases, but not acknowledged in the release announcement or [CHANGELOG.rst](CHANGELOG.rst), hence the advice to always run the latest patch releases.
+
+For more about CKAN releases see: https://docs.ckan.org/en/2.8/maintaining/upgrading/#ckan-releases
+
+## Reporting a Vulnerability
+
+If you find a potential security vulnerability please email security@ckan.org, rather than creating a public issue on GitHub.


### PR DESCRIPTION
Having this file means that GitHub will show it as the official policy in the security tab, and it shows a link to it when people create issues. Every little helps...

<img width="500" alt="Screen Shot 2019-11-07 at 21 21 31" src="https://user-images.githubusercontent.com/307612/68428782-bfa8da80-01a4-11ea-9126-19c3b17a425a.png">

More:
https://help.github.com/en/github/managing-security-vulnerabilities/adding-a-security-policy-to-your-repository

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
