### PR TITLE
Reinstate webtest dep for py2 to avoid WebOb conflict

### DIFF
--- a/requirements-py2.in
+++ b/requirements-py2.in
@@ -40,5 +40,6 @@ unicodecsv>=0.9
 webassets==0.12.1
 WebHelpers==1.3
 WebOb==1.0.8
+WebTest==1.4.3  # need to pin this so that Pylons does not install a newer version that conflicts with WebOb==1.0.8
 Werkzeug[watchdog]==0.16.1
 zope.interface==4.3.2

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -68,5 +68,6 @@ webencodings==0.5.1       # via bleach
 weberror==0.13.1          # via pylons
 webhelpers==1.3
 webob==1.0.8
+webtest==1.4.3
 werkzeug==0.15.5
 zope.interface==4.3.2


### PR DESCRIPTION
We switched from nose to pytest, including for py2, so we don't use
WebTest any more. However we still use pylons in py2 and pylons requires WebTest>=1.1
so it installs WebTest2.0.34 but that in turn needs WebOb>=1.2, when we
specify WebOb==1.0.8, so there is a conflict and error message (well it's a benign warning, but still good to get rid of). So that's why this PR specifies the WebTest version that was removed in https://github.com/ckan/ckan/commit/4fc681ffc87d8084b28f18a63f69437f7c3a53f6#diff-4265e6ab456751bf98411ff15c77b889L41
```
$ pip install -r requirements-py2.txt
...
Collecting WebTest>=1.1
  Downloading WebTest-2.0.34-py2.py3-none-any.whl (32 kB)
...
ERROR: webtest 2.0.34 has requirement WebOb>=1.2, but you'll have webob 1.0.8 which is incompatible.
```
I don't know why pip doesn't work this out! This error can be reproduced with
a blank virtualenv and:

    pip install pylons==0.9.7 WebOb==1.0.8


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
