### PR TITLE
[#5726] Include requirements files in Manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -20,3 +20,6 @@ include ckan/migration/migrate.cfg
 include ckan/migration/README
 recursive-include ckan/migration/versions *.sql
 include requirement-setuptools.txt
+include requirements.txt
+include requirements-py2.txt
+include dev-requirements.txt


### PR DESCRIPTION
Fixes #5726

This was missing from #5408, which allows installing the requirements using pip, but didn't include the actual requirement files in the published package, causing an exception when running `pip install ckan`

@smotornyuk can you have a look?