### PR TITLE
Add missing requirements for py2

### DIFF
--- a/requirements-py2.in
+++ b/requirements-py2.in
@@ -10,6 +10,7 @@ feedgen==0.8.0
 Flask==1.1.1
 Flask-Babel==0.11.2
 flask-multistatic==1.0
+html==1.16
 Jinja2==2.10.1
 Markdown==2.6.7
 passlib==1.6.5

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -20,6 +20,7 @@ flask-multistatic==1.0
 feedgen==0.8.0
 formencode==1.3.1         # via pylons
 funcsigs==1.0.2           # via beaker
+html==1.16
 idna==2.8                 # via requests
 itsdangerous==1.1.0       # via flask
 jinja2==2.10.1


### PR DESCRIPTION
Fixes #5184

`ckan.views.api` uses `html` library, which is not available in python 2 as a top-level module. This wasn't noticed before, as we are usually installing `dev-requirements.txt`, that thiggers installation of `cookiecutter`, which requires `future` which requires `html`. But any installation with only `requirements-py2.txt` would throw an import error. This PR registers `html` as a dependency inside `requirements-py2.txt`