### PR TITLE
fix server error in new_member page

### DIFF
--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -1122,6 +1122,7 @@ class MembersGroupView(MethodView):
             base.abort(404, _(u'Group not found'))
         except ValidationError as e:
             h.flash_error(e.error_summary)
+            return h.redirect_to(u'{}.member_new'.format(group_type), id=id)
 
         # TODO: Remove
         g.group_dict = group_dict


### PR DESCRIPTION
Fixes #
internal server error occurs when trying to add a non-exist user on group(organization)_member_new page
`
  File "/usr/lib/ckan/venv/src/ckan/ckan/views/group.py", line 1127, in post
    g.group_dict = group_dict
UnboundLocalError: local variable 'group_dict' referenced before assignment
`

### Proposed fixes:
Fix to redirect to current page with error message.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
