### PR TITLE
Fix failing group test

### DIFF
--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -450,9 +450,9 @@ class TestGroupList(object):
 
     def test_group_list_limit_and_offset(self):
 
-        group1 = factories.Group()
-        group2 = factories.Group()
-        group3 = factories.Group()
+        group1 = factories.Group(name='aa')
+        group2 = factories.Group(name='bb')
+        group3 = factories.Group(name='cc')
 
         group_list = helpers.call_action("group_list", offset=1, limit=1)
 


### PR DESCRIPTION
Update failing test for group list, by explicitly setting group names, so that they won't be reordered in edge cases.