### PR TITLE
Allow vocabulary_id in /api/2/util/tag/autocomplete

### DIFF
--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -378,12 +378,15 @@ def dataset_autocomplete(ver=API_REST_DEFAULT_VERSION):
 def tag_autocomplete(ver=API_REST_DEFAULT_VERSION):
     q = request.args.get(u'incomplete', u'')
     limit = request.args.get(u'limit', 10)
+    vocab = request.args.get(u'vocabulary_id', u'')
     tag_names = []
     if q:
         context = {u'model': model, u'session': model.Session,
                    u'user': g.user, u'auth_user_obj': g.userobj}
 
         data_dict = {u'q': q, u'limit': limit}
+        if vocab != '':
+            data_dict['vocabulary_id'] = vocab
 
         tag_names = get_action(u'tag_autocomplete')(context, data_dict)
 

--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -385,8 +385,8 @@ def tag_autocomplete(ver=API_REST_DEFAULT_VERSION):
                    u'user': g.user, u'auth_user_obj': g.userobj}
 
         data_dict = {u'q': q, u'limit': limit}
-        if vocab != '':
-            data_dict['vocabulary_id'] = vocab
+        if vocab != u'':
+            data_dict[u'vocabulary_id'] = vocab
 
         tag_names = get_action(u'tag_autocomplete')(context, data_dict)
 


### PR DESCRIPTION
/api/2/util/tag/autocomplete is still used by scheming (for example) but only autocompletes from the free text tags. Add an argument vocabulary_id to allow autocompletion from the specified tag vocabulary. The user can then add their own preset to build their schema and UI using it.

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
