### PR TITLE
invoke after_action hooks after transactions are committed

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -206,8 +206,6 @@ def package_create(context, data_dict):
     for item in plugins.PluginImplementations(plugins.IPackageController):
         item.create(pkg)
 
-        item.after_create(context, data)
-
     # Make sure that a user provided schema is not used in create_views
     # and on package_show
     context.pop('schema', None)
@@ -232,6 +230,9 @@ def package_create(context, data_dict):
 
     if not context.get('defer_commit'):
         model.repo.commit()
+
+    for item in plugins.PluginImplementations(plugins.IPackageController):
+        item.after_create(context, data)
 
     return_id_only = context.get('return_id_only', False)
 

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -94,8 +94,6 @@ def package_delete(context, data_dict):
     for item in plugins.PluginImplementations(plugins.IPackageController):
         item.delete(entity)
 
-        item.after_delete(context, data_dict)
-
     entity.delete()
 
     dataset_memberships = model.Session.query(model.Member).filter(
@@ -122,6 +120,9 @@ def package_delete(context, data_dict):
         session.add(activity)
 
     model.repo.commit()
+
+    for item in plugins.PluginImplementations(plugins.IPackageController):
+        item.after_delete(context, data_dict)
 
 
 def dataset_purge(context, data_dict):
@@ -206,10 +207,10 @@ def resource_delete(context, data_dict):
         errors = e.error_dict['resources'][-1]
         raise ValidationError(errors)
 
+    model.repo.commit()
+
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.after_delete(context, pkg_dict.get('resources', []))
-
-    model.repo.commit()
 
 
 def resource_view_delete(context, data_dict):

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -327,8 +327,6 @@ def package_update(context, data_dict):
     for item in plugins.PluginImplementations(plugins.IPackageController):
         item.edit(pkg)
 
-        item.after_update(context, data)
-
     # Create activity
     if not pkg.private:
         user_obj = model.User.by_name(user)
@@ -342,6 +340,9 @@ def package_update(context, data_dict):
 
     if not context.get('defer_commit'):
         model.repo.commit()
+
+    for item in plugins.PluginImplementations(plugins.IPackageController):
+        item.after_update(context, data)
 
     log.debug('Updated object %s' % pkg.name)
 


### PR DESCRIPTION
### Proposed fixes:

Invoking these hooks before calling `model.repo.commit()` could lead to a race condition in plugins.

I'll defer to review, but my reading of [the documentation](https://docs.ckan.org/en/2.9/extensions/plugin-interfaces.html) is that the user should expect the transaction to be persisted at the point these hooks are invoked (accepting there is an edge case if the action is invoked with `defer_commit: True` for `package_update` and `package_create`).

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
