### PR TITLE
Type in templates

### DIFF
--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1196,7 +1196,7 @@ class IDatasetForm(Interface):
 
         '''
 
-    def new_template(self):
+    def new_template(self, package_type):
         u'''Return the path to the template for the new dataset page.
 
         The path should be relative to the plugin's templates dir, e.g.
@@ -1206,7 +1206,7 @@ class IDatasetForm(Interface):
 
         '''
 
-    def read_template(self):
+    def read_template(self, package_type):
         u'''Return the path to the template for the dataset read page.
 
         The path should be relative to the plugin's templates dir, e.g.
@@ -1223,7 +1223,7 @@ class IDatasetForm(Interface):
 
         '''
 
-    def edit_template(self):
+    def edit_template(self, package_type):
         u'''Return the path to the template for the dataset edit page.
 
         The path should be relative to the plugin's templates dir, e.g.
@@ -1233,7 +1233,7 @@ class IDatasetForm(Interface):
 
         '''
 
-    def search_template(self):
+    def search_template(self, package_type):
         u'''Return the path to the template for use in the dataset search page.
 
         This template is used to render each dataset that is listed in the
@@ -1246,14 +1246,14 @@ class IDatasetForm(Interface):
 
         '''
 
-    def history_template(self):
+    def history_template(self, package_type):
         u'''
         .. warning:: This template is removed. The function exists for
             compatibility. It now returns None.
 
         '''
 
-    def resource_template(self):
+    def resource_template(self, package_type):
         u'''Return the path to the template for the resource read page.
 
         The path should be relative to the plugin's templates dir, e.g.
@@ -1263,7 +1263,7 @@ class IDatasetForm(Interface):
 
         '''
 
-    def package_form(self):
+    def package_form(self, package_type):
         u'''Return the path to the template for the dataset form.
 
         The path should be relative to the plugin's templates dir, e.g.
@@ -1273,7 +1273,7 @@ class IDatasetForm(Interface):
 
         '''
 
-    def resource_form(self):
+    def resource_form(self, package_type):
         u'''Return the path to the template for the resource form.
 
         The path should be relative to the plugin's templates dir, e.g.
@@ -1418,39 +1418,39 @@ class IGroupForm(Interface):
 
     # Hooks for customising the GroupController's behaviour          ##########
     # TODO: flesh out the docstrings a little more
-    def new_template(self):
+    def new_template(self, group_type):
         u'''
         Returns a string representing the location of the template to be
         rendered for the 'new' page. Uses the default_group_type configuration
         option to determine which plugin to use the template from.
         '''
 
-    def index_template(self):
+    def index_template(self, group_type):
         u'''
         Returns a string representing the location of the template to be
         rendered for the index page. Uses the default_group_type configuration
         option to determine which plugin to use the template from.
         '''
 
-    def read_template(self):
+    def read_template(self, group_type):
         u'''
         Returns a string representing the location of the template to be
         rendered for the read page
         '''
 
-    def history_template(self):
+    def history_template(self, group_type):
         u'''
         Returns a string representing the location of the template to be
         rendered for the history page
         '''
 
-    def edit_template(self):
+    def edit_template(self, group_type):
         u'''
         Returns a string representing the location of the template to be
         rendered for the edit page
         '''
 
-    def group_form(self):
+    def group_form(self, group_type):
         u'''
         Returns a string representing the location of the template to be
         rendered.  e.g. ``group/new_group_form.html``.

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -53,7 +53,8 @@ def _setup_template_variables(context, data_dict, package_type=None):
 
 def _get_pkg_template(template_type, package_type=None):
     pkg_plugin = lookup_package_plugin(package_type)
-    return getattr(pkg_plugin, template_type)()
+    method = getattr(pkg_plugin, template_type)
+    return method()
 
 
 def _encode_params(params):

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -54,12 +54,10 @@ def _setup_template_variables(context, data_dict, package_type=None):
 def _get_pkg_template(template_type, package_type=None):
     pkg_plugin = lookup_package_plugin(package_type)
     method = getattr(pkg_plugin, template_type)
-    if method.__code__.co_argcount == 1:
-        # method declared with the only argument `self`
+    try:
+        return method(package_type)
+    except TypeError:
         return method()
-
-    options = {u'package_type': package_type}
-    return method(options)
 
 
 def _encode_params(params):

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -56,7 +56,9 @@ def _get_pkg_template(template_type, package_type=None):
     method = getattr(pkg_plugin, template_type)
     try:
         return method(package_type)
-    except TypeError:
+    except TypeError as err:
+        if u'takes 1' not in str(err) and u'takes exactly 1' not in str(err):
+            raise
         return method()
 
 

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -58,7 +58,7 @@ def _get_pkg_template(template_type, package_type=None):
         # method declared with the only argument `self`
         return method()
 
-    options = {'package_type': package_type}
+    options = {u'package_type': package_type}
     return method(options)
 
 

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -54,7 +54,12 @@ def _setup_template_variables(context, data_dict, package_type=None):
 def _get_pkg_template(template_type, package_type=None):
     pkg_plugin = lookup_package_plugin(package_type)
     method = getattr(pkg_plugin, template_type)
-    return method()
+    if method.__code__.co_argcount == 1:
+        # method declared with the only argument `self`
+        return method()
+
+    options = {'package_type': package_type}
+    return method(options)
 
 
 def _encode_params(params):

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -46,7 +46,9 @@ def _get_group_template(template_type, group_type=None):
     method = getattr(group_plugin, template_type)
     try:
         return method(group_type)
-    except TypeError:
+    except TypeError as err:
+        if 'takes no arguments' not in str(err):
+            raise
         return method()
 
 

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -179,7 +179,7 @@ def index(group_type, is_organization):
         extra_vars["page"] = h.Page([], 0)
         extra_vars["group_type"] = group_type
         return base.render(
-            _get_group_template('index_template', group_type), extra_vars)
+            _get_group_template(u'index_template', group_type), extra_vars)
 
     data_dict_page_results = {
         u'all_fields': True,
@@ -206,7 +206,7 @@ def index(group_type, is_organization):
     # compatibility with templates in existing extensions
     g.page = extra_vars["page"]
     return base.render(
-        _get_group_template('index_template', group_type), extra_vars)
+        _get_group_template(u'index_template', group_type), extra_vars)
 
 
 def _read(id, limit, group_type):
@@ -458,7 +458,7 @@ def read(group_type, is_organization, id=None, limit=20):
     extra_vars["group_dict"] = group_dict
 
     return base.render(
-        _get_group_template('read_template', g.group_dict['type']), extra_vars)
+        _get_group_template(u'read_template', g.group_dict['type']), extra_vars)
 
 
 def activity(id, group_type, is_organization, offset=0):
@@ -502,7 +502,7 @@ def activity(id, group_type, is_organization, offset=0):
     extra_vars["group_dict"] = group_dict
     extra_vars["id"] = id
     return base.render(
-        _get_group_template('activity_template', group_type), extra_vars)
+        _get_group_template(u'activity_template', group_type), extra_vars)
 
 
 def about(id, group_type, is_organization):
@@ -523,7 +523,7 @@ def about(id, group_type, is_organization):
                   u"group_type": group_type}
 
     return base.render(
-        _get_group_template('about_template', group_type), extra_vars)
+        _get_group_template(u'about_template', group_type), extra_vars)
 
 
 def members(id, group_type, is_organization):
@@ -694,7 +694,7 @@ def admins(id, group_type, is_organization):
     }
 
     return base.render(
-        _get_group_template('admins_template', group_dict['type']), extra_vars)
+        _get_group_template(u'admins_template', group_dict['type']), extra_vars)
 
 
 class BulkProcessView(MethodView):
@@ -749,7 +749,7 @@ class BulkProcessView(MethodView):
         }
 
         return base.render(
-            _get_group_template('bulk_process_template', group_type),
+            _get_group_template(u'bulk_process_template', group_type),
             extra_vars)
 
     def post(self, id, group_type, is_organization, data=None):
@@ -899,7 +899,7 @@ class CreateGroupView(MethodView):
         _setup_template_variables(
             context, data, group_type=group_type)
         form = base.render(
-            _get_group_template('group_form', group_type), extra_vars)
+            _get_group_template(u'group_form', group_type), extra_vars)
 
         # TODO: Remove
         # ckan 2.9: Adding variables that were removed from c object for
@@ -908,7 +908,7 @@ class CreateGroupView(MethodView):
 
         extra_vars["form"] = form
         return base.render(
-            _get_group_template('new_template', group_type), extra_vars)
+            _get_group_template(u'new_template', group_type), extra_vars)
 
 
 class EditGroupView(MethodView):
@@ -987,7 +987,7 @@ class EditGroupView(MethodView):
 
         _setup_template_variables(context, data, group_type=group_type)
         form = base.render(
-            _get_group_template('group_form', group_type), extra_vars)
+            _get_group_template(u'group_form', group_type), extra_vars)
 
         # TODO: Remove
         # ckan 2.9: Adding variables that were removed from c object for
@@ -999,7 +999,7 @@ class EditGroupView(MethodView):
 
         extra_vars["form"] = form
         return base.render(
-            _get_group_template('edit_template', group_type), extra_vars)
+            _get_group_template(u'edit_template', group_type), extra_vars)
 
 
 class DeleteGroupView(MethodView):

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -47,7 +47,7 @@ def _get_group_template(template_type, group_type=None):
     try:
         return method(group_type)
     except TypeError as err:
-        if 'takes 1 positional argument but 2 were given' not in str(err):
+        if u'takes 1' not in str(err) and u'takes exactly 1' not in str(err):
             raise
         return method()
 

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -47,7 +47,7 @@ def _get_group_template(template_type, group_type=None):
     try:
         return method(group_type)
     except TypeError as err:
-        if 'takes no arguments' not in str(err):
+        if 'takes 1 positional argument but 2 were given' not in str(err):
             raise
         return method()
 

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -44,7 +44,12 @@ is_org = False
 def _get_group_template(template_type, group_type=None):
     group_plugin = lookup_group_plugin(group_type)
     method = getattr(group_plugin, template_type)
-    return method()
+    if method.__code__.co_argcount == 1:
+        # method declared with the only argument `self`
+        return method()
+
+    options = {'group_type': group_type}
+    return method(options)
 
 
 def _db_to_form_schema(group_type=None):

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -44,12 +44,10 @@ is_org = False
 def _get_group_template(template_type, group_type=None):
     group_plugin = lookup_group_plugin(group_type)
     method = getattr(group_plugin, template_type)
-    if method.__code__.co_argcount == 1:
-        # method declared with the only argument `self`
+    try:
+        return method(group_type)
+    except TypeError:
         return method()
-
-    options = {u'group_type': group_type}
-    return method(options)
 
 
 def _db_to_form_schema(group_type=None):

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -41,16 +41,10 @@ lookup_group_blueprint = lib_plugins.lookup_group_blueprints
 is_org = False
 
 
-def _index_template(group_type):
-    return lookup_group_plugin(group_type).index_template()
-
-
-def _group_form(group_type=None):
-    return lookup_group_plugin(group_type).group_form()
-
-
-def _form_to_db_schema(group_type=None):
-    return lookup_group_plugin(group_type).form_to_db_schema()
+def _get_group_template(template_type, group_type=None):
+    group_plugin = lookup_group_plugin(group_type)
+    method = getattr(group_plugin, template_type)
+    return method()
 
 
 def _db_to_form_schema(group_type=None):
@@ -64,38 +58,6 @@ def _setup_template_variables(context, data_dict, group_type=None):
         data_dict[u'type'] = group_type
     return lookup_group_plugin(group_type).\
         setup_template_variables(context, data_dict)
-
-
-def _new_template(group_type):
-    return lookup_group_plugin(group_type).new_template()
-
-
-def _about_template(group_type):
-    return lookup_group_plugin(group_type).about_template()
-
-
-def _read_template(group_type):
-    return lookup_group_plugin(group_type).read_template()
-
-
-def _history_template(group_type):
-    return lookup_group_plugin(group_type).history_template()
-
-
-def _edit_template(group_type):
-    return lookup_group_plugin(group_type).edit_template()
-
-
-def _activity_template(group_type):
-    return lookup_group_plugin(group_type).activity_template()
-
-
-def _admins_template(group_type):
-    return lookup_group_plugin(group_type).admins_template()
-
-
-def _bulk_process_template(group_type):
-    return lookup_group_plugin(group_type).bulk_process_template()
 
 
 def _replace_group_org(string):
@@ -211,7 +173,8 @@ def index(group_type, is_organization):
         h.flash_error(msg)
         extra_vars["page"] = h.Page([], 0)
         extra_vars["group_type"] = group_type
-        return base.render(_index_template(group_type), extra_vars)
+        return base.render(
+            _get_group_template('index_template', group_type), extra_vars)
 
     data_dict_page_results = {
         u'all_fields': True,
@@ -237,7 +200,8 @@ def index(group_type, is_organization):
     # ckan 2.9: Adding variables that were removed from c object for
     # compatibility with templates in existing extensions
     g.page = extra_vars["page"]
-    return base.render(_index_template(group_type), extra_vars)
+    return base.render(
+        _get_group_template('index_template', group_type), extra_vars)
 
 
 def _read(id, limit, group_type):
@@ -488,7 +452,8 @@ def read(group_type, is_organization, id=None, limit=20):
     extra_vars["group_type"] = group_type
     extra_vars["group_dict"] = group_dict
 
-    return base.render(_read_template(g.group_dict['type']), extra_vars)
+    return base.render(
+        _get_group_template('read_template', g.group_dict['type']), extra_vars)
 
 
 def activity(id, group_type, is_organization, offset=0):
@@ -531,7 +496,8 @@ def activity(id, group_type, is_organization, offset=0):
     extra_vars["group_type"] = group_type
     extra_vars["group_dict"] = group_dict
     extra_vars["id"] = id
-    return base.render(_activity_template(group_type), extra_vars)
+    return base.render(
+        _get_group_template('activity_template', group_type), extra_vars)
 
 
 def about(id, group_type, is_organization):
@@ -551,7 +517,8 @@ def about(id, group_type, is_organization):
     extra_vars = {u"group_dict": group_dict,
                   u"group_type": group_type}
 
-    return base.render(_about_template(group_type), extra_vars)
+    return base.render(
+        _get_group_template('about_template', group_type), extra_vars)
 
 
 def members(id, group_type, is_organization):
@@ -721,7 +688,8 @@ def admins(id, group_type, is_organization):
         u"admins": admins
     }
 
-    return base.render(_admins_template(group_dict['type']), extra_vars)
+    return base.render(
+        _get_group_template('admins_template', group_dict['type']), extra_vars)
 
 
 class BulkProcessView(MethodView):
@@ -775,7 +743,9 @@ class BulkProcessView(MethodView):
             u'group_type': group_type
         }
 
-        return base.render(_bulk_process_template(group_type), extra_vars)
+        return base.render(
+            _get_group_template('bulk_process_template', group_type),
+            extra_vars)
 
     def post(self, id, group_type, is_organization, data=None):
         set_org(is_organization)
@@ -924,7 +894,7 @@ class CreateGroupView(MethodView):
         _setup_template_variables(
             context, data, group_type=group_type)
         form = base.render(
-            _group_form(group_type=group_type), extra_vars)
+            _get_group_template('group_form', group_type), extra_vars)
 
         # TODO: Remove
         # ckan 2.9: Adding variables that were removed from c object for
@@ -932,7 +902,8 @@ class CreateGroupView(MethodView):
         g.form = form
 
         extra_vars["form"] = form
-        return base.render(_new_template(group_type), extra_vars)
+        return base.render(
+            _get_group_template('new_template', group_type), extra_vars)
 
 
 class EditGroupView(MethodView):
@@ -1010,7 +981,8 @@ class EditGroupView(MethodView):
         }
 
         _setup_template_variables(context, data, group_type=group_type)
-        form = base.render(_group_form(group_type), extra_vars)
+        form = base.render(
+            _get_group_template('group_form', group_type), extra_vars)
 
         # TODO: Remove
         # ckan 2.9: Adding variables that were removed from c object for
@@ -1022,7 +994,7 @@ class EditGroupView(MethodView):
 
         extra_vars["form"] = form
         return base.render(
-            _edit_template(group_type), extra_vars)
+            _get_group_template('edit_template', group_type), extra_vars)
 
 
 class DeleteGroupView(MethodView):

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -458,7 +458,8 @@ def read(group_type, is_organization, id=None, limit=20):
     extra_vars["group_dict"] = group_dict
 
     return base.render(
-        _get_group_template(u'read_template', g.group_dict['type']), extra_vars)
+        _get_group_template(u'read_template', g.group_dict['type']),
+        extra_vars)
 
 
 def activity(id, group_type, is_organization, offset=0):
@@ -694,7 +695,8 @@ def admins(id, group_type, is_organization):
     }
 
     return base.render(
-        _get_group_template(u'admins_template', group_dict['type']), extra_vars)
+        _get_group_template(u'admins_template', group_dict['type']),
+        extra_vars)
 
 
 class BulkProcessView(MethodView):

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -48,7 +48,7 @@ def _get_group_template(template_type, group_type=None):
         # method declared with the only argument `self`
         return method()
 
-    options = {'group_type': group_type}
+    options = {u'group_type': group_type}
     return method(options)
 
 

--- a/ckanext/example_idatasetform/plugin_v7.py
+++ b/ckanext/example_idatasetform/plugin_v7.py
@@ -1,0 +1,26 @@
+# encoding: utf-8
+
+import ckan.plugins as p
+import ckan.plugins.toolkit as tk
+
+
+class ExampleIDatasetFormPlugin(p.SingletonPlugin, tk.DefaultDatasetForm):
+    p.implements(p.IConfigurer)
+    p.implements(p.IDatasetForm)
+
+    def update_config(self, config):
+        tk.add_template_directory(config, 'templates')
+
+    def is_fallback(self):
+        return False
+
+    def package_types(self):
+        return [u'first', 'second']
+
+    def read_template(self, options):
+        return '{}/read.html'.format(
+            options['package_type']
+        )
+
+    def new_template(self):
+        return ['first/new.html', 'first/read.html']

--- a/ckanext/example_idatasetform/plugin_v7.py
+++ b/ckanext/example_idatasetform/plugin_v7.py
@@ -17,10 +17,8 @@ class ExampleIDatasetFormPlugin(p.SingletonPlugin, tk.DefaultDatasetForm):
     def package_types(self):
         return [u'first', u'second']
 
-    def read_template(self, options):
-        return u'{}/read.html'.format(
-            options[u'package_type']
-        )
+    def read_template(self, package_type):
+        return u'{}/read.html'.format(package_type)
 
     def new_template(self):
         return [u'first/new.html', u'first/read.html']

--- a/ckanext/example_idatasetform/plugin_v7.py
+++ b/ckanext/example_idatasetform/plugin_v7.py
@@ -9,18 +9,18 @@ class ExampleIDatasetFormPlugin(p.SingletonPlugin, tk.DefaultDatasetForm):
     p.implements(p.IDatasetForm)
 
     def update_config(self, config):
-        tk.add_template_directory(config, 'templates')
+        tk.add_template_directory(config, u'templates')
 
     def is_fallback(self):
         return False
 
     def package_types(self):
-        return [u'first', 'second']
+        return [u'first', u'second']
 
     def read_template(self, options):
-        return '{}/read.html'.format(
-            options['package_type']
+        return u'{}/read.html'.format(
+            options[u'package_type']
         )
 
     def new_template(self):
-        return ['first/new.html', 'first/read.html']
+        return [u'first/new.html', u'first/read.html']

--- a/ckanext/example_idatasetform/templates/first/new.html
+++ b/ckanext/example_idatasetform/templates/first/new.html
@@ -1,0 +1,1 @@
+new package form

--- a/ckanext/example_idatasetform/templates/first/read.html
+++ b/ckanext/example_idatasetform/templates/first/read.html
@@ -1,0 +1,1 @@
+Hello, first!

--- a/ckanext/example_idatasetform/templates/second/read.html
+++ b/ckanext/example_idatasetform/templates/second/read.html
@@ -1,0 +1,1 @@
+Hello, second!

--- a/ckanext/example_idatasetform/tests/test_example_idatasetform.py
+++ b/ckanext/example_idatasetform/tests/test_example_idatasetform.py
@@ -467,3 +467,31 @@ class TestDatasetBlueprintPreparations(object):
             a['href'] for a in page.select(".breadcrumb a")
         ]
         assert links == ['/', '/fancy_type/']
+
+
+@pytest.mark.ckan_config("ckan.plugins", u"example_idatasetform_v7")
+@pytest.mark.usefixtures("with_plugins", "with_request_context")
+class TestDatasetMultiTypes(object):
+    @pytest.mark.parametrize('type_', ['first', 'second'])
+    def test_untouched_routes(self, type_, app):
+        resp = app.get('/' + type_, status=200)
+        page = bs4.BeautifulSoup(resp.body)
+        assert page.body.header
+
+    @pytest.mark.usefixtures('clean_db')
+    @pytest.mark.parametrize('type_', ['first', 'second'])
+    def test_template_without_options(self, type_, app):
+        user = factories.User()
+        env = {"REMOTE_USER": six.ensure_str(user["name"])}
+
+        resp = app.get(
+            '/{}/new'.format(type_), status=200, environ_overrides=env)
+        assert resp.body == 'new package form'
+
+    @pytest.mark.usefixtures('clean_db')
+    @pytest.mark.parametrize('type_', ['first', 'second'])
+    def test_template_with_options(self, type_, app):
+        dataset = factories.Dataset(type=type_)
+        url = url_for(type_ + '.read', id=dataset['name'])
+        resp = app.get(url, status=200)
+        assert resp.body == 'Hello, {}!'.format(type_)

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ entry_points = {
         'example_idatasetform_v4 = ckanext.example_idatasetform.plugin_v4:ExampleIDatasetFormPlugin',
         'example_idatasetform_v5 = ckanext.example_idatasetform.plugin_v5:ExampleIDatasetFormPlugin',
         'example_idatasetform_v6 = ckanext.example_idatasetform.plugin_v6:ExampleIDatasetFormPlugin',
+        'example_idatasetform_v7 = ckanext.example_idatasetform.plugin_v7:ExampleIDatasetFormPlugin',
         'example_igroupform = ckanext.example_igroupform.plugin:ExampleIGroupFormPlugin',
         'example_igroupform_v2 = ckanext.example_igroupform.plugin_v2:ExampleIGroupFormPlugin',
         'example_igroupform_default_group_type = ckanext.example_igroupform.plugin:ExampleIGroupFormPlugin_DefaultGroupType',


### PR DESCRIPTION
Adds argument to `*_template` methods of `IDatasetForm`/`IGroupForm`. 
New argument is a context dictionary, with additional info, used for more precise template selection. Right now it contains the type of corresponding entity, allowing to do something like:

```python
def read_template(self, options):
    return 'package/{type}/read.html'.format(type=options['package_type'])
```

In order to preserve backward compatibility, this extra argument is passed only to methods, that are expecting it (by checking the declared number of arguments).