### PR TITLE
Use request context in time_ago test

### DIFF
--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -505,6 +505,7 @@ def test_render_datetime(date, extra, exp):
     assert h.render_datetime(date, **extra) == exp
 
 
+@pytest.mark.usefixtures("with_request_context")
 @pytest.mark.freeze_time("2020-02-17 12:00:00")
 @pytest.mark.parametrize(
     "date, exp",


### PR DESCRIPTION
Fixes constantly-red CircleCI results