### PR TITLE
Re-enable tracking data

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -345,7 +345,7 @@ class PackageController(base.BaseController):
         context = {'model': model, 'session': model.Session,
                    'user': c.user, 'for_view': True,
                    'auth_user_obj': c.userobj}
-        data_dict = {'id': id, 'include_tracking': True}
+        data_dict = {'id': id}
 
         try:
             check_access('package_update', context, data_dict)
@@ -371,7 +371,7 @@ class PackageController(base.BaseController):
         context = {'model': model, 'session': model.Session,
                    'user': c.user, 'for_view': True,
                    'auth_user_obj': c.userobj}
-        data_dict = {'id': id, 'include_tracking': True}
+        data_dict = {'id': id}
 
         # interpret @<revision_id> or @<date> suffix
         split = id.split('@')

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -112,11 +112,6 @@ class PackageSearchIndex(SearchIndex):
         if pkg_dict is None:
             return
 
-        # tracking summary values will be stale, never store them
-        tracking_summary = pkg_dict.pop('tracking_summary', None)
-        for r in pkg_dict.get('resources', []):
-            r.pop('tracking_summary', None)
-
         data_dict_json = json.dumps(pkg_dict)
 
         if config.get('ckan.cache_validated_datasets', True):
@@ -194,11 +189,10 @@ class PackageSearchIndex(SearchIndex):
            pkg_dict['organization'] = None
 
         # tracking
-        if not tracking_summary:
-            tracking_summary = model.TrackingSummary.get_for_package(
-                pkg_dict['id'])
-        pkg_dict['views_total'] = tracking_summary['total']
-        pkg_dict['views_recent'] = tracking_summary['recent']
+        tracking_summary = pkg_dict.pop('tracking_summary', None)
+        if tracking_summary:
+            pkg_dict['views_total'] = tracking_summary['total']
+            pkg_dict['views_recent'] = tracking_summary['recent']
 
         resource_fields = [('name', 'res_name'),
                            ('description', 'res_description'),

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -963,9 +963,6 @@ def package_show(context, data_dict):
     :param use_default_schema: use default package schema instead of
         a custom schema defined with an IDatasetForm plugin (default: ``False``)
     :type use_default_schema: bool
-    :param include_tracking: add tracking information to dataset and
-        resources (default: ``False``)
-    :type include_tracking: bool
     :rtype: dictionary
 
     '''
@@ -986,7 +983,6 @@ def package_show(context, data_dict):
 
     if data_dict.get('use_default_schema', False):
         context['schema'] = ckan.logic.schema.default_show_package_schema()
-    include_tracking = asbool(data_dict.get('include_tracking', False))
 
     package_dict = None
     use_cache = (context.get('use_cache', True))
@@ -1015,13 +1011,19 @@ def package_show(context, data_dict):
         package_dict = model_dictize.package_dictize(pkg, context)
         package_dict_validated = False
 
-    if include_tracking:
-        # page-view tracking summary data
-        package_dict['tracking_summary'] = (
-            model.TrackingSummary.get_for_package(package_dict['id']))
+    # Add page-view tracking summary data to the package dict.
+    # If the package_dict came from the Solr cache then it will already have a
+    # potentially outdated tracking_summary, this will overwrite it with a
+    # current one.
+    package_dict['tracking_summary'] = model.TrackingSummary.get_for_package(
+        package_dict['id'])
 
-        for resource_dict in package_dict['resources']:
-            _add_tracking_summary_to_resource_dict(resource_dict, model)
+    # Add page-view tracking summary data to the package's resource dicts.
+    # If the package_dict came from the Solr cache then each resource dict will
+    # already have a potentially outdated tracking_summary, this will overwrite
+    # it with a current one.
+    for resource_dict in package_dict['resources']:
+        _add_tracking_summary_to_resource_dict(resource_dict, model)
 
     if context.get('for_view'):
         for item in plugins.PluginImplementations(plugins.IPackageController):
@@ -1066,9 +1068,6 @@ def resource_show(context, data_dict):
 
     :param id: the id of the resource
     :type id: string
-    :param include_tracking: add tracking information to dataset and
-        resources (default: ``False``)
-    :type include_tracking: bool
 
     :rtype: dictionary
 
@@ -1086,8 +1085,7 @@ def resource_show(context, data_dict):
 
     pkg_dict = logic.get_action('package_show')(
         dict(context),
-        {'id': resource.package.id,
-        'include_tracking': asbool(data_dict.get('include_tracking', False))})
+        {'id': resource.package.id})
 
     for resource_dict in pkg_dict['resources']:
         if resource_dict['id'] == id:

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -50,7 +50,7 @@ def default_resource_schema(
         'created': [ignore_missing, isodate],
         'last_modified': [ignore_missing, isodate],
         'cache_last_updated': [ignore_missing, isodate],
-        'tracking_summary': [],
+        'tracking_summary': [ignore_missing],
         'datastore_active': [ignore_missing],
         '__extras': [ignore_missing, extras_valid_json, keep_extras],
     }

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -50,7 +50,7 @@ def default_resource_schema(
         'created': [ignore_missing, isodate],
         'last_modified': [ignore_missing, isodate],
         'cache_last_updated': [ignore_missing, isodate],
-        'tracking_summary': [ignore_missing],
+        'tracking_summary': [],
         'datastore_active': [ignore_missing],
         '__extras': [ignore_missing, extras_valid_json, keep_extras],
     }

--- a/ckan/tests/legacy/functional/test_tracking.py
+++ b/ckan/tests/legacy/functional/test_tracking.py
@@ -109,7 +109,7 @@ class TestTracking(object):
         # The API should return 0 recent views and 0 total views for the
         # unviewed package.
         package = tests.call_action_api(
-            app, "package_show", id=package["name"], include_tracking=True
+            app, "package_show", id=package["name"]
         )
         tracking_summary = package["tracking_summary"]
         assert tracking_summary["recent"] == 0, (
@@ -131,7 +131,7 @@ class TestTracking(object):
         # The package_show() API should return 0 recent views and 0 total
         # views for the unviewed resource.
         package = tests.call_action_api(
-            app, "package_show", id=package["name"], include_tracking=True
+            app, "package_show", id=package["name"]
         )
         assert len(package["resources"]) == 1
         resource = package["resources"][0]
@@ -150,7 +150,7 @@ class TestTracking(object):
         # The resource_show() API should return 0 recent views and 0 total
         # views for the unviewed resource.
         resource = tests.call_action_api(
-            app, "resource_show", id=resource["id"], include_tracking=True
+            app, "resource_show", id=resource["id"]
         )
         tracking_summary = resource["tracking_summary"]
         assert tracking_summary["recent"] == 0, (
@@ -175,7 +175,7 @@ class TestTracking(object):
         self._update_tracking_summary()
 
         package = tests.call_action_api(
-            app, "package_show", id=package["id"], include_tracking=True
+            app, "package_show", id=package["id"]
         )
         tracking_summary = package["tracking_summary"]
         assert tracking_summary["recent"] == 1, (
@@ -217,7 +217,7 @@ class TestTracking(object):
         self._update_tracking_summary()
 
         package = tests.call_action_api(
-            app, "package_show", id=package["id"], include_tracking=True
+            app, "package_show", id=package["id"]
         )
         assert len(package["resources"]) == 1
         resource = package["resources"][0]
@@ -261,7 +261,7 @@ class TestTracking(object):
         self._update_tracking_summary()
 
         package = tests.call_action_api(
-            app, "package_show", id=package["id"], include_tracking=True
+            app, "package_show", id=package["id"]
         )
         assert len(package["resources"]) == 1
         resource = package["resources"][0]
@@ -284,7 +284,7 @@ class TestTracking(object):
 
         # The resource_show() API should return the same result.
         resource = tests.call_action_api(
-            app, "resource_show", id=resource["id"], include_tracking=True
+            app, "resource_show", id=resource["id"]
         )
         tracking_summary = resource["tracking_summary"]
         assert tracking_summary["recent"] == 1, (
@@ -342,7 +342,7 @@ class TestTracking(object):
         self._update_tracking_summary()
 
         package = tests.call_action_api(
-            app, "package_show", id=package["id"], include_tracking=True
+            app, "package_show", id=package["id"]
         )
         tracking_summary = package["tracking_summary"]
         assert tracking_summary["recent"] == 3, (
@@ -380,7 +380,7 @@ class TestTracking(object):
         self._update_tracking_summary()
 
         package = tests.call_action_api(
-            app, "package_show", id=package["id"], include_tracking=True
+            app, "package_show", id=package["id"]
         )
         assert len(package["resources"]) == 1
         resource = package["resources"][0]
@@ -459,7 +459,7 @@ class TestTracking(object):
         self._update_tracking_summary()
 
         package = tests.call_action_api(
-            app, "package_show", id=package["id"], include_tracking=True
+            app, "package_show", id=package["id"]
         )
         tracking_summary = package["tracking_summary"]
         assert tracking_summary["recent"] == 1, (
@@ -487,7 +487,7 @@ class TestTracking(object):
         self._update_tracking_summary()
 
         resource = tests.call_action_api(
-            app, "resource_show", id=resource["id"], include_tracking=True
+            app, "resource_show", id=resource["id"]
         )
         tracking_summary = resource["tracking_summary"]
         assert (

--- a/ckan/tests/legacy/logic/test_action.py
+++ b/ckan/tests/legacy/logic/test_action.py
@@ -680,6 +680,11 @@ class TestAction(object):
         res = app.post("/api/action/resource_show", json={"id": resource.id})
         result = json.loads(res.body)["result"]
 
+        # Remove tracking data from the result dict. This tracking data is
+        # added by the logic, so the other resource dict taken straight from
+        # resource_dictize() won't have it.
+        del result['tracking_summary']
+
         resource_dict = resource_dictize(resource, {"model": model})
         assert result == resource_dict, (result, resource_dict)
 

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -93,17 +93,6 @@ class TestPackageShow(object):
             u"author": None,
             u"author_email": None,
             u"creator_user_id": u"<SOME-UUID>",
-            u"extras": [{u"key": u"subject", u"value": u"science"}],
-            u"groups": [
-                {
-                    u"description": u"A test description for this test group.",
-                    u"display_name": u"Test Group num",
-                    u"id": u"<SOME-UUID>",
-                    u"image_display_url": u"",
-                    u"name": u"test_group_num",
-                    u"title": u"Test Group num",
-                }
-            ],
             u"id": u"<SOME-UUID>",
             u"isopen": False,
             u"license_id": None,
@@ -117,21 +106,44 @@ class TestPackageShow(object):
             u"num_resources": 1,
             u"num_tags": 1,
             u"organization": {
-                u"approval_status": u"approved",
-                u"created": u"2019-05-24T15:52:30.123456",
-                u"description": u"Just another test organization.",
                 u"id": u"<SOME-UUID>",
-                u"image_url": u"https://placekitten.com/g/200/100",
-                u"is_organization": True,
                 u"name": u"test_org_num",
-                u"state": u"active",
                 u"title": u"Test Organization",
                 u"type": u"organization",
+                u"description": u"Just another test organization.",
+                u"image_url": u"https://placekitten.com/g/200/100",
+                u"created": u"2019-05-24T15:52:30.123456",
+                u"is_organization": True,
+                u"approval_status": u"approved",
+                u"state": u"active"
             },
             u"owner_org": u"<SOME-UUID>",
             u"private": False,
-            u"relationships_as_object": [],
-            u"relationships_as_subject": [],
+            u"state": u"active",
+            u"title": u"Test Dataset",
+            u"tracking_summary": {
+                u"total": 0,
+                u"recent": 0
+            },
+            u"type": u"dataset",
+            u"url": None,
+            u"version": None,
+            u"extras": [
+                {
+                    u"key": u"subject",
+                    u"value": u"science"
+                }
+            ],
+            u"groups": [
+                {
+                    u"description": u"A test description for this test group.",
+                    u"display_name": u"Test Group num",
+                    u"id": u"<SOME-UUID>",
+                    u"image_display_url": u"",
+                    u"name": u"test_group_num",
+                    u"title": u"Test Group num"
+                }
+            ],
             u"resources": [
                 {
                     u"cache_last_updated": None,
@@ -151,24 +163,25 @@ class TestPackageShow(object):
                     u"resource_type": None,
                     u"size": None,
                     u"state": u"active",
+                    u"tracking_summary": {
+                        u"total": 0,
+                        u"recent": 0
+                    },
                     u"url": u"http://example.com/image.png",
-                    u"url_type": None,
+                    u"url_type": None
                 }
             ],
-            u"state": u"active",
             u"tags": [
                 {
                     u"display_name": u"science",
                     u"id": u"<SOME-UUID>",
                     u"name": u"science",
                     u"state": u"active",
-                    u"vocabulary_id": None,
+                    u"vocabulary_id": None
                 }
             ],
-            u"title": u"Test Dataset",
-            u"type": u"dataset",
-            u"url": None,
-            u"version": None,
+            u"relationships_as_subject": [],
+            u"relationships_as_object": []
         }
 
     def test_package_show_with_custom_schema(self):


### PR DESCRIPTION
### Proposed re-implementation:

This brings back `tracking_summary` data by default and allows the flame icon to appear next to popular (views/downloads > 10) datasets and resources when `tracking_enabled` is set in the config.

### Features:

- [x] includes tests covering changes
- [x] includes updated documentation **(documentation was out of date for this and assumed that this functionality still existed by default)**
- [x] includes user-visible changes **(when `tracking_enabled = true` in config, flame icon appears on popular datasets/resources)**
- [x] includes API changes **(changes output of `package_show`/`package_search` to include `tracking_summary`)**
- [ ] includes bugfix for possible backport **(this was the working code in previous CKAN versions)**
