### PR TITLE
parseCompletions handles v3 api result

### DIFF
--- a/ckan/public/base/javascript/client.js
+++ b/ckan/public/base/javascript/client.js
@@ -161,7 +161,10 @@
 
       var map = {};
       // If given a 'result' array then convert it into a Result dict inside a Result dict.
-      data = data.result ? { 'ResultSet': { 'Result': data.result.map(x => ({'Name': x})) } } : data;
+      // new syntax (not used until all browsers support arrow notation):
+      //data = data.result ? { 'ResultSet': { 'Result': data.result.map(x => ({'Name': x})) } } : data;
+      // compatible syntax:
+      data = data.result ? { 'ResultSet': { 'Result': data.result.map(function(val){ return { 'Name' :val } }) } } : data;
       // If given a Result dict inside a ResultSet dict then use the Result dict.
       var raw = jQuery.isArray(data) ? data : data.ResultSet && data.ResultSet.Result || {};
 

--- a/ckan/public/base/javascript/client.js
+++ b/ckan/public/base/javascript/client.js
@@ -160,6 +160,9 @@
       }
 
       var map = {};
+      // If given a 'result' array then convert it into a Result dict inside a Result dict.
+      data = data.result ? { 'ResultSet': { 'Result': data.result.map(x => ({'Name': x})) } } : data;
+      // If given a Result dict inside a ResultSet dict then use the Result dict.
       var raw = jQuery.isArray(data) ? data : data.ResultSet && data.ResultSet.Result || {};
 
       var items = jQuery.map(raw, function (item) {


### PR DESCRIPTION
v2 api returns a ResultSet: { Result: { Name: xxx } }
but the v3 api returns result: [ xxx ]
so map the latter to the former.

Fixes #

https://github.com/ckan/ckanext-scheming/issues/224

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
