### PR TITLE
Update the WSGI entrypoint to not use paste.deploy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -52,6 +52,10 @@ v.2.9.0 TBA
    history open to the public, by setting this in production.ini:
    ``ckan.auth.public_activity_stream_detail = true`` (#3972)
 
+ * Server deployments need changes to their config, because the WSGI Entrypoint
+   has changed. See the upgrade doc for details of updating your
+   mod_wsgi configuration: :ref:`deployment-changes-for-ckan-2.9` (#4802)
+
 Minor changes:
 
  * For navl schemas, the 'default' validator no longer applies the default when

--- a/doc/maintaining/installing/deployment.rst
+++ b/doc/maintaining/installing/deployment.rst
@@ -290,3 +290,42 @@ Some pages on the modwsgi wiki have some useful information for troubleshooting 
 * http://code.google.com/p/modwsgi/wiki/ConfigurationGuidelines
 * http://code.google.com/p/modwsgi/wiki/FrequentlyAskedQuestions
 * http://code.google.com/p/modwsgi/wiki/ConfigurationIssues
+
+.. _deployment-changes-for-ckan-2.9:
+
+-------------------------------
+Deployment changes for CKAN 2.9
+-------------------------------
+
+This section describes how to update your deployment for CKAN 2.9 or later, if
+you have an existing deployment of CKAN 2.8 or earlier. This is necessary,
+whether you continue running CKAN on Python 2 or Python 3, because the WSGI
+entry point for running CKAN has changed. If your existing deployment is
+different to that described in the `official CKAN 2.8 deployment instructions
+<https://docs.ckan.org/en/2.8/maintaining/installing/deployment.html>`_
+(apache2 + mod_wsgi + nginx) then you'll need to adapt these instructions to
+your setup.
+
+1. We now recommend you activate the Python virtual environment in a different
+place, compared to earlier CKAN versions. Activation is now done in the Apache
+mod_wsgi config. To achieve this, edit |apache_config_file| and change the
+WSGIDaemonProcess to include the ``python-home`` parameter::
+
+    WSGIDaemonProcess ckan_default display-name=ckan_default processes=2 threads=15 python-home=/usr/lib/ckan/default
+
+(In CKAN 2.8.x and earlier, the virtual environment was activated in the WSGI
+script file.)
+
+2. The WSGI script file needs replacing because the WSGI entrypoint for CKAN
+has `changed <https://github.com/ckan/ckan/issues/4802>`_. Back-up your
+existing |apache.wsgi| file and then replace it with the new version defined
+above - see: :ref:`create-wsgi-script-file`
+
+3. If/when you are switching from running CKAN with Python 2 to Python 3,
+you'll need to switch to the Python 3 version of the Apache WSGI module:
+
+.. parsed-literal::
+
+    sudo apt-get remove libapache2-mod-wsgi
+    sudo apt-get install libapache2-mod-wsgi-py3
+    |reload_apache|

--- a/doc/maintaining/installing/deployment.rst
+++ b/doc/maintaining/installing/deployment.rst
@@ -87,7 +87,9 @@ contents:
     import os
     from ckan.config.middleware import make_app
     from ckan.cli import CKANConfigLoader
+    from logging.config import fileConfig as loggingFileConfig
     config_filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'ckan.ini')
+    loggingFileConfig(config_filepath)
     config = CKANConfigLoader(config_filepath).get_config()
     application = make_app(config)
 

--- a/doc/maintaining/upgrading/upgrade-to-python3.rst
+++ b/doc/maintaining/upgrading/upgrade-to-python3.rst
@@ -37,18 +37,15 @@ do these sections:
 Deployment
 ----------
 
-For full details of the recommended deployment (Apache, mod_wsgi, nginx) see:
-:doc:`deployment`. Here we detail the changes from the previous instructions.
+For web server deployments, to change from running CKAN under Python 2 to
+Python 3 you need to switch the mod_wsgi module:
 
-1. Now we should activate your Python virtual environment in your Apache mod_wsgi
-config. Edit |apache_config_file| and change the WSGIDaemonProcess to include
-the ``python-home``::
+.. parsed-literal::
 
-    WSGIDaemonProcess ckan_default display-name=ckan_default processes=2 threads=15 python-home=/usr/lib/ckan/default
+    sudo apt-get remove libapache2-mod-wsgi
+    sudo apt-get install libapache2-mod-wsgi-py3
+    |reload_apache|
 
-(The virtual environment was previously activated in the WSGI script file,
-however it used the activate_this.py script provided by virtualenv, however now
-we use 'venv' which is bundled with python3.)
-
-2. The WSGI script file needs replacing. Copy the new |apache.wsgi| defined in
-the deployment doc: :ref:`create-wsgi-script-file`
+.. note:: For more about deployment see:
+ :doc:`/maintaining/installing/install-from-source` and specifically the changes
+ with CKAN 2.9: :ref:`deployment-changes-for-ckan-2.9`.

--- a/doc/maintaining/upgrading/upgrade-to-python3.rst
+++ b/doc/maintaining/upgrading/upgrade-to-python3.rst
@@ -33,3 +33,22 @@ do these sections:
 * 1. Install the required packages
 * 2. Install CKAN into a Python virtual environment
 * 6. Link to who.ini
+
+Deployment
+----------
+
+For full details of the recommended deployment (Apache, mod_wsgi, nginx) see:
+:doc:`deployment`. Here we detail the changes from the previous instructions.
+
+1. Now we should activate your Python virtual environment in your Apache mod_wsgi
+config. Edit |apache_config_file| and change the WSGIDaemonProcess to include
+the ``python-home``::
+
+    WSGIDaemonProcess ckan_default display-name=ckan_default processes=2 threads=15 python-home=/usr/lib/ckan/default
+
+(The virtual environment was previously activated in the WSGI script file,
+however it used the activate_this.py script provided by virtualenv, however now
+we use 'venv' which is bundled with python3.)
+
+2. The WSGI script file needs replacing. Copy the new |apache.wsgi| defined in
+the deployment doc: :ref:`create-wsgi-script-file`


### PR DESCRIPTION
Fixes #4802

With this PR, we update the WSGI script (entrypoint), to get rid of paste-deploy, which is needed when deploying CKAN to a web server (because paste-deploy is Python 2 only).

I decided to move the place where we activate the virtual environment, from the WSGI script to the apache config. Here are some discussion points:

* activate_this.py is part of virtualenv, which we don't use for python3 (we use the built-in venv), it is so not as easily available in our instructions. It could be copied as a single file into our repo - virtualenv is MIT licensed. This would be most similar to the existing CKAN deployment method, so maybe that is easiest for our users to understand, rather than configuring it in mod_wsgi/uwsgi/gunicorn instead.

* However configuring in mod_wsgi/uwsgi/gunicorn seems straightforward - a single option. For uwsgi it's: -H on the command line or 'venv=' in the config. mod_wsgi also prefers you configure the virtualenv in the mod_wsgi options, rather than in the WSGI script itself - source https://modwsgi.readthedocs.io/en/develop/user-guides/virtual-environments.html#adding-additional-module-directories Django also directs you to configure the virtualenv in the server config.

* In the WSGI script, as an alternative to activate_this.py, I tried activating the virtualenv in the wsgi file:

      import sys
      import site
      python_venv = '/usr/lib/ckan/default'
      python_version = '.'.join(map(str, sys.version_info[:2]))
      site_packages = python_venv + '/lib/python%s/site-packages' % python_version
      site.addsitedir(site_packages)

  However it adds the virtualenv at the end of the pythonpath, and we end up with problems when the system version of 'yaml' takes priority.

I also fixed a line in the instructions that reloaded nginx, when it should be restarting - need to start nginx before it will let us reload it. (It doesn't start when you install it because apache is listening on port 80 by default when you installed it)

### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
