### PR TITLE
document the type param for org/group_list actions

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -446,6 +446,9 @@ def _group_or_org_list(context, data_dict, is_org=False):
 def group_list(context, data_dict):
     '''Return a list of the names of the site's groups.
 
+    :param type: the type of group to list (optional, default: ``'group'``),
+        See docs for :py:class:`~ckan.plugins.interfaces.IGroupForm`
+    :type type: string
     :param order_by: the field to sort the list by, must be ``'name'`` or
       ``'packages'`` (optional, default: ``'name'``) Deprecated use sort.
     :type order_by: string
@@ -497,6 +500,10 @@ def group_list(context, data_dict):
 def organization_list(context, data_dict):
     '''Return a list of the names of the site's organizations.
 
+    :param type: the type of organization to list (optional,
+        default: ``'organization'``),
+        See docs for :py:class:`~ckan.plugins.interfaces.IGroupForm`
+    :type type: string
     :param order_by: the field to sort the list by, must be ``'name'`` or
       ``'packages'`` (optional, default: ``'name'``) Deprecated use sort.
     :type order_by: string


### PR DESCRIPTION
### Proposed fixes:

:books: No fixes - documentation only
Both `group_list` and `organization_list` can accept a `type` param which is currently not mentioned in the docs.

### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
