### PR TITLE
Fix broken Solr docs link in package_search (Action API reference)

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1545,8 +1545,8 @@ def package_search(context, data_dict):
 
     **Solr Parameters:**
 
-    For more in depth treatment of each paramter, please read the `Solr
-    Documentation <http://wiki.apache.org/solr/CommonQueryParameters>`_.
+    For more in depth treatment of each parameter, please read the `Solr
+    Documentation <https://lucene.apache.org/solr/guide/6_6/common-query-parameters.html>`_.
 
     This action accepts a *subset* of solr's search query parameters:
 


### PR DESCRIPTION
https://docs.ckan.org/en/latest/api/index.html#ckan.logic.action.get.package_search

Solr RefGuide was moved from cwiki.apache.org to lucene.apache.org but
the link in Action API reference does not reflect this change and ends
up with 'Page Not Found'

I happened to stumble upon a broken link taking to the old Solr RefGuide that doesn't exist anymore http://wiki.apache.org/solr/CommonQueryParameters

https://cwiki.apache.org/confluence/display/solr/ states the following:
>**Solr Reference Guide**
This Confluence space was earlier used for the Solr Reference Guide. If you are looking for the RefGuide, please visit https://lucene.apache.org/solr/guide/

Thus I replaced the broken link with:
https://lucene.apache.org/solr/guide/6_6/common-query-parameters.html

Financed by Finland's open data portal opendata.fi. Find all Finnish open data at https://www.opendata.fi/en.
The Service is provided by the Population Register Centre (https://vrk.fi/en/).