### PR TITLE
change audio_view fallback text and fix url alternative text

### DIFF
--- a/ckanext/audioview/theme/templates/audio_view.html
+++ b/ckanext/audioview/theme/templates/audio_view.html
@@ -3,7 +3,7 @@
 <audio style="margin:auto; max-height:100%; display:block; min-width: 100%;"
 controls src="{{ resource_view.audio_url or resource.get('url') }}">
   {% trans %}
-    Your browser does not support the <code>audio</code> element.
-    But don't worry, you can <a href="{{ res_url }}" alt="video url">download it</a>.
+    <p>Your browser doesn't support <code>HTML5 audio</code>. Here is
+      a <a href="{{ res_url }}" alt="audio url">link to the audio</a> instead.</p>
   {% endtrans %}
 </audio>

--- a/ckanext/audioview/theme/templates/audio_view.html
+++ b/ckanext/audioview/theme/templates/audio_view.html
@@ -3,7 +3,7 @@
 <audio style="margin:auto; max-height:100%; display:block; min-width: 100%;"
 controls src="{{ resource_view.audio_url or resource.get('url') }}">
   {% trans %}
-    <p>Your browser doesn't support <code>HTML5 audio</code>. Here is
-      a <a href="{{ res_url }}" alt="audio url">link to the audio</a> instead.</p>
+    Your browser doesn't support <code>HTML5 audio</code>. Here is
+    a <a href="{{ res_url }}" alt="audio url">link to the audio</a> instead.
   {% endtrans %}
 </audio>


### PR DESCRIPTION
The alternative text of the URL copies the one from video_view :) 

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
