### PR TITLE
Session rollback on sqlalchemy OperationalError

### DIFF
--- a/ckan/model/system_info.py
+++ b/ckan/model/system_info.py
@@ -42,12 +42,12 @@ meta.mapper(SystemInfo, system_info_table)
 
 def get_system_info(key, default=None):
     ''' get data from system_info table '''
-    from sqlalchemy.exc import ProgrammingError
+    from sqlalchemy.exc import ProgrammingError, OperationalError
     try:
         obj = meta.Session.query(SystemInfo).filter_by(key=key).first()
         if obj:
             return obj.value
-    except ProgrammingError:
+    except (ProgrammingError, OperationalError):
         meta.Session.rollback()
     return default
 


### PR DESCRIPTION
Fixes #

### Proposed fixes:
uWSGI has open connections in some cases which get broken (for example, when Postgres restarts). Invalid transaction is occurring and not being rolled back, `sqlalchemy.exc.OperationalError` is thrown.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
