### PR TITLE
Retry datastore tests that are flaky

### DIFF
--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -315,6 +315,7 @@ class TestDatastoreCreateNewTests(object):
 
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    @pytest.mark.flaky(reruns=2)  # because analyze is sometimes delayed
     def test_calculate_record_count(self):
         # how datapusher loads data (send_resource_to_datastore)
         resource = factories.Resource()

--- a/ckanext/datastore/tests/test_delete.py
+++ b/ckanext/datastore/tests/test_delete.py
@@ -93,6 +93,7 @@ class TestDatastoreDelete(object):
 
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    @pytest.mark.flaky(reruns=2)  # because analyze is sometimes delayed
     def test_calculate_record_count(self):
         resource = factories.Resource()
         data = {

--- a/ckanext/datastore/tests/test_upsert.py
+++ b/ckanext/datastore/tests/test_upsert.py
@@ -526,6 +526,7 @@ class TestDatastoreUpsert(object):
 
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    @pytest.mark.flaky(reruns=2)  # because analyze is sometimes delayed
     def test_calculate_record_count(self):
         resource = factories.Resource()
         data = {

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,3 +18,4 @@ cookiecutter==1.6.0
 pytest==4.6.5
 pytest-split-tests==1.0.9
 pytest-cov==2.7.1
+pytest-rerunfailures==8.0


### PR DESCRIPTION
These sorts of test failures are annoying: https://circleci.com/gh/ckan/ckan/6711#tests/containers/3 - they crop up on Travis builds too often :(

I'd like to fix these tests to work reliably, but postgres is non-determinate for these analyze functions ([context](https://github.com/ckan/ckan/pull/4473)), so I can't see how. We already have a sleep(1) in the tests, but it still happens.

Instead we just retry them (i.e. what this PR does)

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
