### PR TITLE
Set Isolation_level to READ_UNCOMMITTED for datastore read-only connection

### DIFF
--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -103,8 +103,8 @@ def identifier(s):
 
 
 def get_read_engine():
-    return _get_engine_from_url(config['ckan.datastore.read_url'], isolation_level= 'READ_UNCOMMITTED')
-
+    return _get_engine_from_url(config['ckan.datastore.read_url'], 
+        isolation_level= 'READ_UNCOMMITTED')
 
 def get_write_engine():
     return _get_engine_from_url(config['ckan.datastore.write_url'])

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -103,19 +103,21 @@ def identifier(s):
 
 
 def get_read_engine():
-    return _get_engine_from_url(config['ckan.datastore.read_url'])
+    return _get_engine_from_url(config['ckan.datastore.read_url'], isolation_level= 'READ_UNCOMMITTED')
 
 
 def get_write_engine():
     return _get_engine_from_url(config['ckan.datastore.write_url'])
 
 
-def _get_engine_from_url(connection_url):
+def _get_engine_from_url(connection_url, **kwargs):
     '''Get either read or write engine.'''
     engine = _engines.get(connection_url)
     if not engine:
         extras = {'url': connection_url}
         config.setdefault('pool_pre_ping', True)
+        for key, value in kwargs.items():
+            config.setdefault(key, value)
         engine = sqlalchemy.engine_from_config(config,
                                                'ckan.datastore.sqlalchemy.',
                                                **extras)


### PR DESCRIPTION
Implements https://github.com/ckan/ideas-and-roadmap/issues/241

### Features:
 * sets isolation_level to READ_UNCOMMITTED
 * enables the passing of additional engine parameters to SQLAlchemy when creating engine connections

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
