### PR TITLE
Replace deadlink to autodoc

### DIFF
--- a/doc/contributing/python.rst
+++ b/doc/contributing/python.rst
@@ -384,7 +384,7 @@ Example of a ckan.logic.action API docstring:
 
         '''
 
-.. _Autodoc: http://sphinx.pocoo.org/ext/autodoc.html
+.. _Autodoc: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
 
 
 Some helpful tools for Python code quality


### PR DESCRIPTION
Fixes deadlink to autodoc in Python Coding Standards.

https://docs.ckan.org/en/2.9/contributing/python.html#action-api-docstrings

### Proposed fixes:

Replace http://sphinx.pocoo.org/ext/autodoc.html with https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html

### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
