### PR TITLE
Documentation - cli fix replacement text

### DIFF
--- a/doc/maintaining/cli.rst
+++ b/doc/maintaining/cli.rst
@@ -75,6 +75,8 @@ to execute. Most commands have their own subcommands and options.
 
 Commands and Subcommands
 
+.. parsed-literal::
+
    ckan -c |ckan.ini| user list
 
 (Here ``user`` is the name of the CKAN command you're running, and ``list`` is
@@ -84,7 +86,9 @@ For a list of all available commands, see `CKAN Commands Reference`_.
 
 Each command has its own help text, which tells you what subcommands and
 options it has (if any). To print out a command's help text, run the command
-with the ``--help`` option, for example::
+with the ``--help`` option, for example:
+
+.. parsed-literal::
 
    ckan -c |ckan.ini| user --help
 
@@ -300,7 +304,8 @@ The ``jobs`` command can be used to manage :ref:`background jobs`.
 
 Run a background job worker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-::
+
+.. parsed-literal::
 
     ckan -c |ckan.ini| jobs worker [--burst] [QUEUES]
 
@@ -308,17 +313,21 @@ Starts a worker that fetches job from the :ref:`job queues <background jobs
 queues>` and executes them. If no queue names are given then it listens to
 the default queue. This is equivalent to
 
-::
+.. parsed-literal::
 
     ckan -c |ckan.ini| jobs worker default
 
 If queue names are given then the worker listens to those queues and only
-those::
+those:
+
+.. parsed-literal::
 
     ckan -c |ckan.ini| jobs worker my-custom-queue another-special-queue
 
 Hence, if you want the worker to listen to the default queue and some others
-then you must list the default queue explicitly::
+then you must list the default queue explicitly
+
+.. parsed-literal::
 
     ckan -c |ckan.ini| jobs worker default my-custom-queue
 
@@ -336,7 +345,8 @@ enqueued (this is the default).
 
 List enqueued jobs
 ^^^^^^^^^^^^^^^^^^
-::
+
+.. parsed-literal::
 
     ckan -c |ckan.ini| jobs list [QUEUES]
 
@@ -349,7 +359,8 @@ listed.
 
 Show details about a job
 ^^^^^^^^^^^^^^^^^^^^^^^^
-::
+
+.. parsed-literal::
 
     ckan -c |ckan.ini| jobs show ID
 
@@ -360,7 +371,8 @@ Shows details about the enqueued job with the given ID.
 
 Cancel a job
 ^^^^^^^^^^^^
-::
+
+.. parsed-literal::
 
     ckan -c |ckan.ini| jobs cancel ID
 
@@ -373,7 +385,8 @@ aborted anymore.
 
 Clear job queues
 ^^^^^^^^^^^^^^^^
-::
+
+.. parsed-literal::
 
     ckan -c |ckan.ini| jobs clear [QUEUES]
 
@@ -385,7 +398,8 @@ queues are given then *all* queues are cleared.
 
 Enqueue a test job
 ^^^^^^^^^^^^^^^^^^
-::
+
+.. parsed-literal::
 
     ckan -c |ckan.ini| jobs test [QUEUES]
 
@@ -407,7 +421,9 @@ Usage::
 minify: Create minified versions of the given Javascript and CSS files
 ======================================================================
 
-Usage::
+Usage
+
+.. parsed-literal::
 
     ckan minify [--clean] PATH    - remove any minified files in the path
 
@@ -423,7 +439,9 @@ If the --clean option is provided any minified files will be removed.
 notify: Send out modification notifications
 ===========================================
 
-Usage::
+Usage
+
+.. parsed-literal::
 
     ckan notify replay    - send out modification signals. In "replay" mode,
                        an update signal is sent for each dataset in the database.
@@ -441,7 +459,9 @@ profile: Code speed profiler
 Provide a ckan url and it will make the request and record how long each function call took in a file that can be read
 by runsnakerun.
 
-Usage::
+Usage
+
+.. parsed-literal::
 
    ckan profile URL
 
@@ -455,7 +475,9 @@ You may need to install the cProfile python module.
 search-index: Search index commands
 ===================================
 
-Usage::
+Usage
+
+.. parsed-literal::
 
     ckan search-index check                    - Check search index
     ckan search-index clear                    - Clear the search index
@@ -471,31 +493,43 @@ search-index: Rebuild search index
 
 Rebuilds the search index. This is useful to prevent search indexes from getting out of sync with the main database.
 
-For example::
+For example
+
+.. parsed-literal::
 
  ckan -c |ckan.ini| search-index rebuild
 
 This default behaviour will clear the index and rebuild it with all datasets. If you want to rebuild it for only
-one dataset, you can provide a dataset name::
+one dataset, you can provide a dataset name
+
+.. parsed-literal::
 
     ckan -c |ckan.ini| search-index rebuild test-dataset-name
 
 Alternatively, you can use the `-o` or `--only-missing` option to only reindex datasets which are not
-already indexed::
+already indexed
+
+.. parsed-literal::
 
     ckan -c |ckan.ini| search-index rebuild -o
 
 If you don't want to rebuild the whole index, but just refresh it, use the `-r` or `--refresh` option. This
-won't clear the index before starting rebuilding it::
+won't clear the index before starting rebuilding it
+
+.. parsed-literal::
 
     ckan -c |ckan.ini| search-index rebuild -r
 
 There is also an option available which works like the refresh option but tries to use all processes on the
-computer to reindex faster::
+computer to reindex faster
+
+.. parsed-literal::
 
     ckan -c |ckan.ini| search-index rebuild_fast
 
-There are other search related commands, mostly useful for debugging purposes::
+There are other search related commands, mostly useful for debugging purposes
+
+.. parsed-literal::
 
     ckan search-index check                  - checks for datasets not indexed
     ckan search-index show DATASET_NAME      - shows index of a dataset
@@ -505,7 +539,9 @@ There are other search related commands, mostly useful for debugging purposes::
 seed: Create test data in the database
 ======================================
 
-Usage::
+Usage
+
+.. parsed-literal::
 
     basic           - annakarenina and warandpeace.
     family          - package relationships data.
@@ -516,7 +552,9 @@ Usage::
     user            - create a user "tester" with api key "tester".
     vocabs          - some test vocabularies.
 
-Examples::
+Examples
+
+.. parsed-literal::
 
       ckan -c |ckan.ini| seed basic
 
@@ -524,7 +562,9 @@ Examples::
 server: Start Development server
 ==================================
 
-Usage::
+Usage
+
+.. parsed-literal::
 
     ckan server --host (-h)          - Set Host
     ckan server --port (-p)          - Set Port
@@ -534,13 +574,17 @@ Usage::
 sysadmin: Give sysadmin rights
 ==============================
 
-Usage::
+Usage
+
+.. parsed-literal::
 
     ckan sysadmin add       - convert user into a sysadmin
     ckan sysadmin list      - list sysadmins
     ckan sysadmin remove    - removes user from sysadmins
 
-For example, to make a user called 'admin' into a sysadmin::
+For example, to make a user called 'admin' into a sysadmin
+
+.. parsed-literal::
 
  ckan -c |ckan.ini| sysadmin add admin
 
@@ -548,7 +592,9 @@ For example, to make a user called 'admin' into a sysadmin::
 tracking: Update tracking statistics
 ====================================
 
-Usage::
+Usage
+
+.. parsed-literal::
 
     ckan tracking update [start_date]       - update tracking stats
     ckan tracking export FILE [start_date]  - export tracking stats to a csv file
@@ -557,7 +603,9 @@ Usage::
 translation: Translation helper functions
 =========================================
 
-Usage::
+Usage
+
+.. parsed-literal::
 
     ckan translation js          - generate the JavaScript translations
     ckan translation mangle      - mangle the zh_TW translations for testing
@@ -577,7 +625,9 @@ user: Create and manage users
 
 Lets you create, remove, list and manage users.
 
-Usage::
+Usage
+
+.. parsed-literal::
 
     ckan user add         - add new user
     ckan user list        - list all users
@@ -585,11 +635,15 @@ Usage::
     ckan user setpass     - set password for the user
     ckan user show        - show user
 
-For example, to create a new user called 'admin'::
+For example, to create a new user called 'admin'
+
+.. parsed-literal::
 
  ckan -c |ckan.ini| user add admin
 
-To delete the 'admin' user::
+To delete the 'admin' user
+
+.. parsed-literal::
 
  ckan -c |ckan.ini| user remove admin
 
@@ -597,7 +651,9 @@ To delete the 'admin' user::
 views: Create views on relevant resources
 =========================================
 
-Usage::
+Usage
+
+.. parsed-literal::
 
     ckan views clean      - permanently delete views for all types no...
     ckan views clear      - permanently delete all views or the ones with...

--- a/doc/maintaining/cli.rst
+++ b/doc/maintaining/cli.rst
@@ -38,7 +38,7 @@ The general form of a CKAN ``ckan`` command is:
 
 .. parsed-literal::
 
-   ckan --config=\ |ckan.ini| **command**
+ ckan --config=\ |ckan.ini| **command**
 
 The `` --config`` option tells CKAN where to find your config file, which it
 reads for example to know which database it should use. As you'll see in the
@@ -57,9 +57,10 @@ to execute. Most commands have their own subcommands and options.
   environment variable. You will no longer need to use --config= or -c to
   tell ckan where the config file is:
 
-  .. parsed-literal::
+  
+.. parsed-literal::
 
-     export CKAN_INI=\ |ckan.ini|
+ export CKAN_INI=\ |ckan.ini|
 
 .. note::
 
@@ -68,16 +69,16 @@ to execute. Most commands have their own subcommands and options.
   not be required to use --config or -c in this case. This usage is deprecated
   and will be phased out in a future CKAN release.
 
-  .. parsed-literal::
+.. parsed-literal::
 
-     cd |virtualenv|\/src/ckan; ckan command
+ cd |virtualenv|\/src/ckan; ckan command
 
 
 Commands and Subcommands
 
 .. parsed-literal::
 
-   ckan -c |ckan.ini| user list
+ ckan -c |ckan.ini| user list
 
 (Here ``user`` is the name of the CKAN command you're running, and ``list`` is
 a subcommand of ``user``.)
@@ -90,7 +91,7 @@ with the ``--help`` option, for example:
 
 .. parsed-literal::
 
-   ckan -c |ckan.ini| user --help
+ ckan -c |ckan.ini| user --help
 
 
 -------------------------------
@@ -104,7 +105,7 @@ If you receive 'Permission Denied' error, try running ckan with sudo.
 
 .. parsed-literal::
 
-  sudo |virtualenv|/bin/ckan -c |ckan.ini| db clean
+ sudo |virtualenv|/bin/ckan -c |ckan.ini| db clean
 
 Virtualenv not activated, or not in ckan dir
 ============================================
@@ -115,8 +116,8 @@ the command:
 
 .. parsed-literal::
 
-   |activate|
-   cd |virtualenv|/src/ckan
+ |activate|
+ cd |virtualenv|/src/ckan
 
 Error messages such as the following are usually caused by forgetting to do
 this:
@@ -138,9 +139,9 @@ source directory not CKAN's source directory. For example:
 
 .. parsed-literal::
 
-   |activate|
-   cd |virtualenv|/src/ckanext-spatial
-   ckan -c |ckan.ini| foo
+ |activate|
+ cd |virtualenv|/src/ckanext-spatial
+ ckan -c |ckan.ini| foo
 
 This should not be necessary when using the pre-installed extensions that come
 with CKAN.
@@ -198,48 +199,58 @@ views             Create views on relevant resources
 asset: WebAssets commands
 ==================================
 
-Usage::
+Usage
 
-    ckan asset build            - Builds bundles, regardless of whether they are changed or not
-    ckan asset watch            - Start a daemon which monitors source files, and rebuilds bundles
-    ckan asset clean            - Will clear out the cache, which after a while can grow quite large
+.. parsed-literal::
+
+ ckan asset build            - Builds bundles, regardless of whether they are changed or not
+ ckan asset watch            - Start a daemon which monitors source files, and rebuilds bundles
+ ckan asset clean            - Will clear out the cache, which after a while can grow quite large
 
 
 config-tool: Tool for editing options in a CKAN config file
 ===========================================================
 
-Usage::
+Usage
 
-    ckan config-tool --section (-s)  - Section of the config file
-    ckan config-tool --edit (-e)     - Checks the option already exists in the config file
-    ckan config-tool --file (-f)     - Supply an options file to merge in
+.. parsed-literal::
 
-Examples::
+ ckan config-tool --section (-s)  - Section of the config file
+ ckan config-tool --edit (-e)     - Checks the option already exists in the config file
+ ckan config-tool --file (-f)     - Supply an options file to merge in
 
-      ckan config-tool |ckan.ini| sqlalchemy.url=123 'ckan.site_title=ABC'
-      ckan config-tool |ckan.ini| -s server:main -e port=8080
-      ckan config-tool |ckan.ini| -f custom_options.ini
+Examples
+
+.. parsed-literal::
+
+ ckan config-tool |ckan.ini| sqlalchemy.url=123 'ckan.site_title=ABC'
+ ckan config-tool |ckan.ini| -s server:main -e port=8080
+ ckan config-tool |ckan.ini| -f custom_options.ini
 
 
 datapusher: Perform commands in the datapusher
 ==============================================
 
-Usage::
+Usage
 
-    ckan datapusher resubmit    - Resubmit udated datastore resources
-    ckan datapusher submit      - Submits resources from package
+.. parsed-literal::
+
+ ckan datapusher resubmit    - Resubmit udated datastore resources
+ ckan datapusher submit      - Submits resources from package
 
 
 dataset: Manage datasets
 ========================
 
-Usage::
+Usage
 
-    ckan dataset DATASET_NAME|ID            - shows dataset properties
-    ckan dataset show DATASET_NAME|ID       - shows dataset properties
-    ckan dataset list                       - lists datasets
-    ckan dataset delete [DATASET_NAME|ID]   - changes dataset state to 'deleted'
-    ckan dataset purge [DATASET_NAME|ID]    - removes dataset from db entirely
+.. parsed-literal::
+
+ ckan dataset DATASET_NAME|ID            - shows dataset properties
+ ckan dataset show DATASET_NAME|ID       - shows dataset properties
+ ckan dataset list                       - lists datasets
+ ckan dataset delete [DATASET_NAME|ID]   - changes dataset state to 'deleted'
+ ckan dataset purge [DATASET_NAME|ID]    - removes dataset from db entirely
 
 
 datastore: Perform commands to set up the datastore
@@ -247,21 +258,25 @@ datastore: Perform commands to set up the datastore
 
 Make sure that the datastore URLs are set properly before you run these commands.
 
-Usage::
+Usage
 
-    ckan datastore set-permissions  - generate SQL for permission configuration
-    ckan datastore dump             - dump a datastore resource
+.. parsed-literal::
+
+ ckan datastore set-permissions  - generate SQL for permission configuration
+ ckan datastore dump             - dump a datastore resource
 
 
 db: Manage databases
 ====================
 
-ckan db clean               - Clean the database
-ckan db downgrade           - Downgrade the database
-ckan db duplicate_emails    - Check users email for duplicate
-ckan db init                - Initialize the database
-ckan db upgrade             - Upgrade the database
-ckan db version             - Returns current version of data schema
+.. parsed-literal::
+
+ ckan db clean               - Clean the database
+ ckan db downgrade           - Downgrade the database
+ ckan db duplicate_emails    - Check users email for duplicate
+ ckan db init                - Initialize the database
+ ckan db upgrade             - Upgrade the database
+ ckan db version             - Returns current version of data schema
 
 See :doc:`database-management`.
 
@@ -269,18 +284,22 @@ See :doc:`database-management`.
 front-end-build: Creates and minifies css and JavaScript files
 ==============================================================
 
-Usage::
+Usage
 
-    ckan front-end-build      - compile css and js
+.. parsed-literal::
+
+ ckan front-end-build      - compile css and js
 
 
 generate: Generate empty extension files to expand CKANs
 ========================================================
 
-Usage::
+Usage
 
-    ckan generate extension           - Create empty extension
-    ckan generate --output-dir (-o)   - Location to put the generated template
+.. parsed-literal::
+
+ ckan generate extension           - Create empty extension
+ ckan generate --output-dir (-o)   - Location to put the generated template
 
 
 .. _cli jobs:
@@ -288,17 +307,18 @@ Usage::
 jobs: Manage background jobs
 ============================
 
-ckan jobs cancel      - cancel a specific job.
-ckan jobs clear       - cancel all jobs.
-ckan jobs list        - list jobs.
-ckan jobs show        - show details about a specific job.
-ckan jobs test        - enqueue a test job.
-ckan jobs worker      - start a worker
+.. parsed-literal::
+
+ ckan jobs cancel      - cancel a specific job.
+ ckan jobs clear       - cancel all jobs.
+ ckan jobs list        - list jobs.
+ ckan jobs show        - show details about a specific job.
+ ckan jobs test        - enqueue a test job.
+ ckan jobs worker      - start a worker
 
 The ``jobs`` command can be used to manage :ref:`background jobs`.
 
 .. versionadded:: 2.7
-
 
 .. _cli jobs worker:
 
@@ -307,7 +327,7 @@ Run a background job worker
 
 .. parsed-literal::
 
-    ckan -c |ckan.ini| jobs worker [--burst] [QUEUES]
+ ckan -c |ckan.ini| jobs worker [--burst] [QUEUES]
 
 Starts a worker that fetches job from the :ref:`job queues <background jobs
 queues>` and executes them. If no queue names are given then it listens to
@@ -315,21 +335,21 @@ the default queue. This is equivalent to
 
 .. parsed-literal::
 
-    ckan -c |ckan.ini| jobs worker default
+ ckan -c |ckan.ini| jobs worker default
 
 If queue names are given then the worker listens to those queues and only
 those:
 
 .. parsed-literal::
 
-    ckan -c |ckan.ini| jobs worker my-custom-queue another-special-queue
+ ckan -c |ckan.ini| jobs worker my-custom-queue another-special-queue
 
 Hence, if you want the worker to listen to the default queue and some others
 then you must list the default queue explicitly
 
 .. parsed-literal::
 
-    ckan -c |ckan.ini| jobs worker default my-custom-queue
+ ckan -c |ckan.ini| jobs worker default my-custom-queue
 
 If the ``--burst`` option is given then the worker will exit as soon as all its
 queues are empty. Otherwise it will wait indefinitely until a new job is
@@ -348,7 +368,7 @@ List enqueued jobs
 
 .. parsed-literal::
 
-    ckan -c |ckan.ini| jobs list [QUEUES]
+ ckan -c |ckan.ini| jobs list [QUEUES]
 
 Lists the currently enqueued jobs from the given :ref:`job queues <background
 jobs queues>`. If no queue names are given then the jobs from all queues are
@@ -362,7 +382,7 @@ Show details about a job
 
 .. parsed-literal::
 
-    ckan -c |ckan.ini| jobs show ID
+ ckan -c |ckan.ini| jobs show ID
 
 Shows details about the enqueued job with the given ID.
 
@@ -374,7 +394,7 @@ Cancel a job
 
 .. parsed-literal::
 
-    ckan -c |ckan.ini| jobs cancel ID
+ ckan -c |ckan.ini| jobs cancel ID
 
 Cancels the enqueued job with the given ID. Jobs can only be canceled while
 they are enqueued. Once a worker has started executing a job it cannot be
@@ -388,7 +408,7 @@ Clear job queues
 
 .. parsed-literal::
 
-    ckan -c |ckan.ini| jobs clear [QUEUES]
+ ckan -c |ckan.ini| jobs clear [QUEUES]
 
 Cancels all jobs on the given :ref:`job queues <background jobs queues>`. If no
 queues are given then *all* queues are cleared.
@@ -401,7 +421,7 @@ Enqueue a test job
 
 .. parsed-literal::
 
-    ckan -c |ckan.ini| jobs test [QUEUES]
+ ckan -c |ckan.ini| jobs test [QUEUES]
 
 Enqueues a test job. If no :ref:`job queues <background jobs queues>` are given
 then the job is added to the default queue. If queue names are given then a
@@ -413,9 +433,11 @@ separate test job is added to each of the queues.
 less: Compile all root less documents into their CSS counterparts
 =================================================================
 
-Usage::
+Usage
 
-    less
+.. parsed-literal::
+
+ less
 
 
 minify: Create minified versions of the given Javascript and CSS files
@@ -425,13 +447,13 @@ Usage
 
 .. parsed-literal::
 
-    ckan minify [--clean] PATH    - remove any minified files in the path
+ ckan minify [--clean] PATH    - remove any minified files in the path
 
-    For example:
+ For example:
 
-    ckan -c |ckan.ini| minify ckan/public/base
-    ckan -c |ckan.ini| minify ckan/public/base/css/*.css
-    ckan -c |ckan.ini| minify ckan/public/base/css/red.css
+ ckan -c |ckan.ini| minify ckan/public/base
+ ckan -c |ckan.ini| minify ckan/public/base/css/*.css
+ ckan -c |ckan.ini| minify ckan/public/base/css/red.css
 
 If the --clean option is provided any minified files will be removed.
 
@@ -443,7 +465,7 @@ Usage
 
 .. parsed-literal::
 
-    ckan notify replay    - send out modification signals. In "replay" mode,
+ ckan notify replay    - send out modification signals. In "replay" mode,
                        an update signal is sent for each dataset in the database.
 
 
@@ -463,7 +485,7 @@ Usage
 
 .. parsed-literal::
 
-   ckan profile URL
+ ckan profile URL
 
 The result is saved in profile.data.search. To view the profile in runsnakerun::
 
@@ -479,11 +501,11 @@ Usage
 
 .. parsed-literal::
 
-    ckan search-index check                    - Check search index
-    ckan search-index clear                    - Clear the search index
-    ckan search-index rebuild                  - Rebuild search index
-    ckan search-index rebuild-fast             - Reindex with multiprocessing
-    ckan search-index show                     - Show index of a dataset
+ ckan search-index check                    - Check search index
+ ckan search-index clear                    - Clear the search index
+ ckan search-index rebuild                  - Rebuild search index
+ ckan search-index rebuild-fast             - Reindex with multiprocessing
+ ckan search-index show                     - Show index of a dataset
 
 
 .. _rebuild search index:
@@ -504,36 +526,36 @@ one dataset, you can provide a dataset name
 
 .. parsed-literal::
 
-    ckan -c |ckan.ini| search-index rebuild test-dataset-name
+ ckan -c |ckan.ini| search-index rebuild test-dataset-name
 
 Alternatively, you can use the `-o` or `--only-missing` option to only reindex datasets which are not
 already indexed
 
 .. parsed-literal::
 
-    ckan -c |ckan.ini| search-index rebuild -o
+ ckan -c |ckan.ini| search-index rebuild -o
 
 If you don't want to rebuild the whole index, but just refresh it, use the `-r` or `--refresh` option. This
 won't clear the index before starting rebuilding it
 
 .. parsed-literal::
 
-    ckan -c |ckan.ini| search-index rebuild -r
+ ckan -c |ckan.ini| search-index rebuild -r
 
 There is also an option available which works like the refresh option but tries to use all processes on the
 computer to reindex faster
 
 .. parsed-literal::
 
-    ckan -c |ckan.ini| search-index rebuild_fast
+ ckan -c |ckan.ini| search-index rebuild_fast
 
 There are other search related commands, mostly useful for debugging purposes
 
 .. parsed-literal::
 
-    ckan search-index check                  - checks for datasets not indexed
-    ckan search-index show DATASET_NAME      - shows index of a dataset
-    ckan search-index clear [DATASET_NAME]   - clears the search index for the provided dataset or for the whole ckan instance
+ ckan search-index check                  - checks for datasets not indexed
+ ckan search-index show DATASET_NAME      - shows index of a dataset
+ ckan search-index clear [DATASET_NAME]   - clears the search index for the provided dataset or for the whole ckan instance
 
 
 seed: Create test data in the database
@@ -543,20 +565,20 @@ Usage
 
 .. parsed-literal::
 
-    basic           - annakarenina and warandpeace.
-    family          - package relationships data.
-    gov             - government style data.
-    hierarchy       - hierarchy of groups.
-    search          - realistic data to test search.
-    translations    - test translations of terms.
-    user            - create a user "tester" with api key "tester".
-    vocabs          - some test vocabularies.
+ basic           - annakarenina and warandpeace.
+ family          - package relationships data.
+ gov             - government style data.
+ hierarchy       - hierarchy of groups.
+ search          - realistic data to test search.
+ translations    - test translations of terms.
+ user            - create a user "tester" with api key "tester".
+ vocabs          - some test vocabularies.
 
 Examples
 
 .. parsed-literal::
 
-      ckan -c |ckan.ini| seed basic
+ ckan -c |ckan.ini| seed basic
 
 
 server: Start Development server
@@ -566,9 +588,9 @@ Usage
 
 .. parsed-literal::
 
-    ckan server --host (-h)          - Set Host
-    ckan server --port (-p)          - Set Port
-    ckan server --reloader (-r)      - Use reloader
+ ckan server --host (-h)          - Set Host
+ ckan server --port (-p)          - Set Port
+ ckan server --reloader (-r)      - Use reloader
 
 
 sysadmin: Give sysadmin rights
@@ -578,9 +600,9 @@ Usage
 
 .. parsed-literal::
 
-    ckan sysadmin add       - convert user into a sysadmin
-    ckan sysadmin list      - list sysadmins
-    ckan sysadmin remove    - removes user from sysadmins
+ ckan sysadmin add       - convert user into a sysadmin
+ ckan sysadmin list      - list sysadmins
+ ckan sysadmin remove    - removes user from sysadmins
 
 For example, to make a user called 'admin' into a sysadmin
 
@@ -596,8 +618,8 @@ Usage
 
 .. parsed-literal::
 
-    ckan tracking update [start_date]       - update tracking stats
-    ckan tracking export FILE [start_date]  - export tracking stats to a csv file
+ ckan tracking update [start_date]       - update tracking stats
+ ckan tracking export FILE [start_date]  - export tracking stats to a csv file
 
 
 translation: Translation helper functions
@@ -607,9 +629,9 @@ Usage
 
 .. parsed-literal::
 
-    ckan translation js          - generate the JavaScript translations
-    ckan translation mangle      - mangle the zh_TW translations for testing
-    ckan translation check-po    - check po files for common mistakes
+ ckan translation js          - generate the JavaScript translations
+ ckan translation mangle      - mangle the zh_TW translations for testing
+ ckan translation check-po    - check po files for common mistakes
 
 .. note::
 
@@ -629,11 +651,11 @@ Usage
 
 .. parsed-literal::
 
-    ckan user add         - add new user
-    ckan user list        - list all users
-    ckan user remove      - remove user
-    ckan user setpass     - set password for the user
-    ckan user show        - show user
+ ckan user add         - add new user
+ ckan user list        - list all users
+ ckan user remove      - remove user
+ ckan user setpass     - set password for the user
+ ckan user show        - show user
 
 For example, to create a new user called 'admin'
 
@@ -645,7 +667,7 @@ To delete the 'admin' user
 
 .. parsed-literal::
 
-    ckan -c |ckan.ini| user remove admin
+ ckan -c |ckan.ini| user remove admin
 
 
 views: Create views on relevant resources
@@ -655,11 +677,11 @@ Usage
 
 .. parsed-literal::
 
-    ckan views clean      - permanently delete views for all types no...
-    ckan views clear      - permanently delete all views or the ones with...
-    ckan views create     - create views on relevant resources.
+ ckan views clean      - permanently delete views for all types no...
+ ckan views clear      - permanently delete all views or the ones with...
+ ckan views create     - create views on relevant resources.
 
-    ckan views --dataset (-d)        - Set Dataset
-    ckan views --no-default-filters
-    ckan views --search (-s)         - Set Search
-    ckan views --yes (-y)
+ ckan views --dataset (-d)        - Set Dataset
+ ckan views --no-default-filters
+ ckan views --search (-s)         - Set Search
+ ckan views --yes (-y)

--- a/doc/maintaining/cli.rst
+++ b/doc/maintaining/cli.rst
@@ -48,7 +48,7 @@ The config file (ckan.ini) will generally be located in the
 ``/etc/ckan/default/`` directory however it can be located in any directory on
 the host machine
 
-``command`` should be replaced with the name of the CKAN command that you wish
+**command** should be replaced with the name of the CKAN command that you wish
 to execute. Most commands have their own subcommands and options.
 
 .. note::
@@ -447,12 +447,12 @@ Usage
 
 .. parsed-literal::
 
- ckan minify [--clean] PATH    - remove any minified files in the path
-
- For example:
+ ckan minify [--clean] PATH     - remove any minified files in the path
+ 
+.. parsed-literal::
 
  ckan -c |ckan.ini| minify ckan/public/base
- ckan -c |ckan.ini| minify ckan/public/base/css/*.css
+ ckan -c |ckan.ini| minify ckan/public/base/css/\*.css
  ckan -c |ckan.ini| minify ckan/public/base/css/red.css
 
 If the --clean option is provided any minified files will be removed.

--- a/doc/maintaining/cli.rst
+++ b/doc/maintaining/cli.rst
@@ -645,7 +645,7 @@ To delete the 'admin' user
 
 .. parsed-literal::
 
- ckan -c |ckan.ini| user remove admin
+    ckan -c |ckan.ini| user remove admin
 
 
 views: Create views on relevant resources


### PR DESCRIPTION
Fixes problems on the cli documentation page

### Proposed fixes:
On the recently updated cli documentation page some of the “replace::” directive’s were not working. These have been fixed and are now all working. This page has been tested after generating the sphinx HTML output


### Features:

- [ ] includes tests covering changes
- [X ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
