### PR TITLE
Prevent guessing format and mimetype from resource urls without path

### DIFF
--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -6,6 +6,7 @@ import datetime
 import logging
 import magic
 import mimetypes
+from six.moves.urllib.parse import urlparse
 
 from werkzeug.datastructures import FileStorage as FlaskFileStorage
 
@@ -211,7 +212,7 @@ class ResourceUpload(object):
         upload_field_storage = resource.pop('upload', None)
         self.clear = resource.pop('clear_upload', None)
 
-        if url and config_mimetype_guess == 'file_ext':
+        if url and config_mimetype_guess == 'file_ext' and urlparse(url).path:
             self.mimetype = mimetypes.guess_type(url)[0]
 
         if bool(upload_field_storage) and \

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -791,6 +791,12 @@ def if_empty_guess_format(key, data, errors, context):
         url = data.get(key[:-1] + ('url',), '')
         if not url:
             return
+
+        # Uploaded files have only the filename as url, so check scheme to determine if it's an actual url
+        parsed = urlparse(url)
+        if parsed.scheme and not parsed.path:
+            return
+
         mimetype, encoding = mimetypes.guess_type(url)
         if mimetype:
             data[key] = mimetype

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -420,6 +420,22 @@ class TestResourceCreate:
         assert mimetype
         assert mimetype == "text/csv"
 
+    def test_mimetype_by_url_without_path(self):
+        """
+        The mimetype should not be guessed from url if url contains only domain
+
+        """
+        context = {}
+        params = {
+            "package_id": factories.Dataset()["id"],
+            "url": "http://example.com",
+            "name": "A nice resource",
+        }
+        result = helpers.call_action("resource_create", context, **params)
+
+        mimetype = result.pop("mimetype")
+        assert mimetype is None
+
     def test_mimetype_by_user(self):
         """
         The mimetype is supplied by the user

--- a/ckan/tests/logic/test_validators.py
+++ b/ckan/tests/logic/test_validators.py
@@ -433,6 +433,8 @@ def test_if_empty_guess_format():
                 "id": "fake_resource_id",
                 "format": "",
             },
+            {"url": "http://example.com", "format": ""},
+            {"url": "my.csv", "format": ""}
         ],
     }
     data = df.flatten_dict(data)
@@ -464,6 +466,18 @@ def test_if_empty_guess_format():
         key=("resources", 3, "format"), data=new_data, errors={}, context={}
     )
     assert new_data[("resources", 3, "format")] == ""
+
+    new_data = copy.deepcopy(data)
+    call_validator(
+        key=("resources", 4, "format"), data=new_data, errors={}, context={}
+    )
+    assert new_data[("resources", 4, "format")] == ""
+
+    new_data = copy.deepcopy(data)
+    call_validator(
+        key=("resources", 5, "format"), data=new_data, errors={}, context={}
+    )
+    assert new_data[("resources", 5, "format")] == "text/csv"
 
 
 def test_clean_format():


### PR DESCRIPTION
### Proposed fixes:
When adding a resource with url containing only domain like http://example.com, format and mimetype is parsed as APPLICATION/X-MSDOS-PROGRAM as mimetypes does not parse it as url. This PR prevents parsing full url's if there is no path with the url.


### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
