### PR TITLE
Allow user to set the log level for error emails

### DIFF
--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -205,6 +205,7 @@ ckan.hide_activity_from_users = %(ckan.site_id)s
 #smtp.password = your_password
 #smtp.mail_from =
 #smtp.reply_to =
+#email_log_level = 40
 
 ## Background Job Settings
 ckan.jobs.timeout = 180

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -571,6 +571,7 @@ def _setup_error_mail_handler(app):
         secure=secure
     )
 
+    mail_handler.setLevel(config.get('email_log_level', 40))
     mail_handler.setFormatter(logging.Formatter('''
 Time:               %(asctime)s
 URL:                %(url)s

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -2409,3 +2409,15 @@ Example::
 Default value: ``None``
 
 This controls from which email the error messages will come from.
+
+email_log_level
+^^^^^^^^^
+
+Example::
+
+  email_log_level = 40
+
+Default value: ``40``
+
+This controls the level of the logs that should be sent as error messages to
+`email_to`. The values should be "Logging Levels" as defined in the [docs](https://docs.python.org/3/library/logging.html#levels).


### PR DESCRIPTION
I've been working on upgrading to the most recent CKAN version and ran into an issue where I get "Application Error" emails for everything that is logged - such as every webasset being loaded. 

This change sets a log level for the email "error mail handler" defined in `flask_app.py`, gives a default value to 40 (errors), and allows the user to adjust the value with a configuration option.

I might have overlooked something that would allow me to just receive the error and not everything, but I couldn't find anything in the documentation related to this.

### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
