### PR TITLE
Datastore cli purge

### DIFF
--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -138,8 +138,9 @@ def purge():
             if record[u'alias_of']:
                 continue
 
-            # we need to do this in the loop to trigger resource_show auth function
-            site_user = logic.get_action(u'get_site_user')({u'ignore_auth': True}, {})
+            # we need to do this to trigger resource_show auth function
+            site_user = logic.get_action(u'get_site_user')(
+                {u'ignore_auth': True}, {})
             context = {u'user': site_user[u'name']}
 
             logic.get_action(u'resource_show')(

--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -133,9 +133,14 @@ def purge():
     resource_id_list = []
     for record in result[u'records']:
         try:
-            # ignore 'alias' records
+            # ignore 'alias' records (views) as they are automatically
+            # deleted when the parent resource table is dropped
             if record[u'alias_of']:
                 continue
+
+            # we need to do this in the loop to trigger resource_show auth function
+            site_user = logic.get_action(u'get_site_user')({u'ignore_auth': True}, {})
+            context = {u'user': site_user[u'name']}
 
             logic.get_action(u'resource_show')(
                 context,

--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -137,13 +137,20 @@ def purge():
                 context,
                 {u'id': record[u'name']}
             )
-            click.echo(u"Resource '%s' found" % record[u'name'])
-        except logic.NotFound:
+        except logicfNotFound:
             resource_id_list.append(record[u'name'])
             click.echo(u"Resource '%s' orphaned - queued for drop" %
                        record[u'name'])
         except KeyError:
             continue
+
+    orphaned_table_count = len(resource_id_list)
+    click.echo(u'%d orphaned tables found.' % orphaned_table_count)
+
+    if not orphaned_table_count:
+        return
+        
+    click.confirm(u'Proceed with purge?', abort=True)
 
     # Drop the orphaned datastore tables. When datastore_delete is called
     # without filters, it does a drop table cascade
@@ -157,3 +164,6 @@ def purge():
         drop_count += 1
 
     click.echo(u'Dropped %s tables' % drop_count)
+
+def get_commands():
+    return (set_permissions, dump, purge)

--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -133,11 +133,15 @@ def purge():
     resource_id_list = []
     for record in result[u'records']:
         try:
+            # ignore 'alias' records
+            if record[u'alias_of']:
+                continue
+
             logic.get_action(u'resource_show')(
                 context,
                 {u'id': record[u'name']}
             )
-        except logicfNotFound:
+        except logic.NotFound:
             resource_id_list.append(record[u'name'])
             click.echo(u"Resource '%s' orphaned - queued for drop" %
                        record[u'name'])
@@ -149,7 +153,7 @@ def purge():
 
     if not orphaned_table_count:
         return
-        
+
     click.confirm(u'Proceed with purge?', abort=True)
 
     # Drop the orphaned datastore tables. When datastore_delete is called
@@ -164,6 +168,7 @@ def purge():
         drop_count += 1
 
     click.echo(u'Dropped %s tables' % drop_count)
+
 
 def get_commands():
     return (set_permissions, dump, purge)

--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -141,7 +141,7 @@ def purge():
         except logic.NotFound:
             resource_id_list.append(record[u'name'])
             click.echo(u"Resource '%s' orphaned - queued for drop" %
-                        record[u'name'])
+                       record[u'name'])
         except KeyError:
             continue
 

--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -122,7 +122,9 @@ def purge():
     u'''Purge deleted resources from the datastore using datastore_delete,
     which actually drops tables when passed an empty filter.'''
 
-    context = {}
+    site_user = logic.get_action(u'get_site_user')({u'ignore_auth': True}, {})
+    context = {u'user': site_user[u'name']}
+    
     result = logic.get_action(u'datastore_search')(
         context,
         {u'resource_id': u'_table_metadata'}

--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -116,11 +116,11 @@ def _parse_db_config(config_key=u'sqlalchemy.url'):
 
 @datastore.command(
     u'purge',
-    short_help=u'purge deleted resources from the datastore.'
+    short_help=u'purge orphaned resources from the datastore.'
 )
 def purge():
-    u'''Purge deleted resources from the datastore using datastore_delete,
-    which actually drops tables when passed an empty filter.'''
+    u'''Purge orphaned resources from the datastore using the datastore_delete
+    action, which drops tables when called without filters.'''
 
     site_user = logic.get_action(u'get_site_user')({u'ignore_auth': True}, {})
     context = {u'user': site_user[u'name']}
@@ -140,11 +140,13 @@ def purge():
             click.echo(u"Resource '%s' found" % record[u'name'])
         except logic.NotFound:
             resource_id_list.append(record[u'name'])
-            click.echo(u"Resource '%s' orphaned - queued for drop" % record[u'name'])
+            click.echo(u"Resource '%s' orphaned - queued for drop" % 
+                record[u'name'])
         except KeyError:
             continue
 
-    # drop the orphaned datastore tables
+    # Drop the orphaned datastore tables. When datastore_delete is called 
+    # without filters, it does a drop table cascade
     drop_count = 0
     for resource_id in resource_id_list:
         logic.get_action(u'datastore_delete')(
@@ -154,4 +156,4 @@ def purge():
         click.echo(u"Table '%s' dropped)" % resource_id)
         drop_count += 1
 
-    click.echo(u"Dropped %s tables" % drop_count)
+    click.echo(u'Dropped %s tables' % drop_count)

--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -140,12 +140,12 @@ def purge():
             click.echo(u"Resource '%s' found" % record[u'name'])
         except logic.NotFound:
             resource_id_list.append(record[u'name'])
-            click.echo(u"Resource '%s' orphaned - queued for drop" % 
-                record[u'name'])
+            click.echo(u"Resource '%s' orphaned - queued for drop" %
+                        record[u'name'])
         except KeyError:
             continue
 
-    # Drop the orphaned datastore tables. When datastore_delete is called 
+    # Drop the orphaned datastore tables. When datastore_delete is called
     # without filters, it does a drop table cascade
     drop_count = 0
     for resource_id in resource_id_list:

--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -124,7 +124,7 @@ def purge():
 
     site_user = logic.get_action(u'get_site_user')({u'ignore_auth': True}, {})
     context = {u'user': site_user[u'name']}
-    
+
     result = logic.get_action(u'datastore_search')(
         context,
         {u'resource_id': u'_table_metadata'}
@@ -133,10 +133,6 @@ def purge():
     resource_id_list = []
     for record in result[u'records']:
         try:
-            # ignore 'alias' records
-            if record[u'alias_of']:
-                continue
-
             logic.get_action(u'resource_show')(
                 context,
                 {u'id': record[u'name']}
@@ -144,7 +140,7 @@ def purge():
             click.echo(u"Resource '%s' found" % record[u'name'])
         except logic.NotFound:
             resource_id_list.append(record[u'name'])
-            click.echo(u"Resource '%s' *not* found" % record[u'name'])
+            click.echo(u"Resource '%s' orphaned - queued for drop" % record[u'name'])
         except KeyError:
             continue
 

--- a/doc/maintaining/cli.rst
+++ b/doc/maintaining/cli.rst
@@ -241,7 +241,7 @@ Usage
  ckan dataset purge [DATASET_NAME|ID]    - removes dataset from db entirely
 
 
-datastore: Perform commands to set up the datastore
+datastore: Perform commands in the datastore
 ===================================================
 
 Make sure that the datastore URLs are set properly before you run these commands.
@@ -252,6 +252,7 @@ Usage
 
  ckan datastore set-permissions  - generate SQL for permission configuration
  ckan datastore dump             - dump a datastore resource
+ ckan datastore purge            - purge orphaned datastore resources
 
 
 db: Manage databases


### PR DESCRIPTION
Fixes #5589

### Proposed fixes:
- [X] implement datastore purge cli command.
  Do this by scanning `_table_metadata` for orphaned resources (i.e. there is an entry in _table_metadata, but no matching resource), and dropping these orphaned tables by calling `datastore_delete` for that resource_id without filters - which results in a drop table cascade.
- [x] update documentation

### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
