### PR TITLE
Bump zope.interface requirement to 4.7.2

### DIFF
--- a/requirements-py2.in
+++ b/requirements-py2.in
@@ -43,4 +43,4 @@ WebHelpers==1.3
 WebOb==1.0.8
 WebTest==1.4.3  # need to pin this so that Pylons does not install a newer version that conflicts with WebOb==1.0.8
 Werkzeug[watchdog]==0.16.1
-zope.interface==4.3.2
+zope.interface==4.7.2

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -72,4 +72,4 @@ webhelpers==1.3
 webob==1.0.8
 webtest==1.4.3
 werkzeug==0.15.5
-zope.interface==4.3.2
+zope.interface==4.7.2

--- a/requirements.in
+++ b/requirements.in
@@ -35,4 +35,4 @@ tzlocal==1.3
 unicodecsv>=0.9
 webassets==0.12.1
 Werkzeug[watchdog]==1.0.0
-zope.interface==4.3.2
+zope.interface==4.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,4 +61,4 @@ webassets==0.12.1
 webencodings==0.5.1       # via bleach
 webob==1.8.5              # via fanstatic, repoze.who
 werkzeug[watchdog]==1.0.0
-zope.interface==4.3.2
+zope.interface==4.7.2


### PR DESCRIPTION
This PR bumps required version of zope.interface to the last released 4.x. This fixes several problems with zope.interface being too old and incompatible with some other components, such as setuptools>=46 where the installation of CKAN (resp. zope.interface==4.3.2) fails with

```
ERROR: Command errored out with exit status 1:
 command: /usr/bin/python3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-4xdobyus/zope.interface/setup.py'"'"'; __file__='"'"'/tmp/pip-install-4xdobyus/zope.interface/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-v8mz9h0j/install-record.txt --single-version-externally-managed --compile --install-headers /usr/include/python3.8/zope.interface
     cwd: /tmp/pip-install-4xdobyus/zope.interface/
Complete output (5 lines):
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/tmp/pip-install-4xdobyus/zope.interface/setup.py", line 26, in <module>
    from setuptools import setup, Extension, Feature
ImportError: cannot import name 'Feature' from 'setuptools' (/usr/lib/python3.8/site-packages/setuptools/__init__.py)
----------------------------------------
ERROR: Command errored out with exit status 1: /usr/bin/python3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-4xdobyus/zope.interface/setup.py'"'"'; __file__='"'"'/tmp/pip-install-4xdobyus/zope.interface/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-v8mz9h0j/install-record.txt --single-version-externally-managed --compile --install-headers /usr/include/python3.8/zope.interface Check the logs for full command output.
```

### Proposed fixes:

Features from zope.interface used by CKAN are compatible with the bumped version 4.7.2 without any additional changes. The bumped version of zope.interface officially supports both python 2.7 and python 3.5 - 3.8, see https://pypi.org/project/zope.interface/4.7.2/

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
