### PR TITLE
Issue: 5248 - "Dataset description:" is a clearer title for the description of the associated dataset

### DIFF
--- a/ckan/templates/package/resource_read.html
+++ b/ckan/templates/package/resource_read.html
@@ -94,7 +94,7 @@
               {{ h.render_markdown(res.description) }}
             {% endif %}
             {% if not res.description and package.notes %}
-              <h3>{{ _('From the dataset abstract') }}</h3>
+              <h3>{{ _('Dataset description:') }}</h3>
               <blockquote>{{ h.markdown_extract(h.get_translated(package, 'notes')) }}</blockquote>
               <p>{% trans dataset=package.title, url=h.url_for('dataset.read', id=package.id if is_activity_archive else package.name) %}Source: <a href="{{ url }}">{{ dataset }}</a>{% endtrans %}
             {% endif %}


### PR DESCRIPTION
Changed the text referring to the dataset description

Fixes #5248 

### Proposed fixes:
Update resource_read.html with "Dataset description:" rather than "From the dataset abstract" as its clearer in describing what the next text is

Issue says versions affected are CKAN **2.4.1** to **2.8.3**


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
