### PR TITLE
Hotfix: dataset.{new,edit}

### DIFF
--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -590,7 +590,11 @@ class CreateView(MethodView):
                 pkg_dict = get_action(u'package_show')(context, data_dict)
                 data_dict[u'state'] = pkg_dict[u'state']
                 return EditView().get(
-                    data_dict[u'id'], data_dict, errors, error_summary
+                    package_type,
+                    data_dict[u'id'],
+                    data_dict,
+                    errors,
+                    error_summary
                 )
             data_dict[u'state'] = u'none'
             return self.get(package_type, data_dict, errors, error_summary)


### PR DESCRIPTION
During package creation, if one makes an attempt to switch back into `datasetDetails` step from `resources` step, 500 error is raised. This is caused by missing `package_type` argument. This PR just adds that missing argument.