### PR TITLE
[#5401] fix dashboard activity filter

### DIFF
--- a/ckan/views/dashboard.py
+++ b/ckan/views/dashboard.py
@@ -27,7 +27,7 @@ def before_request():
         base.abort(403, _(u'Not authorized to see this page'))
 
 
-def _get_dashboard_context(self, filter_type=None, filter_id=None, q=None):
+def _get_dashboard_context(filter_type=None, filter_id=None, q=None):
     u'''Return a dict needed by the dashboard view to determine context.'''
 
     def display_name(followee):


### PR DESCRIPTION
The dashboard blueprint was migrated with a little mistake (self argument) so the activity filter always showed that we are filtering by 'everything'.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
