### PR TITLE
Update CKANTestClient

### DIFF
--- a/ckan/tests/helpers.py
+++ b/ckan/tests/helpers.py
@@ -240,13 +240,11 @@ class CKANTestApp(object):
 
 class CKANTestClient(FlaskClient):
     def open(self, *args, **kwargs):
+        kwargs.pop('expect_errors', None)
         status = kwargs.pop("status", None)
         extra_environ = kwargs.pop("extra_environ", None)
         if extra_environ:
             kwargs["environ_overrides"] = extra_environ
-        # params = kwargs.pop('params', None)
-        # if params:
-        # kwargs['query_string'] = params
 
         if args and isinstance(args[0], six.string_types):
             kwargs.setdefault("follow_redirects", True)


### PR DESCRIPTION
Ignore legacy param `expect_errors` in TestClient requests. Right now it used in [ckanapi](https://github.com/ckan/ckanapi/blob/master/ckanapi/testappckan.py#L54) and can be potentially used in all extensions that are supported in CKAN <=2.8