### PR TITLE
Ignore auth checks on loading user details during password resets, #5185

### DIFF
--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -690,10 +690,12 @@ class PerformResetView(MethodView):
         except logic.NotAuthorized:
             base.abort(403, _(u'Unauthorized to reset password.'))
 
+        context[u'ignore_auth'] = True
         try:
             user_dict = logic.get_action(u'user_show')(context, {u'id': id})
         except logic.NotFound:
             base.abort(404, _(u'User not found'))
+        del context[u'ignore_auth']
         user_obj = context[u'user_obj']
         g.reset_key = request.params.get(u'key')
         if not mailer.verify_reset_link(user_obj, g.reset_key):


### PR DESCRIPTION
This is part of the work that has been completed by Qld Government in maintaining https://www.data.qld.gov.au and https://www.publications.qld.gov.au.

Fixes #

Ignore auth check on loading user details during password resets

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X ] includes bugfix for possible backport

Please [X] all the boxes above that apply
