### PR TITLE
Update dictionary.html for bs2 version

### DIFF
--- a/ckanext/datastore/templates-bs2/datastore/dictionary.html
+++ b/ckanext/datastore/templates-bs2/datastore/dictionary.html
@@ -13,10 +13,17 @@
     {% block dictionary_form %}
       {% for f in fields %}
         <h3>{{ _( "Field {num}.").format(num=loop.index) }} {{ f.id }} ({{ f.type }})</h3>
-        {{ form.input('f' ~ loop.index ~ 'label',
+        {{ form.select('info__' ~ loop.index ~ '__type_override',
+          label=_('Type Override'), options=[
+          {'name': '', 'value': ''},
+          {'name': 'text', 'value': 'text'},
+          {'name': 'numeric', 'value': 'numeric'},
+          {'name': 'timestamp', 'value': 'timestamp'},
+          ], selected=f.get('info', {}).get('type_override', '')) }}
+        {{ form.input('info__' ~ loop.index ~ '__label',
           label=_('Label'), id='field-f' ~ loop.index ~ 'label',
           value=f.get('info', {}).get('label', ''), classes=['control-full']) }}
-        {{ form.markdown('f' ~ loop.index ~ 'notes',
+        {{ form.markdown('info__' ~ loop.index ~ '__notes',
           label=_('Description'), id='field-d' ~ loop.index ~ 'notes',
           value=f.get('info', {}).get('notes', '')) }}
       {% endfor %}


### PR DESCRIPTION
This change adds missing "type override" field, but with the names used by templates (non bs2) "lite" version, to let datastore get these edits.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
