### PR TITLE
#3259: Make default sorting configurable

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1559,7 +1559,7 @@ def package_search(context, data_dict):
     :param fq_list: additional filter queries to apply.
     :type fq_list: list of strings
     :param sort: sorting of the search results.  Optional.  Default:
-        ``'score asc, metadata_modified desc'``.  As per the solr
+        ``'score desc, metadata_modified desc'``.  As per the solr
         documentation, this is a comma-separated string of field names and
         sort-orderings.
     :type sort: string

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -251,7 +251,7 @@ def _group_or_org_list(context, data_dict, is_org=False):
             data_dict, logic.schema.default_pagination_schema(), context)
         if errors:
             raise ValidationError(errors)
-    sort = data_dict.get('sort') or 'title'
+    sort = data_dict.get('sort') or config.get('ckan.default_group_sort') or 'title'
     q = data_dict.get('q')
 
     all_fields = asbool(data_dict.get('all_fields', None))
@@ -358,7 +358,7 @@ def group_list(context, data_dict):
       ``'packages'`` (optional, default: ``'name'``) Deprecated use sort.
     :type order_by: string
     :param sort: sorting of the search results.  Optional.  Default:
-        "name asc" string of field name and sort-order. The allowed fields are
+        "title asc" string of field name and sort-order. The allowed fields are
         'name', 'package_count' and 'title'
     :type sort: string
     :param limit: the maximum number of groups returned (optional)
@@ -409,7 +409,7 @@ def organization_list(context, data_dict):
       ``'packages'`` (optional, default: ``'name'``) Deprecated use sort.
     :type order_by: string
     :param sort: sorting of the search results.  Optional.  Default:
-        "name asc" string of field name and sort-order. The allowed fields are
+        "title asc" string of field name and sort-order. The allowed fields are
         'name', 'package_count' and 'title'
     :type sort: string
     :param limit: the maximum number of organizations returned (optional)
@@ -1559,7 +1559,7 @@ def package_search(context, data_dict):
     :param fq_list: additional filter queries to apply.
     :type fq_list: list of strings
     :param sort: sorting of the search results.  Optional.  Default:
-        ``'relevance asc, metadata_modified desc'``.  As per the solr
+        ``'score asc, metadata_modified desc'``.  As per the solr
         documentation, this is a comma-separated string of field names and
         sort-orderings.
     :type sort: string
@@ -1696,7 +1696,7 @@ def package_search(context, data_dict):
     abort = data_dict.get('abort_search', False)
 
     if data_dict.get('sort') in (None, 'rank'):
-        data_dict['sort'] = 'score desc, metadata_modified desc'
+        data_dict['sort'] = config.get('ckan.search.default_package_sort') or 'score desc, metadata_modified desc'
 
     results = []
     if not abort:

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -289,7 +289,6 @@ class TestGroupList(object):
 
         assert group_list == ["bb", "aa"]
 
-
     def test_group_list_sort_default(self):
 
         factories.Group(name="zz", title="aa")
@@ -299,7 +298,7 @@ class TestGroupList(object):
             "group_list"
         )
 
-        assert group_list == [ 'zz', 'yy']
+        assert group_list == ['zz', 'yy']
 
     @pytest.mark.ckan_config("ckan.default_group_sort", "name")
     def test_group_list_sort_from_config(self):
@@ -311,8 +310,7 @@ class TestGroupList(object):
             "group_list"
         )
 
-        assert group_list == [ 'yy', 'zz']
-
+        assert group_list == ['yy', 'zz']
 
     def eq_expected(self, expected_dict, result_dict):
         superfluous_keys = set(result_dict) - set(expected_dict)

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -289,6 +289,31 @@ class TestGroupList(object):
 
         assert group_list == ["bb", "aa"]
 
+
+    def test_group_list_sort_default(self):
+
+        factories.Group(name="zz", title="aa")
+        factories.Group(name="yy", title="bb")
+
+        group_list = helpers.call_action(
+            "group_list"
+        )
+
+        assert group_list == [ 'zz', 'yy']
+
+    @pytest.mark.ckan_config("ckan.default_group_sort", "name")
+    def test_group_list_sort_from_config(self):
+
+        factories.Group(name="zz", title="aa")
+        factories.Group(name="yy", title="bb")
+
+        group_list = helpers.call_action(
+            "group_list"
+        )
+
+        assert group_list == [ 'yy', 'zz']
+
+
     def eq_expected(self, expected_dict, result_dict):
         superfluous_keys = set(result_dict) - set(expected_dict)
         assert not superfluous_keys, "Did not expect key: %s" % " ".join(
@@ -1341,6 +1366,19 @@ class TestPackageSearch(object):
 
         result_names = [result["name"] for result in search_result["results"]]
         assert result_names == [u"test2", u"test1", u"test0"]
+
+    @pytest.mark.ckan_config("ckan.search.default_package_sort", "metadata_created asc")
+    def test_sort_default_from_config(self):
+        factories.Dataset(name="test0")
+        factories.Dataset(name="test1")
+        factories.Dataset(name="test2")
+
+        search_result = helpers.call_action(
+            "package_search"
+        )
+
+        result_names = [result["name"] for result in search_result["results"]]
+        assert result_names == [u"test0", u"test1", u"test2"]
 
     def test_package_search_on_resource_name(self):
         """

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -773,7 +773,7 @@ visible to everyone.
 .. _ckan.search.default_package_sort:
 
 ckan.search.default_package_sort
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Example::
 
@@ -1259,7 +1259,7 @@ group and 2 datasets are displayed).
 .. _ckan.default_group_sort
 
 ckan.default_group_sort
-^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^
 
 Example::
 

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -770,6 +770,21 @@ Controls whether the default search page (``/dataset``) should include
 private datasets visible to the current user or only public datasets
 visible to everyone.
 
+.. _ckan.search.default_package_sort:
+
+ckan.search.default_package_sort
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+ ckan.search.default_package_sort = "name asc"
+
+Default value:  ``None``
+
+Controls whether the default search page (``/dataset``) should different
+sorting parameter by default when the request does not specify sort.
+
+
 .. _search.facets.limit:
 
 search.facets.limit
@@ -1240,6 +1255,20 @@ Default Value: (empty)
 Defines a list of organization names or ids. This setting is used to display
 an organization and datasets on the home page in the default templates (1
 group and 2 datasets are displayed).
+
+.. _ckan.default_group_sort
+
+ckan.default_group_sort
+^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+ ckan.default_group_sort = name
+
+Default Value: None
+
+Defines if some other sorting is used in group_list and organization_list
+by default when the request does not specify sort.
 
 .. _ckan.gravatar_default:
 

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -779,7 +779,7 @@ Example::
 
  ckan.search.default_package_sort = "name asc"
 
-Default value:  ``None``
+Default value:  ``score desc, metadata_modified desc``
 
 Controls whether the default search page (``/dataset``) should different
 sorting parameter by default when the request does not specify sort.
@@ -1265,7 +1265,7 @@ Example::
 
  ckan.default_group_sort = name
 
-Default Value: None
+Default Value: 'title'
 
 Defines if some other sorting is used in group_list and organization_list
 by default when the request does not specify sort.

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -1256,7 +1256,7 @@ Defines a list of organization names or ids. This setting is used to display
 an organization and datasets on the home page in the default templates (1
 group and 2 datasets are displayed).
 
-.. _ckan.default_group_sort
+.. _ckan.default_group_sort:
 
 ckan.default_group_sort
 ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes #3259

### Proposed fixes:
Organization list default sorting was changed to title instead of name as the original issue requested. However there was a comment that this does not make sense in some languages and I have since the original issue had clients requesting some specific sorting. This PR adds configuration options to change the defaults in group/organization_list and package_search. Also this updates the api documentation to match implementation which was not originally updated.


### Features:

- [x] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
