### PR TITLE
[#2838] Email unique validator

### DIFF
--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -384,7 +384,7 @@ def default_update_relationship_schema(
 @validator_args
 def default_user_schema(
         ignore_missing, unicode_safe, name_validator, user_name_validator,
-        user_password_validator, user_password_not_empty,
+        user_password_validator, user_password_not_empty, email_is_unique,
         ignore_not_sysadmin, not_empty, email_validator,
         user_about_validator, ignore, boolean_validator):
     return {
@@ -395,7 +395,7 @@ def default_user_schema(
         'password': [user_password_validator, user_password_not_empty,
                      ignore_missing, unicode_safe],
         'password_hash': [ignore_missing, ignore_not_sysadmin, unicode_safe],
-        'email': [not_empty, unicode_safe, email_validator],
+        'email': [not_empty, email_validator, email_is_unique, unicode_safe],
         'about': [ignore_missing, user_about_validator, unicode_safe],
         'created': [ignore],
         'sysadmin': [ignore_missing, ignore_not_sysadmin],
@@ -410,9 +410,11 @@ def default_user_schema(
 @validator_args
 def user_new_form_schema(
         unicode_safe, user_both_passwords_entered,
-        user_password_validator, user_passwords_match):
+        user_password_validator, user_passwords_match,
+        email_is_unique):
     schema = default_user_schema()
 
+    schema['email'] = [email_is_unique]
     schema['password1'] = [text_type, user_both_passwords_entered,
                            user_password_validator, user_passwords_match]
     schema['password2'] = [text_type]
@@ -423,9 +425,10 @@ def user_new_form_schema(
 @validator_args
 def user_edit_form_schema(
         ignore_missing, unicode_safe, user_both_passwords_entered,
-        user_password_validator, user_passwords_match):
+        user_password_validator, user_passwords_match, email_is_unique):
     schema = default_user_schema()
 
+    schema['email'] = [email_is_unique]
     schema['password'] = [ignore_missing]
     schema['password1'] = [ignore_missing, unicode_safe,
                            user_password_validator, user_passwords_match]
@@ -437,11 +440,14 @@ def user_edit_form_schema(
 @validator_args
 def default_update_user_schema(
         ignore_missing, name_validator, user_name_validator,
-        unicode_safe, user_password_validator):
+        unicode_safe, user_password_validator, email_is_unique,
+        not_empty, email_validator):
     schema = default_user_schema()
 
     schema['name'] = [
         ignore_missing, name_validator, user_name_validator, unicode_safe]
+    schema['email'] = [
+        not_empty, email_validator, email_is_unique, unicode_safe]
     schema['password'] = [
         user_password_validator, ignore_missing, unicode_safe]
 

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -859,6 +859,26 @@ def email_validator(value, context):
             raise Invalid(_('Email {email} is not a valid format').format(email=value))
     return value
 
+def email_is_unique(key, data, errors, context):
+    '''Validate email is unique'''
+    model = context['model']
+    session = context['session']
+
+    users = session.query(model.User) \
+            .filter(model.User.email == data[key]).all()
+    # is there is no users with this email it's free
+    if not users:
+        return
+    else:
+        # allow user to update their own email
+        for user in users:
+            if user.id == data[("id",)]:
+                return
+
+    raise Invalid(
+                _('The email address \'{email}\' \
+                    belongs to a registered user.').
+                        format(email=data[key]))
 
 def one_of(list_of_value):
     ''' Checks if the provided value is present in a list '''

--- a/ckan/tests/legacy/logic/test_action.py
+++ b/ckan/tests/legacy/logic/test_action.py
@@ -306,7 +306,7 @@ class TestAction(object):
         sysadmin_user_dict = {
             "id": self.sysadmin_user.id,
             "fullname": "Updated sysadmin user full name",
-            "email": "me@test.org",
+            "email": "sys@test.org",
             "about": "Updated sysadmin user about",
         }
 

--- a/ckan/tests/legacy/logic/test_auth.py
+++ b/ckan/tests/legacy/logic/test_auth.py
@@ -64,7 +64,7 @@ def create_user(apikeys, call_api):
         user = {
             "name": name,
             "password": "TestPassword1",
-            "email": "moo@moo.com",
+            "email": "{}@moo.com".format(name),
         }
         res = call_api("user_create", user, "sysadmin", 200)
         apikeys[name] = str(json.loads(res.body)["result"]["apikey"])

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -88,7 +88,8 @@ class TestUserInvite(object):
         rand.return_value.choice.side_effect = "TestPassword1" * 3
 
         for _ in range(3):
-            invited_user = self._invite_user_to_group(email="same@email.com")
+            invited_user = self._invite_user_to_group(
+                email="same{}@email.com".format(_))
             assert invited_user is not None, invited_user
 
     @mock.patch("ckan.lib.mailer.send_invite")

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -160,7 +160,6 @@ class TestUpdate(object):
         user = factories.User()
         user["name"] = name
         with pytest.raises(logic.ValidationError):
-
             helpers.call_action("user_update", **user)
 
     def test_user_update_to_name_that_already_exists(self):
@@ -182,7 +181,8 @@ class TestUpdate(object):
         # we're not updating it, otherwise validation fails.
         helpers.call_action(
             "user_update",
-            id=user["name"],
+            id=user["id"],
+            name=user["name"],
             email=user["email"],
             password="new password",
         )
@@ -270,7 +270,8 @@ class TestUpdate(object):
         # fails.
         helpers.call_action(
             "user_update",
-            id=user["name"],
+            id=user["id"],
+            name=user["name"],
             email=user["email"],
             password=factories.User.attributes()["password"],
             fullname="updated full name",
@@ -317,16 +318,12 @@ class TestUpdate(object):
         helpers.call_action(
             "user_update",
             context={"schema": schema},
-            id=user["name"],
+            id=user["id"],
+            name=user["name"],
             email=user["email"],
             password=factories.User.attributes()["password"],
             fullname="updated full name",
         )
-
-        # Since we passed user['name'] to user_update as the 'id' param,
-        # our mock validator method should have been called once with
-        # user['name'] as arg.
-        mock_validator.assert_called_once_with(user["name"])
 
     def test_user_update_multiple(self):
         """Test that updating multiple user attributes at once works."""

--- a/ckan/tests/logic/test_validators.py
+++ b/ckan/tests/logic/test_validators.py
@@ -164,50 +164,54 @@ def adds_message_to_errors_dict(error_message):
 
 
 @pytest.mark.usefixtures("clean_db")
-def test_email_is_unique_validator_with_existed_value():
-    user1 = factories.User(username="user01", email="user01@email.com")
+def test_email_is_unique_validator_with_existed_value(app):
+    with app.flask_app.test_request_context():
+        user1 = factories.User(username="user01", email="user01@email.com")
 
-    # try to create new user with occupied email
-    with pytest.raises(logic.ValidationError):
-        factories.User(username="new_user", email="user01@email.com")
+        # try to create new user with occupied email
+        with pytest.raises(logic.ValidationError):
+            factories.User(username="new_user", email="user01@email.com")
 
 
 @pytest.mark.usefixtures("clean_db")
-def test_email_is_unique_validator_user_update_email_unchanged():
+def test_email_is_unique_validator_user_update_email_unchanged(app):
     user = factories.User(username="user01", email="user01@email.com")
 
     # try to update user1 and leave email unchanged
     old_email = "user01@email.com"
 
-    helpers.call_action("user_update", **user)
-    updated_user = model.User.get(user["id"])
+    with app.flask_app.test_request_context():
+        helpers.call_action("user_update", **user)
+        updated_user = model.User.get(user["id"])
 
-    assert updated_user.email == old_email
+        assert updated_user.email == old_email
 
 
 @pytest.mark.usefixtures("clean_db")
-def test_email_is_unique_validator_user_update_email_new():
+def test_email_is_unique_validator_user_update_email_new(app):
     user = factories.User(username="user01", email="user01@email.com")
 
     # try to update user1 email to unoccupied one
     new_email = "user_new@email.com"
     user["email"] = new_email
 
-    helpers.call_action("user_update", **user)
-    updated_user = model.User.get(user["id"])
+    with app.flask_app.test_request_context():
+        helpers.call_action("user_update", **user)
+        updated_user = model.User.get(user["id"])
 
-    assert updated_user.email == new_email
+        assert updated_user.email == new_email
 
 
 @pytest.mark.usefixtures("clean_db")
-def test_email_is_unique_validator_user_update_to_existed_email():
+def test_email_is_unique_validator_user_update_to_existed_email(app):
     user1 = factories.User(username="user01", email="user01@email.com")
     user2 = factories.User(username="user02", email="user02@email.com")
 
     # try to update user1 email to existed one
     user1["email"] = user2["email"]
-    with pytest.raises(logic.ValidationError):
-        helpers.call_action("user_update", **user1)
+    with app.flask_app.test_request_context():
+        with pytest.raises(logic.ValidationError):
+                helpers.call_action("user_update", **user1)
 
 
 def test_name_validator_with_invalid_value():

--- a/ckan/tests/logic/test_validators.py
+++ b/ckan/tests/logic/test_validators.py
@@ -10,12 +10,15 @@ import fractions
 import mock
 import pytest
 
+from collections import namedtuple
+
 import ckan.lib.navl.dictization_functions as df
 import ckan.logic.validators as validators
 import ckan.model as model
 import ckan.tests.factories as factories
 import ckan.tests.helpers as helpers
 import ckan.tests.lib.navl.test_validators as t
+import ckan.logic as logic
 
 
 def returns_arg(function):
@@ -158,6 +161,53 @@ def adds_message_to_errors_dict(error_message):
         return call_and_assert
 
     return decorator
+
+
+@pytest.mark.usefixtures("clean_db")
+def test_email_is_unique_validator_with_existed_value():
+    user1 = factories.User(username="user01", email="user01@email.com")
+
+    # try to create new user with occupied email
+    with pytest.raises(logic.ValidationError):
+        factories.User(username="new_user", email="user01@email.com")
+
+
+@pytest.mark.usefixtures("clean_db")
+def test_email_is_unique_validator_user_update_email_unchanged():
+    user = factories.User(username="user01", email="user01@email.com")
+
+    # try to update user1 and leave email unchanged
+    old_email = "user01@email.com"
+
+    helpers.call_action("user_update", **user)
+    updated_user = model.User.get(user["id"])
+
+    assert updated_user.email == old_email
+
+
+@pytest.mark.usefixtures("clean_db")
+def test_email_is_unique_validator_user_update_email_new():
+    user = factories.User(username="user01", email="user01@email.com")
+
+    # try to update user1 email to unoccupied one
+    new_email = "user_new@email.com"
+    user["email"] = new_email
+
+    helpers.call_action("user_update", **user)
+    updated_user = model.User.get(user["id"])
+
+    assert updated_user.email == new_email
+
+
+@pytest.mark.usefixtures("clean_db")
+def test_email_is_unique_validator_user_update_to_existed_email():
+    user1 = factories.User(username="user01", email="user01@email.com")
+    user2 = factories.User(username="user02", email="user02@email.com")
+
+    # try to update user1 email to existed one
+    user1["email"] = user2["email"]
+    with pytest.raises(logic.ValidationError):
+        helpers.call_action("user_update", **user1)
 
 
 def test_name_validator_with_invalid_value():

--- a/ckan/tests/logic/test_validators.py
+++ b/ckan/tests/logic/test_validators.py
@@ -175,12 +175,12 @@ def test_email_is_unique_validator_with_existed_value(app):
 
 @pytest.mark.usefixtures("clean_db")
 def test_email_is_unique_validator_user_update_email_unchanged(app):
-    user = factories.User(username="user01", email="user01@email.com")
-
-    # try to update user1 and leave email unchanged
-    old_email = "user01@email.com"
-
     with app.flask_app.test_request_context():
+        user = factories.User(username="user01", email="user01@email.com")
+
+        # try to update user1 and leave email unchanged
+        old_email = "user01@email.com"
+
         helpers.call_action("user_update", **user)
         updated_user = model.User.get(user["id"])
 
@@ -189,13 +189,13 @@ def test_email_is_unique_validator_user_update_email_unchanged(app):
 
 @pytest.mark.usefixtures("clean_db")
 def test_email_is_unique_validator_user_update_email_new(app):
-    user = factories.User(username="user01", email="user01@email.com")
-
-    # try to update user1 email to unoccupied one
-    new_email = "user_new@email.com"
-    user["email"] = new_email
-
     with app.flask_app.test_request_context():
+        user = factories.User(username="user01", email="user01@email.com")
+
+        # try to update user1 email to unoccupied one
+        new_email = "user_new@email.com"
+        user["email"] = new_email
+
         helpers.call_action("user_update", **user)
         updated_user = model.User.get(user["id"])
 
@@ -204,14 +204,15 @@ def test_email_is_unique_validator_user_update_email_new(app):
 
 @pytest.mark.usefixtures("clean_db")
 def test_email_is_unique_validator_user_update_to_existed_email(app):
-    user1 = factories.User(username="user01", email="user01@email.com")
-    user2 = factories.User(username="user02", email="user02@email.com")
-
-    # try to update user1 email to existed one
-    user1["email"] = user2["email"]
     with app.flask_app.test_request_context():
+        user1 = factories.User(username="user01", email="user01@email.com")
+        user2 = factories.User(username="user02", email="user02@email.com")
+
+        # try to update user1 email to existed one
+        user1["email"] = user2["email"]
+
         with pytest.raises(logic.ValidationError):
-                helpers.call_action("user_update", **user1)
+            helpers.call_action("user_update", **user1)
 
 
 def test_name_validator_with_invalid_value():


### PR DESCRIPTION
At the moment, there is no validation for the uniqueness of the email, which does not allow us to use login via email. And it's also can be a vulnerability to spam attacks.

This changes implements the is_email_unique validator, which prevents from creation two or more users with the same email. Also, it's a step to provide authentication via email. Since this changes doesn't touch the models, there are shouldn't be conflicts with existing portals.


### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
