### PR TITLE
Allow debugtoolbar with non-empty site_root

### DIFF
--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -151,7 +151,7 @@ class TestHelpersUrlFor(BaseUrlFor):
         assert generated_url == url
 
     @pytest.mark.ckan_config("debug", True)
-    @pytest.mark.ckan_config("DEBUG", True) # Flask's internal debug flag
+    @pytest.mark.ckan_config("DEBUG", True)  # Flask's internal debug flag
     @pytest.mark.ckan_config("ckan.root_path", "/my/custom/path")
     def test_debugtoolbar_url(self, ckan_config):
         # test against built-in `url_for`, that is used by debugtoolbar ext.

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -150,6 +150,16 @@ class TestHelpersUrlFor(BaseUrlFor):
         generated_url = h.url_for("dataset.read", id="my_dataset", locale="de")
         assert generated_url == url
 
+    @pytest.mark.ckan_config("debug", True)
+    @pytest.mark.ckan_config("DEBUG", True) # Flask's internal debug flag
+    @pytest.mark.ckan_config("ckan.root_path", "/my/custom/path")
+    def test_debugtoolbar_url(self, ckan_config):
+        # test against built-in `url_for`, that is used by debugtoolbar ext.
+        from flask import url_for
+        expected = "/my/custom/path/_debug_toolbar/static/test.js"
+        url = url_for('_debug_toolbar.static', filename='test.js')
+        assert url == expected
+
 
 class TestHelpersUrlForFlaskandPylons(BaseUrlFor):
     def test_url_for_flask_route_new_syntax(self):


### PR DESCRIPTION
Fixes #5253 

### Proposed fixes:
We cannot modify the source of debug toolbar(obviously), neither we can create PR into debug toolbar repo because it already supports URL-prefixes. Problem is, as Flask extension, it picks URL-prefix form `flask.config['APPLICATION_ROOT']`. Meanwhile, we are not using this option, because it will create additional conditions inside `url_for` for flask\pylons applications. 

So, the best option I can imagine - just register route that uses `ckan.root_path` with the same name as one from debug toolbar. Every time debug toolbar calls built-in `url_for` - our route will be used. Locale(`{{LANG}}` part from site root) is ignored, as we are talking about static files, so it should work.

I've left `todo` comment as a reminder to remove this hack and use `APPLICATION_ROOT` as soon as we remove every bit of pylons code.