### PR TITLE
Use actual default timeout for background jobs

### DIFF
--- a/ckan/lib/jobs.py
+++ b/ckan/lib/jobs.py
@@ -37,7 +37,7 @@ import ckan.plugins as plugins
 log = logging.getLogger(__name__)
 
 DEFAULT_QUEUE_NAME = u'default'
-DEFAULT_JOB_TIMEOUT = config.get(u'ckan.jobs.timeout', 180)
+DEFAULT_JOB_TIMEOUT = 180
 
 # RQ job queues. Do not use this directly, use ``get_queue`` instead.
 _queues = {}
@@ -157,7 +157,8 @@ def enqueue(fn, args=None, kwargs=None, title=None, queue=DEFAULT_QUEUE_NAME,
         kwargs = {}
     if rq_kwargs is None:
         rq_kwargs = {}
-    rq_kwargs[u'timeout'] = rq_kwargs.get(u'timeout', DEFAULT_JOB_TIMEOUT)
+    timeout = config.get(u'ckan.jobs.timeout', DEFAULT_JOB_TIMEOUT)
+    rq_kwargs[u'timeout'] = rq_kwargs.get(u'timeout', timeout)
 
     job = get_queue(queue).enqueue_call(
         func=fn, args=args, kwargs=kwargs, **rq_kwargs)

--- a/ckan/tests/lib/test_jobs.py
+++ b/ckan/tests/lib/test_jobs.py
@@ -76,17 +76,20 @@ class TestEnqueue(RQTestBase):
             jobs.add_queue_name_prefix(u"my_queue")
         ])
 
-    def test_enqueue_timeout(self):
+    def test_enqueue_timeout(self, monkeypatch, ckan_config):
         self.enqueue()
         self.enqueue(rq_kwargs={u'timeout': 0})
         self.enqueue(rq_kwargs={u'timeout': -1})
         self.enqueue(rq_kwargs={u'timeout': 3600})
+        monkeypatch.setitem(ckan_config, 'ckan.jobs.timeout', 10)
+        self.enqueue()
         all_jobs = self.all_jobs()
-        assert len(all_jobs) == 4
+        assert len(all_jobs) == 5
         assert all_jobs[0].timeout == 180
         assert all_jobs[1].timeout == 180
         assert all_jobs[2].timeout == -1
         assert all_jobs[3].timeout == 3600
+        assert all_jobs[4].timeout == 10
 
 
 class TestGetAllQueues(RQTestBase):

--- a/ckan/tests/lib/test_jobs.py
+++ b/ckan/tests/lib/test_jobs.py
@@ -81,7 +81,7 @@ class TestEnqueue(RQTestBase):
         self.enqueue(rq_kwargs={u'timeout': 0})
         self.enqueue(rq_kwargs={u'timeout': -1})
         self.enqueue(rq_kwargs={u'timeout': 3600})
-        monkeypatch.setitem(ckan_config, 'ckan.jobs.timeout', 10)
+        monkeypatch.setitem(ckan_config, u'ckan.jobs.timeout', 10)
         self.enqueue()
         all_jobs = self.all_jobs()
         assert len(all_jobs) == 5


### PR DESCRIPTION
`ckan.jobs.timeout` config option is ignored because it's set on module level before the config file parsed and it is never updated after it.

This PR moves parsing of the default timeout directly into the `enqueue` function. 
It fixes the original issue, allows us to change the timeout in runtime, and patch it with `ckan_config` mark in tests.
