### PR TITLE
[#5814] textview: escape text formats

### DIFF
--- a/ckanext/textview/theme/public/text_view.js
+++ b/ckanext/textview/theme/public/text_view.js
@@ -58,7 +58,9 @@ ckan.module('text_view', function (jQuery) {
           if (p.language) {
             highlighted = hljs.highlight(p.language, data, true).value;
           } else {
-            highlighted = '<pre>' + data + '</pre>';
+            var escape_ = document.createElement('textarea');
+            escape_.textContent = data;
+            highlighted = '<pre>' + escape_.innerHTML + '</pre>';
           }
 
           self.el[0].innerHTML = highlighted;

--- a/ckanext/textview/theme/public/text_view.js
+++ b/ckanext/textview/theme/public/text_view.js
@@ -58,9 +58,7 @@ ckan.module('text_view', function (jQuery) {
           if (p.language) {
             highlighted = hljs.highlight(p.language, data, true).value;
           } else {
-            var escape_ = document.createElement('textarea');
-            escape_.textContent = data;
-            highlighted = '<pre>' + escape_.innerHTML + '</pre>';
+            highlighted = $('<pre></pre>').text(data)[0].outerHTML;
           }
 
           self.el[0].innerHTML = highlighted;


### PR DESCRIPTION
Fixes #5814

### Proposed fixes:

escape HTML tags in text previewed with textview. Appreciate review from an experienced JS developer, used a textarea element for the escaping because it seemed to be the simplest approach

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport