### PR TITLE
Set default group_type to group in group_create

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -702,7 +702,7 @@ def _group_or_org_create(context, data_dict, is_org=False):
     upload.update_data_dict(data_dict, 'image_url',
                             'image_upload', 'clear_upload')
     # get the schema
-    group_type = data_dict.get('type', 'group')
+    group_type = data_dict.get('type', 'organization' if is_org else 'group')
     group_plugin = lib_plugins.lookup_group_plugin(group_type)
     try:
         schema = group_plugin.form_to_db_schema_options({

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -702,7 +702,7 @@ def _group_or_org_create(context, data_dict, is_org=False):
     upload.update_data_dict(data_dict, 'image_url',
                             'image_upload', 'clear_upload')
     # get the schema
-    group_type = data_dict.get('type')
+    group_type = data_dict.get('type', 'group')
     group_plugin = lib_plugins.lookup_group_plugin(group_type)
     try:
         schema = group_plugin.form_to_db_schema_options({

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -822,7 +822,7 @@ def group_create(context, data_dict):
     :param image_url: the URL to an image to be displayed on the group's page
         (optional)
     :type image_url: string
-    :param type: the type of the group (optional),
+    :param type: the type of the group (optional, default: ``'group'``),
         :py:class:`~ckan.plugins.interfaces.IGroupForm` plugins
         associate themselves with different group types and provide custom
         group handling behaviour for these types


### PR DESCRIPTION
### Proposed fixes:
When using custom group schemas, group_create does not use the schema unless type is explicitly defined as group. The models sets it to [group](https://github.com/ckan/ckan/blob/master/ckan/model/group.py#L117) if it not defined, so group_update would use the custom schema.  Organization_create sets it to type [organization](https://github.com/ckan/ckan/blob/master/ckan/logic/action/create.py#L928) so it is incoherent to demand that group_create must explicitly define it.


### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
