### PR TITLE
Revert "Override datapusher site url" in ckan 2.7

### DIFF
--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -60,7 +60,7 @@ def datapusher_submit(context, data_dict):
 
     datapusher_url = config.get('ckan.datapusher.url')
 
-    site_url = 'http://ckan:5000'
+    site_url = h.url_for('/', qualified=True)
 
     callback_url_base = config.get('ckan.datapusher.callback_url_base')
     if callback_url_base:


### PR DESCRIPTION
Fixes #5385

### Proposed fixes:
Reverts hardcoded site url, forcing datapusher requests to go via proxy (if present) rather than direct to ckan server.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
