### PR TITLE
Fix interactive debugger

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -134,8 +134,7 @@ def make_flask_stack(conf, **app_conf):
         DebugToolbarExtension(app)
 
         from werkzeug.debug import DebuggedApplication
-        app = DebuggedApplication(app, True)
-        app = app.app
+        app.wsgi_app = DebuggedApplication(app.wsgi_app, True)
 
         log = logging.getLogger('werkzeug')
         log.setLevel(logging.DEBUG)


### PR DESCRIPTION
At some point werkzeug's debugger(error page with a lot of details when `debug = true`) disappeared. This change makes it available once again