### PR TITLE
Add `coveralls` command to circleci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,7 @@ jobs:
           path: ~/junit
       - <<: *start_test_server
       - <<: *run_front_tests
+      - run: coveralls
 workflows:
   version: 2
   build_and_test:


### PR DESCRIPTION
Restores uploading of coverage reports to https://coveralls.io/github/ckan/ckan . Enabled only for py3 build