### PR TITLE
'map' usage made python3 compatible

### DIFF
--- a/ckan/controllers/api.py
+++ b/ckan/controllers/api.py
@@ -19,6 +19,7 @@ import ckan.lib.munge as munge
 from ckan.views import identify_user
 
 from ckan.common import _, c, request, response
+from six.moves import map
 
 
 log = logging.getLogger(__name__)
@@ -287,7 +288,7 @@ class ApiController(base.BaseController):
             return out
 
         query = query.limit(limit)
-        out = map(convert_to_dict, query.all())
+        out = list(map(convert_to_dict, query.all()))
         return out
 
     @jsonp.jsonpify

--- a/ckan/include/rjsmin.py
+++ b/ckan/include/rjsmin.py
@@ -62,6 +62,7 @@ __version__ = '1.0.3'
 __all__ = ['jsmin']
 
 import re as _re
+from six.moves import map
 
 
 def _make_jsmin(python_only=False):

--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -6,6 +6,7 @@ import logging
 
 from sqlalchemy.orm import class_mapper
 from six import string_types
+from six.moves import map
 
 import ckan.lib.dictization as d
 import ckan.lib.helpers as h
@@ -419,7 +420,7 @@ def group_dict_save(group_dict, context, prevent_packages_update=False):
     package_ids.extend( pkgs_edited['added'] )
     if package_ids:
         session.commit()
-        map( rebuild, package_ids )
+        list(map(rebuild, package_ids))
 
     return group
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -37,6 +37,7 @@ from six import string_types, text_type
 from six.moves.urllib.parse import (
     urlencode, quote, unquote, urlparse, urlunparse
 )
+from six.moves import map
 import jinja2
 
 import ckan.exceptions
@@ -186,8 +187,7 @@ def redirect_to(*args, **kw):
         kw['__no_cache__'] = True
 
     # Routes router doesn't like unicode args
-    uargs = map(lambda arg: str(arg) if isinstance(arg, text_type) else arg,
-                args)
+    uargs = [str(arg) if isinstance(arg, text_type) else arg for arg in args]
 
     _url = ''
     skip_url_parsing = False
@@ -1512,7 +1512,7 @@ def date_str_to_datetime(date_str):
         microseconds = int(m.groupdict(0).get('microseconds'))
         time_tuple = time_tuple[:5] + [seconds, microseconds]
 
-    return datetime.datetime(*map(int, time_tuple))
+    return datetime.datetime(*list(map(int, time_tuple)))
 
 
 @core_helper

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -14,6 +14,7 @@ import pysolr
 from ckan.common import config
 from ckan.common import asbool
 from six import text_type
+from six.moves import map
 
 from common import SearchIndexError, make_connection
 from ckan.model import PackageRelationship

--- a/ckan/model/license.py
+++ b/ckan/model/license.py
@@ -8,6 +8,7 @@ import requests
 from ckan.common import config
 from ckan.common import asbool
 from six import text_type, string_types
+from six.moves import map
 
 from ckan.common import _, json
 import ckan.lib.maintain as maintain
@@ -33,7 +34,8 @@ class License(object):
         for (key, value) in self._data.items():
             if key == 'date_created':
                 # Parse ISO formatted datetime.
-                value = datetime.datetime(*map(int, re.split('[^\d]', value)))
+                value = datetime.datetime(
+                    *list(map(int, re.split('[^\d]', value))))
                 self._data[key] = value
             elif isinstance(value, str):
                 # Convert str to unicode (keeps Pylons and SQLAlchemy happy).

--- a/ckan/tests/legacy/functional/test_package.py
+++ b/ckan/tests/legacy/functional/test_package.py
@@ -127,7 +127,7 @@ class TestPackageForm(TestPackageBase):
         self.check_tag_and_data(main_res, prefix+'notes', params['notes'])
         self.check_tag_and_data(main_res, 'selected', params['license_id'])
         if isinstance(params['tags'], (str, unicode)):
-            tags = map(lambda s: s.strip(), params['tags'].split(','))
+            tags = [s.strip() for s in params['tags'].split(',')]
         else:
             tags = params['tags']
         for tag in tags:

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -820,7 +820,7 @@ def create_indexes(context, data_dict):
             name=_generate_index_name(data_dict['resource_id'], fields_string),
             fields=fields_string))
 
-    sql_index_strings = map(lambda x: x.replace('%', '%%'), sql_index_strings)
+    sql_index_strings = [x.replace('%', '%%') for x in sql_index_strings]
     current_indexes = _get_index_names(context['connection'],
                                        data_dict['resource_id'])
     for sql_index_string in sql_index_strings:

--- a/ckanext/example_idatastorebackend/example_sqlite.py
+++ b/ckanext/example_idatastorebackend/example_sqlite.py
@@ -2,6 +2,7 @@
 
 import logging
 from sqlalchemy import create_engine
+from six.moves import map
 
 from ckanext.datastore.backend import DatastoreBackend
 
@@ -40,7 +41,7 @@ class DatastoreExampleSqliteBackend(DatastoreBackend):
 
     def create(self, context, data_dict):
         columns = str(u', '.join(
-            map(lambda e: e['id'] + u' text', data_dict['fields'])))
+            [e['id'] + u' text' for e in data_dict['fields']]))
         engine = self._get_engine()
         engine.execute(
             u' CREATE TABLE IF NOT EXISTS "{name}"({columns});'.format(
@@ -67,7 +68,7 @@ class DatastoreExampleSqliteBackend(DatastoreBackend):
             data_dict.get(u'limit', 10)
         ))
 
-        data_dict['records'] = map(dict, result.fetchall())
+        data_dict['records'] = list(map(dict, result.fetchall()))
         data_dict['total'] = len(data_dict['records'])
 
         fields_info = []


### PR DESCRIPTION
Used automated tool:

    python-modernize --fix=map .

As suggested: https://github.com/ckan/ckan/pull/5062#issuecomment-551903816
And did a little manual tidying.

#### flake8-comprehensions
I also tried the [flake8-comprehensions](https://pypi.org/project/flake8-comprehensions/) linting @cclauss suggested. I guess rule C400 "Unnecessary generator - rewrite as a list comprehension" is most relevant because it's to do with generators, however there were no violations in ckan code.

Also of interest are C401 "Unnecessary generator - rewrite as a set comprehension" and C402 "Unnecessary generator - rewrite as a dict comprehension", however set & dict comprehensions are not compatible with python 2, so they will have to wait.

I'll cover the others flake8-comprehensions in another PR because they seem less related - see https://github.com/ckan/ckan/pull/5066

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
