### PR TITLE
2.8.x: Qld Government core updates: Incorporate delete() and download() into IUploader and  ResourceUpload for better cloud integrations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@
 Changelog
 ---------
 
+v.2.8.x
+=================
+
+Fixes:
+* Update to Interface IUploader, on get_uploader and get_resource_uploader, new method signatures delete(), download(), allowing integration with other cloud storage providers without overriding routes
+* Update to Interface IUploader, on get_uploader and get_resource_uploader, new to include new method signature metadata() which can be utilised by archiver and other plugins instead of trying on local disk directly
+* Add get api `resource_file_metadata_show` which takes resource id and returns { 'content_type': content_type, 'size': length, 'hash': hash } if found
+
 
 v.2.8.6 2020-10-21
 ==================
@@ -84,7 +92,6 @@ Fixes:
 * Use returned facets in group controller (`#2713 <https://github.com/ckan/ckan/pull/5167>`_)
 * Updated translations
 * Fix broken translation in image view placeholder (`#5099 <https://github.com/ckan/ckan/pull/5116>`_)
-
 
 v.2.8.3 2019-07-03
 ==================

--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -1169,19 +1169,11 @@ class PackageController(base.BaseController):
 
         if rsc.get('url_type') == 'upload':
             upload = uploader.get_resource_uploader(rsc)
-            filepath = upload.get_path(rsc['id'])
-            fileapp = paste.fileapp.FileApp(filepath)
             try:
-                status, headers, app_iter = request.call_application(fileapp)
+                return upload.download(rsc['id'], filename)
             except OSError:
+                # includes FileNotFoundError
                 abort(404, _('Resource data not found'))
-            response.headers.update(dict(headers))
-            content_type, content_enc = mimetypes.guess_type(
-                rsc.get('url', ''))
-            if content_type:
-                response.headers['Content-Type'] = content_type
-            response.status = status
-            return app_iter
         elif 'url' not in rsc:
             abort(404, _('No download is available'))
         h.redirect_to(rsc['url'])

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -28,6 +28,7 @@ from markdown import markdown
 from bleach import clean as bleach_clean, ALLOWED_TAGS, ALLOWED_ATTRIBUTES
 from pylons import url as _pylons_default_url
 from ckan.common import config, is_flask_request
+import ckan.plugins.toolkit as toolkit
 from flask import redirect as _flask_redirect
 from flask import _request_ctx_stack, current_app
 from routes import redirect_to as _routes_redirect_to

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -11,6 +11,7 @@ import ckan.logic
 import ckan.logic.action
 import ckan.plugins as plugins
 import ckan.lib.dictization.model_dictize as model_dictize
+import ckan.lib.uploader as uploader
 from ckan import authz
 
 from ckan.common import _
@@ -180,6 +181,15 @@ def resource_delete(context, data_dict):
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.before_delete(context, data_dict,
                              pkg_dict.get('resources', []))
+
+    # Delete file if it was uploaded
+    if entity.get('url_type') == 'upload':
+        upload = uploader.get_resource_uploader(entity)
+        # Don't break if old plugin/interface is found
+        if hasattr(upload, "delete"):
+            upload.delete(id)
+        else:
+            logging.warning("%s does not have delete function, could not cleanup: %s", type(upload).__name__, id)
 
     if pkg_dict.get('resources'):
         pkg_dict['resources'] = [r for r in pkg_dict['resources'] if not

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -113,6 +113,7 @@ def resource_update(context, data_dict):
     try:
         context['defer_commit'] = True
         context['use_cache'] = False
+        context['resources_only'] = True
         updated_pkg_dict = _get_action('package_update')(context, pkg_dict)
         context.pop('defer_commit')
     except ValidationError as e:
@@ -307,10 +308,11 @@ def package_update(context, data_dict):
     else:
         rev.message = _(u'REST API: Update object %s') % data.get("name")
 
-    #avoid revisioning by updating directly
-    model.Session.query(model.Package).filter_by(id=pkg.id).update(
-        {"metadata_modified": datetime.datetime.utcnow()})
-    model.Session.refresh(pkg)
+    if not context.get('resources_only', False):
+        #avoid revisioning by updating directly
+        model.Session.query(model.Package).filter_by(id=pkg.id).update(
+            {"metadata_modified": datetime.datetime.utcnow()})
+        model.Session.refresh(pkg)
 
     pkg = model_save.package_dict_save(data, context)
 
@@ -388,6 +390,7 @@ def package_resource_reorder(context, data_dict):
     new_resources = ordered_resources + existing_resources
     package_dict['resources'] = new_resources
 
+    context['resources_only'] = True
     _check_access('package_resource_reorder', context, package_dict)
     _get_action('package_update')(context, package_dict)
 

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -638,7 +638,7 @@ def user_update(context, data_dict):
     '''Update a user account.
 
     Normal users can only update their own user accounts. Sysadmins can update
-    any user account. Can not modify exisiting user's name.
+    any user account and modify existing usernames.
 
     For further parameters see
     :py:func:`~ckan.logic.action.create.user_create`.

--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -177,6 +177,10 @@ def resource_view_list(context, data_dict):
     return authz.is_authorized('resource_show', context, data_dict)
 
 
+def resource_file_metadata_show(context, data_dict):
+    return authz.is_authorized('resource_show', context, data_dict)
+
+
 def revision_show(context, data_dict):
     # No authz check in the logic function
     return {'success': True}

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -559,10 +559,13 @@ def user_name_validator(key, data, errors, context):
             return
         else:
             # Otherwise return an error: there's already another user with that
-            # name, so you can create a new user with that name or update an
+            # name, so you can't create a new user with that name or update an
             # existing user's name to that name.
             errors[key].append(_('That login name is not available.'))
     elif user_obj_from_context:
+        requester = context.get('auth_user_obj', None)
+        if requester and requester.sysadmin == True:
+            return
         old_user = model.User.get(user_obj_from_context.id)
         if old_user is not None and old_user.state != model.State.PENDING:
             errors[key].append(_('That login name can not be modified.'))

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1701,7 +1701,8 @@ class IUploader(Interface):
         ``update_data_dict(data_dict, url_field, file_field, clear_field)``
 
         Allow the data_dict to be manipulated before it reaches any
-        validators.
+            validators. Optionally, this data_dict can have the following attribute set:
+            preserve_filename (boolean):  If none, will append utcnow date to Filename
 
         :param data_dict: data_dict to be updated
         :type data_dict: dictionary
@@ -1710,7 +1711,8 @@ class IUploader(Interface):
         :type url_field: string
 
         :param file_field: name of the key where the FieldStorage is kept (i.e
-            the field where the file data actually is).
+            the field where the file data actually is). FileStorage must be an instance of;
+            cgi.FieldStorage or werkzeug.datastructures.FileStorage as FlaskFileStorage
         :type file_field: string
 
         :param clear_field: name of a boolean field which requests the upload
@@ -1723,6 +1725,28 @@ class IUploader(Interface):
 
         :param max_size: upload size can be limited by this value in MBs.
         :type max_size: int
+
+        ``delete(filename)``
+
+        Perform a delete.
+
+        :param filename: The filename to use when deleting a file, may be None depending on the storage provider.
+        :type filename: string
+
+        ``download(filename)``
+
+        Provide redirect url or file stream
+
+        :param filename: The filename to use when downloading a file, may be None depending on the storage provider.
+        :type filename: string
+
+        ``metadata(filename)``
+
+        Collect metadata of file. Returns dict { 'content_type': content_type, 'size': length, 'hash': hash }
+        Throws IOError if file does not exist
+
+        :param filename: The filename to use when collecting metadata
+        :type filename: string
 
         '''
 
@@ -1760,6 +1784,37 @@ class IUploader(Interface):
 
         :param id: resource id
         :type id: string
+
+        ``delete(id, filename)``
+
+        Perform a delete.
+
+        :param id: resource id, used to delete file
+        :type id: string
+
+        :param filename: The filename to use when storing a resource, may be None depending on the storage provider.
+        :type filename: string
+
+        ``download(id, filename)``
+
+        Provide redirect url or file stream
+
+        :param id: resource id, used to locate file
+        :type id: string
+
+        :param filename: The filename to use when storing a resource, may be None depending on the storage provider.
+        :type filename: string
+
+        ``metadata(id, filename)``
+
+        Collect metadata of resource. Returns dict { 'content_type': content_type, 'size': length, 'hash': hash }
+        Throws IOError if file does not exist
+
+        :param id: resource id, used to locate file
+        :type id: string
+
+        :param filename: The filename to use when collecting metadata, may be None depending on the storage provider.
+        :type filename: string
 
         '''
 

--- a/ckan/templates-bs2/user/edit_user_form.html
+++ b/ckan/templates-bs2/user/edit_user_form.html
@@ -5,7 +5,11 @@
 
   <fieldset>
     <legend>{{ _('Change details') }}</legend>
-    {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], attrs={'readonly': ''}) }}
+    {% if c.userobj.sysadmin == True %}
+      {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], is_required=true) }}
+    {% else %}
+      {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], attrs={'readonly': ''}) }}
+    {% endif %}
 
     {{ form.input('fullname', label=_('Full name'), id='field-fullname', value=data.fullname, error=errors.fullname, placeholder=_('eg. Joe Bloggs'), classes=['control-medium']) }}
 

--- a/ckan/templates/user/edit_user_form.html
+++ b/ckan/templates/user/edit_user_form.html
@@ -5,7 +5,11 @@
 
   <fieldset>
     <legend>{{ _('Change details') }}</legend>
-    {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], attrs={'readonly': '', 'class': 'form-control'}) }}
+    {% if c.userobj.sysadmin == True %}
+      {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], is_required=true, attrs={'class': 'form-control'}) }}
+    {% else %}
+      {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], attrs={'readonly': '', 'class': 'form-control'}) }}
+    {% endif %}
 
     {{ form.input('fullname', label=_('Full name'), id='field-fullname', value=data.fullname, error=errors.fullname, placeholder=_('eg. Joe Bloggs'), classes=['control-medium']) }}
 

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -595,10 +595,12 @@ class PerformResetView(MethodView):
         except logic.NotAuthorized:
             base.abort(403, _(u'Unauthorized to reset password.'))
 
+        context[u'ignore_auth'] = True
         try:
             user_dict = logic.get_action(u'user_show')(context, {u'id': id})
         except logic.NotFound:
             base.abort(404, _(u'User not found'))
+        del context[u'ignore_auth']
         user_obj = context[u'user_obj']
         g.reset_key = request.params.get(u'key')
         if not mailer.verify_reset_link(user_obj, g.reset_key):


### PR DESCRIPTION
This is the work that has been completed by Qld Government in maintaining https://www.data.qld.gov.au and https://www.publications.qld.gov.au. 

This includes a change to the IUploader interface which allows better integrations for archiver plugin or similar in verifying files with AWS s3 plugin for resource files off disk. (Allowing nearly immutable web front of house instances for high scaling without the need of a network file store for uploads)

This is backwards compatible, if a plugin extends IUploader but does not incorporate download, then it will fallback to previous functionality. 

### Proposed fixes:
#### Incorporate delete() and download() into IUploader, update ResourceUpload, Upload with functionality from controller resource_download to allow better cloud integrations

- Add metadata to IUploader interface's
- Add new resource_file_metadata_show get api to surface metadata checks, usage case is archiver or similar verifying files have not change or disappeared
- Hook in delete uploader in resource delete action logic, use upload download logic fully
- Remove unneeded code as its now in the ResourceUpload class, call upload delete when a resource is also deleted
- Uploader and interface update so signature has filename
- Allow filenames to be preserved in uploader
- Add logging if delete method not found
- Need package dict to call uploader correctly
- Add metadata to uploader interface, next step, surface it via package…

#### Other Fixes
* Ignore auth check on loading user details during password resets
* Reduce race condition during datastore via adding error handling for race condition during datastore file uploads, #3980
* Stop anyone from editing usernames
  - as sysadmins can already do anything so allow sysadmins to edit usernames
  - add nose test to ensure that sysadmins can change account names  
  - adjust test password handling to match other tests 
  - redirect after updating username
  - include extra environment when redirecting
  - use 'submit_and_follow' helper to simplify proper redirection
  - adjust test steps to better match successful user edit test
  - update context username after updating it in the account
* Replace freshness-based check with a flag
  - don't update the package modification timestamp if we're only updating the resources
  - don't update package modification timestamp more than once every ten seconds, this should reduce lock contention on resource updates


### Features:

- [X] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
