### PR TITLE
fix readthedocs for v2.8

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,27 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+  - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 2.7
+  install:
+    - requirements: pip-requirements-docs.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - readthedocs

--- a/setup.py
+++ b/setup.py
@@ -250,4 +250,8 @@ setup(
         'Programming Language :: Python :: 2 :: Only',
         'Programming Language :: Python :: 2.7',
     ],
+    # this is used to fix an incompatiblity with readthedocs dependencies
+    extras_require={
+        "readthedocs":  ["Jinja2>=2.3"],
+    }
 )


### PR DESCRIPTION
Fixes #5380

a bit hackish, but it works - https://orihoch-ckan.readthedocs.io/en/dev-v2.8-fix-readthedocs/changelog.html

it uses .readthedocs.yaml for the readthedocs configuration, so you may need to modify it according to the settings currently in the readthedocs advanced settings UI, see https://docs.readthedocs.io/en/stable/config-file/v2.html