### PR TITLE
Fix broken import of OrderdDict

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -4,6 +4,7 @@ import logging
 import datetime
 from six.moves.urllib.parse import urlencode
 
+from collections import OrderedDict
 from pylons.i18n import get_lang
 from six import string_types, text_type
 
@@ -16,7 +17,7 @@ import ckan.model as model
 import ckan.authz as authz
 import ckan.lib.plugins
 import ckan.plugins as plugins
-from ckan.common import OrderedDict, c, config, request, _
+from ckan.common import c, config, request, _
 
 log = logging.getLogger(__name__)
 

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -7,8 +7,7 @@ import datetime
 import mimetypes
 import cgi
 
-from ckan.common import config
-from ckan.common import asbool
+from collections import OrderedDict
 import paste.fileapp
 from six import string_types, text_type
 
@@ -25,7 +24,7 @@ import ckan.lib.uploader as uploader
 import ckan.plugins as p
 import ckan.lib.render
 
-from ckan.common import OrderedDict, _, json, request, c, response
+from ckan.common import config, asbool, _, json, request, c, response
 from ckan.controllers.home import CACHE_PARAMETERS
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
* broken since commit 1167dac9b3c81c907ad8e0da926496f56e3583fb

The error was occurred in the travis build in the project ckanext-dcat on the CKAN master:
https://travis-ci.org/ckan/ckanext-dcat/jobs/636277653#L1550

### Proposed fixes:
Fixes broken import of OrderedDict in
* https://github.com/ckan/ckan/blob/master/ckan/controllers/group.py
* https://github.com/ckan/ckan/blob/master/ckan/controllers/package.py

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
