### PR TITLE
[#5586] Don't cache license translations across requests

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2840,7 +2840,7 @@ def license_options(existing_license_id=None):
         license_ids.insert(0, existing_license_id)
     return [
         (license_id,
-         register[license_id].title if license_id in register else license_id)
+         _(register[license_id].title) if license_id in register else license_id)
         for license_id in license_ids]
 
 

--- a/ckan/model/license.py
+++ b/ckan/model/license.py
@@ -141,8 +141,6 @@ class LicenseRegister(object):
         for license in license_data:
             if isinstance(license, string_types):
                 license = license_data[license]
-            if license.get('title'):
-                license['title'] = _(license['title'])
         self._create_license_list(license_data, license_url)
 
     def _create_license_list(self, license_data, license_url=''):


### PR DESCRIPTION
Fixes #5586

### Proposed fixes:

* Licenses are read and cached in the package model in english
* Translate the license in the helper for each request.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply

(note, unclear how to test this as it's tricky to trigger in isolation)