### PR TITLE
Fix broken layout in organization bulk_process

### DIFF
--- a/ckan/templates/organization/bulk_process.html
+++ b/ckan/templates/organization/bulk_process.html
@@ -9,7 +9,7 @@
 {% block primary_content_inner %}
   <div class="row">
     <h1 class="hide-heading">{{ _('Edit datasets') }}</h1>
-    <div class="primary col-md-8">
+    <div class="primary col-md-12">
       <h3 class="page-heading">
         {% block page_heading %}
           {%- if page.item_count -%}
@@ -21,6 +21,16 @@
           {%- endif -%}
         {% endblock %}
       </h3>
+
+      {% block search_form %}
+        {% set sorting = [
+            (_('Name Ascending'), 'title_string asc'),
+            (_('Name Descending'), 'title_string desc'),
+            (_('Last Modified'), 'data_modified desc') ]
+                %}
+        {% snippet 'snippets/search_form.html', form_id='organization-datasets-search-form', type='dataset', query=q, count=page.item_count, sorting=sorting, sorting_selected=sort_by_selected, no_title=true, search_class=' ' %}
+      {% endblock %}
+
       {% block form %}
         {% if page.item_count %}
           <form method="POST" data-module="basic-form">
@@ -89,24 +99,13 @@
         {% endif %}
       {% endblock %}
     </div>
-    <aside class="tertiary col-md-4">
-      {% block tertiary_content %}
-
-        {% block search_form %}
-          {% set sorting = [
-            (_('Name Ascending'), 'title_string asc'),
-            (_('Name Descending'), 'title_string desc'),
-            (_('Last Modified'), 'data_modified desc') ]
-          %}
-          {% snippet 'snippets/search_form.html', form_id='organization-datasets-search-form', type='dataset', query=q, count=page.item_count, sorting=sorting, sorting_selected=sort_by_selected, no_title=true, search_class=' ' %}
-        {% endblock %}
-
-        {#{% snippet 'snippets/simple_search.html', q=q, sort=sort_by_selected, placeholder=_('Search datasets...'), extra_sort=[(_('Last Modified'), 'data_modified asc')], input_class='search-normal', form_class='search-aside' %}#}
-        {% for facet in facet_titles %}
-          {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, extras={'id':group_dict.id}) }}
-        {% endfor %}
-      {% endblock %}
-    </aside>
   </div>
   {{ page.pager() }}
+{% endblock %}
+
+{% block secondary_content %}
+    {{  super() }}
+    {% for facet in c.facet_titles %}
+    {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id':group_dict.id}) }}
+  {% endfor %}
 {% endblock %}

--- a/ckan/tests/controllers/test_organization.py
+++ b/ckan/tests/controllers/test_organization.py
@@ -297,7 +297,7 @@ class TestOrganizationBulkProcess(object):
         self.organization = factories.Organization(user=self.user)
 
         datasets = [
-            factories.Dataset(owner_org=self.organization["id"])
+            factories.Dataset(owner_org=self.organization["id"], private=False)
             for i in range(0, 5)
         ]
         response = app.get(
@@ -306,7 +306,7 @@ class TestOrganizationBulkProcess(object):
             ),
             extra_environ=self.user_env,
         )
-        form = response.forms[1]
+        form = response.forms[2]
         for v in form.fields.values():
             try:
                 v[0].checked = True
@@ -338,7 +338,7 @@ class TestOrganizationBulkProcess(object):
             ),
             extra_environ=self.user_env,
         )
-        form = response.forms[1]
+        form = response.forms[2]
         for v in form.fields.values():
             try:
                 v[0].checked = True
@@ -369,7 +369,7 @@ class TestOrganizationBulkProcess(object):
             ),
             extra_environ=self.user_env,
         )
-        form = response.forms[1]
+        form = response.forms[2]
         for v in form.fields.values():
             try:
                 v[0].checked = True


### PR DESCRIPTION
### Proposed fixes:
Reorganizes bulk_process layout and removes tertiary block completely.

Before:
![before](https://user-images.githubusercontent.com/830663/72064412-7aa83e00-32e4-11ea-9fca-0f33429020a9.PNG)

After:
![after](https://user-images.githubusercontent.com/830663/72064423-809e1f00-32e4-11ea-9c78-4d3cdeb923ce.PNG)

facet_titles are for some reason still within c-variable.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply

Financed by Finland's open data portal opendata.fi. Find all Finnish open data at https://www.opendata.fi/en.
The Service is provided by the Digital and Population Data Services Agency (https://dvv.fi/en/).