### PR TITLE
Documentation - update filestore.rst with correct parameter name

### DIFF
--- a/doc/maintaining/filestore.rst
+++ b/doc/maintaining/filestore.rst
@@ -95,7 +95,7 @@ To create a new resource and upload a file to it using the Python library
  requests.post('http://0.0.0.0:5000/api/action/resource_create',
                data={"package_id":"my_dataset"},
                headers={"X-CKAN-API-Key": "21a47217-6d7b-49c5-88f9-72ebd5a4d4bb"},
-               files=[('upload', file('/path/to/file/to/upload.csv'))])
+               files=[('upload', open('/path/to/file/to/upload.csv', 'rb'))])
 
 (Requests automatically sends a ``multipart-form-data`` heading when you use the
 ``files=`` parameter.)


### PR DESCRIPTION
On the documentation page: **filestore.rst**, the `"files=[(..."` parameter had an incorrect argument name `"file()"`...the correct name is `"open()"`

Fixes #5652 

### Proposed fixes:
Documentation is now using the `"open()"` argument


### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
