### PR TITLE
ensure HTTP_HOST is bytes under python2

### DIFF
--- a/ckan/config/middleware/common_middleware.py
+++ b/ckan/config/middleware/common_middleware.py
@@ -111,5 +111,5 @@ class HostHeaderMiddleware(object):
                          '/user/logged_out']:
             site_url = config.get('ckan.site_url')
             parts = urlparse(site_url)
-            environ['HTTP_HOST'] = parts.netloc
+            environ['HTTP_HOST'] = str(parts.netloc)
         return self.app(environ, start_response)


### PR DESCRIPTION
### Proposed fixes:

In https://github.com/ckan/ckan/commit/011405f7734ec0f580ea7bd67d9772b763fcab12 @amercader introduced this change to resolve a security vuln in `repoze.who`. This change does not cause any error when running under python 3 or when serving via `paster`. However, when serving behind `uwsgi` on python 2, this code throws

```
Traceback (most recent call last):
  File "/srv/app/src/ckan/ckan/config/middleware/__init__.py", line 210, in __call__
    return self.apps[app_name](environ, start_response)
  File "/srv/app/src/ckan/ckan/config/middleware/common_middleware.py", line 115, in __call__
    return self.app(environ, start_response)
  File "/usr/lib/python2.7/site-packages/paste/cascade.py", line 130, in __call__
    return self.apps[-1](environ, start_response)
  File "/usr/lib/python2.7/site-packages/paste/registry.py", line 379, in __call__
    app_iter = self.application(environ, start_response)
  File "/usr/lib/python2.7/site-packages/repoze/who/middleware.py", line 117, in __call__
    wrapper.finish_response(remember_headers)
  File "/usr/lib/python2.7/site-packages/repoze/who/middleware.py", line 177, in finish_response
    write = self.start_response(self.status, headers, self.exc_info)
TypeError: http header value must be a string
```

because `parts.netloc` is `unicode` not `bytes`, causing a partial/malformed response to be served. This PR ensures the value of `environ['HTTP_HOST']` is `bytes` under python2 and should make no change under python3, resolving the issue.

#### Testing:

I haven't added a test case for this because as far as I can tell there are no existing tests explicitly covering `HostHeaderMiddleware`. I don't mind adding some tests, but I think I'd need a bit of guidance about how to test something this low-level in the CKAN stack.

#### Backporting:

I've targetted this PR at master, but this issue affects CKAN >=2.8.5. Can someone with labelling powers apply the "Backport 2.8.7" label please.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport