### PR TITLE
Fix broken datapusher documentation links

### DIFF
--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -17,7 +17,7 @@ The DataStore is integrated into the :doc:`CKAN API </api/index>` and
 authorization system.
 
 The DataStore is generally used alongside the
-`DataPusher <http://docs.ckan.org/projects/datapusher>`_, which will
+`DataPusher <https://docs.ckan.org/projects/datapusher/en/latest/>`_, which will
 automatically upload data to the DataStore from suitable files, whether
 uploaded to CKAN's FileStore or externally linked.
 
@@ -213,7 +213,7 @@ This task of automatically parsing and then adding data to the DataStore is
 performed by the `DataPusher`_, a service that runs asynchronously and can be installed
 alongside CKAN.
 
-To install this please look at the docs here: http://docs.ckan.org/projects/datapusher
+To install this please look at the docs here: https://docs.ckan.org/projects/datapusher/en/latest/
 
 .. note:: The DataPusher only imports the first worksheet of a spreadsheet. It also does
    not support duplicate column headers. That includes blank column headings.


### PR DESCRIPTION
### Proposed fixes:
Datastore documentation has links to datapusher documentation https://docs.ckan.org/projects/datapusher which does not exist.


### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
