### PR TITLE
docs: fix simple typo, udated -> updated

### DIFF
--- a/ckanext/datapusher/cli.py
+++ b/ckanext/datapusher/cli.py
@@ -38,7 +38,7 @@ def datapusher():
 @datapusher.command()
 @requires_confirmation
 def resubmit(yes):
-    u'''Resubmit udated datastore resources.
+    u'''Resubmit updated datastore resources.
     '''
     confirm(yes)
 


### PR DESCRIPTION
There is a small typo in ckanext/datapusher/cli.py.

Should read `updated` rather than `udated`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md