### PR TITLE
[#5443] unflatten allow nesting >1 level

### DIFF
--- a/ckan/lib/navl/dictization_functions.py
+++ b/ckan/lib/navl/dictization_functions.py
@@ -410,23 +410,18 @@ def unflatten(data):
     for flattend_key in sorted(data.keys(), key=flattened_order_key):
         current_pos = unflattened
 
-        if (len(flattend_key) > 1
-                and not flattend_key[0] in convert_to_list
-                and not flattend_key[0] in unflattened):
-            convert_to_list.append(flattend_key[0])
-
         for key in flattend_key[:-1]:
             try:
                 current_pos = current_pos[key]
-            except KeyError:
+            except IndexError:
                 new_pos = {}
+                current_pos.append(new_pos)
+                current_pos = new_pos
+            except KeyError:
+                new_pos = []
                 current_pos[key] = new_pos
                 current_pos = new_pos
         current_pos[flattend_key[-1]] = data[flattend_key]
-
-    for key in convert_to_list:
-        unflattened[key] = [unflattened[key][s]
-                            for s in sorted(unflattened[key])]
 
     return unflattened
 

--- a/ckan/tests/legacy/lib/test_navl.py
+++ b/ckan/tests/legacy/lib/test_navl.py
@@ -251,6 +251,27 @@ def test_flatten():
     assert data == unflatten(flatten_dict(data))
 
 
+def test_flatten_deeper():
+    data = {
+        u"resources": [
+            {
+                u"subfields": [
+                    {
+                        u"test": u"hello",
+                    },
+                ],
+            },
+        ],
+    }
+
+    assert flatten_dict(data) == {
+        ("resources", 0, u"subfields", 0, u"test"): u"hello",
+    }, pformat(flatten_dict(data))
+
+    assert data == unflatten(flatten_dict(data)), pformat(
+        unflatten(flatten_dict(data)))
+
+
 def test_simple():
     schema = {
         "name": [not_empty],


### PR DESCRIPTION
Fixes #5443

### Proposed fixes:

simplify unflatten, allowing more than one level of dict/list/dict nesting

### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport