### PR TITLE
[#5501] Remove line breaks and whitespace from translatable strings

### DIFF
--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -937,9 +937,8 @@ def email_is_unique(key, data, errors, context):
                 return
 
     raise Invalid(
-                _('The email address \'{email}\' \
-                    belongs to a registered user.').
-                        format(email=data[key]))
+        _('The email address \'{email}\' belongs to a registered user.').format(email=data[key]))
+
 
 def one_of(list_of_value):
     ''' Checks if the provided value is present in a list '''

--- a/ckan/templates/snippets/changes/author_email.html
+++ b/ckan/templates/snippets/changes/author_email.html
@@ -2,8 +2,7 @@
   <p>
     {% if change.method == "change" %}
 
-      {{ _('Set author email of {pkg_link} to {new_author_email}
-          (previously {old_author_email})').format(
+      {{ _('Set author email of {pkg_link} to {new_author_email} (previously {old_author_email})').format(
             pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
               pkg_url = h.url_for(controller='dataset',
                                   action='read', id=change.pkg_id),

--- a/ckan/templates/snippets/changes/extension_fields.html
+++ b/ckan/templates/snippets/changes/extension_fields.html
@@ -1,7 +1,6 @@
 <li>
   <p>
-    {{ _('Changed value of field <q>{key}</q> to <q>{value}</q> in
-        {pkg_link}').format(
+    {{ _('Changed value of field <q>{key}</q> to <q>{value}</q> in {pkg_link}').format(
         pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
           pkg_url = h.url_for(controller='dataset',
                               action='read', id=change.pkg_id),

--- a/ckan/templates/snippets/changes/extra_fields.html
+++ b/ckan/templates/snippets/changes/extra_fields.html
@@ -2,8 +2,7 @@
   <p>
     {% if change.method == "add_one_value" %}
 
-      {{ _('Added field <q>{key}</q> with value <q>{value}</q> to
-        {pkg_link}').format(
+      {{ _('Added field <q>{key}</q> with value <q>{value}</q> to {pkg_link}').format(
           pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
             pkg_url = h.url_for(controller='dataset',
                                 action='read', id=change.pkg_id),
@@ -52,8 +51,7 @@
 
     {% elif change.method == "change_with_old_value" %}
 
-      {{ _('Changed value of field <q>{key}</q> to <q>{new_val}</q>
-        (previously <q>{old_val}</q>) in {pkg_link}').format(
+      {{ _('Changed value of field <q>{key}</q> to <q>{new_val}</q> (previously <q>{old_val}</q>) in {pkg_link}').format(
           pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
             pkg_url = h.url_for(controller='dataset',
                                 action='read', id=change.pkg_id),
@@ -66,8 +64,7 @@
 
     {% elif change.method == "change_no_old_value" %}
 
-      {{ _('Changed value of field <q>{key}</q> to <q>{new_val}</q>
-        in {pkg_link}').format(
+      {{ _('Changed value of field <q>{key}</q> to <q>{new_val}</q> in {pkg_link}').format(
           pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
             pkg_url = h.url_for(controller='dataset',
                                 action='read', id=change.pkg_id),
@@ -79,8 +76,7 @@
 
     {% elif change.method == "remove_one" %}
 
-      {{ _('Removed field <q>{key}</q> from
-        {pkg_link}').format(
+      {{ _('Removed field <q>{key}</q> from {pkg_link}').format(
           pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
             pkg_url = h.url_for(controller='dataset',
                                 action='read', id=change.pkg_id),
@@ -111,7 +107,7 @@
     {% else %}
 
       {{ _('No fields were updated. See the metadata diff for more details.') }}
-      
+
     {% endif %}
   </p>
 </li>

--- a/ckan/templates/snippets/changes/license.html
+++ b/ckan/templates/snippets/changes/license.html
@@ -3,8 +3,7 @@
     {# if both of them have URLs #}
     {% if change.new_url != "" and change.old_url != "" %}
 
-      {{ _('Changed the license of {pkg_link} to
-          {new_link} (previously {old_link})').format(
+      {{ _('Changed the license of {pkg_link} to {new_link} (previously {old_link})').format(
             pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
               pkg_url = h.url_for(controller='dataset',
                                   action='read', id=change.pkg_id),
@@ -23,8 +22,7 @@
     {# if only the new one has a URL #}
     {% elif change.new_url != "" and change.old_url == "" %}
 
-      {{ _('Changed the license of {pkg_link} to
-          {new_link} (previously {old_title})').format(
+      {{ _('Changed the license of {pkg_link} to {new_link} (previously {old_title})').format(
             pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
               pkg_url = h.url_for(controller='dataset',
                                   action='read', id=change.pkg_id),
@@ -40,8 +38,7 @@
     {# if only the old one has a URL #}
     {% elif change.new_url == "" and change.old_url != "" %}
 
-    {{ _('Changed the license of {pkg_link} to
-        {new_title} (previously {old_link})').format(
+    {{ _('Changed the license of {pkg_link} to {new_title} (previously {old_link})').format(
           pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
             pkg_url = h.url_for(controller='dataset',
                                 action='read', id=change.pkg_id),
@@ -58,8 +55,7 @@
     {% else %}
 
 
-      {{ _('Changed the license of {pkg_link} to
-          {new_title} (previously {old_title})').format(
+      {{ _('Changed the license of {pkg_link} to {new_title} (previously {old_title})').format(
             pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
               pkg_url = h.url_for(controller='dataset',
                                   action='read', id=change.pkg_id),

--- a/ckan/templates/snippets/changes/maintainer.html
+++ b/ckan/templates/snippets/changes/maintainer.html
@@ -2,8 +2,7 @@
   <p>
     {% if change.method == "change" %}
 
-      {{ _('Set maintainer of {pkg_link} to {new_maintainer}
-        (previously {old_maintainer})').format(
+      {{ _('Set maintainer of {pkg_link} to {new_maintainer} (previously {old_maintainer})').format(
             pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
               pkg_url = h.url_for(controller='dataset',
                                   action='read', id=change.pkg_id),
@@ -15,8 +14,7 @@
 
     {% elif change.method == "add" %}
 
-      {{ _('Set maintainer of {pkg_link} to
-          {new_maintainer}').format(
+      {{ _('Set maintainer of {pkg_link} to {new_maintainer}').format(
             pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
               pkg_url = h.url_for(controller='dataset',
                                   action='read', id=change.pkg_id),

--- a/ckan/templates/snippets/changes/maintainer_email.html
+++ b/ckan/templates/snippets/changes/maintainer_email.html
@@ -2,8 +2,7 @@
   <p>
     {% if change.method == "change" %}
 
-      {{ _('Set maintainer email of {pkg_link} to {new_email}
-           (previously {old_email})').format(
+      {{ _('Set maintainer email of {pkg_link} to {new_email} (previously {old_email})').format(
              pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
                pkg_url = h.url_for(controller='dataset',
                                    action='read', id=change.pkg_id),

--- a/ckan/templates/snippets/changes/notes.html
+++ b/ckan/templates/snippets/changes/notes.html
@@ -2,10 +2,7 @@
   <p>
     {% if change.method == "change" %}
 
-      {{ _('Updated description of {pkg_link} from
-            <br class="line-height2"><blockquote>{old_notes}</blockquote>
-            to <br class="line-height2"><blockquote>{new_notes}
-            </blockquote>').format(
+      {{ _('Updated description of {pkg_link} from <br class="line-height2"><blockquote>{old_notes}</blockquote> to <br class="line-height2"><blockquote>{new_notes}</blockquote>').format(
               pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
                 pkg_url = h.url_for(controller='dataset',
                                     action='read', id=change.pkg_id),
@@ -17,9 +14,7 @@
 
     {% elif change.method == "add" %}
 
-      {{ _('Updated description of {pkg_link}
-            to <br class="line-height2"><blockquote>{new_notes}
-            </blockquote>').format(
+      {{ _('Updated description of {pkg_link} to <br class="line-height2"><blockquote>{new_notes}</blockquote>').format(
               pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
                 pkg_url = h.url_for(controller='dataset',
                                     action='read', id=change.pkg_id),

--- a/ckan/templates/snippets/changes/org.html
+++ b/ckan/templates/snippets/changes/org.html
@@ -2,8 +2,7 @@
   <p>
     {% if change.method == "change" %}
 
-      {{ _('Moved {pkg_link} from organization {old_org_link} to
-          organization {new_org_link}').format(
+      {{ _('Moved {pkg_link} from organization {old_org_link} to organization {new_org_link}').format(
             pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
               pkg_url = h.url_for(controller='dataset',
                                   action='read', id=change.pkg_id),

--- a/ckan/templates/snippets/changes/resource_desc.html
+++ b/ckan/templates/snippets/changes/resource_desc.html
@@ -2,9 +2,7 @@
   <p>
     {% if change.method == "add" %}
 
-      {{ _('Updated description of resource {resource_link} in {pkg_link}
-          to <br class="line-height2"><blockquote>{new_desc}</blockquote>'
-          ).format(
+    {{ _('Updated description of resource {resource_link} in {pkg_link} to <br class="line-height2"><blockquote>{new_desc}</blockquote>').format(
             pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
               pkg_url = h.url_for(controller='dataset',
                                   action='read', id=change.pkg_id),
@@ -21,8 +19,7 @@
 
     {% elif change.method == "remove" %}
 
-      {{ _('Removed description from resource {resource_link} in
-          {pkg_link}').format(
+      {{ _('Removed description from resource {resource_link} in {pkg_link}').format(
             pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
               pkg_url = h.url_for(controller='dataset',
                                   action='read', id=change.pkg_id),
@@ -38,10 +35,7 @@
 
     {% elif change.method == "change" %}
 
-      {{ _('Updated description of resource {resource_link} in {pkg_link}
-          from <br class="line-height2"><blockquote>{old_desc}</blockquote>
-          to <br class="line-height2"><blockquote>{new_desc}</blockquote>'
-          ).format(
+    {{ _('Updated description of resource {resource_link} in {pkg_link} from <br class="line-height2"><blockquote>{old_desc}</blockquote> to <br class="line-height2"><blockquote>{new_desc}</blockquote>').format(
             pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
               pkg_url = h.url_for(controller='dataset',
                                   action='read', id=change.pkg_id),

--- a/ckan/templates/snippets/changes/resource_extras.html
+++ b/ckan/templates/snippets/changes/resource_extras.html
@@ -2,8 +2,7 @@
   <p>
     {% if change.method == "add_one_value" %}
 
-      {{ _('Added field <q>{key}</q> with value <q>{value}</q>
-        to resource {resource_link} in {pkg_link}').format(
+      {{ _('Added field <q>{key}</q> with value <q>{value}</q> to resource {resource_link} in {pkg_link}').format(
           pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
             pkg_url = h.url_for(controller='dataset',
                                 action='read', id=change.pkg_id),
@@ -68,8 +67,7 @@
 
     {% elif change.method == "remove_one" %}
 
-      {{ _('Removed field <q>{key}</q> from resource {resource_link}
-        in {pkg_link}').format(
+      {{ _('Removed field <q>{key}</q> from resource {resource_link} in {pkg_link}').format(
           pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
             pkg_url = h.url_for(controller='dataset',
                                 action='read', id=change.pkg_id),
@@ -86,8 +84,7 @@
 
     {% elif change.method == "remove_multiple" %}
 
-      {{ _('Removed the following fields from resource {resource_link}
-        in {pkg_link}').format(
+      {{ _('Removed the following fields from resource {resource_link} in {pkg_link}').format(
           pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
             pkg_url = h.url_for(controller='dataset',
                                 action='read', id=change.pkg_id),
@@ -110,8 +107,7 @@
 
     {% elif change.method == "change_value_with_old" %}
 
-      {{ _('Changed value of field <q>{key}</q> of resource {resource_link} to
-        <q>{new_val}</q> (previously <q>{old_val}</q>) in {pkg_link}').format(
+      {{ _('Changed value of field <q>{key}</q> of resource {resource_link} to <q>{new_val}</q> (previously <q>{old_val}</q>) in {pkg_link}').format(
           pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
             pkg_url = h.url_for(controller='dataset',
                                 action='read', id=change.pkg_id),
@@ -130,8 +126,7 @@
 
     {% elif change.method == "change_value_no_old" %}
 
-      {{ _('Changed value of field <q>{key}</q> to <q>{new_val}</q> in resource
-        {resource_link} in {pkg_link}').format(
+      {{ _('Changed value of field <q>{key}</q> to <q>{new_val}</q> in resource {resource_link} in {pkg_link}').format(
           pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
             pkg_url = h.url_for(controller='dataset',
                                 action='read', id=change.pkg_id),
@@ -149,8 +144,7 @@
 
     {% elif change.method == "change_value_no_new" %}
 
-      {{ _('Removed the value of field <q>{key}</q> in resource {resource_link}
-        in {pkg_link}').format(
+      {{ _('Removed the value of field <q>{key}</q> in resource {resource_link} in {pkg_link}').format(
           pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
             pkg_url = h.url_for(controller='dataset',
                                 action='read', id=change.pkg_id),

--- a/ckan/templates/snippets/changes/resource_format.html
+++ b/ckan/templates/snippets/changes/resource_format.html
@@ -7,8 +7,7 @@
 
     {% if change.method == "add" %}
 
-      {{ _('Set format of resource {resource_link} to {format_link} in
-          {pkg_link}').format(
+      {{ _('Set format of resource {resource_link} to {format_link} in {pkg_link}').format(
             pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
               pkg_url = h.url_for(controller='dataset',
                                   action='read', id=change.pkg_id),
@@ -28,8 +27,7 @@
 
     {% elif change.method == "change" %}
 
-      {{ _('Set format of resource {resource_link} to {new_format_link}
-        (previously {old_format_link}) in {pkg_link}').format(
+      {{ _('Set format of resource {resource_link} to {new_format_link} (previously {old_format_link}) in {pkg_link}').format(
           pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
             pkg_url = h.url_for(controller='dataset',
                                 action='read', id=change.pkg_id),

--- a/ckan/templates/snippets/changes/resource_name.html
+++ b/ckan/templates/snippets/changes/resource_name.html
@@ -1,7 +1,6 @@
 <li>
   <p>
-    {{ _('Renamed resource {old_resource_link} to {new_resource_link}
-        in {pkg_link}').format(
+    {{ _('Renamed resource {old_resource_link} to {new_resource_link} in {pkg_link}').format(
           pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
             pkg_url = h.url_for(controller='dataset',
                                 action='read', id=change.pkg_id),

--- a/ckan/templates/snippets/changes/version.html
+++ b/ckan/templates/snippets/changes/version.html
@@ -2,8 +2,7 @@
   <p>
     {% if change.method == "change" %}
 
-      {{ _('Changed the version of {pkg_link}
-          to {new_version} (previously {old_version})').format(
+      {{ _('Changed the version of {pkg_link} to {new_version} (previously {old_version})').format(
             pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
               pkg_url = h.url_for(controller='dataset',
                                   action='read', id=change.pkg_id),
@@ -25,8 +24,7 @@
 
     {% elif change.method == "add" %}
 
-      {{ _('Changed the version of {pkg_link}
-          to {new_version}').format(
+      {{ _('Changed the version of {pkg_link} to {new_version}').format(
             pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
               pkg_url = h.url_for(controller='dataset',
                                   action='read', id=change.pkg_id),


### PR DESCRIPTION
Fixes #5501

This removes line breaks and extra whitespace from translatable strings.

The plan is to:

1. Merge this to master
2. Cherry-pick it to `dev-v2.9`
3. Extract strings to pot file (now without line breaks)
4. Pull latest po files from Transifex
5. Run `ckan translation sync-msgids` so the po files get the new updated `msgids` without line breaks while we keep the existing translations
6. Push to Transifex and commit changes

