### PR TITLE
[#5683] Remove TopRatedDatasets from stats

### DIFF
--- a/ckanext/stats/blueprint.py
+++ b/ckanext/stats/blueprint.py
@@ -13,7 +13,6 @@ stats = Blueprint(u'stats', __name__)
 def index():
     stats = stats_lib.Stats()
     extra_vars = {
-        u'top_rated_packages': stats.top_rated_packages(),
         u'largest_groups': stats.largest_groups(),
         u'top_tags': stats.top_tags(),
         u'top_package_creators': stats.top_package_creators(),

--- a/ckanext/stats/stats.py
+++ b/ckanext/stats/stats.py
@@ -33,30 +33,6 @@ def datetime2date(datetime_):
 class Stats(object):
 
     @classmethod
-    def top_rated_packages(cls, limit=10):
-        # NB Not using sqlalchemy as sqla 0.4 doesn't work using both group_by
-        # and apply_avg
-        package = table('package')
-        rating = table('rating')
-        sql = select(
-            [
-                package.c.id,
-                func.avg(rating.c.rating),
-                func.count(rating.c.rating)
-            ],
-            from_obj=[package.join(rating)]
-        ).where(and_(package.c.private == False, package.c.state == 'active')
-                ).group_by(package.c.id).order_by(
-                    func.avg(rating.c.rating).desc(),
-                    func.count(rating.c.rating).desc()
-                ).limit(limit)
-        res_ids = model.Session.execute(sql).fetchall()
-        res_pkgs = [(
-            model.Session.query(model.Package).get(text_type(pkg_id)), avg, num
-        ) for pkg_id, avg, num in res_ids]
-        return res_pkgs
-
-    @classmethod
     def largest_groups(cls, limit=10):
         member = table('member')
         package = table('package')

--- a/ckanext/stats/templates/ckanext/stats/index.html
+++ b/ckanext/stats/templates/ckanext/stats/index.html
@@ -7,32 +7,6 @@
 {% block primary_content %}
   <article class="module">
 
-    <section id="stats-top-rated" class="module-content tab-content">
-      <h2>{{ _('Top Rated Datasets') }}</h2>
-      {% if c.top_rated_packages %}
-        <table class="table table-chunky table-bordered table-striped">
-          <thead>
-            <tr>
-              <th>Dataset</th>
-              <th class="metric">{{ _('Average rating') }}</th>
-              <th class="metric">{{ _('Number of ratings') }}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for package, rating, num_ratings in c.top_rated_packages %}
-              <tr>
-                <th>{{ h.link_to(package.title or package.name, h.url_for(package.type ~ '.read', id=package.name)) }}</th>
-                <td class="metric">{{ rating }}</td>
-                <td class="metric">{{ num_ratings }}</td>
-              </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      {% else %}
-        <p class="empty">{{ _('No ratings') }}</p>
-      {% endif %}
-    </section>
-
     <section id="stats-largest-groups" class="module-content tab-content">
       <h2>{{ _('Largest Groups') }}</h2>
       {% if c.largest_groups %}
@@ -104,7 +78,6 @@
     <h2 class="module-heading"><i class="fa fa-bar-chart-o"></i> {{ _('Statistics Menu') }}</h2>
     <nav data-module="stats-nav">
       <ul class="unstyled nav nav-simple">
-        <li class="nav-item active"><a href="#stats-top-rated" data-toggle="tab">{{ _('Top Rated Datasets') }}</a></li>
         <li class="nav-item"><a href="#stats-largest-groups" data-toggle="tab">{{ _('Largest Groups') }}</a></li>
         <li class="nav-item"><a href="#stats-top-tags" data-toggle="tab">{{ _('Top Tags') }}</a></li>
         <li class="nav-item"><a href="#stats-most-create" data-toggle="tab">{{ _('Users Creating Most Datasets') }}</a></li>

--- a/ckanext/stats/tests/test_stats_lib.py
+++ b/ckanext/stats/tests/test_stats_lib.py
@@ -54,10 +54,6 @@ class TestStatsPlugin(object):
         model.Package.by_name(u"test3").notes = "Test 3 notes"
         model.repo.commit_and_remove()
 
-    def test_top_rated_packages(self):
-        pkgs = Stats.top_rated_packages()
-        assert pkgs == []
-
     def test_largest_groups(self):
         grps = Stats.largest_groups()
         grps = [(grp.name, count) for grp, count in grps]


### PR DESCRIPTION
Fixes #5683

Remove TopRatedDatasets from stats extension, because we no longer
have dataset rating