### PR TITLE
Fix Travis CI docker build failing on 2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ RUN virtualenv $CKAN_HOME
 RUN ln -s $CKAN_HOME/bin/pip /usr/local/bin/ckan-pip
 RUN ln -s $CKAN_HOME/bin/paster /usr/local/bin/ckan-paster
 
+# Update pip version
+RUN ckan-pip install -U pip
+
 # SetUp Requirements
 # https://github.com/ckan/ckan/pull/4197
 ADD ./requirement-setuptools.txt $CKAN_HOME/src/ckan/requirement-setuptools.txt


### PR DESCRIPTION
Docker builds were failing on 2.7 as the pip version installed by default was 1.5.6 and does not have the --disable-pip-version-check option available.

Error message:
```
    Usage:
      /usr/lib/ckan/default/bin/python2 -m pip <command> [options]
    
    no such option: --disable-pip-version-check
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/tmp/pip-build-T_Nh5o/mox3/setup.py", line 29, in <module>
        pbr=True)
      File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/setuptools/__init__.py", line 143, in setup
        _install_setup_requires(attrs)
      File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/setuptools/__init__.py", line 138, in _install_setup_requires
        dist.fetch_build_eggs(dist.setup_requires)
      File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/setuptools/dist.py", line 698, in fetch_build_eggs
        replace_conflicting=True,
      File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 783, in resolve
        replace_conflicting=replace_conflicting
      File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1066, in best_match
        return self.obtain(req, installer)
      File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1078, in obtain
        return installer(requirement)
      File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/setuptools/dist.py", line 754, in fetch_build_egg
        return fetch_build_egg(self, req)
      File "/usr/lib/ckan/default/local/lib/python2.7/site-packages/setuptools/installer.py", line 130, in fetch_build_egg
        raise DistutilsError(str(e))
    distutils.errors.DistutilsError: Command '['/usr/lib/ckan/default/bin/python2', '-m', 'pip', '--disable-pip-version-check', 'wheel', '--no-deps', '-w', '/tmp/tmpK3CS8m', '--quiet', 'pbr>=2.0.0']' returned non-zero exit status 2
```

### Proposed fixes:
Upgrading pip in the Dockerfile before running installation of the ckan dependencies. This is done in the same way on the 2.8 branch version of Dockerfile.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
