### PR TITLE
Fix JavaScript error on Edge

### DIFF
--- a/ckan/public/base/javascript/view-filters.js
+++ b/ckan/public/base/javascript/view-filters.js
@@ -24,7 +24,7 @@ String.prototype.queryStringToJSON = String.prototype.queryStringToJSON || funct
     // Do we have JSON string?
     try {
       return JSON.parse(decodeURIComponent(params));
-    } catch  {
+    } catch(error) {
       // We have a params string
       params = params.split(/\&(amp\;)?/);
     }


### PR DESCRIPTION
### Proposed fixes:
Argument for catch block is optional only in ES2019 which Edge does not support. PR is done against dev-v2.9 as this whole function was replaced with qs in master.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
