### PR TITLE
Cast group and orgs max_limit config values to ints.

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -350,10 +350,11 @@ def _group_or_org_list(context, data_dict, is_org=False):
 
     if all_fields:
         # all_fields is really computationally expensive, so need a tight limit
-        max_limit = config.get(
-            'ckan.group_and_organization_list_all_fields_max', 25)
+        max_limit = int(config.get(
+            'ckan.group_and_organization_list_all_fields_max', 25))
     else:
-        max_limit = config.get('ckan.group_and_organization_list_max', 1000)
+        max_limit = int(config.get(
+            'ckan.group_and_organization_list_max', 1000))
     if limit is None or limit > max_limit:
         limit = max_limit
 

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -734,10 +734,22 @@ class TestOrganizationList(object):
         results = helpers.call_action("organization_list")
         assert len(results) == 5  # i.e. configured limit
 
+    @pytest.mark.ckan_config("ckan.group_and_organization_list_max", "5")
+    def test_limit_with_custom_max_limit(self):
+        self._create_bulk_orgs("org_default", 5)
+        results = helpers.call_action("organization_list", limit=2)
+        assert len(results) == 2
+
     def test_all_fields_limit_default(self):
         self._create_bulk_orgs("org_all_fields_default", 30)
         results = helpers.call_action("organization_list", all_fields=True)
         assert len(results) == 25  # i.e. default value
+
+    @pytest.mark.ckan_config("ckan.group_and_organization_list_all_fields_max", "5")
+    def test_all_fields_limit_with_custom_max_limit(self):
+        self._create_bulk_orgs("org_all_fields_default", 5)
+        results = helpers.call_action("organization_list", all_fields=True, limit=2)
+        assert len(results) == 2
 
     @pytest.mark.ckan_config(
         "ckan.group_and_organization_list_all_fields_max", "5"


### PR DESCRIPTION
Fixes # Type error while comparing integer limit with string max_limit values provided in ckan.ini config.
I've encountered an error coming from core ckan code when accessing organizations list with http://ckan:5000/organization:
```
    File "/usr/lib/ckan/venv/src/ckan/ckan/logic/action/get.py", line 567, in organization_list
    return _group_or_org_list(context, data_dict, is_org=True)
    File "/usr/lib/ckan/venv/src/ckan/ckan/logic/action/get.py", line 374, in _group_or_org_list
    if limit is None or limit > max_limit:
    TypeError: '>' not supported between instances of 'int' and 'str'
```
The relevant piece of action/get.py:374 looks like this:
```
# ckan/ckan/views/group.py
    if all_fields:
        # all_fields is really computationally expensive, so need a tight limit
        max_limit = config.get(
            'ckan.group_and_organization_list_all_fields_max', 25)
    else:
        max_limit = config.get('ckan.group_and_organization_list_max', 1000)
    if limit is None or limit > max_limit:
        limit = max_limit
```
With debugger I've double checked that max_limit is actually of type `str`.
After I've casted max values to ints organization list loads withour any errors. Everything works fine too if used with python2, bug is present only with python3.
My ckan.ini config for those variables looks like this:
```
# ckan.ini
ckan.group_and_organization_list_all_fields_max = 1000
ckan.group_and_organization_list_max = 1000
```
### Proposed fixes:
Cast `config.get` values to integers. Also I've created two tests for regression.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
