### PR TITLE
Ignore metadata_modified during revision migration

### DIFF
--- a/ckan/migration/revision_legacy_code.py
+++ b/ckan/migration/revision_legacy_code.py
@@ -68,6 +68,9 @@ def package_dictize_with_revisions(pkg, context):
         res = model.resource_table
     else:
         res = revision_model.resource_revision_table
+    mm_col = res._columns.get('metadata_modified')
+    if mm_col is not None:
+        res._columns.remove(mm_col)
     q = select([res]).where(res.c.package_id == pkg.id)
     result = execute(q, res, context)
     result_dict["resources"] = resource_list_dictize(result, context)


### PR DESCRIPTION
In the edge case(for the last revision), the script, that converts revisions into activities, is using metadata of `resource` table for fetching data from `resource_revision`. As we recently have added `metadata_modified` column to the `resource` table, this causes error in transaction.

In this PR I suggest dropping the `metadata_modified` column when it present as the smallest possible change. I wouldn't say that I'm very familiar with this script, thus it's the best I can suggest in order to deliver working script inside v2.9.

PS. [Because of this line](https://github.com/ckan/ckan/blob/master/ckan/migration/migrate_package_activity.py#L277) it's possible to run migration script only using py2 environment. Not sure if it's worth fixing. This script will be used only by existing instances, so you definitely have py2 environment and can run revision-migration from there, right?