### PR TITLE
Allow multiple `ext_*` params in search views

### DIFF
--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -11,6 +11,8 @@ import ckan.model as model
 import ckan.model.activity as activity_model
 import ckan.plugins as p
 import ckan.lib.dictization as dictization
+import ckan.logic as logic
+
 from ckan.logic.validators import object_id_validators, package_id_exists
 
 import ckan.tests.helpers as helpers
@@ -1639,6 +1641,22 @@ class TestSearch(object):
         )
         assert [n.string for n in ds_titles] == ["A private dataset"]
 
+    def test_search_with_extra_params(self, app, monkeypatch):
+        url = url_for('dataset.search')
+        url += '?ext_a=1&ext_a=2&ext_b=3'
+        search_result = {
+            'count': 0,
+            'sort': "score desc, metadata_modified desc",
+            'facets': {},
+            'search_facets': {},
+            'results': []
+        }
+        search = mock.Mock(return_value=search_result)
+        logic._actions['package_search'] = search
+        app.get(url)
+        search.assert_called()
+        extras = search.call_args[0][1]['extras']
+        assert extras == {'ext_a': ['1', '2'], 'ext_b': '3'}
 
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 class TestPackageFollow(object):

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -1658,6 +1658,7 @@ class TestSearch(object):
         extras = search.call_args[0][1]['extras']
         assert extras == {'ext_a': ['1', '2'], 'ext_b': '3'}
 
+
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 class TestPackageFollow(object):
     def test_package_follow(self, app):

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 from flask import Blueprint
 from flask.views import MethodView
+from werkzeug.datastructures import MultiDict
 from ckan.common import asbool
 
 import six
@@ -24,6 +25,7 @@ from ckan.lib.plugins import lookup_package_plugin
 from ckan.lib.render import TemplateNotFound
 from ckan.lib.search import SearchError, SearchQueryError, SearchIndexError
 from ckan.views import LazyView
+
 
 NotFound = logic.NotFound
 NotAuthorized = logic.NotAuthorized
@@ -157,6 +159,41 @@ def _get_package_type(id):
     return None
 
 
+def _get_search_details():
+    fq = u''
+
+    # fields_grouped will contain a dict of params containing
+    # a list of values eg {u'tags':[u'tag1', u'tag2']}
+
+    fields = []
+    fields_grouped = {}
+    search_extras = MultiDict()
+
+    for (param, value) in request.args.items(multi=True):
+        if param not in [u'q', u'page', u'sort'] \
+                and len(value) and not param.startswith(u'_'):
+            if not param.startswith(u'ext_'):
+                fields.append((param, value))
+                fq += u' %s:"%s"' % (param, value)
+                if param not in fields_grouped:
+                    fields_grouped[param] = [value]
+                else:
+                    fields_grouped[param].append(value)
+            else:
+                search_extras.update({param: value})
+
+    search_extras = dict([
+        (k, v[0]) if len(v) == 1 else (k, v)
+        for k, v in search_extras.lists()
+    ])
+    return {
+        'fields': fields,
+        'fields_grouped': fields_grouped,
+        'fq': fq,
+        'search_extras': search_extras,
+    }
+
+
 def search(package_type):
     extra_vars = {}
 
@@ -200,89 +237,74 @@ def search(package_type):
     search_url_params = urlencode(_encode_params(params_nopage))
     extra_vars[u'search_url_params'] = search_url_params
 
+    details = _get_search_details()
+    extra_vars[u'fields'] = details[u'fields']
+    extra_vars[u'fields_grouped'] = details[u'fields_grouped']
+    fq = details[u'fq']
+    search_extras = details[u'search_extras']
+
+    context = {
+        u'model': model,
+        u'session': model.Session,
+        u'user': g.user,
+        u'for_view': True,
+        u'auth_user_obj': g.userobj
+    }
+
+    # Unless changed via config options, don't show other dataset
+    # types any search page. Potential alternatives are do show them
+    # on the default search page (dataset) or on one other search page
+    search_all_type = config.get(u'ckan.search.show_all_types', u'dataset')
+    search_all = False
+
     try:
-        # fields_grouped will contain a dict of params containing
-        # a list of values eg {u'tags':[u'tag1', u'tag2']}
+        # If the "type" is set to True or False, convert to bool
+        # and we know that no type was specified, so use traditional
+        # behaviour of applying this only to dataset type
+        search_all = asbool(search_all_type)
+        search_all_type = u'dataset'
+    # Otherwise we treat as a string representing a type
+    except ValueError:
+        search_all = True
 
-        extra_vars[u'fields'] = fields = []
-        extra_vars[u'fields_grouped'] = fields_grouped = {}
-        search_extras = {}
-        fq = u''
-        for (param, value) in request.args.items(multi=True):
-            if param not in [u'q', u'page', u'sort'] \
-                    and len(value) and not param.startswith(u'_'):
-                if not param.startswith(u'ext_'):
-                    fields.append((param, value))
-                    fq += u' %s:"%s"' % (param, value)
-                    if param not in fields_grouped:
-                        fields_grouped[param] = [value]
-                    else:
-                        fields_grouped[param].append(value)
-                else:
-                    search_extras[param] = value
+    if not search_all or package_type != search_all_type:
+        # Only show datasets of this particular type
+        fq += u' +dataset_type:{type}'.format(type=package_type)
 
-        context = {
-            u'model': model,
-            u'session': model.Session,
-            u'user': g.user,
-            u'for_view': True,
-            u'auth_user_obj': g.userobj
-        }
+    facets = OrderedDict()
 
-        # Unless changed via config options, don't show other dataset
-        # types any search page. Potential alternatives are do show them
-        # on the default search page (dataset) or on one other search page
-        search_all_type = config.get(u'ckan.search.show_all_types', u'dataset')
-        search_all = False
+    default_facet_titles = {
+        u'organization': _(u'Organizations'),
+        u'groups': _(u'Groups'),
+        u'tags': _(u'Tags'),
+        u'res_format': _(u'Formats'),
+        u'license_id': _(u'Licenses'),
+    }
 
-        try:
-            # If the "type" is set to True or False, convert to bool
-            # and we know that no type was specified, so use traditional
-            # behaviour of applying this only to dataset type
-            search_all = asbool(search_all_type)
-            search_all_type = u'dataset'
-        # Otherwise we treat as a string representing a type
-        except ValueError:
-            search_all = True
+    for facet in h.facets():
+        if facet in default_facet_titles:
+            facets[facet] = default_facet_titles[facet]
+        else:
+            facets[facet] = facet
 
-        if not search_all or package_type != search_all_type:
-            # Only show datasets of this particular type
-            fq += u' +dataset_type:{type}'.format(type=package_type)
+    # Facet titles
+    for plugin in plugins.PluginImplementations(plugins.IFacets):
+        facets = plugin.dataset_facets(facets, package_type)
 
-        facets = OrderedDict()
-
-        default_facet_titles = {
-            u'organization': _(u'Organizations'),
-            u'groups': _(u'Groups'),
-            u'tags': _(u'Tags'),
-            u'res_format': _(u'Formats'),
-            u'license_id': _(u'Licenses'),
-        }
-
-        for facet in h.facets():
-            if facet in default_facet_titles:
-                facets[facet] = default_facet_titles[facet]
-            else:
-                facets[facet] = facet
-
-        # Facet titles
-        for plugin in plugins.PluginImplementations(plugins.IFacets):
-            facets = plugin.dataset_facets(facets, package_type)
-
-        extra_vars[u'facet_titles'] = facets
-        data_dict = {
-            u'q': q,
-            u'fq': fq.strip(),
-            u'facet.field': list(facets.keys()),
-            u'rows': limit,
-            u'start': (page - 1) * limit,
-            u'sort': sort_by,
-            u'extras': search_extras,
-            u'include_private': asbool(
-                config.get(u'ckan.search.default_include_private', True)
-            ),
-        }
-
+    extra_vars[u'facet_titles'] = facets
+    data_dict = {
+        u'q': q,
+        u'fq': fq.strip(),
+        u'facet.field': list(facets.keys()),
+        u'rows': limit,
+        u'start': (page - 1) * limit,
+        u'sort': sort_by,
+        u'extras': search_extras,
+        u'include_private': asbool(
+            config.get(u'ckan.search.default_include_private', True)
+        ),
+    }
+    try:
         query = get_action(u'package_search')(context, data_dict)
 
         extra_vars[u'sort_by_selected'] = query[u'sort']

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -187,10 +187,10 @@ def _get_search_details():
         for k, v in search_extras.lists()
     ])
     return {
-        'fields': fields,
-        'fields_grouped': fields_grouped,
-        'fq': fq,
-        'search_extras': search_extras,
+        u'fields': fields,
+        u'fields_grouped': fields_grouped,
+        u'fq': fq,
+        u'search_extras': search_extras,
     }
 
 

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -25,7 +25,6 @@ from flask import Blueprint
 from flask.views import MethodView
 
 
-
 NotFound = logic.NotFound
 NotAuthorized = logic.NotAuthorized
 ValidationError = logic.ValidationError
@@ -329,8 +328,6 @@ def _read(id, limit, group_type):
     # compatibility with templates in existing extensions
     g.fields = extra_vars[u'fields']
     g.fields_grouped = extra_vars[u'fields_grouped']
-
-
 
     facets = OrderedDict()
 


### PR DESCRIPTION
When `package_search` requested with multiple `ext_*` params with the same name, they are aggregated into dict. `/api/action/package_search?ext_a=1&ext_a=2&ext_b=3` turns into:
```python
data_dict = {
  'extras': {
    'ext_a': ['1', '2'],
    'ext_b': '3'
  }
}
```
But doing the same from `dataset.search`, `organization.read`, `group.read` will keep only last value for search extras.  `/dataset?ext_a=1&ext_a=2&ext_b=3` turns into:
```python
data_dict = {
  'extras': {
    'ext_a': '2',
    'ext_b': '3'
  }
}
```

This PR updates behavior of the mentioned views and they will behave just like a direct call to `package_search` action.

As for other changes - I've reduced the size of surrounding try/except block. Previously it was wrapping code, that won't throw an expected exception. Unfortunately, GitHub doesn't highlight the fact, that only indentation is changed, so diff looks pretty bad