### PR TITLE
Include db migrations into distribution / install configparser in py2

### DIFF
--- a/ckan/cli/__init__.py
+++ b/ckan/cli/__init__.py
@@ -5,7 +5,7 @@ import os
 import click
 import logging
 from logging.config import fileConfig as loggingFileConfig
-from configparser import ConfigParser
+from six.moves.configparser import ConfigParser
 
 from ckan.exceptions import CkanConfigurationException
 

--- a/requirements-py2.in
+++ b/requirements-py2.in
@@ -4,6 +4,7 @@ alembic==1.0.0
 Babel==2.7.0
 bleach==3.1.4
 click==6.7
+configparser==4.0.2
 dominate==2.4.0
 fanstatic==0.12
 feedgen==0.9.0

--- a/requirements-py2.in
+++ b/requirements-py2.in
@@ -4,7 +4,6 @@ alembic==1.0.0
 Babel==2.7.0
 bleach==3.1.4
 click==6.7
-configparser==4.0.2
 dominate==2.4.0
 fanstatic==0.12
 feedgen==0.9.0

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -11,6 +11,7 @@ bleach==3.1.4
 certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
 click==6.7
+configparser==4.0.2
 decorator==4.4.0          # via pylons, sqlalchemy-migrate
 dominate==2.4.0
 fanstatic==0.12

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -11,7 +11,6 @@ bleach==3.1.4
 certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
 click==6.7
-configparser==4.0.2
 decorator==4.4.0          # via pylons, sqlalchemy-migrate
 dominate==2.4.0
 fanstatic==0.12


### PR DESCRIPTION
I was testing installation from the package and noticed two issues(fixed by this pr):

* DB migrations are not included in sdist/bdist because there were no `__init__.py` file inside`versions` folder. We are not importing versions, so it isn't an issue unless you are installing CKAN from PyPI.
* py2 raises an error, because we are [importing configparser](https://github.com/ckan/ckan/blob/master/ckan/cli/__init__.py#L8) instead of `ConfigParser`. I've added backport to py2 requirements

BTW, here's installation overview:
```bash
## Activate venv

# pip install '../ckan/src/ckan[requirements]'
pip install 'ckan[requirements]'

## Create DB `ckan_env`, Solr core `ckan_env` ##

ln -snf lib/python3.8/site-packages/ckan/config/who.ini ./
ln -snf lib/python3.8/site-packages/ckan/config/solr/schema.xml ./
docker cp -L schema.xml solr55:/opt/solr/server/solr/ckan_env/conf/


ckan generate config development.ini
sed '/ckan.site_url/s/$/ http:\/\/127.0.0.1:5000/'  -i development.ini
sed '/sqlalchemy/ s/:pass/:root/; s/ckan_default$/ckan_env/' -i development.ini
sed '/solr/ s/solr$/solr\/ckan_env/; /solr/ s/^\#//' -i development.ini
export CKAN_INI=$PWD/development.ini

ckan db init

ckan run
```

Using `sed` is ok, I think, because end-user will likely open the config file in the text editor. But having ability to do it via `ckan config-tool` will make scripted installations much more straightforward. Right now it's not possible to use `config-tool` unless you've configured `ckan.site_url` and `sqlalchemy.url`.  
What I don't like - creating links to `who.ini/schema.xml` from venv's `lib` folder. Maybe it has the sense to add command, that will link/copy them into specified destination? Or use `setup.py`'s `data_files` and copy those files into root of venv(or sub-folder) during the installation of CKAN?