### PR TITLE
Listing users or sysadmins error

### DIFF
--- a/ckan/cli/sysadmin.py
+++ b/ckan/cli/sysadmin.py
@@ -2,6 +2,8 @@
 
 import click
 from six import text_type
+from sqlalchemy.exc import ProgrammingError
+
 
 import ckan.model as model
 from ckan.cli import error_shout
@@ -24,6 +26,9 @@ def sysadmin(ctx):
 
 @sysadmin.command(name=u"list", help=u"List sysadmins.")
 def list_sysadmins():
+    """
+    List all the sysadmins
+    """
     click.secho(u"Sysadmins:")
     sysadmins = model.Session.query(model.User).filter_by(
         sysadmin=True, state=u"active"
@@ -40,8 +45,8 @@ def list_sysadmins():
                     sysadmin.id,
                 )
             )
-    except Exception:
-        error_shout("There are no users in the database. Maybe you should create one!")
+    except ProgrammingError:
+        error_shout(u'The database is not created. Please initialize database first')
 
 
 @sysadmin.command(help=u"Convert user into a sysadmin.")

--- a/ckan/cli/sysadmin.py
+++ b/ckan/cli/sysadmin.py
@@ -54,19 +54,22 @@ def list_sysadmins():
 @click.argument(u"args", nargs=-1)
 @click.pass_context
 def add(ctx, username, args):
-    user = model.User.by_name(text_type(username))
-    if not user:
-        click.secho(u'User "%s" not found' % username, fg=u"red")
-        if click.confirm(
-            u"Create new user: %s?" % username, default=True, abort=True
-        ):
-            ctx.forward(add_user)
-            user = model.User.by_name(text_type(username))
+    try:
+        user = model.User.by_name(text_type(username))
+        if not user:
+            click.secho(u'User "%s" not found' % username, fg=u"red")
+            if click.confirm(
+                u"Create new user: %s?" % username, default=True, abort=True
+            ):
+                ctx.forward(add_user)
+                user = model.User.by_name(text_type(username))
 
-    user.sysadmin = True
-    model.Session.add(user)
-    model.repo.commit_and_remove()
-    click.secho(u"Added %s as sysadmin" % username, fg=u"green")
+        user.sysadmin = True
+        model.Session.add(user)
+        model.repo.commit_and_remove()
+        click.secho(u"Added %s as sysadmin" % username, fg=u"green")
+    except ProgrammingError:
+        error_shout(u'The database is not created. Please initialize database first')
 
 
 @sysadmin.command(help=u"Removes user from sysadmins.")

--- a/ckan/cli/sysadmin.py
+++ b/ckan/cli/sysadmin.py
@@ -46,7 +46,8 @@ def list_sysadmins():
                 )
             )
     except ProgrammingError:
-        error_shout(u'The database is not created. Please initialize database first')
+        error_shout(u'The database is not created.\
+                    Please initialize database first')
 
 
 @sysadmin.command(help=u"Convert user into a sysadmin.")
@@ -69,7 +70,8 @@ def add(ctx, username, args):
         model.repo.commit_and_remove()
         click.secho(u"Added %s as sysadmin" % username, fg=u"green")
     except ProgrammingError:
-        error_shout(u'The database is not created. Please initialize database first')
+        error_shout(u'The database is not created.\
+                    Please initialize database first')
 
 
 @sysadmin.command(help=u"Removes user from sysadmins.")

--- a/ckan/cli/sysadmin.py
+++ b/ckan/cli/sysadmin.py
@@ -13,6 +13,7 @@ from ckan.cli.user import add_user
     invoke_without_command=True,
 )
 @click.pass_context
+@click.help_option(u'-h', u'--help')
 def sysadmin(ctx):
     """Gives sysadmin rights to a named user.
 
@@ -27,17 +28,20 @@ def list_sysadmins():
     sysadmins = model.Session.query(model.User).filter_by(
         sysadmin=True, state=u"active"
     )
-    click.secho(u"count = %i" % sysadmins.count())
-    for sysadmin in sysadmins:
-        click.secho(
-            u"%s name=%s email=%s id=%s"
-            % (
-                sysadmin.__class__.__name__,
-                sysadmin.name,
-                sysadmin.email,
-                sysadmin.id,
+    try:
+        click.secho(u"count = %i" % sysadmins.count())
+        for sysadmin in sysadmins:
+            click.secho(
+                u"%s name=%s email=%s id=%s"
+                % (
+                    sysadmin.__class__.__name__,
+                    sysadmin.name,
+                    sysadmin.email,
+                    sysadmin.id,
+                )
             )
-        )
+    except Exception:
+        error_shout("There is no users in the database. Maybe you should create one!")
 
 
 @sysadmin.command(help=u"Convert user into a sysadmin.")

--- a/ckan/cli/sysadmin.py
+++ b/ckan/cli/sysadmin.py
@@ -41,7 +41,7 @@ def list_sysadmins():
                 )
             )
     except Exception:
-        error_shout("There is no users in the database. Maybe you should create one!")
+        error_shout("There are no users in the database. Maybe you should create one!")
 
 
 @sysadmin.command(help=u"Convert user into a sysadmin.")

--- a/ckan/cli/user.py
+++ b/ckan/cli/user.py
@@ -80,7 +80,8 @@ def add_user(ctx, username, args):
     except logic.ValidationError as e:
         error_shout(e)
         raise click.Abort()
-
+    except ProgrammingError:
+        error_shout(u'The database is not created. Please initialize database first')
 
 def get_user_str(user):
     user_str = u'name=%s' % user.name

--- a/ckan/cli/user.py
+++ b/ckan/cli/user.py
@@ -7,6 +7,8 @@ from pprint import pprint
 import six
 import click
 from six import text_type
+from sqlalchemy.exc import ProgrammingError
+
 
 import ckan.logic as logic
 import ckan.plugins as plugin
@@ -90,14 +92,15 @@ def get_user_str(user):
 @user.command(u'list', short_help=u'List all users')
 def list_users():
     import ckan.model as model
-    click.secho(u'Users:')
+
     users = model.Session.query(model.User).filter_by(state=u'active')
     try:
+        click.secho(u'Users:')
         click.secho(u'count = %i' % users.count())
         for user in users:
             click.secho(get_user_str(user))
-    except Exception:
-        error_shout("There are no users in the database. Maybe you should create one!")
+    except ProgrammingError:
+        error_shout(u'The database is not created. Please initialize database first')
 
 
 @user.command(u'remove', short_help=u'Remove user')

--- a/ckan/cli/user.py
+++ b/ckan/cli/user.py
@@ -81,7 +81,8 @@ def add_user(ctx, username, args):
         error_shout(e)
         raise click.Abort()
     except ProgrammingError:
-        error_shout(u'The database is not created. Please initialize database first')
+        error_shout(u'The database is not created.\
+                    Please initialize database first')
 
 def get_user_str(user):
     user_str = u'name=%s' % user.name
@@ -101,7 +102,8 @@ def list_users():
         for user in users:
             click.secho(get_user_str(user))
     except ProgrammingError:
-        error_shout(u'The database is not created. Please initialize database first')
+        error_shout(u'The database is not created.\
+                    Please initialize database first')
 
 
 @user.command(u'remove', short_help=u'Remove user')

--- a/ckan/cli/user.py
+++ b/ckan/cli/user.py
@@ -92,9 +92,12 @@ def list_users():
     import ckan.model as model
     click.secho(u'Users:')
     users = model.Session.query(model.User).filter_by(state=u'active')
-    click.secho(u'count = %i' % users.count())
-    for user in users:
-        click.secho(get_user_str(user))
+    try:
+        click.secho(u'count = %i' % users.count())
+        for user in users:
+            click.secho(get_user_str(user))
+    except Exception:
+        error_shout("There is no users in the database. Maybe you should create one!")
 
 
 @user.command(u'remove', short_help=u'Remove user')

--- a/ckan/cli/user.py
+++ b/ckan/cli/user.py
@@ -97,7 +97,7 @@ def list_users():
         for user in users:
             click.secho(get_user_str(user))
     except Exception:
-        error_shout("There is no users in the database. Maybe you should create one!")
+        error_shout("There are no users in the database. Maybe you should create one!")
 
 
 @user.command(u'remove', short_help=u'Remove user')

--- a/ckan/cli/user.py
+++ b/ckan/cli/user.py
@@ -84,6 +84,7 @@ def add_user(ctx, username, args):
         error_shout(u'The database is not created.\
                     Please initialize database first')
 
+
 def get_user_str(user):
     user_str = u'name=%s' % user.name
     if user.name != user.display_name:


### PR DESCRIPTION
When we are listing users or sysadmins but there is no records in the database, error stack is displayed. Proposed fix is to display an error message and maybe we could invoke add user command 

Fixes #5621 
### Proposed fixes:
Display an error message 
`"There are no users in the database. Maybe you should create one!"
`

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x ] includes bugfix for possible backport

Please [X] all the boxes above that apply
