### PR TITLE
[#5259] allow returning response from IAuthenticator.identify() for f…

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -359,7 +359,7 @@ def ckan_before_request():
 
     # Identify the user from the repoze cookie or the API header
     # Sets g.user and g.userobj
-    identify_user()
+    response = identify_user()
 
     # Provide g.controller and g.action for backward compatibility
     # with extensions
@@ -367,6 +367,8 @@ def ckan_before_request():
 
     set_ckan_current_url(request.environ)
     g.__timer = time.time()
+
+    return response
 
 
 def ckan_after_request(response):

--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -168,7 +168,8 @@ def _run_plugin_authenticators():
         for item in authenticators:
             response = item.identify()
             if response:
-                # assume that no further extensions need to run if a plugin returned a response
+                # Assume that no further extensions need to run if a plugin
+                # returned a response.
                 return response
             try:
                 if g.user:


### PR DESCRIPTION
Fixes #5259 

### Proposed fixes:

Allow returning response from IAuthenticator.identify() for flask. This allows plugins to send e.g. a redirect like they can do with pylons.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
