### PR TITLE
[#5731] Add a PluginImplementations wrapper to maintain ordering

### DIFF
--- a/ckan/plugins/core.py
+++ b/ckan/plugins/core.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 import logging
 from pkg_resources import iter_entry_points
 from pyutilib.component.core import PluginGlobals, implements
-from pyutilib.component.core import ExtensionPoint as PluginImplementations
+from pyutilib.component.core import ExtensionPoint
 from pyutilib.component.core import SingletonPlugin as _pca_SingletonPlugin
 from pyutilib.component.core import Plugin as _pca_Plugin
 from ckan.common import asbool
@@ -69,6 +69,21 @@ def use_plugin(*plugins):
         yield p
     finally:
         unload(*plugins)
+
+
+class PluginImplementations(ExtensionPoint):
+
+    def __iter__(self):
+        '''
+        When we upgraded pyutilib on CKAN 2.9 the order in which
+        plugins were returned by `PluginImplementations` changed
+        so we use this wrapper to maintain the previous order
+        (which is the same as the ckan.plugins config option)
+        '''
+
+        iterator = super(PluginImplementations, self).__iter__()
+
+        return reversed(list(iterator))
 
 
 class PluginNotFoundException(Exception):

--- a/ckan/tests/plugins/test_core.py
+++ b/ckan/tests/plugins/test_core.py
@@ -1,0 +1,21 @@
+# encoding: utf-8
+
+import pytest
+
+import ckan.plugins as p
+
+
+@pytest.mark.usefixtures(u"with_plugins")
+@pytest.mark.ckan_config(
+    u"ckan.plugins",
+    u"example_idatasetform_v1 example_idatasetform_v2 example_idatasetform_v3")
+def test_plugins_order_in_pluginimplementations():
+
+    assert (
+        [plugin.name for plugin in p.PluginImplementations(p.IDatasetForm)] ==
+        [
+            u"example_idatasetform_v1",
+            u"example_idatasetform_v2",
+            u"example_idatasetform_v3"
+        ]
+    )


### PR DESCRIPTION
Fixes #5731

The order in which plugins were returned by `PluginImplementations` changed between CKAN 2.8 and CKAN 2.9. This has important implications as plugin ordering affects template overriding, chained actions and auth functions, etc See #5731 for more details.

This patch overrides the `__iter__()` method of pyutilib's `ExtensionPoint` to reverse its output before returning it.

Added test to ensure we don't break this again.
