### PR TITLE
Add draft datasets to dataset page

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -334,6 +334,7 @@ class GroupController(base.BaseController):
                 'q': q,
                 'fq': fq,
                 'include_private': True,
+                'include_drafts': True,
                 'facet.field': facets.keys(),
                 'rows': limit,
                 'sort': sort_by,

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -282,6 +282,8 @@ class PackageController(base.BaseController):
                 'extras': search_extras,
                 'include_private': asbool(config.get(
                     'ckan.search.default_include_private', True)),
+                'include_drafts': asbool(config.get(
+                    'ckan.search_default_include_drafts', True)),
             }
 
             query = get_action('package_search')(context, data_dict)

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -283,8 +283,10 @@ def search(package_type):
             u'sort': sort_by,
             u'extras': search_extras,
             u'include_private': asbool(
-                config.get(u'ckan.search.default_include_private', True)
-            ),
+                config.get(u'ckan.search.default_include_private', True)),
+            u'include_drafts': asbool(
+                config.get(u'ckan.search.default_include_drafts', True)
+            )
         }
 
         query = get_action(u'package_search')(context, data_dict)

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -361,6 +361,7 @@ def _read(id, limit, group_type):
             u'q': q,
             u'fq': fq,
             u'include_private': True,
+            u'include_drafts': True,
             u'facet.field': facets.keys(),
             u'rows': limit,
             u'sort': sort_by,

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -744,6 +744,21 @@ Controls whether the default search page (``/dataset``) should include
 private datasets visible to the current user or only public datasets
 visible to everyone.
 
+.. _ckan.search.default_include_drafts:
+
+ckan.search.default_include_drafts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+ ckan.search.default_include_drafts = false
+
+Default value:  ``true``
+
+Controls whether the default search page (``/dataset``) should include
+draft datasets visible to the current user or only public datasets
+visible to everyone.
+
 .. _search.facets.limit:
 
 search.facets.limit


### PR DESCRIPTION
### Proposed fixes:
Currently datasets in draft state are only displayed in the user profile, this makes hard to find them if the user creating the dataset is somewhat clueless and sysadmin tries to fix the problem.

This PR adds draft datasets to dataset search and group and organization pages similarly how private datasets are handled.


### Features:

- [x] includes tests covering changes
- [x] includes updated documentation
- [x] includes user-visible changes
- [x] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply

Financed by Finland's open data portal opendata.fi. Find all Finnish open data at https://www.opendata.fi/en.
The Service is provided by the Population Register Centre (https://vrk.fi/en/).
