### PR TITLE
Correctly unflatten extras

### DIFF
--- a/ckan/logic/converters.py
+++ b/ckan/logic/converters.py
@@ -26,14 +26,24 @@ def convert_to_extras(key, data, errors, context):
 
 def convert_from_extras(key, data, errors, context):
 
-    def remove_from_extras(data, key):
-        to_remove = []
-        for data_key, data_value in six.iteritems(data):
-            if (data_key[0] == 'extras'
-                and data_key[1] == key):
-                to_remove.append(data_key)
-        for item in to_remove:
-            del data[item]
+    def remove_from_extras(data, idx):
+        for key in sorted(data):
+            if key[0] != 'extras' or key[1] < idx:
+                continue
+            if key[1] == idx:
+                del data[key]
+
+            # Following block required for unflattening extras with
+            # "gaps" created sometimes by `convert_from_extra`
+            # validator :
+            #
+            #   {
+            #     ('extras', 0, 'key'): 'x',
+            #     ('extras', 2, 'key): 'y'
+            #   }
+            if key[1] > idx:
+                new_key = (key[0], key[1] - 1) + key[2:]
+                data[new_key] = data.pop(key)
 
     for data_key, data_value in six.iteritems(data):
         if (data_key[0] == 'extras'

--- a/ckanext/example_idatasetform/plugin_v5.py
+++ b/ckanext/example_idatasetform/plugin_v5.py
@@ -30,7 +30,9 @@ class ExampleIDatasetFormPlugin(p.SingletonPlugin, tk.DefaultDatasetForm):
         schema = super(ExampleIDatasetFormPlugin, self).show_package_schema()
         schema.update({
             u'custom_text': [tk.get_converter(u'convert_from_extras'),
-                             tk.get_validator(u'ignore_missing')]
+                             tk.get_validator(u'ignore_missing')],
+            u'custom_text_2': [tk.get_converter(u'convert_from_extras'),
+                               tk.get_validator(u'ignore_missing')],
         })
         return schema
 

--- a/ckanext/example_idatasetform/tests/test_example_idatasetform.py
+++ b/ckanext/example_idatasetform/tests/test_example_idatasetform.py
@@ -79,6 +79,22 @@ class TestVersion5(object):
             url_for("fancy_type.edit", id="check") == "/fancy_type/edit/check"
         )
 
+    def test_custom_field_with_extras(self):
+        dataset = factories.Dataset(
+            type='fancy_type',
+            name='test-dataset',
+            custom_text='custom-text',
+            extras=[
+                {'key': 'key1', 'value': 'value1'},
+                {'key': 'key2', 'value': 'value2'},
+            ]
+        )
+        assert dataset['custom_text'] == 'custom-text'
+        assert dataset['extras'] == [
+            {'key': 'key1', 'value': 'value1'},
+            {'key': 'key2', 'value': 'value2'},
+        ]
+
 
 @pytest.mark.ckan_config("ckan.plugins", u"example_idatasetform_v5")
 @pytest.mark.ckan_config("package_edit_return_url", None)

--- a/ckanext/example_idatasetform/tests/test_example_idatasetform.py
+++ b/ckanext/example_idatasetform/tests/test_example_idatasetform.py
@@ -95,6 +95,24 @@ class TestVersion5(object):
             {'key': 'key2', 'value': 'value2'},
         ]
 
+    def test_mixed_extras(self):
+        dataset = factories.Dataset(
+            type='fancy_type',
+            name='test-dataset',
+            custom_text='custom-text',
+            extras=[
+                {'key': 'key1', 'value': 'value1'},
+                {'key': 'custom_text_2', 'value': 'custom-text-2'},
+                {'key': 'key2', 'value': 'value2'},
+            ],
+        )
+        assert dataset['custom_text'] == 'custom-text'
+        assert dataset['custom_text_2'] == 'custom-text-2'
+        assert dataset['extras'] == [
+            {'key': 'key1', 'value': 'value1'},
+            {'key': 'key2', 'value': 'value2'},
+        ]
+
 
 @pytest.mark.ckan_config("ckan.plugins", u"example_idatasetform_v5")
 @pytest.mark.ckan_config("package_edit_return_url", None)


### PR DESCRIPTION
Fixes #5537 . Some degree of luck required for getting this error

One need `convert_from_extras` in order to reproduce it. Imagine dataset, created with following extras:
```python
package_create({..., extras=[
  {'key': 'a', 'value': '1'},
  {'key': 'b', 'value': '2'},
  {'key': 'c', 'value': '3'},
], ...}).
```
After flattening it looks like 
```python
{ ...,
  ('extras', 0, 'key'): 'a', ('extras', 0, 'value'): 1,
  ('extras', 1, 'key'): 'b', ('extras', 1, 'value'): 2,
  ('extras', 2, 'key'): 'c', ('extras', 2, 'value'): 3,
...}
```

If **only** `b` field have `convert_from_extras`, it will be converted to the following form with "gap" between **0** and **2**:
```python
{ ...,
  ('b',): 2,
  ('extras', 0, 'key'): 'a', ('extras', 0, 'value'): 1,
  ('extras', 2, 'key'): 'c', ('extras', 2, 'value'): 3,
...}
```

Afterward, [because of these lines](https://github.com/ckan/ckan/blob/master/ckan/lib/navl/dictization_functions.py#L416-L419) extra **2** will be unflattened into a broken form:
```python
{..., 
  "b": 2, 
  "extras": [
    {'key': 'a', 'value': '1'},
    {'key': 'c'},
    {'value': '3'},
  ], 
...}
```

Fixing this issue during unflattening will turn into an unnecessary complex block of code with a number of contradictory places, so I suggest "realigning" extras when they are updated by `convert_from_extras`. The example above will be converted to the following form when **b** property extracted from extras(the gap is fixed by shifting all the extras that follow this gap one position back):
```python
{ ...,
  ('b',): 2,
  ('extras', 0, 'key'): 'a', ('extras', 0, 'value'): 1,
  ('extras', 1, 'key'): 'c', ('extras', 1, 'value'): 3,
...}
```