### PR TITLE
[#5142] add default license when create dataset via API

### DIFF
--- a/ckan/templates/package/snippets/package_basic_fields.html
+++ b/ckan/templates/package/snippets/package_basic_fields.html
@@ -33,6 +33,8 @@
         <div class="col-md-6">
           <select id="field-license" name="license_id" data-module="autocomplete">
             {% set existing_license_id = data.get('license_id') %}
+            {% set empty_license = _('Please select the license') %}
+            <option value="">{{ empty_license }}</option>
             {% for license_id, license_desc in h.license_options(existing_license_id) %}
             <option value="{{ license_id }}" {% if existing_license_id == license_id %}selected="selected"{% endif %}>{{ license_desc }}</option>
             {% endfor %}

--- a/ckan/templates/snippets/license.html
+++ b/ckan/templates/snippets/license.html
@@ -2,19 +2,18 @@
   {% if 'license_url' in pkg_dict %}
     <a href="{{ pkg_dict.license_url }}" rel="dc:rights">{{ pkg_dict.license_title }}</a>
   {% else %}
-    <span property="dc:rights">{{ pkg_dict.license_title }}</span>
+    {% if pkg_dict.license_id %}
+      <span property="dc:rights">{{ pkg_dict.license_title }}</span>
+    {% else %}
+      <span>{{ _('No License Provided') }}</span>
+    {% endif %}
   {% endif %}
 {% endmacro %}
 
 {% block license %}
   {% if text_only %}
-    {% if pkg_dict.license_id %}
-      {{ license_string(pkg_dict) }}
-    {% else %}
-      {{ _('No License Provided') }}
-    {% endif %}
+    {{ license_string(pkg_dict) }}
   {% else %}
-    {% if pkg_dict.license_id %}
       {% block license_wrapper %}
         <section class="module module-narrow module-shallow license">
           {% block license_title %}
@@ -34,6 +33,5 @@
           {% endblock %}
         </section>
       {% endblock %}
-    {% endif %}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
Fixes #
Set default license as `notspecified` when creating dataset via API. Currently, it's `None` if not provided and will be changed on first entity from select box after package update from UI. This behaviour may not be obvious for some users.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
