### PR TITLE
[#2713] Fix IFacet group customization

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -326,7 +326,7 @@ class GroupController(base.BaseController):
                     facets[facet] = facet
 
             # Facet titles
-            self._update_facet_titles(facets, group_type)
+            facets = self._update_facet_titles(facets, group_type)
 
             c.facet_titles = facets
 
@@ -377,6 +377,7 @@ class GroupController(base.BaseController):
         for plugin in plugins.PluginImplementations(plugins.IFacets):
             facets = plugin.group_facets(
                 facets, group_type, None)
+        return facets
 
     def bulk_process(self, id):
         ''' Allow bulk processing of datasets for an organization.  Make

--- a/ckan/controllers/organization.py
+++ b/ckan/controllers/organization.py
@@ -28,3 +28,4 @@ class OrganizationController(group.GroupController):
         for plugin in plugins.PluginImplementations(plugins.IFacets):
             facets = plugin.organization_facets(
                 facets, group_type, None)
+        return facets

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -353,7 +353,7 @@ def _read(id, limit, group_type):
                 facets[facet] = facet
 
         # Facet titles
-        _update_facet_titles(facets, group_type)
+        facets = _update_facet_titles(facets, group_type)
 
         extra_vars["facet_titles"] = facets
 
@@ -413,6 +413,7 @@ def _read(id, limit, group_type):
 def _update_facet_titles(facets, group_type):
     for plugin in plugins.PluginImplementations(plugins.IFacets):
         facets = plugin.group_facets(facets, group_type, None)
+    return facets
 
 
 def _get_group_dict(id, group_type):


### PR DESCRIPTION
Fixes #2713 

### Proposed fixes:
`_update_facet_titles` returns and uses the facets object from the `IFacet` calls, so that `IFacet.group_facets` implementations don't need to modify the passed in facets object.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
