### PR TITLE
[#5146] Make creation of API keys configurable

### DIFF
--- a/ckan/authz.py
+++ b/ckan/authz.py
@@ -479,7 +479,7 @@ CONFIG_PERMISSIONS_DEFAULTS = {
     'allow_dataset_collaborators': False,
     'allow_admin_collaborators': False,
     'allow_collaborators_to_change_owner_org': False,
-    'create_default_api_keys': True,
+    'create_default_api_keys': False,
 }
 
 

--- a/ckan/authz.py
+++ b/ckan/authz.py
@@ -479,6 +479,7 @@ CONFIG_PERMISSIONS_DEFAULTS = {
     'allow_dataset_collaborators': False,
     'allow_admin_collaborators': False,
     'allow_collaborators_to_change_owner_org': False,
+    'create_default_api_keys': True,
 }
 
 

--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -76,6 +76,7 @@ ckan.auth.roles_that_cascade_to_sub_groups = admin
 ckan.auth.public_user_details = true
 ckan.auth.public_activity_stream_detail = true
 ckan.auth.allow_dataset_collaborators = false
+ckan.auth.create_default_api_keys = false
 
 ## API Token Settings
 api_token.nbytes = 60

--- a/ckan/model/user.py
+++ b/ckan/model/user.py
@@ -23,7 +23,7 @@ from ckan.common import config, asbool
 
 
 def set_api_key():
-    if asbool(config.get('ckan.auth.create_default_api_keys', True)):
+    if asbool(config.get('ckan.auth.create_default_api_keys', False)):
         return _types.make_uuid()
     return None
 

--- a/ckan/model/user.py
+++ b/ckan/model/user.py
@@ -19,6 +19,13 @@ from ckan.model import meta
 from ckan.model import core
 from ckan.model import types as _types
 from ckan.model import domain_object
+from ckan.common import config, asbool
+
+
+def set_api_key():
+    if asbool(config.get('ckan.auth.create_default_api_keys', True)):
+        return _types.make_uuid()
+    return None
 
 
 user_table = Table('user', meta.metadata,
@@ -28,7 +35,7 @@ user_table = Table('user', meta.metadata,
         Column('password', types.UnicodeText),
         Column('fullname', types.UnicodeText),
         Column('email', types.UnicodeText),
-        Column('apikey', types.UnicodeText, default=_types.make_uuid),
+        Column('apikey', types.UnicodeText, default=set_api_key),
         Column('created', types.DateTime, default=datetime.datetime.now),
         Column('reset_key', types.UnicodeText),
         Column('about', types.UnicodeText),

--- a/ckan/tests/model/test_user.py
+++ b/ckan/tests/model/test_user.py
@@ -136,5 +136,22 @@ class TestUser:
         user_obj = model.User.by_name(user["name"])
         user_obj._set_password(password)
         user_obj.save()
-
         assert user_obj.validate_password(password)
+
+    def test_api_key_created_by_default(self):
+        user = factories.User()
+
+        assert user['apikey']
+
+    @pytest.mark.ckan_config('ckan.auth.create_default_api_keys', True)
+    def test_api_key_created_when_config_true(self):
+        user = factories.User()
+
+        assert user['apikey']
+
+    @pytest.mark.ckan_config('ckan.auth.create_default_api_keys', False)
+    def test_api_key_not_created_when_config_false(self):
+
+        user = factories.User()
+
+        assert user['apikey'] is None

--- a/ckan/tests/test_coding_standards.py
+++ b/ckan/tests/test_coding_standards.py
@@ -108,6 +108,7 @@ def test_building_the_docs():
         u"WARNING: duplicate label ckan.auth.allow_dataset_collaborators",
         u"WARNING: duplicate label ckan.auth.allow_admin_collaborators",
         u"WARNING: duplicate label ckan.auth.allow_collaborators_to_change_owner_org",
+        u"WARNING: duplicate label ckan.auth.create_default_api_keys",
     ]
 
     # Remove the allowed warnings from the list of collected warnings.

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -242,9 +242,14 @@ request that doesn't specify the API version number cannot be relied on.
 
 .. _api authentication:
 
----------------------------------------
-Authentication, API keys and API tokens
----------------------------------------
+-----------------------------
+Authentication and API tokens
+-----------------------------
+
+.. warning:: Starting from CKAN 2.9, API tokens are the preferred way of authenticating API calls.
+    The old legacy API keys will still work but they will be removed in future versions so it is
+    recommended to switch to use API tokens. Read below for more details.
+
 
 Some API functions require authorization. The API uses the same authorization
 functions and configuration as the web interface, so if a user is authorized to
@@ -252,16 +257,19 @@ do something in the web interface they'll be authorized to do it via the API as
 well.
 
 When calling an API function that requires authorization, you must
-authenticate yourself by providing your API key or API token with your
-HTTP request. To find your API key, login to the CKAN site using its
-web interface and visit your user profile page. To generate a new API
-token visit the *API Tokens* tab available on your user profile.
-page.
+authenticate yourself by providing an authentication key with your
+HTTP request. Starting from CKAN 2.9 the recommended mechanism to use are API tokens. These are
+encrypted keys that can be generated manually from the UI (User Profile > Manage > API tokens)
+or via the :py:func:`~ckan.logic.action.create.api_token_create` function. A user can create as many tokens as needed
+for different uses, and revoke one or multiple tokens at any time. In addition, enabling
+the ``expire_api_token`` core plugin allows to define the expiration timestamp for a token. 
 
-.. note:: API keys will be marked as deprecated in the near future
-  and, eventually, completely removed. There are no gains in using API
-  keys instead of API tokens so it's strongly recommended to always
-  use API tokens for API calls.
+Site maintainers can use :ref:`config-api-tokens` to configure the token generation.
+
+Legacy API keys (UUIDs that look like `ec5c0860-9e48-41f3-8850-4a7128b18df8`) are still supported,
+but its use is discouraged as they are not as secure as tokens and are limited to one per user.
+Support for legacy API keys will be removed in future CKAN versions.
+
 
 To provide your API token in an HTTP request, include it in either an
 ``Authorization`` or ``X-CKAN-API-Key`` header.  (The name of the HTTP header

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -767,6 +767,19 @@ Default value: ``False``
 
 Allows dataset collaborators to change the owner organization of the datasets they are collaborators on. Defaults to False, meaning that collaborators with role admin or editor can edit the dataset metadata but not the organization field.
 
+.. _ckan.auth.create_default_api_keys:
+
+ckan.auth.create_default_api_keys
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+  ckan.auth.create_default_api_keys = False
+
+Default value: ``True``
+
+
+Determines if a an API key should be automatically created for every user when creating a user account. If set to False users can manually create an API token from their profile instead. See :ref:`api authentication`: for more details.
 
 
 .. end_config-authorization

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -774,15 +774,17 @@ ckan.auth.create_default_api_keys
 
 Example::
 
-  ckan.auth.create_default_api_keys = False
+  ckan.auth.create_default_api_keys = True
 
-Default value: ``True``
+Default value: ``False``
 
 
-Determines if a an API key should be automatically created for every user when creating a user account. If set to False users can manually create an API token from their profile instead. See :ref:`api authentication`: for more details.
+Determines if a an API key should be automatically created for every user when creating a user account. If set to False (the default value), users can manually create an API token from their profile instead. See :ref:`api authentication`: for more details.
 
 
 .. end_config-authorization
+
+.. _config-api-tokens:
 
 API Token Settings
 ------------------

--- a/test-core.ini
+++ b/test-core.ini
@@ -47,6 +47,7 @@ ckan.auth.anon_create_dataset = false
 ckan.auth.user_delete_groups=true
 ckan.auth.user_delete_organizations=true
 ckan.auth.create_unowned_dataset=true
+ckan.auth.create_default_api_keys =true
 
 ckan.cache_validation_enabled = True
 ckan.cache_enabled = False


### PR DESCRIPTION
Follow up from #5146. This allows site admins to disable the creation of API keys by default on all users