### PR TITLE
Fix skip to content link hiding on screen readers

### DIFF
--- a/ckan/templates/page.html
+++ b/ckan/templates/page.html
@@ -3,7 +3,7 @@
 {%- block page -%}
 
   {% block skip %}
-    <div class="hide"><a href="#content">{{ _('Skip to content') }}</a></div>
+    <div class="sr-only sr-only-focusable"><a href="#content">{{ _('Skip to content') }}</a></div>
   {% endblock %}
 
   {#


### PR DESCRIPTION
### Proposed fixes:
Using .hide to hide content for accessibility has been deprecated since 3.0.1 https://getbootstrap.com/docs/3.4/css/#helper-classes-show-hide, this PR fixes it for current recommendations.



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
