### PR TITLE
Remove HTSQL reference

### DIFF
--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -422,16 +422,16 @@ A resource in the DataStore can have multiple aliases that are easier to remembe
 Comparison of different querying methods
 ----------------------------------------
 
-The DataStore supports querying with multiple API endpoints. They are similar but support different features. The following list gives an overview of the different methods.
+The DataStore supports querying with two API endpoints. They are similar but support different features. The following list gives an overview of the different methods.
 
-==============================  ========================================================  ============================================================  =============================
-..                              :meth:`~ckanext.datastore.logic.action.datastore_search`  :meth:`~ckanext.datastore.logic.action.datastore_search_sql`  :ref:`HTSQL<datastore_search_htsql>`
-==============================  ========================================================  ============================================================  =============================
-**Ease of use**                 Easy                                                      Complex                                                       Medium
-**Flexibility**                 Low                                                       High                                                          Medium
-**Query language**              Custom (JSON)                                             SQL                                                           HTSQL
-**Join resources**              No                                                        Yes                                                           No
-==============================  ========================================================  ============================================================  =============================
+==============================  ========================================================  ============================================================
+..                              :meth:`~ckanext.datastore.logic.action.datastore_search`  :meth:`~ckanext.datastore.logic.action.datastore_search_sql`
+==============================  ========================================================  ============================================================
+**Ease of use**                 Easy                                                      Complex
+**Flexibility**                 Low                                                       High
+**Query language**              Custom (JSON)                                             SQL
+**Join resources**              No                                                        Yes
+==============================  ========================================================  ============================================================
 
 
 .. _db_internals:

--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -416,14 +416,6 @@ Resource aliases
 
 A resource in the DataStore can have multiple aliases that are easier to remember than the resource id. Aliases can be created and edited with the :meth:`~ckanext.datastore.logic.action.datastore_create` API endpoint. All aliases can be found in a special view called ``_table_metadata``. See :ref:`db_internals` for full reference.
 
-.. _datastore_search_htsql:
-
-HTSQL support
--------------
-
-
-The `ckanext-htsql <https://github.com/okfn/ckanext-htsql>`_ extension adds an API action that allows a user to search data in a resource using the `HTSQL <http://htsql.org/doc/>`_ query expression language. Please refer to the extension documentation to know more.
-
 
 .. _comparison_querying:
 


### PR DESCRIPTION
Resolves #5745

### Proposed fixes:
Remove HTSQL section in datastore documentation.


### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
