### PR TITLE
add class dropdown to 'New view' menu

### DIFF
--- a/ckan/templates/package/resource_views.html
+++ b/ckan/templates/package/resource_views.html
@@ -4,7 +4,7 @@
 {% block subtitle %}{{ _('View') }} {{ g.template_title_delimiter }} {{ h.resource_display_name(res) }}{% endblock %}
 
 {% block page_primary_action %}
-  <div class="btn-group">
+  <div class="dropdown btn-group">
     <a class="btn btn-primary dropdown-toggle" data-toggle="dropdown" href="#">
       <i class="fa fa-plus-square"></i>
       {{ _('New view') }}

--- a/ckan/templates/package/snippets/resource_info.html
+++ b/ckan/templates/package/snippets/resource_info.html
@@ -1,21 +1,25 @@
 {#
-Displays a sidebard module with information for given resource
+Displays a sidebar module with information for given resource
 
-res    - The respource dict
+res    - The resource dict
 
 Example:
 
-  {% snippet "package/snippets/resrouce_info.html", res=res %}
+  {% snippet "package/snippets/resource_info.html", res=res %}
 
 #}
 <div class="module context-info">
   <div class="module-content">
-    <h1 class="heading">{{ h.resource_display_name(res) or res.id }}</h1>
-    <div class="nums">
-      <dl>
-        <dt>{{ _('Format') }}</dt>
-        <dd>{{ h.get_translated(res, 'format') }}</dd>
-      </dl>
-    </div>
+    {% block page_title %}
+      <h1 class="heading">{{ h.resource_display_name(res) or res.id }}</h1>
+    {% endblock %}
+    {% block resource_info %}
+      <div class="nums">
+        <dl>
+          <dt>{{ _('Format') }}</dt>
+          <dd>{{ h.get_translated(res, 'format') }}</dd>
+        </dl>
+      </div>
+    {% endblock %}
   </div>
 </div>


### PR DESCRIPTION
Fixes #

### Proposed fixes:

The dropdown menu for 'New view' is missing a class 'dropdown' which is prohibiting the dropdown menu to render properly. The patch adds the class making it similar to the '[Explore](https://github.com/ckan/ckan/blob/7b587c81372c39eeb00cfa1d6514f0d625370543/ckan/templates/package/snippets/resource_item.html#L34)' menu 

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
