### PR TITLE
Close database connection on operational error

### DIFF
--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -10,6 +10,8 @@ import inspect
 import sys
 
 from jinja2.exceptions import TemplateNotFound
+from sqlalchemy.exc import OperationalError
+
 import six
 from flask import (
     render_template as flask_render_template,
@@ -261,6 +263,10 @@ if six.PY2:
 
             try:
                 res = WSGIController.__call__(self, environ, start_response)
+            except OperationalError as error:
+                log.warn('%s: %s' % (type(error).__name__, error.message.rstrip()))
+                model.Session.connection().should_close_with_result = True
+                raise
             finally:
                 model.Session.remove()
 


### PR DESCRIPTION
This exception handler ensures that a connection that's invalidated as a result of using it (for example, the connection may no longer be alive), is correctly closed and removed from the connection pool.

Previously, a defunct connection would be left in the pool and reused indiscriminately.

Note that the response is unchanged since we re-raise the exception.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

