### PR TITLE
Add aria tag to the link to remove search filter

### DIFF
--- a/ckan/templates/snippets/search_form.html
+++ b/ckan/templates/snippets/search_form.html
@@ -61,12 +61,14 @@
           <span class="facet">{{ facets.titles.get(field) }}:</span>
           {% for value in facets.fields[field] %}
             <span class="filtered pill">
-              {%- if facets.translated_fields and (field,value) in facets.translated_fields -%}
-                {{ facets.translated_fields[(field,value)] }}
-              {%- else -%}
-                {{ h.list_dict_filter(search_facets_items, 'name', 'display_name', value) }}
-              {%- endif %}
-              <a href="{{ facets.remove_field(field, value) }}" class="remove" title="{{ _('Remove') }}"><i class="fa fa-times"></i></a>
+              <span id="filter-name">
+                {%- if facets.translated_fields and (field,value) in facets.translated_fields -%}
+                  {{ facets.translated_fields[(field,value)] }}
+                {%- else -%}
+                  {{ h.list_dict_filter(search_facets_items, 'name', 'display_name', value) }}
+                {%- endif %}
+              </span>
+              <a href="{{ facets.remove_field(field, value) }}" class="remove" title="{{ _('Remove Filter') }}" aria-describedby="filter-name"><i class="fa fa-times"></i></a>
             </span>
           {% endfor %}
         {% endfor %}


### PR DESCRIPTION
### Issue:
Empty link error to remove filter(s) on dataset search result page.
![capture](https://user-images.githubusercontent.com/24879621/89681448-f5f5c080-d8c2-11ea-9e50-7ebf836dac05.png)

### Proposed fix:
Added a aria label to the link so that the screen reader will tell what filter to remove.

### Features:
- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply