### PR TITLE
Improvement: Add text to mobile nav button.

### DIFF
--- a/ckan/templates/header.html
+++ b/ckan/templates/header.html
@@ -66,7 +66,8 @@
   {% endif %} {% endblock %}
   <div class="container">
     <div class="navbar-right">
-      <button data-target="#main-navigation-toggle" data-toggle="collapse" class="navbar-toggle collapsed" type="button" aria-label="expand or collapse">
+      <button data-target="#main-navigation-toggle" data-toggle="collapse" class="navbar-toggle collapsed" type="button" aria-label="expand or collapse" aria-expanded="false">
+        <span class="sr-only">Toggle navigation</span>
         <span class="fa fa-bars"></span>
       </button>
     </div>

--- a/ckan/templates/header.html
+++ b/ckan/templates/header.html
@@ -67,7 +67,7 @@
   <div class="container">
     <div class="navbar-right">
       <button data-target="#main-navigation-toggle" data-toggle="collapse" class="navbar-toggle collapsed" type="button" aria-label="expand or collapse" aria-expanded="false">
-        <span class="sr-only">Toggle navigation</span>
+        <span class="sr-only">{{ _('Toggle navigation') }}</span>
         <span class="fa fa-bars"></span>
       </button>
     </div>


### PR DESCRIPTION
Add aria attribute and accessible screen reader text to the mobile nav button as per BootStrap 3 docs.
https://getbootstrap.com/docs/3.3/components/#navbar

Fixes #

### Proposed fixes:

Make mobile nav button more accessible. Backport to 2.8 would be nice.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
