### PR TITLE
PasteDeploy dep removed from 'Profile' command in the paster cli

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -26,6 +26,7 @@ import sqlalchemy as sa
 
 import routes
 import paste.script
+from paste.script import command
 from paste.registry import Registry
 from paste.script.util.logging_config import fileConfig
 import click
@@ -299,7 +300,7 @@ click_config_option = click.option(
     help=u'Config file to use (default: development.ini)')
 
 
-class CkanCommand(paste.script.command.Command):
+class CkanCommand(command.Command):
     '''Base class for classes that implement CKAN paster commands to inherit.'''
     parser = paste.script.command.Command.standard_parser(verbose=True)
     parser.add_option('-c', '--config', dest='config',
@@ -1341,6 +1342,8 @@ class Profile(CkanCommand):
         if not os.path.exists(self.filename):
             raise AssertionError('Config filename %r does not exist.' % self.filename)
         fileConfig(self.filename)
+
+        print(CkanCommand)
 
         wsgiapp = loadapp('config:' + self.filename)
         self.app = paste.fixture.TestApp(wsgiapp)

--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -1333,19 +1333,12 @@ class Profile(CkanCommand):
     min_args = 1
 
     def _load_config_into_test_app(self):
-        from paste.deploy import loadapp
         import paste.fixture
-        if not self.options.config:
-            msg = 'No config file supplied'
-            raise self.BadCommand(msg)
-        self.filename = os.path.abspath(self.options.config)
-        if not os.path.exists(self.filename):
-            raise AssertionError('Config filename %r does not exist.' % self.filename)
-        fileConfig(self.filename)
 
-        print(CkanCommand)
+        conf = _get_config(self.options.config)
 
-        wsgiapp = loadapp('config:' + self.filename)
+        wsgiapp = make_app(conf.global_conf, **conf.local_conf)
+
         self.app = paste.fixture.TestApp(wsgiapp)
 
     def command(self):


### PR DESCRIPTION
Part of #4802

This helps us get rid of the PasteDeploy dependency on CKAN 2.9. So assuming this works it is useful to merge. (However arguably we could simply delete this paster Profile command as we have the click version.)

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
