### PR TITLE
[#5379] change edit settings to profile settings

### DIFF
--- a/ckan/templates/header.html
+++ b/ckan/templates/header.html
@@ -30,9 +30,9 @@
         </li>
         {% block header_account_settings_link %}
         <li>
-          <a href="{{ h.url_for('user.edit', id=c.userobj.name) }}" title="{{ _('Edit settings') }}">
+          <a href="{{ h.url_for('user.edit', id=c.userobj.name) }}" title="{{ _('Profile settings') }}">
             <i class="fa fa-cog" aria-hidden="true"></i>
-            <span class="text">{{ _('Settings') }}</span>
+            <span class="text">{{ _('Profile settings') }}</span>
           </a>
         </li>
         {% endblock %} {% block header_account_log_out_link %}

--- a/ckan/templates/user/dashboard.html
+++ b/ckan/templates/user/dashboard.html
@@ -13,7 +13,7 @@
     {% block page_header %}
       <header class="module-content page-header hug">
         <div class="content_action">
-          {% link_for _('Edit settings'), named_route='user.edit', id=user.name, class_='btn btn-default', icon='cog' %}
+          {% link_for _('Profile settings'), named_route='user.edit', id=user.name, class_='btn btn-default', icon='cog' %}
         </div>
         <ul class="nav nav-tabs">
           {{ h.build_nav_icon('dashboard.index', _('News feed'), icon='list') }}


### PR DESCRIPTION
Change "Edit settings" link title to "Profile settings" in dashboard and account-masthead block.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
