### PR TITLE
Preserve formatting of multi-line translations

### DIFF
--- a/ckan/lib/extract.py
+++ b/ckan/lib/extract.py
@@ -1,44 +1,10 @@
 # encoding: utf-8
 
-import re
-from jinja2.ext import babel_extract as extract_jinja2
-import ckan.lib.jinja_extensions
-from six import string_types
-
-jinja_extensions = '''
-                    jinja2.ext.do, jinja2.ext.with_,
-                    ckan.lib.jinja_extensions.SnippetExtension,
-                    ckan.lib.jinja_extensions.CkanExtend,
-                    ckan.lib.jinja_extensions.LinkForExtension,
-                    ckan.lib.jinja_extensions.ResourceExtension,
-                    ckan.lib.jinja_extensions.AssetExtension,
-                    ckan.lib.jinja_extensions.UrlForStaticExtension,
-                    ckan.lib.jinja_extensions.UrlForExtension
-                   '''
+from jinja2.ext import babel_extract
 
 
-def jinja2_cleaner(fileobj, *args, **kw):
-    # We want to format the messages correctly and intercepting here seems
-    # the best location
-    # add our custom tags
-    kw['options']['extensions'] = jinja_extensions
-
-    raw_extract = extract_jinja2(fileobj, *args, **kw)
-
-    for lineno, func, message, finder in raw_extract:
-
-        if isinstance(message, string_types):
-            message = ckan.lib.jinja_extensions.regularise_html(message)
-        elif message is not None:
-            message = (ckan.lib.jinja_extensions.regularise_html(message[0]),
-                       ckan.lib.jinja_extensions.regularise_html(message[1]))
-
-        yield lineno, func, message, finder
-
-
+# It's no longer needed but all the extensions are using this
+# function. Let's keep it, just in case we need to extract messages in
+# some special way in future
 def extract_ckan(fileobj, *args, **kw):
-    source = fileobj.read()
-    output = jinja2_cleaner(fileobj, *args, **kw)
-    # we've eaten the file so we need to get back to the start
-    fileobj.seek(0)
-    return output
+    return babel_extract(fileobj, *args, **kw)


### PR DESCRIPTION
Fixes #4968

CKAN has a custom message extractor(`ckan.lib.extract`), which internally just calls extractor provided by jinja2 and then formats extracted message, removing whitespace, newlines, etc.  Apparently, it was ok for older babel versions, but the new one has more strict rules and all the formatting should be preserved. So, I've just removed all the custom code and calling Jinja2's extractor directly. It'd better not to remove this file, as all extensions that were generated from our templates are using this custom extractor. 