### PR TITLE
Allow to run the development server using SSL

### DIFF
--- a/ckan/cli/server.py
+++ b/ckan/cli/server.py
@@ -24,18 +24,21 @@ log = logging.getLogger(__name__)
     u"--processes", type=int, default=0,
     help=u"Maximum number of concurrent processes"
 )
-@click.option(u"-e", u"--extra-files", multiple=True,
+@click.option(
+    u"-e", u"--extra-files", multiple=True,
     help=u"Additional files that should be watched for server reloading"
     " (you can provide multiple values)")
-@click.option(u"-C", u"--ssl-cert", default=None,
+@click.option(
+    u"-C", u"--ssl-cert", default=None,
     help=u"Certificate file to use to enable SSL. Passing 'adhoc' will "
     " automatically generate a new one (on each server reload).")
-@click.option(u"-K", u"--ssl-key", default=None,
+@click.option(
+    u"-K", u"--ssl-key", default=None,
     help=u"Key file to use to enable SSL. Passing 'adhoc' will "
     " automatically generate a new one (on each server reload).")
 @click.pass_context
 def run(ctx, host, port, disable_reloader, threaded, extra_files, processes,
-    ssl_cert, ssl_key):
+        ssl_cert, ssl_key):
     u"""Runs the Werkzeug development server"""
 
     # Reloading
@@ -68,7 +71,7 @@ def run(ctx, host, port, disable_reloader, threaded, extra_files, processes,
     else:
         ssl_context = None
 
-    log.info(u"Running CKAN on {scheme}://{host}/{port}".format(
+    log.info(u"Running CKAN on {scheme}://{host}:{port}".format(
         scheme='https' if ssl_context else 'http', host=host, port=port))
 
     run_simple(

--- a/ckan/cli/server.py
+++ b/ckan/cli/server.py
@@ -20,15 +20,34 @@ log = logging.getLogger(__name__)
     u"-t", u"--threaded", is_flag=True,
     help=u"Handle each request in a separate thread"
 )
-@click.option(u"-e", u"--extra-files", multiple=True)
 @click.option(
     u"--processes", type=int, default=0,
     help=u"Maximum number of concurrent processes"
 )
+@click.option(u"-e", u"--extra-files", multiple=True,
+    help=u"Additional files that should be watched for server reloading"
+    " (you can provide multiple values)")
+@click.option(u"-C", u"--ssl-cert", default=None,
+    help=u"Certificate file to use to enable SSL. Passing 'adhoc' will "
+    " automatically generate a new one (on each server reload).")
+@click.option(u"-K", u"--ssl-key", default=None,
+    help=u"Key file to use to enable SSL. Passing 'adhoc' will "
+    " automatically generate a new one (on each server reload).")
 @click.pass_context
-def run(ctx, host, port, disable_reloader, threaded, extra_files, processes):
+def run(ctx, host, port, disable_reloader, threaded, extra_files, processes,
+    ssl_cert, ssl_key):
     u"""Runs the Werkzeug development server"""
+
+    # Reloading
     use_reloader = not disable_reloader
+    config_extra_files = tk.aslist(
+        config.get(u"ckan.devserver.watch_patterns")
+    )
+    extra_files = list(extra_files) + [
+        config[u"__file__"]
+    ] + config_extra_files
+
+    # Threads and processes
     threaded = threaded or tk.asbool(config.get(u"ckan.devserver.threaded"))
     processes = processes or tk.asint(
         config.get(u"ckan.devserver.multiprocess", 1)
@@ -37,14 +56,20 @@ def run(ctx, host, port, disable_reloader, threaded, extra_files, processes):
         tk.error_shout(u"Cannot have a multithreaded and multi process server")
         raise click.Abort()
 
-    log.info(u"Running server {0} on port {1}".format(host, port))
+    # SSL
+    cert_file = ssl_cert or config.get('ckan.devserver.ssl_cert')
+    key_file = ssl_key or config.get('ckan.devserver.ssl_key')
 
-    config_extra_files = tk.aslist(
-        config.get(u"ckan.devserver.watch_patterns")
-    )
-    extra_files = list(extra_files) + [
-        config[u"__file__"]
-    ] + config_extra_files
+    if cert_file and key_file:
+        if cert_file == key_file == 'adhoc':
+            ssl_context = 'adhoc'
+        else:
+            ssl_context = (ssl_cert, ssl_key)
+    else:
+        ssl_context = None
+
+    log.info(u"Running CKAN on {scheme}://{host}/{port}".format(
+        scheme='https' if ssl_context else 'http', host=host, port=port))
 
     run_simple(
         host,
@@ -55,4 +80,5 @@ def run(ctx, host, port, disable_reloader, threaded, extra_files, processes):
         threaded=threaded,
         processes=processes,
         extra_files=extra_files,
+        ssl_context=ssl_context,
     )

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -158,7 +158,7 @@ Example::
 
 Default value: False
 
-Controls, whether development server handle each request in a separate
+Controls whether the development server should handle each request in a separate
 thread.
 
 .. _ckan.devserver.multiprocess:
@@ -172,7 +172,7 @@ Example::
 
 Default value: 1
 
-If greater than 1 then handle each request in a new process up to this
+If greater than 1 then the developmente server will handle each request in a new process, up to this
 maximum number of concurrent processes.
 
 .. _ckan.devserver.watch_patterns:
@@ -186,8 +186,48 @@ Example::
 
 Default value: None
 
-A list of files the reloader should watch additionally to the
-modules. For example configuration files.
+A list of files the reloader should watch to restart the development server, in addition to the
+Python modules (for example configuration files)
+
+.. _ckan.devserver.ssl_cert:
+
+ckan.devserver.ssl_cert
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+  ckan.devserver.ssl_cert = path/to/host.cert
+
+Default value: None (SSL disabled)
+
+Path to a certificate file that will be used to enable SSL (ie to serve the
+local development server on https://localhost:5000). You can generate a
+self-signed certificate and key (see :ref:`ckan.devserver.ssl_key`) running
+the following commands::
+
+    openssl genrsa 2048 > host.key
+    chmod 400 host.key
+    openssl req -new -x509 -nodes -sha256 -days 3650 -key host.key > host.cert
+
+Alternatively, setting this option to ``adhoc`` will automatically generate a new
+certificate file (on each server reload, which means that you'll get a browser warning
+about the certificate on each reload).
+
+.. _ckan.devserver.ssl_key:
+
+ckan.devserver.ssl_key
+^^^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+  ckan.devserver.ssl_key = path/to/host.key
+
+Default value: None (SSL disabled)
+
+Path to a certificate file that will be used to enable SSL (ie to serve the
+local development server on https://localhost:5000). See :ref:`ckan.devserver.ssl_cert`
+for more details. This option also supports the ``adhoc`` value, with the same caveat.
+
 
 Repoze.who Settings
 -------------------


### PR DESCRIPTION
Running CKAN using SSL locally is very useful sometimes to replicate live setups, and mandatory in some situations like when developing a SAML2 authentication based instance (which requires CKAN to run on eg https://localhost:5000).

With paster with did that adding the `ssl_pem=/path/to/cert.pem` config option to the ini file. On Werkzeug we need to use the [`ssl_context`](https://werkzeug.palletsprojects.com/en/1.0.x/serving/#werkzeug.serving.run_simple
) param on the call to run the server that we invoke in `ckan run`.

This adds supports for this, both as CLI parameters and as config options, replicating existing `ckan.devserver.*` options. In addition to provide your self-signed cert and key you can also pass `adhoc`, which will make Werkzeug create one for you (on each reload though)

I'm proposing this to be backported to 2.9 as it is really useful and doesn't add any breaking changes.