### PR TITLE
check tracking summary data exists before attempting to load it

### DIFF
--- a/ckan/model/tracking.py
+++ b/ckan/model/tracking.py
@@ -31,8 +31,8 @@ class TrackingSummary(domain_object.DomainObject):
     def get_for_package(cls, package_id):
         obj = meta.Session.query(cls).autoflush(False)
         obj = obj.filter_by(package_id=package_id)
-        data = obj.order_by(text('tracking_date desc')).first()
-        if data:
+        if meta.Session.query(obj.exists()).scalar():
+            data = obj.order_by(text('tracking_date desc')).first()
             return {'total' : data.running_total,
                     'recent': data.recent_views}
 


### PR DESCRIPTION
Fixes #5030 (QOL-6246) by avoiding poor optimisation choices documented in https://stackoverflow.com/questions/21385555/postgresql-query-very-slow-with-limit-1

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X ] includes bugfix for possible backport

Please [X] all the boxes above that apply
