### PR TITLE
DataPusher fixes for 2.9

### DIFF
--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -151,9 +151,11 @@ def datapusher_submit(context, data_dict):
         raise p.toolkit.ValidationError(error)
 
     except requests.exceptions.HTTPError as e:
-        m = 'An Error occurred while sending the job: {0}'.format(e.message)
+        m = 'An Error occurred while sending the job: {0}'.format(str(e))
         try:
             body = e.response.json()
+            if body.get('error'):
+                m += ' ' + body['error']
         except ValueError:
             body = e.response.text
         error = {'message': m,

--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -121,6 +121,9 @@ def datapusher_submit(context, data_dict):
     context['ignore_auth'] = True
     p.toolkit.get_action('task_status_update')(context, task)
 
+    site_user = p.toolkit.get_action(
+        'get_site_user')({'ignore_auth': True}, {})
+
     try:
         r = requests.post(
             urljoin(datapusher_url, 'job'),
@@ -128,7 +131,7 @@ def datapusher_submit(context, data_dict):
                 'Content-Type': 'application/json'
             },
             data=json.dumps({
-                'api_key': user['apikey'],
+                'api_key': site_user['apikey'],
                 'job_type': 'push_to_datastore',
                 'result_url': callback_url,
                 'metadata': {


### PR DESCRIPTION
Two fixes:

* Replace py2-only syntax for exception handling
* Use site user API key to send DataPusher job

The second one is the one worth discussing. As we recently did changes in the way API keys are created in #5488, by default users don't have an API key created so services can no longer rely on users having one.
We can think of a more generic solution for this (like creating a token for them) but for now it makes sense to use the site user API key, which as of now always has an API key. I checked and Xloader uses the same approach.

