### PR TITLE
Always 404 on non-existing user lookup

### DIFF
--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -80,8 +80,7 @@ class UserController(base.BaseController):
         try:
             user_dict = get_action('user_show')(context, data_dict)
         except NotFound:
-            h.flash_error(_('Not authorized to see this page'))
-            h.redirect_to(controller='user', action='login')
+            abort(404, _('User not found'))
         except NotAuthorized:
             abort(403, _('Not authorized to see this page'))
 
@@ -147,10 +146,6 @@ class UserController(base.BaseController):
         return render('user/read.html')
 
     def me(self, locale=None):
-        if not c.user:
-            h.redirect_to(locale=locale, controller='user', action='login',
-                          id=None)
-        user_ref = c.userobj.get_reference_preferred_for_uri()
         h.redirect_to(locale=locale, controller='user', action='dashboard')
 
     def register(self, data=None, errors=None, error_summary=None):
@@ -674,6 +669,11 @@ class UserController(base.BaseController):
         context = {'model': model, 'session': model.Session,
                    'user': c.user, 'auth_user_obj': c.userobj,
                    'for_view': True}
+
+        if authz.auth_is_anon_user(context):
+            h.flash_error(_('Not authorized to see this page'))
+            return h.redirect_to(controller='user', action='login')
+
         data_dict = {'id': id, 'user_obj': c.userobj, 'offset': offset}
         self._setup_template_variables(context, data_dict)
 

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -155,7 +155,6 @@ class TestUser(object):
         assert "/my/prefix/user/logout" in logout_response.headers['location']
 
     def test_not_logged_in_dashboard(self, app):
-
         for route in ["index", "organizations", "datasets", "groups"]:
             response = app.get(url=url_for(u"dashboard.{}".format(route)), follow_redirects=False)
             assert response.status_code == 302
@@ -423,7 +422,7 @@ class TestUser(object):
         follow_url = url_for(controller="user", action="follow", id="not-here")
         response = app.post(follow_url, extra_environ=env)
 
-        assert "Not found" in response.body
+        assert response.status_code == 404
 
     def test_user_unfollow(self, app):
 
@@ -473,7 +472,7 @@ class TestUser(object):
             controller="user", action="unfollow", id="not-here")
         response = app.post(unfollow_url, extra_environ=env)
 
-        assert "Not found" in response.body
+        assert response.status_code == 404
 
     def test_user_follower_list(self, app):
         """Following users appear on followers list page."""

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -157,7 +157,9 @@ class TestUser(object):
     def test_not_logged_in_dashboard(self, app):
 
         for route in ["index", "organizations", "datasets", "groups"]:
-            app.get(url=url_for(u"dashboard.{}".format(route)), status=403)
+            response = app.get(url=url_for(u"dashboard.{}".format(route)), follow_redirects=False)
+            assert response.status_code == 302
+            assert "user/login" in response.headers['location']
 
     def test_own_datasets_show_up_on_user_dashboard(self, app):
         user = factories.User()

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -421,7 +421,7 @@ class TestUser(object):
         follow_url = url_for(controller="user", action="follow", id="not-here")
         response = app.post(follow_url, extra_environ=env)
 
-        assert "You're already logged in" in response.body
+        assert "Not found" in response.body
 
     def test_user_unfollow(self, app):
 
@@ -467,10 +467,11 @@ class TestUser(object):
         user_one = factories.User()
 
         env = {"REMOTE_USER": six.ensure_str(user_one["name"])}
-        unfollow_url = url_for("user.unfollow", id="not-here")
-        unfollow_response = app.post(
-            unfollow_url, extra_environ=env, follow_redirects=False, status=302
-        )
+        unfollow_url = url_for(
+            controller="user", action="unfollow", id="not-here")
+        response = app.post(unfollow_url, extra_environ=env)
+
+        assert "Not found" in response.body
 
     def test_user_follower_list(self, app):
         """Following users appear on followers list page."""

--- a/ckan/views/dashboard.py
+++ b/ckan/views/dashboard.py
@@ -17,10 +17,11 @@ dashboard = Blueprint(u'dashboard', __name__, url_prefix=u'/dashboard')
 
 @dashboard.before_request
 def before_request():
-    try:
-        if not g.userobj:
-            raise logic.NotAuthorized()
+    if not g.userobj:
+        h.flash_error(_(u'Not authorized to see this page'))
+        return h.redirect_to(u'user.login')
 
+    try:
         context = dict(model=model, user=g.user, auth_user_obj=g.userobj)
         logic.check_access(u'site_read', context)
     except logic.NotAuthorized:

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -122,7 +122,8 @@ def index():
 
 
 def me():
-    return h.redirect_to(config.get(u'ckan.route_after_login', u'dashboard.index'))
+    return h.redirect_to(
+        config.get(u'ckan.route_after_login', u'dashboard.index'))
 
 
 def read(id):

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -56,8 +56,7 @@ def _extra_template_variables(context, data_dict):
     try:
         user_dict = logic.get_action(u'user_show')(context, data_dict)
     except logic.NotFound:
-        h.flash_error(_(u'Not authorized to see this page'))
-        return
+        base.abort(404, _(u'User not found'))
     except logic.NotAuthorized:
         base.abort(403, _(u'Not authorized to see this page'))
 
@@ -123,11 +122,7 @@ def index():
 
 
 def me():
-    if g.user:
-        route = config.get(u'ckan.route_after_login', u'dashboard.index')
-    else:
-        route = u'user.login'
-    return h.redirect_to(route)
+    return h.redirect_to(config.get(u'ckan.route_after_login', u'dashboard.index'))
 
 
 def read(id):

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -679,7 +679,7 @@ def follow(id):
     except logic.ValidationError as e:
         error_message = (e.message or e.error_summary or e.error_dict)
         h.flash_error(error_message)
-    except logic.NotAuthorized as e:
+    except (logic.NotFound, logic.NotAuthorized) as e:
         h.flash_error(e.message)
     return h.redirect_to(u'user.read', id=id)
 
@@ -699,12 +699,11 @@ def unfollow(id):
         h.flash_success(
             _(u'You are no longer following {0}').format(
                 user_dict[u'display_name']))
-    except (logic.NotFound, logic.NotAuthorized) as e:
-        error_message = e.message
-        h.flash_error(error_message)
     except logic.ValidationError as e:
         error_message = (e.error_summary or e.message or e.error_dict)
         h.flash_error(error_message)
+    except (logic.NotFound, logic.NotAuthorized) as e:
+        h.flash_error(e.message)
     return h.redirect_to(u'user.read', id=id)
 
 


### PR DESCRIPTION
Moved specific redirect to login when accessing dashboard into the action for dashboard.
See #3224 for original work around this.

### Proposed fixes:

This is roughly as discussed in #5432 @smotornyuk , though I found that the redirect to login had been implemented intentionally in #3224. I believe that my implementation here solves both problems:
- redirect to login if anonymous/unauthenticated user accesses `/dashboard` or `/user/me`
- display 404 page for `/user/non-existing-user`

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
