### PR TITLE
Remove alert-warning from flash div.

### DIFF
--- a/ckan/templates/page.html
+++ b/ckan/templates/page.html
@@ -24,7 +24,7 @@
             <div class="flash-messages">
               {% block flash_inner %}
                 {% for message in h.flash.pop_messages() | list %}
-                  <div class="alert alert-warning fade in {{ message.category }}">
+                  <div class="alert fade in {{ message.category }}">
                     {{ h.literal(message) }}
                   </div>
                 {% endfor %}


### PR DESCRIPTION


Fixes #

### Proposed fixes:

Remove `alert-warning` class from flash div in page.html.  This class was added a [while ago](https://github.com/ckan/ckan/commit/927cb947655831b27a3d867fa8537fcf37a22e31#diff-3a3c92fefd91654892ad323c0935035c) and overrides the passed in flash message category. It makes all flash messages in this div appear as a warning (e.g. if you call [`flash_success`](https://docs.ckan.org/en/2.8/theming/template-helper-functions.html#ckan.lib.helpers.flash_success) it will never appear as green).

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
