### PR TITLE
[#5562] Fix KeyErrors in change list detection

### DIFF
--- a/ckan/lib/changes.py
+++ b/ckan/lib/changes.py
@@ -598,7 +598,7 @@ def _name_change(change_list, old, new):
     can be accessed at) between two versions (old and new) to
     change_list.
     '''
-    change_list.append({u'type': u'name', u'pkg_id': new.getu(u'id'),
+    change_list.append({u'type': u'name', u'pkg_id': new.get(u'id'),
                         u'title': new.get(u'title'), u'old_name':
                         old.get(u'name'), u'new_name': new.get(u'name')})
 

--- a/ckan/lib/changes.py
+++ b/ckan/lib/changes.py
@@ -327,10 +327,10 @@ def check_metadata_changes(change_list, old, new):
 
     # if the visibility of the dataset changed
     if old.get(u'private') != new.get(u'private'):
-        change_list.append({u'type': u'private', u'pkg_id': new['id'],
-                            u'title': new['title'],
+        change_list.append({u'type': u'private', u'pkg_id': new.get(u'id'),
+                            u'title': new.get(u'title'),
                             u'new':
-                            u'Private' if bool(new['private'])
+                            u'Private' if bool(new.get(u'private'))
                             else u'Public'})
 
     # if the description of the dataset changed
@@ -338,8 +338,8 @@ def check_metadata_changes(change_list, old, new):
         _notes_change(change_list, old, new)
 
     # make sets out of the tags for each dataset
-    old_tags = {tag.get(u'name') for tag in old.get(u'tags')}
-    new_tags = {tag.get(u'name') for tag in new.get(u'tags')}
+    old_tags = {tag.get(u'name') for tag in old.get(u'tags', [])}
+    new_tags = {tag.get(u'name') for tag in new.get(u'tags', [])}
     # if the tags have changed
     if old_tags != new_tags:
         _tag_change(change_list, new_tags, old_tags, new)
@@ -375,9 +375,9 @@ def _title_change(change_list, old, new):
     Appends a summary of a change to a dataset's title between two versions
     (old and new) to change_list.
     '''
-    change_list.append({u'type': u'title', u'id': new['name'],
-                        u'new_title': new['title'],
-                        u'old_title': old['title']})
+    change_list.append({u'type': u'title', u'id': new.get('name'),
+                        u'new_title': new.get('title'),
+                        u'old_title': old.get('title')})
 
 
 def _org_change(change_list, old, new):
@@ -387,34 +387,34 @@ def _org_change(change_list, old, new):
     '''
 
     # if both versions belong to an organization
-    if old['owner_org'] and new['owner_org']:
+    if old.get('owner_org') and new.get('owner_org'):
         change_list.append({u'type': u'org',
                             u'method': u'change',
-                            u'pkg_id': new['id'],
-                            u'title': new['title'],
-                            u'old_org_id': old['organization']['id'],
+                            u'pkg_id': new.get('id'),
+                            u'title': new.get('title'),
+                            u'old_org_id': old.get('organization').get('id'),
                             u'old_org_title':
-                            old['organization']['title'],
-                            u'new_org_id': new['organization']['id'],
-                            u'new_org_title': new['organization']['title']})
+                            old.get('organization').get('title'),
+                            u'new_org_id': new.get('organization').get('id'),
+                            u'new_org_title': new.get('organization').get('title')})
     # if the dataset was not in an organization before and it is now
-    elif not old['owner_org'] and new['owner_org']:
+    elif not old.get('owner_org') and new.get('owner_org'):
         change_list.append({u'type': u'org',
                             u'method': u'add',
-                            u'pkg_id': new['id'],
-                            u'title': new['title'],
-                            u'new_org_id': new['organization']['id'],
+                            u'pkg_id': new.get('id'),
+                            u'title': new.get('title'),
+                            u'new_org_id': new.get('organization').get('id'),
                             u'new_org_title':
-                            new['organization']['title']})
+                            new.get('organization').get('title')})
     # if the user removed the organization
     else:
         change_list.append({u'type': u'org',
                             u'method': u'remove',
-                            u'pkg_id': new['id'],
-                            u'title': new['title'],
-                            u'old_org_id': old['organization']['id'],
+                            u'pkg_id': new.get('id'),
+                            u'title': new.get('title'),
+                            u'old_org_id': old.get('organization').get('id'),
                             u'old_org_title':
-                            old['organization']['title']})
+                            old.get('organization').get('title')})
 
 
 def _maintainer_change(change_list, old, new):
@@ -423,22 +423,22 @@ def _maintainer_change(change_list, old, new):
     versions (old and new) to change_list.
     '''
     # if the old dataset had a maintainer
-    if old['maintainer'] and new['maintainer']:
+    if old.get(u'maintainer') and new.get(u'maintainer'):
         change_list.append({u'type': u'maintainer', u'method': u'change',
-                            u'pkg_id': new['id'],
-                            u'title': new['title'], u'new_maintainer':
+                            u'pkg_id': new.get('id'),
+                            u'title': new.get('title'), u'new_maintainer':
                             new['maintainer'], u'old_maintainer':
                             old['maintainer']})
     # if they removed the maintainer
-    elif not new['maintainer']:
+    elif not new.get(u'maintainer'):
         change_list.append({u'type': u'maintainer', u'pkg_id':
-                            new['id'], u'title': new['title'],
+                            new.get('id'), u'title': new.get('title'),
                             u'method': u'remove'})
     # if there wasn't one there before
     else:
         change_list.append({u'type': u'maintainer', u'pkg_id':
-                            new['id'], u'title': new['title'],
-                            u'new_maintainer': new['maintainer'],
+                            new.get('id'), u'title': new.get('title'),
+                            u'new_maintainer': new.get('maintainer'),
                             u'method': u'add'})
 
 
@@ -448,23 +448,23 @@ def _maintainer_email_change(change_list, old, new):
     field between two versions (old and new) to change_list.
     '''
     # if the old dataset had a maintainer email
-    if old['maintainer_email'] and new['maintainer_email']:
+    if old.get(u'maintainer_email') and new.get(u'maintainer_email'):
         change_list.append({u'type': u'maintainer_email', u'pkg_id':
-                            new['id'], u'title': new['title'],
-                            u'new_maintainer_email': new['maintainer_email'],
+                            new.get(u'id'), u'title': new.get(u'title'),
+                            u'new_maintainer_email': new.get(u'maintainer_email'),
                             u'old_maintainer_email':
-                            old['maintainer_email'],
+                            old.get(u'maintainer_email'),
                             u'method': u'change'})
     # if they removed the maintainer email
-    elif not new['maintainer_email']:
+    elif not new.get(u'maintainer_email'):
         change_list.append({u'type': u'maintainer_email', u'pkg_id':
-                            new['id'], u'title': new['title'],
+                            new.get(u'id'), u'title': new.get(u'title'),
                             u'method': u'remove'})
     # if there wasn't one there before e
     else:
         change_list.append({u'type': u'maintainer_email', u'pkg_id':
-                            new['id'], u'title': new['title'],
-                            u'new_maintainer_email': new['maintainer_email'],
+                            new.get(u'id'), u'title': new.get(u'title'),
+                            u'new_maintainer_email': new.get(u'maintainer_email'),
                             u'method': u'add'})
 
 
@@ -474,20 +474,20 @@ def _author_change(change_list, old, new):
     versions (old and new) to change_list.
     '''
     # if the old dataset had an author
-    if old['author'] and new['author']:
-        change_list.append({u'type': u'author', u'pkg_id': new['id'],
-                            u'title': new['title'], u'new_author':
-                            new['author'], u'old_author': old['author'],
+    if old.get(u'author') and new.get(u'author'):
+        change_list.append({u'type': u'author', u'pkg_id': new.get(u'id'),
+                            u'title': new.get(u'title'), u'new_author':
+                            new.get(u'author'), u'old_author': old.get(u'author'),
                             u'method': u'change'})
     # if they removed the author
-    elif not new['author']:
-        change_list.append({u'type': u'author', u'pkg_id': new['id'],
-                            u'title': new['title'], u'method': u'remove'})
+    elif not new.get(u'author'):
+        change_list.append({u'type': u'author', u'pkg_id': new.get(u'id'),
+                            u'title': new.get(u'title'), u'method': u'remove'})
     # if there wasn't one there before
     else:
-        change_list.append({u'type': u'author', u'pkg_id': new['id'],
-                            u'title': new['title'], u'new_author':
-                            new['author'], u'method': u'add'})
+        change_list.append({u'type': u'author', u'pkg_id': new.get(u'id'),
+                            u'title': new.get(u'title'), u'new_author':
+                            new.get(u'author'), u'method': u'add'})
 
 
 def _author_email_change(change_list, old, new):
@@ -495,22 +495,22 @@ def _author_email_change(change_list, old, new):
     Appends a summary of a change to a dataset's author e-mail address field
     between two versions (old and new) to change_list.
     '''
-    if old['author_email'] and new['author_email']:
+    if old.get(u'author_email') and new.get(u'author_email'):
         change_list.append({u'type': u'author_email', u'pkg_id':
-                            new['id'], u'title': new['title'],
-                            u'new_author_email': new['author_email'],
-                            u'old_author_email': old['author_email'],
+                            new.get(u'id'), u'title': new.get(u'title'),
+                            u'new_author_email': new.get(u'author_email'),
+                            u'old_author_email': old.get(u'author_email'),
                             u'method': u'change'})
     # if they removed the author
-    elif not new['author_email']:
+    elif not new.get(u'author_email'):
         change_list.append({u'type': u'author_email', u'pkg_id':
-                            new['id'], u'title': new['title'],
+                            new.get(u'id'), u'title': new.get(u'title'),
                             u'method': u'remove'})
     # if there wasn't one there before
     else:
         change_list.append({u'type': u'author_email', u'pkg_id':
-                            new['id'], u'title': new['title'],
-                            u'new_author_email': new['author_email'],
+                            new.get(u'id'), u'title': new.get(u'title'),
+                            u'new_author_email': new.get(u'author_email'),
                             u'method': u'add'})
 
 
@@ -520,20 +520,20 @@ def _notes_change(change_list, old, new):
     versions (old and new) to change_list.
     '''
     # if the old dataset had a description
-    if old['notes'] and new['notes']:
+    if old.get(u'notes') and new.get(u'notes'):
         change_list.append({u'type': u'notes', u'pkg_id':
-                            new['id'], u'title': new['title'],
-                            u'new_notes': new['notes'],
-                            u'old_notes': old['notes'],
+                            new.get(u'id'), u'title': new.get(u'title'),
+                            u'new_notes': new.get(u'notes'),
+                            u'old_notes': old.get(u'notes'),
                             u'method': u'change'})
-    elif not new['notes']:
+    elif not new.get(u'notes'):
         change_list.append({u'type': u'notes', u'pkg_id':
-                            new['id'], u'title': new['title'],
+                            new.get(u'id'), u'title': new.get(u'title'),
                             u'method': u'remove'})
     else:
         change_list.append({u'type': u'notes', u'pkg_id':
-                            new['id'], u'title': new['title'],
-                            u'new_notes': new['notes'], u'method': u'add'})
+                            new.get(u'id'), u'title': new.get(u'title'),
+                            u'new_notes': new.get(u'notes'), u'method': u'add'})
 
 
 def _tag_change(change_list, new_tags, old_tags, new):
@@ -545,25 +545,25 @@ def _tag_change(change_list, new_tags, old_tags, new):
     deleted_tags_list = list(deleted_tags)
     if len(deleted_tags) == 1:
         change_list.append({u'type': u'tags', u'method': u'remove_one',
-                            u'pkg_id': new['id'],
-                            u'title': new['title'],
+                            u'pkg_id': new.get(u'id'),
+                            u'title': new.get(u'title'),
                             u'tag': deleted_tags_list[0]})
     elif len(deleted_tags) > 1:
         change_list.append({u'type': u'tags', u'method': u'remove_multiple',
-                            u'pkg_id': new['id'],
-                            u'title': new['title'],
+                            u'pkg_id': new.get(u'id'),
+                            u'title': new.get(u'title'),
                             u'tags': deleted_tags_list})
 
     added_tags = new_tags - old_tags
     added_tags_list = list(added_tags)
     if len(added_tags) == 1:
         change_list.append({u'type': u'tags', u'method': u'add_one', u'pkg_id':
-                            new['id'], u'title': new['title'],
+                            new.get(u'id'), u'title': new.get(u'title'),
                             u'tag': added_tags_list[0]})
     elif len(added_tags) > 1:
         change_list.append({u'type': u'tags', u'method': u'add_multiple',
-                            u'pkg_id': new['id'],
-                            u'title': new['title'],
+                            u'pkg_id': new.get(u'id'),
+                            u'title': new.get(u'title'),
                             u'tags': added_tags_list})
 
 
@@ -579,12 +579,12 @@ def _license_change(change_list, old, new):
         old_license_url = old['license_url']
     if u'license_url' in new and new['license_url']:
         new_license_url = new['license_url']
-    change_list.append({u'type': u'license', u'pkg_id': new['id'],
-                        u'title': new['title'],
+    change_list.append({u'type': u'license', u'pkg_id': new.get(u'id'),
+                        u'title': new.get(u'title'),
                         u'old_url': old_license_url,
                         u'new_url': new_license_url, u'new_title':
-                        new['license_title'], u'old_title':
-                        old['license_title']})
+                        new.get(u'license_title'), u'old_title':
+                        old.get(u'license_title')})
 
 
 def _name_change(change_list, old, new):

--- a/ckan/lib/changes.py
+++ b/ckan/lib/changes.py
@@ -67,12 +67,12 @@ def check_resource_changes(change_list, old, new, old_activity_id):
     new_resource_set = set()
     new_resource_dict = {}
 
-    for resource in old.get('resources'):
+    for resource in old.get(u'resources'):
         old_resource_set.add(resource['id'])
         old_resource_dict[resource['id']] = {
             key: value for (key, value) in resource.items() if key != u'id'}
 
-    for resource in new.get('resources'):
+    for resource in new.get(u'resources'):
         new_resource_set.add(resource['id'])
         new_resource_dict[resource['id']] = {
             key: value for (key, value) in resource.items() if key != u'id'}
@@ -82,9 +82,9 @@ def check_resource_changes(change_list, old, new, old_activity_id):
     for resource_id in new_resources:
         change_list.append({u'type': u'new_resource',
                             u'pkg_id': new['id'],
-                            u'title': new.get('title'),
+                            u'title': new.get(u'title'),
                             u'resource_name':
-                            new_resource_dict[resource_id].get('name'),
+                            new_resource_dict[resource_id].get(u'name'),
                             u'resource_id': resource_id})
 
     # get the IDs of resources that have been deleted between versions
@@ -92,10 +92,10 @@ def check_resource_changes(change_list, old, new, old_activity_id):
     for resource_id in deleted_resources:
         change_list.append({u'type': u'delete_resource',
                             u'pkg_id': new['id'],
-                            u'title': new.get('title'),
+                            u'title': new.get(u'title'),
                             u'resource_id': resource_id,
                             u'resource_name':
-                            old_resource_dict[resource_id].get('name'),
+                            old_resource_dict[resource_id].get(u'name'),
                             u'old_activity_id': old_activity_id})
 
     # now check the resources that are in both and see if any
@@ -105,94 +105,94 @@ def check_resource_changes(change_list, old, new, old_activity_id):
         old_metadata = old_resource_dict[resource_id]
         new_metadata = new_resource_dict[resource_id]
 
-        if old_metadata.get('name') != new_metadata.get('name'):
+        if old_metadata.get(u'name') != new_metadata.get(u'name'):
             change_list.append({u'type': u'resource_name',
-                                u'title': new.get('title'),
+                                u'title': new.get(u'title'),
                                 u'old_pkg_id': old['id'],
                                 u'new_pkg_id': new['id'],
                                 u'resource_id': resource_id,
                                 u'old_resource_name':
-                                old_resource_dict[resource_id].get('name'),
+                                old_resource_dict[resource_id].get(u'name'),
                                 u'new_resource_name':
-                                new_resource_dict[resource_id].get('name'),
+                                new_resource_dict[resource_id].get(u'name'),
                                 u'old_activity_id': old_activity_id})
 
         # you can't remove a format, but if a resource's format isn't
         # recognized, it won't have one set
 
         # if a format was not originally set and the user set one
-        if not old_metadata.get('format') and new_metadata.get('format'):
+        if not old_metadata.get(u'format') and new_metadata.get(u'format'):
             change_list.append({u'type': u'resource_format',
                                 u'method': u'add',
                                 u'pkg_id': new['id'],
-                                u'title': new.get('title'),
+                                u'title': new.get(u'title'),
                                 u'resource_id': resource_id,
                                 u'resource_name':
-                                new_resource_dict[resource_id].get('name'),
-                                u'org_id': new.get('organization')['id']
-                                    if new.get('organization') else u'',
-                                u'format': new_metadata.get('format')})
+                                new_resource_dict[resource_id].get(u'name'),
+                                u'org_id': new.get(u'organization')['id']
+                                    if new.get(u'organization') else u'',
+                                u'format': new_metadata.get(u'format')})
 
         # if both versions have a format but the format changed
-        elif old_metadata.get('format') != new_metadata.get('format'):
+        elif old_metadata.get(u'format') != new_metadata.get(u'format'):
             change_list.append({u'type': u'resource_format',
                                 u'method': u'change',
                                 u'pkg_id': new['id'],
-                                u'title': new.get('title'),
+                                u'title': new.get(u'title'),
                                 u'resource_id': resource_id,
                                 u'resource_name':
-                                new_resource_dict[resource_id].get('name'),
-                                u'org_id': new.get('organization')['id']
-                                    if new.get('organization') else u'',
-                                u'old_format': old_metadata.get('format'),
-                                u'new_format': new_metadata.get('format')})
+                                new_resource_dict[resource_id].get(u'name'),
+                                u'org_id': new.get(u'organization')['id']
+                                    if new.get(u'organization') else u'',
+                                u'old_format': old_metadata.get(u'format'),
+                                u'new_format': new_metadata.get(u'format')})
 
         # if the description changed
-        if not old_metadata.get('description') and \
-                new_metadata.get('description'):
+        if not old_metadata.get(u'description') and \
+                new_metadata.get(u'description'):
             change_list.append({u'type': u'resource_desc',
                                 u'method': u'add',
                                 u'pkg_id': new['id'],
-                                u'title': new.get('title'),
+                                u'title': new.get(u'title'),
                                 u'resource_id': resource_id,
                                 u'resource_name':
-                                new_resource_dict[resource_id].get('name'),
-                                u'new_desc': new_metadata.get('description')})
+                                new_resource_dict[resource_id].get(u'name'),
+                                u'new_desc': new_metadata.get(u'description')})
 
         # if there was a description but the user removed it
-        elif old_metadata.get('description') and \
-                not new_metadata.get('description'):
+        elif old_metadata.get(u'description') and \
+                not new_metadata.get(u'description'):
             change_list.append({u'type': u'resource_desc',
                                 u'method': u'remove',
                                 u'pkg_id': new['id'],
-                                u'title': new.get('title'),
+                                u'title': new.get(u'title'),
                                 u'resource_id': resource_id,
                                 u'resource_name':
-                                new_resource_dict[resource_id].get('name')})
+                                new_resource_dict[resource_id].get(u'name')})
 
         # if both have descriptions but they are different
-        elif old_metadata.get('description') \
-                != new_metadata.get('description'):
+        elif old_metadata.get(u'description') \
+                != new_metadata.get(u'description'):
             change_list.append({u'type': u'resource_desc',
                                 u'method': u'change',
                                 u'pkg_id': new['id'],
-                                u'title': new.get('title'),
+                                u'title': new.get(u'title'),
                                 u'resource_id': resource_id,
                                 u'resource_name':
-                                new_resource_dict[resource_id].get('name'),
-                                u'new_desc': new_metadata.get('description'),
-                                u'old_desc': old_metadata.get('description')})
+                                new_resource_dict[resource_id].get(u'name'),
+                                u'new_desc': new_metadata.get(u'description'),
+                                u'old_desc': old_metadata.get(u'description')})
 
         # check if the url changes (e.g. user uploaded a new file)
         # TODO: use regular expressions to determine the actual name of the
         # new and old files
-        if old_metadata.get('url') != new_metadata.get('url'):
+        if old_metadata.get(u'url') != new_metadata.get(u'url'):
             change_list.append({u'type': u'new_file',
                                 u'pkg_id': new['id'],
-                                u'title': new.get('title'),
+                                u'title': new.get(u'title'),
                                 u'resource_id': resource_id,
                                 u'resource_name':
-                                new_metadata.get('name')})
+                                new_metadata.get(u'name')})
 
         # check any extra fields in the resource
         # remove default fields from these sets to make sure we only check
@@ -209,29 +209,29 @@ def check_resource_changes(change_list, old, new, old_activity_id):
                 change_list.append({u'type': u'resource_extras',
                                     u'method': u'add_one_value',
                                     u'pkg_id': new['id'],
-                                    u'title': new.get('title'),
+                                    u'title': new.get(u'title'),
                                     u'resource_id': resource_id,
                                     u'resource_name':
-                                    new_metadata.get('name'),
+                                    new_metadata.get(u'name'),
                                     u'key': new_fields[0],
                                     u'value': new_metadata[new_fields[0]]})
             else:
                 change_list.append({u'type': u'resource_extras',
                                     u'method': u'add_one_no_value',
                                     u'pkg_id': new['id'],
-                                    u'title': new.get('title'),
+                                    u'title': new.get(u'title'),
                                     u'resource_id': resource_id,
                                     u'resource_name':
-                                    new_metadata.get('name'),
+                                    new_metadata.get(u'name'),
                                     u'key': new_fields[0]})
         elif len(new_fields) > 1:
             change_list.append({u'type': u'resource_extras',
                                 u'method': u'add_multiple',
                                 u'pkg_id': new['id'],
-                                u'title': new.get('title'),
+                                u'title': new.get(u'title'),
                                 u'resource_id': resource_id,
                                 u'resource_name':
-                                new_metadata.get('name'),
+                                new_metadata.get(u'name'),
                                 u'key_list': new_fields,
                                 u'value_list':
                                 [new_metadata[field] for field in new_fields]})
@@ -242,19 +242,19 @@ def check_resource_changes(change_list, old, new, old_activity_id):
             change_list.append({u'type': u'resource_extras',
                                 u'method': u'remove_one',
                                 u'pkg_id': new['id'],
-                                u'title': new.get('title'),
+                                u'title': new.get(u'title'),
                                 u'resource_id': resource_id,
                                 u'resource_name':
-                                new_metadata.get('name'),
+                                new_metadata.get(u'name'),
                                 u'key': deleted_fields[0]})
         elif len(deleted_fields) > 1:
             change_list.append({u'type': u'resource_extras',
                                 u'method': u'remove_multiple',
                                 u'pkg_id': new['id'],
-                                u'title': new.get('title'),
+                                u'title': new.get(u'title'),
                                 u'resource_id': resource_id,
                                 u'resource_name':
-                                new_metadata.get('name'),
+                                new_metadata.get(u'name'),
                                 u'key_list': deleted_fields})
 
         # determine if any extra fields have been changed
@@ -268,10 +268,10 @@ def check_resource_changes(change_list, old, new, old_activity_id):
                     change_list.append({u'type': u'resource_extras',
                                         u'method': u'change_value_with_old',
                                         u'pkg_id': new['id'],
-                                        u'title': new.get('title'),
+                                        u'title': new.get(u'title'),
                                         u'resource_id': resource_id,
                                         u'resource_name':
-                                        new_metadata.get('name'),
+                                        new_metadata.get(u'name'),
                                         u'key': field,
                                         u'old_value': old_metadata[field],
                                         u'new_value': new_metadata[field]})
@@ -279,20 +279,20 @@ def check_resource_changes(change_list, old, new, old_activity_id):
                     change_list.append({u'type': u'resource_extras',
                                         u'method': u'change_value_no_old',
                                         u'pkg_id': new['id'],
-                                        u'title': new.get('title'),
+                                        u'title': new.get(u'title'),
                                         u'resource_id': resource_id,
                                         u'resource_name':
-                                        new_metadata.get('name'),
+                                        new_metadata.get(u'name'),
                                         u'key': field,
                                         u'new_value': new_metadata[field]})
                 elif not new_metadata[field]:
                     change_list.append({u'type': u'resource_extras',
                                         u'method': u'change_value_no_new',
                                         u'pkg_id': new['id'],
-                                        u'title': new.get('title'),
+                                        u'title': new.get(u'title'),
                                         u'resource_id': resource_id,
                                         u'resource_name':
-                                        new_metadata.get('name'),
+                                        new_metadata.get(u'name'),
                                         u'key': field})
 
 
@@ -302,31 +302,31 @@ def check_metadata_changes(change_list, old, new):
     (excluding resources) in change_list.
     '''
     # if the title has changed
-    if old.get('title') != new.get('title'):
+    if old.get(u'title') != new.get(u'title'):
         _title_change(change_list, old, new)
 
     # if the owner organization changed
-    if old.get('owner_org') != new.get('owner_org'):
+    if old.get(u'owner_org') != new.get(u'owner_org'):
         _org_change(change_list, old, new)
 
     # if the maintainer of the dataset changed
-    if old.get('maintainer') != new.get('maintainer'):
+    if old.get(u'maintainer') != new.get(u'maintainer'):
         _maintainer_change(change_list, old, new)
 
     # if the maintainer email of the dataset changed
-    if old.get('maintainer_email') != new.get('maintainer_email'):
+    if old.get(u'maintainer_email') != new.get(u'maintainer_email'):
         _maintainer_email_change(change_list, old, new)
 
     # if the author of the dataset changed
-    if old.get('author') != new.get('author'):
+    if old.get(u'author') != new.get(u'author'):
         _author_change(change_list, old, new)
 
     # if the author email of the dataset changed
-    if old.get('author_email') != new.get('author_email'):
+    if old.get(u'author_email') != new.get(u'author_email'):
         _author_email_change(change_list, old, new)
 
     # if the visibility of the dataset changed
-    if old.get('private') != new.get('private'):
+    if old.get(u'private') != new.get(u'private'):
         change_list.append({u'type': u'private', u'pkg_id': new['id'],
                             u'title': new['title'],
                             u'new':
@@ -334,33 +334,33 @@ def check_metadata_changes(change_list, old, new):
                             else u'Public'})
 
     # if the description of the dataset changed
-    if old.get('notes') != new.get('notes'):
+    if old.get(u'notes') != new.get(u'notes'):
         _notes_change(change_list, old, new)
 
     # make sets out of the tags for each dataset
-    old_tags = {tag.get('name') for tag in old.get('tags')}
-    new_tags = {tag.get('name') for tag in new.get('tags')}
+    old_tags = {tag.get(u'name') for tag in old.get(u'tags')}
+    new_tags = {tag.get(u'name') for tag in new.get(u'tags')}
     # if the tags have changed
     if old_tags != new_tags:
         _tag_change(change_list, new_tags, old_tags, new)
 
     # if the license has changed
-    if old.get('license_title') != new.get('license_title'):
+    if old.get(u'license_title') != new.get(u'license_title'):
         _license_change(change_list, old, new)
 
     # if the name of the dataset has changed
     # this is only visible to the user via the dataset's URL,
     # so display the change using that
-    if old.get('name') != new.get('name'):
+    if old.get(u'name') != new.get(u'name'):
         _name_change(change_list, old, new)
 
     # if the source URL (metadata value, not the actual URL of the dataset)
     # has changed
-    if old.get('url') != new.get('url'):
+    if old.get(u'url') != new.get(u'url'):
         _url_change(change_list, old, new)
 
     # if the user-provided version has changed
-    if old.get('version') != new.get('version'):
+    if old.get(u'version') != new.get(u'version'):
         _version_change(change_list, old, new)
 
     # check whether fields added by extensions or custom fields

--- a/ckan/lib/changes.py
+++ b/ckan/lib/changes.py
@@ -396,7 +396,8 @@ def _org_change(change_list, old, new):
                             u'old_org_title':
                             old.get(u'organization').get(u'title'),
                             u'new_org_id': new.get(u'organization').get(u'id'),
-                            u'new_org_title': new.get(u'organization').get(u'title')})
+                            u'new_org_title':
+                                new.get(u'organization').get(u'title')})
     # if the dataset was not in an organization before and it is now
     elif not old.get(u'owner_org') and new.get(u'owner_org'):
         change_list.append({u'type': u'org',
@@ -451,7 +452,8 @@ def _maintainer_email_change(change_list, old, new):
     if old.get(u'maintainer_email') and new.get(u'maintainer_email'):
         change_list.append({u'type': u'maintainer_email', u'pkg_id':
                             new.get(u'id'), u'title': new.get(u'title'),
-                            u'new_maintainer_email': new.get(u'maintainer_email'),
+                            u'new_maintainer_email':
+                                new.get(u'maintainer_email'),
                             u'old_maintainer_email':
                             old.get(u'maintainer_email'),
                             u'method': u'change'})
@@ -464,7 +466,8 @@ def _maintainer_email_change(change_list, old, new):
     else:
         change_list.append({u'type': u'maintainer_email', u'pkg_id':
                             new.get(u'id'), u'title': new.get(u'title'),
-                            u'new_maintainer_email': new.get(u'maintainer_email'),
+                            u'new_maintainer_email':
+                                new.get(u'maintainer_email'),
                             u'method': u'add'})
 
 
@@ -477,7 +480,8 @@ def _author_change(change_list, old, new):
     if old.get(u'author') and new.get(u'author'):
         change_list.append({u'type': u'author', u'pkg_id': new.get(u'id'),
                             u'title': new.get(u'title'), u'new_author':
-                            new.get(u'author'), u'old_author': old.get(u'author'),
+                            new.get(u'author'), u'old_author':
+                                old.get(u'author'),
                             u'method': u'change'})
     # if they removed the author
     elif not new.get(u'author'):
@@ -533,7 +537,8 @@ def _notes_change(change_list, old, new):
     else:
         change_list.append({u'type': u'notes', u'pkg_id':
                             new.get(u'id'), u'title': new.get(u'title'),
-                            u'new_notes': new.get(u'notes'), u'method': u'add'})
+                            u'new_notes': new.get(u'notes'),
+                            u'method': u'add'})
 
 
 def _tag_change(change_list, new_tags, old_tags, new):

--- a/ckan/lib/changes.py
+++ b/ckan/lib/changes.py
@@ -375,9 +375,9 @@ def _title_change(change_list, old, new):
     Appends a summary of a change to a dataset's title between two versions
     (old and new) to change_list.
     '''
-    change_list.append({u'type': u'title', u'id': new.get('name'),
-                        u'new_title': new.get('title'),
-                        u'old_title': old.get('title')})
+    change_list.append({u'type': u'title', u'id': new.get(u'name'),
+                        u'new_title': new.get(u'title'),
+                        u'old_title': old.get(u'title')})
 
 
 def _org_change(change_list, old, new):
@@ -387,34 +387,34 @@ def _org_change(change_list, old, new):
     '''
 
     # if both versions belong to an organization
-    if old.get('owner_org') and new.get('owner_org'):
+    if old.get(u'owner_org') and new.get(u'owner_org'):
         change_list.append({u'type': u'org',
                             u'method': u'change',
-                            u'pkg_id': new.get('id'),
-                            u'title': new.get('title'),
-                            u'old_org_id': old.get('organization').get('id'),
+                            u'pkg_id': new.get(u'id'),
+                            u'title': new.get(u'title'),
+                            u'old_org_id': old.get(u'organization').get(u'id'),
                             u'old_org_title':
-                            old.get('organization').get('title'),
-                            u'new_org_id': new.get('organization').get('id'),
-                            u'new_org_title': new.get('organization').get('title')})
+                            old.get(u'organization').get(u'title'),
+                            u'new_org_id': new.get(u'organization').get(u'id'),
+                            u'new_org_title': new.get(u'organization').get(u'title')})
     # if the dataset was not in an organization before and it is now
-    elif not old.get('owner_org') and new.get('owner_org'):
+    elif not old.get(u'owner_org') and new.get(u'owner_org'):
         change_list.append({u'type': u'org',
                             u'method': u'add',
-                            u'pkg_id': new.get('id'),
-                            u'title': new.get('title'),
-                            u'new_org_id': new.get('organization').get('id'),
+                            u'pkg_id': new.get(u'id'),
+                            u'title': new.get(u'title'),
+                            u'new_org_id': new.get(u'organization').get(u'id'),
                             u'new_org_title':
-                            new.get('organization').get('title')})
+                            new.get(u'organization').get(u'title')})
     # if the user removed the organization
     else:
         change_list.append({u'type': u'org',
                             u'method': u'remove',
-                            u'pkg_id': new.get('id'),
-                            u'title': new.get('title'),
-                            u'old_org_id': old.get('organization').get('id'),
+                            u'pkg_id': new.get(u'id'),
+                            u'title': new.get(u'title'),
+                            u'old_org_id': old.get(u'organization').get(u'id'),
                             u'old_org_title':
-                            old.get('organization').get('title')})
+                            old.get(u'organization').get(u'title')})
 
 
 def _maintainer_change(change_list, old, new):
@@ -425,20 +425,20 @@ def _maintainer_change(change_list, old, new):
     # if the old dataset had a maintainer
     if old.get(u'maintainer') and new.get(u'maintainer'):
         change_list.append({u'type': u'maintainer', u'method': u'change',
-                            u'pkg_id': new.get('id'),
-                            u'title': new.get('title'), u'new_maintainer':
+                            u'pkg_id': new.get(u'id'),
+                            u'title': new.get(u'title'), u'new_maintainer':
                             new['maintainer'], u'old_maintainer':
                             old['maintainer']})
     # if they removed the maintainer
     elif not new.get(u'maintainer'):
         change_list.append({u'type': u'maintainer', u'pkg_id':
-                            new.get('id'), u'title': new.get('title'),
+                            new.get(u'id'), u'title': new.get(u'title'),
                             u'method': u'remove'})
     # if there wasn't one there before
     else:
         change_list.append({u'type': u'maintainer', u'pkg_id':
-                            new.get('id'), u'title': new.get('title'),
-                            u'new_maintainer': new.get('maintainer'),
+                            new.get(u'id'), u'title': new.get(u'title'),
+                            u'new_maintainer': new.get(u'maintainer'),
                             u'method': u'add'})
 
 
@@ -593,9 +593,9 @@ def _name_change(change_list, old, new):
     can be accessed at) between two versions (old and new) to
     change_list.
     '''
-    change_list.append({u'type': u'name', u'pkg_id': new['id'],
-                        u'title': new['title'], u'old_name':
-                        old['name'], u'new_name': new['name']})
+    change_list.append({u'type': u'name', u'pkg_id': new.getu(u'id'),
+                        u'title': new.get(u'title'), u'old_name':
+                        old.get(u'name'), u'new_name': new.get(u'name')})
 
 
 def _url_change(change_list, old, new):
@@ -605,23 +605,23 @@ def _url_change(change_list, old, new):
     new) to change_list.
     '''
     # if both old and new versions have source URLs
-    if old['url'] and new['url']:
+    if old.get(u'url') and new.get(u'url'):
         change_list.append({u'type': u'url', u'method': u'change',
-                            u'pkg_id': new['id'], u'title':
-                            new['title'], u'new_url': new['url'],
-                            u'old_url': old['url']})
+                            u'pkg_id': new.get(u'id'), u'title':
+                            new.get(u'title'), u'new_url': new.get(u'url'),
+                            u'old_url': old.get(u'url')})
     # if the user removed the source URL
-    elif not new['url']:
+    elif not new.get(u'url'):
         change_list.append({u'type': u'url', u'method': u'remove',
-                            u'pkg_id': new['id'],
-                            u'title': new['title'],
-                            u'old_url': old['url']})
+                            u'pkg_id': new.get(u'id'),
+                            u'title': new.get(u'title'),
+                            u'old_url': old.get(u'url')})
     # if there wasn't one there before
     else:
         change_list.append({u'type': u'url', u'method': u'add',
-                            u'pkg_id': new['id'],
-                            u'title': new['title'],
-                            u'new_url': new['url']})
+                            u'pkg_id': new.get(u'id'),
+                            u'title': new.get(u'title'),
+                            u'new_url': new.get(u'url')})
 
 
 def _version_change(change_list, old, new):
@@ -631,23 +631,24 @@ def _version_change(change_list, old, new):
     and new) to change_list.
     '''
     # if both old and new versions have version numbers
-    if old['version'] and new['version']:
+    if old.get(u'version') and new.get(u'version'):
         change_list.append({u'type': u'version', u'method': u'change',
-                            u'pkg_id': new['id'], u'title':
-                            new['title'], u'old_version':
-                            old['version'], u'new_version':
-                            new['version']})
+                            u'pkg_id': new.get(u'id'), u'title':
+                            new.get(u'title'), u'old_version':
+                            old.get(u'version'), u'new_version':
+                            new.get(u'version')})
     # if the user removed the version number
-    elif not new['version']:
+    elif not new.get(u'version'):
         change_list.append({u'type': u'version', u'method': u'remove',
-                            u'pkg_id': new['id'],
-                            u'title': new['title']})
+                            u'pkg_id': new.get(u'id'),
+                            u'title': new.get(u'title'),
+                            u'old_version': old.get(u'version')})
     # if there wasn't one there before
     else:
         change_list.append({u'type': u'version', u'method': u'add',
-                            u'pkg_id': new['id'],
-                            u'title': new['title'],
-                            u'new_version': new['version']})
+                            u'pkg_id': new.get(u'id'),
+                            u'title': new.get(u'title'),
+                            u'new_version': new.get(u'version')})
 
 
 def _extension_fields(change_list, old, new):
@@ -695,12 +696,12 @@ def _extension_fields(change_list, old, new):
     # if additional fields have been changed
     addl_fields_list = list(addl_fields)
     for field in addl_fields_list:
-        if old[field] != new[field]:
+        if old.get(field) != new.get(field):
             change_list.append({u'type': u'extension_fields',
-                                u'pkg_id': new['id'],
-                                u'title': new['title'],
+                                u'pkg_id': new.get(u'id'),
+                                u'title': new.get(u'title'),
                                 u'key': field,
-                                u'value': new[field]})
+                                u'value': new.get(field)})
 
 
 def _extra_fields(change_list, old, new):
@@ -710,13 +711,13 @@ def _extra_fields(change_list, old, new):
     change_list.
     '''
     if u'extras' in new:
-        extra_fields_new = _extras_to_dict(new['extras'])
+        extra_fields_new = _extras_to_dict(new.get(u'extras'))
         extra_new_set = set(extra_fields_new.keys())
 
         # if the old version has extra fields, we need
         # to compare the new version's extras to the old ones
         if u'extras' in old:
-            extra_fields_old = _extras_to_dict(old['extras'])
+            extra_fields_old = _extras_to_dict(old.get(u'extras'))
             extra_old_set = set(extra_fields_old.keys())
 
             # if some fields were added
@@ -725,22 +726,22 @@ def _extra_fields(change_list, old, new):
                 if extra_fields_new[new_fields[0]]:
                     change_list.append({u'type': u'extra_fields',
                                         u'method': u'add_one_value',
-                                        u'pkg_id': new['id'],
-                                        u'title': new['title'],
+                                        u'pkg_id': new.get(u'id'),
+                                        u'title': new.get(u'title'),
                                         u'key': new_fields[0],
                                         u'value':
                                         extra_fields_new[new_fields[0]]})
                 else:
                     change_list.append({u'type': u'extra_fields',
                                         u'method': u'add_one_no_value',
-                                        u'pkg_id': new['id'],
-                                        u'title': new['title'],
+                                        u'pkg_id': new.get(u'id'),
+                                        u'title': new.get(u'title'),
                                         u'key': new_fields[0]})
             elif len(new_fields) > 1:
                 change_list.append({u'type': u'extra_fields',
                                     u'method': u'add_multiple',
-                                    u'pkg_id': new['id'],
-                                    u'title': new['title'],
+                                    u'pkg_id': new.get(u'id'),
+                                    u'title': new.get(u'title'),
                                     u'key_list': new_fields,
                                     u'value_list': extra_fields_new})
 
@@ -749,14 +750,14 @@ def _extra_fields(change_list, old, new):
             if len(deleted_fields) == 1:
                 change_list.append({u'type': u'extra_fields',
                                     u'method': u'remove_one',
-                                    u'pkg_id': new['id'],
-                                    u'title': new['title'],
+                                    u'pkg_id': new.get(u'id'),
+                                    u'title': new.get(u'title'),
                                     u'key': deleted_fields[0]})
             elif len(deleted_fields) > 1:
                 change_list.append({u'type': u'extra_fields',
                                     u'method': u'remove_multiple',
-                                    u'pkg_id': new['id'],
-                                    u'title': new['title'],
+                                    u'pkg_id': new.get(u'id'),
+                                    u'title': new.get(u'title'),
                                     u'key_list': deleted_fields})
 
             # if some existing fields were changed
@@ -768,8 +769,8 @@ def _extra_fields(change_list, old, new):
                         change_list.append({u'type': u'extra_fields',
                                             u'method':
                                             u'change_with_old_value',
-                                            u'pkg_id': new['id'],
-                                            u'title': new['title'],
+                                            u'pkg_id': new.get(u'id'),
+                                            u'title': new.get(u'title'),
                                             u'key': field,
                                             u'old_value':
                                             extra_fields_old[field],
@@ -778,8 +779,8 @@ def _extra_fields(change_list, old, new):
                     else:
                         change_list.append({u'type': u'extra_fields',
                                             u'method': u'change_no_old_value',
-                                            u'pkg_id': new['id'],
-                                            u'title': new['title'],
+                                            u'pkg_id': new.get(u'id'),
+                                            u'title': new.get(u'title'),
                                             u'key': field,
                                             u'new_value':
                                             extra_fields_new[field]})
@@ -792,23 +793,23 @@ def _extra_fields(change_list, old, new):
                 if extra_fields_new[new_fields[0]]:
                     change_list.append({u'type': u'extra_fields',
                                         u'method': u'add_one_value',
-                                        u'pkg_id': new['id'],
-                                        u'title': new['title'],
+                                        u'pkg_id': new.get(u'id'),
+                                        u'title': new.get(u'title'),
                                         u'key': new_fields[0],
                                         u'value':
                                         extra_fields_new[new_fields[0]]})
                 else:
                     change_list.append({u'type': u'extra_fields',
                                         u'method': u'add_one_no_value',
-                                        u'pkg_id': new['id'],
-                                        u'title': new['title'],
+                                        u'pkg_id': new.get(u'id'),
+                                        u'title': new.get(u'title'),
                                         u'key': new_fields[0]})
 
             elif len(new_fields) > 1:
                 change_list.append({u'type': u'extra_fields',
                                     u'method': u'add_multiple',
-                                    u'pkg_id': new['id'],
-                                    u'title': new['title'],
+                                    u'pkg_id': new.get(u'id'),
+                                    u'title': new.get(u'title'),
                                     u'key_list': new_fields,
                                     u'value_list': extra_fields_new})
 
@@ -817,12 +818,12 @@ def _extra_fields(change_list, old, new):
         if len(deleted_fields) == 1:
             change_list.append({u'type': u'extra_fields',
                                 u'method': u'remove_one',
-                                u'pkg_id': new['id'],
-                                u'title': new['title'],
+                                u'pkg_id': new.get(u'id'),
+                                u'title': new.get(u'title'),
                                 u'key': deleted_fields[0]})
         elif len(deleted_fields) > 1:
             change_list.append({u'type': u'extra_fields',
                                 u'method': u'remove_multiple',
-                                u'pkg_id': new['id'],
-                                u'title': new['title'],
+                                u'pkg_id': new.get(u'id'),
+                                u'title': new.get(u'title'),
                                 u'key_list': deleted_fields})

--- a/ckan/lib/changes.py
+++ b/ckan/lib/changes.py
@@ -171,17 +171,17 @@ def check_resource_changes(change_list, old, new, old_activity_id):
                                 new_resource_dict[resource_id].get('name')})
 
         # if both have descriptions but they are different
-        elif old_metadata.get('description') != \
-            new_metadata.get('description'):
-                change_list.append({u'type': u'resource_desc',
-                                    u'method': u'change',
-                                    u'pkg_id': new['id'],
-                                    u'title': new.get('title'),
-                                    u'resource_id': resource_id,
-                                    u'resource_name':
-                                    new_resource_dict[resource_id].get('name'),
-                                    u'new_desc': new_metadata.get('description'),
-                                    u'old_desc': old_metadata.get('description')})
+        elif old_metadata.get('description') \
+                != new_metadata.get('description'):
+            change_list.append({u'type': u'resource_desc',
+                                u'method': u'change',
+                                u'pkg_id': new['id'],
+                                u'title': new.get('title'),
+                                u'resource_id': resource_id,
+                                u'resource_name':
+                                new_resource_dict[resource_id].get('name'),
+                                u'new_desc': new_metadata.get('description'),
+                                u'old_desc': old_metadata.get('description')})
 
         # check if the url changes (e.g. user uploaded a new file)
         # TODO: use regular expressions to determine the actual name of the

--- a/ckan/lib/changes.py
+++ b/ckan/lib/changes.py
@@ -173,15 +173,15 @@ def check_resource_changes(change_list, old, new, old_activity_id):
         # if both have descriptions but they are different
         elif old_metadata.get('description') != \
             new_metadata.get('description'):
-            change_list.append({u'type': u'resource_desc',
-                                u'method': u'change',
-                                u'pkg_id': new['id'],
-                                u'title': new.get('title'),
-                                u'resource_id': resource_id,
-                                u'resource_name':
-                                new_resource_dict[resource_id].get('name'),
-                                u'new_desc': new_metadata.get('description'),
-                                u'old_desc': old_metadata.get('description')})
+                change_list.append({u'type': u'resource_desc',
+                                    u'method': u'change',
+                                    u'pkg_id': new['id'],
+                                    u'title': new.get('title'),
+                                    u'resource_id': resource_id,
+                                    u'resource_name':
+                                    new_resource_dict[resource_id].get('name'),
+                                    u'new_desc': new_metadata.get('description'),
+                                    u'old_desc': old_metadata.get('description')})
 
         # check if the url changes (e.g. user uploaded a new file)
         # TODO: use regular expressions to determine the actual name of the

--- a/ckan/lib/changes.py
+++ b/ckan/lib/changes.py
@@ -67,12 +67,12 @@ def check_resource_changes(change_list, old, new, old_activity_id):
     new_resource_set = set()
     new_resource_dict = {}
 
-    for resource in old['resources']:
+    for resource in old.get('resources'):
         old_resource_set.add(resource['id'])
         old_resource_dict[resource['id']] = {
             key: value for (key, value) in resource.items() if key != u'id'}
 
-    for resource in new['resources']:
+    for resource in new.get('resources'):
         new_resource_set.add(resource['id'])
         new_resource_dict[resource['id']] = {
             key: value for (key, value) in resource.items() if key != u'id'}
@@ -82,9 +82,9 @@ def check_resource_changes(change_list, old, new, old_activity_id):
     for resource_id in new_resources:
         change_list.append({u'type': u'new_resource',
                             u'pkg_id': new['id'],
-                            u'title': new['title'],
+                            u'title': new.get('title'),
                             u'resource_name':
-                            new_resource_dict[resource_id]['name'],
+                            new_resource_dict[resource_id].get('name'),
                             u'resource_id': resource_id})
 
     # get the IDs of resources that have been deleted between versions
@@ -92,10 +92,10 @@ def check_resource_changes(change_list, old, new, old_activity_id):
     for resource_id in deleted_resources:
         change_list.append({u'type': u'delete_resource',
                             u'pkg_id': new['id'],
-                            u'title': new['title'],
+                            u'title': new.get('title'),
                             u'resource_id': resource_id,
                             u'resource_name':
-                            old_resource_dict[resource_id]['name'],
+                            old_resource_dict[resource_id].get('name'),
                             u'old_activity_id': old_activity_id})
 
     # now check the resources that are in both and see if any
@@ -105,93 +105,93 @@ def check_resource_changes(change_list, old, new, old_activity_id):
         old_metadata = old_resource_dict[resource_id]
         new_metadata = new_resource_dict[resource_id]
 
-        if old_metadata['name'] != new_metadata['name']:
+        if old_metadata.get('name') != new_metadata.get('name'):
             change_list.append({u'type': u'resource_name',
-                                u'title': new['title'],
+                                u'title': new.get('title'),
                                 u'old_pkg_id': old['id'],
                                 u'new_pkg_id': new['id'],
                                 u'resource_id': resource_id,
                                 u'old_resource_name':
-                                old_resource_dict[resource_id]['name'],
+                                old_resource_dict[resource_id].get('name'),
                                 u'new_resource_name':
-                                new_resource_dict[resource_id]['name'],
+                                new_resource_dict[resource_id].get('name'),
                                 u'old_activity_id': old_activity_id})
 
         # you can't remove a format, but if a resource's format isn't
         # recognized, it won't have one set
 
         # if a format was not originally set and the user set one
-        if not old_metadata['format'] and new_metadata['format']:
+        if not old_metadata.get('format') and new_metadata.get('format'):
             change_list.append({u'type': u'resource_format',
                                 u'method': u'add',
                                 u'pkg_id': new['id'],
-                                u'title': new['title'],
+                                u'title': new.get('title'),
                                 u'resource_id': resource_id,
                                 u'resource_name':
-                                new_resource_dict[resource_id]['name'],
-                                u'org_id': new['organization']['id']
-                                    if new['organization'] else u'',
-                                u'format': new_metadata['format']})
+                                new_resource_dict[resource_id].get('name'),
+                                u'org_id': new.get('organization')['id']
+                                    if new.get('organization') else u'',
+                                u'format': new_metadata.get('format')})
 
         # if both versions have a format but the format changed
-        elif old_metadata['format'] != new_metadata['format']:
+        elif old_metadata.get('format') != new_metadata.get('format'):
             change_list.append({u'type': u'resource_format',
                                 u'method': u'change',
                                 u'pkg_id': new['id'],
-                                u'title': new['title'],
+                                u'title': new.get('title'),
                                 u'resource_id': resource_id,
                                 u'resource_name':
-                                new_resource_dict[resource_id]['name'],
-                                u'org_id': new['organization']['id']
-                                    if new['organization'] else u'',
-                                u'old_format': old_metadata['format'],
-                                u'new_format': new_metadata['format']})
+                                new_resource_dict[resource_id].get('name'),
+                                u'org_id': new.get('organization')['id']
+                                    if new.get('organization') else u'',
+                                u'old_format': old_metadata.get('format'),
+                                u'new_format': new_metadata.get('format')})
 
         # if the description changed
-        if not old_metadata['description'] and \
-                new_metadata['description']:
+        if not old_metadata.get('description') and \
+                new_metadata.get('description'):
             change_list.append({u'type': u'resource_desc',
                                 u'method': u'add',
                                 u'pkg_id': new['id'],
-                                u'title': new['title'],
+                                u'title': new.get('title'),
                                 u'resource_id': resource_id,
                                 u'resource_name':
-                                new_resource_dict[resource_id]['name'],
-                                u'new_desc': new_metadata['description']})
+                                new_resource_dict[resource_id].get('name'),
+                                u'new_desc': new_metadata.get('description')})
 
         # if there was a description but the user removed it
-        elif old_metadata['description'] and \
-                not new_metadata['description']:
+        elif old_metadata.get('description') and \
+                not new_metadata.get('description'):
             change_list.append({u'type': u'resource_desc',
                                 u'method': u'remove',
                                 u'pkg_id': new['id'],
-                                u'title': new['title'],
+                                u'title': new.get('title'),
                                 u'resource_id': resource_id,
                                 u'resource_name':
-                                new_resource_dict[resource_id]['name']})
+                                new_resource_dict[resource_id].get('name')})
 
         # if both have descriptions but they are different
-        elif old_metadata['description'] != new_metadata['description']:
+        elif old_metadata.get('description') != new_metadata.get('description'):
             change_list.append({u'type': u'resource_desc',
                                 u'method': u'change',
                                 u'pkg_id': new['id'],
-                                u'title': new['title'],
+                                u'title': new.get('title'),
                                 u'resource_id': resource_id,
                                 u'resource_name':
-                                new_resource_dict[resource_id]['name'],
-                                u'new_desc': new_metadata['description'],
-                                u'old_desc': old_metadata['description']})
+                                new_resource_dict[resource_id].get('name'),
+                                u'new_desc': new_metadata.get('description'),
+                                u'old_desc': old_metadata.get('description')})
 
         # check if the url changes (e.g. user uploaded a new file)
         # TODO: use regular expressions to determine the actual name of the
         # new and old files
-        if old_metadata['url'] != new_metadata['url']:
+        if old_metadata.get('url') != new_metadata.get('url'):
             change_list.append({u'type': u'new_file',
                                 u'pkg_id': new['id'],
-                                u'title': new['title'],
+                                u'title': new.get('title'),
                                 u'resource_id': resource_id,
                                 u'resource_name':
-                                new_metadata['name']})
+                                new_metadata.get('name')})
 
         # check any extra fields in the resource
         # remove default fields from these sets to make sure we only check
@@ -208,29 +208,29 @@ def check_resource_changes(change_list, old, new, old_activity_id):
                 change_list.append({u'type': u'resource_extras',
                                     u'method': u'add_one_value',
                                     u'pkg_id': new['id'],
-                                    u'title': new['title'],
+                                    u'title': new.get('title'),
                                     u'resource_id': resource_id,
                                     u'resource_name':
-                                    new_metadata['name'],
+                                    new_metadata.get('name'),
                                     u'key': new_fields[0],
                                     u'value': new_metadata[new_fields[0]]})
             else:
                 change_list.append({u'type': u'resource_extras',
                                     u'method': u'add_one_no_value',
                                     u'pkg_id': new['id'],
-                                    u'title': new['title'],
+                                    u'title': new.get('title'),
                                     u'resource_id': resource_id,
                                     u'resource_name':
-                                    new_metadata['name'],
+                                    new_metadata.get('name'),
                                     u'key': new_fields[0]})
         elif len(new_fields) > 1:
             change_list.append({u'type': u'resource_extras',
                                 u'method': u'add_multiple',
                                 u'pkg_id': new['id'],
-                                u'title': new['title'],
+                                u'title': new.get('title'),
                                 u'resource_id': resource_id,
                                 u'resource_name':
-                                new_metadata['name'],
+                                new_metadata.get('name'),
                                 u'key_list': new_fields,
                                 u'value_list':
                                 [new_metadata[field] for field in new_fields]})
@@ -241,19 +241,19 @@ def check_resource_changes(change_list, old, new, old_activity_id):
             change_list.append({u'type': u'resource_extras',
                                 u'method': u'remove_one',
                                 u'pkg_id': new['id'],
-                                u'title': new['title'],
+                                u'title': new.get('title'),
                                 u'resource_id': resource_id,
                                 u'resource_name':
-                                new_metadata['name'],
+                                new_metadata.get('name'),
                                 u'key': deleted_fields[0]})
         elif len(deleted_fields) > 1:
             change_list.append({u'type': u'resource_extras',
                                 u'method': u'remove_multiple',
                                 u'pkg_id': new['id'],
-                                u'title': new['title'],
+                                u'title': new.get('title'),
                                 u'resource_id': resource_id,
                                 u'resource_name':
-                                new_metadata['name'],
+                                new_metadata.get('name'),
                                 u'key_list': deleted_fields})
 
         # determine if any extra fields have been changed
@@ -267,10 +267,10 @@ def check_resource_changes(change_list, old, new, old_activity_id):
                     change_list.append({u'type': u'resource_extras',
                                         u'method': u'change_value_with_old',
                                         u'pkg_id': new['id'],
-                                        u'title': new['title'],
+                                        u'title': new.get('title'),
                                         u'resource_id': resource_id,
                                         u'resource_name':
-                                        new_metadata['name'],
+                                        new_metadata.get('name'),
                                         u'key': field,
                                         u'old_value': old_metadata[field],
                                         u'new_value': new_metadata[field]})
@@ -278,20 +278,20 @@ def check_resource_changes(change_list, old, new, old_activity_id):
                     change_list.append({u'type': u'resource_extras',
                                         u'method': u'change_value_no_old',
                                         u'pkg_id': new['id'],
-                                        u'title': new['title'],
+                                        u'title': new.get('title'),
                                         u'resource_id': resource_id,
                                         u'resource_name':
-                                        new_metadata['name'],
+                                        new_metadata.get('name'),
                                         u'key': field,
                                         u'new_value': new_metadata[field]})
                 elif not new_metadata[field]:
                     change_list.append({u'type': u'resource_extras',
                                         u'method': u'change_value_no_new',
                                         u'pkg_id': new['id'],
-                                        u'title': new['title'],
+                                        u'title': new.get('title'),
                                         u'resource_id': resource_id,
                                         u'resource_name':
-                                        new_metadata['name'],
+                                        new_metadata.get('name'),
                                         u'key': field})
 
 
@@ -301,31 +301,31 @@ def check_metadata_changes(change_list, old, new):
     (excluding resources) in change_list.
     '''
     # if the title has changed
-    if old['title'] != new['title']:
+    if old.get('title') != new.get('title'):
         _title_change(change_list, old, new)
 
     # if the owner organization changed
-    if old['owner_org'] != new['owner_org']:
+    if old.get('owner_org') != new.get('owner_org'):
         _org_change(change_list, old, new)
 
     # if the maintainer of the dataset changed
-    if old['maintainer'] != new['maintainer']:
+    if old.get('maintainer') != new.get('maintainer'):
         _maintainer_change(change_list, old, new)
 
     # if the maintainer email of the dataset changed
-    if old['maintainer_email'] != new['maintainer_email']:
+    if old.get('maintainer_email') != new.get('maintainer_email'):
         _maintainer_email_change(change_list, old, new)
 
     # if the author of the dataset changed
-    if old['author'] != new['author']:
+    if old.get('author') != new.get('author'):
         _author_change(change_list, old, new)
 
     # if the author email of the dataset changed
-    if old['author_email'] != new['author_email']:
+    if old.get('author_email') != new.get('author_email'):
         _author_email_change(change_list, old, new)
 
     # if the visibility of the dataset changed
-    if old['private'] != new['private']:
+    if old.get('private') != new.get('private'):
         change_list.append({u'type': u'private', u'pkg_id': new['id'],
                             u'title': new['title'],
                             u'new':
@@ -333,33 +333,33 @@ def check_metadata_changes(change_list, old, new):
                             else u'Public'})
 
     # if the description of the dataset changed
-    if old['notes'] != new['notes']:
+    if old.get('notes') != new.get('notes'):
         _notes_change(change_list, old, new)
 
     # make sets out of the tags for each dataset
-    old_tags = {tag['name'] for tag in old['tags']}
-    new_tags = {tag['name'] for tag in new['tags']}
+    old_tags = {tag.get('name') for tag in old.get('tags')}
+    new_tags = {tag.get('name') for tag in new.get('tags')}
     # if the tags have changed
     if old_tags != new_tags:
         _tag_change(change_list, new_tags, old_tags, new)
 
     # if the license has changed
-    if old['license_title'] != new['license_title']:
+    if old.get('license_title') != new.get('license_title'):
         _license_change(change_list, old, new)
 
     # if the name of the dataset has changed
     # this is only visible to the user via the dataset's URL,
     # so display the change using that
-    if old['name'] != new['name']:
+    if old.get('name') != new.get('name'):
         _name_change(change_list, old, new)
 
     # if the source URL (metadata value, not the actual URL of the dataset)
     # has changed
-    if old['url'] != new['url']:
+    if old.get('url') != new.get('url'):
         _url_change(change_list, old, new)
 
     # if the user-provided version has changed
-    if old['version'] != new['version']:
+    if old.get('version') != new.get('version'):
         _version_change(change_list, old, new)
 
     # check whether fields added by extensions or custom fields

--- a/ckan/lib/changes.py
+++ b/ckan/lib/changes.py
@@ -171,7 +171,8 @@ def check_resource_changes(change_list, old, new, old_activity_id):
                                 new_resource_dict[resource_id].get('name')})
 
         # if both have descriptions but they are different
-        elif old_metadata.get('description') != new_metadata.get('description'):
+        elif old_metadata.get('description') != \
+            new_metadata.get('description'):
             change_list.append({u'type': u'resource_desc',
                                 u'method': u'change',
                                 u'pkg_id': new['id'],

--- a/ckan/tests/lib/test_changes.py
+++ b/ckan/tests/lib/test_changes.py
@@ -1133,7 +1133,7 @@ class TestChangesWithSingleAttributes(object):
         assert changes[0]["method"] == u"remove_multiple"
         assert set(changes[0]["tags"]) == set((u"rivers", u"oceans", u"streams"))
 
-    def test_licence_title_added_when_it_does_not_exist(self):
+    def test_license_title_added_when_it_does_not_exist(self):
         changes = []
         original = {}
         new = {u"license_title": u"new license"}
@@ -1144,7 +1144,7 @@ class TestChangesWithSingleAttributes(object):
         assert changes[0]["type"] == u"license"
         assert changes[0]["new_title"] == u"new license"
 
-    def test_licence_title_changed(self):
+    def test_license_title_changed(self):
         changes = []
         original = {u"license_title": u"old license"}
         new = {u"license_title": u"new license"}
@@ -1156,7 +1156,7 @@ class TestChangesWithSingleAttributes(object):
         assert changes[0]["old_title"] == u"old license"
         assert changes[0]["new_title"] == u"new license"
 
-    def test_licence_title_removed_with_non_existing(self):
+    def test_license_title_removed_with_non_existing(self):
         changes = []
         original = {u"license_title": u"old license"}
         new = {}
@@ -1167,3 +1167,77 @@ class TestChangesWithSingleAttributes(object):
         assert changes[0]["type"] == u"license"
         assert changes[0]["old_title"] == u"old license"
         assert changes[0]["new_title"] is None
+
+    def test_url_added_when_it_does_not_exist(self):
+        changes = []
+        original = {}
+        new = {u'url': u'http://example.com'}
+
+        check_metadata_changes(changes, original, new)
+
+        assert len(changes) == 1, changes
+        assert changes[0]["type"] == u"url"
+        assert changes[0]["method"] == u"add"
+        assert changes[0]["new_url"] == u'http://example.com'
+
+    def test_url_changed(self):
+        changes = []
+        original = {u"url": u"http://example.com"}
+        new = {u"url": u"http://example.com/new"}
+
+        check_metadata_changes(changes, original, new)
+
+        assert len(changes) == 1, changes
+        assert changes[0]["type"] == u"url"
+        assert changes[0]["method"] == u"change"
+        assert changes[0]["old_url"] == u"http://example.com"
+        assert changes[0]["new_url"] == u"http://example.com/new"
+
+    def test_url_removed_with_non_existing(self):
+        changes = []
+        original = {u"url": u"http://example.com"}
+        new = {}
+
+        check_metadata_changes(changes, original, new)
+
+        assert len(changes) == 1, changes
+        assert changes[0]["type"] == u"url"
+        assert changes[0]["method"] == u"remove"
+        assert changes[0]["old_url"] == u"http://example.com"
+
+    def test_version_added_when_it_does_not_exist(self):
+        changes = []
+        original = {}
+        new = {u'version': u'1'}
+
+        check_metadata_changes(changes, original, new)
+
+        assert len(changes) == 1, changes
+        assert changes[0]["type"] == u"version"
+        assert changes[0]["method"] == u"add"
+        assert changes[0]["new_version"] == u'1'
+
+    def test_version_changed(self):
+        changes = []
+        original = {u"version": u"1"}
+        new = {u"version": u"2"}
+
+        check_metadata_changes(changes, original, new)
+
+        assert len(changes) == 1, changes
+        assert changes[0]["type"] == u"version"
+        assert changes[0]["method"] == u"change"
+        assert changes[0]["old_version"] == u"1"
+        assert changes[0]["new_version"] == u"2"
+
+    def test_version_removed_with_non_existing(self):
+        changes = []
+        original = {u"version": u"1"}
+        new = {}
+
+        check_metadata_changes(changes, original, new)
+
+        assert len(changes) == 1, changes
+        assert changes[0]["type"] == u"version"
+        assert changes[0]["method"] == u"remove"
+        assert changes[0]["old_version"] == u"1"

--- a/ckan/tests/lib/test_changes.py
+++ b/ckan/tests/lib/test_changes.py
@@ -827,7 +827,6 @@ class TestChangesWithSingleAttributes(object):
 
         check_metadata_changes(changes, original, new)
 
-
         assert len(changes) == 1, changes
         assert changes[0]["type"] == u"title"
         assert changes[0]["old_title"] is None
@@ -839,7 +838,6 @@ class TestChangesWithSingleAttributes(object):
         new = {'title': u"new title"}
 
         check_metadata_changes(changes, original, new)
-
 
         assert len(changes) == 1, changes
         assert changes[0]["type"] == u"title"
@@ -853,12 +851,10 @@ class TestChangesWithSingleAttributes(object):
 
         check_metadata_changes(changes, original, new)
 
-
         assert len(changes) == 1, changes
         assert changes[0]["type"] == u"title"
         assert changes[0]["old_title"] == u'old title'
         assert changes[0]["new_title"] is None
-
 
     def test_owner_org_added_when_it_does_not_exist(self):
         changes = []
@@ -867,7 +863,6 @@ class TestChangesWithSingleAttributes(object):
         new = {'owner_org': new_org['id'], 'organization': new_org}
 
         check_metadata_changes(changes, original, new)
-
 
         assert len(changes) == 1, changes
         assert changes[0]["type"] == u"org"
@@ -883,14 +878,11 @@ class TestChangesWithSingleAttributes(object):
 
         check_metadata_changes(changes, original, new)
 
-
         assert len(changes) == 1, changes
         assert changes[0]["type"] == u"org"
         assert changes[0]["method"] == u"change"
         assert changes[0]["old_org_id"] == old_org['id']
         assert changes[0]["new_org_id"] == new_org['id']
-
-
 
     def test_owner_org_removed_with_non_existing(self):
         changes = []
@@ -899,7 +891,6 @@ class TestChangesWithSingleAttributes(object):
         new = {}
 
         check_metadata_changes(changes, original, new)
-
 
         assert len(changes) == 1, changes
         assert changes[0]["type"] == u"org"
@@ -912,7 +903,6 @@ class TestChangesWithSingleAttributes(object):
         new = {'maintainer': u"new maintainer"}
 
         check_metadata_changes(changes, original, new)
-
 
         assert changes[0]["type"] == u"maintainer"
         assert changes[0]["method"] == u"add"
@@ -947,7 +937,6 @@ class TestChangesWithSingleAttributes(object):
 
         check_metadata_changes(changes, original, new)
 
-
         assert changes[0]["type"] == u"maintainer_email"
         assert changes[0]["method"] == u"add"
         assert changes[0]["new_maintainer_email"] == u"new@example.com"
@@ -981,7 +970,6 @@ class TestChangesWithSingleAttributes(object):
 
         check_metadata_changes(changes, original, new)
 
-
         assert changes[0]["type"] == u"author"
         assert changes[0]["method"] == u"add"
         assert changes[0]["new_author"] == u"new author"
@@ -1014,7 +1002,6 @@ class TestChangesWithSingleAttributes(object):
         new = {'author_email': u"new@example.com"}
 
         check_metadata_changes(changes, original, new)
-
 
         assert changes[0]["type"] == u"author_email"
         assert changes[0]["method"] == u"add"
@@ -1075,7 +1062,6 @@ class TestChangesWithSingleAttributes(object):
         assert changes[0]["type"] == u"notes"
         assert changes[0]["method"] == u"remove"
 
-
     def test_tag_added_when_it_does_not_exist(self):
         changes = []
         original = {}
@@ -1091,11 +1077,11 @@ class TestChangesWithSingleAttributes(object):
     def test_multiple_tags_added_when_it_does_not_exist(self):
         changes = []
         original = {"tags": [{u"name": u"rivers"}]}
-        new = {"tags":[
-                {u"name": u"rivers"},
-                {u"name": u"oceans"},
-                {u"name": u"streams"},
-            ]}
+        new = {"tags": [
+            {u"name": u"rivers"},
+            {u"name": u"oceans"},
+            {u"name": u"streams"},
+        ]}
 
         check_metadata_changes(changes, original, new)
 
@@ -1119,10 +1105,10 @@ class TestChangesWithSingleAttributes(object):
     def test_multiple_tags_removed_with_non_existing(self):
         changes = []
         original = {"tags": [
-                {u"name": u"rivers"},
-                {u"name": u"oceans"},
-                {u"name": u"streams"},
-            ]}
+            {u"name": u"rivers"},
+            {u"name": u"oceans"},
+            {u"name": u"streams"},
+        ]}
 
         new = {}
 

--- a/ckan/tests/lib/test_changes.py
+++ b/ckan/tests/lib/test_changes.py
@@ -823,7 +823,7 @@ class TestChangesWithSingleAttributes(object):
     def test_title_added_when_it_does_not_exist(self):
         changes = []
         original = {}
-        new = {'title': u"new title"}
+        new = {u'title': u"new title"}
 
         check_metadata_changes(changes, original, new)
 
@@ -834,8 +834,8 @@ class TestChangesWithSingleAttributes(object):
 
     def test_title_changed(self):
         changes = []
-        original = {'title': u'old title'}
-        new = {'title': u"new title"}
+        original = {u'title': u'old title'}
+        new = {u'title': u"new title"}
 
         check_metadata_changes(changes, original, new)
 
@@ -846,7 +846,7 @@ class TestChangesWithSingleAttributes(object):
 
     def test_title_removed_with_non_existing(self):
         changes = []
-        original = {'title': u'old title'}
+        original = {u'title': u'old title'}
         new = {}
 
         check_metadata_changes(changes, original, new)
@@ -860,7 +860,7 @@ class TestChangesWithSingleAttributes(object):
         changes = []
         original = {}
         new_org = {u'id': u'new_org_id'}
-        new = {'owner_org': new_org['id'], 'organization': new_org}
+        new = {u'owner_org': new_org['id'], u'organization': new_org}
 
         check_metadata_changes(changes, original, new)
 
@@ -872,9 +872,9 @@ class TestChangesWithSingleAttributes(object):
     def test_owner_org_changed(self):
         changes = []
         old_org = {u'id': u'old_org_id'}
-        original = {'owner_org': old_org['id'], 'organization': old_org}
+        original = {u'owner_org': old_org['id'], u'organization': old_org}
         new_org = {u'id': u'new_org_id'}
-        new = {'owner_org': new_org['id'], 'organization': new_org}
+        new = {u'owner_org': new_org['id'], u'organization': new_org}
 
         check_metadata_changes(changes, original, new)
 
@@ -887,7 +887,7 @@ class TestChangesWithSingleAttributes(object):
     def test_owner_org_removed_with_non_existing(self):
         changes = []
         old_org = {u'id': u'org_id'}
-        original = {'owner_org': old_org['id'], 'organization': old_org}
+        original = {u'owner_org': old_org['id'], u'organization': old_org}
         new = {}
 
         check_metadata_changes(changes, original, new)
@@ -900,7 +900,7 @@ class TestChangesWithSingleAttributes(object):
     def test_maintainer_added_when_it_does_not_exist(self):
         changes = []
         original = {}
-        new = {'maintainer': u"new maintainer"}
+        new = {u'maintainer': u"new maintainer"}
 
         check_metadata_changes(changes, original, new)
 
@@ -910,8 +910,8 @@ class TestChangesWithSingleAttributes(object):
 
     def test_maintainer_changed(self):
         changes = []
-        original = {'maintainer': u"old maintainer"}
-        new = {'maintainer': u"new maintainer"}
+        original = {u'maintainer': u"old maintainer"}
+        new = {u'maintainer': u"new maintainer"}
 
         check_metadata_changes(changes, original, new)
 
@@ -922,7 +922,7 @@ class TestChangesWithSingleAttributes(object):
 
     def test_maintainer_removed_with_non_existing(self):
         changes = []
-        original = {'maintainer': u"old maintainer"}
+        original = {u'maintainer': u"old maintainer"}
         new = {}
 
         check_metadata_changes(changes, original, new)
@@ -933,7 +933,7 @@ class TestChangesWithSingleAttributes(object):
     def test_maintainer_email_added_when_it_does_not_exist(self):
         changes = []
         original = {}
-        new = {'maintainer_email': u"new@example.com"}
+        new = {u'maintainer_email': u"new@example.com"}
 
         check_metadata_changes(changes, original, new)
 
@@ -943,8 +943,8 @@ class TestChangesWithSingleAttributes(object):
 
     def test_maintainer_email_changed(self):
         changes = []
-        original = {'maintainer_email': u"old@example.com"}
-        new = {'maintainer_email': u"new@example.com"}
+        original = {u'maintainer_email': u"old@example.com"}
+        new = {u'maintainer_email': u"new@example.com"}
 
         check_metadata_changes(changes, original, new)
 
@@ -955,7 +955,7 @@ class TestChangesWithSingleAttributes(object):
 
     def test_maintainer_email_removed_with_non_existing(self):
         changes = []
-        original = {'maintainer_email': u"old@example.com"}
+        original = {u'maintainer_email': u"old@example.com"}
         new = {}
 
         check_metadata_changes(changes, original, new)
@@ -966,7 +966,7 @@ class TestChangesWithSingleAttributes(object):
     def test_author_added_when_it_does_not_exist(self):
         changes = []
         original = {}
-        new = {'author': u"new author"}
+        new = {u'author': u"new author"}
 
         check_metadata_changes(changes, original, new)
 
@@ -976,8 +976,8 @@ class TestChangesWithSingleAttributes(object):
 
     def test_author_changed(self):
         changes = []
-        original = {'author': u"old author"}
-        new = {'author': u"new author"}
+        original = {u'author': u"old author"}
+        new = {u'author': u"new author"}
 
         check_metadata_changes(changes, original, new)
 
@@ -988,7 +988,7 @@ class TestChangesWithSingleAttributes(object):
 
     def test_author_removed_with_non_existing(self):
         changes = []
-        original = {'author': u"old author"}
+        original = {u'author': u"old author"}
         new = {}
 
         check_metadata_changes(changes, original, new)
@@ -999,7 +999,7 @@ class TestChangesWithSingleAttributes(object):
     def test_author_email_added_when_it_does_not_exist(self):
         changes = []
         original = {}
-        new = {'author_email': u"new@example.com"}
+        new = {u'author_email': u"new@example.com"}
 
         check_metadata_changes(changes, original, new)
 
@@ -1009,8 +1009,8 @@ class TestChangesWithSingleAttributes(object):
 
     def test_author_email_changed(self):
         changes = []
-        original = {'author_email': u"old@example.com"}
-        new = {'author_email': u"new@example.com"}
+        original = {u'author_email': u"old@example.com"}
+        new = {u'author_email': u"new@example.com"}
 
         check_metadata_changes(changes, original, new)
 
@@ -1021,7 +1021,7 @@ class TestChangesWithSingleAttributes(object):
 
     def test_author_email_removed_with_non_existing(self):
         changes = []
-        original = {'author_email': u"old@example.com"}
+        original = {u'author_email': u"old@example.com"}
         new = {}
 
         check_metadata_changes(changes, original, new)
@@ -1032,7 +1032,7 @@ class TestChangesWithSingleAttributes(object):
     def test_notes_added_when_it_does_not_exist(self):
         changes = []
         original = {}
-        new = {'notes': u'new notes'}
+        new = {u'notes': u'new notes'}
 
         check_metadata_changes(changes, original, new)
 
@@ -1042,8 +1042,8 @@ class TestChangesWithSingleAttributes(object):
 
     def test_notes_changed(self):
         changes = []
-        original = {'notes': u'old notes'}
-        new = {'notes': u'new notes'}
+        original = {u'notes': u'old notes'}
+        new = {u'notes': u'new notes'}
 
         check_metadata_changes(changes, original, new)
 
@@ -1054,7 +1054,7 @@ class TestChangesWithSingleAttributes(object):
 
     def test_notes_removed_with_non_existing(self):
         changes = []
-        original = {'notes': u'old notes'}
+        original = {u'notes': u'old notes'}
         new = {}
 
         check_metadata_changes(changes, original, new)
@@ -1065,7 +1065,7 @@ class TestChangesWithSingleAttributes(object):
     def test_tag_added_when_it_does_not_exist(self):
         changes = []
         original = {}
-        new = {"tags": [{u"name": u"rivers"}]}
+        new = {u"tags": [{u"name": u"rivers"}]}
 
         check_metadata_changes(changes, original, new)
 
@@ -1076,8 +1076,8 @@ class TestChangesWithSingleAttributes(object):
 
     def test_multiple_tags_added_when_it_does_not_exist(self):
         changes = []
-        original = {"tags": [{u"name": u"rivers"}]}
-        new = {"tags": [
+        original = {u"tags": [{u"name": u"rivers"}]}
+        new = {u"tags": [
             {u"name": u"rivers"},
             {u"name": u"oceans"},
             {u"name": u"streams"},
@@ -1092,7 +1092,7 @@ class TestChangesWithSingleAttributes(object):
 
     def test_tag_removed_with_non_existing(self):
         changes = []
-        original = {"tags": [{u"name": u"oceans"}]}
+        original = {u"tags": [{u"name": u"oceans"}]}
         new = {}
 
         check_metadata_changes(changes, original, new)
@@ -1104,7 +1104,7 @@ class TestChangesWithSingleAttributes(object):
 
     def test_multiple_tags_removed_with_non_existing(self):
         changes = []
-        original = {"tags": [
+        original = {u"tags": [
             {u"name": u"rivers"},
             {u"name": u"oceans"},
             {u"name": u"streams"},

--- a/ckan/tests/lib/test_changes.py
+++ b/ckan/tests/lib/test_changes.py
@@ -816,3 +816,354 @@ class TestChanges(object):
         else:
             assert changes[0]["resource_name"] == u"Image 2"
             assert changes[1]["resource_name"] == u"Image 1"
+
+
+class TestChangesWithSingleAttributes(object):
+
+    def test_title_added_when_it_does_not_exist(self):
+        changes = []
+        original = {}
+        new = {'title': u"new title"}
+
+        check_metadata_changes(changes, original, new)
+
+
+        assert len(changes) == 1, changes
+        assert changes[0]["type"] == u"title"
+        assert changes[0]["old_title"] is None
+        assert changes[0]["new_title"] == u"new title"
+
+    def test_title_changed(self):
+        changes = []
+        original = {'title': u'old title'}
+        new = {'title': u"new title"}
+
+        check_metadata_changes(changes, original, new)
+
+
+        assert len(changes) == 1, changes
+        assert changes[0]["type"] == u"title"
+        assert changes[0]["old_title"] == u"old title"
+        assert changes[0]["new_title"] == u"new title"
+
+    def test_title_removed_with_non_existing(self):
+        changes = []
+        original = {'title': u'old title'}
+        new = {}
+
+        check_metadata_changes(changes, original, new)
+
+
+        assert len(changes) == 1, changes
+        assert changes[0]["type"] == u"title"
+        assert changes[0]["old_title"] == u'old title'
+        assert changes[0]["new_title"] is None
+
+
+    def test_owner_org_added_when_it_does_not_exist(self):
+        changes = []
+        original = {}
+        new_org = {u'id': u'new_org_id'}
+        new = {'owner_org': new_org['id'], 'organization': new_org}
+
+        check_metadata_changes(changes, original, new)
+
+
+        assert len(changes) == 1, changes
+        assert changes[0]["type"] == u"org"
+        assert changes[0]["method"] == u"add"
+        assert changes[0]["new_org_id"] == new_org['id']
+
+    def test_owner_org_changed(self):
+        changes = []
+        old_org = {u'id': u'old_org_id'}
+        original = {'owner_org': old_org['id'], 'organization': old_org}
+        new_org = {u'id': u'new_org_id'}
+        new = {'owner_org': new_org['id'], 'organization': new_org}
+
+        check_metadata_changes(changes, original, new)
+
+
+        assert len(changes) == 1, changes
+        assert changes[0]["type"] == u"org"
+        assert changes[0]["method"] == u"change"
+        assert changes[0]["old_org_id"] == old_org['id']
+        assert changes[0]["new_org_id"] == new_org['id']
+
+
+
+    def test_owner_org_removed_with_non_existing(self):
+        changes = []
+        old_org = {u'id': u'org_id'}
+        original = {'owner_org': old_org['id'], 'organization': old_org}
+        new = {}
+
+        check_metadata_changes(changes, original, new)
+
+
+        assert len(changes) == 1, changes
+        assert changes[0]["type"] == u"org"
+        assert changes[0]["method"] == u"remove"
+        assert changes[0]["old_org_id"] == old_org['id']
+
+    def test_maintainer_added_when_it_does_not_exist(self):
+        changes = []
+        original = {}
+        new = {'maintainer': u"new maintainer"}
+
+        check_metadata_changes(changes, original, new)
+
+
+        assert changes[0]["type"] == u"maintainer"
+        assert changes[0]["method"] == u"add"
+        assert changes[0]["new_maintainer"] == u"new maintainer"
+
+    def test_maintainer_changed(self):
+        changes = []
+        original = {'maintainer': u"old maintainer"}
+        new = {'maintainer': u"new maintainer"}
+
+        check_metadata_changes(changes, original, new)
+
+        assert changes[0]["type"] == u"maintainer"
+        assert changes[0]["method"] == u"change"
+        assert changes[0]["new_maintainer"] == u"new maintainer"
+        assert changes[0]["old_maintainer"] == u"old maintainer"
+
+    def test_maintainer_removed_with_non_existing(self):
+        changes = []
+        original = {'maintainer': u"old maintainer"}
+        new = {}
+
+        check_metadata_changes(changes, original, new)
+
+        assert changes[0]["type"] == u"maintainer"
+        assert changes[0]["method"] == u"remove"
+
+    def test_maintainer_email_added_when_it_does_not_exist(self):
+        changes = []
+        original = {}
+        new = {'maintainer_email': u"new@example.com"}
+
+        check_metadata_changes(changes, original, new)
+
+
+        assert changes[0]["type"] == u"maintainer_email"
+        assert changes[0]["method"] == u"add"
+        assert changes[0]["new_maintainer_email"] == u"new@example.com"
+
+    def test_maintainer_email_changed(self):
+        changes = []
+        original = {'maintainer_email': u"old@example.com"}
+        new = {'maintainer_email': u"new@example.com"}
+
+        check_metadata_changes(changes, original, new)
+
+        assert changes[0]["type"] == u"maintainer_email"
+        assert changes[0]["method"] == u"change"
+        assert changes[0]["new_maintainer_email"] == u"new@example.com"
+        assert changes[0]["old_maintainer_email"] == u"old@example.com"
+
+    def test_maintainer_email_removed_with_non_existing(self):
+        changes = []
+        original = {'maintainer_email': u"old@example.com"}
+        new = {}
+
+        check_metadata_changes(changes, original, new)
+
+        assert changes[0]["type"] == u"maintainer_email"
+        assert changes[0]["method"] == u"remove"
+
+    def test_author_added_when_it_does_not_exist(self):
+        changes = []
+        original = {}
+        new = {'author': u"new author"}
+
+        check_metadata_changes(changes, original, new)
+
+
+        assert changes[0]["type"] == u"author"
+        assert changes[0]["method"] == u"add"
+        assert changes[0]["new_author"] == u"new author"
+
+    def test_author_changed(self):
+        changes = []
+        original = {'author': u"old author"}
+        new = {'author': u"new author"}
+
+        check_metadata_changes(changes, original, new)
+
+        assert changes[0]["type"] == u"author"
+        assert changes[0]["method"] == u"change"
+        assert changes[0]["new_author"] == u"new author"
+        assert changes[0]["old_author"] == u"old author"
+
+    def test_author_removed_with_non_existing(self):
+        changes = []
+        original = {'author': u"old author"}
+        new = {}
+
+        check_metadata_changes(changes, original, new)
+
+        assert changes[0]["type"] == u"author"
+        assert changes[0]["method"] == u"remove"
+
+    def test_author_email_added_when_it_does_not_exist(self):
+        changes = []
+        original = {}
+        new = {'author_email': u"new@example.com"}
+
+        check_metadata_changes(changes, original, new)
+
+
+        assert changes[0]["type"] == u"author_email"
+        assert changes[0]["method"] == u"add"
+        assert changes[0]["new_author_email"] == u"new@example.com"
+
+    def test_author_email_changed(self):
+        changes = []
+        original = {'author_email': u"old@example.com"}
+        new = {'author_email': u"new@example.com"}
+
+        check_metadata_changes(changes, original, new)
+
+        assert changes[0]["type"] == u"author_email"
+        assert changes[0]["method"] == u"change"
+        assert changes[0]["new_author_email"] == u"new@example.com"
+        assert changes[0]["old_author_email"] == u"old@example.com"
+
+    def test_author_email_removed_with_non_existing(self):
+        changes = []
+        original = {'author_email': u"old@example.com"}
+        new = {}
+
+        check_metadata_changes(changes, original, new)
+
+        assert changes[0]["type"] == u"author_email"
+        assert changes[0]["method"] == u"remove"
+
+    def test_notes_added_when_it_does_not_exist(self):
+        changes = []
+        original = {}
+        new = {'notes': u'new notes'}
+
+        check_metadata_changes(changes, original, new)
+
+        assert changes[0]["type"] == u"notes"
+        assert changes[0]["method"] == u"add"
+        assert changes[0]["new_notes"] == u"new notes"
+
+    def test_notes_changed(self):
+        changes = []
+        original = {'notes': u'old notes'}
+        new = {'notes': u'new notes'}
+
+        check_metadata_changes(changes, original, new)
+
+        assert changes[0]["type"] == u"notes"
+        assert changes[0]["method"] == u"change"
+        assert changes[0]["new_notes"] == u"new notes"
+        assert changes[0]["old_notes"] == u"old notes"
+
+    def test_notes_removed_with_non_existing(self):
+        changes = []
+        original = {'notes': u'old notes'}
+        new = {}
+
+        check_metadata_changes(changes, original, new)
+
+        assert changes[0]["type"] == u"notes"
+        assert changes[0]["method"] == u"remove"
+
+
+    def test_tag_added_when_it_does_not_exist(self):
+        changes = []
+        original = {}
+        new = {"tags": [{u"name": u"rivers"}]}
+
+        check_metadata_changes(changes, original, new)
+
+        assert len(changes) == 1, changes
+        assert changes[0]["type"] == u"tags"
+        assert changes[0]["method"] == u"add_one"
+        assert changes[0]["tag"] == u"rivers"
+
+    def test_multiple_tags_added_when_it_does_not_exist(self):
+        changes = []
+        original = {"tags": [{u"name": u"rivers"}]}
+        new = {"tags":[
+                {u"name": u"rivers"},
+                {u"name": u"oceans"},
+                {u"name": u"streams"},
+            ]}
+
+        check_metadata_changes(changes, original, new)
+
+        assert len(changes) == 1, changes
+        assert changes[0]["type"] == u"tags"
+        assert changes[0]["method"] == u"add_multiple"
+        assert set(changes[0]["tags"]) == set((u"oceans", u"streams"))
+
+    def test_tag_removed_with_non_existing(self):
+        changes = []
+        original = {"tags": [{u"name": u"oceans"}]}
+        new = {}
+
+        check_metadata_changes(changes, original, new)
+
+        assert len(changes) == 1, changes
+        assert changes[0]["type"] == u"tags"
+        assert changes[0]["method"] == u"remove_one"
+        assert changes[0]["tag"] == u"oceans"
+
+    def test_multiple_tags_removed_with_non_existing(self):
+        changes = []
+        original = {"tags": [
+                {u"name": u"rivers"},
+                {u"name": u"oceans"},
+                {u"name": u"streams"},
+            ]}
+
+        new = {}
+
+        check_metadata_changes(changes, original, new)
+
+        assert len(changes) == 1, changes
+        assert changes[0]["type"] == u"tags"
+        assert changes[0]["method"] == u"remove_multiple"
+        assert set(changes[0]["tags"]) == set((u"rivers", u"oceans", u"streams"))
+
+    def test_licence_title_added_when_it_does_not_exist(self):
+        changes = []
+        original = {}
+        new = {u"license_title": u"new license"}
+
+        check_metadata_changes(changes, original, new)
+
+        assert len(changes) == 1, changes
+        assert changes[0]["type"] == u"license"
+        assert changes[0]["new_title"] == u"new license"
+
+    def test_licence_title_changed(self):
+        changes = []
+        original = {u"license_title": u"old license"}
+        new = {u"license_title": u"new license"}
+
+        check_metadata_changes(changes, original, new)
+
+        assert len(changes) == 1, changes
+        assert changes[0]["type"] == u"license"
+        assert changes[0]["old_title"] == u"old license"
+        assert changes[0]["new_title"] == u"new license"
+
+    def test_licence_title_removed_with_non_existing(self):
+        changes = []
+        original = {u"license_title": u"old license"}
+        new = {}
+
+        check_metadata_changes(changes, original, new)
+
+        assert len(changes) == 1, changes
+        assert changes[0]["type"] == u"license"
+        assert changes[0]["old_title"] == u"old license"
+        assert changes[0]["new_title"] is None


### PR DESCRIPTION
Fixes #5562 

### Proposed fixes:
Use .get() calls instead of indexes which won't raise KeyError.

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
