### PR TITLE
Update supervisor-ckan-worker.conf

### DIFF
--- a/ckan/config/supervisor-ckan-worker.conf
+++ b/ckan/config/supervisor-ckan-worker.conf
@@ -9,7 +9,7 @@
 [program:ckan-worker]
 
 ; Use the full paths to the virtualenv and your configuration file here.
-command=/usr/lib/ckan/default/bin/paster --plugin=ckan jobs worker --config=/etc/ckan/default/production.ini
+command=/usr/lib/ckan/default/bin/ckan -c /etc/ckan/default/ckan.ini jobs worker
 
 
 ; User the worker runs as.
@@ -23,8 +23,8 @@ process_name=%(program_name)s-%(process_num)02d
 
 
 ; Log files.
-stdout_logfile=/var/log/ckan-worker.log
-stderr_logfile=/var/log/ckan-worker.log
+stdout_logfile=/var/log/ckan/ckan-worker.stdout.log
+stderr_logfile=/var/log/ckan/ckan-worker.stderr.log
 
 
 ; Make sure that the worker is started on system start and automatically
@@ -40,4 +40,3 @@ startsecs=10
 ; Need to wait for currently executing tasks to finish at shutdown.
 ; Increase this if you have very long running tasks.
 stopwaitsecs = 600
-


### PR DESCRIPTION
Update to use correct command and log files

Fixes #5548 

### Proposed fixes:
- `supervisor-ckan-worker.conf` should use the `ckan` command rather than `paster`
- Log file location set to `/var/log/ckan/` rather than `/var/log`
- Seperate log files for stdout and stderr (`ckan-worker.stdout.log` and `ckan-worker.stderr.log`)


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
