### PR TITLE
Set host based on site_url on middleware

### DIFF
--- a/ckan/config/middleware/common_middleware.py
+++ b/ckan/config/middleware/common_middleware.py
@@ -5,11 +5,12 @@ import hashlib
 import cgi
 
 import six
-from six.moves.urllib.parse import unquote
+from six.moves.urllib.parse import unquote, urlparse
 
 import sqlalchemy as sa
 from webob.request import FakeCGIBody
 
+from ckan.common import config
 from ckan.lib.i18n import get_locales_from_config
 
 
@@ -108,5 +109,7 @@ class HostHeaderMiddleware(object):
         if path_info in ['/login_generic', '/user/login',
                          '/user/logout', '/user/logged_in',
                          '/user/logged_out']:
-            environ.pop('HTTP_HOST', None)
+            site_url = config.get('ckan.site_url')
+            parts = urlparse(site_url)
+            environ['HTTP_HOST'] = parts.netloc
         return self.app(environ, start_response)


### PR DESCRIPTION
The recently introduced HostHeaderMiddleware used to remove the `HTTP_HOST` key completely. But that breaks setups where CKAN (uWSGI) is sitting behind a reverse proxy like Nginx, as the redirect is then issued to the internal CKAN host (eg localhost:8080)
