### PR TITLE
Move USER root up in Dockerfile

### DIFF
--- a/contrib/docker/solr/Dockerfile
+++ b/contrib/docker/solr/Dockerfile
@@ -1,6 +1,8 @@
 FROM solr:6.6.5
 MAINTAINER Open Knowledge
 
+USER root
+
 # Enviroment
 ENV SOLR_CORE ckan
 
@@ -23,7 +25,6 @@ RUN echo name=$SOLR_CORE > /opt/solr/server/solr/$SOLR_CORE/core.properties
 
 # Giving ownership to Solr
 
-USER root
 RUN chown -R $SOLR_USER:$SOLR_USER /opt/solr/server/solr/$SOLR_CORE
 
 # User


### PR DESCRIPTION
Fixes this build error
```
/bin/sh: 1: cannot create /opt/solr/server/solr/ckan/core.properties: Permission denied
The command '/bin/sh -c echo name=$SOLR_CORE > /opt/solr/server/solr/$SOLR_CORE/core.properties' returned a non-zero code: 2
```

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
