### PR TITLE
Document when IBlueprint was introduced

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -446,7 +446,8 @@ Major changes:
  * Common session object for Flask and Pylons (#3208)
  * Rename deleted datasets when they conflict with new ones (#3370)
  * DataStore dump more formats: CSV, TSV, XML, JSON; BOM option (#3390)
- * Common requests code for Flask and Pylons (#3212)
+ * Common requests code for Flask and Pylons so you can use Flask views via the
+   new IBlueprint interface (#3212)
  * Generate complete datastore dump files (#3344)
  * A new system for asynchronous background jobs (#3165)
  * Chaining of action functions (#3494)


### PR DESCRIPTION
IBlueprint was added in https://github.com/ckan/ckan/pull/3207 which was merged in as part of #3212, so was introduced in CKAN 2.7. This is helpful info when updating extensions from controllers and IBlueprint and need to retain compatibility with older CKAN versions.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
