### PR TITLE
Fix helper for getting user object in Python 3

### DIFF
--- a/ckan/authz.py
+++ b/ckan/authz.py
@@ -13,7 +13,7 @@ from ckan.common import asbool
 
 import ckan.plugins as p
 import ckan.model as model
-from ckan.common import _, c
+from ckan.common import _, g
 
 import ckan.lib.maintain as maintain
 
@@ -143,18 +143,21 @@ def is_sysadmin(username):
 
 
 def _get_user(username):
-    ''' Try to get the user from c, if possible, and fallback to using the DB '''
+    '''
+    Try to get the user from g, if possible.
+    If not fallback to using the DB
+    '''
     if not username:
         return None
     # See if we can get the user without touching the DB
     try:
-        if c.userobj and c.userobj.name == username:
-            return c.userobj
+        if g.userobj and g.userobj.name == username:
+            return g.userobj
     except AttributeError:
-        # c.userobj not set
+        # g.userobj not set
         pass
     except TypeError:
-        # c is not available
+        # c is not available (py2)
         pass
     # Get user from the DB
     return model.User.get(username)
@@ -382,13 +385,7 @@ def has_user_permission_for_some_org(user_name, permission):
 def get_user_id_for_username(user_name, allow_none=False):
     ''' Helper function to get user id '''
     # first check if we have the user object already and get from there
-    try:
-        if c.userobj and c.userobj.name == user_name:
-            return c.userobj.id
-    except (TypeError, AttributeError):
-        # c is not available
-        pass
-    user = model.User.get(user_name)
+    user = _get_user(user_name)
     if user:
         return user.id
     if allow_none:

--- a/ckan/authz.py
+++ b/ckan/authz.py
@@ -159,6 +159,10 @@ def _get_user(username):
     except TypeError:
         # c is not available (py2)
         pass
+    except RuntimeError:
+        # g is not available (py3)
+        pass
+
     # Get user from the DB
     return model.User.get(username)
 

--- a/ckan/authz.py
+++ b/ckan/authz.py
@@ -455,7 +455,7 @@ def auth_is_registered_user():
 def auth_is_loggedin_user():
     ''' Do we have a logged in user '''
     try:
-        context_user = c.user
+        context_user = g.user
     except TypeError:
         context_user = None
     return bool(context_user)

--- a/ckan/tests/test_authz.py
+++ b/ckan/tests/test_authz.py
@@ -1,8 +1,11 @@
 # encoding: utf-8
 
+import six
+import mock
 import pytest
 
 from ckan import authz as auth
+from ckan.tests import factories
 
 _check = auth.check_config_permission
 
@@ -47,3 +50,29 @@ def test_roles_that_cascade_to_sub_groups_is_a_list():
     assert sorted(_check("roles_that_cascade_to_sub_groups")) == sorted(
         ["admin", "editor"]
     )
+
+
+@pytest.mark.skipif(six.PY3, reason='Only relevant to py2')
+@mock.patch('paste.registry.TypeError')
+def test_get_user_outside_web_request_py2(mock_TypeError):
+    auth._get_user('example')
+    assert mock_TypeError.called
+
+
+@pytest.mark.skipif(six.PY2, reason='Only relevant to py3')
+@mock.patch('flask.globals.RuntimeError')
+def test_get_user_outside_web_request_py3(mock_RuntimeError):
+    auth._get_user('example')
+    assert mock_RuntimeError.called
+
+
+@pytest.mark.usefixtures('with_request_context', 'clean_db')
+def test_get_user_inside_web_request_returns_user_obj():
+    user = factories.User()
+    assert auth._get_user(user['name']).name == user['name']
+
+
+@pytest.mark.usefixtures('with_request_context')
+def test_get_user_inside_web_request_not_found():
+
+    assert auth._get_user('example') is None


### PR DESCRIPTION
The authz.py module has a function called `_get_user()` that returns the user object from `g` if present or the DB one if exists. When outside the context of a web request we had been defaulting to the Pylons `c` object, which raises a `TypeError` if it's not ready. With Pylons gone, we are asking to Flask's `g` if the user obj is there. `g` raises a `RuntimeError` if it's not ready (if you are outside of an application context in Flask terms), so I updated the helper.

Also removed duplication and updated the code to use `g`, which is what we should be getting used to from now on. Plus added tests
