### PR TITLE
Allow testing IClick-extensions

### DIFF
--- a/ckan/cli/cli.py
+++ b/ckan/cli/cli.py
@@ -7,9 +7,9 @@ import six
 import click
 
 import ckan.plugins as p
+import ckan.cli as ckan_cli
 from ckan.config.middleware import make_app
 from ckan.cli import (
-    load_config,
     config_tool,
     jobs,
     datapusher,
@@ -39,7 +39,9 @@ log = logging.getLogger(__name__)
 class CkanCommand(object):
 
     def __init__(self, conf=None):
-        self.config = load_config(conf)
+        # Don't import `load_config` by itself, rather call it using
+        # module so that it can be patched during tests
+        self.config = ckan_cli.load_config(conf)
         self.app = make_app(self.config.global_conf, **self.config.local_conf)
 
 

--- a/ckan/tests/cli/test_cli.py
+++ b/ckan/tests/cli/test_cli.py
@@ -43,3 +43,30 @@ def test_config_via_env_var(cli, ckan_config):
     result = cli.invoke(ckan, [u'-c', None, u'-h'],
                         env={u'CKAN_INI': ckan_config[u'__file__']})
     assert not result.exit_code
+
+
+def test_command_from_extension_is_not_available_without_extension(cli):
+    """Extension must be enabled in order to make its commands available.
+    """
+    result = cli.invoke(ckan, [u'example-iclick-hello'])
+    assert result.exit_code
+
+
+@pytest.mark.ckan_config(u'ckan.plugins', u'example_iclick')
+@pytest.mark.usefixtures(u'with_plugins')
+def test_command_from_extension_is_not_available_without_additional_fixture(cli):
+    """Without `with_extended_cli` extension still unable to register
+    command durint tests.
+
+    """
+    result = cli.invoke(ckan, [u'example-iclick-hello'])
+    assert result.exit_code
+
+
+@pytest.mark.ckan_config(u'ckan.plugins', u'example_iclick')
+@pytest.mark.usefixtures(u'with_plugins', u'with_extended_cli')
+def test_command_from_extension_is_available_when_all_requirements_satisfied(cli):
+    """When enabled, extension register its CLI commands.
+    """
+    result = cli.invoke(ckan, [u'example-iclick-hello'])
+    assert not result.exit_code

--- a/ckan/tests/pytest_ckan/fixtures.py
+++ b/ckan/tests/pytest_ckan/fixtures.py
@@ -39,6 +39,7 @@ import rq
 
 import ckan.tests.helpers as test_helpers
 import ckan.plugins
+import ckan.cli
 import ckan.lib.search as search
 
 from ckan.common import config
@@ -230,3 +231,23 @@ def with_test_worker(monkeypatch):
             rq.Worker, u"execute_job", rq.SimpleWorker.execute_job
         )
     yield
+
+
+@pytest.fixture
+def with_extended_cli(ckan_config, monkeypatch):
+    """Enables effects of IClick.
+
+    Without this fixture, only CLI command that came from plugins
+    specified in real config file are available. When this fixture
+    enabled, changing `ckan.plugins` on test level allows to update
+    list of available CLI command.
+
+    """
+    class MockConfig(object):
+        global_conf = ckan_config
+        local_conf = ckan_config
+    # Main `ckan` command is initialized from config file instead of
+    # using global config object.  With this patch it becomes possible
+    # to apply per-test config changes to it without creating real
+    # config file.
+    monkeypatch.setattr(ckan.cli, u'load_config', lambda _: MockConfig())


### PR DESCRIPTION
Provide `with_extended_cli` fixture, which extends the effect of config patching on test level to CLI. Previously, CLI was using config files directly for initialization, so any changes to global config were ignored. Now, during tests, `load_cofig` function is monkey-patched and returns available config object instead of the re-parsing config file.
