### PR TITLE
Replace usage of map unsupported on Python 3

### DIFF
--- a/ckanext/example_idatastorebackend/example_sqlite.py
+++ b/ckanext/example_idatastorebackend/example_sqlite.py
@@ -113,8 +113,8 @@ class DatastoreExampleSqliteBackend(DatastoreBackend):
         return False, alias
 
     def get_all_ids(self):
-        return map(lambda t: t.name, self._get_engine().execute(
+        return [t.name for t in self._get_engine().execute(
             u'''
             select name from sqlite_master
             where type = "table"'''
-        ).fetchall())
+        ).fetchall()]

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,9 @@ from ckan import (__version__, __description__, __long_description__,
 #
 
 def parse_version(s):
-    return map(int, s.split('.'))
+    return [int(part) for part in s.split('.')]
+
+
 
 HERE = os.path.dirname(__file__)
 with open(os.path.join(HERE, 'requirement-setuptools.txt')) as f:


### PR DESCRIPTION
In Python 3, `map` returns a map object not a list. Replaced the occurrences I could find with list comprehensions.
