### PR TITLE
Restore member edit page

### DIFF
--- a/ckan/tests/controllers/test_group.py
+++ b/ckan/tests/controllers/test_group.py
@@ -414,6 +414,25 @@ class TestGroupMembership(object):
         assert user_roles["My Owner"] == "Admin"
         assert user_roles["My Fullname"] == "Member"
 
+    def test_membership_edit_page(self, app):
+        """If `user` parameter provided, render edit page."""
+        owner = factories.User(fullname="My Owner")
+        member = factories.User(fullname="My Fullname", name="my-user")
+        group = self._create_group(owner["name"], users=[
+            {'name': member['name'], 'capacity': 'admin'}
+        ])
+
+        env = {"REMOTE_USER": six.ensure_str(owner["name"])}
+        url = url_for("group.member_new", id=group["name"], user=member['name'])
+
+        response = app.get(url, environ_overrides=env)
+
+        page = BeautifulSoup(response.body)
+        assert page.select_one('.page-heading').text.strip() == 'Edit Member'
+        role_option = page.select_one('#role [selected]')
+        assert role_option and role_option.get('value') == 'admin'
+        assert page.select_one('#username').get('value') == member['name']
+
     def test_admin_add(self, app):
         """Admin can be added via add member page"""
         owner = factories.User(fullname="My Owner")

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -1146,12 +1146,12 @@ class MembersGroupView(MethodView):
         g.roles = roles
         g.user_role = user_role
 
-        extra_vars = {
+        extra_vars.update({
             u"group_dict": group_dict,
             u"roles": roles,
             u"user_role": user_role,
             u"group_type": group_type
-        }
+        })
         return base.render(_replace_group_org(u'group/member_new.html'),
                            extra_vars)
 


### PR DESCRIPTION
Right now there is a bug in code, that makes the MemberEdit page for the group inaccessible. Instead, when user tries to visit this page, the MemberCreate form is rendered. This happens because the variable that controls whether **edit** or **new** form is shown, is overridden inside the group view.