### PR TITLE
Correct faulty example and add another in a Jinja macro

### DIFF
--- a/ckan/templates/macros/form.html
+++ b/ckan/templates/macros/form.html
@@ -79,7 +79,17 @@ options     - A list/tuple of fields to be used as <options>.
     Examples:
 
     {% import 'macros/form.html' as form %}
-    {{ form.select('year', label=_('Year'), options=[{'name':2010, 'value': 2010},{'name': 2011, 'value': 2011}], selected=2011, error=errors.year) }}
+    {{ form.select('year', label=_('Year'), options=[{'value':2010, 'text': 2010},{'value': 2011, 'text': 2011}], selected=2011, error=errors.year) }}
+
+    Or only with values if they are the same as text:
+    {{ form.select('year', label=_('Year'), options=[{'value':2010},{'value': 2011}], selected=2011, error=errors.year) }}
+
+    Complete example:
+    {{ form.select('the_data_type', id='the_data_type', label=_('Data Type'), options=[
+        {'value': '0', 'text': _('[Choose Data Type]')}
+        , {'value': '1', 'text': _('Private data')}
+        , {'value': '2', 'text': _('Not private data')}
+    ], selected=data.the_data_type if data.the_data_type else '0', is_required=true) }}
 
     #}
     {% macro select(name, id='', label='', options='', selected='', error='', classes=[], attrs={'class': 'form-control'}, is_required=false) %}


### PR DESCRIPTION
Signed-off-by: Mikko Johannes Koivunalho <mikko.koivunalho@iki.fi>

Fixes #

### Proposed fixes:

Correct faulty example and add another in a Jinja macro

### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
