### PR TITLE
[#5602] unflatten: skip empty items regression + test

### DIFF
--- a/ckan/lib/navl/dictization_functions.py
+++ b/ckan/lib/navl/dictization_functions.py
@@ -405,7 +405,7 @@ def unflatten(data):
     '''
 
     unflattened = {}
-    convert_to_list = []
+    clean_lists = {}
 
     for flattend_key in sorted(data.keys(), key=flattened_order_key):
         current_pos = unflattened
@@ -414,14 +414,22 @@ def unflatten(data):
             try:
                 current_pos = current_pos[key]
             except IndexError:
-                new_pos = {}
-                current_pos.append(new_pos)
+                while True:
+                    new_pos = {}
+                    current_pos.append(new_pos)
+                    if key < len(current_pos):
+                        break
+                    # skipped list indexes need to be removed before returning
+                    clean_lists[id(current_pos)] = current_pos
                 current_pos = new_pos
             except KeyError:
                 new_pos = []
                 current_pos[key] = new_pos
                 current_pos = new_pos
         current_pos[flattend_key[-1]] = data[flattend_key]
+
+    for cl in clean_lists.values():
+        cl[:] = [i for i in cl if i]
 
     return unflattened
 

--- a/ckan/logic/converters.py
+++ b/ckan/logic/converters.py
@@ -26,24 +26,14 @@ def convert_to_extras(key, data, errors, context):
 
 def convert_from_extras(key, data, errors, context):
 
-    def remove_from_extras(data, idx):
-        for key in sorted(data):
-            if key[0] != 'extras' or key[1] < idx:
-                continue
-            if key[1] == idx:
-                del data[key]
-
-            # Following block required for unflattening extras with
-            # "gaps" created sometimes by `convert_from_extra`
-            # validator :
-            #
-            #   {
-            #     ('extras', 0, 'key'): 'x',
-            #     ('extras', 2, 'key): 'y'
-            #   }
-            if key[1] > idx:
-                new_key = (key[0], key[1] - 1) + key[2:]
-                data[new_key] = data.pop(key)
+    def remove_from_extras(data, key):
+        to_remove = []
+        for data_key, data_value in six.iteritems(data):
+            if (data_key[0] == 'extras'
+                and data_key[1] == key):
+                to_remove.append(data_key)
+        for item in to_remove:
+            del data[item]
 
     for data_key, data_value in six.iteritems(data):
         if (data_key[0] == 'extras'

--- a/ckan/tests/legacy/lib/test_navl.py
+++ b/ckan/tests/legacy/lib/test_navl.py
@@ -272,6 +272,22 @@ def test_flatten_deeper():
         unflatten(flatten_dict(data)))
 
 
+def test_unflatten_regression():
+    fdata = {
+        (u"items", 0, u"name"): u"first",
+        (u"items", 0, u"value"): u"v1",
+        (u"items", 3, u"name"): u"second",
+        (u"items", 3, u"value"): u"v2",
+    }
+    expected = {
+        u"items": [
+            {u"name": u"first", u"value": u"v1"},
+            {u"name": u"second", u"value": u"v2"},
+        ],
+    }
+    assert unflatten(fdata) == expected, pformat(unflatten(fdata))
+
+
 def test_simple():
     schema = {
         "name": [not_empty],


### PR DESCRIPTION
Fixes #5602 

### Proposed fixes:

fix regression in unflatten that caused:
```python
unflatten({("items", 1, "name"): "first", ("items", 1, "value"): "v1",}) == {
    "items": [
        {"name": "first"},
        {"value": "v1}
    ]
}
```
when it should be:
```python
unflatten({("items", 1, "name"): "first", ("items", 1, "value"): "v1",}) == {
    "items": [
        {"name": "first", "value": "v1}
    ]
}
```

This regression appears in 2.9.0 and 2.8.5. This PR is should replace the earlier partial fix #5546 

### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport