### PR TITLE
Keep get parameters while redirecting

### DIFF
--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -489,9 +489,10 @@ def read(package_type, id):
     # if the user specified a package id, redirect to the package name
     if data_dict['id'] == pkg_dict['id'] and \
             data_dict['id'] != pkg_dict['name']:
-        return h.redirect_to(u'{}.read'.format(package_type),
+        return h.redirect_to(h.url_for(u'{}.read'.format(package_type),
                              id=pkg_dict['name'],
-                             activity_id=activity_id)
+                             activity_id=activity_id,
+                             **request.args))
 
     # can the resources be previewed?
     for resource in pkg_dict[u'resources']:


### PR DESCRIPTION
I had a problem with pagination at harvester source. I found out that harvester using source.id to create a path for pagination (_package_list_for_source_ func) '.
In this part of code (dataset.read:491) we redirect the user using pkg.name if he using pkg.id. And in process we are loosing the get parameters. In this changes I'm trying to keep the get parameters during redirect.



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
