### PR TITLE
[#5435] extract_message does not ignore Jinja2 extensions

### DIFF
--- a/ckan/lib/extract.py
+++ b/ckan/lib/extract.py
@@ -1,15 +1,24 @@
 # encoding: utf-8
 
 from jinja2.ext import babel_extract
+from ckan.lib.jinja_extensions import _get_extensions
 
 
-# It's no longer needed but all the extensions are using this
-# function. Let's keep it, just in case we need to extract messages in
-# some special way in future
 def extract_ckan(fileobj, *args, **kw):
+    extensions = [
+        ':'.join([ext.__module__, ext.__name__])
+        if isinstance(ext, type)
+        else ext
+        for ext in _get_extensions()
+    ]
     if 'options' not in kw:
         kw['options'] = {}
     if 'trimmed' not in kw['options']:
         kw['options']['trimmed'] = 'True'
+    if 'silent' not in kw['options']:
+        kw['options']['silent'] = 'False'
+    if 'extensions' not in kw['options']:
+        kw['options']['extensions'] = ','.join(extensions)
+
 
     return babel_extract(fileobj, *args, **kw)

--- a/ckan/lib/extract.py
+++ b/ckan/lib/extract.py
@@ -20,5 +20,4 @@ def extract_ckan(fileobj, *args, **kw):
     if 'extensions' not in kw['options']:
         kw['options']['extensions'] = ','.join(extensions)
 
-
     return babel_extract(fileobj, *args, **kw)

--- a/ckan/lib/jinja_extensions.py
+++ b/ckan/lib/jinja_extensions.py
@@ -23,19 +23,23 @@ from ckan.common import config
 log = logging.getLogger(__name__)
 
 
+def _get_extensions():
+    return ['jinja2.ext.do', 'jinja2.ext.with_',
+            SnippetExtension,
+            CkanExtend,
+            CkanInternationalizationExtension,
+            LinkForExtension,
+            ResourceExtension,
+            UrlForStaticExtension,
+            UrlForExtension,
+            AssetExtension]
+
+
 def get_jinja_env_options():
     return dict(
         loader=CkanFileSystemLoader(config['computed_template_paths']),
         autoescape=True,
-        extensions=['jinja2.ext.do', 'jinja2.ext.with_',
-                    SnippetExtension,
-                    CkanExtend,
-                    CkanInternationalizationExtension,
-                    LinkForExtension,
-                    ResourceExtension,
-                    UrlForStaticExtension,
-                    UrlForExtension,
-                    AssetExtension],
+        extensions=_get_extensions(),
     )
 
 


### PR DESCRIPTION
Fixes #5435

1. Enable all Jinja2 extensions provided by CKAN when extracting messages
2. Report any unexpected error