### PR TITLE
[#5698] Filter activities from user at the database level

### DIFF
--- a/changes/5699.bugfix
+++ b/changes/5699.bugfix
@@ -1,0 +1,1 @@
+Fix missing activities from UI when internal processes are run by ignored users

--- a/ckan/model/activity.py
+++ b/ckan/model/activity.py
@@ -201,7 +201,7 @@ def package_activity_list(
     return _activities_at_offset(q, limit, offset)
 
 
-def _group_activity_query(group_id):
+def _group_activity_query(group_id, include_hidden_activity=False):
     '''Return an SQLAlchemy query for all activities about group_id.
 
     Returns a query for all activities whose object is either the group itself

--- a/ckan/model/activity.py
+++ b/ckan/model/activity.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
     text,
 )
 
+from ckan.common import config
 import ckan.model
 from ckan.model import meta
 from ckan.model import domain_object, types as _types
@@ -164,6 +165,9 @@ def user_activity_list(user_id, limit, offset):
 
     '''
     q = _user_activity_query(user_id, limit + offset)
+
+    q = _filter_activitites_from_users(q)
+
     return _activities_at_offset(q, limit, offset)
 
 
@@ -177,7 +181,8 @@ def _package_activity_query(package_id):
     return q
 
 
-def package_activity_list(package_id, limit, offset):
+def package_activity_list(
+        package_id, limit, offset, include_hidden_activity=False):
     '''Return the given dataset (package)'s public activity stream.
 
     Returns all activities about the given dataset, i.e. where the given
@@ -189,6 +194,10 @@ def package_activity_list(package_id, limit, offset):
 
     '''
     q = _package_activity_query(package_id)
+
+    if not include_hidden_activity:
+        q = _filter_activitites_from_users(q)
+
     return _activities_at_offset(q, limit, offset)
 
 
@@ -245,7 +254,7 @@ def _group_activity_query(group_id):
     return q
 
 
-def _organization_activity_query(org_id):
+def _organization_activity_query(org_id, include_hidden_activity=False):
     '''Return an SQLAlchemy query for all activities about org_id.
 
     Returns a query for all activities whose object is either the org itself
@@ -278,11 +287,14 @@ def _organization_activity_query(org_id):
             model.Activity.object_id == org_id
         )
     )
+    if not include_hidden_activity:
+        q = _filter_activitites_from_users(q)
 
     return q
 
 
-def group_activity_list(group_id, limit, offset):
+def group_activity_list(group_id, limit, offset, include_hidden_activity=False):
+
     '''Return the given group's public activity stream.
 
     Returns activities where the given group or one of its datasets is the
@@ -293,11 +305,12 @@ def group_activity_list(group_id, limit, offset):
     etc.
 
     '''
-    q = _group_activity_query(group_id)
+    q = _group_activity_query(group_id, include_hidden_activity)
     return _activities_at_offset(q, limit, offset)
 
 
-def organization_activity_list(group_id, limit, offset):
+def organization_activity_list(
+        group_id, limit, offset, include_hidden_activity=False):
     '''Return the given org's public activity stream.
 
     Returns activities where the given org or one of its datasets is the
@@ -308,7 +321,7 @@ def organization_activity_list(group_id, limit, offset):
     etc.
 
     '''
-    q = _organization_activity_query(group_id)
+    q = _organization_activity_query(group_id, include_hidden_activity)
     return _activities_at_offset(q, limit, offset)
 
 
@@ -402,7 +415,11 @@ def dashboard_activity_list(user_id, limit, offset):
 
     '''
     q = _dashboard_activity_query(user_id, limit + offset)
+
+    q = _filter_activitites_from_users(q)
+
     return _activities_at_offset(q, limit, offset)
+
 
 def _changed_packages_activity_query():
     '''Return an SQLAlchemy query for all changed package activities.
@@ -425,4 +442,37 @@ def recently_changed_packages_activity_list(limit, offset):
 
     '''
     q = _changed_packages_activity_query()
+
+    q = _filter_activitites_from_users(q)
+
     return _activities_at_offset(q, limit, offset)
+
+
+def _filter_activitites_from_users(q):
+    '''
+    Adds a filter to an existing query object ot avoid activities from users
+    defined in :ref:`ckan.hide_activity_from_users` (defaults to the site user)
+    '''
+    users_to_avoid = _activity_stream_get_filtered_users()
+    if users_to_avoid:
+        q = q.filter(ckan.model.Activity.user_id.notin_(users_to_avoid))
+
+    return q
+
+
+def _activity_stream_get_filtered_users():
+    '''
+    Get the list of users from the :ref:`ckan.hide_activity_from_users` config
+    option and return a list of their ids. If the config is not specified,
+    returns the id of the site user.
+    '''
+    users = config.get('ckan.hide_activity_from_users')
+    if users:
+        users_list = users.split()
+    else:
+        from ckan.logic import get_action
+        context = {'ignore_auth': True}
+        site_user = get_action('get_site_user')(context)
+        users_list = [site_user.get('name')]
+
+    return ckan.model.User.user_ids_for_name_or_id(users_list)

--- a/ckan/model/activity.py
+++ b/ckan/model/activity.py
@@ -251,6 +251,9 @@ def _group_activity_query(group_id, include_hidden_activity=False):
         )
     )
 
+    if not include_hidden_activity:
+        q = _filter_activitites_from_users(q)
+
     return q
 
 

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -1864,7 +1864,8 @@ class TestDatasetRead(object):
         assert response.headers['location'] == expected_url
 
     def test_redirect_also_with_activity_parameter(self, app):
-        dataset = factories.Dataset()
+        user = factories.User()
+        dataset = factories.Dataset(user=user)
         activity = activity_model.package_activity_list(
             dataset["id"], limit=1, offset=0
         )[0]

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -3164,9 +3164,11 @@ class TestPackageActivityList(object):
         dataset = factories.Dataset()
         from ckan import model
 
+        user = factories.User()
+
         objs = [
             model.Activity(
-                user_id=None,
+                user_id=user['id'],
                 object_id=dataset["id"],
                 activity_type=None,
                 data=None,
@@ -3396,8 +3398,9 @@ class TestUserActivityList(object):
         assert activities[0]["data"]["group"]["title"] == org["title"]
 
     def _create_bulk_user_activities(self, count):
-        user = factories.User()
         from ckan import model
+
+        user = factories.User()
 
         objs = [
             model.Activity(
@@ -3613,9 +3616,11 @@ class TestGroupActivityList(object):
         group = factories.Group()
         from ckan import model
 
+        user = factories.User()
+
         objs = [
             model.Activity(
-                user_id=None,
+                user_id=user['id'],
                 object_id=group["id"],
                 activity_type=None,
                 data=None,
@@ -3844,9 +3849,11 @@ class TestOrganizationActivityList(object):
         org = factories.Organization()
         from ckan import model
 
+        user = factories.User()
+
         objs = [
             model.Activity(
-                user_id=None,
+                user_id=user['id'],
                 object_id=org["id"],
                 activity_type=None,
                 data=None,
@@ -4013,9 +4020,11 @@ class TestRecentlyChangedPackagesActivityList(object):
     def _create_bulk_package_activities(self, count):
         from ckan import model
 
+        user = factories.User()
+
         objs = [
             model.Activity(
-                user_id=None,
+                user_id=user['id'],
                 object_id=None,
                 activity_type="new_package",
                 data=None,


### PR DESCRIPTION
Fixes #5698

The `ckan.hide-activity-from-users` configuration option allows you to define the users that you don't want to show activities from on the various activity feeds. It defaults to the internal site user as this is generally used to perform bulk internal processes like harvesting and you don't want to flood the activity stream with their operations.

The problem is that we first get the relevant activities from the database and *then* filter these activities in Python based on the users in the config option.

This means that if more activities from the site user were performed than the limit requested, they are filtered out and you get an empty feed, even though the activities are still there.

These moves the filtering to the model queries so the actions already get filtered lists with the relevant activities.

