### PR TITLE
[#5370] Update date formatters

### DIFF
--- a/ckan/lib/formatters.py
+++ b/ckan/lib/formatters.py
@@ -21,7 +21,8 @@ def localised_nice_date(datetime_, show_date=False, with_hours=False,
          '1 day ago'
          'April 24, 2013'  (show_date=True)
          'October 25, 2017, 16:03 (UTC)' (show_date=True, with_hours=True)
-         'Apr 3, 2020, 4:00:31 PM' (show_date=True, format='medium')
+         'Apr 3, 2020, 4:00:31 PM' (
+                 show_date=True, with_hours=True, format='medium')
          'April 03, 20' (show_date=True, format='MMMM dd, YY')
 
     :param datetime_: The date to format

--- a/ckan/lib/formatters.py
+++ b/ckan/lib/formatters.py
@@ -39,12 +39,10 @@ def localised_nice_date(datetime_, show_date=False, with_hours=False,
 
     :rtype: sting
     '''
-
+    if datetime_.tzinfo is None:
+        datetime_ = datetime_.replace(tzinfo=pytz.utc)
     if not show_date:
         now = datetime.datetime.now(pytz.utc)
-        if datetime_.tzinfo is None:
-            datetime_ = datetime_.replace(tzinfo=pytz.utc)
-
         date_diff = datetime_ - now
         if abs(date_diff) < datetime.timedelta(seconds=1):
             return _('Just now')
@@ -53,14 +51,7 @@ def localised_nice_date(datetime_, show_date=False, with_hours=False,
     if with_seconds:
         return format_datetime(datetime_, format or 'long')
     elif with_hours:
-        if six.PY2:
-            # timezones rendered as offset in py2 - let's use
-            # abbreviation instead
-            fmt_str = "MMMM d, YYYY, HH:mm ('{zone'})".format(
-                datetime_.tzname()
-            )
-        else:
-            fmt_str = "MMMM d, YYYY, HH:mm (z)"
+        fmt_str = "MMMM d, YYYY, HH:mm (z)"
         return format_datetime(datetime_, format or fmt_str)
     else:
         return format_date(datetime_, format or 'long')

--- a/ckan/lib/formatters.py
+++ b/ckan/lib/formatters.py
@@ -2,6 +2,8 @@
 
 import datetime
 import pytz
+import six
+
 from flask_babel import (
     format_number,
     format_datetime,
@@ -51,7 +53,15 @@ def localised_nice_date(datetime_, show_date=False, with_hours=False,
     if with_seconds:
         return format_datetime(datetime_, format or 'long')
     elif with_hours:
-        return format_datetime(datetime_, format or 'MMMM d, YYYY, HH:mm (z)')
+        if six.PY2:
+            # timezones rendered as offset in py2 - let's use
+            # abbreviation instead
+            fmt_str = "MMMM d, YYYY, HH:mm ('{zone'})".format(
+                datetime_.tzname()
+            )
+        else:
+            fmt_str = "MMMM d, YYYY, HH:mm (z)"
+        return format_datetime(datetime_, format or fmt_str)
     else:
         return format_date(datetime_, format or 'long')
 

--- a/ckan/lib/formatters.py
+++ b/ckan/lib/formatters.py
@@ -2,80 +2,25 @@
 
 import datetime
 import pytz
-from babel import numbers
+from flask_babel import (
+    format_number,
+    format_datetime,
+    format_date,
+    format_timedelta
+)
 
-import ckan.lib.i18n as i18n
-
-from ckan.common import _, ungettext
-
-
-##################################################
-#                                                #
-#              Month translations                #
-#                                                #
-##################################################
-
-def _month_jan():
-    return _('January')
-
-
-def _month_feb():
-    return _('February')
-
-
-def _month_mar():
-    return _('March')
-
-
-def _month_apr():
-    return _('April')
-
-
-def _month_may():
-    return _('May')
-
-
-def _month_june():
-    return _('June')
-
-
-def _month_july():
-    return _('July')
-
-
-def _month_aug():
-    return _('August')
-
-
-def _month_sept():
-    return _('September')
-
-
-def _month_oct():
-    return _('October')
-
-
-def _month_nov():
-    return _('November')
-
-
-def _month_dec():
-    return _('December')
-
-
-# _MONTH_FUNCTIONS provides an easy way to get a localised month via
-# _MONTH_FUNCTIONS[month]() where months are zero based ie jan = 0, dec = 11
-_MONTH_FUNCTIONS = [_month_jan, _month_feb, _month_mar, _month_apr,
-                   _month_may, _month_june, _month_july, _month_aug,
-                   _month_sept, _month_oct, _month_nov, _month_dec]
+from ckan.common import _
 
 
 def localised_nice_date(datetime_, show_date=False, with_hours=False,
-                        with_seconds=False):
+                        with_seconds=False, format=None):
     ''' Returns a friendly localised unicode representation of a datetime.
     e.g. '31 minutes ago'
          '1 day ago'
          'April 24, 2013'  (show_date=True)
+         'October 25, 2017, 16:03 (UTC)' (show_date=True, with_hours=True)
+         'Apr 3, 2020, 4:00:31 PM' (show_date=True, format='medium')
+         'April 03, 20' (show_date=True, format='MMMM dd, YY')
 
     :param datetime_: The date to format
     :type datetime_: datetime
@@ -85,87 +30,35 @@ def localised_nice_date(datetime_, show_date=False, with_hours=False,
     :type with_hours: bool
     :param with_seconds: should the `hours:mins:seconds` be shown for dates
     :type with_seconds: bool
+    :param format: override format of datetime representation using babel
+        date/time pattern syntax of predefined pattern.
+    :type format: str
+
 
     :rtype: sting
     '''
-
-    def months_between(date1, date2):
-        if date1 > date2:
-            date1, date2 = date2, date1
-        m1 = date1.year * 12 + date1.month
-        m2 = date2.year * 12 + date2.month
-        months = m2 - m1
-        if date1.day > date2.day:
-            months -= 1
-        elif date1.day == date2.day:
-            seconds1 = date1.hour * 3600 + date1.minute + date1.second
-            seconds2 = date2.hour * 3600 + date2.minute + date2.second
-            if seconds1 > seconds2:
-                months -= 1
-        return months
 
     if not show_date:
         now = datetime.datetime.now(pytz.utc)
         if datetime_.tzinfo is None:
             datetime_ = datetime_.replace(tzinfo=pytz.utc)
 
-        date_diff = now - datetime_
-        days = date_diff.days
-        if days < 1 and now > datetime_:
-            # less than one day
-            seconds = date_diff.seconds
-            if seconds < 3600:
-                # less than one hour
-                if seconds < 60:
-                    return _('Just now')
-                else:
-                    return ungettext('{mins} minute ago', '{mins} minutes ago',
-                                     seconds // 60).format(mins=seconds // 60)
-            else:
-                return ungettext('{hours} hour ago', '{hours} hours ago',
-                                 seconds // 3600).format(hours=seconds // 3600)
-        # more than one day
-        months = months_between(datetime_, now)
-
-        if months < 1:
-            return ungettext('{days} day ago', '{days} days ago',
-                             days).format(days=days)
-        if months < 13:
-            return ungettext('{months} month ago', '{months} months ago',
-                             months).format(months=months)
-        return ungettext('over {years} year ago', 'over {years} years ago',
-                         months // 12).format(years=months // 12)
-
-    # actual date
-    details = {
-        'sec': int(datetime_.second),
-        'min': datetime_.minute,
-        'hour': datetime_.hour,
-        'day': datetime_.day,
-        'year': datetime_.year,
-        'month': _MONTH_FUNCTIONS[datetime_.month - 1](),
-        'timezone': datetime_.tzname(),
-    }
+        date_diff = datetime_ - now
+        if abs(date_diff) < datetime.timedelta(seconds=1):
+            return _('Just now')
+        return format_timedelta(date_diff, add_direction=True)
 
     if with_seconds:
-        return (
-            # Example output: `April 24, 2013, 10:45:21 (Europe/Zurich)`
-            _('{month} {day}, {year}, {hour:02}:{min:02}:{sec:02} ({timezone})') \
-            .format(**details))
+        return format_datetime(datetime_, format or 'long')
     elif with_hours:
-        return (
-            # Example output: `April 24, 2013, 10:45 (Europe/Zurich)`
-            _('{month} {day}, {year}, {hour:02}:{min:02} ({timezone})') \
-            .format(**details))
+        return format_datetime(datetime_, format or 'MMMM d, YYYY, HH:mm (z)')
     else:
-        return (
-            # Example output: `April 24, 2013`
-            _('{month} {day}, {year}').format(**details))
+        return format_date(datetime_, format or 'long')
 
 
 def localised_number(number):
     ''' Returns a localised unicode representation of number '''
-    return numbers.format_number(number, locale=i18n.get_lang())
+    return format_number(number)
 
 
 def localised_filesize(number):

--- a/ckan/lib/formatters.py
+++ b/ckan/lib/formatters.py
@@ -67,7 +67,7 @@ def localised_filesize(number):
     etc '''
     def rnd(number, divisor):
         # round to 1 decimal place
-        return localised_number(float(number * 10 / divisor) / 10)
+        return localised_number(float(number * 10 // divisor) / 10)
 
     if number < 1024:
         return _('{bytes} bytes').format(bytes=localised_number(number))
@@ -87,7 +87,7 @@ def localised_SI_number(number):
 
     def rnd(number, divisor):
         # round to 1 decimal place
-        return localised_number(float(number * 10 / divisor) / 10)
+        return localised_number(float(number * 10 // divisor) / 10)
 
     if number < 1000:
         return _('{n}').format(n=localised_number(number))

--- a/ckan/tests/legacy/test_coding_standards.py
+++ b/ckan/tests/legacy/test_coding_standards.py
@@ -317,7 +317,6 @@ class TestPep8(object):
         "ckan/lib/email_notifications.py",
         "ckan/lib/fanstatic_extensions.py",
         "ckan/lib/fanstatic_resources.py",
-        "ckan/lib/formatters.py",
         "ckan/lib/hash.py",
         "ckan/lib/help/flash_messages.py",
         "ckan/lib/jinja_extensions.py",

--- a/ckan/tests/lib/test_formatters.py
+++ b/ckan/tests/lib/test_formatters.py
@@ -1,41 +1,48 @@
 # -*- coding: utf-8 -*-
 
+import six
 import pytest
 import pytz
 from ckan.lib import formatters as f
 from datetime import datetime
 
 
-@pytest.mark.parametrize(u'number,expected', [
-    (1, u'1'),
-    (1e3, u'1k'),
-    (1e6, u'1M'),
-    (1e6 + 32e3, u'1.032M'),
-    (1e9, u'1G'),
-    (1e9 + 1, u'1G'),
-    (1e12, u'1T'),
-    (1e12 + 9e11, u'1.9T'),
-    (1e15, u'1P'),
-    (1e18, u'1E'),
-    (1e21, u'1Z'),
-    (1e25, u'10Y'),
-])
-@pytest.mark.usefixtures(u'with_request_context')
+@pytest.mark.parametrize(
+    u"number,expected",
+    [
+        (1, u"1"),
+        (1e3, u"1k"),
+        (1e6, u"1M"),
+        (1e6 + 32e3, u"1.032M"),
+        (1e9, u"1G"),
+        (1e9 + 1, u"1G"),
+        (1e12, u"1T"),
+        (1e12 + 9e11, u"1.9T"),
+        (1e15, u"1P"),
+        (1e18, u"1E"),
+        (1e21, u"1Z"),
+        (1e25, u"10Y"),
+    ],
+)
+@pytest.mark.usefixtures(u"with_request_context")
 def test_localized_SI_number(number, expected):
     assert f.localised_SI_number(number) == expected
 
 
-@pytest.mark.parametrize(u'size,expected', [
-    (1, u'1 bytes'),
-    (1024, u'1 KiB'),
-    (1024 ** 2, u'1 MiB'),
-    (1024 ** 2 + 1024 * 31, u'1.03 MiB'),
-    (1024 ** 3, u'1 GiB'),
-    (1024 ** 3 + 1, u'1 GiB'),
-    (1024 ** 4, u'1 TiB'),
-    (1024 ** 4 + 1024 ** 3 * 900, u'1.879 TiB'),
-])
-@pytest.mark.usefixtures(u'with_request_context')
+@pytest.mark.parametrize(
+    u"size,expected",
+    [
+        (1, u"1 bytes"),
+        (1024, u"1 KiB"),
+        (1024 ** 2, u"1 MiB"),
+        (1024 ** 2 + 1024 * 31, u"1.03 MiB"),
+        (1024 ** 3, u"1 GiB"),
+        (1024 ** 3 + 1, u"1 GiB"),
+        (1024 ** 4, u"1 TiB"),
+        (1024 ** 4 + 1024 ** 3 * 900, u"1.879 TiB"),
+    ],
+)
+@pytest.mark.usefixtures(u"with_request_context")
 def test_localized_filesize(size, expected):
     assert f.localised_filesize(size) == expected
 
@@ -44,52 +51,65 @@ _now = datetime(2017, 10, 23, 16, 3, 52, tzinfo=pytz.UTC)
 
 
 @pytest.mark.freeze_time(_now)
-@pytest.mark.usefixtures(u'with_request_context')
+@pytest.mark.usefixtures(u"with_request_context")
 class TestLocalizedNiceDate(object):
-    @pytest.mark.parametrize(u'dt,date,hours,seconds,expected', [
-        (_now, False, False, False, u'Just now'),
-        (_now, True, False, False, u'October 23, 2017'),
-        (_now, True, True, False, u'October 23, 2017, 16:03 (UTC)'),
-        (_now, True, True, True, u'October 23, 2017 at 4:03:52 PM UTC'),
-        (_now, False, True, True, u'Just now'),
-        (_now, False, False, True, u'Just now'),
-        (_now, False, True, False, u'Just now'),
-    ])
-    def test_params(
-            self, dt, date, hours, seconds, expected):
+    @pytest.mark.parametrize(
+        u"dt,date,hours,seconds,expected",
+        [
+            (_now, False, False, False, u"Just now"),
+            (_now, True, False, False, u"October 23, 2017"),
+            (_now, True, True, False, u"October 23, 2017, 16:03 (UTC)"),
+            (_now, True, True, True, u"October 23, 2017 at 4:03:52 PM UTC"),
+            (_now, False, True, True, u"Just now"),
+            (_now, False, False, True, u"Just now"),
+            (_now, False, True, False, u"Just now"),
+        ],
+    )
+    def test_params(self, dt, date, hours, seconds, expected):
         assert f.localised_nice_date(dt, date, hours, seconds) == expected
 
-    @pytest.mark.parametrize(u'dt,expected', [
-        (_now, u'Just now'),
-        (_now.replace(second=_now.second-30), u'30 seconds ago'),
-        (_now.replace(minute=_now.minute-2), u'2 minutes ago'),
-        (_now.replace(hour=_now.hour-4), u'4 hours ago'),
-        (_now.replace(day=_now.day-5), u'5 days ago'),
-        (_now.replace(day=_now.day-8), u'1 week ago'),
-        (_now.replace(month=_now.month-4), u'4 months ago'),
-        (_now.replace(year=_now.year-5), u'5 years ago'),
-        (_now.replace(second=_now.second+5), u'in 5 seconds'),
-        (_now.replace(minute=_now.minute+2), u'in 2 minutes'),
-        (_now.replace(hour=_now.hour+4), u'in 4 hours'),
-        (_now.replace(day=_now.day+5), u'in 5 days'),
-        (_now.replace(day=_now.day+8), u'in 1 week'),
-        (_now.replace(month=_now.month+1), u'in 1 month'),
-        (_now.replace(year=_now.year+5), u'in 5 years'),
-
-    ])
+    @pytest.mark.parametrize(
+        u"dt,expected",
+        [
+            (_now, u"Just now"),
+            (_now.replace(second=_now.second - 30), u"30 seconds ago"),
+            (_now.replace(minute=_now.minute - 2), u"2 minutes ago"),
+            (_now.replace(hour=_now.hour - 4), u"4 hours ago"),
+            (_now.replace(day=_now.day - 5), u"5 days ago"),
+            (_now.replace(day=_now.day - 8), u"1 week ago"),
+            (_now.replace(month=_now.month - 4), u"4 months ago"),
+            (_now.replace(year=_now.year - 5), u"5 years ago"),
+            (_now.replace(second=_now.second + 5), u"in 5 seconds"),
+            (_now.replace(minute=_now.minute + 2), u"in 2 minutes"),
+            (_now.replace(hour=_now.hour + 4), u"in 4 hours"),
+            (_now.replace(day=_now.day + 5), u"in 5 days"),
+            (_now.replace(day=_now.day + 8), u"in 1 week"),
+            (_now.replace(month=_now.month + 1), u"in 1 month"),
+            (_now.replace(year=_now.year + 5), u"in 5 years"),
+        ],
+    )
     def test_relative_dates(self, dt, expected):
         assert f.localised_nice_date(dt) == expected
 
-    @pytest.mark.parametrize(u'dt,hours,seconds,fmt,expected', [
-        (_now, False, False, None, u'October 23, 2017'),
-        (_now, False, False, u'MMM, YY', u'Oct, 17'),
-        (_now, True, False, None, u'October 23, 2017, 16:03 (UTC)'),
-        (_now, True, False, u'EEE, HH:mm', u'Mon, 16:03'),
-        (_now, True, True, None, u'October 23, 2017 at 4:03:52 PM UTC'),
-        (_now, True, False, u'MMM dd, yy. EEEE \'at\' hh:mm:ss [z]',
-         u'Oct 23, 17. Monday at 04:03:52 [UTC]'),
-
-    ])
+    @pytest.mark.parametrize(
+        u"dt,hours,seconds,fmt,expected",
+        [
+            (_now, False, False, None, u"October 23, 2017"),
+            (_now, False, False, u"MMM, YY", u"Oct, 17"),
+            (_now, True, False, None, u"October 23, 2017, 16:03 (UTC)"),
+            (_now, True, False, u"EEE, HH:mm", u"Mon, 16:03"),
+            (_now, True, True, None, u"October 23, 2017 at 4:03:52 PM UTC"),
+            pytest.param(
+                _now,
+                True,
+                False,
+                u"MMM dd, yy. EEEE 'at' hh:mm:ss [z]",
+                u"Oct 23, 17. Monday at 04:03:52 [UTC]",
+                marks=pytest.mark.skipif(
+                    six.PY2,
+                    reason="Py2 renders offset instead of tz abbreviation")
+            ),
+        ],
+    )
     def test_with_dates(self, dt, hours, seconds, fmt, expected):
-        assert f.localised_nice_date(
-            dt, True, hours, seconds, fmt) == expected
+        assert f.localised_nice_date(dt, True, hours, seconds, fmt) == expected

--- a/ckan/tests/lib/test_formatters.py
+++ b/ckan/tests/lib/test_formatters.py
@@ -99,15 +99,12 @@ class TestLocalizedNiceDate(object):
             (_now, True, False, None, u"October 23, 2017, 16:03 (UTC)"),
             (_now, True, False, u"EEE, HH:mm", u"Mon, 16:03"),
             (_now, True, True, None, u"October 23, 2017 at 4:03:52 PM UTC"),
-            pytest.param(
+            (
                 _now,
                 True,
                 False,
                 u"MMM dd, yy. EEEE 'at' hh:mm:ss [z]",
                 u"Oct 23, 17. Monday at 04:03:52 [UTC]",
-                marks=pytest.mark.skipif(
-                    six.PY2,
-                    reason="Py2 renders offset instead of tz abbreviation")
             ),
         ],
     )

--- a/ckan/tests/lib/test_formatters.py
+++ b/ckan/tests/lib/test_formatters.py
@@ -13,7 +13,7 @@ from datetime import datetime
         (1, u"1"),
         (1e3, u"1k"),
         (1e6, u"1M"),
-        (1e6 + 32e3, u"1.032M"),
+        (1e6 + 32e3, u"1M"),
         (1e9, u"1G"),
         (1e9 + 1, u"1G"),
         (1e12, u"1T"),
@@ -35,11 +35,11 @@ def test_localized_SI_number(number, expected):
         (1, u"1 bytes"),
         (1024, u"1 KiB"),
         (1024 ** 2, u"1 MiB"),
-        (1024 ** 2 + 1024 * 31, u"1.03 MiB"),
+        (1024 ** 2 + 1024 * 31, u"1 MiB"),
         (1024 ** 3, u"1 GiB"),
         (1024 ** 3 + 1, u"1 GiB"),
         (1024 ** 4, u"1 TiB"),
-        (1024 ** 4 + 1024 ** 3 * 900, u"1.879 TiB"),
+        (1024 ** 4 + 1024 ** 3 * 900, u"1.8 TiB"),
     ],
 )
 @pytest.mark.usefixtures(u"with_request_context")

--- a/ckan/tests/lib/test_formatters.py
+++ b/ckan/tests/lib/test_formatters.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+import pytz
+from ckan.lib import formatters as f
+from datetime import datetime
+
+
+@pytest.mark.parametrize(u'number,expected', [
+    (1, u'1'),
+    (1e3, u'1k'),
+    (1e6, u'1M'),
+    (1e6 + 32e3, u'1.032M'),
+    (1e9, u'1G'),
+    (1e9 + 1, u'1G'),
+    (1e12, u'1T'),
+    (1e12 + 9e11, u'1.9T'),
+    (1e15, u'1P'),
+    (1e18, u'1E'),
+    (1e21, u'1Z'),
+    (1e25, u'10Y'),
+])
+@pytest.mark.usefixtures(u'with_request_context')
+def test_localized_SI_number(number, expected):
+    assert f.localised_SI_number(number) == expected
+
+
+@pytest.mark.parametrize(u'size,expected', [
+    (1, u'1 bytes'),
+    (1024, u'1 KiB'),
+    (1024 ** 2, u'1 MiB'),
+    (1024 ** 2 + 1024 * 31, u'1.03 MiB'),
+    (1024 ** 3, u'1 GiB'),
+    (1024 ** 3 + 1, u'1 GiB'),
+    (1024 ** 4, u'1 TiB'),
+    (1024 ** 4 + 1024 ** 3 * 900, u'1.879 TiB'),
+])
+@pytest.mark.usefixtures(u'with_request_context')
+def test_localized_filesize(size, expected):
+    assert f.localised_filesize(size) == expected
+
+
+_now = datetime(2017, 10, 23, 16, 3, 52, tzinfo=pytz.UTC)
+
+
+@pytest.mark.freeze_time(_now)
+@pytest.mark.usefixtures(u'with_request_context')
+class TestLocalizedNiceDate(object):
+    @pytest.mark.parametrize(u'dt,date,hours,seconds,expected', [
+        (_now, False, False, False, u'Just now'),
+        (_now, True, False, False, u'October 23, 2017'),
+        (_now, True, True, False, u'October 23, 2017, 16:03 (UTC)'),
+        (_now, True, True, True, u'October 23, 2017 at 4:03:52 PM UTC'),
+        (_now, False, True, True, u'Just now'),
+        (_now, False, False, True, u'Just now'),
+        (_now, False, True, False, u'Just now'),
+    ])
+    def test_params(
+            self, dt, date, hours, seconds, expected):
+        assert f.localised_nice_date(dt, date, hours, seconds) == expected
+
+    @pytest.mark.parametrize(u'dt,expected', [
+        (_now, u'Just now'),
+        (_now.replace(second=_now.second-30), u'30 seconds ago'),
+        (_now.replace(minute=_now.minute-2), u'2 minutes ago'),
+        (_now.replace(hour=_now.hour-4), u'4 hours ago'),
+        (_now.replace(day=_now.day-5), u'5 days ago'),
+        (_now.replace(day=_now.day-8), u'1 week ago'),
+        (_now.replace(month=_now.month-4), u'4 months ago'),
+        (_now.replace(year=_now.year-5), u'5 years ago'),
+        (_now.replace(second=_now.second+5), u'in 5 seconds'),
+        (_now.replace(minute=_now.minute+2), u'in 2 minutes'),
+        (_now.replace(hour=_now.hour+4), u'in 4 hours'),
+        (_now.replace(day=_now.day+5), u'in 5 days'),
+        (_now.replace(day=_now.day+8), u'in 1 week'),
+        (_now.replace(month=_now.month+1), u'in 1 month'),
+        (_now.replace(year=_now.year+5), u'in 5 years'),
+
+    ])
+    def test_relative_dates(self, dt, expected):
+        assert f.localised_nice_date(dt) == expected
+
+    @pytest.mark.parametrize(u'dt,hours,seconds,fmt,expected', [
+        (_now, False, False, None, u'October 23, 2017'),
+        (_now, False, False, u'MMM, YY', u'Oct, 17'),
+        (_now, True, False, None, u'October 23, 2017, 16:03 (UTC)'),
+        (_now, True, False, u'EEE, HH:mm', u'Mon, 16:03'),
+        (_now, True, True, None, u'October 23, 2017 at 4:03:52 PM UTC'),
+        (_now, True, False, u'MMM dd, yy. EEEE \'at\' hh:mm:ss [z]',
+         u'Oct 23, 17. Monday at 04:03:52 [UTC]'),
+
+    ])
+    def test_with_dates(self, dt, hours, seconds, fmt, expected):
+        assert f.localised_nice_date(
+            dt, True, hours, seconds, fmt) == expected

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -502,7 +502,7 @@ class TestGetDisplayTimezone(object):
         (
             datetime.datetime(2008, 4, 13, 20, 40, 59, 123456),
             {"with_seconds": True},
-            "April 13, 2008, 20:40:59 (UTC)",
+            "April 13, 2008 at 8:40:59 PM UTC",
         ),
         ("2008-04-13T20:40:20.123456", {}, "April 13, 2008"),
         (None, {}, ""),
@@ -511,6 +511,7 @@ class TestGetDisplayTimezone(object):
         ("2008-04-13T20:40:20.123456", {"date_format": "%%%Y"}, "%2008"),
     ],
 )
+@pytest.mark.usefixtures("with_request_context")
 def test_render_datetime(date, extra, exp):
     assert h.render_datetime(date, **extra) == exp
 
@@ -522,7 +523,7 @@ def test_render_datetime(date, extra, exp):
     [
         (
             datetime.datetime(2020, 2, 17, 11, 59, 30),
-            "Just now",
+            "30 seconds ago",
         ),
         (
             datetime.datetime(2020, 2, 17, 11, 59, 0),
@@ -558,11 +559,11 @@ def test_render_datetime(date, extra, exp):
         ),
         (
             datetime.datetime(2019, 1, 17, 12, 0, 0),
-            "over 1 year ago",
+            "1 year ago",
         ),
         (
             datetime.datetime(2015, 1, 17, 12, 0, 0),
-            "over 5 years ago",
+            "5 years ago",
         ),
     ]
 )
@@ -749,7 +750,7 @@ if six.PY2:
             return base.render("tests/helper_as_item.html")
 
 
-@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("clean_db", "with_request_context")
 class TestActivityListSelect(object):
     def test_simple(self):
         pkg_activity = {
@@ -762,7 +763,7 @@ class TestActivityListSelect(object):
         html = out[0]
         assert (
             str(html)
-            == '<option value="id1" >February 1, 2018, 10:58:59 (UTC)'
+            == '<option value="id1" >February 1, 2018 at 10:58:59 AM UTC'
             "</option>"
         )
         assert hasattr(html, "__html__")  # shows it is safe Markup
@@ -778,7 +779,7 @@ class TestActivityListSelect(object):
         html = out[0]
         assert (
             str(html)
-            == '<option value="id1" selected>February 1, 2018, 10:58:59 (UTC)'
+            == '<option value="id1" selected>February 1, 2018 at 10:58:59 AM UTC'
             "</option>"
         )
         assert hasattr(html, "__html__")  # shows it is safe Markup

--- a/requirements-py2.in
+++ b/requirements-py2.in
@@ -1,7 +1,7 @@
 # The file contains the direct ckan requirements (python2).
 # Use pip-compile to create a requirements.txt file from this
 alembic==1.0.0
-Babel==2.3.4
+Babel==2.7.0
 bleach==3.1.4
 click==6.7
 dominate==2.4.0

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file requirements=py2.txt requirements-py2.in
 #
 alembic==1.0.0
-babel==2.3.4
+babel==2.7.0
 beaker==1.10.1            # via pylons
 bleach==3.1.4
 certifi==2019.3.9         # via requests

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 # The file contains the direct ckan requirements (python3).
 # Use pip-compile to create a requirements.txt file from this
 alembic==1.0.0
-Babel==2.3.4
+Babel==2.7.0
 Beaker==1.11.0
 bleach==3.1.4
 click==6.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 alembic==1.0.0
-babel==2.3.4
+babel==2.7.0
 beaker==1.11.0
 bleach==3.1.4
 certifi==2019.11.28       # via requests


### PR DESCRIPTION
Update `ckan.lib.formatters.localised_nice_date` relying in Babel's formatters, instead of custom code + provide tests for formatters