### PR TITLE
Fix problem with logo path having duplicate 'root_path' segments

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -1190,9 +1190,7 @@ def config_option_update(context, data_dict):
         # Set full Logo url
         if key == 'ckan.site_logo' and value and not value.startswith('http')\
                 and not value.startswith('/'):
-            image_path = 'uploads/admin/'
-
-            value = h.url_for_static('{0}{1}'.format(image_path, value))
+            value = 'uploads/admin/{0}'.format(value)
 
         # Save value in database
         model.set_system_info(key, value)


### PR DESCRIPTION
### Proposed fixes:

Currently if you set 'ckan.root_path' in the .ini file and try to upload
a new logo, it will fail to load because the logo image path has two
'root_path' segments

This change prevents 'root_path' being added to the logo image path twice.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
