### PR TITLE
DevServer: threaded mode and extra files

### DIFF
--- a/ckan/cli/server.py
+++ b/ckan/cli/server.py
@@ -14,13 +14,18 @@ log = logging.getLogger(__name__)
 @click.option(u'-H', u'--host', default=u'localhost', help=u'Set host')
 @click.option(u'-p', u'--port', default=5000, help=u'Set port')
 @click.option(u'-r', u'--reloader', default=True, help=u'Use reloader')
+@click.option(
+    u'-t', u'--threaded', is_flag=True,
+    help=u'Handle each request in a separate thread'
+)
+@click.option(u'-e', u'--extra-files', multiple=True)
 @click.pass_context
-def run(ctx, host, port, reloader):
+def run(ctx, host, port, reloader, threaded, extra_files):
     u'''Runs the Werkzeug development server'''
 
     log.info(u"Running server {0} on port {1}".format(host, port))
 
-    extra_files = [
+    extra_files = list(extra_files) + [
         config['__file__'],
     ]
     run_simple(
@@ -29,4 +34,5 @@ def run(ctx, host, port, reloader):
         ctx.obj.app,
         use_reloader=reloader,
         use_evalex=True,
+        threaded=threaded,
         extra_files=extra_files)

--- a/ckan/cli/server.py
+++ b/ckan/cli/server.py
@@ -11,34 +11,33 @@ import ckan.plugins.toolkit as tk
 log = logging.getLogger(__name__)
 
 
-@click.command(u'run', short_help=u'Start development server')
-@click.option(u'-H', u'--host', default=u'localhost', help=u'Set host')
-@click.option(u'-p', u'--port', default=5000, help=u'Set port')
-@click.option(u'-r', u'--reloader', default=True, help=u'Use reloader')
+@click.command(u"run", short_help=u"Start development server")
+@click.option(u"-H", u"--host", default=u"localhost", help=u"Set host")
+@click.option(u"-p", u"--port", default=5000, help=u"Set port")
+@click.option(u"-r", u"--reloader", default=True, help=u"Use reloader")
 @click.option(
-    u'-t', u'--threaded', is_flag=True,
-    help=u'Handle each request in a separate thread'
+    u"-t", u"--threaded", is_flag=True, help=u"Handle each request in a separate thread"
 )
-@click.option(u'-e', u'--extra-files', multiple=True)
+@click.option(u"-e", u"--extra-files", multiple=True)
 @click.option(
-    u'--processes', type=int,
-    default=1,
-    help=u'Maximum number of concurrent processes'
+    u"--processes", type=int, default=0, help=u"Maximum number of concurrent processes"
 )
 @click.pass_context
 def run(ctx, host, port, reloader, threaded, extra_files, processes):
-    u'''Runs the Werkzeug development server'''
+    u"""Runs the Werkzeug development server"""
+    threaded = threaded or tk.asbool(config.get(u"ckan.devserver.threaded"))
+    processes = processes or tk.asint(
+        config.get(u"ckan.devserver.multiprocess", 1)
+    )
     if threaded and processes > 1:
-        tk.error_shout(
-            u'Cannot have a multithreaded and multi process server'
-        )
+        tk.error_shout(u"Cannot have a multithreaded and multi process server")
         raise click.Abort()
 
     log.info(u"Running server {0} on port {1}".format(host, port))
-    extra_files = list(extra_files) + [
-        config[u'__file__'],
-        tk.aslist(config.get(u'ckan.dev.server.watcher.extra_files'))
-    ]
+
+    config_extra_files = tk.aslist(config.get(u"ckan.devserver.watch_patterns"))
+    extra_files = list(extra_files) + [config[u"__file__"]] + config_extra_files
+
     run_simple(
         host,
         port,
@@ -47,4 +46,5 @@ def run(ctx, host, port, reloader, threaded, extra_files, processes):
         use_evalex=True,
         threaded=threaded,
         processes=processes,
-        extra_files=extra_files)
+        extra_files=extra_files,
+    )

--- a/ckan/cli/server.py
+++ b/ckan/cli/server.py
@@ -16,11 +16,13 @@ log = logging.getLogger(__name__)
 @click.option(u"-p", u"--port", default=5000, help=u"Set port")
 @click.option(u"-r", u"--reloader", default=True, help=u"Use reloader")
 @click.option(
-    u"-t", u"--threaded", is_flag=True, help=u"Handle each request in a separate thread"
+    u"-t", u"--threaded", is_flag=True,
+    help=u"Handle each request in a separate thread"
 )
 @click.option(u"-e", u"--extra-files", multiple=True)
 @click.option(
-    u"--processes", type=int, default=0, help=u"Maximum number of concurrent processes"
+    u"--processes", type=int, default=0,
+    help=u"Maximum number of concurrent processes"
 )
 @click.pass_context
 def run(ctx, host, port, reloader, threaded, extra_files, processes):
@@ -35,8 +37,12 @@ def run(ctx, host, port, reloader, threaded, extra_files, processes):
 
     log.info(u"Running server {0} on port {1}".format(host, port))
 
-    config_extra_files = tk.aslist(config.get(u"ckan.devserver.watch_patterns"))
-    extra_files = list(extra_files) + [config[u"__file__"]] + config_extra_files
+    config_extra_files = tk.aslist(
+        config.get(u"ckan.devserver.watch_patterns")
+    )
+    extra_files = list(extra_files) + [
+        config[u"__file__"]
+    ] + config_extra_files
 
     run_simple(
         host,

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -137,6 +137,24 @@ maintain compatibility.
   .. warning:: This configuration will be removed when migration to Flask is completed. Please
     update the extension code to use the new Flask-based route names.
 
+
+Development Settings
+--------------------
+
+.. _ckan.dev.server.watcher.extra_files:
+
+ckan.dev.server.watcher.extra_files
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+  ckan.dev.server.watcher.extra_files = /var/run/xxx.sock %(here)s/schemas/*.json
+
+Default value: None
+
+A list of files the reloader should watch additionally to the
+modules. For example configuration files.
+
 Repoze.who Settings
 -------------------
 

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -141,14 +141,42 @@ maintain compatibility.
 Development Settings
 --------------------
 
-.. _ckan.dev.server.watcher.extra_files:
+.. _ckan.devserver.threaded:
 
-ckan.dev.server.watcher.extra_files
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ckan.devserver.threaded
+^^^^^^^^^^^^^^^^^^^^^^^
 
 Example::
 
-  ckan.dev.server.watcher.extra_files = /var/run/xxx.sock %(here)s/schemas/*.json
+  ckan.devserver.threaded = true
+
+Default value: False
+
+Controls, whether development server handle each request in a separate
+thread.
+
+.. _ckan.devserver.multiprocess:
+
+ckan.devserver.multiprocess
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+  ckan.devserver.multiprocess = 8
+
+Default value: 1
+
+If greater than 1 then handle each request in a new process up to this
+maximum number of concurrent processes.
+
+.. _ckan.devserver.watch_patterns:
+
+ckan.devserver.watch_patterns
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+  ckan.devserver.watch_patterns = mytheme/**/*.yaml mytheme/**/*.json
 
 Default value: None
 


### PR DESCRIPTION
* Allow running dev server in threaded mode(`-t/--threaded`) in order to handle each request in separate thread.
* Specify extra-watched files (`-e/--extra-files`). Something like `ckan -e xxx.json -e 'sub-path/**/*.json'` works as well 