### PR TITLE
add less to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gulp-rename": "^2.0.0",
     "gulp-sourcemaps": "^2.6.5",
     "jquery": "^3.5.0",
+    "less": "^3.11.2",
     "moment": "^2.24.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR fixes the following bug:

### reproduction steps
* make sure `less` is not installed globally
* `rm -rf node_modules`
* `npm install`

#### expected
installed all node dependencies

#### actual
fails with the following error:
```
$ npm install
npm WARN deprecated urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
npm WARN deprecated chokidar@2.1.8: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.
npm WARN deprecated resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
npm WARN deprecated fsevents@1.2.13: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.

> cypress@4.7.0 postinstall /home/ori/ckan/node_modules/cypress
> node index.js --exec install

Installing Cypress (version: 4.7.0)

  ✔  Downloaded Cypress
  ✔  Unzipped Cypress
  ✔  Finished Installation /home/ori/.cache/Cypress/4.7.0

You can now open Cypress by running: node_modules/.bin/cypress open

https://on.cypress.io/installing-cypress


> ckan@1.0.0 postinstall /home/ori/ckan
> gulp updateVendorLibs

Error: Cannot find module 'less'
Require stack:
- /home/ori/ckan/node_modules/accord/lib/index.js
- /home/ori/ckan/node_modules/gulp-less/index.js
- /home/ori/ckan/gulpfile.js
- /home/ori/ckan/node_modules/gulp/node_modules/gulp-cli/lib/shared/require-or-import.js
- /home/ori/ckan/node_modules/gulp/node_modules/gulp-cli/lib/versioned/^4.0.0/index.js
- /home/ori/ckan/node_modules/gulp/node_modules/gulp-cli/index.js
- /home/ori/ckan/node_modules/gulp/bin/gulp.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:982:15)
    at Function.resolve (internal/modules/cjs/helpers.js:83:19)
    at resolve_engine_path (/home/ori/ckan/node_modules/accord/lib/index.js:65:18)
    at Object.exports.load (/home/ori/ckan/node_modules/accord/lib/index.js:25:19)
    at Object.<anonymous> (/home/ori/ckan/node_modules/gulp-less/index.js:9:29)
    at Module._compile (internal/modules/cjs/loader.js:1158:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1178:10)
    at Module.load (internal/modules/cjs/loader.js:1002:32)
    at Function.Module._load (internal/modules/cjs/loader.js:901:14)
    at Module.require (internal/modules/cjs/loader.js:1044:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/home/ori/ckan/node_modules/accord/lib/index.js',
    '/home/ori/ckan/node_modules/gulp-less/index.js',
    '/home/ori/ckan/gulpfile.js',
    '/home/ori/ckan/node_modules/gulp/node_modules/gulp-cli/lib/shared/require-or-import.js',
    '/home/ori/ckan/node_modules/gulp/node_modules/gulp-cli/lib/versioned/^4.0.0/index.js',
    '/home/ori/ckan/node_modules/gulp/node_modules/gulp-cli/index.js',
    '/home/ori/ckan/node_modules/gulp/bin/gulp.js'
  ]
}
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! ckan@1.0.0 postinstall: `gulp updateVendorLibs`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the ckan@1.0.0 postinstall script.
```