### PR TITLE
Allow re-creation of extra fields

### DIFF
--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -132,7 +132,7 @@ def package_extras_save(extra_dicts, pkg, context):
     #deleted
     for key in set(old_extras.keys()) - set(new_extras.keys()):
         extra = old_extras[key]
-        extra.delete()
+        session.delete(extra)
 
 
 def package_tag_list_save(tag_dicts, package, context):

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -558,6 +558,40 @@ class TestDatasetUpdate(object):
         assert dataset_["extras"][0]["key"] == "original media"
         assert dataset_["extras"][0]["value"] == '"book"'
 
+    def test_extra_can_be_restored_after_deletion(self):
+        user = factories.User()
+        dataset = factories.Dataset(user=user)
+
+        dataset_ = helpers.call_action(
+            "package_update",
+            id=dataset["id"],
+            extras=[
+                {"key": u"old attribute", "value": u'value'},
+                {"key": u"original media", "value": u'"book"'},
+            ],
+        )
+
+        assert len(dataset_["extras"]) == 2
+
+        dataset_ = helpers.call_action(
+            "package_update",
+            id=dataset["id"],
+            extras=[],
+        )
+
+        assert dataset_["extras"] == []
+
+        dataset_ = helpers.call_action(
+            "package_update",
+            id=dataset["id"],
+            extras=[
+                {"key": u"original media", "value": u'"book"'},
+                {"key": u"new attribute", "value": u'value'},
+            ],
+        )
+
+        assert len(dataset_["extras"]) == 2
+
     def test_license(self):
         user = factories.User()
         dataset = factories.Dataset(user=user)

--- a/ckan/tests/model/test_package_extra.py
+++ b/ckan/tests/model/test_package_extra.py
@@ -57,6 +57,8 @@ class TestPackageExtra(object):
 
         pkg = model.Package.by_name(dataset[u"name"])
         assert isinstance(pkg.extras_list[0], model.PackageExtra)
+
+        # Extras are removed from database, not just marked as deleted
         assert set(
             [
                 (pe.package_id, pe.key, pe.value, pe.state)
@@ -64,7 +66,6 @@ class TestPackageExtra(object):
             ]
         ) == set(
             [
-                (dataset["id"], u"subject", u"science", u"deleted"),
                 (dataset["id"], u"accuracy", u"metre", u"active"),
                 (dataset["id"], u"sample_years", u"2012-2013", u"active"),
             ]


### PR DESCRIPTION
If a package had an extra field and this field was deleted, there is no way of adding the same extra field with the same value again. Actually, CKAN just marks field as deleted(we are expecting real deletion, as there are no revisions anymore and one can check old values via activity stream instead) and when the extra field is `re-added`, CKAN just doesn't restore state back to `active`.

When revisioned workflow was removed for packageExtras, `core.StatefulObjectMixin` was added as the parent class for `PackageExtra`. It has a `delete` method that set `state` column to `deleted` instead of real erasing.
We are expecting `domain_object.DomainObject::delete` to be called instead, which would delete a row, but it shadowed by `core.StatefulObjectMixin::delete`. This PR uses `session.delete` directly, so there will be no such mistakes in the future