### PR TITLE
Use pkg_resources.parse_version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@
 import os
 import os.path
 
+from pkg_resources import parse_version
+
 # Avoid problem releasing to pypi from vagrant
 if os.environ.get('USER', '') == 'vagrant':
     del os.link
@@ -23,11 +25,6 @@ from ckan import (__version__, __description__, __long_description__,
 #
 # Check setuptools version
 #
-
-def parse_version(s):
-    return [int(part) for part in s.split('.')]
-
-
 
 HERE = os.path.dirname(__file__)
 with open(os.path.join(HERE, 'requirement-setuptools.txt')) as f:


### PR DESCRIPTION
Fixes a problem with setup on some distros, where the python setuptools package is installed from distro repository (i.e. not via pip) and its version string contains also characters other than digits.

E.g. following happens on Alpine linux with setuptools installed from OS repository:
```
Obtaining ckan from git+https://github.com/ckan/ckan.git#egg=ckan
  Cloning https://github.com/ckan/ckan.git to ./src/ckan
  Running command git clone -q https://github.com/ckan/ckan.git /srv/ckan/src/ckan
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python3.8 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/srv/ckan/src/ckan/setup.py'"'"'; __file__='"'"'/srv/ckan/src/ckan/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info
         cwd: /srv/ckan/src/ckan/
    Complete output (9 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/srv/ckan/src/ckan/setup.py", line 36, in <module>
        if parse_version(setuptools_version) < min_setuptools_version:
      File "/srv/ckan/src/ckan/setup.py", line 28, in parse_version
        return [int(part) for part in s.split('.')]
      File "/srv/ckan/src/ckan/setup.py", line 28, in <listcomp>
        return [int(part) for part in s.split('.')]
    ValueError: invalid literal for int() with base 10: 'post20191202'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

### Proposed fixes:

The proposed fix uses `parse_version()` function provided by `pkg_resources` which is provided by setuptools themselves, so it's pretty much guaranteed that the user either already has the module installed or needs to install the whole setuptools anyway.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
