### PR TITLE
[#5626] delete get_fields function

### DIFF
--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -413,25 +413,6 @@ class Package(core.StatefulObjectMixin,
             groups = [g[0] for g in groupcaps if g[1] == capacity]
         return groups
 
-    @staticmethod
-    def get_fields(core_only=False, fields_to_ignore=None):
-        '''Returns a list of the properties of a package.
-        @param core_only - limit it to fields actually in the package table and
-                           not those on related objects, such as tags & extras.
-        @param fields_to_ignore - a list of names of fields to not return if
-                           present.
-        '''
-        # ['id', 'name', 'title', 'version', 'url', 'author', 'author_email', 'maintainer', 'maintainer_email', 'notes', 'license_id', 'state']
-        fields = Package.revisioned_fields()
-        if not core_only:
-            fields += ['resources', 'tags', 'groups', 'extras', 'relationships']
-
-        if fields_to_ignore:
-            for field in fields_to_ignore:
-                fields.remove(field)
-
-        return fields
-
     def activity_stream_item(self, activity_type, user_id):
         import ckan.model
         import ckan.logic


### PR DESCRIPTION
The get_fields function is unused and refers to the non-existed function

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
