### PR TITLE
Datastore CLI docs optimized for source install

### DIFF
--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -136,30 +136,33 @@ superuser using::
 
     sudo -u postgres psql
 
-Then you can use this connection to set the permissions::
-
-    sudo ckan datastore set-permissions | sudo -u postgres psql --set ON_ERROR_STOP=1
-
-.. note::
-
-   If you performed a source install, you will need to replace all references to
-   ``sudo ckan ...`` with 'ckan -c |ckan.ini| ...' and provide the path to
-   the config file, e.g.:
+Then you can use this connection to set the permissions:
 
    .. parsed-literal::
 
     ckan -c |ckan.ini| datastore set-permissions | sudo -u postgres psql --set ON_ERROR_STOP=1
 
-If your database server is not local, but you can access it over SSH, you can
-pipe the permissions script over SSH::
+.. note::
 
-    sudo ckan datastore set-permissions |
-    ssh dbserver sudo -u postgres psql --set ON_ERROR_STOP=1
+   If you performed a package install, you will need to replace all references to
+   'ckan -c |ckan.ini| ...' with 'sudo ckan ...' and provide the path to
+   the config file, e.g.::
+
+    sudo ckan datastore set-permissions | sudo -u postgres psql --set ON_ERROR_STOP=1
+
+If your database server is not local, but you can access it over SSH, you can
+pipe the permissions script over SSH:
+
+    .. parsed-literal::
+
+     ckan -c |ckan.ini| datastore set-permissions | ssh dbserver sudo -u postgres psql --set ON_ERROR_STOP=1
 
 If you can't use the ``psql`` command in this way, you can simply copy and paste
-the output of::
+the output of:
 
-    sudo ckan datastore set-permissions
+    .. parsed-literal::
+
+     ckan -c |ckan.ini| datastore set-permissions
 
 into a |postgres| superuser console.
 


### PR DESCRIPTION
I swapped the order that the two versions are read - now it describes the source install's 'ckan' command in the body, and the package install's 'ckan' command in the note.

This is because CKAN's package install is rather neglected and I think more people use source install these days. And this is more important with the introduction of the new 'ckan' command. we should optimize for the new and most used one to avoid confusion.

### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
