### PR TITLE
[#5620] Fix managing resources by collaborators

### DIFF
--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -588,6 +588,33 @@ class TestResourceCreate:
         assert (result['metadata_modified'] ==
                 datetime.datetime.utcnow().isoformat())
 
+    @pytest.mark.ckan_config('ckan.auth.allow_dataset_collaborators', True)
+    @pytest.mark.ckan_config('ckan.auth.allow_admin_collaborators', True)
+    @pytest.mark.parametrize('role', ['admin', 'editor'])
+    def test_collaborators_can_create_resources(self, role):
+
+        org1 = factories.Organization()
+        dataset = factories.Dataset(owner_org=org1['id'])
+
+        user = factories.User()
+
+        helpers.call_action(
+            'package_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity=role)
+
+        context = {
+            'user': user['name'],
+            'ignore_auth': False,
+
+        }
+
+        created_resource = helpers.call_action('resource_create',
+            context=context,
+            package_id=dataset['id'],
+            name='created by collaborator',
+            url='https://example.com')
+
+        assert created_resource['name'] == 'created by collaborator'
 
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 class TestMemberCreate(object):

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -608,13 +608,15 @@ class TestResourceCreate:
 
         }
 
-        created_resource = helpers.call_action('resource_create',
+        created_resource = helpers.call_action(
+            'resource_create',
             context=context,
             package_id=dataset['id'],
             name='created by collaborator',
             url='https://example.com')
 
         assert created_resource['name'] == 'created by collaborator'
+
 
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 class TestMemberCreate(object):

--- a/ckan/tests/logic/action/test_delete.py
+++ b/ckan/tests/logic/action/test_delete.py
@@ -56,7 +56,8 @@ class TestDelete:
 
         }
 
-        created_resource = helpers.call_action('resource_delete',
+        created_resource = helpers.call_action(
+            'resource_delete',
             context=context,
             id=resource['id'])
 

--- a/ckan/tests/logic/action/test_delete.py
+++ b/ckan/tests/logic/action/test_delete.py
@@ -35,6 +35,31 @@ class TestDelete:
         res_obj = model.Resource.get(resource["id"])
         assert res_obj.state == "deleted"
 
+    @pytest.mark.ckan_config('ckan.auth.allow_dataset_collaborators', True)
+    @pytest.mark.ckan_config('ckan.auth.allow_admin_collaborators', True)
+    @pytest.mark.parametrize('role', ['admin', 'editor'])
+    def test_collaborators_can_delete_resources(self, role):
+
+        org1 = factories.Organization()
+        dataset = factories.Dataset(owner_org=org1['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+
+        user = factories.User()
+
+        helpers.call_action(
+            'package_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity=role)
+
+        context = {
+            'user': user['name'],
+            'ignore_auth': False,
+
+        }
+
+        created_resource = helpers.call_action('resource_delete',
+            context=context,
+            id=resource['id'])
+
 
 @pytest.mark.ckan_config("ckan.plugins", "image_view")
 @pytest.mark.usefixtures("clean_db", "with_plugins", "with_request_context")

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -1714,13 +1714,13 @@ class TestCollaboratorsUpdate(object):
 
         }
 
-        updated_resource = helpers.call_action('resource_update',
+        updated_resource = helpers.call_action(
+            'resource_update',
             context=context,
             id=resource['id'],
             description='updated')
 
         assert updated_resource['description'] == 'updated'
-
 
     def test_collaborators_can_not_change_owner_org_by_default(self):
 

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -1694,6 +1694,34 @@ class TestDashboardMarkActivitiesOld(object):
 @pytest.mark.ckan_config('ckan.auth.allow_dataset_collaborators', True)
 class TestCollaboratorsUpdate(object):
 
+    @pytest.mark.ckan_config('ckan.auth.allow_admin_collaborators', True)
+    @pytest.mark.parametrize('role', ['admin', 'editor'])
+    def test_collaborators_can_update_resources(self, role):
+
+        org1 = factories.Organization()
+        dataset = factories.Dataset(owner_org=org1['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+
+        user = factories.User()
+
+        helpers.call_action(
+            'package_collaborator_create',
+            id=dataset['id'], user_id=user['id'], capacity=role)
+
+        context = {
+            'user': user['name'],
+            'ignore_auth': False,
+
+        }
+
+        updated_resource = helpers.call_action('resource_update',
+            context=context,
+            id=resource['id'],
+            description='updated')
+
+        assert updated_resource['description'] == 'updated'
+
+
     def test_collaborators_can_not_change_owner_org_by_default(self):
 
         org1 = factories.Organization()


### PR DESCRIPTION
Fixes #5620

Fixes validation errors when collaborators created, updated or deleted resources of datasets they are members of.

The `owner_org_validator` correctly checked and prevented if necessary if a collaborator was changing the owner org of a dataset, but it then followed up with the standard logic, which checks if the user can creates dataset in the target organization.

For the case where a user is just editing the dataset (or its resources) this failed for collaborators as they are missing the org permissions. With these changes, the check is only performed if we are creating a new dataset or changing the value of `owner_org`.

This was not raised when logged in as a collaborator in the main dataset edit form because the `owner_org` field is hidden and not sent to validation.



- [x] includes tests covering changes
- [x] includes bugfix for possible backport


