### PR TITLE
[#5016] fix resource upload filename fetching in IE

### DIFF
--- a/ckan/public/base/javascript/modules/image-upload.js
+++ b/ckan/public/base/javascript/modules/image-upload.js
@@ -204,6 +204,15 @@ this.ckan.module('image-upload', function($) {
      */
     _onInputChange: function() {
       var file_name = this.input.val().split(/^C:\\fakepath\\/).pop();
+
+      // Internet Explorer 6-11 and Edge 20+
+      var isIE = false || !!document.documentMode;
+      var isEdge = !isIE && !!window.StyleMedia;
+      // for IE/Edge when 'include filepath option' is enabled
+      if (isIE || isEdge) {
+        (file_name=file_name.match(/[^\\\/]+$/)) && file_name[0];
+      }
+
       this.field_url_input.val(file_name);
       this.field_url_input.prop('readonly', true);
 

--- a/ckan/public/base/javascript/modules/image-upload.js
+++ b/ckan/public/base/javascript/modules/image-upload.js
@@ -211,7 +211,7 @@ this.ckan.module('image-upload', function($) {
       // for IE/Edge when 'include filepath option' is enabled
       if (isIE || isEdge) {
         var fName = file_name.match(/[^\\\/]+$/);
-        file_name = fName ? fname[0] : file_name;
+        file_name = fName ? fName[0] : file_name;
       }
 
       this.field_url_input.val(file_name);

--- a/ckan/public/base/javascript/modules/image-upload.js
+++ b/ckan/public/base/javascript/modules/image-upload.js
@@ -206,11 +206,12 @@ this.ckan.module('image-upload', function($) {
       var file_name = this.input.val().split(/^C:\\fakepath\\/).pop();
 
       // Internet Explorer 6-11 and Edge 20+
-      var isIE = false || !!document.documentMode;
+      var isIE = !!document.documentMode;
       var isEdge = !isIE && !!window.StyleMedia;
       // for IE/Edge when 'include filepath option' is enabled
       if (isIE || isEdge) {
-        (file_name=file_name.match(/[^\\\/]+$/)) && file_name[0];
+        var fName = file_name.match(/[^\\\/]+$/);
+        file_name = fName ? fname[0] : file_name;
       }
 
       this.field_url_input.val(file_name);


### PR DESCRIPTION
There is a problem in IE when you are trying to upload a resource with 'Include local directory path when uploading files to a server' option enabled. This little hack tries to fetch filename from this 'path' if we detect that user uses IE or Edge browser.

Also, I don't know how to write test for this code, if it's really necessary. So if someone can help me, I'll appreciate it.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
