### PR TITLE
Adapt render_snippet exceptions for py3

### DIFF
--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -88,7 +88,7 @@ def render_snippet(*template_names, **kw):
     :type kw: named arguments of any type that are supported by the template
     '''
 
-    exc = None
+    last_exc = None
     for template_name in template_names:
         try:
             output = render(template_name, extra_vars=kw)
@@ -99,7 +99,10 @@ def render_snippet(*template_names, **kw):
             return h.literal(output)
         except TemplateNotFound as exc:
             if exc.name == template_name:
-                # the specified template doesn't exist - try the next fallback
+                # the specified template doesn't exist - try the next
+                # fallback, but store the exception in case it was
+                # last one
+                last_exc = exc
                 continue
             # a nested template doesn't exist - don't fallback
             raise exc

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -107,7 +107,7 @@ def render_snippet(*template_names, **kw):
             # a nested template doesn't exist - don't fallback
             raise exc
     else:
-        raise exc or TemplateNotFound
+        raise last_exc or TemplateNotFound
 
 
 def render_jinja2(template_name, extra_vars):


### PR DESCRIPTION
`ckan.lib.render_snippet` makes multiple attempts to find a template for rendering and, if failed, throws an exception from the last attempt. Previously it was handled by creating a function-scoped variable outside the `try` block and it was overridden by `except` block. 

In python 3, variable that stores caught exception implicitly unset right after `try/catch` so this gives un undefined variable. This PR adapts existing logic so that it works in both versions of python