### PR TITLE
Document python version for latest stable release (2.8.4) of ckan

### DIFF
--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -125,6 +125,8 @@ c. Install the CKAN source code into your virtualenv.
 
       pip install -e 'git+\ |git_url|\@\ |latest_release_tag|\#egg=ckan'
 
+   *** Please note that the latest stable version of CKAN 2.8.* requires Python 2 ***
+
    If you're installing CKAN for development, you may want to install the
    latest development version (the most recent commit on the master branch of
    the CKAN git repository). In that case, run this command instead:

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -125,7 +125,7 @@ c. Install the CKAN source code into your virtualenv.
 
       pip install -e 'git+\ |git_url|\@\ |latest_release_tag|\#egg=ckan'
 
-   *** Please note that the latest stable version of CKAN (2.8.*) requires Python 2 ***
+   ** Please note that the latest stable version of CKAN (2.8.*) requires Python 2 **
 
    If you're installing CKAN for development, you may want to install the
    latest development version (the most recent commit on the master branch of

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -125,7 +125,7 @@ c. Install the CKAN source code into your virtualenv.
 
       pip install -e 'git+\ |git_url|\@\ |latest_release_tag|\#egg=ckan'
 
-   ** Please note that the latest stable version of CKAN (2.8.*) requires Python 2 **
+   *** Please note that the latest stable version of CKAN (2.8.*) requires Python 2 ***
 
    If you're installing CKAN for development, you may want to install the
    latest development version (the most recent commit on the master branch of

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -125,7 +125,7 @@ c. Install the CKAN source code into your virtualenv.
 
       pip install -e 'git+\ |git_url|\@\ |latest_release_tag|\#egg=ckan'
 
-   *** Please note that the latest stable version of CKAN 2.8.* requires Python 2 ***
+   *** Please note that the latest stable version of CKAN (2.8.*) requires Python 2 ***
 
    If you're installing CKAN for development, you may want to install the
    latest development version (the most recent commit on the master branch of


### PR DESCRIPTION
Fixes #5366

### Proposed fixes:
Update docs to specify "latest stable version" of CKAN (2.8.4) requires Python 2


### Features:

- [ ] includes tests covering changes
- [X ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
