### PR TITLE
Fix: Remove o in template

### DIFF
--- a/ckan/templates/package/resources.html
+++ b/ckan/templates/package/resources.html
@@ -5,7 +5,7 @@
 {% block subtitle %}{{ _('Resources') }} {{ g.template_title_delimiter }} {{ h.dataset_display_name(pkg) }}{% endblock %}
 
 {% block page_primary_action %}
-o  {% link_for _('Add new resource'), named_route=pkg_dict.type ~ '_resource.new', id=pkg_dict.name, class_='btn btn-primary', icon='plus' %}
+  {% link_for _('Add new resource'), named_route=pkg_dict.type ~ '_resource.new', id=pkg_dict.name, class_='btn btn-primary', icon='plus' %}
 {% endblock %}
 
 {% block primary_content_inner %}


### PR DESCRIPTION
### Proposed fixes:

This PR removes an **o** in `ckan/templates/package/resources.html` template.

![extra o](https://user-images.githubusercontent.com/6672339/85628147-03722680-b646-11ea-80f3-384e91a3b0c4.png)

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
