### PR TITLE
bugfix: persisiting auth attributes

### DIFF
--- a/ckan/authz.py
+++ b/ckan/authz.py
@@ -116,7 +116,7 @@ class AuthFunctions:
                     prev_func = self._functions[name]
                 
                 new_func = (functools.partial(func, prev_func))
-                # persisting attributes to the new partiall function
+                # persisting attributes to the new partial function
                 attributes = list(func.__dict__.keys())
                 for attribute in attributes:
                     value = getattr(func, attribute)

--- a/ckan/authz.py
+++ b/ckan/authz.py
@@ -117,9 +117,7 @@ class AuthFunctions:
                 
                 new_func = (functools.partial(func, prev_func))
                 # persisting attributes to the new partial function
-                attributes = list(func.__dict__.keys())
-                for attribute in attributes:
-                    value = getattr(func, attribute)
+                for attribute, value in six.iteritems(func.__dict__):
                     setattr(new_func, attribute, value)
                 
                 fetched_auth_functions[name] = new_func

--- a/ckan/authz.py
+++ b/ckan/authz.py
@@ -116,16 +116,9 @@ class AuthFunctions:
                     prev_func = self._functions[name]
                 
                 new_func = (functools.partial(func, prev_func))
-                attributes_list = [
-                    'auth_allow_anonymous_access',
-                    'auth_disallow_anonymous_access',
-                    'auth_sysadmins_check',
-                    'chained_auth_function'
-                ]
-                for attribute in attributes_list:
-                    if hasattr(func, attribute):
-                        attval = getattr(func, attribute)
-                        setattr(new_func, attribute, attval)
+                # persisting attributes to the new partial function
+                for attribute, value in func.__dict__.iteritems():
+                    setattr(new_func, attribute, value)
                 
                 fetched_auth_functions[name] = new_func
 

--- a/ckan/authz.py
+++ b/ckan/authz.py
@@ -116,8 +116,10 @@ class AuthFunctions:
                     prev_func = self._functions[name]
                 
                 new_func = (functools.partial(func, prev_func))
-                # persisting attributes to the new partial function
-                for attribute, value in func.__dict__.iteritems():
+                # persisting attributes to the new partiall function
+                attributes = list(func.__dict__.keys())
+                for attribute in attributes:
+                    value = getattr(func, attribute)
                     setattr(new_func, attribute, value)
                 
                 fetched_auth_functions[name] = new_func

--- a/ckan/authz.py
+++ b/ckan/authz.py
@@ -114,8 +114,20 @@ class AuthFunctions:
                 else:
                     # fallback to chaining off the builtin auth function
                     prev_func = self._functions[name]
-                fetched_auth_functions[name] = (
-                    functools.partial(func, prev_func))
+                
+                new_func = (functools.partial(func, prev_func))
+                attributes_list = [
+                    'auth_allow_anonymous_access',
+                    'auth_disallow_anonymous_access',
+                    'auth_sysadmins_check',
+                    'chained_auth_function'
+                ]
+                for attribute in attributes_list:
+                    if hasattr(func, attribute):
+                        attval = getattr(func, attribute)
+                        setattr(new_func, attribute, attval)
+                
+                fetched_auth_functions[name] = new_func
 
         # Use the updated ones in preference to the originals.
         self._functions.update(fetched_auth_functions)

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2922,9 +2922,7 @@ def load_plugin_helpers():
             new_func = functools.partial(
                 func, helper_functions[name])
             # persisting attributes to the new partial function
-            attributes = list(func.__dict__.keys())
-            for attribute in attributes:
-                value = getattr(func, attribute)
+            for attribute, value in six.iteritems(func.__dict__):
                 setattr(new_func, attribute, value)
             helper_functions[name] = new_func
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2919,8 +2919,14 @@ def load_plugin_helpers():
             raise logic.NotFoud(
                 u'The helper %r is not found for chained helper' % (name))
         for func in reversed(func_list):
-            helper_functions[name] = functools.partial(
+            new_func = functools.partial(
                 func, helper_functions[name])
+            # persisting attributes to the new partial function
+            attributes = list(func.__dict__.keys())
+            for attribute in attributes:
+                value = getattr(func, attribute)
+                setattr(new_func, attribute, value)
+            helper_functions[name] = new_func
 
 
 @core_helper

--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -444,7 +444,13 @@ def get_action(action):
         for func in reversed(func_list):
             # try other plugins first, fall back to core
             prev_func = fetched_actions.get(name, _actions.get(name))
-            fetched_actions[name] = functools.partial(func, prev_func)
+            new_func = functools.partial(func, prev_func)
+            # persisting attributes to the new partial function
+            attributes = list(func.__dict__.keys())
+            for attribute in attributes:
+                value = getattr(func, attribute)
+                setattr(new_func, attribute, value)
+            fetched_actions[name] = new_func
 
     # Use the updated ones in preference to the originals.
     _actions.update(fetched_actions)

--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -446,9 +446,7 @@ def get_action(action):
             prev_func = fetched_actions.get(name, _actions.get(name))
             new_func = functools.partial(func, prev_func)
             # persisting attributes to the new partial function
-            attributes = list(func.__dict__.keys())
-            for attribute in attributes:
-                value = getattr(func, attribute)
+            for attribute, value in six.iteritems(func.__dict__):
                 setattr(new_func, attribute, value)
             fetched_actions[name] = new_func
 


### PR DESCRIPTION
Fixes #
Fixes #5751 and (partially) #4597. 

### Proposed fixes:
Because chained authentication functions are wrapped into partials, they lose access to any attributes that may have been set on the functions themselves (like allowing anonymous access). This fix defines a list of attributes, checks them against the original function, then applies them to the new partial function.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
