### PR TITLE
Use correct scope for jQuery

### DIFF
--- a/ckan/public/base/javascript/modules/basic-form.js
+++ b/ckan/public/base/javascript/modules/basic-form.js
@@ -1,4 +1,4 @@
-this.ckan.module('basic-form', function (jQuery) {
+this.ckan.module('basic-form', function ($) {
   return {
     initialize: function () {
       var message = this._('There are unsaved modifications to this form');


### PR DESCRIPTION
Previously the correct scope for jQuery was not used.
This causes it to fail intermittently as `$.proxyAll` was undefined.

This solution will fix it for all cases.

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
