### PR TITLE
[#5836] plugin template and public dirs fix

### DIFF
--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -404,7 +404,7 @@ content type, cookies, etc.
 
         this_dir = os.path.dirname(filename)
         absolute_path = os.path.join(this_dir, relative_path)
-        if absolute_path not in config.get(config_var, ''):
+        if absolute_path not in config.get(config_var, '').split(','):
             if config.get(config_var):
                 config[config_var] += ',' + absolute_path
             else:


### PR DESCRIPTION
Allow adding template and public dirs even if they are a partial string match of existing dirs

Fixes #5836

### Proposed fixes:

ignore duplicates by searching list instead of comma-separated string

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport
