### PR TITLE
Fixes the links that were pointing to http://pylonsbook.com to point …

### DIFF
--- a/doc/extensions/testing-extensions.rst
+++ b/doc/extensions/testing-extensions.rst
@@ -54,7 +54,7 @@ Some notes on how these tests work:
 * You might also find it useful to read the
   `Pylons testing documentation <http://docs.pylonsproject.org/projects/pylons-webframework/en/latest/testing.html>`_.
 
-* The Pylons book also has a `chapter on testing <http://pylonsbook.com/en/1.0/testing.html>`_.
+* The Pylons book also has a `chapter on testing <https://thejimmyg.github.io/pylonsbook/en/1.0/testing.html>`_.
 
 * Avoid importing the plugin modules directly into your test modules
   (e.g from example_iauthfunctions import plugin_v5_custom_config_setting).

--- a/doc/theming/variables-and-functions.rst
+++ b/doc/theming/variables-and-functions.rst
@@ -33,7 +33,7 @@ templates in their top-level namespace:
 
 .. py:data:: tmpl_context
 
-   The `Pylons template context object <http://pylonsbook.com/en/1.0/exploring-pylons.html?highlight=template%20context#context-object>`_,
+   The `Pylons template context object <https://thejimmyg.github.io/pylonsbook/en/1.0/exploring-pylons.html?highlight=template%20context#context-object>`_,
    a thread-safe object that the application can store request-specific
    variables against without the variables associated with one HTTP request
    getting confused with variables from another request.
@@ -51,7 +51,7 @@ templates in their top-level namespace:
 
 .. py:data:: app_globals
 
-   The `Pylons App Globals object <http://pylonsbook.com/en/1.0/exploring-pylons.html?highlight=template%20context#app-globals-object>`_,
+   The `Pylons App Globals object <https://thejimmyg.github.io/pylonsbook/en/1.0/exploring-pylons.html?highlight=template%20context#app-globals-object>`_,
    an instance of the :py:class:`ckan.lib.app_globals.Globals` class.
    The application can store request-independent variables
    against the ``app_globals`` object. Variables stored against
@@ -70,14 +70,14 @@ templates in their top-level namespace:
 
 .. py:data:: request
 
-   The `Pylons Request object <http://pylonsbook.com/en/1.0/exploring-pylons.html?highlight=request#request>`_,
+   The `Pylons Request object <https://thejimmyg.github.io/pylonsbook/en/1.0/exploring-pylons.html?highlight=request#request>`_,
    contains information about the HTTP request that is currently being
    responded to, including the request headers and body, URL parameters, the
    requested URL, etc.
 
 .. py:data:: response
 
-   The `Pylons Response object <http://pylonsbook.com/en/1.0/exploring-pylons.html?highlight=request#response>`_,
+   The `Pylons Response object <https://thejimmyg.github.io/pylonsbook/en/1.0/exploring-pylons.html?highlight=request#response>`_,
    contains information about the HTTP response that is currently being
    prepared to be sent back to the user, including the HTTP status code,
    headers, cookies, etc.


### PR DESCRIPTION
…to https://thejimmyg.github.io/pylonsbook

Fixes #5844 

### Proposed fixes:
Fixes the links that were pointing to the defunct http://pylonsbook.com to point to https://thejimmyg.github.io/pylonsbook


### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation (it only includes updated documentation..)
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
