### PR TITLE
rtl fixes: homepage search button + layout1

### DIFF
--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -17653,6 +17653,7 @@ th.dataset-label,
 .search-form .search-input.search-giant button {
   margin-top: -15px;
   left: 15px;
+  right: auto;
 }
 .context-info .nums dl,
 .toolbar .breadcrumb {
@@ -17698,4 +17699,10 @@ td.diff_header {
 }
 .diff_sub {
   background-color:#ffaaaa;
+}
+@media (min-width: 992px) {
+  .homepage.layout-1 .row1 .col2 {
+    right: auto;
+    left: 0;
+  }
 }

--- a/ckan/public/base/less/ckan-rtl.less
+++ b/ckan/public/base/less/ckan-rtl.less
@@ -70,6 +70,7 @@
 .search-form .search-input.search-giant button {
     margin-top: -15px;
     left: 15px;
+    right: auto;
 }
 
 .context-info .nums dl, .toolbar .breadcrumb {
@@ -97,4 +98,11 @@
 
 .nav-facet .nav-item a span.item-label {
     padding-right: 15px;
+}
+
+@media (min-width: @screen-md-min) {
+    .homepage.layout-1 .row1 .col2 {
+        right: auto;
+        left: 0;
+    }
 }


### PR DESCRIPTION
Fixes 2 RTL bugs in homepage:

1. default layout - search box misaligned
2. search giant button misaligned

### before
![image](https://user-images.githubusercontent.com/1198854/83734262-6b40dd00-a657-11ea-8c9a-c431a16516d3.png)

### after
![image](https://user-images.githubusercontent.com/1198854/83734174-4fd5d200-a657-11ea-9c5e-5f53f1419485.png)
