### PR TITLE
Add API Token CLI commands

### DIFF
--- a/changes/5868.feature
+++ b/changes/5868.feature
@@ -1,0 +1,1 @@
+Add CLI commands for API Token management

--- a/ckan/cli/user.py
+++ b/ckan/cli/user.py
@@ -159,7 +159,7 @@ def token():
     metavar=u"EXTRAS",
     type=json.loads,
     default=u"{}",
-    help=u"Valid JSON object with additional fields passed to api_token_create",
+    help=u"Valid JSON object with additional fields for api_token_create",
 )
 def add_token(username, token_name, extras, json):
     """Create new API Token for the given user.

--- a/ckan/cli/user.py
+++ b/ckan/cli/user.py
@@ -161,7 +161,8 @@ def token():
 @click.argument(u'extras', type=click.UNPROCESSED, nargs=-1)
 @click.option(
     u'--json', metavar=u'EXTRAS', type=json.loads, default=u'{}',
-    help=u"Valid JSON object with additional fields passed to api_token_create")
+    help=u"Valid JSON object with additional fields passed to api_token_create"
+)
 def add_token(username, token_name, extras, json):
     """Create new API Token for the given user.
 
@@ -180,7 +181,8 @@ def add_token(username, token_name, extras, json):
         try:
             key, value = chunk.split(u'=')
         except ValueError:
-            error_shout(u"Extras must be passed in `key=value` format. Got: {}".format(chunk))
+            error_shout(
+                u"Extras must be passed in `key=value` format. Got: {}".format(chunk))
             raise click.Abort()
         json[key] = value
     json.update({u"user": username, u"name": token_name})
@@ -226,7 +228,8 @@ def list_tokens(username):
     for token in tokens:
         last_access = token[u"last_access"]
         if last_access:
-            accessed = plugin.toolkit.h.date_str_to_datetime(last_access).isoformat(u" ", u"seconds")
+            accessed = plugin.toolkit.h.date_str_to_datetime(
+                last_access).isoformat(u" ", u"seconds")
 
         else:
             accessed = u"Never"

--- a/ckan/cli/user.py
+++ b/ckan/cli/user.py
@@ -1,9 +1,6 @@
 # encoding: utf-8
 
 import logging
-import sys
-from pprint import pprint
-
 import six
 import click
 from six import text_type
@@ -149,19 +146,20 @@ def set_password(username):
 
 @user.group()
 def token():
-    """Control API Tokens
-    """
+    """Control API Tokens"""
     pass
 
 
-@token.command(u"add", context_settings=dict(
-    ignore_unknown_options=True))
-@click.argument(u'username')
-@click.argument(u'token_name')
-@click.argument(u'extras', type=click.UNPROCESSED, nargs=-1)
+@token.command(u"add", context_settings=dict(ignore_unknown_options=True))
+@click.argument(u"username")
+@click.argument(u"token_name")
+@click.argument(u"extras", type=click.UNPROCESSED, nargs=-1)
 @click.option(
-    u'--json', metavar=u'EXTRAS', type=json.loads, default=u'{}',
-    help=u"Valid JSON object with additional fields passed to api_token_create"
+    u"--json",
+    metavar=u"EXTRAS",
+    type=json.loads,
+    default=u"{}",
+    help=u"Valid JSON object with additional fields passed to api_token_create",
 )
 def add_token(username, token_name, extras, json):
     """Create new API Token for the given user.
@@ -179,10 +177,13 @@ def add_token(username, token_name, extras, json):
     """
     for chunk in extras:
         try:
-            key, value = chunk.split(u'=')
+            key, value = chunk.split(u"=")
         except ValueError:
             error_shout(
-                u"Extras must be passed in `key=value` format. Got: {}".format(chunk))
+                u"Extras must be passed in `key=value` format. Got: {}".format(
+                    chunk
+                )
+            )
             raise click.Abort()
         json[key] = value
     json.update({u"user": username, u"name": token_name})
@@ -199,10 +200,9 @@ def add_token(username, token_name, extras, json):
 
 
 @token.command(u"revoke")
-@click.argument(u'id')
+@click.argument(u"id")
 def revoke_token(id):
-    """Remove API Token with the given ID
-    """
+    """Remove API Token with the given ID"""
     if not model.ApiToken.revoke(id):
         error_shout(u"API Token not found")
         raise click.Abort()
@@ -210,13 +210,13 @@ def revoke_token(id):
 
 
 @token.command(u"list")
-@click.argument(u'username')
+@click.argument(u"username")
 def list_tokens(username):
-    """List all API Tokens for the given user
-    """
+    """List all API Tokens for the given user"""
     try:
         tokens = plugin.toolkit.get_action(u"api_token_list")(
-            {u"ignore_auth": True}, {u"user": username})
+            {u"ignore_auth": True}, {u"user": username}
+        )
     except plugin.toolkit.ObjectNotFound as e:
         error_shout(e)
         raise click.Abort()
@@ -229,12 +229,13 @@ def list_tokens(username):
         last_access = token[u"last_access"]
         if last_access:
             accessed = plugin.toolkit.h.date_str_to_datetime(
-                last_access).isoformat(u" ", u"seconds")
+                last_access
+            ).isoformat(u" ", u"seconds")
 
         else:
             accessed = u"Never"
-        click.echo(u"\t[{id}] {name} - {accessed}".format(
-            name=token[u"name"],
-            id=token[u"id"],
-            accessed=accessed
-        ))
+        click.echo(
+            u"\t[{id}] {name} - {accessed}".format(
+                name=token[u"name"], id=token[u"id"], accessed=accessed
+            )
+        )

--- a/ckan/cli/user.py
+++ b/ckan/cli/user.py
@@ -10,7 +10,10 @@ from six import text_type
 
 import ckan.logic as logic
 import ckan.plugins as plugin
+import ckan.model as model
 from ckan.cli import error_shout
+from ckan.common import json
+
 
 log = logging.getLogger(__name__)
 
@@ -142,3 +145,93 @@ def set_password(username):
     user.password = password
     model.repo.commit_and_remove()
     click.secho(u'Password updated!', fg=u'green', bold=True)
+
+
+@user.group()
+def token():
+    """Control API Tokens
+    """
+    pass
+
+
+@token.command(u"add", context_settings=dict(
+    ignore_unknown_options=True))
+@click.argument(u'username')
+@click.argument(u'token_name')
+@click.argument(u'extras', type=click.UNPROCESSED, nargs=-1)
+@click.option(
+    u'--json', metavar=u'EXTRAS', type=json.loads, default=u'{}',
+    help=u"Valid JSON object with additional fields passed to api_token_create")
+def add_token(username, token_name, extras, json):
+    """Create new API Token for the given user.
+
+    Either arbitary numer of arguments in format `key=value` or --json
+    option containing encoded JSON object can be passed in order to
+    customize behavior of api_token_create action. When both privided,
+    `key=value` will have higher precedence and will replace
+    corresponding keys from --json object.
+
+    Example::
+
+      ckan user token add john_doe new_token x=y --json '{"prop": "value"}'
+
+    """
+    for chunk in extras:
+        try:
+            key, value = chunk.split(u'=')
+        except ValueError:
+            error_shout(u"Extras must be passed in `key=value` format. Got: {}".format(chunk))
+            raise click.Abort()
+        json[key] = value
+    json.update({u"user": username, u"name": token_name})
+    try:
+        token = plugin.toolkit.get_action(u"api_token_create")(
+            {u"ignore_auth": True}, json
+        )
+    except plugin.toolkit.ObjectNotFound as e:
+        error_shout(e)
+        raise click.Abort()
+    click.secho(u"API Token created:", fg=u"green")
+    click.echo(u"\t", nl=False)
+    click.echo(token[u"token"])
+
+
+@token.command(u"revoke")
+@click.argument(u'id')
+def revoke_token(id):
+    """Remove API Token with the given ID
+    """
+    if not model.ApiToken.revoke(id):
+        error_shout(u"API Token not found")
+        raise click.Abort()
+    click.secho(u"API Token has been revoked", fg=u"green")
+
+
+@token.command(u"list")
+@click.argument(u'username')
+def list_tokens(username):
+    """List all API Tokens for the given user
+    """
+    try:
+        tokens = plugin.toolkit.get_action(u"api_token_list")(
+            {u"ignore_auth": True}, {u"user": username})
+    except plugin.toolkit.ObjectNotFound as e:
+        error_shout(e)
+        raise click.Abort()
+    if not tokens:
+        click.secho(u"No tokens have been created for user yet", fg=u"red")
+        return
+    click.echo(u"Tokens([id] name - lastAccess):")
+
+    for token in tokens:
+        last_access = token[u"last_access"]
+        if last_access:
+            accessed = plugin.toolkit.h.date_str_to_datetime(last_access).isoformat(u" ", u"seconds")
+
+        else:
+            accessed = u"Never"
+        click.echo(u"\t[{id}] {name} - {accessed}".format(
+            name=token[u"name"],
+            id=token[u"id"],
+            accessed=accessed
+        ))

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -1609,6 +1609,9 @@ def api_token_create(context, data_dict):
     model = context[u'model']
     user, name = _get_or_bust(data_dict, [u'user', u'name'])
 
+    if model.User.get(user) is None:
+        raise NotFound("User not found")
+
     _check_access(u'api_token_create', context, data_dict)
 
     schema = context.get(u'schema')

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -3548,7 +3548,8 @@ def api_token_list(context, data_dict):
     id_or_name = _get_or_bust(data_dict, u'user')
     _check_access(u'api_token_list', context, data_dict)
     user = model.User.get(id_or_name)
-
+    if user is None:
+        raise NotFound("User not found")
     tokens = model.Session.query(model.ApiToken).filter(
         model.ApiToken.user_id == user.id
     )


### PR DESCRIPTION
Adds following CLI commands for API Token management:
* `ckan user token add <USERNAME> <TOKENNAME> [key1=value1...] [--json='{"key2": "value2"}']` - create new token for user. `key` and `value` pairs are passed into `api_token_create` action and may be used by different plugins that extend `IApiToken`. If there are no such plugins, those parameters will be silently ignored
* `ckan user token list <USERNAME>` - List IDs, names, and LastAccess dates for all tokens of the specified user 
* `ckan user token revoke <TOKENID>` - removes API Token

