### PR TITLE
[#5259] Allow IAuthenticator methods to return responses

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -355,14 +355,22 @@ def get_locale():
 
 
 def ckan_before_request():
-    u'''Common handler executed before all Flask requests'''
+    u'''
+    Common handler executed before all Flask requests
+
+    If a response is returned by any of the functions called (
+    currently ``identify_user()` only) any further processing of the
+    request will be stopped and that response will be returned.
+
+    '''
+    response = None
 
     # Update app_globals
     app_globals.app_globals._check_uptodate()
 
     # Identify the user from the repoze cookie or the API header
     # Sets g.user and g.userobj
-    identify_user()
+    response = identify_user()
 
     # Provide g.controller and g.action for backward compatibility
     # with extensions
@@ -370,6 +378,8 @@ def ckan_before_request():
 
     set_ckan_current_url(request.environ)
     g.__timer = time.time()
+
+    return response
 
 
 def ckan_after_request(response):

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1667,24 +1667,67 @@ class IFacets(Interface):
 
 
 class IAuthenticator(Interface):
-    u'''Allows custom authentication methods to be integrated into CKAN.'''
+    u'''Allows custom authentication methods to be integrated into CKAN.
+
+        All interface methods except for the ``abort()`` one support
+        returning a Flask response object. This can be used for instance to
+        issue redirects or set cookies in the response. If a response object
+        is returned there will be no further processing of the current request
+        and that response will be returned. This can be used by plugins to:
+
+        * Issue a redirect::
+
+            def identify(self):
+
+                return toolkit.redirect_to('myplugin.custom_endpoint')
+
+        * Set or clear cookies (or headers)::
+
+            from Flask import make_response
+
+            def identify(self)::
+
+                response = make_response(toolkit.render('my_page.html'))
+                response.set_cookie(cookie_name, expires=0)
+
+                return response
+
+    '''
 
     def identify(self):
         u'''Called to identify the user.
 
         If the user is identified then it should set:
 
-         - c.user: The id of the user
-         - c.userobj: The actual user object (this may be removed as a
-           requirement in a later release so that access to the model is not
-           required)
+         - g.user: The name of the user
+         - g.userobj: The actual user object
+
+        Alternatively, plugins can return a response object in order to prevent
+        the default CKAN authorization flow. See
+        the :py:class:`~ckan.plugins.interfaces.IAuthenticator` documentation
+        for more details.
+
         '''
 
     def login(self):
-        u'''Called at login.'''
+        u'''Called before the login starts (that is before asking the user for
+        user name and a password in the default authentication).
+
+        Plugins can return a response object to prevent the default CKAN
+        authorization flow. See
+        the :py:class:`~ckan.plugins.interfaces.IAuthenticator` documentation
+        for more details.
+        '''
 
     def logout(self):
-        u'''Called at logout.'''
+        u'''Called before the logout starts (that is before clicking the logout
+        button in the default authentication).
+
+        Plugins can return a response object to prevent the default CKAN
+        authorization flow. See
+        the :py:class:`~ckan.plugins.interfaces.IAuthenticator` documentation
+        for more details.
+        '''
 
     def abort(self, status_code, detail, headers, comment):
         u'''Called on abort.  This allows aborts due to authorization issues

--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -139,12 +139,13 @@ def identify_user():
                                             u'Unknown IP Address')
 
     # Authentication plugins get a chance to run here break as soon as a user
-    # is identified.
-
+    # is identified or a response is returned
     authenticators = p.PluginImplementations(p.IAuthenticator)
     if authenticators:
         for item in authenticators:
-            item.identify()
+            response = item.identify()
+            if response:
+                return response
             try:
                 if g.user:
                     break

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -449,7 +449,9 @@ class RegisterView(MethodView):
 def login():
     # Do any plugin login stuff
     for item in plugins.PluginImplementations(plugins.IAuthenticator):
-        item.login()
+        response = item.login()
+        if response:
+            return response
 
     extra_vars = {}
     if g.user:
@@ -480,7 +482,10 @@ def logged_in():
 def logout():
     # Do any plugin logout stuff
     for item in plugins.PluginImplementations(plugins.IAuthenticator):
-        item.logout()
+        response = item.logout()
+        if response:
+            return response
+
     url = h.url_for(u'user.logged_out_page')
     return h.redirect_to(
         _get_repoze_handler(u'logout_handler_path') + u'?came_from=' + url,

--- a/ckanext/example_iauthenticator/plugin.py
+++ b/ckanext/example_iauthenticator/plugin.py
@@ -1,0 +1,59 @@
+# encoding: utf-8
+
+from flask import Blueprint, make_response
+
+from ckan import plugins as p
+
+
+toolkit = p.toolkit
+
+
+blueprint = Blueprint(u'example_iauthenticator', __name__, url_prefix=u'/user')
+
+
+def custom_login():
+
+    return u'logged in'
+
+
+def custom_logout():
+
+    return u'logged out'
+
+
+blueprint.add_url_rule(u'/custom_login', view_func=custom_login)
+blueprint.add_url_rule(u'/custom_logout', view_func=custom_logout)
+
+
+class ExampleIAuthenticatorPlugin(p.SingletonPlugin):
+
+    p.implements(p.IAuthenticator)
+    p.implements(p.IBlueprint)
+
+    # IAuthenticator
+
+    def identify(self):
+
+        if toolkit.request.path not in [
+                toolkit.url_for(u'user.login'),
+                toolkit.url_for(u'user.logout'),
+                toolkit.url_for(u'example_iauthenticator.custom_login'),
+                toolkit.url_for(u'example_iauthenticator.custom_logout')]:
+            response = make_response(toolkit.request.path)
+            response.set_cookie(u'example_iauthenticator', u'hi')
+
+            return response
+
+    def login(self):
+
+        return toolkit.redirect_to(u'example_iauthenticator.custom_login')
+
+    def logout(self):
+
+        return toolkit.redirect_to(u'example_iauthenticator.custom_logout')
+
+    # IBlueprint
+
+    def get_blueprint(self):
+
+        return [blueprint]

--- a/ckanext/example_iauthenticator/tests/test_example_iauthenticator.py
+++ b/ckanext/example_iauthenticator/tests/test_example_iauthenticator.py
@@ -1,0 +1,38 @@
+# encoding: utf-8
+
+import pytest
+
+import ckan.plugins as p
+
+toolkit = p.toolkit
+
+
+@pytest.mark.ckan_config(u'ckan.plugins', u'example_iauthenticator')
+@pytest.mark.usefixtures(u'with_plugins')
+class TestExampleIAuthenticator(object):
+
+    def test_identify_sets_cookie(self, app):
+
+        resp = app.get(toolkit.url_for(u'home.index'))
+
+        assert u'example_iauthenticator=hi' in resp.headers[u'Set-Cookie']
+
+    def test_login_redirects(self, app):
+
+        resp = app.get(
+            toolkit.url_for(u'user.login'),
+            follow_redirects=False
+        )
+
+        assert resp.status_code == 302
+        assert resp.headers[u'Location'] == toolkit.url_for(u'example_iauthenticator.custom_login', _external=True)
+
+    def test_logout_redirects(self, app):
+
+        resp = app.get(
+            toolkit.url_for(u'user.logout'),
+            follow_redirects=False
+        )
+
+        assert resp.status_code == 302
+        assert resp.headers[u'Location'] == toolkit.url_for(u'example_iauthenticator.custom_logout', _external=True)

--- a/setup.py
+++ b/setup.py
@@ -158,6 +158,7 @@ entry_points = {
         'example_ipermissionlabels = ckanext.example_ipermissionlabels.plugin:ExampleIPermissionLabelsPlugin',
         'example_iapitoken = ckanext.example_iapitoken.plugin:ExampleIApiTokenPlugin',
         'example_iclick = ckanext.example_iclick.plugin:ExampleIClickPlugin',
+        'example_iauthenticator = ckanext.example_iauthenticator.plugin:ExampleIAuthenticatorPlugin',
         'example_humanizer = ckanext.example_humanizer.plugin:ExampleHumanizerPlugin',
     ],
     'ckan.system_plugins': [


### PR DESCRIPTION
Fixes #5259

It's quite common for `IAuthenticator` methods to need to clear cookies, issue redirects etc. In Pylons, plugins could
just do `toolkit.response.cookies = ...` or `toolkit.redirect_to()` and the web response would be immediately affected.

On Flask though the current code just calls the plugin methods and carries on with the normal view function execution, so extensions can't do any of these actions.

These changes allow the interface methods to return a response object, where the previous actions can take place. If a response object is returned, no further processing of the request is performed and that response will be returned.

I added some examples on the interface documentation, plus an example plugin with tests.

- [x] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport
