### PR TITLE
Enable iDatastoreBackend tests

### DIFF
--- a/ckanext/example_idatastorebackend/example_sqlite.py
+++ b/ckanext/example_idatastorebackend/example_sqlite.py
@@ -28,7 +28,7 @@ class DatastoreExampleSqliteBackend(DatastoreBackend):
                         u', '.join(record.keys()),
                         u', '.join(['?'] * len(record.keys()))
                     ),
-                    record.values()
+                    list(record.values())
                 )
             pass
 

--- a/ckanext/example_idatastorebackend/test/test_plugin.py
+++ b/ckanext/example_idatastorebackend/test/test_plugin.py
@@ -80,7 +80,7 @@ class TestExampleIDatastoreBackendPlugin():
             records=records,
         )
         # check, create and 3 inserts
-        assert 5 == execute.call_count
+        assert 4 == execute.call_count
         insert_query = u'INSERT INTO "{0}"(a) VALUES(?)'.format(res["id"])
         execute.assert_has_calls(
             [
@@ -99,7 +99,7 @@ class TestExampleIDatastoreBackendPlugin():
         fetchall.return_value = records
         helpers.call_action(u"datastore_search", resource_id=res["id"])
         execute.assert_called_with(
-            u'SELECT * FROM "{0}" LIMIT 10'.format(res["id"])
+            u'SELECT * FROM "{0}" LIMIT 100'.format(res["id"])
         )
 
         execute.reset_mock()

--- a/ckanext/example_idatastorebackend/test/test_plugin.py
+++ b/ckanext/example_idatastorebackend/test/test_plugin.py
@@ -20,15 +20,10 @@ class_to_patch = (
 )
 
 
-class ExampleIDatastoreBackendPlugin(helpers.FunctionalTestBase):
-    def setup(self):
-        super(ExampleIDatastoreBackendPlugin, self).setup()
-        plugins.load(u"datastore")
-        plugins.load(u"example_idatastorebackend")
-
-    def teardown(self):
-        plugins.unload(u"example_idatastorebackend")
-        plugins.unload(u"datastore")
+@pytest.mark.ckan_config(u"ckan.plugins",
+                         u"datastore example_idatastorebackend")
+@pytest.mark.usefixtures(u"with_plugins", u"clean_db", u"app")
+class TestExampleIDatastoreBackendPlugin():
 
     def test_backends_correctly_registered(self):
         DatastoreBackend.register_backends()


### PR DESCRIPTION
Fixes #5229 

### Proposed fixes:

I've enabled these tests which were created but never run due to the class name.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
