### PR TITLE
Deployment doc - little improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,7 +34,7 @@ v.2.9.0 TBA
    standard `paster db upgrade` migrations need CKAN to be stopped). Ideally it
    is run before CKAN is upgraded, but it can be run afterwards. If running
    previous versions or this version of CKAN, download and run
-   migrate_package_activity.py like this:
+   migrate_package_activity.py like this::
 
      cd /usr/lib/ckan/default/src/ckan/
      wget https://raw.githubusercontent.com/ckan/ckan/3484_revision_ui_removal2/ckan/migration/migrate_package_activity.py

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -55,8 +55,8 @@ rst_epilog = '''
 .. |storage_parent_dir| replace:: /var/lib/ckan
 .. |storage_dir| replace:: |storage_parent_dir|/default
 .. |storage_path| replace:: |storage_parent_dir|/default
-.. |reload_apache| replace:: sudo service apache2 reload
-.. |restart_apache| replace:: sudo service apache2 restart
+.. |reload_apache| replace:: sudo systemctl reload apache2
+.. |restart_apache| replace:: sudo systemctl restart apache2
 .. |restart_solr| replace:: sudo service jetty8 restart
 .. |solr| replace:: Solr
 .. |restructuredtext| replace:: reStructuredText
@@ -67,7 +67,7 @@ rst_epilog = '''
 .. |javascript| replace:: JavaScript
 .. |apache| replace:: Apache
 .. |nginx_config_file| replace:: /etc/nginx/sites-available/ckan
-.. |reload_nginx| replace:: sudo service nginx reload
+.. |restart_nginx| replace:: sudo systemctl restart nginx
 .. |jquery| replace:: jQuery
 .. |nodejs| replace:: Node.js
 

--- a/doc/maintaining/installing/deployment.rst
+++ b/doc/maintaining/installing/deployment.rst
@@ -205,7 +205,7 @@ To prevent conflicts, disable your default nginx and apache sites.  Finally, ena
     sudo rm -vi /etc/nginx/sites-enabled/default
     sudo ln -s |nginx_config_file| /etc/nginx/sites-enabled/ckan_default
     |reload_apache|
-    |reload_nginx|
+    |restart_nginx|
 
 You should now be able to visit your server in a web browser and see your new
 CKAN instance.

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -27,7 +27,7 @@ required packages with this command::
 .. note::
 
     For Python 2 (deprecated, but compatible with CKAN 2.9 and earlier), do
-    this instead:
+    this instead::
 
         sudo apt-get install python-dev postgresql libpq-dev python-pip python-virtualenv git-core solr-jetty openjdk-8-jdk redis-server
 


### PR DESCRIPTION
* fixed instruction of reloading nginx, when it should be restarting -
you need to start nginx before it will let us reload it. (It doesn't
start when you install it, because apache is listening on port 80 by
default when you installed it)
* service -> systemctl - because systemd replaced upstart in ubuntu
since 16.04, and people are very unlikely to be installing on 14.04 now.
* rst syntax corrections

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
