### PR TITLE
fix gulp watch/build to compile main-rtl.less file

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,7 +15,7 @@ const renamer = path => {
 };
 
 const build = () =>
-  src(__dirname + "/ckan/public/base/less/main.less")
+  src([__dirname + "/ckan/public/base/less/main.less", __dirname + "/ckan/public/base/less/main-rtl.less"])
     .pipe(if_(with_sourcemaps(), sourcemaps.init()))
     .pipe(less())
     .pipe(if_(with_sourcemaps(), sourcemaps.write()))


### PR DESCRIPTION
running `npm watch` doesn't build rtl css files, this fixes it