### PR TITLE
add jinja2 loop control extensions

### DIFF
--- a/ckan/lib/jinja_extensions.py
+++ b/ckan/lib/jinja_extensions.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 
 
 def _get_extensions():
-    return ['jinja2.ext.do', 'jinja2.ext.with_',
+    return ['jinja2.ext.do', 'jinja2.ext.loopcontrols',
             SnippetExtension,
             CkanExtend,
             CkanInternationalizationExtension,


### PR DESCRIPTION
Fixes #
break and continue are not supported in jinja templates.

### Proposed fixes:
Add jinja2.ext.loopcontrols :  support for break and continue in loops.
[https://jinja.palletsprojects.com/en/2.11.x/extensions/#loop-controls](https://jinja.palletsprojects.com/en/2.11.x/extensions/#loop-controls)

Remove jinja2.ext.with_ : now built-in and no longer does anything. (changed in version 2.9)
[https://jinja.palletsprojects.com/en/2.11.x/extensions/#with-statement](https://jinja.palletsprojects.com/en/2.11.x/extensions/#with-statement)


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
