### PR TITLE
Prevent account presence exposure when ckan.auth.public_user_details = false

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1280,14 +1280,15 @@ def user_show(context, data_dict):
     if id:
         user_obj = model.User.get(id)
         context['user_obj'] = user_obj
-        if user_obj is None:
-            raise NotFound
     elif provided_user:
         context['user_obj'] = user_obj = provided_user
     else:
         raise NotFound
 
     _check_access('user_show', context, data_dict)
+
+    if not bool(user_obj):
+        raise NotFound
 
     # include private and draft datasets?
     requester = context.get('user')


### PR DESCRIPTION
### Proposed fixes:

This gives the access check the opportunity to fail with a NotAuthorized first. This means that when ckan.auth.public_user_details = false the auth check supercedes the NotFound, since we don't want to expose information about whether the user account exists or not.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
