### PR TITLE
Conditianally allow missing config in CLI

### DIFF
--- a/ckan/cli/__init__.py
+++ b/ckan/cli/__init__.py
@@ -91,14 +91,12 @@ ERROR: You need to specify the CKAN config (.ini) file path.
 Use the --config parameter or set environment variable CKAN_INI
 or have one of {} in the current directory.'''.format(
         ', '.join(default_filenames))
-            error_shout(msg)
-            sys.exit(1)
+            raise CkanConfigurationException(msg)
 
     if not os.path.exists(filename):
         msg = u'Config file not found: %s' % filename
         msg += u'\n(Given by: %s)' % config_source
-        error_shout(msg)
-        sys.exit(1)
+        raise CkanConfigurationException(msg)
 
     config_loader = CKANConfigLoader(filename)
     loggingFileConfig(filename)

--- a/ckan/cli/cli.py
+++ b/ckan/cli/cli.py
@@ -93,7 +93,7 @@ def _init_ckan_config(ctx, param, value):
         if no_config or is_help:
             return
         else:
-            log.warn(u'Configuration not loaded: %s', e)
+            p.toolkit.error_shout(e)
             raise click.Abort()
 
     if six.PY2:


### PR DESCRIPTION
Changes a bit way of reporting errors from #5516. Instead of using `exit` immediately, throw an exception, which will be caught inside the decorator, that provides config object for CLI commands. Thus, two problems will be solved:

* we can potentially write tests for CLI and intentionally skip config file. Using `exit` interrupts test while raising an exception naturally works as a part of a test workflow
* `config-tool` and `generate` branches work without `--config` parameter.