### PR TITLE
Fix twine warning for extension build for pypi

### DIFF
--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/setup.py
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/setup.py
@@ -20,6 +20,7 @@ setup(
 
     description='''{{ cookiecutter.description }}''',
     long_description=long_description,
+    long_description_content_type='text/x-rst',
 
     # The project's main homepage.
     url='https://github.com/{{ cookiecutter.github_user_name }}/'\


### PR DESCRIPTION
Without this change, you get this when building the extension for pypi:

    $ python setup.py sdist bdist_wheel && twine check dist/*
      warning: `long_description_content_type` missing.  defaulting to `text/x-rst`.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
