### PR TITLE
Fix upload log activity sorting

### DIFF
--- a/ckanext/datapusher/templates-bs2/datapusher/resource_data.html
+++ b/ckanext/datapusher/templates-bs2/datapusher/resource_data.html
@@ -61,7 +61,7 @@
   {% if status.status and status.task_info and show_table %}
     <h3>{{ _('Upload Log') }}</h3>
     <ul class="activity">
-      {% for item in status.task_info.logs %}
+      {% for item in status.task_info.logs|sort(attribute='timestamp') %}
         {% set icon = 'ok' if item.level == 'INFO' else 'exclamation' %}
         {% set class = ' failure' if icon == 'exclamation' else ' success' %}
         {% set popover_content = 'test' %}

--- a/ckanext/datapusher/templates/datapusher/resource_data.html
+++ b/ckanext/datapusher/templates/datapusher/resource_data.html
@@ -61,7 +61,7 @@
   {% if status.status and status.task_info and show_table %}
     <h3>{{ _('Upload Log') }}</h3>
     <ul class="activity">
-      {% for item in status.task_info.logs %}
+      {% for item in status.task_info.logs|sort(attribute='timestamp') %}
         {% set icon = 'ok' if item.level == 'INFO' else 'exclamation' %}
         {% set class = ' failure' if icon == 'exclamation' else ' success' %}
         {% set popover_content = 'test' %}


### PR DESCRIPTION
Fixes #5826.

### Proposed fixes:
Use jinja2's built-in sort filter to sort by timestamp.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
