### PR TITLE
fix #4973 ignore non-existent search facets from query params

### DIFF
--- a/ckan/templates/snippets/search_form.html
+++ b/ckan/templates/snippets/search_form.html
@@ -56,7 +56,7 @@
   {% block search_facets %}
     {% if facets %}
       <p class="filter-list">
-        {% for field in facets.fields %}
+        {% for field in facets.fields if field in facets.titles %}
           {% set search_facets_items = facets.search.get(field)['items'] %}
           <span class="facet">{{ facets.titles.get(field) }}:</span>
           {% for value in facets.fields[field] %}


### PR DESCRIPTION
Fixes #4973 

### Proposed fixes:

It seems that in CKAN 2.9 the non-existent search field is ignored and does not affect the search results.

However, the non-existent label is still shown as `None` - so this is hidden in this PR.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
