### PR TITLE
Only add error to tag_errors if not empty

### DIFF
--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -78,7 +78,8 @@ class ValidationError(ActionError):
                     tag_errors.append(', '.join(error['name']))
                 except KeyError:
                     # e.g. if it is a vocabulary_id error
-                    tag_errors.append(error)
+                    if error:
+                        tag_errors.append(error)
             error_dict['tags'] = tag_errors
         self.error_dict = error_dict
         self._error_summary = error_summary


### PR DESCRIPTION
Fixes #

Empty errors being propagated to the end user.

### Proposed fixes:

Tag errors were being propagated as {}, so checking that the error is not empty will ensure that a meaningful error message reaches the end user.

Suggest backport to 2.7 and 2.8 releases

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
