### PR TITLE
Remove fa-medium to fix the wrong logo

### DIFF
--- a/ckanext/stats/templates/ckanext/stats/index.html
+++ b/ckanext/stats/templates/ckanext/stats/index.html
@@ -101,7 +101,7 @@
 
 {% block secondary_content %}
   <section class="module module-narrow">
-    <h2 class="module-heading"><i class="fa fa-bar-chart-o fa-medium"></i> {{ _('Statistics Menu') }}</h2>
+    <h2 class="module-heading"><i class="fa fa-bar-chart-o"></i> {{ _('Statistics Menu') }}</h2>
     <nav data-module="stats-nav">
       <ul class="unstyled nav nav-simple">
         <li class="nav-item active"><a href="#stats-top-rated" data-toggle="tab">{{ _('Top Rated Datasets') }}</a></li>


### PR DESCRIPTION
Fixes #5371 

### Proposed fixes:
fa-medium logos were removed in contributions by @markstuart from dev-v2.7 and dev-v2.8 branches in #5392 and #5388, this is the final one in master to get that issue closed.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
