### PR TITLE
[docker] rebuild search index in entrypoint

### DIFF
--- a/contrib/docker/ckan-entrypoint.sh
+++ b/contrib/docker/ckan-entrypoint.sh
@@ -69,4 +69,5 @@ fi
 
 set_environment
 ckan-paster --plugin=ckan db init -c "${CKAN_CONFIG}/production.ini"
+ckan-paster --plugin=ckan search-index rebuild -c "${CKAN_CONFIG}/production.ini"
 exec "$@"


### PR DESCRIPTION
When rebuilding the docker-compose stack, solr's index isn't rebuilt, leading to a scary "0 datasets" messages.

### Proposed fixes:

Add `paster --plugin ckan search-index rebuild -c /path/to/config.ini` to the ckan's entrypoint. This will also fix 

Added benefit (not sure ?) : this will also make changes in `ckan.site_url` be applied on restart.
Drawback : this will make restarts slower, esp. for big datasets.



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
