### PR TITLE
[#5667] Add secondary order_by to sorting by number_created_packages

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -881,7 +881,8 @@ def user_list(context, data_dict):
                 else_=model.User.fullname
             )
         )
-    elif order_by == 'number_created_packages':
+    elif order_by_field == 'number_created_packages' or order_by_field == 'fullname' \
+            or order_by_field == 'about' or order_by_field == 'sysadmin':
         query = query.order_by(order_by_field, model.User.name)
     else:
         query = query.order_by(order_by_field)

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -881,6 +881,8 @@ def user_list(context, data_dict):
                 else_=model.User.fullname
             )
         )
+    elif order_by == 'number_created_packages':
+        query = query.order_by(order_by_field, model.User.name)
     else:
         query = query.order_by(order_by_field)
 


### PR DESCRIPTION
Fixes #5667

### Proposed fixes:
Adds secondary sorting to order_by when sorting by number of created packages. This should fix flaky test as order_by is not guaranteed to be stable.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
