### PR TITLE
Fix link substitution in pager

### DIFF
--- a/ckan/lib/pagination.py
+++ b/ckan/lib/pagination.py
@@ -650,7 +650,7 @@ class Page(BasePage):
         # Convert ..
         dotdot = u'<span class="pager_dotdot">..</span>'
         dotdot_link = tags.li(tags.a(u"...", href=u"#"), cls=u"disabled")
-        html = re.sub(dotdot, dotdot_link, html)
+        html = re.sub(dotdot, text_type(dotdot_link), html)
 
         # Convert current page
         text = u"%s" % self.page


### PR DESCRIPTION
Convert tag generated by `dominate` to the string, when using it as a substitution in conjunction with `re` (because in this case string is required)