### PR TITLE
Remove requester check from edit user

### DIFF
--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -316,11 +316,6 @@ class UserController(base.BaseController):
 
         user_obj = context.get('user_obj')
 
-        if not (authz.is_sysadmin(c.user)
-                or c.user == user_obj.name):
-            abort(403, _('User %s not authorized to edit %s') %
-                  (str(c.user), id))
-
         errors = errors or {}
         vars = {'data': data, 'errors': errors, 'error_summary': error_summary}
 

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -324,7 +324,6 @@ class UserController(base.BaseController):
                                         'user': c.user},
                                        data_dict)
 
-        c.is_myself = True
         c.show_email_notifications = asbool(
             config.get('ckan.activity_streams_email_notifications'))
         c.form = render(self.edit_user_form, extra_vars=vars)

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -232,6 +232,13 @@ class TestUser(object):
         assert user.about == "new about"
         assert user.activity_streams_email_notifications
 
+    def test_edit_user_as_wrong_user(self, app):
+        user = factories.User(password="TestPassword1")
+        other_user = factories.User(password="TestPassword2")
+
+        env = {"REMOTE_USER": six.ensure_str(other_user["name"])}
+        response = app.get(url_for("user.edit", id=user['name']), extra_environ=env, status=403)
+
     def test_email_change_without_password(self, app):
 
         user = factories.User()

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -264,7 +264,6 @@ class EditView(MethodView):
             u'user': g.user
         }, data_dict)
 
-        extra_vars[u'is_myself'] = True
         extra_vars[u'show_email_notifications'] = asbool(
             config.get(u'ckan.activity_streams_email_notifications'))
         vars.update(extra_vars)

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -251,10 +251,6 @@ class EditView(MethodView):
             base.abort(404, _(u'User not found'))
         user_obj = context.get(u'user_obj')
 
-        if not (authz.is_sysadmin(g.user) or g.user == user_obj.name):
-            msg = _(u'User %s not authorized to edit %s') % (g.user, id)
-            base.abort(403, msg)
-
         errors = errors or {}
         vars = {
             u'data': data,


### PR DESCRIPTION
### Proposed fixes:
Removes checks in controller/view level if the requester is syadmin or ther requester is the same as the user being modified. The checks should be in auth functions and this prevents writing auth functions where some user is allowed to edit another without sysadmin rights.

Added test to demonstrate that this doesn't alter functionality by default.

Also removes forced is_myself set to true as it already set to true or false in [here](https://github.com/ckan/ckan/blob/master/ckan/views/user.py#L64) and [here](https://github.com/ckan/ckan/blob/master/ckan/controllers/user.py#L89)

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
