### PR TITLE
fix code injection in autocomplete module

### DIFF
--- a/ckan/public/base/javascript/modules/autocomplete.js
+++ b/ckan/public/base/javascript/modules/autocomplete.js
@@ -186,15 +186,20 @@ this.ckan.module('autocomplete', function (jQuery) {
      *
      * Returns a text string.
      */
-    formatResult: function (state, container, query) {
-      var term = this._lastTerm || null; // same as query.term
+    formatResult: function (state, container, query, escapeMarkup) {
+      var term = this._lastTerm || (query ? query.term : null) || null; // same as query.term
 
       if (container) {
         // Append the select id to the element for styling.
         container.attr('data-value', state.id);
       }
 
-      return state.text.split(term).join(term && term.bold());
+      var result = [];
+      $(state.text.split(term)).each(function() {
+        result.push(escapeMarkup ? escapeMarkup(this) : this);
+      });
+
+      return result.join(term && (escapeMarkup ? escapeMarkup(term) : term).bold());
     },
 
     /* Formatter for the select2 plugin that returns a string used when


### PR DESCRIPTION
Fixes #
Prevent code injection into autocomplete module
e.g.)
- make group with name "<script>alert('injection')</script>
- change the group of dataset.
- injection code is performed by pressing the autocomplete input element

### Proposed fixes:
Check markup in select2 library before rendering


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
