### PR TITLE
Little improvements to extension template generator

### DIFF
--- a/ckan/cli/generate.py
+++ b/ckan/cli/generate.py
@@ -38,14 +38,22 @@ def extension(output_dir):
 
     # Prompt user for information
     click.echo(u"\n")
-    name = click.prompt(u"Extenion's name", default=u"must begin 'ckanext-'")
+    while True:
+        name = click.prompt(u"Extension's name",
+                            default=u"must begin 'ckanext-'")
+        if not name.startswith(u"ckanext-"):
+            print(u"ERROR: Project name must start with 'ckanext-' > {}\n"
+                  .format(name))
+        else:
+            break
+
     author = click.prompt(u"Author's name", default=u"")
     email = click.prompt(u"Author's email", default=u"")
     github = click.prompt(u"Your Github user or organization name",
                           default=u"")
     description = click.prompt(u"Brief description of the project",
                                default=u"")
-    keywords = click.prompt(u"List of keywords (seperated by spaces)",
+    keywords = click.prompt(u"List of keywords (separated by spaces)",
                             default=u"CKAN")
 
     # Ensure one instance of 'CKAN' in keywords
@@ -73,13 +81,10 @@ def extension(output_dir):
         os.chdir(u'../../../..')
         output_dir = os.getcwd()
 
-    if not name.startswith(u"ckanext-"):
-        print(u"\nERROR: Project name must start with 'ckanext-' > {}"
-              .format(name))
-        sys.exit(1)
-
     cookiecutter(template_loc, no_input=True, extra_context=context,
                  output_dir=output_dir)
+
+    print(u"\nWritten: {}/{}".format(output_dir, name))
 
 
 @generate.command(name=u'config',

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/README.rst
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/README.rst
@@ -136,6 +136,7 @@ To publish a new version to PyPI follow these steps:
 5. Commit any outstanding changes::
 
        git commit -a
+       git push
 
 6. Tag the new release of the project on GitHub with the version number from
    the ``setup.py`` file. For example if the version number in ``setup.py`` is


### PR DESCRIPTION
* Tells you where it wrote the template
* If you make an error in the extension name it gives you another chance
* When you release your extension, push the version commit (it doesn't
et included when you "push --tags")
* "seperated" typo

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
