### PR TITLE
Allow passing arguments to the RQ enqueue_call function

### DIFF
--- a/ckan/lib/jobs.py
+++ b/ckan/lib/jobs.py
@@ -160,8 +160,8 @@ def enqueue(fn, args=None, kwargs=None, title=None, queue=DEFAULT_QUEUE_NAME,
         kwargs = {}
     if rq_kwargs is None:
         rq_kwargs = {}
-    if not rq_kwargs.get('timeout'):
-        rq_kwargs['timeout'] = timeout
+    if not rq_kwargs.get(u'timeout'):
+        rq_kwargs[u'timeout'] = timeout
 
     job = get_queue(queue).enqueue_call(
         func=fn, args=args, kwargs=kwargs, **rq_kwargs)

--- a/ckan/lib/jobs.py
+++ b/ckan/lib/jobs.py
@@ -126,7 +126,7 @@ def get_queue(name=DEFAULT_QUEUE_NAME):
 
 
 def enqueue(fn, args=None, kwargs=None, title=None, queue=DEFAULT_QUEUE_NAME,
-            timeout=DEFAULT_JOB_TIMEOUT, rq_kwargs=None):
+            rq_kwargs=None):
     u'''
     Enqueue a job to be run in the background.
 
@@ -144,12 +144,9 @@ def enqueue(fn, args=None, kwargs=None, title=None, queue=DEFAULT_QUEUE_NAME,
     :param string queue: Name of the queue. If not given then the
         default queue is used.
 
-    :param integer timeout: The timeout, in seconds, to be passed
-        to the background job via rq. DEPRECATED, use
-        ```rq_kwargs={'timeout': 123}``` instead.
-
     :param dict rq_kwargs: Dict of keyword arguments that will get passed
-        to the RQ ``enqueue_call`` invocation (eg ``depends_on``, ``ttl`` etc).
+        to the RQ ``enqueue_call`` invocation (eg ``timeout``, ``depends_on``,
+        ``ttl`` etc).
 
     :returns: The enqueued job.
     :rtype: ``rq.job.Job``
@@ -160,8 +157,7 @@ def enqueue(fn, args=None, kwargs=None, title=None, queue=DEFAULT_QUEUE_NAME,
         kwargs = {}
     if rq_kwargs is None:
         rq_kwargs = {}
-    if not rq_kwargs.get(u'timeout'):
-        rq_kwargs[u'timeout'] = timeout
+    rq_kwargs[u'timeout'] = rq_kwargs.get(u'timeout', DEFAULT_JOB_TIMEOUT)
 
     job = get_queue(queue).enqueue_call(
         func=fn, args=args, kwargs=kwargs, **rq_kwargs)

--- a/ckan/tests/lib/test_jobs.py
+++ b/ckan/tests/lib/test_jobs.py
@@ -78,9 +78,9 @@ class TestEnqueue(RQTestBase):
 
     def test_enqueue_timeout(self):
         self.enqueue()
-        self.enqueue(rq_kwargs={'timeout': 0})
-        self.enqueue(rq_kwargs={'timeout': -1})
-        self.enqueue(rq_kwargs={'timeout': 3600})
+        self.enqueue(rq_kwargs={u'timeout': 0})
+        self.enqueue(rq_kwargs={u'timeout': -1})
+        self.enqueue(rq_kwargs={u'timeout': 3600})
         all_jobs = self.all_jobs()
         assert len(all_jobs) == 4
         assert all_jobs[0].timeout == 180

--- a/ckan/tests/lib/test_jobs.py
+++ b/ckan/tests/lib/test_jobs.py
@@ -78,9 +78,9 @@ class TestEnqueue(RQTestBase):
 
     def test_enqueue_timeout(self):
         self.enqueue()
-        self.enqueue(timeout=0)
-        self.enqueue(timeout=-1)
-        self.enqueue(timeout=3600)
+        self.enqueue(rq_kwargs={'timeout': 0})
+        self.enqueue(rq_kwargs={'timeout': -1})
+        self.enqueue(rq_kwargs={'timeout': 3600})
         all_jobs = self.all_jobs()
         assert len(all_jobs) == 4
         assert all_jobs[0].timeout == 180


### PR DESCRIPTION
Right now you can only pass the `timeout` argument to the RQ `enqueue_call` invocation that we use on `toolkit.enqueue_job()` (added in https://github.com/ckan/ckan/pull/4601), but there are other useful arguments that can be passed, like `depends_on`, `ttl` etc

Rather than explicitly allow just one of them, it's better to just pass through all of them.

This is backwards compatible, so I proposed we backport it to at least 2.8