### PR TITLE
Accept timestamps with seconds having less than 6 decimals

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1653,7 +1653,8 @@ def date_str_to_datetime(date_str):
             raise ValueError('Unable to parse %s as seconds.microseconds' %
                              time_tuple[5])
         seconds = int(m.groupdict().get('seconds'))
-        microseconds = int((str(m.groupdict(0).get('microseconds')) + '00000')[0:6])
+        microseconds = int((str(m.groupdict(0).get('microseconds')) +
+                            '00000')[0:6])
         time_tuple = time_tuple[:5] + [seconds, microseconds]
 
     return datetime.datetime(*list(int(item) for item in time_tuple))

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1647,13 +1647,13 @@ def date_str_to_datetime(date_str):
 
     # Extract seconds and microseconds
     if len(time_tuple) >= 6:
-        m = re.match(r'(?P<seconds>\d{2})(\.(?P<microseconds>\d{6}))?$',
+        m = re.match(r'(?P<seconds>\d{2})(\.(?P<microseconds>\d+))?$',
                      time_tuple[5])
         if not m:
             raise ValueError('Unable to parse %s as seconds.microseconds' %
                              time_tuple[5])
         seconds = int(m.groupdict().get('seconds'))
-        microseconds = int(m.groupdict(0).get('microseconds'))
+        microseconds = int((str(m.groupdict(0).get('microseconds')) + '00000')[0:6])
         time_tuple = time_tuple[:5] + [seconds, microseconds]
 
     return datetime.datetime(*list(int(item) for item in time_tuple))

--- a/ckan/tests/legacy/lib/test_helpers.py
+++ b/ckan/tests/legacy/lib/test_helpers.py
@@ -52,8 +52,8 @@ class TestHelpers(object):
             h.date_str_to_datetime("2008-04-13T20:40:20foobar")
 
     def test_date_str_to_datetime_with_ambiguous_microseconds(self):
-        with pytest.raises(ValueError):
-            h.date_str_to_datetime("2008-04-13T20:40:20.500")
+        res = h.date_str_to_datetime("2008-04-13T20:40:20.1234")
+        assert res == datetime.datetime(2008, 4, 13, 20, 40, 20, 123400)
 
     def test_gravatar(self):
         email = "zephod@gmail.com"


### PR DESCRIPTION
Fixes #5416

### Proposed fixes:
Allow the `date_str_to_datetime` helper function to accept dates that have more or less precision than 6 digits for the seconds decimals (for example 3 digits for milliseconds) and convert the value to 6 digit microseconds.


### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport