### PR TITLE
Allow repeaded params in h.add_url_param

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1969,12 +1969,11 @@ def add_url_param(alternative_url=None, controller=None, action=None,
         (k, v) for k, v in params_items
         if k != 'page'
     ]
-    params = set(params_nopage)
     if new_params:
-        params |= set(new_params.items())
+        params_nopage += list(new_params.items())
     if alternative_url:
-        return _url_with_params(alternative_url, params)
-    return _create_url_with_params(params=params, controller=controller,
+        return _url_with_params(alternative_url, params_nopage)
+    return _create_url_with_params(params=params_nopage, controller=controller,
                                    action=action, extras=extras)
 
 


### PR DESCRIPTION
`ckan.lib.helpers.add_url_param` will remove all duplicates from query string. i.e, in my case
```
# current url: /dataset?ext_param=a
h.add_url_param(new_params={'ext_param': 'a'}) 

# builds
'/dataset?ext_param=a'

# expected
'/dataset?ext_param=a&ext_param=a'
```

Duplicated params are parsed/stored/accessible by pylons and flask and they can be expected in URL(like in my case), so I don't see any reason, to keep only distinct values. In templates, this helper is used for facets and if facet already available in URL, `h.remove_url_param` applied instead, so this change won't affect existing logic.
The only case when it can cause problem - if someone actually relies on this duplicate removal, but as it's just implementation detail, I don't think it's a likely situation.

