### PR TITLE
HTML emails

### DIFF
--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -108,6 +108,10 @@ class _Toolkit(object):
         'HelperError',
         # Enqueue background job
         'enqueue_job',
+        # Email a recipient
+        'mail_recipient',
+        # Email a user
+        'mail_user',
 
         # Fully defined in this file ##
         'add_template_directory',
@@ -148,6 +152,7 @@ class _Toolkit(object):
             HelperError
         )
         from ckan.lib.jobs import enqueue as enqueue_job
+        from ckan.lib import mailer
 
         import ckan.common as converters
         if six.PY2:
@@ -269,6 +274,8 @@ For example: ``bar = toolkit.aslist(config.get('ckan.foo.bar', []))``
         t['auth_disallow_anonymous_access'] = (
             logic.auth_disallow_anonymous_access
         )
+        t['mail_recipient'] = mailer.mail_recipient
+        t['mail_user'] = mailer.mail_user
 
         # class functions
         t['render_snippet'] = self._render_snippet


### PR DESCRIPTION
Allows mailer to send HTML emails (i.e. multipart, with both a HTML and plain text fallback version). And adds emailing to the toolkit for plugins to use.

Justification: I'm currently using this in ckanext-subscribe, so I can add links without displaying the full URL. I'm sure others have asked about sending HTML in the past. HTML emails are the norm these days - so few people use text-based clients. So I think it would be a natural extension to use HTML in existing reset password and invite emails.

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
