### PR TITLE
5582 fix purge dataset with member

### DIFF
--- a/ckan/migration/versions/101_3f93f80a50f8_add_ondelete_to_package_member_table.py
+++ b/ckan/migration/versions/101_3f93f80a50f8_add_ondelete_to_package_member_table.py
@@ -1,4 +1,6 @@
-"""privet
+# encoding: utf-8
+ 
+"""Add ondelete to package_member table
 
 Revision ID: 3f93f80a50f8
 Revises: ccd38ad5fced

--- a/ckan/migration/versions/101_3f93f80a50f8_add_ondelete_to_package_member_table.py
+++ b/ckan/migration/versions/101_3f93f80a50f8_add_ondelete_to_package_member_table.py
@@ -1,0 +1,61 @@
+"""privet
+
+Revision ID: 3f93f80a50f8
+Revises: ccd38ad5fced
+Create Date: 2020-10-03 15:45:21.942192
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '3f93f80a50f8'
+down_revision = 'ccd38ad5fced'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    _drop_fk_constraints()
+
+    op.create_foreign_key(
+        u'package_member_user_id_fkey',
+        u'package_member',
+        u'user', ['user_id'], ['id'],
+        ondelete=u'CASCADE'
+    )
+    op.create_foreign_key(
+        u'package_member_package_id_fkey',
+        u'package_member',
+        u'package', ['package_id'], ['id'],
+        ondelete=u'CASCADE'
+    )
+
+
+def downgrade():
+    _drop_fk_constraints()
+
+    op.create_foreign_key(
+        u'package_member_user_id_fkey',
+        u'package_member',
+        u'user', ['user_id'], ['id']
+    )
+    op.create_foreign_key(
+        u'package_member_package_id_fkey',
+        u'package_member',
+        u'package', ['package_id'], ['id']
+    )
+
+
+def _drop_fk_constraints():
+    op.drop_constraint(
+        u"package_member_user_id_fkey",
+        u"package_member",
+        type_=u"foreignkey",
+    )
+    op.drop_constraint(
+        u"package_member_package_id_fkey",
+        u"package_member",
+        type_=u"foreignkey",
+    )

--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -60,8 +60,10 @@ package_table = Table('package', meta.metadata,
 package_member_table = Table(
     'package_member',
     meta.metadata,
-    Column('package_id', ForeignKey('package.id'), primary_key=True),
-    Column('user_id', ForeignKey('user.id'), primary_key = True),
+    Column('package_id',
+           ForeignKey('package.id', ondelete='CASCADE'), primary_key=True),
+    Column('user_id',
+           ForeignKey('user.id', ondelete='CASCADE'), primary_key=True),
     Column('capacity', types.UnicodeText, nullable=False),
     Column('modified', types.DateTime, default=datetime.datetime.utcnow),
 )


### PR DESCRIPTION
If we try to purge a dataset with an existing member (collaborator), we'll get an error.
Fixed foreign key constraint on package_member (add ondelete) to solve this problem.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
