### PR TITLE
extras_require in setup.py

### DIFF
--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -123,7 +123,15 @@ c. Install the CKAN source code into your virtualenv.
 
    .. parsed-literal::
 
-      pip install -e 'git+\ |git_url|\@\ |latest_release_tag|\#egg=ckan'
+      pip install -e 'git+\ |git_url|\@\ |latest_release_tag|\#egg=ckan[py3]'
+
+   .. note::
+
+      For Python 2 replace the last fragment with `py2`
+
+      .. parsed-literal::
+
+         pip install -e 'git+\ |git_url|\@\ |latest_release_tag|\#egg=ckan[py2]'
 
    If you're installing CKAN for development, you may want to install the
    latest development version (the most recent commit on the master branch of
@@ -131,7 +139,7 @@ c. Install the CKAN source code into your virtualenv.
 
    .. parsed-literal::
 
-       pip install -e 'git+\ |git_url|\#egg=ckan'
+       pip install -e 'git+\ |git_url|\#egg=ckan[py3,dev]'
 
    .. warning::
 
@@ -139,17 +147,7 @@ c. Install the CKAN source code into your virtualenv.
       production websites! Only install this version if you're doing CKAN
       development.
 
-d. Install the Python modules that CKAN requires into your virtualenv:
-
-   .. parsed-literal::
-
-       pip install -r |virtualenv|/src/ckan/requirements.txt
-
-.. note::
-
-    For Python 2 adjust the filename to: `requirements-py2.txt`
-
-e. Deactivate and reactivate your virtualenv, to make sure you're using the
+d. Deactivate and reactivate your virtualenv, to make sure you're using the
    virtualenv's copies of commands like ``ckan`` rather than any system-wide
    installed copies:
 

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -123,15 +123,15 @@ c. Install the CKAN source code into your virtualenv.
 
    .. parsed-literal::
 
-      pip install -e 'git+\ |git_url|\@\ |latest_release_tag|\#egg=ckan[py3]'
+      pip install -e 'git+\ |git_url|\@\ |latest_release_tag|\#egg=ckan[requirements]'
 
    .. note::
 
-      For Python 2 replace the last fragment with `py2`
+      For Python 2 replace the last fragment with `requirements-py2`
 
       .. parsed-literal::
 
-         pip install -e 'git+\ |git_url|\@\ |latest_release_tag|\#egg=ckan[py2]'
+         pip install -e 'git+\ |git_url|\@\ |latest_release_tag|\#egg=ckan[requirements-py2]'
 
    If you're installing CKAN for development, you may want to install the
    latest development version (the most recent commit on the master branch of
@@ -139,7 +139,7 @@ c. Install the CKAN source code into your virtualenv.
 
    .. parsed-literal::
 
-       pip install -e 'git+\ |git_url|\#egg=ckan[py3,dev]'
+       pip install -e 'git+\ |git_url|\#egg=ckan[requirements,dev]'
 
    .. warning::
 

--- a/setup.py
+++ b/setup.py
@@ -195,8 +195,9 @@ _extras_groups = [
     ('requirements', 'requirements.txt'), ('requirements-py2', 'requirements-py2.txt'),
     ('setuptools', 'requirement-setuptools.txt'), ('dev', 'dev-requirements.txt'),
 ]
+
 for group, filepath in _extras_groups:
-    with open(filepath, 'r') as f:
+    with open(os.path.join(HERE, filepath), 'r') as f:
         extras_require[group] = f.readlines()
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -190,6 +190,15 @@ entry_points = {
     ],
 }
 
+extras_require = {}
+_extras_groups = [
+    ('py3', 'requirements.txt'), ('py2', 'requirements-py2.txt'),
+    ('setuptools', 'requirement-setuptools.txt'), ('dev', 'dev-requirements.txt'),
+]
+for group, filepath in _extras_groups:
+    with open(filepath, 'r') as f:
+        extras_require[group] = f.readlines()
+
 setup(
     name='ckan',
     version=__version__,
@@ -224,6 +233,7 @@ setup(
     entry_points=entry_points,
     # setup.py test command needs a TestSuite so does not work with py.test
     # tests_require=[ 'py >= 0.8.0-alpha2' ]
+    extras_require=extras_require,
     classifiers=[
         # https://pypi.python.org/pypi?%3Aaction=list_classifiers
         'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -192,7 +192,7 @@ entry_points = {
 
 extras_require = {}
 _extras_groups = [
-    ('py3', 'requirements.txt'), ('py2', 'requirements-py2.txt'),
+    ('requirements', 'requirements.txt'), ('requirements-py2', 'requirements-py2.txt'),
     ('setuptools', 'requirement-setuptools.txt'), ('dev', 'dev-requirements.txt'),
 ]
 for group, filepath in _extras_groups:


### PR DESCRIPTION
Allow installation of requirements without any additional actions using pip(fetch requirements.txt, etc).
For example:
```bash
pip install ckan[requirements]
pip install ckan[setuptools,requirements-py2]
pip install ckan[requirements,dev]
```

For testing, try to use my fork:
```
pip install -e "git+https://github.com/DataShades/ckan.git@extras-require#egg=ckan[requirements,dev]"
``` 
