### PR TITLE
Flake8 comprehensions

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -129,9 +129,9 @@ def make_flask_stack(conf, **app_conf):
             session.save()
 
     namespace = 'beaker.session.'
-    session_opts = dict([(k.replace('beaker.', ''), v)
-                        for k, v in config.iteritems()
-                        if k.startswith(namespace)])
+    session_opts = {k.replace('beaker.', ''): v
+                    for k, v in config.iteritems()
+                    if k.startswith(namespace)}
     if (not session_opts.get('session.data_dir') and
             session_opts.get('session.type', 'file') == 'file'):
         cache_dir = app_conf.get('cache_dir') or app_conf.get('cache.dir')

--- a/ckan/lib/changes.py
+++ b/ckan/lib/changes.py
@@ -337,8 +337,8 @@ def check_metadata_changes(change_list, old, new):
         _notes_change(change_list, old, new)
 
     # make sets out of the tags for each dataset
-    old_tags = set([tag['name'] for tag in old['tags']])
-    new_tags = set([tag['name'] for tag in new['tags']])
+    old_tags = {tag['name'] for tag in old['tags']}
+    new_tags = {tag['name'] for tag in new['tags']}
     # if the tags have changed
     if old_tags != new_tags:
         _tag_change(change_list, new_tags, old_tags, new)

--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -2272,8 +2272,8 @@ Not used when using the `-d` option.''')
                         view_types=loaded_view_plugins)
 
                     if views:
-                        view_types = list(set([view['view_type']
-                                               for view in views]))
+                        view_types = list({view['view_type']
+                                           for view in views})
                         msg = ('Added {0} view(s) of type(s) {1} to ' +
                                'resources from dataset {2}')
                         log.debug(msg.format(len(views),

--- a/ckan/lib/config_tool.py
+++ b/ckan/lib/config_tool.py
@@ -89,8 +89,8 @@ class Option(object):
 
 
 def calculate_new_sections(existing_options, desired_options):
-    existing_sections = set([option.section for option in existing_options])
-    desired_sections = set([option.section for option in desired_options])
+    existing_sections = {option.section for option in existing_options}
+    desired_sections = {option.section for option in desired_options}
     new_sections = desired_sections - existing_sections
     return new_sections
 

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -539,9 +539,11 @@ def group_to_api(group, context):
     dictized["extras"] = dict((extra["key"], extra["value"])
                               for extra in dictized["extras"])
     if api_version == 1:
-        dictized["packages"] = sorted([pkg["name"] for pkg in dictized["packages"]])
+        dictized["packages"] = sorted(pkg["name"]
+                                      for pkg in dictized["packages"])
     else:
-        dictized["packages"] = sorted([pkg["id"] for pkg in dictized["packages"]])
+        dictized["packages"] = sorted(pkg["id"]
+                                      for pkg in dictized["packages"])
     return dictized
 
 def tag_to_api(tag, context):
@@ -549,9 +551,9 @@ def tag_to_api(tag, context):
     assert api_version, 'No api_version supplied in context'
     dictized = tag_dictize(tag, context)
     if api_version == 1:
-        return sorted([package["name"] for package in dictized["packages"]])
+        return sorted(package["name"] for package in dictized["packages"])
     else:
-        return sorted([package["id"] for package in dictized["packages"]])
+        return sorted(package["id"] for package in dictized["packages"])
 
 
 def resource_dict_to_api(res_dict, package_id, context):

--- a/ckan/lib/navl/dictization_functions.py
+++ b/ckan/lib/navl/dictization_functions.py
@@ -124,7 +124,7 @@ def get_all_key_combinations(data, flattened_schema):
     match the schema ignoring the last value in the tuple.
 
     '''
-    schema_prefixes = set([key[:-1] for key in flattened_schema])
+    schema_prefixes = {key[:-1] for key in flattened_schema}
     combinations = set([()])
 
     for key in sorted(data.keys(), key=flattened_order_key):

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -220,7 +220,7 @@ def check():
     log.debug("Checking packages search index...")
     pkgs_q = model.Session.query(model.Package).filter_by(
         state=model.State.ACTIVE)
-    pkgs = set([pkg.id for pkg in pkgs_q])
+    pkgs = {pkg.id for pkg in pkgs_q}
     indexed_pkgs = set(package_query.get_all_entity_ids(max_results=len(pkgs)))
     pkgs_not_indexed = pkgs - indexed_pkgs
     print('Packages not indexed = %i out of %i' % (len(pkgs_not_indexed),

--- a/ckan/tests/helpers.py
+++ b/ckan/tests/helpers.py
@@ -457,7 +457,7 @@ def mock_auth(auth_function_path):
             try:
                 with mock.patch(auth_function_path) as mocked_auth:
                     clear_auth_functions_cache()
-                    new_args = args + tuple([mocked_auth])
+                    new_args = args + (mocked_auth,)
                     return_value = func(*new_args, **kwargs)
             finally:
                 clear_auth_functions_cache()
@@ -513,7 +513,7 @@ def mock_action(action_name):
                     mock_get_action.side_effect = side_effect
                     mock_get_action_toolkit.side_effect = side_effect
 
-                    new_args = args + tuple([mock_action])
+                    new_args = args + (mock_action,)
                     return_value = func(*new_args, **kwargs)
             finally:
                 # Make sure to stop the mock, even with an exception

--- a/ckan/tests/legacy/functional/api/model/test_group.py
+++ b/ckan/tests/legacy/functional/api/model/test_group.py
@@ -63,8 +63,8 @@ class GroupsTestCase(BaseModelApiTestCase):
         group = self.loads(res.body)
         expected_group = copy.deepcopy(self.testgroupvalues)
         expected_group['packages'] = \
-               sorted([self.ref_package(self.get_package_by_name(pkg_name)) \
-                for pkg_name in expected_group['packages']])
+               sorted(self.ref_package(self.get_package_by_name(pkg_name))
+                      for pkg_name in expected_group['packages'])
         for expected_key, expected_value in expected_group.items():
             assert_equal(group.get(expected_key), expected_value)
 

--- a/ckan/tests/legacy/functional/api/model/test_vocabulary.py
+++ b/ckan/tests/legacy/functional/api/model/test_vocabulary.py
@@ -129,8 +129,8 @@ class TestVocabulary(object):
             assert updated_vocab['name'] == original_vocab['name']
         # tags should change only if given in params.
         if 'tags' in params:
-            assert sorted([tag['name'] for tag in params['tags']]) \
-                    == sorted([tag['name'] for tag in updated_vocab['tags']])
+            assert sorted(tag['name'] for tag in params['tags']) \
+                == sorted(tag['name'] for tag in updated_vocab['tags'])
         else:
             assert updated_vocab['tags'] == original_vocab['tags']
 
@@ -905,7 +905,7 @@ class TestVocabulary(object):
         assert tag['name'] not in tags_after
         difference = [tag_name for tag_name in tags_before if tag_name not in
                 tags_after]
-        assert sorted(difference) == sorted([tag['name'] for tag in tags])
+        assert sorted(difference) == sorted(tag['name'] for tag in tags)
 
         # Test that the tags no longer appear in the list of tags for the
         # package.

--- a/ckan/tests/legacy/lib/test_resource_search.py
+++ b/ckan/tests/legacy/lib/test_resource_search.py
@@ -59,7 +59,7 @@ class TestSearch(object):
     def res_search(self, query='', fields={}, terms=[], options=search.QueryOptions()):
         result = search.query_for(model.Resource).run(query=query, fields=fields, terms=terms, options=options)
         resources = [model.Session.query(model.Resource).get(resource_id) for resource_id in result['results']]
-        urls = set([resource.url for resource in resources])
+        urls = {resource.url for resource in resources}
         return urls
 
     def test_01_search_url(self):
@@ -67,7 +67,7 @@ class TestSearch(object):
         result = search.query_for(model.Resource).run(fields=fields)
         assert result['count'] == 6, result
         resources = [model.Session.query(model.Resource).get(resource_id) for resource_id in result['results']]
-        urls = set([resource.url for resource in resources])
+        urls = {resource.url for resource in resources}
         assert set([self.ab, self.cd, self.ef]) == urls, urls
 
     def test_02_search_url_2(self):

--- a/ckan/tests/legacy/lib/test_resource_search.py
+++ b/ckan/tests/legacy/lib/test_resource_search.py
@@ -75,7 +75,7 @@ class TestSearch(object):
         assert set([self.ab]) == urls, urls
 
     def test_03_search_url_multiple_words(self):
-        fields = dict([['url', 'e f']])
+        fields = {'url': 'e f'}
         urls = self.res_search(fields=fields)
         assert_set_equal({self.ef}, urls)
 

--- a/ckan/tests/legacy/lib/test_solr_search_index.py
+++ b/ckan/tests/legacy/lib/test_solr_search_index.py
@@ -53,6 +53,6 @@ class TestSolrSearch:
 
     def test_1_basic(self):
         results = self.solr.search(q='sweden', fq=self.fq)
-        result_names = sorted([r['name'] for r in results])
+        result_names = sorted(r['name'] for r in results)
 
         assert_equal([u'se-opengov', u'se-publications'], result_names)

--- a/ckan/tests/legacy/logic/test_action.py
+++ b/ckan/tests/legacy/logic/test_action.py
@@ -615,7 +615,7 @@ class TestAction(WsgiAppCase):
             {'id': group_id}
         )
         assert len(group_packages) == 2, group_packages
-        group_names = set([g.get('name') for g in group_packages])
+        group_names = {g.get('name') for g in group_packages}
         assert group_names == set(['annakarenina', 'warandpeace']), group_names
 
 

--- a/ckan/tests/legacy/models/test_group.py
+++ b/ckan/tests/legacy/models/test_group.py
@@ -88,11 +88,11 @@ class TestGroup(object):
 
     def _search_results(self, query, is_org=False):
         results = model.Group.search_by_name_or_title(query,is_org=is_org)
-        return set([group.name for group in results])
+        return {group.name for group in results}
 
-name_set_from_dicts = lambda groups: set([group['name'] for group in groups])
-name_set_from_group_tuple = lambda tuples: set([t[1] for t in tuples])
-name_set_from_groups = lambda groups: set([group.name for group in groups])
+name_set_from_dicts = lambda groups: {group['name'] for group in groups}
+name_set_from_group_tuple = lambda tuples: {t[1] for t in tuples}
+name_set_from_groups = lambda groups: {group.name for group in groups}
 names_from_groups = lambda groups: [group.name for group in groups]
 
 group_type = 'organization'

--- a/ckan/tests/legacy/test_plugins.py
+++ b/ckan/tests/legacy/test_plugins.py
@@ -100,7 +100,7 @@ class TestPlugins(object):
         plugins.load_all()
 
         # synchronous_search automatically gets loaded
-        current_plugins = set([plugins.get_plugin(p) for p in ['mapper_plugin', 'routes_plugin', 'synchronous_search'] + find_system_plugins()])
+        current_plugins = {plugins.get_plugin(p) for p in ['mapper_plugin', 'routes_plugin', 'synchronous_search'] + find_system_plugins()}
         assert set(plugins.core._PLUGINS_SERVICE.values()) == current_plugins
         # cleanup
         config['ckan.plugins'] = config_plugins

--- a/ckan/tests/lib/search/test_index.py
+++ b/ckan/tests/lib/search/test_index.py
@@ -92,14 +92,14 @@ class TestSearchIndex(object):
 
         response = self.solr_client.search(q='title:Monkey', fq=self.fq)
         assert_equal(len(response), 2)
-        response_ids = sorted([x['id'] for x in response.docs])
+        response_ids = sorted(x['id'] for x in response.docs)
         assert_equal(response_ids, ['test-index', 'test-index-2'])
 
         self.package_index.delete_package(pkg_dict)
 
         response = self.solr_client.search(q='title:Monkey', fq=self.fq)
         assert_equal(len(response), 1)
-        response_ids = sorted([x['id'] for x in response.docs])
+        response_ids = sorted(x['id'] for x in response.docs)
         assert_equal(response_ids, ['test-index'])
 
     def test_index_illegal_xml_chars(self):

--- a/ckan/tests/lib/test_datapreview.py
+++ b/ckan/tests/lib/test_datapreview.py
@@ -74,7 +74,8 @@ class TestDefaultViewsConfig(object):
 
         default_views = datapreview.get_default_view_plugins()
 
-        eq_(sorted([view_plugin.info()['name'] for view_plugin in default_views]),
+        eq_(sorted(view_plugin.info()['name']
+                   for view_plugin in default_views),
             sorted(datapreview.DEFAULT_RESOURCE_VIEW_TYPES))
 
     @helpers.change_config('ckan.views.default_views', '')
@@ -89,7 +90,8 @@ class TestDefaultViewsConfig(object):
 
         default_views = datapreview.get_default_view_plugins()
 
-        eq_(sorted([view_plugin.info()['name'] for view_plugin in default_views]),
+        eq_(sorted(view_plugin.info()['name']
+                   for view_plugin in default_views),
             ['image_view'])
 
     @helpers.change_config('ckan.views.default_views', 'test_datastore_view')
@@ -97,7 +99,8 @@ class TestDefaultViewsConfig(object):
 
         default_views = datapreview.get_default_view_plugins(get_datastore_views=True)
 
-        eq_(sorted([view_plugin.info()['name'] for view_plugin in default_views]),
+        eq_(sorted(view_plugin.info()['name']
+                   for view_plugin in default_views),
             ['test_datastore_view'])
 
     @helpers.change_config('ckan.views.default_views', 'test_datastore_view')
@@ -112,7 +115,8 @@ class TestDefaultViewsConfig(object):
 
         default_views = datapreview.get_default_view_plugins()
 
-        eq_(sorted([view_plugin.info()['name'] for view_plugin in default_views]),
+        eq_(sorted(view_plugin.info()['name']
+                   for view_plugin in default_views),
             ['image_view'])
 
     @helpers.change_config('ckan.views.default_views', 'image_view test_datastore_view')
@@ -120,7 +124,8 @@ class TestDefaultViewsConfig(object):
 
         default_views = datapreview.get_default_view_plugins(get_datastore_views=True)
 
-        eq_(sorted([view_plugin.info()['name'] for view_plugin in default_views]),
+        eq_(sorted(view_plugin.info()['name']
+                   for view_plugin in default_views),
             ['test_datastore_view'])
 
 

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -976,12 +976,12 @@ class TestDatasetCreate(helpers.FunctionalTestBase):
             tags=[{'name': u'russian'}, {'name': u'tolstoy'}],
         )
 
-        tag_names = sorted([tag_dict['name']
-                            for tag_dict in dataset['tags']])
+        tag_names = sorted(tag_dict['name']
+                           for tag_dict in dataset['tags'])
         assert_equals(tag_names, ['russian', 'tolstoy'])
         dataset = helpers.call_action('package_show', id=dataset['id'])
-        tag_names = sorted([tag_dict['name']
-                            for tag_dict in dataset['tags']])
+        tag_names = sorted(tag_dict['name']
+                           for tag_dict in dataset['tags'])
         assert_equals(tag_names, ['russian', 'tolstoy'])
 
     def test_return_id_only(self):

--- a/ckan/tests/logic/action/test_delete.py
+++ b/ckan/tests/logic/action/test_delete.py
@@ -223,14 +223,14 @@ class TestGroupPurge(object):
         helpers.call_action('group_purge', id=group1['name'])
 
         # the Group and related objects are gone
-        assert_equals(sorted([g.name for g in
-                              model.Session.query(model.Group).all()]),
+        assert_equals(sorted(g.name for g in
+                             model.Session.query(model.Group).all()),
                       ['child', 'parent'])
         assert_equals(model.Session.query(model.GroupExtra).all(), [])
         # the only members left are the users for the parent and child
-        assert_equals(sorted([
+        assert_equals(sorted(
             (m.table_name, m.group.name)
-            for m in model.Session.query(model.Member).join(model.Group)]),
+            for m in model.Session.query(model.Member).join(model.Group)),
             [('user', 'child'), ('user', 'parent')])
         # the dataset is still there though
         assert_equals([p.name for p in model.Session.query(model.Package)],
@@ -313,14 +313,14 @@ class TestOrganizationPurge(object):
         helpers.call_action('organization_purge', id=org1['name'])
 
         # the Organization and related objects are gone
-        assert_equals(sorted([o.name for o in
-                              model.Session.query(model.Group).all()]),
+        assert_equals(sorted(o.name for o in
+                             model.Session.query(model.Group).all()),
                       ['child', 'parent'])
         assert_equals(model.Session.query(model.GroupExtra).all(), [])
         # the only members left are the users for the parent and child
-        assert_equals(sorted([
+        assert_equals(sorted(
             (m.table_name, m.group.name)
-            for m in model.Session.query(model.Member).join(model.Group)]),
+            for m in model.Session.query(model.Member).join(model.Group)),
             [('user', 'child'), ('user', 'parent')])
         # the dataset is still there though
         assert_equals([p.name for p in model.Session.query(model.Package)],
@@ -416,8 +416,8 @@ class TestDatasetPurge(object):
         # the only member left is for the user created in factories.Group() and
         # factories.Organization()
         assert_equals(sorted(
-            [(m.table_name, m.group.name)
-             for m in model.Session.query(model.Member).join(model.Group)]),
+            (m.table_name, m.group.name)
+            for m in model.Session.query(model.Member).join(model.Group)),
             [('user', 'group1'), ('user', org['name'])])
 
     def test_purged_dataset_removed_from_relationships(self):

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -956,7 +956,7 @@ class TestUserShow(helpers.FunctionalTestBase):
                                        id=user['id'])
 
         eq(len(got_user['datasets']), 3)
-        datasets_got = set([user_['name'] for user_ in got_user['datasets']])
+        datasets_got = {user_['name'] for user_ in got_user['datasets']}
         assert dataset_deleted['name'] not in datasets_got
         eq(got_user['number_created_packages'], 3)
 
@@ -977,7 +977,7 @@ class TestUserShow(helpers.FunctionalTestBase):
                                        id=user['id'])
 
         eq(len(got_user['datasets']), 3)
-        datasets_got = set([user_['name'] for user_ in got_user['datasets']])
+        datasets_got = {user_['name'] for user_ in got_user['datasets']}
         assert dataset_deleted['name'] not in datasets_got
         eq(got_user['number_created_packages'], 3)
 

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -203,7 +203,7 @@ class TestGroupList(helpers.FunctionalTestBase):
         group_list = helpers.call_action('group_list')
 
         assert (sorted(group_list) ==
-                sorted([g['name'] for g in [group1, group2]]))
+                sorted(g['name'] for g in [group1, group2]))
 
     def test_group_list_in_presence_of_organizations(self):
         '''
@@ -218,7 +218,7 @@ class TestGroupList(helpers.FunctionalTestBase):
         group_list = helpers.call_action('group_list')
 
         assert (sorted(group_list) ==
-                sorted([g['name'] for g in [group1, group2]]))
+                sorted(g['name'] for g in [group1, group2]))
 
     def test_group_list_in_presence_of_custom_group_types(self):
         '''Getting the group_list shouldn't return custom group types.'''
@@ -229,7 +229,7 @@ class TestGroupList(helpers.FunctionalTestBase):
         group_list = helpers.call_action('group_list')
 
         assert (sorted(group_list) ==
-                sorted([g['name'] for g in [group1, group2]]))
+                sorted(g['name'] for g in [group1, group2]))
 
     def test_group_list_return_custom_group(self):
         '''
@@ -244,7 +244,7 @@ class TestGroupList(helpers.FunctionalTestBase):
         group_list = helpers.call_action('group_list', type='custom')
 
         assert (sorted(group_list) ==
-                sorted([g['name'] for g in [group1, group2]]))
+                sorted(g['name'] for g in [group1, group2]))
 
     def test_group_list_sort_by_package_count(self):
 
@@ -575,7 +575,7 @@ class TestOrganizationList(helpers.FunctionalTestBase):
         org_list = helpers.call_action('organization_list')
 
         assert (sorted(org_list) ==
-                sorted([g['name'] for g in [org1, org2]]))
+                sorted(g['name'] for g in [org1, org2]))
 
     def test_organization_list_in_presence_of_groups(self):
         '''
@@ -590,7 +590,7 @@ class TestOrganizationList(helpers.FunctionalTestBase):
         org_list = helpers.call_action('organization_list')
 
         assert (sorted(org_list) ==
-                sorted([g['name'] for g in [org1, org2]]))
+                sorted(g['name'] for g in [org1, org2]))
 
     def test_organization_list_in_presence_of_custom_group_types(self):
         '''
@@ -605,7 +605,7 @@ class TestOrganizationList(helpers.FunctionalTestBase):
         org_list = helpers.call_action('organization_list')
 
         assert (sorted(org_list) ==
-                sorted([g['name'] for g in [org1, org2]]))
+                sorted(g['name'] for g in [org1, org2]))
 
     def test_organization_list_return_custom_organization_type(self):
         '''
@@ -620,7 +620,7 @@ class TestOrganizationList(helpers.FunctionalTestBase):
         org_list = helpers.call_action('organization_list', type='custom_org')
 
         assert (sorted(org_list) ==
-                sorted([g['name'] for g in [org2]])), '{}'.format(org_list)
+                sorted(g['name'] for g in [org2])), '{}'.format(org_list)
 
     def _create_bulk_orgs(self, name, count):
         from ckan import model
@@ -1937,12 +1937,14 @@ class TestOrganizationListForUser(helpers.FunctionalTestBase):
         org_list_for_user1 = helpers.call_action('organization_list_for_user',
                                                  id=user1['id'])
 
-        assert sorted([org['id'] for org in org_list_for_user1]) == sorted([org1['id'], org2['id'], org3['id']])
+        assert sorted(org['id'] for org in org_list_for_user1) == \
+            sorted([org1['id'], org2['id'], org3['id']])
 
         org_list_for_user2 = helpers.call_action('organization_list_for_user',
                                                  id=user2['id'])
 
-        assert sorted([org['id'] for org in org_list_for_user2]) == sorted([org1['id'], org2['id']])
+        assert sorted(org['id'] for org in org_list_for_user2) == \
+            sorted([org1['id'], org2['id']])
 
         org_list_for_user3 = helpers.call_action('organization_list_for_user',
                                                  id=user3['id'])
@@ -2313,7 +2315,7 @@ class TestFollow(helpers.FunctionalTestBase):
                                             id=user['name'])
 
         eq(len(followee_list), 2)
-        eq(sorted([f['display_name'] for f in followee_list]),
+        eq(sorted(f['display_name'] for f in followee_list),
            ['Environment', 'Finance'])
 
     def test_followee_list_with_q(self):

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -644,12 +644,12 @@ class TestDatasetUpdate(helpers.FunctionalTestBase):
             tags=[{'name': u'russian'}, {'name': u'tolstoy'}],
         )
 
-        tag_names = sorted([tag_dict['name']
-                            for tag_dict in dataset_['tags']])
+        tag_names = sorted(tag_dict['name']
+                           for tag_dict in dataset_['tags'])
         assert_equals(tag_names, ['russian', 'tolstoy'])
         dataset_ = helpers.call_action('package_show', id=dataset['id'])
-        tag_names = sorted([tag_dict['name']
-                            for tag_dict in dataset_['tags']])
+        tag_names = sorted(tag_dict['name']
+                           for tag_dict in dataset_['tags'])
         assert_equals(tag_names, ['russian', 'tolstoy'])
 
     def test_return_id_only(self):

--- a/ckan/tests/logic/test_conversion.py
+++ b/ckan/tests/logic/test_conversion.py
@@ -63,9 +63,9 @@ class TestConvertToExtras(object):
 
         assert 'extras' in data
         eq_(len(data['extras']), 2)
-        eq_(sorted([e['key'] for e in data['extras']]),
+        eq_(sorted(e['key'] for e in data['extras']),
             ['custom_text', 'proper_extra'])
-        eq_(sorted([e['value'] for e in data['extras']]),
+        eq_(sorted(e['value'] for e in data['extras']),
             ['Bye', 'Hi'])
 
     def test_convert_to_extras_field_can_be_combined_with_more_extras(self):
@@ -92,9 +92,9 @@ class TestConvertToExtras(object):
 
         assert 'extras' in data
         eq_(len(data['extras']), 3)
-        eq_(sorted([e['key'] for e in data['extras']]),
+        eq_(sorted(e['key'] for e in data['extras']),
             ['custom_text', 'proper_extra', 'proper_extra2'])
-        eq_(sorted([e['value'] for e in data['extras']]),
+        eq_(sorted(e['value'] for e in data['extras']),
             ['Bye', 'Bye2', 'Hi'])
 
     def test_convert_to_extras_field_can_be_combined_with_extras_deleted(self):
@@ -121,9 +121,9 @@ class TestConvertToExtras(object):
 
         assert 'extras' in data
         eq_(len(data['extras']), 3)
-        eq_(sorted([e['key'] for e in data['extras']]),
+        eq_(sorted(e['key'] for e in data['extras']),
             ['custom_text', 'proper_extra', 'proper_extra2'])
-        eq_(sorted([e['value'] for e in data['extras']]),
+        eq_(sorted(e['value'] for e in data['extras']),
             ['Bye', 'Bye2', 'Hi'])
 
     def test_convert_to_extras_free_extra_can_not_have_the_same_key(self):

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -882,7 +882,7 @@ def create_table(context, data_dict):
             field['type'] = _guess_type(records[0][field['id']])
 
     # Check for duplicate fields
-    unique_fields = set([f['id'] for f in supplied_fields])
+    unique_fields = {f['id'] for f in supplied_fields}
     if not len(unique_fields) == len(supplied_fields):
         raise ValidationError({
             'field': ['Duplicate column names are not supported']

--- a/ckanext/reclineview/plugin.py
+++ b/ckanext/reclineview/plugin.py
@@ -17,8 +17,9 @@ def get_mapview_config():
     Extracts and returns map view configuration of the reclineview extension.
     '''
     namespace = 'ckanext.spatial.common_map.'
-    return dict([(k.replace(namespace, ''), v) for k, v in config.iteritems()
-                 if k.startswith(namespace)])
+    return {k.replace(namespace, ''): v
+            for k, v in config.iteritems()
+            if k.startswith(namespace)}
 
 
 def get_dataproxy_url():


### PR DESCRIPTION
I ran some extra flake8 linting, on the subject of comprehensions, prompted by @cclauss in https://github.com/ckan/ckan/pull/5062#issuecomment-551903816

These are the lint rules, as per https://pypi.org/project/flake8-comprehensions/ :

C400 | Unnecessary generator - rewrite as a list comprehension.
C401 | Unnecessary generator - rewrite as a set comprehension.
C402 | Unnecessary generator - rewrite as a dict comprehension.
C403 | Unnecessary list comprehension - rewrite as a set comprehension.
C404 | Unnecessary list comprehension - rewrite as a dict comprehension.
C405 | Unnecessary (list/tuple) literal - rewrite as a set literal.
C406 | Unnecessary (list/tuple) literal - rewrite as a dict literal.
C407 | Unnecessary list comprehension - ‘<builtin>’ can take a generator.
C408 | Unnecessary (dict/list/tuple) call - rewrite as a literal.
C409 | Unnecessary (list/tuple) passed to tuple() - (remove the outer call to tuple()/rewrite as a tuple literal).
C410 | Unnecessary (list/tuple) passed to list() - (remove the outer call to list()/rewrite as a list literal).
C411 | Unnecessary list call - remove the outer call to list().
C412 | Unnecessary list comprehension - ‘in’ can take a generator.

This is what I've done for each rule:

* C400, C401, C402 are discussed on https://github.com/ckan/ckan/pull/5065
* C403 - most fixed in this PR - left some tests where it was clearer as it is e.g.
```
./ckan/tests/legacy/lib/test_dictization.py:455:22: C403 Unnecessary list comprehension - rewrite as a set comprehension.
        assert_equal(set([tag.name for tag in pkg.get_tags()]), set(('tag1',)))
                     ^
```
* C404 - all fixed in this PR
* C405 - python2 doesn't have set literals 
* C406 - all fixed in this PR
* C407 - all fixed in this PR
* C408 - there are 63 of these and there seems marginal benefit e.g.
```
./ckan/views/user.py:78:19: C408 Unnecessary dict call - rewrite as a literal.
        context = dict(model=model, user=g.user, auth_user_obj=g.userobj)
                  ^
```
* C409 - all fixed in this PR
* C410 - no violations
* C411 - no violations
* C412 - no violations

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
