### PR TITLE
Allow `search-index rebuild` for single dataset

### DIFF
--- a/ckan/cli/search_index.py
+++ b/ckan/cli/search_index.py
@@ -28,11 +28,16 @@ def search_index():
                    u'ensures that changes are immediately available on the'
                    u'search, but slows significantly the process. Default'
                    u'is false.')
-def rebuild(verbose, force, refresh, only_missing, quiet, commit_each):
+@click.argument(u'package_id', required=False)
+def rebuild(
+        verbose, force, refresh, only_missing, quiet, commit_each, package_id
+):
     u''' Rebuild search index '''
     from ckan.lib.search import rebuild, commit
     try:
-        rebuild(only_missing=only_missing,
+
+        rebuild(package_id,
+                only_missing=only_missing,
                 force=force,
                 refresh=refresh,
                 defer_commit=(not commit_each),

--- a/ckan/tests/cli/test_search_index.py
+++ b/ckan/tests/cli/test_search_index.py
@@ -45,9 +45,9 @@ class TestSearchIndex(object):
         search_result = helpers.call_action(u'package_search', q=u"package")
         assert search_result[u'count'] == 1
 
-        # Rebuild index and make sure all dataset are there
+        # Restore removed dataset and make sure all dataset are there
         result = cli.invoke(ckan,
-                            [u'search-index', u'rebuild'])
+                            [u'search-index', u'rebuild', dataset[u'id']])
         assert not result.exit_code
         search_result = helpers.call_action(u'package_search', q=u"package")
         assert search_result[u'count'] == 2


### PR DESCRIPTION
`paster` CLI had an ability to re-index a single dataset when optional additional argument provided. During the `click` migration, this feature was missing. This PR is putting optional `package_id` back there and now `search-index rebuild` has following form:
```
 ckan search-index rebuild [OPTIONS] [PACKAGE_ID]
```