### PR TITLE
Improve "ckan check-po-files" 

### DIFF
--- a/ckan/cli/cli.py
+++ b/ckan/cli/cli.py
@@ -2,6 +2,7 @@
 
 import logging
 from collections import defaultdict
+import sys
 
 import six
 import click
@@ -46,6 +47,11 @@ class CkanCommand(object):
 
 
 def _init_ckan_config(ctx, param, value):
+    # Some commands don't need to init the config
+    command = sys.argv[1] if len(sys.argv) > 1 else None
+    if command == u'translation':
+        return
+
     ctx.obj = CkanCommand(value)
     if six.PY2:
         ctx.meta["flask_app"] = ctx.obj.app.apps["flask_app"]._wsgi_app

--- a/doc/contributing/release-process.rst
+++ b/doc/contributing/release-process.rst
@@ -188,7 +188,7 @@ Turn this file into a github issue with a checklist using this command::
 
    g. Run our script that checks for mistakes in the ckan.po files::
 
-        paster check-po-files ckan/i18n/*/LC_MESSAGES/ckan.po
+          ckan translation check-po ckan/i18n/*/LC_MESSAGES/ckan.po
 
       If the script finds any mistakes then at some point before release you
       will need to correct them, but it doesn't need to be done now, since the priority
@@ -301,7 +301,7 @@ Leading up to the release
 
    Check and compile them as before::
 
-        paster check-po-files ckan/i18n/*/LC_MESSAGES/ckan.po
+        ckan translation check-po ckan/i18n/*/LC_MESSAGES/ckan.po
         python setup.py compile_catalog
 
     The compilation shows the translation percentage. Compare this with the new
@@ -450,7 +450,7 @@ a release.
    to make sure you have the latest commits on master and no local changes.
    Then use ``git cherry-pick`` when on the master branch to cherry-pick these
    commits onto master. You should not get any merge conflicts. Run the
-   ``check-po-files`` command again just to be safe, it should not report any
+   ``check-po`` command again just to be safe, it should not report any
    problems. Run CKAN's tests, again just to be safe.  Then do ``git push
    origin master``.
 


### PR DESCRIPTION
* Updated docs with the 'ckan' version. NB The name of the command was renamed since the paster version - see https://github.com/ckan/ckan/issues/4639
* This command doesn't need to init config

### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
