### PR TITLE
[uwsgi] set uwsgi buffer size from 4096 to 32768

### DIFF
--- a/ckan-uwsgi.ini
+++ b/ckan-uwsgi.ini
@@ -12,3 +12,4 @@ harakiri        =  50
 max-requests    =  5000
 vacuum          =  true
 callable        =  application
+buffer-size     =  32768


### PR DESCRIPTION
Fixes equivalent issue as https://github.com/okfn/docker-ckan/issues/50
Pull request here as requested in https://github.com/okfn/docker-ckan/pull/51

### Proposed fixes:

- ckan closes connection when request header size exceeds 4069 bytes when using uwsgi
- this can easily happen when requests include long cookies (e.g. oauth tokens) etc.
- max setting for buffer size would be 65535 bytes, see https://uwsgi-docs.readthedocs.io/en/latest/ThingsToKnow.html
- this is the same issue as okfn/docker-ckan repo https://github.com/okfn/docker-ckan/issues/50 and this fix should be equivalent to my pull request there which was already merged

Note that I did not test this in this repo, only in okfn/docker-ckan. It _should_ work though...
Steps to reproduce and test this are described in the issue https://github.com/okfn/docker-ckan/issues/50

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
