### PR TITLE
Remove jinja2 blocks from robots.txt

### DIFF
--- a/ckan/public/robots.txt
+++ b/ckan/public/robots.txt
@@ -1,11 +1,6 @@
 User-agent: *
-{% block all_user_agents -%}
 Disallow: /dataset/rate/
 Disallow: /revision/
 Disallow: /dataset/*/history
 Disallow: /api/
 Crawl-Delay: 10
-{%- endblock %}
-
-{% block additional_user_agents -%}
-{%- endblock %}


### PR DESCRIPTION
Previously, robots.txt was rendered as a Jinja2 template and had few blocks for extensions. Now it served as a static file and doesn't need those blocks, because an extension can just contain its own robots.txt in the public folder, which will be served instead

