### PR TITLE
Check for min postgres version

### DIFF
--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1742,6 +1742,10 @@ class DatastorePostgresqlBackend(DatastoreBackend):
         if rows_max is not None:
             int(rows_max)
 
+        if not _pg_version_is_at_least(self.read_engine, "9.5"):
+            error_msg = 'At least PostgreSQL v9.5 is required.'
+            raise DatastoreException(error_msg)
+
     def datastore_delete(self, context, data_dict, fields_types, query_dict):
         query_dict['where'] += _where_clauses(data_dict, fields_types)
         return query_dict

--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -47,7 +47,7 @@ Setting up the DataStore
 .. versionchanged:: 2.6
 
    Previous CKAN (and DataStore) versions were compatible with earlier versions
-   of |postgres|.
+   of |postgres|. Currently, at least |postgres| version 9.5 is required.
 
 1. Enable the plugin
 ====================


### PR DESCRIPTION
Partly resolves #5854.

### Proposed fixes:
Check for minimum postgres version in datastore postgres backend.


### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
