### PR TITLE
Fix link to a primer page in documentation

### DIFF
--- a/doc/theming/templates.rst
+++ b/doc/theming/templates.rst
@@ -683,8 +683,8 @@ There are two places to look for CSS classes available in CKAN:
    provided by Bootstrap is available to use in CKAN.
 
 2. CKAN's development primer page, which can be found on any CKAN site at
-   ``/development/primer.html``, for example
-   `demo.ckan.org/development/primer.html <http://demo.ckan.org/development/primer.html>`_.
+   ``/testing/primer``, for example
+   `demo.ckan.org/testing/primer <http://demo.ckan.org/testing/primer>`_.
 
    The primer page demonstrates many of the HTML and CSS elements available in
    CKAN, and by viewing the source of the page you can see what HTML tags and


### PR DESCRIPTION
The link to the primer page in a documentation was wrong.


### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
