### PR TITLE
Fetch less data for `get_all_entity_ids`

### DIFF
--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -260,7 +260,7 @@ class PackageSearchQuery(SearchQuery):
         fq += "+state:active "
 
         conn = make_connection()
-        data = conn.search(query, fq=fq, rows=max_results, fields='id')
+        data = conn.search(query, fq=fq, rows=max_results, fl='id')
         return [r.get('id') for r in data.docs]
 
     def get_index(self,reference):


### PR DESCRIPTION
Recently I was reindexing the data portal with ~1.5M datasets, where 500K of datasets were already in the index. `only_missing` flag gave me `Out of memory` error. After short investigations, I've found out that we are using incorrect argument name for `solr.search` and requesting all the data instead of just `id` field inside `PackageSearchQuery::get_all_entity_ids`. 