### PR TITLE
Action for current user to get id or details #5490

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1488,9 +1488,9 @@ def current_user_show(context, data_dict):
     model = context['model']
     # Get the current user that is making the request
     # raise NotAuthorized if the requestor is not found
-    requester = context.get('user')
-    if requester:
-        user_obj = model.User.get(requester)
+    requestor = context.get('user')
+    if requestor:
+        user_obj = model.User.get(requestor)
         context['user_obj'] = user_obj
     else:
         raise NotAuthorized

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1476,9 +1476,11 @@ def user_show(context, data_dict):
 
 def current_user_show(context, data_dict):
     '''Return user account of requestor
+
     :param include_details: Include details of the requstor.
         (optional, default:``False``)
     :type include_details: bool
+
     :returns: the id of the user. If include_details: true is passed
         then it will return the details of the user including email_hash,
         apikey and email. Excludes the password (hash) and reset_key.

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1474,6 +1474,42 @@ def user_show(context, data_dict):
     return user_dict
 
 
+def current_user_show(context, data_dict):
+    '''Return user account of requestor
+    :param include_details: Include a details of the requstor.
+        (optional, default:``False``)
+    :type include_details: bool
+    :returns: the id of the user. If include_details: true is passed
+        then it will return the details of the user including email_hash,
+        apikey and email. Excludes the password (hash) and reset_key.
+    :rtype: dictionary
+
+    '''
+    model = context['model']
+    # Get the current user that is making the request
+    # raise NotAuthorized if the requestor is not found
+    requester = context.get('user')
+    if requester:
+        user_obj = model.User.get(requester)
+        context['user_obj'] = user_obj
+    else:
+        raise NotAuthorized
+
+    _check_access('user_show', context, data_dict)
+
+    if not bool(user_obj):
+        raise NotFound
+
+    user_dict = model_dictize.user_dictize(
+        user_obj, context)
+    # Check if include_details is passed, default is False
+    include_details = asbool(
+        data_dict.get('include_details', False))
+    if not include_details:
+        user_dict = {'id': user_dict['id']}
+    return user_dict
+
+
 @logic.validate(logic.schema.default_autocomplete_schema)
 def package_autocomplete(context, data_dict):
     '''Return a list of datasets (packages) that match a string.

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1476,7 +1476,7 @@ def user_show(context, data_dict):
 
 def current_user_show(context, data_dict):
     '''Return user account of requestor
-    :param include_details: Include a details of the requstor.
+    :param include_details: Include details of the requstor.
         (optional, default:``False``)
     :type include_details: bool
     :returns: the id of the user. If include_details: true is passed
@@ -1497,6 +1497,7 @@ def current_user_show(context, data_dict):
 
     _check_access('user_show', context, data_dict)
 
+    # Raise Not Found if the requestor is not a valid user
     if not bool(user_obj):
         raise NotFound
 

--- a/ckan/tests/legacy/test_coding_standards.py
+++ b/ckan/tests/legacy/test_coding_standards.py
@@ -548,6 +548,7 @@ class TestActionAuth(object):
         "get: user_follower_count",
         "update: task_status_update_many",
         "update: term_translation_update_many",
+        "get: current_user_show",
     ]
 
     AUTH_NO_ACTION_BLACKLIST = [

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -1173,14 +1173,17 @@ class TestUserShow(object):
 
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 class TestCurrentUserShow(object):
-    def test_user_show_default_values(self):
+    def test_current_user_show_default_values(self):
+        """Test that calling current_user_show returns id only"""
 
+        # 1. Setup.
         user = factories.User()
-
+        # 2. Calling action with user
         got_user = helpers.call_action(
             "current_user_show",
             context={"user": user["name"]}
         )
+        # 3. Assertion to Validate Test
         assert got_user["id"] == user["id"]
         assert "name" not in got_user
         assert "fullname" not in got_user
@@ -1198,14 +1201,16 @@ class TestCurrentUserShow(object):
         assert "image_display_url" not in got_user
 
     def test_current_user_show_with_details(self):
+        """Test that calling current_user_show returns details"""
 
+        # 1. Setup.
         user = factories.User()
-
+        # 2. Calling action with include_details param
         got_user = helpers.call_action(
             "current_user_show", include_details=True,
             context={"user": user["name"]}
         )
-
+        # 3. Assertion to Validate Test
         assert got_user["name"] == user["name"]
         assert got_user["fullname"] == user["fullname"]
         assert got_user["created"] == user["created"]
@@ -1227,22 +1232,26 @@ class TestCurrentUserShow(object):
         assert "reset_key" not in got_user
 
     def test_current_user_show_no_password_hash(self):
+        """Test that calling current_user_show returns no password hash"""
 
+        # 1. Setup.
         user = factories.User()
-
+        # 2. Calling action with include_details param
         got_user = helpers.call_action(
             "current_user_show", include_details=True,
             context={"user": user["name"]}
         )
-
+        # 3. Assertion to Validate Test
         assert "password_hash" not in got_user
 
     def test_current_user_show_unauthorized(self):
+        """Test that calling current_user_show returns not authorized"""
 
         with pytest.raises(logic.NotAuthorized):
             helpers.call_action("current_user_show", context={'user':''})
 
     def test_current_user_show_not_found(self):
+        """Test that calling current_user_show returns not found"""
 
         with pytest.raises(logic.NotFound):
             helpers.call_action("current_user_show")

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -1171,6 +1171,82 @@ class TestUserShow(object):
         assert got_user["number_created_packages"] == 3
 
 
+@pytest.mark.usefixtures("clean_db", "with_request_context")
+class TestCurrentUserShow(object):
+    def test_user_show_default_values(self):
+
+        user = factories.User()
+
+        got_user = helpers.call_action(
+            "current_user_show",
+            context={"user": user["name"]}
+        )
+        assert got_user["id"] == user["id"]
+        assert "name" not in got_user
+        assert "fullname" not in got_user
+        assert "created" not in got_user
+        assert "about" not in got_user
+        assert "activity_streams_email_notifications" not in got_user
+        assert "sysadmin" not in got_user
+        assert "state" not in got_user
+        assert "image_url" not in got_user
+        assert "display_name" not in got_user
+        assert "email_hash" not in got_user
+        assert "number_created_packages" not in got_user
+        assert "apikey" not in got_user
+        assert "email" not in got_user
+        assert "image_display_url" not in got_user
+
+    def test_current_user_show_with_details(self):
+
+        user = factories.User()
+
+        got_user = helpers.call_action(
+            "current_user_show", include_details=True,
+            context={"user": user["name"]}
+        )
+
+        assert got_user["name"] == user["name"]
+        assert got_user["fullname"] == user["fullname"]
+        assert got_user["created"] == user["created"]
+        assert got_user["about"] == user["about"]
+        assert got_user["activity_streams_email_notifications"] \
+            == user["activity_streams_email_notifications"]
+        assert got_user["sysadmin"] == user["sysadmin"]
+        assert got_user["state"] == user["state"]
+        assert got_user["image_url"] == user["image_url"]
+        assert got_user["display_name"] == user["display_name"]
+        assert got_user["email_hash"] == user["email_hash"]
+        assert got_user["number_created_packages"] \
+            == user["number_created_packages"]
+        assert got_user["apikey"] == user["apikey"]
+        assert got_user["email"] == user["email"]
+        assert got_user["image_display_url"] == user["image_display_url"]
+        assert got_user["email"] == user["email"]
+        assert "password" not in got_user
+        assert "reset_key" not in got_user
+
+    def test_current_user_show_no_password_hash(self):
+
+        user = factories.User()
+
+        got_user = helpers.call_action(
+            "current_user_show", include_details=True,
+            context={"user": user["name"]}
+        )
+
+        assert "password_hash" not in got_user
+
+    def test_current_user_show_unauthorized(self):
+
+        with pytest.raises(logic.NotAuthorized):
+            helpers.call_action("current_user_show", context={'user':''})
+
+    def test_current_user_show_not_found(self):
+
+        with pytest.raises(logic.NotFound):
+            helpers.call_action("current_user_show")
+
 @pytest.mark.usefixtures("clean_db", "clean_index", "with_request_context")
 class TestCurrentPackageList(object):
     def test_current_package_list(self):

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -1248,13 +1248,14 @@ class TestCurrentUserShow(object):
         """Test that calling current_user_show returns not authorized"""
 
         with pytest.raises(logic.NotAuthorized):
-            helpers.call_action("current_user_show", context={'user':''})
+            helpers.call_action("current_user_show", context={'user': ''})
 
     def test_current_user_show_not_found(self):
         """Test that calling current_user_show returns not found"""
 
         with pytest.raises(logic.NotFound):
             helpers.call_action("current_user_show")
+
 
 @pytest.mark.usefixtures("clean_db", "clean_index", "with_request_context")
 class TestCurrentPackageList(object):


### PR DESCRIPTION
Fixes #5490

### Proposed fixes:
New Action that will return the id of the current logged in user or by API-KEY and can return details if `include_details` is passed explicitly.

### Steps to Test:-
http://{host}:5000/api/3/action/current_user_show - **Without  API-Key/Logged In (Should give Authorization Error)**
http://{host}:5000/api/3/action/current_user_show - **API-KEY/Logged In (Should return only id of user)**
http://{host}:5000/api/3/action/current_user_show?include_details=true - **API-KEY/Logged In (Should return details of user)**

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [x] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
