### PR TITLE
add difflib style

### DIFF
--- a/ckan/public/base/css/fuchsia.css
+++ b/ckan/public/base/css/fuchsia.css
@@ -10760,3 +10760,25 @@ iframe {
 .reduced-padding {
   padding: 3px 5px;
 }
+table.diff {
+  font-family:Courier;
+  border:medium;
+}
+.diff_header {
+  background-color:#e0e0e0;
+}
+td.diff_header {
+  text-align:right;
+}
+.diff_next {
+  background-color:#c0c0c0;
+}
+.diff_add {
+  background-color:#aaffaa;
+}
+.diff_chg {
+  background-color:#ffff77;
+}
+.diff_sub {
+  background-color:#ffaaaa;
+}

--- a/ckan/public/base/css/green.css
+++ b/ckan/public/base/css/green.css
@@ -10760,3 +10760,25 @@ iframe {
 .reduced-padding {
   padding: 3px 5px;
 }
+table.diff {
+  font-family:Courier;
+  border:medium;
+}
+.diff_header {
+  background-color:#e0e0e0;
+}
+td.diff_header {
+  text-align:right;
+}
+.diff_next {
+  background-color:#c0c0c0;
+}
+.diff_add {
+  background-color:#aaffaa;
+}
+.diff_chg {
+  background-color:#ffff77;
+}
+.diff_sub {
+  background-color:#ffaaaa;
+}

--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -17677,3 +17677,25 @@ th.dataset-label,
 .nav-facet .nav-item a span.item-label {
   padding-right: 15px;
 }
+table.diff {
+  font-family:Courier;
+  border:medium;
+}
+.diff_header {
+  background-color:#e0e0e0;
+}
+td.diff_header {
+  text-align:right;
+}
+.diff_next {
+  background-color:#c0c0c0;
+}
+.diff_add {
+  background-color:#aaffaa;
+}
+.diff_chg {
+  background-color:#ffff77;
+}
+.diff_sub {
+  background-color:#ffaaaa;
+}

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -10767,3 +10767,25 @@ iframe {
 .reduced-padding {
   padding: 3px 5px;
 }
+table.diff {
+  font-family:Courier;
+  border:medium;
+}
+.diff_header {
+  background-color:#e0e0e0;
+}
+td.diff_header {
+  text-align:right;
+}
+.diff_next {
+  background-color:#c0c0c0;
+}
+.diff_add {
+  background-color:#aaffaa;
+}
+.diff_chg {
+  background-color:#ffff77;
+}
+.diff_sub {
+  background-color:#ffaaaa;
+}

--- a/ckan/public/base/css/maroon.css
+++ b/ckan/public/base/css/maroon.css
@@ -10760,3 +10760,25 @@ iframe {
 .reduced-padding {
   padding: 3px 5px;
 }
+table.diff {
+  font-family:Courier;
+  border:medium;
+}
+.diff_header {
+  background-color:#e0e0e0;
+}
+td.diff_header {
+  text-align:right;
+}
+.diff_next {
+  background-color:#c0c0c0;
+}
+.diff_add {
+  background-color:#aaffaa;
+}
+.diff_chg {
+  background-color:#ffff77;
+}
+.diff_sub {
+  background-color:#ffaaaa;
+}

--- a/ckan/public/base/css/red.css
+++ b/ckan/public/base/css/red.css
@@ -10760,3 +10760,25 @@ iframe {
 .reduced-padding {
   padding: 3px 5px;
 }
+table.diff {
+  font-family:Courier;
+  border:medium;
+}
+.diff_header {
+  background-color:#e0e0e0;
+}
+td.diff_header {
+  text-align:right;
+}
+.diff_next {
+  background-color:#c0c0c0;
+}
+.diff_add {
+  background-color:#aaffaa;
+}
+.diff_chg {
+  background-color:#ffff77;
+}
+.diff_sub {
+  background-color:#ffaaaa;
+}


### PR DESCRIPTION
Fixes #

### Proposed fixes:
It's hard to see the changes on the difflib view, so I apply difflib's default style.

refer to [https://github.com/python/cpython/blob/be5c79e0338005d675a64ba6e5b137e850d556d1/Lib/difflib.py#L1660](https://github.com/python/cpython/blob/be5c79e0338005d675a64ba6e5b137e850d556d1/Lib/difflib.py#L1660)

![image](https://user-images.githubusercontent.com/7775824/69254491-b898b800-0bf9-11ea-8365-2c198e8590f7.png)

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
