### PR TITLE
Add allow_partial_update to fix losing users in group and organization patch actions

### DIFF
--- a/ckan/logic/action/patch.py
+++ b/ckan/logic/action/patch.py
@@ -137,7 +137,7 @@ def organization_patch(context, data_dict):
     patched = dict(organization_dict)
     patched.pop('display_name', None)
     patched.update(data_dict)
-    return _update.group_update(dict(context, allow_partial_update=True), patched)
+    return _update.organization_update(dict(context, allow_partial_update=True), patched)
 
 
 def user_patch(context, data_dict):

--- a/ckan/logic/action/patch.py
+++ b/ckan/logic/action/patch.py
@@ -107,6 +107,7 @@ def group_patch(context, data_dict):
     patched = dict(group_dict)
     patched.pop('display_name', None)
     patched.update(data_dict)
+    context['allow_partial_update'] = True
     return _update.group_update(context, patched)
 
 
@@ -137,6 +138,7 @@ def organization_patch(context, data_dict):
     patched = dict(organization_dict)
     patched.pop('display_name', None)
     patched.update(data_dict)
+    context['allow_partial_update'] = True
     return _update.organization_update(context, patched)
 
 

--- a/ckan/logic/action/patch.py
+++ b/ckan/logic/action/patch.py
@@ -107,7 +107,8 @@ def group_patch(context, data_dict):
     patched = dict(group_dict)
     patched.pop('display_name', None)
     patched.update(data_dict)
-    return _update.group_update(dict(context, allow_partial_update=True), patched)
+    return _update.group_update(
+        dict(context, allow_partial_update=True), patched)
 
 
 def organization_patch(context, data_dict):
@@ -137,7 +138,8 @@ def organization_patch(context, data_dict):
     patched = dict(organization_dict)
     patched.pop('display_name', None)
     patched.update(data_dict)
-    return _update.organization_update(dict(context, allow_partial_update=True), patched)
+    return _update.organization_update(
+        dict(context, allow_partial_update=True), patched)
 
 
 def user_patch(context, data_dict):

--- a/ckan/logic/action/patch.py
+++ b/ckan/logic/action/patch.py
@@ -107,8 +107,7 @@ def group_patch(context, data_dict):
     patched = dict(group_dict)
     patched.pop('display_name', None)
     patched.update(data_dict)
-    context['allow_partial_update'] = True
-    return _update.group_update(context, patched)
+    return _update.group_update(dict(context, allow_partial_update=True), patched)
 
 
 def organization_patch(context, data_dict):
@@ -138,8 +137,7 @@ def organization_patch(context, data_dict):
     patched = dict(organization_dict)
     patched.pop('display_name', None)
     patched.update(data_dict)
-    context['allow_partial_update'] = True
-    return _update.organization_update(context, patched)
+    return _update.group_update(dict(context, allow_partial_update=True), patched)
 
 
 def user_patch(context, data_dict):

--- a/ckan/tests/logic/action/test_patch.py
+++ b/ckan/tests/logic/action/test_patch.py
@@ -94,7 +94,6 @@ class TestPatch(object):
         assert len(group2["users"]) == 1
         assert group2["users"][0]["name"] == user["name"]
 
-
     def test_group_patch_preserve_datasets(self):
         user = factories.User()
         group = factories.Group(
@@ -172,7 +171,6 @@ class TestPatch(object):
         assert organization2["description"] == "somethingnew"
         assert len(organization2["users"]) == 1
         assert organization2["users"][0]["name"] == user["name"]
-
 
     def test_user_patch_updating_single_field(self):
         user = factories.User(

--- a/ckan/tests/logic/action/test_patch.py
+++ b/ckan/tests/logic/action/test_patch.py
@@ -70,6 +70,31 @@ class TestPatch(object):
         assert group2["name"] == "economy"
         assert group2["description"] == "somethingnew"
 
+    @pytest.mark.ckan_config(u"ckan.auth.public_user_details", u"false")
+    def test_group_patch_updating_single_field_when_public_user_details_is_false(self):
+        user = factories.User()
+        group = factories.Group(
+            name="economy", description="some test now", user=user
+        )
+
+        group = helpers.call_action(
+            "group_patch",
+            id=group["id"],
+            description="somethingnew",
+            context={"user": user["name"]},
+        )
+
+        assert group["name"] == "economy"
+        assert group["description"] == "somethingnew"
+
+        group2 = helpers.call_action("group_show", id=group["id"], include_users=True)
+
+        assert group2["name"] == "economy"
+        assert group2["description"] == "somethingnew"
+        assert len(group2["users"]) == 1
+        assert group2["users"][0]["name"] == user["name"]
+
+
     def test_group_patch_preserve_datasets(self):
         user = factories.User()
         group = factories.Group(
@@ -121,6 +146,33 @@ class TestPatch(object):
 
         assert organization2["name"] == "economy"
         assert organization2["description"] == "somethingnew"
+
+    @pytest.mark.ckan_config(u"ckan.auth.public_user_details", u"false")
+    def test_organization_patch_updating_single_field_when_public_user_details_is_false(self):
+        user = factories.User()
+        organization = factories.Organization(
+            name="economy", description="some test now", user=user
+        )
+
+        organization = helpers.call_action(
+            "organization_patch",
+            id=organization["id"],
+            description="somethingnew",
+            context={"user": user["name"]},
+        )
+
+        assert organization["name"] == "economy"
+        assert organization["description"] == "somethingnew"
+
+        organization2 = helpers.call_action(
+            "organization_show", id=organization["id"], include_users=True
+        )
+
+        assert organization2["name"] == "economy"
+        assert organization2["description"] == "somethingnew"
+        assert len(organization2["users"]) == 1
+        assert organization2["users"][0]["name"] == user["name"]
+
 
     def test_user_patch_updating_single_field(self):
         user = factories.User(


### PR DESCRIPTION
### Proposed fixes:
When public user details is set to false, group and organization show actions do not include users by default. Calling group or organization patch actions will lose users unless developer sets allow_partial_update to the context. This is documented in [here](https://github.com/ckan/ckan/blob/master/ckan/logic/action/update.py#L769). This PR set allow_partial_update to the context so that the developer doesn't need to know about it and enables patch functions to work properly over http. 


### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
