### PR TITLE
Update organization_show package limit docs

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1277,7 +1277,7 @@ def organization_show(context, data_dict):
 
     :rtype: dictionary
 
-    .. note:: Only its first 1000 datasets are returned
+    .. note:: Only its first 10 datasets are returned
     '''
     return _group_or_org_show(context, data_dict, is_org=True)
 


### PR DESCRIPTION
Fixes #5775 

### Proposed fixes:

An update was made to let package_search set the package limit for organization_show. As it turns out, package_search always uses 10 in this case. Thus the docs update.

### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
