### PR TITLE
remove unused var in task_status_update

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -932,7 +932,6 @@ def task_status_update(context, data_dict):
     session = model.Session
     context['session'] = session
 
-    user = context['user']
     id = data_dict.get("id")
     schema = context.get('schema') or schema_.default_task_status_schema()
 


### PR DESCRIPTION
### Proposed fixes:

This var is never used and requiring `'user'` to be in `context` here causes us to throw `KeyError: 'user'` if we call the action with `ignore_auth: True`

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport
