### PR TITLE
add user_patch action, allow sysadmins to be managed via the web frontend

### DIFF
--- a/ckan/logic/action/patch.py
+++ b/ckan/logic/action/patch.py
@@ -138,3 +138,33 @@ def organization_patch(context, data_dict):
     patched.pop('display_name', None)
     patched.update(data_dict)
     return _update.organization_update(context, patched)
+
+
+def user_patch(context, data_dict):
+    '''Patch a user
+
+    :param id: the id or name of the user
+    :type id: string
+
+    The difference between the update and patch methods is that the patch will
+    perform an update of the provided parameters, while leaving all other
+    parameters unchanged, whereas the update methods deletes all parameters
+    not explicitly provided in the data_dict
+    '''
+    _check_access('user_patch', context, data_dict)
+
+    show_context = {
+        'model': context['model'],
+        'session': context['session'],
+        'user': context['user'],
+        'auth_user_obj': context['auth_user_obj'],
+    }
+
+    user_dict = _get_action('user_show')(
+        show_context,
+        {'id': _get_or_bust(data_dict, 'id')})
+
+    patched = dict(user_dict)
+    patched.pop('display_name', None)
+    patched.update(data_dict)
+    return _update.user_update(context, patched)

--- a/ckan/logic/auth/patch.py
+++ b/ckan/logic/auth/patch.py
@@ -17,3 +17,7 @@ def group_patch(context, data_dict):
 
 def organization_patch(context, data_dict):
     return authz.is_authorized('organization_update', context, data_dict)
+
+
+def user_patch(context, data_dict):
+    return authz.is_authorized('user_update', context, data_dict)

--- a/ckan/templates/admin/index.html
+++ b/ckan/templates/admin/index.html
@@ -13,11 +13,11 @@
     <tbody>
       {% for user in sysadmins %}
         <tr>
-          <td>{{ h.linked_user(user.name) }}</td>
+          <td>{{ h.linked_user(user) }}</td>
           <td>
             <div class="btn-group pull-right">
               <form method="POST" action="{% url_for 'user.sysadmin' %}">
-                <input type="hidden" value="{{ user.id }}" name="id" />
+                <input type="hidden" value="{{ user }}" name="username" />
                 <input type="hidden" value="0" name="status" />
                 <button
                   type="submit"
@@ -43,12 +43,11 @@
       <div class="col-md-6">
 
         <div class="form-group">
-          <select name="id" id="promote-userid" required="required" style="width: 100%">
-            <option value=""></option>
-            {% for user in all_users %}
-              <option value="{{ user.id }}">{{ user.display_name }}</option>
-            {% endfor %}
-          </select>
+          <input
+            id="promote-username" type="text" name="username" placeholder="Username"
+            value="" class="control-medium" data-module="autocomplete"
+            data-module-source="/api/2/util/user/autocomplete?ignore_self=true&q=?"
+          >
           <input type="hidden" value="1" name="status" />
         </div>
 
@@ -63,15 +62,6 @@
       </div>
     </div>
   </form>
-
-  <script>
-  document.addEventListener("DOMContentLoaded", function(event) {
-    $('#promote-userid')
-      .select2({
-        placeholder: "{{ _('Click or start typing a user name') }}",
-      });
-  });
-  </script>
 {% endblock %}
 
 {% block secondary_content %}

--- a/ckan/templates/admin/index.html
+++ b/ckan/templates/admin/index.html
@@ -1,12 +1,12 @@
 {% extends "admin/base.html" %}
 
 {% block primary_content_inner %}
-  <h2>Current Sysadmins</h2>
+  <h2>{{ _('Current Sysadmins') }}</h2>
 
   <table class="table table-header table-hover table-bordered">
     <thead>
       <tr>
-        <th>User</th>
+        <th>{{ _('User') }}</th>
         <th>&nbsp;</th>
       </tr>
     </thead>
@@ -22,7 +22,7 @@
                 <button
                   type="submit"
                   class="btn btn-danger btn-sm"
-                  title="Revoke Sysadmin permission"
+                  title="{{ _('Revoke Sysadmin permission') }}"
                 >
                   <i class="fa fa-times"></i>
                 </button>
@@ -36,7 +36,7 @@
 
   <hr />
 
-  <h2>Promote user to Sysadmin</h2>
+  <h2>{{ _('Promote user to Sysadmin') }}</h2>
 
   <form method="POST" action="{% url_for 'user.sysadmin' %}">
     <div class="row">
@@ -56,8 +56,8 @@
           <button
             type="submit"
             class="btn btn-primary"
-            title="Promote user to Sysadmin"
-          >Promote</button>
+            title="{{ _('Promote user to Sysadmin') }}"
+          >{{ _('Promote') }}</button>
         </div>
 
       </div>
@@ -68,7 +68,7 @@
   document.addEventListener("DOMContentLoaded", function(event) {
     $('#promote-userid')
       .select2({
-        placeholder: 'Click or start typing a user name',
+        placeholder: "{{ _('Click or start typing a user name') }}",
       });
   });
   </script>

--- a/ckan/templates/admin/index.html
+++ b/ckan/templates/admin/index.html
@@ -1,11 +1,77 @@
 {% extends "admin/base.html" %}
 
 {% block primary_content_inner %}
-  <ul class="user-list">
-    {% for user in sysadmins %}
-      <li>{{ h.linked_user(user) }}</li>
-    {% endfor %}
-  </ul>
+  <h2>Current Sysadmins</h2>
+
+  <table class="table table-header table-hover table-bordered">
+    <thead>
+      <tr>
+        <th>User</th>
+        <th>&nbsp;</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for user in sysadmins %}
+        <tr>
+          <td>{{ h.linked_user(user.name) }}</td>
+          <td>
+            <div class="btn-group pull-right">
+              <form method="POST" action="{% url_for 'user.sysadmin' %}">
+                <input type="hidden" value="{{ user.id }}" name="id" />
+                <input type="hidden" value="0" name="status" />
+                <button
+                  type="submit"
+                  class="btn btn-danger btn-sm"
+                  title="Revoke Sysadmin permission"
+                >
+                  <i class="fa fa-times"></i>
+                </button>
+              </form>
+            </div>
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  <hr />
+
+  <h2>Promote user to Sysadmin</h2>
+
+  <form method="POST" action="{% url_for 'user.sysadmin' %}">
+    <div class="row">
+      <div class="col-md-6">
+
+        <div class="form-group">
+          <select name="id" id="promote-userid" required="required" style="width: 100%">
+            <option value=""></option>
+            {% for user in all_users %}
+              <option value="{{ user.id }}">{{ user.display_name }}</option>
+            {% endfor %}
+          </select>
+          <input type="hidden" value="1" name="status" />
+        </div>
+
+        <div class="form-actions">
+          <button
+            type="submit"
+            class="btn btn-primary"
+            title="Promote user to Sysadmin"
+          >Promote</button>
+        </div>
+
+      </div>
+    </div>
+  </form>
+
+  <script>
+  document.addEventListener("DOMContentLoaded", function(event) {
+    $('#promote-userid')
+      .select2({
+        placeholder: 'Click or start typing a user name',
+      });
+  });
+  </script>
 {% endblock %}
 
 {% block secondary_content %}

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -842,6 +842,66 @@ class TestUser(object):
 
         assert "Error sending the email" in response
 
+    def test_sysadmin_not_authorized(self, app):
+        user = factories.User()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        app.post(
+            url_for("user.sysadmin"),
+            data={'id': user['id'], 'status': '1'},
+            extra_environ=env,
+            status=403
+        )
+
+    def test_sysadmin_invalid_user(self, app):
+        user = factories.Sysadmin()
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+        app.post(
+            url_for("user.sysadmin"),
+            data={'id': 'fred', 'status': '1'},
+            extra_environ=env,
+            status=404
+        )
+
+    def test_sysadmin_promote_success(self, app):
+        admin = factories.Sysadmin()
+        env = {'REMOTE_USER': admin['name'].encode('ascii')}
+
+        # create a normal user
+        user = factories.User(fullname='Alice')
+
+        # promote them
+        resp = app.post(
+            url_for("user.sysadmin"),
+            data={'id': user['id'], 'status': '1'},
+            extra_environ=env,
+            status=200
+        )
+        assert 'Promoted Alice to sysadmin' in resp.body
+
+        # now they are a sysadmin
+        userobj = model.User.get(user['id'])
+        assert userobj.sysadmin
+
+    def test_sysadmin_revoke_success(self, app):
+        admin = factories.Sysadmin()
+        env = {'REMOTE_USER': admin['name'].encode('ascii')}
+
+        # create another sysadmin
+        user = factories.Sysadmin(fullname='Bob')
+
+        # revoke their status
+        resp = app.post(
+            url_for("user.sysadmin"),
+            data={'id': user['id'], 'status': '0'},
+            extra_environ=env,
+            status=200
+        )
+        assert 'Revoked sysadmin permission from Bob' in resp.body
+
+        # now they are not a sysadmin any more
+        userobj = model.User.get(user['id'])
+        assert not userobj.sysadmin
+
 
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 class TestUserImage(object):

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -847,7 +847,7 @@ class TestUser(object):
         env = {'REMOTE_USER': user['name'].encode('ascii')}
         app.post(
             url_for("user.sysadmin"),
-            data={'id': user['id'], 'status': '1'},
+            data={'username': user['name'], 'status': '1'},
             extra_environ=env,
             status=403
         )
@@ -857,7 +857,7 @@ class TestUser(object):
         env = {'REMOTE_USER': user['name'].encode('ascii')}
         app.post(
             url_for("user.sysadmin"),
-            data={'id': 'fred', 'status': '1'},
+            data={'username': 'fred', 'status': '1'},
             extra_environ=env,
             status=404
         )
@@ -872,7 +872,7 @@ class TestUser(object):
         # promote them
         resp = app.post(
             url_for("user.sysadmin"),
-            data={'id': user['id'], 'status': '1'},
+            data={'username': user['name'], 'status': '1'},
             extra_environ=env,
             status=200
         )
@@ -892,7 +892,7 @@ class TestUser(object):
         # revoke their status
         resp = app.post(
             url_for("user.sysadmin"),
-            data={'id': user['id'], 'status': '0'},
+            data={'username': user['name'], 'status': '0'},
             extra_environ=env,
             status=200
         )

--- a/ckan/tests/logic/action/test_patch.py
+++ b/ckan/tests/logic/action/test_patch.py
@@ -121,3 +121,24 @@ class TestPatch(object):
 
         assert organization2["name"] == "economy"
         assert organization2["description"] == "somethingnew"
+
+    def test_user_patch_updating_single_field(self):
+        user = factories.User(
+            fullname="Mr. Test User",
+            about="Just another test user.",
+        )
+
+        user = helpers.call_action(
+            "user_patch",
+            id=user["id"],
+            about="somethingnew",
+            context={"user": user["name"]},
+        )
+
+        assert user["fullname"] == "Mr. Test User"
+        assert user["about"] == "somethingnew"
+
+        user2 = helpers.call_action("user_show", id=user["id"])
+
+        assert user2["fullname"] == "Mr. Test User"
+        assert user2["about"] == "somethingnew"

--- a/ckan/views/admin.py
+++ b/ckan/views/admin.py
@@ -60,8 +60,12 @@ def before_request():
 
 
 def index():
-    data = dict(sysadmins=[a.name for a in _get_sysadmins()])
-    return base.render(u'admin/index.html', extra_vars=data)
+    context = {u'user': g.user}
+    users = logic.get_action(u'user_list')(context, {})
+    return base.render(u'admin/index.html', {
+        u'sysadmins': [u for u in users if u[u'sysadmin']],
+        u'all_users': [u for u in users if not u[u'sysadmin']],
+    })
 
 
 class ResetConfigView(MethodView):
@@ -200,7 +204,9 @@ class TrashView(MethodView):
         return h.redirect_to(u'admin.trash')
 
 
-admin.add_url_rule(u'/', view_func=index, strict_slashes=False)
+admin.add_url_rule(
+    u'/', view_func=index, methods=['GET'], strict_slashes=False
+)
 admin.add_url_rule(u'/reset_config',
                    view_func=ResetConfigView.as_view(str(u'reset_config')))
 admin.add_url_rule(u'/config', view_func=ConfigView.as_view(str(u'config')))

--- a/ckan/views/admin.py
+++ b/ckan/views/admin.py
@@ -60,12 +60,8 @@ def before_request():
 
 
 def index():
-    context = {u'user': g.user}
-    users = logic.get_action(u'user_list')(context, {})
-    return base.render(u'admin/index.html', {
-        u'sysadmins': [u for u in users if u[u'sysadmin']],
-        u'all_users': [u for u in users if not u[u'sysadmin']],
-    })
+    data = dict(sysadmins=[a.name for a in _get_sysadmins()])
+    return base.render(u'admin/index.html', extra_vars=data)
 
 
 class ResetConfigView(MethodView):

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -829,18 +829,23 @@ def sysadmin():
         data_dict = {u'id': id_, u'sysadmin': status}
         user = logic.get_action(u'user_patch')(context, data_dict)
     except logic.NotAuthorized:
-        return base.abort(403, u'Not authorized to promote user to sysadmin')
+        return base.abort(
+            403,
+            _(u'Not authorized to promote user to sysadmin')
+        )
     except logic.NotFound:
-        return base.abort(404, u'User not found')
+        return base.abort(404, _(u'User not found'))
 
     if status:
         h.flash_success(
-            u'Promoted {} to sysadmin'.format(user[u'display_name'])
+            _(u'Promoted {} to sysadmin'.format(user[u'display_name']))
         )
     else:
         h.flash_success(
-            u'Revoked sysadmin permission from {}'.format(
-                user[u'display_name']
+            _(
+                u'Revoked sysadmin permission from {}'.format(
+                    user[u'display_name']
+                )
             )
         )
     return h.redirect_to(u'admin.index')

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -815,6 +815,37 @@ def followers(id):
     return base.render(u'user/followers.html', extra_vars)
 
 
+def sysadmin():
+    id_ = request.form.get(u'id')
+    status = asbool(request.form.get(u'status'))
+
+    try:
+        context = {
+            u'model': model,
+            u'session': model.Session,
+            u'user': g.user,
+            u'auth_user_obj': g.userobj,
+        }
+        data_dict = {u'id': id_, u'sysadmin': status}
+        user = logic.get_action(u'user_patch')(context, data_dict)
+    except logic.NotAuthorized:
+        return base.abort(403, u'Not authorized to promote user to sysadmin')
+    except logic.NotFound:
+        return base.abort(404, u'User not found')
+
+    if status:
+        h.flash_success(
+            u'Promoted {} to sysadmin'.format(user[u'display_name'])
+        )
+    else:
+        h.flash_success(
+            u'Revoked sysadmin permission from {}'.format(
+                user[u'display_name']
+            )
+        )
+    return h.redirect_to(u'admin.index')
+
+
 user.add_url_rule(u'/', view_func=index, strict_slashes=False)
 user.add_url_rule(u'/me', view_func=me)
 
@@ -858,3 +889,4 @@ user.add_url_rule(
     u'/<id>/api-tokens/<jti>/revoke', view_func=api_token_revoke,
     methods=(u'POST',)
 )
+user.add_url_rule(rule=u'/sysadmin', view_func=sysadmin, methods=['POST'])

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -816,7 +816,7 @@ def followers(id):
 
 
 def sysadmin():
-    id_ = request.form.get(u'id')
+    username = request.form.get(u'username')
     status = asbool(request.form.get(u'status'))
 
     try:
@@ -826,7 +826,7 @@ def sysadmin():
             u'user': g.user,
             u'auth_user_obj': g.userobj,
         }
-        data_dict = {u'id': id_, u'sysadmin': status}
+        data_dict = {u'id': username, u'sysadmin': status}
         user = logic.get_action(u'user_patch')(context, data_dict)
     except logic.NotAuthorized:
         return base.abort(


### PR DESCRIPTION
At the moment it is only possible to manage sysadmins via the CLI

This PR adds a `user_patch` action and permits a sysadmin to promote other users to sysadmin or revoke sysadmin permissions from a user without needing console access.

### Features:

- [x] includes tests covering changes
- [x] includes updated documentation (yes: docstring for action function)
- [x] includes user-visible changes
- [x] includes API changes
- [ ] includes bugfix for possible backport
