### PR TITLE
Flask raises RuntimeError when not in a request context

### DIFF
--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -676,7 +676,7 @@ def _insert_links(data_dict, limit, offset):
     # get the url from the request
     try:
         urlstring = toolkit.request.environ['CKAN_CURRENT_URL']
-    except (KeyError, TypeError):
+    except (KeyError, TypeError, RuntimeError):
         return  # no links required for local actions
 
     # change the offset in the url


### PR DESCRIPTION
I saw the issue in an extension's test which calls `datastore_search`, but not in a request context:

```
...
File "/usr/lib/ckan/default/src/ckan/ckan/logic/__init__.py", line 472, in wrapped
    result = _action(context, data_dict, **kw)
File "/usr/lib/ckan/default/src/ckan/ckanext/datastore/logic/action.py", line 518, in datastore_search
    result = backend.search(context, data_dict)
File "/usr/lib/ckan/default/src/ckan/ckanext/datastore/backend/postgres.py", line 1919, in search
    return search(context, data_dict)
File "/usr/lib/ckan/default/src/ckan/ckanext/datastore/backend/postgres.py", line 1536, in search
    return search_data(context, data_dict)
File "/usr/lib/ckan/default/src/ckan/ckanext/datastore/backend/postgres.py", line 1322, in search_data
    _insert_links(data_dict, limit, offset)
File "/usr/lib/ckan/default/src/ckan/ckanext/datastore/backend/postgres.py", line 678, in _insert_links
    urlstring = toolkit.request.environ['CKAN_CURRENT_URL']
File "/usr/lib/ckan/default/lib/python3.6/site-packages/werkzeug/local.py", line 348, in __getattr__
    return getattr(self._get_current_object(), name)
File "/usr/lib/ckan/default/lib/python3.6/site-packages/werkzeug/local.py", line 348, in __getattr__
    return getattr(self._get_current_object(), name)
File "/usr/lib/ckan/default/lib/python3.6/site-packages/werkzeug/local.py", line 307, in _get_current_object
    return self.__local()
File "/usr/lib/ckan/default/lib/python3.6/site-packages/flask/globals.py", line 38, in _lookup_req_object
    raise RuntimeError(_request_ctx_err_msg)
RuntimeError: Working outside of request context.
```

The flask docs are [clear](https://flask.palletsprojects.com/en/1.1.x/reqcontext/#manually-push-a-context) that any access of 'request' when not in an request context will raise RuntimeError, rather than one of the other exceptions - I guess they were for pylons.

I think this can be tested if we enable the tests mentioned here: https://github.com/ckan/ckan/pull/5230 which calls 'datastore_search'.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
