### PR TITLE
[#5152] Fix wrong resource URL after ValidationErrors

### DIFF
--- a/ckan/public/base/css/fuchsia.css
+++ b/ckan/public/base/css/fuchsia.css
@@ -8150,6 +8150,11 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
 .js .image-upload .btn-remove-url .icon-remove {
   margin-right: 0;
 }
+.js .image-upload .error-inline {
+  margin-top: 5px;
+  margin-left: 2px;
+  font-weight: bold;
+}
 .add-member-form .control-label {
   display: block;
 }
@@ -8480,6 +8485,29 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
 }
 #activity-archive-notice {
   clear: both;
+}
+/* diff styles */
+table.diff {
+  font-family: Courier;
+  border: medium;
+}
+.diff_header {
+  background-color: #e0e0e0;
+}
+td.diff_header {
+  text-align: right;
+}
+.diff_next {
+  background-color: #c0c0c0;
+}
+.diff_add {
+  background-color: #aaffaa;
+}
+.diff_chg {
+  background-color: #ffff77;
+}
+.diff_sub {
+  background-color: #ffaaaa;
 }
 .search-form {
   margin-bottom: 20px;
@@ -10366,6 +10394,13 @@ h4 small {
 .activity .item.follow-group .icon {
   background-color: #8ba669;
 }
+.select-time {
+  width: 250px;
+  display: inline;
+}
+br.line-height2 {
+  line-height: 2;
+}
 .dropdown:hover .dropdown-menu {
   display: block;
 }
@@ -10759,26 +10794,4 @@ iframe {
 }
 .reduced-padding {
   padding: 3px 5px;
-}
-table.diff {
-  font-family:Courier;
-  border:medium;
-}
-.diff_header {
-  background-color:#e0e0e0;
-}
-td.diff_header {
-  text-align:right;
-}
-.diff_next {
-  background-color:#c0c0c0;
-}
-.diff_add {
-  background-color:#aaffaa;
-}
-.diff_chg {
-  background-color:#ffff77;
-}
-.diff_sub {
-  background-color:#ffaaaa;
 }

--- a/ckan/public/base/css/green.css
+++ b/ckan/public/base/css/green.css
@@ -8150,6 +8150,11 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
 .js .image-upload .btn-remove-url .icon-remove {
   margin-right: 0;
 }
+.js .image-upload .error-inline {
+  margin-top: 5px;
+  margin-left: 2px;
+  font-weight: bold;
+}
 .add-member-form .control-label {
   display: block;
 }
@@ -8480,6 +8485,29 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
 }
 #activity-archive-notice {
   clear: both;
+}
+/* diff styles */
+table.diff {
+  font-family: Courier;
+  border: medium;
+}
+.diff_header {
+  background-color: #e0e0e0;
+}
+td.diff_header {
+  text-align: right;
+}
+.diff_next {
+  background-color: #c0c0c0;
+}
+.diff_add {
+  background-color: #aaffaa;
+}
+.diff_chg {
+  background-color: #ffff77;
+}
+.diff_sub {
+  background-color: #ffaaaa;
 }
 .search-form {
   margin-bottom: 20px;
@@ -10366,6 +10394,13 @@ h4 small {
 .activity .item.follow-group .icon {
   background-color: #8ba669;
 }
+.select-time {
+  width: 250px;
+  display: inline;
+}
+br.line-height2 {
+  line-height: 2;
+}
 .dropdown:hover .dropdown-menu {
   display: block;
 }
@@ -10759,26 +10794,4 @@ iframe {
 }
 .reduced-padding {
   padding: 3px 5px;
-}
-table.diff {
-  font-family:Courier;
-  border:medium;
-}
-.diff_header {
-  background-color:#e0e0e0;
-}
-td.diff_header {
-  text-align:right;
-}
-.diff_next {
-  background-color:#c0c0c0;
-}
-.diff_add {
-  background-color:#aaffaa;
-}
-.diff_chg {
-  background-color:#ffff77;
-}
-.diff_sub {
-  background-color:#ffaaaa;
 }

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -8150,6 +8150,11 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
 .js .image-upload .btn-remove-url .icon-remove {
   margin-right: 0;
 }
+.js .image-upload .error-inline {
+  margin-top: 5px;
+  margin-left: 2px;
+  font-weight: bold;
+}
 .add-member-form .control-label {
   display: block;
 }
@@ -8480,6 +8485,29 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
 }
 #activity-archive-notice {
   clear: both;
+}
+/* diff styles */
+table.diff {
+  font-family: Courier;
+  border: medium;
+}
+.diff_header {
+  background-color: #e0e0e0;
+}
+td.diff_header {
+  text-align: right;
+}
+.diff_next {
+  background-color: #c0c0c0;
+}
+.diff_add {
+  background-color: #aaffaa;
+}
+.diff_chg {
+  background-color: #ffff77;
+}
+.diff_sub {
+  background-color: #ffaaaa;
 }
 .search-form {
   margin-bottom: 20px;
@@ -10766,26 +10794,4 @@ iframe {
 }
 .reduced-padding {
   padding: 3px 5px;
-}
-table.diff {
-  font-family:Courier;
-  border:medium;
-}
-.diff_header {
-  background-color:#e0e0e0;
-}
-td.diff_header {
-  text-align:right;
-}
-.diff_next {
-  background-color:#c0c0c0;
-}
-.diff_add {
-  background-color:#aaffaa;
-}
-.diff_chg {
-  background-color:#ffff77;
-}
-.diff_sub {
-  background-color:#ffaaaa;
 }

--- a/ckan/public/base/css/maroon.css
+++ b/ckan/public/base/css/maroon.css
@@ -8150,6 +8150,11 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
 .js .image-upload .btn-remove-url .icon-remove {
   margin-right: 0;
 }
+.js .image-upload .error-inline {
+  margin-top: 5px;
+  margin-left: 2px;
+  font-weight: bold;
+}
 .add-member-form .control-label {
   display: block;
 }
@@ -8480,6 +8485,29 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
 }
 #activity-archive-notice {
   clear: both;
+}
+/* diff styles */
+table.diff {
+  font-family: Courier;
+  border: medium;
+}
+.diff_header {
+  background-color: #e0e0e0;
+}
+td.diff_header {
+  text-align: right;
+}
+.diff_next {
+  background-color: #c0c0c0;
+}
+.diff_add {
+  background-color: #aaffaa;
+}
+.diff_chg {
+  background-color: #ffff77;
+}
+.diff_sub {
+  background-color: #ffaaaa;
 }
 .search-form {
   margin-bottom: 20px;
@@ -10366,6 +10394,13 @@ h4 small {
 .activity .item.follow-group .icon {
   background-color: #8ba669;
 }
+.select-time {
+  width: 250px;
+  display: inline;
+}
+br.line-height2 {
+  line-height: 2;
+}
 .dropdown:hover .dropdown-menu {
   display: block;
 }
@@ -10759,26 +10794,4 @@ iframe {
 }
 .reduced-padding {
   padding: 3px 5px;
-}
-table.diff {
-  font-family:Courier;
-  border:medium;
-}
-.diff_header {
-  background-color:#e0e0e0;
-}
-td.diff_header {
-  text-align:right;
-}
-.diff_next {
-  background-color:#c0c0c0;
-}
-.diff_add {
-  background-color:#aaffaa;
-}
-.diff_chg {
-  background-color:#ffff77;
-}
-.diff_sub {
-  background-color:#ffaaaa;
 }

--- a/ckan/public/base/css/red.css
+++ b/ckan/public/base/css/red.css
@@ -8150,6 +8150,11 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
 .js .image-upload .btn-remove-url .icon-remove {
   margin-right: 0;
 }
+.js .image-upload .error-inline {
+  margin-top: 5px;
+  margin-left: 2px;
+  font-weight: bold;
+}
 .add-member-form .control-label {
   display: block;
 }
@@ -8480,6 +8485,29 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
 }
 #activity-archive-notice {
   clear: both;
+}
+/* diff styles */
+table.diff {
+  font-family: Courier;
+  border: medium;
+}
+.diff_header {
+  background-color: #e0e0e0;
+}
+td.diff_header {
+  text-align: right;
+}
+.diff_next {
+  background-color: #c0c0c0;
+}
+.diff_add {
+  background-color: #aaffaa;
+}
+.diff_chg {
+  background-color: #ffff77;
+}
+.diff_sub {
+  background-color: #ffaaaa;
 }
 .search-form {
   margin-bottom: 20px;
@@ -10366,6 +10394,13 @@ h4 small {
 .activity .item.follow-group .icon {
   background-color: #8ba669;
 }
+.select-time {
+  width: 250px;
+  display: inline;
+}
+br.line-height2 {
+  line-height: 2;
+}
 .dropdown:hover .dropdown-menu {
   display: block;
 }
@@ -10759,26 +10794,4 @@ iframe {
 }
 .reduced-padding {
   padding: 3px 5px;
-}
-table.diff {
-  font-family:Courier;
-  border:medium;
-}
-.diff_header {
-  background-color:#e0e0e0;
-}
-td.diff_header {
-  text-align:right;
-}
-.diff_next {
-  background-color:#c0c0c0;
-}
-.diff_add {
-  background-color:#aaffaa;
-}
-.diff_chg {
-  background-color:#ffff77;
-}
-.diff_sub {
-  background-color:#ffaaaa;
 }

--- a/ckan/public/base/javascript/modules/image-upload.js
+++ b/ckan/public/base/javascript/modules/image-upload.js
@@ -11,7 +11,8 @@ this.ckan.module('image-upload', function($) {
       field_url: 'image_url',
       field_clear: 'clear_upload',
       field_name: 'name',
-      upload_label: ''
+      upload_label: '',
+      previous_upload: false
     },
 
     /* Should be changed to true if user modifies resource's name
@@ -43,6 +44,7 @@ this.ckan.module('image-upload', function($) {
       this.label_location = $('label[for="field-image-url"]');
       // determines if the resource is a data resource
       this.is_data_resource = (this.options.field_url === 'url') && (this.options.field_upload === 'upload');
+      this.previousUpload = this.options.previous_upload;
 
       // Is there a clear checkbox on the form already?
       var checkbox = $(field_clear, this.el);
@@ -67,6 +69,11 @@ this.ckan.module('image-upload', function($) {
                              '<i class="fa fa-cloud-upload"></i>' +
                              this._('Upload') + '</a>')
         .insertAfter(this.input);
+
+      if (this.previousUpload) {
+        $('<div class="error-inline"><i class="fa fa-warning"></i> ' +
+          this._('Please select the file to upload again') + '</div>').appendTo(this.field_image);
+      }
 
       // Button for resetting the form when there is a URL set
       var removeText = this._('Remove');

--- a/ckan/public/base/less/forms.less
+++ b/ckan/public/base/less/forms.less
@@ -752,6 +752,12 @@ select[data-module="autocomplete"] {
             margin-right: 0;
         }
     }
+
+    .error-inline {
+      margin-top: 5px;
+      margin-left: 2px;
+      font-weight: bold;
+    }
 }
 
 .add-member-form .control-label {

--- a/ckan/templates/macros/form.html
+++ b/ckan/templates/macros/form.html
@@ -418,14 +418,24 @@ options     - A list/tuple of fields to be used as <options>.
   #}
 {% macro image_upload(data, errors, field_url='image_url', field_upload='image_upload', field_clear='clear_upload',
                       is_url=false, is_upload=false, is_upload_enabled=false, placeholder=false,
-                      url_label='', upload_label='', field_name='image_url')  %}
+                      url_label='', upload_label='', field_name='image_url', previous_upload=false)  %}
   {% set placeholder = placeholder if placeholder else _('http://example.com/my-image.jpg') %}
   {% set url_label = url_label or _('Image URL')  %}
   {% set upload_label = upload_label or _('Image')  %}
 
   {% if is_upload_enabled %}
-  <div class="image-upload" data-module="image-upload" data-module-is_url="{{ 'true' if is_url else 'false' }}" data-module-is_upload="{{ 'true' if is_upload else 'false' }}"
-       data-module-field_url="{{ field_url }}" data-module-field_upload="{{ field_upload }}" data-module-field_clear="{{ field_clear }}" data-module-upload_label="{{ upload_label }}" data-module-field_name="{{ field_name }}">
+
+
+  <div class="image-upload"
+       data-module="image-upload"
+       data-module-is_url="{{ 'true' if is_url else 'false' }}"
+       data-module-is_upload="{{ 'true' if is_upload else 'false' }}"
+       data-module-field_url="{{ field_url }}"
+       data-module-field_upload="{{ field_upload }}"
+       data-module-field_clear="{{ field_clear }}"
+       data-module-upload_label="{{ upload_label }}"
+       data-module-field_name="{{ field_name }}"
+       data-module-previous_upload="{{ 'true' if previous_upload else 'false' }}">
   {% endif %}
 
 

--- a/ckan/templates/macros/form.html
+++ b/ckan/templates/macros/form.html
@@ -418,10 +418,11 @@ options     - A list/tuple of fields to be used as <options>.
   #}
 {% macro image_upload(data, errors, field_url='image_url', field_upload='image_upload', field_clear='clear_upload',
                       is_url=false, is_upload=false, is_upload_enabled=false, placeholder=false,
-                      url_label='', upload_label='', field_name='image_url', previous_upload=false)  %}
+                      url_label='', upload_label='', field_name='image_url')  %}
   {% set placeholder = placeholder if placeholder else _('http://example.com/my-image.jpg') %}
   {% set url_label = url_label or _('Image URL')  %}
   {% set upload_label = upload_label or _('Image')  %}
+  {% set previous_upload = data['previous_upload'] %}
 
   {% if is_upload_enabled %}
 

--- a/ckan/templates/package/snippets/resource_form.html
+++ b/ckan/templates/package/snippets/resource_form.html
@@ -23,7 +23,9 @@
       {% set is_upload = (data.url_type == 'upload') %}
       {{ form.image_upload(data, errors, field_url='url', field_upload='upload', field_clear='clear_upload',
          is_upload_enabled=h.uploads_enabled(), is_url=data.url and not is_upload, is_upload=is_upload,
-         upload_label=_('Data'), url_label=_('URL'), placeholder=_('http://example.com/external-data.csv'), field_name='name') }}
+         upload_label=_('Data'), url_label=_('URL'), placeholder=_('http://example.com/external-data.csv'), field_name='name',
+         previous_upload=(errors['previous_upload'] == True)
+         ) }}
     {% endblock %}
 
     {% block basic_fields_name %}

--- a/ckan/templates/package/snippets/resource_form.html
+++ b/ckan/templates/package/snippets/resource_form.html
@@ -24,7 +24,7 @@
       {{ form.image_upload(data, errors, field_url='url', field_upload='upload', field_clear='clear_upload',
          is_upload_enabled=h.uploads_enabled(), is_url=data.url and not is_upload, is_upload=is_upload,
          upload_label=_('Data'), url_label=_('URL'), placeholder=_('http://example.com/external-data.csv'), field_name='name',
-         previous_upload=(errors['previous_upload'] == True)
+         previous_upload=(data['previous_upload'] == True)
          ) }}
     {% endblock %}
 

--- a/ckan/templates/package/snippets/resource_form.html
+++ b/ckan/templates/package/snippets/resource_form.html
@@ -23,9 +23,7 @@
       {% set is_upload = (data.url_type == 'upload') %}
       {{ form.image_upload(data, errors, field_url='url', field_upload='upload', field_clear='clear_upload',
          is_upload_enabled=h.uploads_enabled(), is_url=data.url and not is_upload, is_upload=is_upload,
-         upload_label=_('Data'), url_label=_('URL'), placeholder=_('http://example.com/external-data.csv'), field_name='name',
-         previous_upload=(data['previous_upload'] == True)
-         ) }}
+         upload_label=_('Data'), url_label=_('URL'), placeholder=_('http://example.com/external-data.csv'), field_name='name') }}
     {% endblock %}
 
     {% block basic_fields_name %}

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -850,7 +850,7 @@ class TestUser(object):
         emailed_users = [
             call[0][0].name for call in send_reset_link.call_args_list
         ]
-        assert emailed_users == [user_a["name"], user_b["name"]]
+        assert sorted(emailed_users) == sorted([user_a["name"], user_b["name"]])
 
     def test_request_reset_without_param(self, app):
 

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -243,7 +243,7 @@ class CreateView(MethodView):
         except ValidationError as e:
             errors = e.error_dict
             error_summary = e.error_summary
-            if data.get(u'url_type') == u'upload' and data.get('url'):
+            if data.get(u'url_type') == u'upload' and data.get(u'url'):
                 data[u'url'] = u''
                 data[u'url_type'] = u''
                 errors[u'previous_upload'] = True

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -243,10 +243,10 @@ class CreateView(MethodView):
         except ValidationError as e:
             errors = e.error_dict
             error_summary = e.error_summary
-            if data.get('url_type') == 'upload' and data.get('url'):
-                data['url'] = ''
-                data['url_type'] = ''
-                errors['previous_upload'] = True
+            if data.get(u'url_type') == u'upload' and data.get('url'):
+                data[u'url'] = u''
+                data[u'url_type'] = u''
+                errors[u'previous_upload'] = True
             return self.get(package_type, id, data, errors, error_summary)
         except NotAuthorized:
             return base.abort(403, _(u'Unauthorized to create a resource'))

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -243,6 +243,10 @@ class CreateView(MethodView):
         except ValidationError as e:
             errors = e.error_dict
             error_summary = e.error_summary
+            if data.get('url_type') == 'upload' and data.get('url'):
+                data['url'] = ''
+                data['url_type'] = ''
+                errors['previous_upload'] = True
             return self.get(package_type, id, data, errors, error_summary)
         except NotAuthorized:
             return base.abort(403, _(u'Unauthorized to create a resource'))

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -246,7 +246,7 @@ class CreateView(MethodView):
             if data.get(u'url_type') == u'upload' and data.get(u'url'):
                 data[u'url'] = u''
                 data[u'url_type'] = u''
-                errors[u'previous_upload'] = True
+                data[u'previous_upload'] = True
             return self.get(package_type, id, data, errors, error_summary)
         except NotAuthorized:
             return base.abort(403, _(u'Unauthorized to create a resource'))


### PR DESCRIPTION
Fixes #5152

### Proposed fixes:
Clears the `upload` and `url_type` fields if there is a validation error to avoid submitting the file name.
Adds a warning for users if they had previously selected a file for upload, as it's easy to miss it, creating an empty resource:

![Screenshot_2020-01-10 Add resource - Test URLs 4 - CKAN](https://user-images.githubusercontent.com/200230/72161494-82d5ab80-33c0-11ea-85d6-f8c57868ebff.png)

Happy to change the language being used if it doesn't seem clear enough
