### PR TITLE
Upgrade Click

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@
 
 beautifulsoup4==4.9.1
 coveralls   #Let Unpinned - Requires latest coveralls
-docutils==0.12
+docutils==0.16
 factory-boy==2.12.0
 Flask-DebugToolbar==0.11.0
 freezegun==0.3.15

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@
 
 beautifulsoup4==4.9.1
 coveralls   #Let Unpinned - Requires latest coveralls
-docutils==0.16
+docutils==0.12
 factory-boy==2.12.0
 Flask-DebugToolbar==0.11.0
 freezegun==0.3.15

--- a/requirements-py2.in
+++ b/requirements-py2.in
@@ -3,7 +3,7 @@
 alembic==1.0.0
 Babel==2.7.0
 bleach==3.1.4
-click==6.7
+click==7.1.2
 dominate==2.4.0
 fanstatic==0.12
 feedgen==0.9.0

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -10,7 +10,7 @@ beaker==1.10.1            # via pylons
 bleach==3.1.4
 certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
-click==6.7
+click==7.1.2
 decorator==4.4.0          # via pylons, sqlalchemy-migrate
 dominate==2.4.0
 fanstatic==0.12

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ alembic==1.0.0
 Babel==2.7.0
 Beaker==1.11.0
 bleach==3.1.4
-click==6.7
+click==7.1.2
 dominate==2.4.0
 fanstatic==1.1
 feedgen==0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ beaker==1.11.0
 bleach==3.1.4
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
-click==6.7
+click==7.1.2
 decorator==4.4.1          # via sqlalchemy-migrate
 dominate==2.4.0
 fanstatic==1.1


### PR DESCRIPTION
Right now we have two conflicts after installing `dev-requirements.txt`:
```
pip-tools 5.1.2 requires click>=7, but you'll have click 6.7 which is incompatible.
cookiecutter 1.7.0 requires click>=7.0, but you'll have click 6.7 which is incompatible.
```

Click is upgraded to the latest stable version in this PR and [here](https://github.com/pallets/click/blob/master/CHANGES.rst) one can find release notes

