### PR TITLE
Add active class to main nav on sub page

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -813,7 +813,7 @@ def _link_active_pylons(kwargs):
     highlight_controllers = kwargs.get('highlight_controllers', [])
     if highlight_controllers and c.controller in highlight_controllers:
         return True
-    
+
     highlight_actions = kwargs.get('highlight_actions',
                                    kwargs.get('action', '')).split()
     return (c.controller == kwargs.get('controller')
@@ -829,6 +829,7 @@ def _link_active_flask(kwargs):
 
     return (kwargs.get('controller') == blueprint and
             kwargs.get('action') == endpoint)
+
 
 def _link_to(text, *args, **kwargs):
     '''Common link making code for several helper functions'''
@@ -1016,7 +1017,8 @@ def build_nav_main(*args):
     Outputs ``<li><a href="...">title</a></li>``
 
     :param args: tuples of (menu type, title) eg ('login', _('Login')).
-        Third item specifies controllers which should be used to mark link as active.
+        Third item specifies controllers which should be used to
+        mark link as active.
         Fourth item specifies auth function to check permissions against.
     :type args: tuple[str, str, Optional[list], Optional[str]]
 
@@ -1024,10 +1026,11 @@ def build_nav_main(*args):
     """
     output = ''
     for item in args:
-        menu_item, title, highlight_controllers = (list(item) +[None]*3)[:3]
+        menu_item, title, highlight_controllers = (list(item) + [None] * 3)[:3]
         if len(item) == 4 and not check_access(item[3]):
             continue
-        output += _make_menu_item(menu_item, title, highlight_controllers=highlight_controllers)
+        output += _make_menu_item(menu_item, title,
+                                  highlight_controllers=highlight_controllers)
     return output
 
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -810,6 +810,10 @@ def _link_active(kwargs):
 
 
 def _link_active_pylons(kwargs):
+    highlight_controllers = kwargs.get('highlight_controllers', [])
+    if highlight_controllers and c.controller in highlight_controllers:
+        return True
+    
     highlight_actions = kwargs.get('highlight_actions',
                                    kwargs.get('action', '')).split()
     return (c.controller == kwargs.get('controller')
@@ -818,9 +822,13 @@ def _link_active_pylons(kwargs):
 
 def _link_active_flask(kwargs):
     blueprint, endpoint = p.toolkit.get_endpoint()
-    return(kwargs.get('controller') == blueprint and
-           kwargs.get('action') == endpoint)
 
+    highlight_controllers = kwargs.get('highlight_controllers', [])
+    if highlight_controllers and blueprint in highlight_controllers:
+        return True
+
+    return (kwargs.get('controller') == blueprint and
+            kwargs.get('action') == endpoint)
 
 def _link_to(text, *args, **kwargs):
     '''Common link making code for several helper functions'''
@@ -1003,17 +1011,23 @@ def subnav_named_route(text, named_route, **kwargs):
 
 @core_helper
 def build_nav_main(*args):
-    ''' build a set of menu items.
+    """Build a set of menu items.
 
-    args: tuples of (menu type, title) eg ('login', _('Login'))
-    outputs <li><a href="...">title</a></li>
-    '''
+    Outputs ``<li><a href="...">title</a></li>``
+
+    :param args: tuples of (menu type, title) eg ('login', _('Login')).
+        Third item specifies controllers which should be used to mark link as active.
+        Fourth item specifies auth function to check permissions against.
+    :type args: tuple[str, str, Optional[list], Optional[str]]
+
+    :rtype: str
+    """
     output = ''
     for item in args:
-        menu_item, title = item[:2]
-        if len(item) == 3 and not check_access(item[2]):
+        menu_item, title, highlight_controllers = (list(item) +[None]*3)[:3]
+        if len(item) == 4 and not check_access(item[3]):
             continue
-        output += _make_menu_item(menu_item, title)
+        output += _make_menu_item(menu_item, title, highlight_controllers=highlight_controllers)
     return output
 
 
@@ -1115,6 +1129,9 @@ def _make_menu_item(menu_item, title, **kw):
     item = copy.copy(_menu_items[menu_item])
     item.update(kw)
     active = _link_active(item)
+
+    # Remove highlight controllers so that they won't appear in generated urls.
+    item.pop('highlight_controllers', False)
     needed = item.pop('needed')
     for need in needed:
         if need not in kw:

--- a/ckan/templates/header.html
+++ b/ckan/templates/header.html
@@ -90,7 +90,7 @@
               {% set group_type = h.default_group_type('group') %}
 
 		          {{ h.build_nav_main(
-		            ('dataset.search', _('Datasets')),
+		            ('dataset.search', _('Datasets'), ["dataset", "resource"]),
 		            (org_type ~ '.index',
                   h.humanize_entity_type('organization', org_type, 'main nav') or _('Organizations')),
 		            (group_type ~ '.index',

--- a/ckan/templates/header.html
+++ b/ckan/templates/header.html
@@ -92,9 +92,9 @@
 		          {{ h.build_nav_main(
 		            ('dataset.search', _('Datasets'), ["dataset", "resource"]),
 		            (org_type ~ '.index',
-                  h.humanize_entity_type('organization', org_type, 'main nav') or _('Organizations')),
+                  h.humanize_entity_type('organization', org_type, 'main nav') or _('Organizations'), ['organization']),
 		            (group_type ~ '.index',
-                  h.humanize_entity_type('group_type', group_type, 'main nav') or _('Groups')),
+                  h.humanize_entity_type('group_type', group_type, 'main nav') or _('Groups'), ['group']),
 		            ('home.about', _('About')) ) }}
 	          {% endblock %}
           </ul>

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -13,7 +13,7 @@ from ckan.common import config
 import ckan.lib.helpers as h
 import ckan.plugins as p
 import ckan.exceptions
-from ckan.tests import helpers
+from ckan.tests import helpers, factories
 import ckan.lib.base as base
 
 
@@ -601,6 +601,61 @@ class TestBuildNavMain(object):
             '<li><a href="/about">About</a></li>'
         )
 
+    def test_active_in_flask_routes(self, test_request_context):
+        with test_request_context(u'/organization'):
+            menu = (
+                ("home.index", "Home"),
+                ("dataset.search", "Datasets", ['dataset', 'resource']),
+                ("organization.index", "Organizations"),
+                ("group.index", "Groups"),
+                ("home.about", "About"),
+            )
+            assert h.build_nav_main(*menu) == (
+                '<li><a href="/">Home</a></li>'
+                '<li><a href="/dataset/">Datasets</a></li>'
+                '<li class="active"><a href="/organization/">Organizations</a></li>'
+                '<li><a href="/group/">Groups</a></li>'
+                '<li><a href="/about">About</a></li>'
+            )
+
+    @pytest.mark.usefixtures("clean_db")
+    def test_active_in_resource_controller(self, test_request_context):
+
+        dataset = factories.Dataset()
+        with test_request_context(u'/dataset/' + dataset['id']):
+            menu = (
+                ("home.index", "Home"),
+                ("dataset.search", "Datasets", ['dataset', 'resource']),
+                ("organization.index", "Organizations"),
+                ("group.index", "Groups"),
+                ("home.about", "About"),
+            )
+            assert h.build_nav_main(*menu) == (
+                '<li><a href="/">Home</a></li>'
+                '<li class="active"><a href="/dataset/">Datasets</a></li>'
+                '<li><a href="/organization/">Organizations</a></li>'
+                '<li><a href="/group/">Groups</a></li>'
+                '<li><a href="/about">About</a></li>'
+            )
+
+
+        resource = factories.Resource(name="some_resource")
+        with test_request_context(u'/dataset/' + resource['package_id'] + '/resource/' + resource['id']):
+            menu = (
+                ("home.index", "Home"),
+                ("dataset.search", "Datasets", ['dataset', 'resource']),
+                ("organization.index", "Organizations"),
+                ("group.index", "Groups"),
+                ("home.about", "About"),
+            )
+            assert h.build_nav_main(*menu) == (
+                '<li><a href="/">Home</a></li>'
+                '<li class="active"><a href="/dataset/">Datasets</a></li>'
+                '<li><a href="/organization/">Organizations</a></li>'
+                '<li><a href="/group/">Groups</a></li>'
+                '<li><a href="/about">About</a></li>'
+            )
+
     def test_legacy_pylon_routes(self):
         menu = (
             ("home", "Home"),
@@ -617,6 +672,59 @@ class TestBuildNavMain(object):
             '<li><a href="/about">About</a></li>'
         )
 
+    def test_active_in_legacy_pylon_routes(self, test_request_context):
+
+        with test_request_context(u'/organization'):
+            menu = (
+                ("home", "Home"),
+                ("search", "Datasets", ['dataset', 'resource']),
+                ("organizations_index", "Organizations"),
+                ("group_index", "Groups"),
+                ("about", "About"),
+            )
+            assert h.build_nav_main(*menu) == (
+                '<li><a href="/">Home</a></li>'
+                '<li><a href="/dataset/">Datasets</a></li>'
+                '<li class="active"><a href="/organization/">Organizations</a></li>'
+                '<li><a href="/group/">Groups</a></li>'
+                '<li><a href="/about">About</a></li>'
+            )
+    @pytest.mark.usefixtures("clean_db")
+    def test_active_in_resource_controller_legacy_pylon_routes(self, test_request_context):
+
+        dataset = factories.Dataset()
+        with test_request_context(u'/dataset/' + dataset['id']):
+            menu = (
+                ("home", "Home"),
+                ("search", "Datasets", ['dataset', 'resource']),
+                ("organizations_index", "Organizations"),
+                ("group_index", "Groups"),
+                ("about", "About"),
+            )
+            assert h.build_nav_main(*menu) == (
+                '<li><a href="/">Home</a></li>'
+                '<li class="active"><a href="/dataset/">Datasets</a></li>'
+                '<li><a href="/organization/">Organizations</a></li>'
+                '<li><a href="/group/">Groups</a></li>'
+                '<li><a href="/about">About</a></li>'
+            )
+
+        resource = factories.Resource(name="some_resource")
+        with test_request_context(u'/dataset/' + resource['package_id'] + '/resource/' + resource['id']):
+            menu = (
+                ("home", "Home"),
+                ("search", "Datasets", ['dataset', 'resource']),
+                ("organizations_index", "Organizations"),
+                ("group_index", "Groups"),
+                ("about", "About"),
+            )
+            assert h.build_nav_main(*menu) == (
+                '<li><a href="/">Home</a></li>'
+                '<li class="active"><a href="/dataset/">Datasets</a></li>'
+                '<li><a href="/organization/">Organizations</a></li>'
+                '<li><a href="/group/">Groups</a></li>'
+                '<li><a href="/about">About</a></li>'
+            )
     def test_dataset_navigation_legacy_routes(self):
         dataset_name = "test-dataset"
         assert (

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -638,7 +638,6 @@ class TestBuildNavMain(object):
                 '<li><a href="/about">About</a></li>'
             )
 
-
         resource = factories.Resource(name="some_resource")
         with test_request_context(u'/dataset/' + resource['package_id'] + '/resource/' + resource['id']):
             menu = (
@@ -689,6 +688,7 @@ class TestBuildNavMain(object):
                 '<li><a href="/group/">Groups</a></li>'
                 '<li><a href="/about">About</a></li>'
             )
+
     @pytest.mark.usefixtures("clean_db")
     def test_active_in_resource_controller_legacy_pylon_routes(self, test_request_context):
 
@@ -725,6 +725,7 @@ class TestBuildNavMain(object):
                 '<li><a href="/group/">Groups</a></li>'
                 '<li><a href="/about">About</a></li>'
             )
+
     def test_dataset_navigation_legacy_routes(self):
         dataset_name = "test-dataset"
         assert (


### PR DESCRIPTION
### Proposed fixes:
Our accessibility audit thought that main navigation should have active class on sub pages. For example when user is on page /dataset/somedataset dataset link should be active.

This PR adds functionality to build_nav_main to specify list of controllers which should mark nav link as active when user is is some action within said controller. 

Old functionality:
User in /dataset -> dataset link active
User in /dataset/somedataset -> dataset link not active
User in /organization/someorganization -> organization not link active
User in /group/somegroup -> group not link active

New functionality:
User in /dataset -> dataset link active
User in /dataset/somedataset -> dataset link active
User in /dataset/somedataset/resource/someresource -> dataset link active
User in /organization/someorganization -> organization link active
User in /group/somegroup -> group link active

Also updates documentation of build_nav_main as auth function parameter was not documented.

### Features:

- [x] includes tests covering changes
- [x] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply

Financed by Finland's open data portal opendata.fi. Find all Finnish open data at https://www.opendata.fi/en.
The Service is provided by the Digital and Population Data Services Agency (https://dvv.fi/en/).