### PR TITLE
Remove all instances of fa-medium class in ckan 2.7

### DIFF
--- a/ckan/templates/development/snippets/facet.html
+++ b/ckan/templates/development/snippets/facet.html
@@ -1,6 +1,6 @@
 <section class="module module-narrow">
   {% with items=(("First", true), ("Second", false), ("Third", true), ("Fourth", false), ("Last", false)) %}
-    <h2 class="module-heading"><i class="fa fa-medium fa-filter"></i>  Facet List</h2>
+    <h2 class="module-heading"><i class="fa fa-filter"></i>  Facet List</h2>
     <nav>
       <ul class="unstyled nav nav-simple nav-facet">
         {% for value, active in items %}

--- a/ckan/templates/development/snippets/module.html
+++ b/ckan/templates/development/snippets/module.html
@@ -5,7 +5,7 @@
     {% elif heading_action %}
       <h{{ hn }} class="module-heading">{{ heading }}</h{{ hn }}>
     {% elif heading_icon %}
-      <h{{ hn }} class="module-heading"><i class="fa fa-medium fa-wrench"></i> {{ heading }}</h{{ hn }}>
+      <h{{ hn }} class="module-heading"><i class="fa fa-wrench"></i> {{ heading }}</h{{ hn }}>
     {% else %}
       <h{{ hn }} class="module-heading">{{ heading }}</h{{ hn }}>
     {% endif %}

--- a/ckan/templates/development/snippets/simple-input.html
+++ b/ckan/templates/development/snippets/simple-input.html
@@ -1,4 +1,4 @@
 <section class="module module-narrow module-shallow simple-input">
-  <h2 class="module-heading"><i class="fa fa-medium fa-link"></i> Module Narrow Input</h2>
+  <h2 class="module-heading"><i class="fa fa-link"></i> Module Narrow Input</h2>
   <div class="module-content field"><input type="text" value="simple-input" /></div>
 </section>

--- a/ckan/templates/snippets/disqus_trackback.html
+++ b/ckan/templates/snippets/disqus_trackback.html
@@ -1,4 +1,4 @@
 <section class="module module-narrow module-shallow disqus-trackback simple-input">
-  <h2 class="module-heading"><i class="fa fa-medium fa-link"></i> {{ _('Trackback URL') }}</h2>
+  <h2 class="module-heading"><i class="fa fa-link"></i> {{ _('Trackback URL') }}</h2>
   <div class="field module-content"><input type="text" value="http://trackback.com" /></div>
 </section>

--- a/ckan/templates/snippets/facet_list.html
+++ b/ckan/templates/snippets/facet_list.html
@@ -50,7 +50,7 @@ within_tertiary
         <section class="{{ wrapper_class or 'module module-narrow module-shallow' }}">
           {% block facet_list_heading %}
             <h2 class="module-heading">
-              <i class="fa fa-medium fa-filter"></i>
+              <i class="fa fa-filter"></i>
               {% set title = title or h.get_facet_title(name) %}
               {{ title }}
             </h2>

--- a/ckan/templates/snippets/license.html
+++ b/ckan/templates/snippets/license.html
@@ -18,7 +18,7 @@
       {% block license_wrapper %}
         <section class="module module-narrow module-shallow license">
           {% block license_title %}
-            <h2 class="module-heading"><i class="fa fa-medium fa-lock"></i> {{ _('License') }}</h2>
+            <h2 class="module-heading"><i class="fa fa-lock"></i> {{ _('License') }}</h2>
           {% endblock %}
           {% block license_content %}
             <p class="module-content">

--- a/ckan/templates/snippets/social.html
+++ b/ckan/templates/snippets/social.html
@@ -2,7 +2,7 @@
 {% block social %}
   <section class="module module-narrow social">
     {% block social_title %}
-      <h2 class="module-heading"><i class="fa fa-medium fa-share-square-o"></i> {{ _('Social') }}</h2>
+      <h2 class="module-heading"><i class="fa fa-share-square-o"></i> {{ _('Social') }}</h2>
     {% endblock %}
     {% block social_nav %}
       <ul class="nav nav-simple">

--- a/ckan/templates/snippets/subscribe.html
+++ b/ckan/templates/snippets/subscribe.html
@@ -1,5 +1,5 @@
 <section class="module module-narrow subscribe">
-<h2 class="module-heading"><i class="fa fa-medium fa-rss"></i> {{ _('Subscribe') }}</h2>
+<h2 class="module-heading"><i class="fa fa-rss"></i> {{ _('Subscribe') }}</h2>
   <ul class="nav nav-simple">
     <li class="nav-item"><a href="#"><i class="ckan-icon ckan-icon-email"></i> {{ _('Email') }}</a></li>
     <li class="nav-item"><a href="#"><i class="ckan-icon ckan-icon-feed"></i> {{ _('RSS') }}</a></li>

--- a/ckan/templates/user/edit.html
+++ b/ckan/templates/user/edit.html
@@ -14,7 +14,7 @@
 
 {% block secondary_content %}
   <section class="module module-narrow module-shallow">
-    <h2 class="module-heading"><i class="fa fa-medium fa-info-circle"></i> {{ _('Account Info') }}</h2>
+    <h2 class="module-heading"><i class="fa fa-info-circle"></i> {{ _('Account Info') }}</h2>
     <div class="module-content">
       {% trans %}
         Your profile lets other CKAN users know about who you are and what you

--- a/ckanext/stats/templates/ckanext/stats/index.html
+++ b/ckanext/stats/templates/ckanext/stats/index.html
@@ -172,7 +172,7 @@
 
 {% block secondary_content %}
   <section class="module module-narrow">
-    <h2 class="module-heading"><i class="fa fa-bar-chart-o fa-medium"></i> {{ _('Statistics Menu') }}</h2>
+    <h2 class="module-heading"><i class="fa fa-bar-chart-o"></i> {{ _('Statistics Menu') }}</h2>
     <nav data-module="stats-nav">
       <ul class="unstyled nav nav-simple">
         <li class="nav-item active"><a href="#stats-total-datasets" data-toggle="tab">{{ _('Total Number of Datasets') }}</a></li>


### PR DESCRIPTION
This PR addresses part of #5384 and is complementary to #5389 

### Proposed fixes:
Removing fa-medium class as it was causing a medium.com icon to display instead of the expected icon.

Before:
![Screenshot from 2020-05-17 00-55-33](https://user-images.githubusercontent.com/1121256/82120434-28b77d80-97da-11ea-96c2-07183ef1052f.png)

After:
![Screenshot from 2020-05-17 00-56-06](https://user-images.githubusercontent.com/1121256/82120436-2fde8b80-97da-11ea-9522-399a32f8060a.png)

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
