### PR TITLE
Documentation - Update background-tasks.rst with the correct format for timeout

### DIFF
--- a/doc/maintaining/background-tasks.rst
+++ b/doc/maintaining/background-tasks.rst
@@ -101,7 +101,7 @@ You can also give the job a title which can be useful for identifying it when
 
 A timeout can also be set on a job iwth the ``timeout`` keyword argument::
 
-    jobs.enqueue(log_job, [u'My log message'], timeout=3600)
+    jobs.enqueue(log_job, [u'My log message'], rq_kwargs={"timeout": 3600})
 
 The default background job timeout is 180 seconds. This is set in the
 ckan config ``.ini`` file under the ``ckan.jobs.timeout`` item.


### PR DESCRIPTION
Fixes #5566 

### Proposed fixes:
The jobs.enqueue function does not have a "timeout" argument as specified in the current documentation. This change addresses this.


### Features:

- [ ] includes tests covering changes
- [X ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
