### PR TITLE
[#5759] Raise NotFound when creating a non-existing collaborator

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -668,7 +668,7 @@ def package_collaborator_create(context, data_dict):
 
     user = model.User.get(user_id)
     if not user:
-        raise NotAuthorized(_('Not allowed to add collaborators'))
+        raise NotFound(_('User not found'))
 
     if not authz.check_config_permission('allow_dataset_collaborators'):
         raise ValidationError(_('Dataset collaborators not enabled'))

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -1243,12 +1243,12 @@ class TestPackageMemberCreate(object):
                 'package_collaborator_create',
                 id=dataset['id'], user_id=user['id'], capacity=capacity)
 
-    def test_create_user_not_authorized(self):
+    def test_create_user_not_found(self):
         dataset = factories.Dataset()
         user = {'id': 'yyy'}
         capacity = 'editor'
 
-        with pytest.raises(logic.NotAuthorized):
+        with pytest.raises(logic.NotFound):
             helpers.call_action(
                 'package_collaborator_create',
                 id=dataset['id'], user_id=user['id'], capacity=capacity)

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -1313,10 +1313,12 @@ class CollaboratorEditView(MethodView):
         except NotAuthorized:
             message = _(u'Unauthorized to edit collaborators {}').format(id)
             return base.abort(401, _(message))
-        except NotFound:
-            return base.abort(404, _(u'Resource not found'))
+        except NotFound as e:
+            h.flash_error(_('User not found'))
+            return h.redirect_to(u'dataset.new_collaborator', id=id)
         except ValidationError as e:
             h.flash_error(e.error_summary)
+            return h.redirect_to(u'dataset.new_collaborator', id=id)
         else:
             h.flash_success(_(u'User added to collaborators'))
 


### PR DESCRIPTION
Instead of the current `NotAuthorized`  exception we were raising. Also
redirect to the Add collaborator form when there is an error instead of
the collaborators list page.

Fixes #5759

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport
