### PR TITLE
Quick fix to the solr-jetty install on 18.04

### DIFF
--- a/doc/maintaining/installing/solr.rst
+++ b/doc/maintaining/installing/solr.rst
@@ -113,6 +113,12 @@ installed, we need to install and configure Solr.
 
    Check that Solr is running by opening http://localhost:8983/solr/.
 
+   .. note::
+
+    If you're installing on Ubuntu 18.04 (Bionic) you'll find you get a 404
+    error due to a bad solr-jetty package (3.6.2+dfsg-18~18.04). This can be
+    solved by following these extra instructions:
+    https://stackoverflow.com/a/56007895
 
 #. Finally, change the :ref:`solr_url` setting in your :ref:`config_file` (|production.ini|) to
    point to your Solr server, for example::


### PR DESCRIPTION
Fixes #4762

This solution is as discussed in https://github.com/ckan/ckan/issues/4762#issuecomment-559763975

I suggest this is also backported to the docs for 2.7 and 2.8.

Of course solr-jetty gives only SOLR 3.6, which is end of life, but there
are other initiatives to provide an updated version:
https://github.com/ckan/ideas-and-roadmap/issues/232

### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
