### PR TITLE
Fix docker install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,8 @@ RUN useradd -r -u 900 -m -c "ckan account" -d $CKAN_HOME -s /bin/false ckan
 RUN mkdir -p $CKAN_VENV $CKAN_CONFIG $CKAN_STORAGE_PATH && \
     virtualenv $CKAN_VENV && \
     ln -s $CKAN_VENV/bin/pip /usr/local/bin/ckan-pip &&\
-    ln -s $CKAN_VENV/bin/paster /usr/local/bin/ckan-paster
+    ln -s $CKAN_VENV/bin/paster /usr/local/bin/ckan-paster &&\
+    ln -s $CKAN_VENV/bin/ckan /usr/local/bin/ckan
 
 # Setup CKAN
 ADD . $CKAN_VENV/src/ckan/
@@ -62,4 +63,4 @@ ENTRYPOINT ["/ckan-entrypoint.sh"]
 USER ckan
 EXPOSE 5000
 
-CMD ["ckan-paster","serve","/etc/ckan/production.ini"]
+CMD ["ckan","-c","/etc/ckan/production.ini", "run", "--host", "0.0.0.0"]

--- a/contrib/docker/ckan-entrypoint.sh
+++ b/contrib/docker/ckan-entrypoint.sh
@@ -37,7 +37,8 @@ set_environment () {
 }
 
 write_config () {
-  ckan-paster make-config --no-interactive ckan "$CONFIG"
+  echo "Generating config at ${CONFIG}..."
+  ckan generate config "$CONFIG"
 }
 
 # Wait for PostgreSQL
@@ -68,5 +69,5 @@ if [ -z "$CKAN_DATAPUSHER_URL" ]; then
 fi
 
 set_environment
-ckan-paster --plugin=ckan db init -c "${CKAN_CONFIG}/production.ini"
+ckan --config "$CONFIG" db init
 exec "$@"


### PR DESCRIPTION
I attempted to install the master (2.9.0a) version of CKAN using docker, but was seeing errors in the logs when running `docker-compose logs -f`. The ckan container would exit almost immediately after starting. 

The only similar info I can see in issues is this comment by @kowh-ai https://github.com/ckan/ckan/issues/5243#issuecomment-595737103

I haven't raised an accompanying issue, I chose to hopefully provide a fix instead.

### Proposed fixes:
[Docker installation instructions for 2.9.0a](https://docs.ckan.org/en/latest/maintaining/installing/install-from-docker-compose.html) should now work as expected.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
