### PR TITLE
Examples of IClick

### DIFF
--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1791,6 +1791,19 @@ class IClick(Interface):
         Return a list of command functions objects
         to be registered by the click.add_command.
 
+        Example::
+
+            p.implements(p.IClick)
+            # IClick
+            def get_commands(self):
+                """Call me via: `ckan hello`"""
+                import click
+                @click.command()
+                def hello():
+                    click.echo('Hello, World!')
+                return [hello]
+
         :returns: command functions objects
         :rtype: list of function objects
         '''
+        return []

--- a/ckanext/example_iclick/cli.py
+++ b/ckanext/example_iclick/cli.py
@@ -3,6 +3,7 @@
 import click
 import ckan.plugins.toolkit as tk
 
+
 @click.command(u"example-iclick-hello")
 def hello_cmd():
     """Example of single command.
@@ -26,7 +27,6 @@ def bye(name):
         tk.error_shout(u"I do not know your name.")
     else:
         click.secho(u"Bye, {}".format(name))
-
 
 
 def get_commands():

--- a/ckanext/example_iclick/cli.py
+++ b/ckanext/example_iclick/cli.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+import click
+import ckan.plugins.toolkit as tk
+
+@click.command(u"example-iclick-hello")
+def hello_cmd():
+    """Example of single command.
+    """
+    click.secho(u"Hello, World!", fg=u"green")
+
+
+@click.group(u"example-iclick-bye")
+def bye_cmd():
+    """Example of group of commands.
+    """
+    pass
+
+
+@bye_cmd.command()
+@click.argument(u"name", required=False)
+def bye(name):
+    """Command with optional argument.
+    """
+    if not name:
+        tk.error_shout(u"I do not know your name.")
+    else:
+        click.secho(u"Bye, {}".format(name))
+
+
+
+def get_commands():
+    return [hello_cmd, bye_cmd]

--- a/ckanext/example_iclick/plugin.py
+++ b/ckanext/example_iclick/plugin.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+import ckan.plugins as p
+from ckanext.example_iclick.cli import get_commands
+
+
+class ExampleIClickPlugin(p.SingletonPlugin):
+    p.implements(p.IClick)
+
+    # IClick
+
+    def get_commands(self):
+        return get_commands()

--- a/setup.py
+++ b/setup.py
@@ -177,6 +177,7 @@ entry_points = {
         'example_iuploader = ckanext.example_iuploader.plugin:ExampleIUploader',
         'example_idatastorebackend = ckanext.example_idatastorebackend.plugin:ExampleIDatastoreBackendPlugin',
         'example_ipermissionlabels = ckanext.example_ipermissionlabels.plugin:ExampleIPermissionLabelsPlugin',
+        'example_iclick = ckanext.example_iclick.plugin:ExampleIClickPlugin',
     ],
     'ckan.system_plugins': [
         'domain_object_mods = ckan.model.modification:DomainObjectModificationExtension',


### PR DESCRIPTION
Improves #5108 

### Features:

- [List commands registered by extensions in `ckan -h`](https://github.com/ckan/ckan/compare/master...DataShades:ext-click-help?expand=1#diff-0e409a523668d377588e719582c66b22R48-R61)
- [Store name of command's source extension](https://github.com/ckan/ckan/compare/master...DataShades:ext-click-help?expand=1#diff-0e409a523668d377588e719582c66b22R78). This allows to group commands by related extension while rendering help message.
- [Add a tiny example to docs](https://github.com/ckan/ckan/compare/master...DataShades:ext-click-help?expand=1#diff-4a6382e3872769be8829f4e5968cb848R1794-R1805) 
- [Add `example_iclick` extension](https://github.com/ckan/ckan/compare/master...DataShades:ext-click-help?expand=1#diff-2eeaed663bd0d25b7e608891384b7298R180)

After accepting `pytest` I'm going to add some tests as well