### PR TITLE
Removed hardcoded references to db host and users

### DIFF
--- a/contrib/docker/.env.template
+++ b/contrib/docker/.env.template
@@ -34,12 +34,18 @@ CKAN_SMTP_MAIL_FROM=ckan@localhost
 # Image: db
 POSTGRES_PASSWORD=ckan
 #
+# POSTGRES_USER must be set to the database user used by CKAN, typically named ckan
+POSTGRES_USER=ckan
+#
 # POSTGRES_PORT must be available on the host: sudo netstat -na | grep 5432
 # To apply change: docker-compose down && docker rmi docker_db docker_ckan && docker-compose build
 POSTGRES_PORT=5432
 #
 # The datastore database will be created in the db container as docs
-# Readwrite user/pass will be ckan:POSTGRES_PASSWORD
-# Readonly user/pass will be datastore_ro:DATASTORE_READONLY_PASSWORD
+# Readwrite user/pass will be POSTGRES_USER:POSTGRES_PASSWORD
+# Readonly user/pass will be DATASTORE_READONLY_USER:DATASTORE_READONLY_PASSWORD
 DATASTORE_READONLY_PASSWORD=datastore
-
+DATASTORE_READONLY_USER=datastore_ro
+# POSTGRES_HOST must be set to the host for the postgres server.
+# As a default 'db' will point to the postgres running in the docker container specified by the docker-compose.yml file.
+POSTGRES_HOST=db

--- a/contrib/docker/ckan-entrypoint.sh
+++ b/contrib/docker/ckan-entrypoint.sh
@@ -42,7 +42,7 @@ write_config () {
 }
 
 # Wait for PostgreSQL
-while ! pg_isready -h ${POSTGRES_HOST}; do
+while ! pg_isready -h ${POSTGRES_HOST} -U ${POSTGRES_USER}; do
   sleep 1;
 done
 

--- a/contrib/docker/ckan-entrypoint.sh
+++ b/contrib/docker/ckan-entrypoint.sh
@@ -42,7 +42,7 @@ write_config () {
 }
 
 # Wait for PostgreSQL
-while ! pg_isready -h db -U ckan; do
+while ! pg_isready -h ${POSTGRES_HOST}; do
   sleep 1;
 done
 

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -26,9 +26,9 @@ services:
       - "0.0.0.0:${CKAN_PORT}:5000"
     environment:
       # Defaults work with linked containers, change to use own Postgres, SolR, Redis or Datapusher
-      - CKAN_SQLALCHEMY_URL=postgresql://ckan:${POSTGRES_PASSWORD}@db/ckan
-      - CKAN_DATASTORE_WRITE_URL=postgresql://ckan:${POSTGRES_PASSWORD}@db/datastore
-      - CKAN_DATASTORE_READ_URL=postgresql://datastore_ro:${DATASTORE_READONLY_PASSWORD}@db/datastore
+      - CKAN_SQLALCHEMY_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}/ckan
+      - CKAN_DATASTORE_WRITE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}/datastore
+      - CKAN_DATASTORE_READ_URL=postgresql://${DATASTORE_READONLY_USER}:${DATASTORE_READONLY_PASSWORD}@${POSTGRES_HOST}/datastore
       - CKAN_SOLR_URL=http://solr:8983/solr/ckan
       - CKAN_REDIS_URL=redis://redis:6379/1
       - CKAN_DATAPUSHER_URL=http://datapusher:8800
@@ -36,6 +36,7 @@ services:
       - CKAN_MAX_UPLOAD_SIZE_MB=${CKAN_MAX_UPLOAD_SIZE_MB}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - DS_RO_PASS=${DATASTORE_READONLY_PASSWORD}
+      - POSTGRES_HOST=${POSTGRES_HOST}
 
     volumes:
       - ckan_config:/etc/ckan

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     volumes:
       - pg_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "ckan"]
+      test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER}"]
 
   solr:
     container_name: solr


### PR DESCRIPTION
Fixes #
The docker-compose.yml file describes that you can modify it to use your own postgres database. Currently this is not possible, since the contrib/docker/ckan-entrypoint.sh is hardcoded check the host db for the database being up. I consider the hardcoded reference to "db" in ckan-entrypoint.sh a bug.

It is also currently not possible to modify the names of the database users in the .env file. This patch enables this, while keeping the existing calues (ckan and datastore_ro) as defaults. If running on on Azure's Postgress PAAS offering it is currently not possible to have as user named ckan as it postfixes the servername to the username. If an Azure Postgres server is hosted on myhost.postgres.database.azure.com the ckan user on that server would have to log in with the username "ckan@myhost". This patch makes it easy to use such a setup in a production environment without bothering any users without this need.

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
