### PR TITLE
Register storage as public folder

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -29,6 +29,7 @@ import ckan.model as model
 from ckan.lib import base
 from ckan.lib import helpers
 from ckan.lib import jinja_extensions
+from ckan.lib import uploader
 from ckan.common import config, g, request, ungettext
 from ckan.config.middleware.common_middleware import TrackingMiddleware
 import ckan.lib.app_globals as app_globals
@@ -97,11 +98,18 @@ def make_flask_stack(conf, **app_conf):
     testing = asbool(app_conf.get('testing', app_conf.get('TESTING', False)))
     app = flask_app = CKANFlask(__name__, static_url_path='')
 
+    # Register storage for accessing group images, site logo, etc.
+    storage_folder = []
+    storage = uploader.get_storage_path()
+    if storage:
+        storage_folder = [os.path.join(storage, 'storage')]
+
     # Static files folders (core and extensions)
     public_folder = config.get(u'ckan.base_public_folder')
     app.static_folder = config.get(
         'extra_public_paths', ''
-    ).split(',') + [os.path.join(root, public_folder)]
+    ).split(',') + [os.path.join(root, public_folder)] + storage_folder
+
 
     app.jinja_options = jinja_extensions.get_jinja_env_options()
 

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -110,7 +110,6 @@ def make_flask_stack(conf, **app_conf):
         'extra_public_paths', ''
     ).split(',') + [os.path.join(root, public_folder)] + storage_folder
 
-
     app.jinja_options = jinja_extensions.get_jinja_env_options()
 
     app.debug = debug

--- a/ckan/tests/lib/test_uploader.py
+++ b/ckan/tests/lib/test_uploader.py
@@ -88,6 +88,7 @@ class TestInitResourceUpload(object):
         eq_(res_upload.filesize, 0)
         eq_(res_upload.filename, u'data.csv')
 
+
 class TestUpload(object):
     def test_group_upload(self, monkeypatch, tmpdir, make_app, ckan_config):
         """Reproduce group's logo upload and check that file available through

--- a/ckan/tests/lib/test_uploader.py
+++ b/ckan/tests/lib/test_uploader.py
@@ -99,12 +99,12 @@ class TestUpload(object):
         monkeypatch.setattr(ckan.lib.uploader, u'_storage_path', str(tmpdir))
         group = {u'clear_upload': u'',
                  u'upload': FileStorage(
-                     six.BytesIO(six.ensure_binary('hello')),
+                     six.BytesIO(six.ensure_binary(u'hello')),
                      filename=u'logo.png',
                      content_type=u'PNG'
                  ),
                  u'name': u'test-group-upload'}
-        group_upload = Upload('group')
+        group_upload = Upload(u'group')
         group_upload.update_data_dict(group, u'url', u'upload', u'clear_upload')
         group_upload.upload()
         uploads_dir = tmpdir / u'storage' / u'uploads' / u'group'
@@ -113,4 +113,4 @@ class TestUpload(object):
         app = make_app()
         resp = app.get(u'/uploads/group/' + group[u'url'])
         assert resp.status_code == 200
-        assert resp.body == 'hello'
+        assert resp.body == u'hello'


### PR DESCRIPTION
As we no longer use pylons for serving static files in Py3, we need to register all static paths in Flask. Previously, `public` paths were added and this pull request additionally registers `storage` path for serving files, like group and site logos via Flask