### PR TITLE
Upgrade werkzeug and flask-babel

### DIFF
--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -5,7 +5,7 @@ from ckan.common import asbool
 import six
 from six import text_type
 from six.moves.urllib.parse import quote
-from werkzeug import import_string, cached_property
+from werkzeug.utils import import_string, cached_property
 
 import ckan.model as model
 from ckan.common import g, request, config, session

--- a/requirements.in
+++ b/requirements.in
@@ -9,7 +9,7 @@ dominate==2.4.0
 fanstatic==1.1
 feedgen==0.9.0
 Flask==1.1.1
-Flask-Babel==0.11.2
+Flask-Babel==1.0.0
 flask-multistatic==1.0
 Jinja2==2.10.1
 Markdown==2.6.7
@@ -33,5 +33,5 @@ sqlparse==0.2.2
 tzlocal==1.3
 unicodecsv>=0.9
 webassets==0.12.1
-Werkzeug[watchdog]==0.16.1
+Werkzeug[watchdog]==1.0.0
 zope.interface==4.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,10 +15,9 @@ decorator==4.4.1          # via sqlalchemy-migrate
 dominate==2.4.0
 fanstatic==1.1
 feedgen==0.9.0
-flask-babel==0.11.2
-flask==1.1.1
+flask-babel==1.0.0
 flask-multistatic==1.0
-funcsigs==1.0.2           # via beaker
+flask==1.1.1
 idna==2.8                 # via requests
 itsdangerous==1.1.0       # via flask
 jinja2==2.10.1
@@ -28,7 +27,8 @@ markdown==2.6.7
 markupsafe==1.1.1         # via jinja2, mako
 nose==1.3.7               # via pyutilib
 passlib==1.6.5
-pastedeploy==2.0.1        # via pastescript
+pastedeploy==2.0.1        # manually kept - remove when #4802 is complete
+pathtools==0.1.2          # via watchdog
 pbr==5.4.4                # via sqlalchemy-migrate
 polib==1.0.7
 psycopg2==2.8.2
@@ -47,7 +47,7 @@ routes==1.13
 rq==1.0
 shutilwhich==1.1.0        # via fanstatic
 simplejson==3.10.0
-six==1.13.0               # via bleach, pastescript, python-dateutil, pyutilib, sqlalchemy-migrate
+six==1.13.0               # via bleach, python-dateutil, pyutilib, sqlalchemy-migrate
 sqlalchemy-migrate==0.12.0
 sqlalchemy==1.3.5
 sqlparse==0.2.2
@@ -59,5 +59,5 @@ watchdog==0.10.2          # via werkzeug
 webassets==0.12.1
 webencodings==0.5.1       # via bleach
 webob==1.8.5              # via fanstatic, repoze.who
-werkzeug==0.15.5
+werkzeug[watchdog]==1.0.0
 zope.interface==4.3.2


### PR DESCRIPTION
Might as well be up to date and upgrade werkzeug - 0.15.5 -> 1.0.0. With that, some old ways of importing it have changed, hence the change in `views/__init__` and the Flask-Babel upgrade 0.11.2 -> 1.0.0. I've not done any manual testing - just the automated tests. I guess any problems will come out in the wash in coming weeks before release.

In the course of this I also did:

    pip-compile --output-file requirements.txt requirements.in

which resulted in some minor changes:

* PasteDeploy is still needed temporarily (I added it to requirements.txt manually), until we finish #4802. (It is also a dependency of pastescript, but that's only still used in python 2 - paster commands and python 2 tests)

* funcsigs is a backport only needed on python 2

* Watchdog is a recommended addition to Werkzeug. It's a more efficient way to monitor the file system for changes to files, used when you use the --reload option with `ckan serve` More info: https://werkzeug.palletsprojects.com/en/1.0.x/serving/#reloader
It was previously added to the requirements.in but missing from .txt, hence why it's popped up now.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
