### PR TITLE
[#5452] allow lists in resource extras

### DIFF
--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -41,8 +41,6 @@ def resource_dict_save(res_dict, context):
     new_extras = {}
     has_changed = False
     for key, value in six.iteritems(res_dict):
-        if isinstance(value, list):
-            continue
         if key in ('extras', 'revision_timestamp', 'tracking_summary'):
             continue
         if key in fields:

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -29,7 +29,7 @@ def validator_args(fn):
 def default_resource_schema(
         ignore_empty, unicode_safe, ignore, ignore_missing,
         remove_whitespace, if_empty_guess_format, clean_format, isodate,
-        int_validator, extras_unicode_convert, keep_extras):
+        int_validator, extras_valid_json, keep_extras):
     return {
         'id': [ignore_empty, unicode_safe],
         'package_id': [ignore],
@@ -52,7 +52,7 @@ def default_resource_schema(
         'cache_last_updated': [ignore_missing, isodate],
         'tracking_summary': [ignore_missing],
         'datastore_active': [ignore_missing],
-        '__extras': [ignore_missing, extras_unicode_convert, keep_extras],
+        '__extras': [ignore_missing, extras_valid_json, keep_extras],
     }
 
 

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -907,7 +907,8 @@ def json_object(value):
 def extras_valid_json(extras, context):
     try:
         for extra, value in iteritems(extras):
-            json.dumps(extra)
+            json.dumps(value)
     except ValueError as e:
-        raise Invalid(_('Could not parse the value as valid JSON'))
+        raise Invalid(_(u'Could not parse extra \'{name}\' as valid JSON').
+                format(name=extra))
     return extras

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -9,7 +9,7 @@ import mimetypes
 import string
 import json
 
-from six import string_types
+from six import string_types, iteritems
 from six.moves.urllib.parse import urlparse
 
 import ckan.lib.navl.dictization_functions as df
@@ -902,3 +902,12 @@ def json_object(value):
         raise Invalid(_('Could not parse the value as a valid JSON object'))
 
     return value
+
+
+def extras_valid_json(extras, context):
+    try:
+        for extra, value in iteritems(extras):
+            json.dumps(extra)
+    except ValueError as e:
+        raise Invalid(_('Could not parse the value as valid JSON'))
+    return extras

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -631,7 +631,7 @@ class TestResourceCreate:
             somekey="somevalue",  # this is how to do resource extras
             extras={u"someotherkey": u"alt234"},  # this isnt
             subobject={u'hello': u'there'},  # JSON objects supported
-            sublist=[1, 2, 3], # JSON lists suppoted
+            sublist=[1, 2, 3],  # JSON lists suppoted
             format=u"plain text",
             url=u"http://datahub.io/download/",
         )

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -630,6 +630,8 @@ class TestResourceCreate:
             package_id=dataset["id"],
             somekey="somevalue",  # this is how to do resource extras
             extras={u"someotherkey": u"alt234"},  # this isnt
+            subobject={u'hello': u'there'},  # JSON objects supported
+            sublist=[1, 2, 3], # JSON lists suppoted
             format=u"plain text",
             url=u"http://datahub.io/download/",
         )
@@ -637,12 +639,16 @@ class TestResourceCreate:
         assert resource["somekey"] == "somevalue"
         assert "extras" not in resource
         assert "someotherkey" not in resource
+        assert resource["subobject"] == {u"hello": u"there"}
+        assert resource["sublist"] == [1, 2, 3]
         resource = helpers.call_action("package_show", id=dataset["id"])[
             "resources"
         ][0]
         assert resource["somekey"] == "somevalue"
         assert "extras" not in resource
         assert "someotherkey" not in resource
+        assert resource["subobject"] == {u"hello": u"there"}
+        assert resource["sublist"] == [1, 2, 3]
 
     @freeze_time('2020-02-25 12:00:00')
     def test_metadata_modified_is_set_to_utcnow_when_created(self):


### PR DESCRIPTION
Fixes #5452 

### Proposed fixes:
remove two lines of code from resource_dict_save. This allows ckanext-scheming and other extensions to have repeating subfields and other list values in their resource schemas without hacks like converting to/from JSON (resource extras are already stored in the DB as JSON)


### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport