### PR TITLE
[#5757] Fix error when deleting resource with missing datastore table

### DIFF
--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -145,9 +145,10 @@ class DatastorePlugin(p.SingletonPlugin):
             if res.extras.get('datastore_active') is True]
 
         for res in deleted:
-            self.backend.delete(context, {
-                'resource_id': res.id,
-            })
+            if self.backend.resource_exists(res.id):
+                self.backend.delete(context, {
+                    'resource_id': res.id,
+                })
             res.extras['datastore_active'] = False
             res_query.filter_by(id=res.id).update(
                 {'extras': res.extras}, synchronize_session=False)


### PR DESCRIPTION
Fixes #5757 

### Proposed fixes:
Exception is thrown when trying to delete a resource for which a datastore table should exist, so datastore_active == true, but the table does not actually exist in the datastore for whatever reason. Just ignore that now since we are just trying to delete the resource anyways.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
