### PR TITLE
[#5789] Adds typechecks for the max_limit and limit field causing the issue

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -354,8 +354,8 @@ def _group_or_org_list(context, data_dict, is_org=False):
             'ckan.group_and_organization_list_all_fields_max', 25)
     else:
         max_limit = config.get('ckan.group_and_organization_list_max', 1000)
-    if limit is None or limit > max_limit:
-        limit = max_limit
+    if limit is None or int(limit) > max_limit:
+        limit = str(max_limit)
 
     # order_by deprecated in ckan 1.8
     # if it is supplied and sort isn't use order_by and raise a warning


### PR DESCRIPTION
Fixes #5789 

Currently when querying the `organization_list` endpoint with a limit
parameter set the server returns an error as described in the issue.

The fix is just converting the types before comparing

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport
