### PR TITLE
Use user performing the action on activity context on user_update

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -651,7 +651,7 @@ def user_update(context, data_dict):
 
     '''
     model = context['model']
-    user = context['user']
+    user = author = context['user']
     session = context['session']
     schema = context.get('schema') or schema_.default_update_user_schema()
     id = _get_or_bust(data_dict, 'id')
@@ -681,7 +681,7 @@ def user_update(context, data_dict):
             }
     activity_create_context = {
         'model': model,
-        'user': user,
+        'user': author,
         'defer_commit': True,
         'ignore_auth': True,
         'session': session


### PR DESCRIPTION
### Proposed fixes:

https://github.com/ckan/ckan/commit/7aa70a94de2a0ac979975dce079f15823a990f9e fixed this bug on the 2.9 branch, but it never got backported to 2.8 (I think because it was one commit in a much bigger PR and the whole PR was not suitable for backport)
I propose backporting the fix. Note this PR targets the 2.8 branch. It probably applies to 2.7 too.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport
