### PR TITLE
Delete senseless comments from types.py and do some pep8 styling

### DIFF
--- a/ckan/tests/legacy/test_coding_standards.py
+++ b/ckan/tests/legacy/test_coding_standards.py
@@ -364,7 +364,6 @@ class TestPep8(object):
         "ckan/model/term_translation.py",
         "ckan/model/test_user.py",
         "ckan/model/tracking.py",
-        "ckan/model/types.py",
         "ckan/model/user.py",
         "ckan/model/vocabulary.py",
         "ckan/authz.py",


### PR DESCRIPTION
There are some useless comments in this file. Also, some code doesn't match the pep-8.



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
