### PR TITLE
[#5595] Fix instantiation of smtp on python 3.8

### DIFF
--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -56,15 +56,13 @@ def _mail_recipient(recipient_name, recipient_email,
     subject = Header(subject.encode('utf-8'), 'utf-8')
     msg['Subject'] = subject
     msg['From'] = _("%s <%s>") % (sender_name, mail_from)
-    recipient = u"%s <%s>" % (recipient_name, recipient_email)
-    msg['To'] = Header(recipient, 'utf-8')
+    msg['To'] = u"%s <%s>" % (recipient_name, recipient_email)
     msg['Date'] = utils.formatdate(time())
     msg['X-Mailer'] = "CKAN %s" % ckan.__version__
     if reply_to and reply_to != '':
         msg['Reply-to'] = reply_to
 
     # Send the email using Python's smtplib.
-    smtp_connection = smtplib.SMTP()
     if 'smtp.test_server' in config:
         # If 'smtp.test_server' is configured we assume we're running tests,
         # and don't use the smtp.server, starttls, user, password etc. options.
@@ -80,11 +78,12 @@ def _mail_recipient(recipient_name, recipient_email,
         smtp_password = config.get('smtp.password')
 
     try:
-        smtp_connection.connect(smtp_server)
-    except socket.error as e:
+        smtp_connection = smtplib.SMTP(smtp_server)
+    except (socket.error, smtplib.SMTPConnectError) as e:
         log.exception(e)
         raise MailerException('SMTP server could not be connected to: "%s" %s'
                               % (smtp_server, e))
+
     try:
         # Identify ourselves and prompt the server for supported features.
         smtp_connection.ehlo()


### PR DESCRIPTION
Due to the python bug https://bugs.python.org/issue36094, smtp
connection failed to instantiate. Also removes encoding of To field.

Fixes #5595 

### Proposed fixes:
This a commit of @shasan-marsdd, just against master branch with little extra info, will merge after builds are done.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
