### PR TITLE
[#5099] Fix broken translation in image view placeholder

### DIFF
--- a/ckanext/imageview/theme/templates/image_form.html
+++ b/ckanext/imageview/theme/templates/image_form.html
@@ -1,3 +1,3 @@
 {% import 'macros/form.html' as form %}
 
-{{ form.input('image_url', id='field-image_url', label=_('Image url'), placeholder=_('eg. http://example.com/image.jpg  (if blank uses resource url)'), value=data.image_url, error=errors.image_url, classes=['control-full', 'control-large']) }}
+{{ form.input('image_url', id='field-image_url', label=_('Image url'), placeholder=_('eg. http://example.com/image.jpg (if blank uses resource url)'), value=data.image_url, error=errors.image_url, classes=['control-full', 'control-large']) }}


### PR DESCRIPTION
Fixes #5099 

### Proposed fixes:
The placeholder has an extra space which does not exist in translations: https://github.com/ckan/ckan/blob/8c40f3908369d340e57689268ba811616021cbc3/ckan/i18n/ckan.pot#L464


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
