### PR TITLE
config-tool can be used with incomplete config file

### DIFF
--- a/ckan/cli/cli.py
+++ b/ckan/cli/cli.py
@@ -37,9 +37,9 @@ from ckan.cli import seed
 log = logging.getLogger(__name__)
 
 _no_config_commands = [
-    ['config-tool'],
-    ['generate', 'config'],
-    ['generate', 'extension'],
+    [u'config-tool'],
+    [u'generate', u'config'],
+    [u'generate', u'extension'],
 ]
 
 

--- a/ckan/cli/cli.py
+++ b/ckan/cli/cli.py
@@ -36,6 +36,12 @@ from ckan.cli import seed
 
 log = logging.getLogger(__name__)
 
+_no_config_commands = [
+    ['config-tool'],
+    ['generate', 'config'],
+    ['generate', 'extension'],
+]
+
 
 class CkanCommand(object):
 
@@ -83,18 +89,20 @@ def _get_commands_from_entry_point(entry_point=u'ckan.click_command'):
 
 def _init_ckan_config(ctx, param, value):
     is_help = u'--help' in sys.argv
-    no_config = len(sys.argv) > 1 and sys.argv[1] in (
-        u'generate', u'config-tool')
+    no_config = False
+    if len(sys.argv) > 1:
+        for cmd in _no_config_commands:
+            if sys.argv[1:len(cmd) + 1] == cmd:
+                no_config = True
+                break
+    if no_config or is_help:
+        return
 
     try:
         ctx.obj = CkanCommand(value)
     except CkanConfigurationException as e:
-        # Some commands don't require the config loaded
-        if no_config or is_help:
-            return
-        else:
-            p.toolkit.error_shout(e)
-            raise click.Abort()
+        p.toolkit.error_shout(e)
+        raise click.Abort()
 
     if six.PY2:
         ctx.meta["flask_app"] = ctx.obj.app.apps["flask_app"]._wsgi_app


### PR DESCRIPTION
Fixes #5568

Right now a config file will be loaded during CLI initialization as long as it's available, even if it's not required(`generate extension`, `config-tool`). This may cause issues if the config file contains options that prevent the initialization of CKAN(plugin, that is not installed yet; incorrect DB URL). The biggest problem here, those incorrect values cannot be changed even with `config-tool`, because of fail during app initialization. 

This PR makes CLI completely ignore the config file for the given subset of commands(`ckan.cli:_no_config_commands` variable).
