### PR TITLE
Ignore auth check during CLI `dataset purge`

### DIFF
--- a/ckan/cli/dataset.py
+++ b/ckan/cli/dataset.py
@@ -73,7 +73,7 @@ def purge(package):
     name = dataset.name
 
     site_user = logic.get_action(u'get_site_user')({u'ignore_auth': True}, {})
-    context = {u'user': site_user[u'name']}
+    context = {u'user': site_user[u'name'], u'ignore_auth': True}
     logic.get_action(u'dataset_purge')(context, {u'id': package})
     click.echo(u'%s purged' % name)
 


### PR DESCRIPTION
Currently, `ckan dataset purge` raises `RuntimeError: Working outside of application context.` because of access checks that are involving `c.user`. There are two possible solutions:
1. wrap `with flask.application_context` block
2. `ignore_auth=True`

I prefer the second option, as it's CLI command, thus it's safe to ignore auth functions.