### PR TITLE
Fixes fullscreen for resource webpageview

### DIFF
--- a/ckanext/webpageview/theme/templates/webpage_view.html
+++ b/ckanext/webpageview/theme/templates/webpage_view.html
@@ -1,3 +1,3 @@
-<iframe src="{{ resource_view.get('page_url') or resource.get('url') }}" frameborder="0" width="100%" data-module="data-viewer">
+<iframe src="{{ resource_view.get('page_url') or resource.get('url') }}" frameborder="0" width="100%" style="height:100vh" data-module="data-viewer">
   <p>{{ _('Your browser does not support iframes.') }}</p>
 </iframe>


### PR DESCRIPTION
Fixes #5547

### Proposed fixes:
Added `style="height:100vh"` so fullscreen works.

Viewport units are supported by all major browsers.
https://caniuse.com/#feat=viewport-units

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
