### PR TITLE
Werkzeug dev server improvements

### DIFF
--- a/ckan/cli/server.py
+++ b/ckan/cli/server.py
@@ -5,6 +5,8 @@ import logging
 import click
 from werkzeug.serving import run_simple
 
+from ckan.common import config
+
 log = logging.getLogger(__name__)
 
 
@@ -14,6 +16,17 @@ log = logging.getLogger(__name__)
 @click.option(u'-r', u'--reloader', default=True, help=u'Use reloader')
 @click.pass_context
 def run(ctx, host, port, reloader):
-    u'''Runs development server'''
+    u'''Runs the Werkzeug development server'''
+
     log.info(u"Running server {0} on port {1}".format(host, port))
-    run_simple(host, port, ctx.obj.app, use_reloader=reloader, use_evalex=True)
+
+    extra_files = [
+        config['__file__'],
+    ]
+    run_simple(
+        host,
+        port,
+        ctx.obj.app,
+        use_reloader=reloader,
+        use_evalex=True,
+        extra_files=extra_files)

--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -201,7 +201,7 @@ ckan.jobs.timeout = 180
 
 ## Logging configuration
 [loggers]
-keys = root, ckan, ckanext
+keys = root, ckan, ckanext, werkzeug
 
 [handlers]
 keys = console
@@ -212,6 +212,12 @@ keys = generic
 [logger_root]
 level = WARNING
 handlers = console
+
+[logger_werkzeug]
+level = WARNING
+handlers = console
+qualname = werkzeug
+propagate = 0
 
 [logger_ckan]
 level = INFO

--- a/requirements-py2.in
+++ b/requirements-py2.in
@@ -40,5 +40,5 @@ unicodecsv>=0.9
 webassets==0.12.1
 WebHelpers==1.3
 WebOb==1.0.8
-werkzeug==0.15.5
+Werkzeug[watchdog]==0.16.1
 zope.interface==4.3.2

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -62,6 +62,7 @@ tempita==0.5.2            # via pylons, sqlalchemy-migrate, weberror
 tzlocal==1.3
 unicodecsv==0.14.1
 urllib3==1.25.2           # via requests
+watchdog==0.10.2          # via werkzeug
 webassets==0.12.1
 webencodings==0.5.1       # via bleach
 weberror==0.13.1          # via pylons

--- a/requirements.in
+++ b/requirements.in
@@ -33,5 +33,5 @@ sqlparse==0.2.2
 tzlocal==1.3
 unicodecsv>=0.9
 webassets==0.12.1
-werkzeug==0.15.5
+Werkzeug[watchdog]==0.16.1
 zope.interface==4.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,6 +55,7 @@ tempita==0.5.2            # via sqlalchemy-migrate
 tzlocal==1.3
 unicodecsv==0.14.1
 urllib3==1.25.7           # via requests
+watchdog==0.10.2          # via werkzeug
 webassets==0.12.1
 webencodings==0.5.1       # via bleach
 webob==1.8.5              # via fanstatic, repoze.who


### PR DESCRIPTION
* Upgrade Werkzeug to 0.16.1. **Note** that there is a Werkzeug 1.0.0 release, but we can not use it because Flask-babel does not support it and it fails on startup
* Use watchdog as file reloader, as [it is faster than the default one](https://werkzeug.palletsprojects.com/en/0.16.x/serving/#reloader).
* Add Werkzeug logger section to ini file template so the log level can be tweaked
* Reload server when there are changes to the ini file. It's easy to add additional files to watch. Any other files that might be useful to watch?