### PR TITLE
[#5297] previous button redirect to dataset edit without creating new resource

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -655,9 +655,6 @@ class PackageController(base.BaseController):
                     break
 
             if not data_provided and save_action != "go-dataset-complete":
-                if save_action == 'go-dataset':
-                    # go to final stage of adddataset
-                    h.redirect_to(controller='package', action='edit', id=id)
                 # see if we have added any resources
                 try:
                     data_dict = get_action('package_show')(context, {'id': id})
@@ -714,9 +711,6 @@ class PackageController(base.BaseController):
                     dict(context, allow_state_change=True),
                     dict(data_dict, state='active'))
                 h.redirect_to(controller='package', action='read', id=id)
-            elif save_action == 'go-dataset':
-                # go to first stage of add dataset
-                h.redirect_to(controller='package', action='edit', id=id)
             elif save_action == 'go-dataset-complete':
                 # go to first stage of add dataset
                 h.redirect_to(controller='package', action='read', id=id)

--- a/ckan/templates/package/snippets/stages.html
+++ b/ckan/templates/package/snippets/stages.html
@@ -22,7 +22,7 @@ Example:
     {% if s1 != 'complete' %}
       <span class="highlight">{{ _('Create dataset') }}</span>
     {% else %}
-      <button class="highlight" name="save" value="go-dataset" type="submit">{{ _('Create dataset') }}</button>
+      <a href="{{ h.url_for('dataset.edit', id=pkg_name) }}" class="highlight">{{ _('Create dataset') }}</a>
     {% endif %}
   </li>
   <li class="last {{ s2 }}">

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -154,13 +154,10 @@ class TestPackageNew(object):
             "_ckan_phase": 1
         }, follow_redirects=False)
 
-        location = _get_location(response)
-        response = app.post(location, environ_overrides=user_env, data={
-            "id": "",
-            "save": "go-dataset"
-        }, follow_redirects=False)
-
-        assert '/dataset/edit/' in response.headers['location']
+        url = url_for("dataset.edit", id="previous-button-works")
+        response = app.get(url=url, environ_overrides=user_env)
+        # dataset-edit form is in response
+        assert 'id="dataset-edit"' in response
 
     def test_previous_button_populates_form(self, app, user_env):
         url = url_for("dataset.new")
@@ -170,13 +167,11 @@ class TestPackageNew(object):
             "_ckan_phase": 1
         }, follow_redirects=False)
 
-        location = _get_location(response)
-        response = app.post(location, environ_overrides=user_env, data={
-            "id": "",
-            "save": "go-dataset"
-        })
+        # edit package page response
+        url = url_for("dataset.edit", id="previous-button-populates-form")
+        pkg_response = app.get(url=url, environ_overrides=user_env)
 
-        assert 'name="title"' in response
+        assert 'name="title"' in pkg_response
         assert 'value="previous-button-populates-form"'
 
     def test_previous_next_maintains_draft_state(self, app, user_env):
@@ -187,13 +182,11 @@ class TestPackageNew(object):
             "_ckan_phase": 1
         }, follow_redirects=False)
 
-        location = _get_location(response)
-        response = app.post(location, environ_overrides=user_env, data={
-            "id": "",
-            "save": "go-dataset"
-        })
+        url = url_for("dataset.edit", id="previous-next-maintains-draft")
+        response = app.get(url=url, environ_overrides=user_env)
 
         pkg = model.Package.by_name(u"previous-next-maintains-draft")
+        assert 'value="previous-next-maintains-draft"'
         assert pkg.state == "draft"
 
     def test_dataset_edit_org_dropdown_visible_to_normal_user_with_orgs_available(

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -209,9 +209,6 @@ class CreateView(MethodView):
                 break
 
         if not data_provided and save_action != u"go-dataset-complete":
-            if save_action == u'go-dataset':
-                # go to final stage of adddataset
-                return h.redirect_to(u'{}.edit'.format(package_type), id=id)
             # see if we have added any resources
             try:
                 data_dict = get_action(u'package_show')(context, {u'id': id})

--- a/ckanext/example_idatasetform/tests/test_example_idatasetform.py
+++ b/ckanext/example_idatasetform/tests/test_example_idatasetform.py
@@ -102,15 +102,6 @@ class TestUrlsForCustomDatasetType(object):
         )
 
         res_form_url = url_for("fancy_type_resource.new", id=name)
-        resp = app.post(
-            res_form_url,
-            environ_overrides=env,
-            data={"id": "", "url": "", "save": "go-dataset", "_ckan_phase": 2},
-            follow_redirects=False,
-        )
-        assert resp.location == url_for(
-            "fancy_type.edit", id=name, _external=True
-        )
 
         resp = app.post(
             res_form_url,


### PR DESCRIPTION
Currently, after pressing the `previous` button during dataset creation process, the new resource for this dataset creates. It's pretty unexpected behavior which could lead to resource duplicity. Now the 'previous' button is a link that goes directly to `dataset.edit` page. Since it's a link, the browser will show us a warning if we are leaving form unsaved.


- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
