### PR TITLE
config-tool - fix mention of paster

### DIFF
--- a/ckan/cli/cli.py
+++ b/ckan/cli/cli.py
@@ -48,9 +48,10 @@ class CkanCommand(object):
 
 def _init_ckan_config(ctx, param, value):
 
-    # This is necessary to allow the user to create
-    # a config file when one isn't already present
-    if len(sys.argv) > 1 and sys.argv[1] == u'generate' and not value:
+    # Some commands don't require the config loaded
+    if (len(sys.argv) > 1 and not value
+            and sys.argv[1] in (u'generate', u'config-tool')) \
+            or u'--help' in sys.argv:
         return
 
     ctx.obj = CkanCommand(value)

--- a/ckan/cli/config_tool.py
+++ b/ckan/cli/config_tool.py
@@ -50,17 +50,17 @@ class ConfigOption(click.ParamType):
 def config_tool(config_filepath, options, section, edit, merge_filepath):
     u'''Tool for editing options in a CKAN config file
 
-    paster config-tool <default.ini> <key>=<value> [<key>=<value> ...]
+    ckan config-tool <default.ini> <key>=<value> [<key>=<value> ...]
 
-    paster config-tool <default.ini> -f <custom_options.ini>
+    ckan config-tool <default.ini> -f <custom_options.ini>
 
     Examples:
 
-      paster config-tool default.ini sqlalchemy.url=123 'ckan.site_title=ABC'
+      ckan config-tool default.ini sqlalchemy.url=123 'ckan.site_title=ABC'
 
-      paster config-tool default.ini -s server:main -e port=8080
+      ckan config-tool default.ini -s server:main -e port=8080
 
-      paster config-tool default.ini -f custom_options.ini
+      ckan config-tool default.ini -f custom_options.ini
     '''
 
     if merge_filepath:


### PR DESCRIPTION
Fixes the docs for config-tool to use 'ckan' command instead of paster.

Also, there's no need to load config for this CLI command. (Nor if you're doing any command with --help either)


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
