### PR TITLE
Add CKAN compatibility table to extension readme

### DIFF
--- a/ckan/pastertemplates/template/README.rst_tmpl
+++ b/ckan/pastertemplates/template/README.rst_tmpl
@@ -37,8 +37,23 @@
 Requirements
 ------------
 
-For example, you might want to mention here which versions of CKAN this
-extension works with.
+.. Say what versions of CKAN this is compatible with.
+   Suggested values:
+   "yes"
+   "not tested" - I can't think of a reason why it wouldn't work
+   "not yet" - there is an intention to get it working
+   "no"
+
+Compatibility with core CKAN versions:
+
+================ =============
+CKAN version     Compatible?
+================ =============
+2.6 and earlier  not tested
+2.7              not tested
+2.8              not tested
+2.9              not tested
+================ =============
 
 
 ------------


### PR DESCRIPTION
Adds to the template for the extension README file a table of compatibility e.g.
https://github.com/davidread/ckanext-downloadall#requirements

This should be helpful with the 2.9 and 3.0 breaking changes.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
