### PR TITLE
unify organization & groups new.html templates and delete redundant blocks

### DIFF
--- a/ckan/templates/group/base_form_page.html
+++ b/ckan/templates/group/base_form_page.html
@@ -1,14 +1,14 @@
 {% extends "group/edit_base.html" %}
 
-{% block page_primary_action %}{% endblock %}
-
 {% block breadcrumb_content %}
   <li>{{ h.nav_link(_('Groups'), named_route=group_type+'.index') }}</li>
   <li class="active">{% block breadcrumb_link %}{{ h.nav_link(_('Add a Group'), named_route=group_type+'.new') }}{% endblock %}</li>
 {% endblock %}
 
 {% block primary_content_inner %}
-  <h1 class="{% block page_heading_class %}page-heading{% endblock %}">{% block page_heading %}{{ _('Group Form') }}{% endblock %}</h1>
+  <h1 class="{% block page_heading_class %}page-heading{% endblock %}">
+    {% block page_heading %}{{ _('Group Form') }}{% endblock %}
+  </h1>
   {% block form %}
     {{ form | safe }}
   {% endblock %}

--- a/ckan/templates/organization/base_form_page.html
+++ b/ckan/templates/organization/base_form_page.html
@@ -1,5 +1,10 @@
 {% extends "organization/edit_base.html" %}
 
+{% block breadcrumb_content %}
+  <li>{{ h.nav_link(_('Organizations'), named_route=group_type+'.index') }}</li>
+  <li class="active">{% block breadcrumb_link %}{{ h.nav_link(_('Add an Organization'), named_route=group_type+'.new') }}{% endblock %}</li>
+{% endblock %}
+
 {% block primary_content_inner %}
   <h1 class="{% block page_heading_class %}page-heading{% endblock %}">
     {% block page_heading %}{{ _('Organization Form') }}{% endblock %}

--- a/ckan/templates/organization/new.html
+++ b/ckan/templates/organization/new.html
@@ -2,15 +2,11 @@
 
 {% block subtitle %}{{ _('Create an Organization') }}{% endblock %}
 
-{% block breadcrumb_link %}{{ h.nav_link(_('Create an Organization'), named_route=group_type+'.edit', id=organization.name) }}{% endblock %}
+{% block breadcrumb_link %}{{ h.nav_link(_('Create an Organization'), named_route=group_type+'.new') }}{% endblock %}
 
 {% block page_heading %}{{ _('Create an Organization') }}{% endblock %}
 
 {% block page_header %}{% endblock %}
-
-{% block breadcrumb_content_inner %}
-  <li class="active"><a href="#">{{ _('Create an Organization') }}</a></li>
-{% endblock %}
 
 {% block secondary_content %}
   {% snippet "organization/snippets/helper.html" %}


### PR DESCRIPTION
Well, this little PR comes to unify organization&group templates a bit(creating pages particularly). Also, I found a few lines that do nothing:
eg.
`{% block breadcrumb_link %}{{ h.nav_link(_('Create an Organization'), named_route=group_type+'.edit', id=organization.name) }}{% endblock %}`
or 
`{% block page_primary_action %}{% endblock %}`


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
