### PR TITLE
[#5131] index template with template path instead of numeric index

### DIFF
--- a/ckan/lib/jinja_extensions.py
+++ b/ckan/lib/jinja_extensions.py
@@ -106,13 +106,13 @@ class CkanExtend(ext.Extension):
         node = nodes.Extends(lineno)
         template_path = parser.filename
         # find where in the search path this template is from
-        index = 0
+        current_path = None
         if not hasattr(self, 'searchpath'):
             return node
         for searchpath in self.searchpath:
             if template_path.startswith(searchpath):
+                current_path = searchpath
                 break
-            index += 1
 
         # get filename from full path
         filename = template_path[len(searchpath) + 1:]
@@ -128,8 +128,8 @@ class CkanExtend(ext.Extension):
                              % template_path)
 
         # provide our magic format
-        # format is *<search path parent index>*<template name>
-        magic_filename = '*' + str(index) + '*' + filename
+        # format is *<search path parent directory>*<template name>
+        magic_filename = '*' + current_path + '*' + filename
         # set template
         node.template = nodes.Const(magic_filename)
         return node
@@ -183,13 +183,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     def get_source(self, environment, template):
         # if the template name starts with * then this should be
         # treated specially.
-        # format is *<search path parent index>*<template name>
+        # format is *<search path parent directory>*<template name>
         # so we only search from then downwards.  This allows recursive
         # ckan_extends tags
         if template.startswith('*'):
             parts = template.split('*')
             template = parts[2]
-            searchpaths = self.searchpath[int(parts[1]) + 1:]
+            index = self.searchpath.index(parts[1])
+            searchpaths = self.searchpath[index + 1:]
         else:
             searchpaths = self.searchpath
         # end of ckan changes


### PR DESCRIPTION
Fixes #5131 

### Proposed fixes:
Following the suggested fix in the issue #5131, this change allows `{% ckan_extends %}` to emit the path of the current template directory instead of its numeric index in the template path list. This would prevent caching issues when a plugin is added/removed from the plugins list. 

### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
