### PR TITLE
#5320 Don't encode error detail before aborting.

### DIFF
--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -64,10 +64,6 @@ def abort(status_code=None, detail='', headers=None, comment=None):
     if is_flask_request():
         flask_abort(status_code, detail)
 
-    # #1267 Convert detail to plain text, since WebOb 0.9.7.1 (which comes
-    # with Lucid) causes an exception when unicode is received.
-    detail = detail.encode('utf8')
-
     return _abort(status_code=status_code,
                   detail=detail,
                   headers=headers,


### PR DESCRIPTION
This line was added because WebOb < 1.0 caused an exception when receiving unicode. It now causes an exception when it doesn't receive unicode.

Fixes #5320

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
