### PR TITLE
Samesite auth cookie

### DIFF
--- a/ckan/lib/repoze_plugins/auth_tkt.py
+++ b/ckan/lib/repoze_plugins/auth_tkt.py
@@ -6,6 +6,11 @@ import os
 
 import six
 
+try:
+    from http.cookies import SimpleCookie
+except ImportError:
+    from Cookie import SimpleCookie
+
 from ckan.common import config
 from repoze.who.plugins import auth_tkt as repoze_auth_tkt
 
@@ -27,9 +32,10 @@ class CkanAuthTktCookiePlugin(repoze_auth_tkt.AuthTktCookiePlugin):
 
     userid_type_decoders = _ckan_userid_type_decoders
 
-    def __init__(self, httponly, *args, **kwargs):
+    def __init__(self, httponly, samesite, *args, **kwargs):
         super(CkanAuthTktCookiePlugin, self).__init__(*args, **kwargs)
         self.httponly = httponly
+        self.samesite = samesite
 
     def _get_cookies(self, *args, **kwargs):
         u'''
@@ -40,9 +46,25 @@ class CkanAuthTktCookiePlugin(repoze_auth_tkt.AuthTktCookiePlugin):
 
         cookies = []
         for k, v in super_cookies:
-            replace_with = '; HttpOnly' if self.httponly else ''
-            v = v.replace('; HttpOnly', '') + replace_with
-            cookies.append((k, v))
+            cookie = SimpleCookie(str(v))
+            morsel = cookie.values()[0]
+            # SameSite was only added on Python 3.8
+            morsel._reserved['samesite'] = 'SameSite'
+            # Keep old case as it's the one used in tests, it should make no
+            # difference in the browser
+            morsel._reserved['httponly'] = 'HttpOnly'
+
+            if self.httponly:
+                cookie[self.cookie_name]['HttpOnly'] = True
+
+            if self.samesite == 'none':
+                cookie[self.cookie_name]['SameSite'] = 'None'
+            elif self.samesite == 'strict':
+                cookie[self.cookie_name]['SameSite'] = 'Strict'
+            else:
+                cookie[self.cookie_name]['SameSite'] = 'Lax'
+
+            cookies.append((k, cookie.output().replace('Set-Cookie: ', '')))
 
         return cookies
 
@@ -69,9 +91,15 @@ def make_plugin(secret=None,
     if timeout is not None and reissue_time is None:
         reissue_time = int(math.ceil(int(timeout) * 0.1))
     # Set httponly based on config value. Default is True
-    httponly = config.get(u'who.httponly', True)
+    httponly = _bool(config.get(u'who.httponly', True))
     # Set secure based on config value. Default is False
-    secure = config.get(u'who.secure', False)
+    secure = _bool(config.get(u'who.secure', False))
+    # Set samesite based on config value. Default is lax
+    samesite = config.get(u'who.samesite', 'lax').lower()
+    if samesite == 'none' and not secure:
+        raise ValueError(
+            'SameSite=None requires the Secure attribute,'
+            'please set who.secure=True')
 
     # back to repoze boilerplate
     if (secret is None and secretfile is None):
@@ -89,10 +117,11 @@ def make_plugin(secret=None,
         reissue_time = int(reissue_time)
     if userid_checker is not None:
         userid_checker = resolveDotted(userid_checker)
-    plugin = CkanAuthTktCookiePlugin(_bool(httponly),
+    plugin = CkanAuthTktCookiePlugin(httponly,
+                                     samesite,
                                      secret,
                                      cookie_name,
-                                     _bool(secure),
+                                     secure,
                                      _bool(include_ip),
                                      timeout,
                                      reissue_time,

--- a/ckan/lib/repoze_plugins/auth_tkt.py
+++ b/ckan/lib/repoze_plugins/auth_tkt.py
@@ -47,12 +47,13 @@ class CkanAuthTktCookiePlugin(repoze_auth_tkt.AuthTktCookiePlugin):
         cookies = []
         for k, v in super_cookies:
             cookie = SimpleCookie(str(v))
-            morsel = cookie.values()[0]
+            morsel = list(cookie.values())[0]
             # SameSite was only added on Python 3.8
             morsel._reserved['samesite'] = 'SameSite'
             # Keep old case as it's the one used in tests, it should make no
             # difference in the browser
             morsel._reserved['httponly'] = 'HttpOnly'
+            morsel._reserved['secure'] = 'Secure'
 
             if self.httponly:
                 cookie[self.cookie_name]['HttpOnly'] = True

--- a/ckan/tests/lib/test_auth_tkt.py
+++ b/ckan/tests/lib/test_auth_tkt.py
@@ -9,8 +9,14 @@ after each test.
 
 
 import pytest
-from ckan.tests import helpers
 from ckan.lib.repoze_plugins.auth_tkt import make_plugin
+
+
+def _sorted_cookie_values(cookies):
+    out = []
+    for cookie in cookies:
+        out.append((cookie[0], '; '.join(sorted(cookie[1].split('; ')))))
+    return out
 
 
 @pytest.mark.ckan_config("who.httponly", True)
@@ -23,14 +29,13 @@ def test_httponly_expected_cookies_with_config_httponly_true():
         environ={"SERVER_NAME": "0.0.0.0"}, value="HELLO"
     )
     expected_cookies = [
-        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; HttpOnly'),
-        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=0.0.0.0; HttpOnly'),
-        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=.0.0.0.0; HttpOnly'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; HttpOnly; SameSite=Lax'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=0.0.0.0; HttpOnly; SameSite=Lax'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=.0.0.0.0; HttpOnly; SameSite=Lax'),
     ]
-    assert cookies == expected_cookies
+    assert _sorted_cookie_values(cookies) == _sorted_cookie_values(expected_cookies)
 
 
-@pytest.mark.usefixtures("clean_db")
 @pytest.mark.ckan_config("who.httponly", False)
 def test_httponly_expected_cookies_with_config_httponly_false():
     """
@@ -42,11 +47,11 @@ def test_httponly_expected_cookies_with_config_httponly_false():
         environ={"SERVER_NAME": "0.0.0.0"}, value="HELLO"
     )
     expected_cookies = [
-        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/'),
-        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=0.0.0.0'),
-        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=.0.0.0.0'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; SameSite=Lax'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=0.0.0.0; SameSite=Lax'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=.0.0.0.0; SameSite=Lax'),
     ]
-    assert cookies == expected_cookies
+    assert _sorted_cookie_values(cookies) == _sorted_cookie_values(expected_cookies)
 
 
 def test_httponly_expected_cookies_without_config_httponly():
@@ -58,11 +63,88 @@ def test_httponly_expected_cookies_without_config_httponly():
         environ={"SERVER_NAME": "0.0.0.0"}, value="HELLO"
     )
     expected_cookies = [
-        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; HttpOnly'),
-        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=0.0.0.0; HttpOnly'),
-        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=.0.0.0.0; HttpOnly'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; HttpOnly; SameSite=Lax'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=0.0.0.0; HttpOnly; SameSite=Lax'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=.0.0.0.0; HttpOnly; SameSite=Lax'),
     ]
-    assert cookies == expected_cookies
+    assert _sorted_cookie_values(cookies) == _sorted_cookie_values(expected_cookies)
+
+
+@pytest.mark.ckan_config("who.samesite", "lax")
+def test_samesite_expected_cookies_with_config_samesite_lax():
+    """
+    The returned cookies are in the format we expect, with SameSite flag set to lax.
+    """
+    plugin = make_plugin(secret="sosecret")
+    cookies = plugin._get_cookies(
+        environ={"SERVER_NAME": "0.0.0.0"}, value="HELLO"
+    )
+    expected_cookies = [
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; HttpOnly; SameSite=Lax'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=0.0.0.0; HttpOnly; SameSite=Lax'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=.0.0.0.0; HttpOnly; SameSite=Lax'),
+    ]
+    assert _sorted_cookie_values(cookies) == _sorted_cookie_values(expected_cookies)
+
+
+@pytest.mark.ckan_config("who.samesite", "strict")
+def test_samesite_expected_cookies_with_config_samesite_strict():
+    """
+    The returned cookies are in the format we expect, with SameSite flag set to strict.
+    """
+    plugin = make_plugin(secret="sosecret")
+    cookies = plugin._get_cookies(
+        environ={"SERVER_NAME": "0.0.0.0"}, value="HELLO"
+    )
+    expected_cookies = [
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; HttpOnly; SameSite=Strict'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=0.0.0.0; HttpOnly; SameSite=Strict'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=.0.0.0.0; HttpOnly; SameSite=Strict'),
+    ]
+    assert _sorted_cookie_values(cookies) == _sorted_cookie_values(expected_cookies)
+
+
+@pytest.mark.ckan_config("who.secure", "true")
+@pytest.mark.ckan_config("who.samesite", "none")
+def test_samesite_expected_cookies_with_config_samesite_none():
+    """
+    The returned cookies are in the format we expect, with SameSite flag set to none.
+    """
+    plugin = make_plugin(secret="sosecret")
+    cookies = plugin._get_cookies(
+        environ={"SERVER_NAME": "0.0.0.0"}, value="HELLO"
+    )
+    expected_cookies = [
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; HttpOnly; secure; SameSite=None'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=0.0.0.0; secure; HttpOnly; SameSite=None'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=.0.0.0.0; HttpOnly; secure; SameSite=None'),
+    ]
+    assert _sorted_cookie_values(cookies) == _sorted_cookie_values(expected_cookies)
+
+
+@pytest.mark.ckan_config("who.samesite", "none")
+def test_config_samesite_none_without_secure_raises_exception():
+    """
+    If setting the SameSite flag to none without Secure being true, an exception is raised.
+    """
+    with pytest.raises(ValueError):
+        make_plugin(secret="sosecret")
+
+
+def test_samesite_expected_cookies_without_config_samesite():
+    """
+    The returned cookies are in the format we expect, with SameSite flag set to lax.
+    """
+    plugin = make_plugin(secret="sosecret")
+    cookies = plugin._get_cookies(
+        environ={"SERVER_NAME": "0.0.0.0"}, value="HELLO"
+    )
+    expected_cookies = [
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; HttpOnly; SameSite=Lax'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=0.0.0.0; HttpOnly; SameSite=Lax'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=.0.0.0.0; HttpOnly; SameSite=Lax'),
+    ]
+    assert _sorted_cookie_values(cookies) == _sorted_cookie_values(expected_cookies)
 
 
 @pytest.mark.ckan_config("who.secure", True)
@@ -75,17 +157,17 @@ def test_secure_expected_cookies_with_config_secure_true():
         environ={"SERVER_NAME": "0.0.0.0"}, value="HELLO"
     )
     expected_cookies = [
-        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; secure; HttpOnly'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; secure; HttpOnly; SameSite=Lax'),
         (
             "Set-Cookie",
-            'auth_tkt="HELLO"; Path=/; Domain=0.0.0.0; secure; HttpOnly',
+            'auth_tkt="HELLO"; Path=/; Domain=0.0.0.0; secure; HttpOnly; SameSite=Lax',
         ),
         (
             "Set-Cookie",
-            'auth_tkt="HELLO"; Path=/; Domain=.0.0.0.0; secure; HttpOnly',
+            'auth_tkt="HELLO"; Path=/; Domain=.0.0.0.0; secure; HttpOnly; SameSite=Lax',
         ),
     ]
-    assert cookies == expected_cookies
+    assert _sorted_cookie_values(cookies) == _sorted_cookie_values(expected_cookies)
 
 
 @pytest.mark.ckan_config("who.secure", False)
@@ -99,11 +181,11 @@ def test_secure_expected_cookies_with_config_secure_false():
         environ={"SERVER_NAME": "0.0.0.0"}, value="HELLO"
     )
     expected_cookies = [
-        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; HttpOnly'),
-        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=0.0.0.0; HttpOnly'),
-        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=.0.0.0.0; HttpOnly'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; HttpOnly; SameSite=Lax'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=0.0.0.0; HttpOnly; SameSite=Lax'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=.0.0.0.0; HttpOnly; SameSite=Lax'),
     ]
-    assert cookies == expected_cookies
+    assert _sorted_cookie_values(cookies) == _sorted_cookie_values(expected_cookies)
 
 
 def test_secure_expected_cookies_without_config_secure():
@@ -115,11 +197,11 @@ def test_secure_expected_cookies_without_config_secure():
         environ={"SERVER_NAME": "0.0.0.0"}, value="HELLO"
     )
     expected_cookies = [
-        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; HttpOnly'),
-        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=0.0.0.0; HttpOnly'),
-        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=.0.0.0.0; HttpOnly'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; HttpOnly; SameSite=Lax'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=0.0.0.0; HttpOnly; SameSite=Lax'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=.0.0.0.0; HttpOnly; SameSite=Lax'),
     ]
-    assert cookies == expected_cookies
+    assert _sorted_cookie_values(cookies) == _sorted_cookie_values(expected_cookies)
 
 
 def test_timeout_not_set_in_config():

--- a/ckan/tests/lib/test_auth_tkt.py
+++ b/ckan/tests/lib/test_auth_tkt.py
@@ -115,9 +115,9 @@ def test_samesite_expected_cookies_with_config_samesite_none():
         environ={"SERVER_NAME": "0.0.0.0"}, value="HELLO"
     )
     expected_cookies = [
-        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; HttpOnly; secure; SameSite=None'),
-        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=0.0.0.0; secure; HttpOnly; SameSite=None'),
-        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=.0.0.0.0; HttpOnly; secure; SameSite=None'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; HttpOnly; Secure; SameSite=None'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=0.0.0.0; Secure; HttpOnly; SameSite=None'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Domain=.0.0.0.0; HttpOnly; Secure; SameSite=None'),
     ]
     assert _sorted_cookie_values(cookies) == _sorted_cookie_values(expected_cookies)
 
@@ -157,14 +157,14 @@ def test_secure_expected_cookies_with_config_secure_true():
         environ={"SERVER_NAME": "0.0.0.0"}, value="HELLO"
     )
     expected_cookies = [
-        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; secure; HttpOnly; SameSite=Lax'),
+        ("Set-Cookie", 'auth_tkt="HELLO"; Path=/; Secure; HttpOnly; SameSite=Lax'),
         (
             "Set-Cookie",
-            'auth_tkt="HELLO"; Path=/; Domain=0.0.0.0; secure; HttpOnly; SameSite=Lax',
+            'auth_tkt="HELLO"; Path=/; Domain=0.0.0.0; Secure; HttpOnly; SameSite=Lax',
         ),
         (
             "Set-Cookie",
-            'auth_tkt="HELLO"; Path=/; Domain=.0.0.0.0; secure; HttpOnly; SameSite=Lax',
+            'auth_tkt="HELLO"; Path=/; Domain=.0.0.0.0; Secure; HttpOnly; SameSite=Lax',
         ),
     ]
     assert _sorted_cookie_values(cookies) == _sorted_cookie_values(expected_cookies)

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -173,6 +173,21 @@ This determines whether the secure flag will be set for the repoze.who
 authorization cookie. If ``True``, the cookie will be sent over HTTPS. The
 default in the absence of the setting is ``False``.
 
+.. _who.samesite:
+
+who.samesite
+^^^^^^^^^^^^
+
+Example::
+
+ who.samesite = Strict
+
+Default value: Lax
+
+This determines whether the SameSite flag will be set for the repoze.who
+authorization cookie. Allowed values are ``Lax`` (the default one), ``Strict`` or ``None``.
+If set to ``None``,  ``who.secure`` must be set to ``True``.
+
 
 Database Settings
 -----------------


### PR DESCRIPTION
Allows setting the SameSite attribute on the auth cookie, and aligning with what browsers are moving towards to, default it to `Lax`.

Refactored the code to not rely on string manipulation for modifying the cookie attributes but rather the standard library module.

This causes some changes in the case of the attributes and their order which means updating the tests, but I think it's worth the extra work.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies