### PR TITLE
[#5254] show error in text view if xhr failed

### DIFF
--- a/ckanext/textview/theme/public/text_view.js
+++ b/ckanext/textview/theme/public/text_view.js
@@ -64,11 +64,12 @@ ckan.module('text_view', function (jQuery) {
           self.el[0].innerHTML = highlighted;
         },
         error: function(jqXHR, textStatus, errorThrown) {
-          if (textStatus == 'error' && jqXHR.responseText.length) {
+          if (textStatus == 'error' && jqXHR.responseText) {
             self.el.html(jqXHR.responseText);
           } else {
-            self.el.html(self_('An error occurred: %(text)s %(error)s',
-                               {text: textStatus, error: errorThrown}));
+            self.el.html(self._(
+              'An error occured during AJAX request. Could not load view.')
+            );
           }
         }
       });


### PR DESCRIPTION
Return a common error message if ajax request failed during text view load


- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
