### PR TITLE
Missed display_name on group validation error

### DIFF
--- a/ckan/tests/controllers/test_group.py
+++ b/ckan/tests/controllers/test_group.py
@@ -163,6 +163,43 @@ class TestGroupControllerEdit(object):
         assert group.description == "Sciencey datasets"
         assert group.image_url == "http://example.com/image.png"
 
+    def test_display_name_shown(self, app):
+        user = factories.User()
+        group = factories.Group(
+            name="display-name",
+            title="Display name",
+            user=user,
+        )
+
+        env = {"REMOTE_USER": six.ensure_str(user["name"])}
+
+        form = {
+            "name": "",
+            "save": "",
+        }
+        resp = app.get(
+            url=url_for("group.edit", id=group["name"]),
+            extra_environ=env,
+        )
+        page = BeautifulSoup(resp.body)
+        breadcrumbs = page.select('.breadcrumb a')
+        # Home -> Groups -> NAME -> Manage
+        assert len(breadcrumbs) == 4
+        # Verify that `NAME` is not empty, as well as other parts
+        assert all([part.text for part in breadcrumbs])
+
+        resp = app.post(
+            url=url_for("group.edit", id=group["name"]),
+            extra_environ=env,
+            data=form,
+        )
+        page = BeautifulSoup(resp.body)
+        breadcrumbs = page.select('.breadcrumb a')
+        # Home -> Groups -> NAME -> Manage
+        assert len(breadcrumbs) == 4
+        # Verify that `NAME` is not empty, as well as other parts
+        assert all([part.text for part in breadcrumbs])
+
 
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 class TestGroupRead(object):

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -404,22 +404,26 @@ class TestGroupList(object):
         group1 = factories.Group()
         group2 = factories.Group()
         group3 = factories.Group()
+        group_names = [g["name"] for g in [group1, group2, group3]]
 
         group_list = helpers.call_action("group_list", limit=1)
 
         assert len(group_list) == 1
-        assert group_list[0] == group1["name"]
+        assert group_list[0] == sorted(group_names)[0]
 
     def test_group_list_offset(self):
 
         group1 = factories.Group()
         group2 = factories.Group()
         group3 = factories.Group()
+        group_names = [g["name"] for g in [group1, group2, group3]]
 
         group_list = helpers.call_action("group_list", offset=2)
 
         assert len(group_list) == 1
-        assert group_list[0] == group3["name"]
+        # group list returns sorted result. This is not necessarily
+        # order of creation
+        assert group_list[0] == sorted(group_names)[2]
 
     def test_group_list_limit_and_offset(self):
 

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -985,13 +985,10 @@ class EditGroupView(MethodView):
         context = self._prepare(id, is_organization)
         data_dict = {u'id': id, u'include_datasets': False}
         try:
-            old_data = _action(u'group_show')(context, data_dict)
-            grouptitle = old_data.get(u'title')
-            groupname = old_data.get(u'name')
-            data = data or old_data
+            group_dict = _action(u'group_show')(context, data_dict)
         except (NotFound, NotAuthorized):
             base.abort(404, _(u'Group not found'))
-        group_dict = data
+        data = data or group_dict
         errors = errors or {}
         extra_vars = {
             u'data': data,
@@ -1008,8 +1005,8 @@ class EditGroupView(MethodView):
         # TODO: Remove
         # ckan 2.9: Adding variables that were removed from c object for
         # compatibility with templates in existing extensions
-        g.grouptitle = grouptitle
-        g.groupname = groupname
+        g.grouptitle = group_dict.get(u'title')
+        g.groupname = group_dict.get(u'name')
         g.data = data
         g.group_dict = group_dict
 


### PR DESCRIPTION
When group/organization form contains invalid data, after submission page is rendered without group name in the title and breadcrumbs:
![image](https://user-images.githubusercontent.com/11091199/76870083-e58c6d00-6871-11ea-888d-af23800bf201.png)

When the form is submitted, form's payload passed into templates as `data` variable(which is absolutely correct). But, for some reason, this payload also replaces the original `group_dict`. I don't think it's desired behavior, so I've changed those lines. Test included :100:  

PS don't blame the empty `name` field - it's just the simplest way to create validation error for a group. If you are using custom group\org schema - any validation error will have the same effect.