### PR TITLE
Dont fail with existing user sessions from py2

### DIFF
--- a/ckan/lib/repoze_plugins/auth_tkt.py
+++ b/ckan/lib/repoze_plugins/auth_tkt.py
@@ -4,6 +4,8 @@ import logging
 import math
 import os
 
+import six
+
 from ckan.common import config
 from repoze.who.plugins import auth_tkt as repoze_auth_tkt
 
@@ -11,8 +13,19 @@ _bool = repoze_auth_tkt._bool
 
 log = logging.getLogger(__name__)
 
+# With `unicode` decoder users that were logged in on CKAN+py2 will
+# get 500 on CKAN+py3 error because of to utf8_decode attempts applied
+# to str, while bytes-like object expected.
+_ckan_userid_type_decoders = (
+    repoze_auth_tkt.AuthTktCookiePlugin.userid_type_decoders.copy()
+)
+if six.PY3:
+    _ckan_userid_type_decoders.pop('unicode')
+
 
 class CkanAuthTktCookiePlugin(repoze_auth_tkt.AuthTktCookiePlugin):
+
+    userid_type_decoders = _ckan_userid_type_decoders
 
     def __init__(self, httponly, *args, **kwargs):
         super(CkanAuthTktCookiePlugin, self).__init__(*args, **kwargs)

--- a/ckan/lib/repoze_plugins/auth_tkt.py
+++ b/ckan/lib/repoze_plugins/auth_tkt.py
@@ -16,8 +16,8 @@ log = logging.getLogger(__name__)
 # With `unicode` decoder users that were logged in on CKAN+py2 will
 # get 500 on CKAN+py3 error because of to utf8_decode attempts applied
 # to str, while bytes-like object expected.
-_ckan_userid_type_decoders = (
-    repoze_auth_tkt.AuthTktCookiePlugin.userid_type_decoders.copy()
+_ckan_userid_type_decoders = dict(
+    repoze_auth_tkt.AuthTktCookiePlugin.userid_type_decoders
 )
 if six.PY3:
     _ckan_userid_type_decoders.pop('unicode')


### PR DESCRIPTION
I think @tino097 remembers this issue: 
```
  File "/usr/lib/ckan/py3/lib/python3.8/site-packages/repoze/who/plugins/auth_tkt.py", line 34, in <lambda>
    'unicode': lambda x: utf_8_decode(x)[0],
TypeError: a bytes-like object is required, not 'str'
```

Basically, on Python2 `repoze.who` was adding something like `user_id_type=unicode` to the `auth_tkt` cookie and using this flag in order to utf8_decode cookie during authentication. By on Python3 such an attempt will raise an error because of changes inside bytes-str-unicode relationships. This may become an issue, as every upgraded portal is likely will have some users with old-style-authentication cookie.

This PR just drops `unicode` decoder. Internally, `repoze.who` will skip decoding if no decoder is registered for the data type, so it should fix the issue. 
