### PR TITLE
Support ckan.ini by default in the CLI

### DIFF
--- a/ckan/cli/__init__.py
+++ b/ckan/cli/__init__.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+import sys
 import os
 
 import click
@@ -75,21 +76,30 @@ def load_config(ini_path=None):
         config_source = u'$CKAN_INI'
     else:
         # deprecated method since CKAN 2.9
-        default_filename = u'development.ini'
-        filename = os.path.join(os.getcwd(), default_filename)
-        if not os.path.exists(filename):
+        default_filenames = [u'ckan.ini', u'development.ini']
+        filename = None
+        for default_filename in default_filenames:
+            check_file = os.path.join(os.getcwd(), default_filename)
+            if os.path.exists(check_file):
+                filename = check_file
+                break
+        if not filename:
             # give really clear error message for this common situation
-            msg = u'ERROR: You need to specify the CKAN config (.ini) '\
-                u'file path.'\
-                u'\nUse the --config parameter or set environment ' \
-                u'variable CKAN_INI or have {}\nin the current directory.' \
-                .format(default_filename)
-            raise CkanConfigurationException(msg)
+            msg = u'''
+ERROR: You need to specify the CKAN config (.ini) file path.
+
+Use the --config parameter or set environment variable CKAN_INI
+or have one of {} in the current directory.'''.format(
+        ', '.join(default_filenames))
+            error_shout(msg)
+            sys.exit(1)
 
     if not os.path.exists(filename):
         msg = u'Config file not found: %s' % filename
         msg += u'\n(Given by: %s)' % config_source
-        raise CkanConfigurationException(msg)
+        error_shout(msg)
+        sys.exit(1)
+
     config_loader = CKANConfigLoader(filename)
     loggingFileConfig(filename)
     log.info(u'Using configuration file {}'.format(filename))


### PR DESCRIPTION
Starting from 2.9 we changed the docs to use `ckan.ini` as config file name consistently everywhere, but the CLI still defaults to a `development.ini` file in the same folder. We probably haven't noticed because all our local ini files are named `development.ini`. 
This adds support for both file names for better compatibility.

Also fixes the way in which errors are displayed, as the errors where not showing up on the console.
