### PR TITLE
Documentation: Update templates.rst

### DIFF
--- a/doc/theming/templates.rst
+++ b/doc/theming/templates.rst
@@ -23,13 +23,8 @@ static files, so before getting started on our CKAN theme we'll have to create
 an extension and plugin. For a detailed explanation of the steps below, see
 :doc:`/extensions/tutorial`.
 
-1. Use the ``paster create`` command to create an empty extension:
-
-   .. parsed-literal::
-
-      |activate|
-      cd |virtualenv|/src
-      ckan -c |ckan.ini| create -t ckanext |extension_dir|
+1. Use the ``ckan generate extension`` command as per the
+:doc:`/extensions/tutorial`. 
 
 2. Create the file |plugin.py| with the following contents:
 


### PR DESCRIPTION
Fixes https://github.com/ckan/ckan/issues/5702

### Proposed fixes:
The documentation is updated to delete a reference to the paster command, plus it now links to the https://docs.ckan.org/en/2.9/extensions/tutorial.html#creating-a-new-extension documentation rather than write the same documentation.


### Features:

- [ ] includes tests covering changes
- [X ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
