### PR TITLE
Documentation:   update "Getting Started" page

### DIFF
--- a/doc/maintaining/getting-started.rst
+++ b/doc/maintaining/getting-started.rst
@@ -79,7 +79,7 @@ command line with the following ``seed`` commands:
 If you later want to delete this test data and start again with an empty
 database, you can use the :ref:`db clean <db clean>` command.
 
-For a list of other command line commands for creating tests data, run:
+For a short description of these seed subcommands for creating test data, run:
 
 .. parsed-literal::
 

--- a/doc/maintaining/getting-started.rst
+++ b/doc/maintaining/getting-started.rst
@@ -79,7 +79,7 @@ command line with the following ``seed`` commands:
 If you later want to delete this test data and start again with an empty
 database, you can use the :ref:`db clean <db clean>` command.
 
-For a list of other command line commands for creating tests data, run::
+For a list of other command line commands for creating tests data, run:
 
 .. parsed-literal::
 

--- a/doc/maintaining/getting-started.rst
+++ b/doc/maintaining/getting-started.rst
@@ -46,9 +46,11 @@ Or, if you already have an existing user, you could promote him to a sysadmin:
 
    ckan -c |ckan.ini| sysadmin add seanh
 
-For a list of other command line commands for managing sysadmins, run::
+For a list of other command line commands for managing sysadmins, run:
 
- ckan -c |ckan.ini| sysadmin --help
+.. parsed-literal::
+
+   ckan -c |ckan.ini| sysadmin --help
 
 Read the :doc:`/sysadmin-guide` to learn what you can do as a
 CKAN sysadmin.
@@ -61,18 +63,27 @@ Creating test data
 
 It can be handy to have some test data to start with, to quickly check that
 everything works. You can add a standard set of test data to your site from the
-command line with the ``create-test-data`` command:
+command line with the following ``seed`` commands:
 
 .. parsed-literal::
 
-   ckan -c |ckan.ini| create-test-data
+   ckan -c |ckan.ini| seed basic
+   ckan -c |ckan.ini| seed family
+   ckan -c |ckan.ini| seed gov
+   ckan -c |ckan.ini| seed hierarchy
+   ckan -c |ckan.ini| seed search
+   ckan -c |ckan.ini| seed translations
+   ckan -c |ckan.ini| seed user
+   ckan -c |ckan.ini| seed vocabs
 
 If you later want to delete this test data and start again with an empty
 database, you can use the :ref:`db clean <db clean>` command.
 
 For a list of other command line commands for creating tests data, run::
 
- ckan -c |ckan.ini| create-test-data --help
+.. parsed-literal::
+
+   ckan -c |ckan.ini| seed --help
 
 -----------
 Config file


### PR DESCRIPTION
Fixes the CKAN 2.9 Getting Started documentation page

### Proposed fixes:
The CKAN "Getting Started" page had references to pre CKAN 2.9 commands for creating test data. This has been updated to CKAN 2.9 commands.

The documentation changes have been tested with building the HTML pages using sphinx


### Features:

- [ ] includes tests covering changes
- [X ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
