### PR TITLE
[#5479] Fixed Activity stream on bulk update

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -1202,6 +1202,17 @@ def _bulk_update_dataset(context, data_dict, update_dict):
         .filter(model.Package.owner_org == org_id) \
         .update(update_dict, synchronize_session=False)
 
+    # Handle Activity Stream for Bulk Operations
+    user = context['user']
+    user_obj = model.User.by_name(user)
+    if user_obj:
+        user_id = user_obj.id
+    else:
+        user_id = 'not logged in'
+    for dataset in datasets:
+        entity = model.Package.get(dataset)
+        activity = entity.activity_stream_item('changed', user_id)
+        model.Session.add(activity)
     model.Session.commit()
 
     # solr update here

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -1688,6 +1688,10 @@ class TestBulkOperations(object):
         )
         for dataset in datasets:
             assert not (dataset.private)
+        activities = helpers.call_action(
+            "organization_activity_list", id=org["id"]
+        )
+        assert activities[0]['activity_type'] == 'changed package'
 
     def test_bulk_delete(self):
 
@@ -1718,6 +1722,11 @@ class TestBulkOperations(object):
         )
         for dataset in datasets:
             assert dataset.state == "deleted"
+
+        activities = helpers.call_action(
+            "organization_activity_list", id=org["id"]
+        )
+        assert activities[0]['activity_type'] == 'deleted package'
 
 
 @pytest.mark.usefixtures("clean_db", "with_request_context")


### PR DESCRIPTION
Fixes #5479 

### Proposed fixes:
Add logic of Activity Stream in case of the bulk update

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [x] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
