### PR TITLE
Fix 5705: Cannot update group's image_url field

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -655,7 +655,7 @@ def _group_or_org_update(context, data_dict, is_org=False):
     except AttributeError:
         schema = group_plugin.form_to_db_schema()
 
-    upload = uploader.get_uploader('group', group.image_url)
+    upload = uploader.get_uploader('group')
     upload.update_data_dict(data_dict, 'image_url',
                             'image_upload', 'clear_upload')
 

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -467,25 +467,6 @@ class TestUpdate(object):
             == "organization"
         )
 
-    def test_update_group_cant_change_type(self):
-        user = factories.User()
-        context = {"user": user["name"]}
-        group = factories.Group(type="group", name="unchanging", user=user)
-
-        group = helpers.call_action(
-            "group_update",
-            context=context,
-            id=group["id"],
-            name="unchanging",
-            type="favouritecolour",
-        )
-
-        assert group["type"] == "group"
-        assert (
-            helpers.call_action("group_show", id="unchanging")["type"]
-            == "group"
-        )
-
 
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 class TestDatasetUpdate(object):
@@ -1480,6 +1461,62 @@ class TestUserUpdate(object):
 
         user_obj = model.User.get(user["id"])
         assert user_obj.password != "pretend-this-is-a-valid-hash"
+
+    def test_user_update_image_url(self):
+        user = factories.User(image_url='user_image.jpg')
+        context = {"user": user["name"]}
+
+        user = helpers.call_action(
+            "user_update",
+            context=context,
+            id=user["name"],
+            email="test@example.com",
+            image_url="new_image_url.jpg",
+        )
+
+        assert user["image_url"] == "new_image_url.jpg"
+
+
+@pytest.mark.usefixtures("clean_db", "with_request_context")
+class TestGroupUpdate(object):
+    def test_group_update_image_url_field(self):
+        user = factories.User()
+        context = {"user": user["name"]}
+        group = factories.Group(
+            type="group",
+            name="testing",
+            user=user,
+            image_url='group_image.jpg')
+
+        group = helpers.call_action(
+            "group_update",
+            context=context,
+            id=group["id"],
+            name=group["name"],
+            type=group["type"],
+            image_url="new_image_url.jpg"
+        )
+
+        assert group["image_url"] == "new_image_url.jpg"
+
+    def test_group_update_cant_change_type(self):
+        user = factories.User()
+        context = {"user": user["name"]}
+        group = factories.Group(type="group", name="unchanging", user=user)
+
+        group = helpers.call_action(
+            "group_update",
+            context=context,
+            id=group["id"],
+            name="unchanging",
+            type="favouritecolour",
+        )
+
+        assert group["type"] == "group"
+        assert (
+            helpers.call_action("group_show", id="unchanging")["type"]
+            == "group"
+        )
 
 
 @pytest.mark.usefixtures("clean_db", "with_request_context")


### PR DESCRIPTION
Fixes #5705 

### Proposed fixes:
This PR doesn't set `old_filename` when updating groups since this avoid users to update the field properly and it is inconsistent with how `user_update` works.

It also creates a new `TestGroupUpdate` class to group up tests related to `groups` and add a test into `TestUserUpdate` class to keep a consistent behaviour between `user_update` and `group_update`.


### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
