### PR TITLE
[#5785] Solve encoding error by simplifying changes templates

### DIFF
--- a/ckan/templates/snippets/changes/author.html
+++ b/ckan/templates/snippets/changes/author.html
@@ -3,35 +3,23 @@
     {% if change.method == "change" %}
 
       {{ _('Set author of {pkg_link} to {new_author} (previously {old_author})').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe,
-          new_author = change.new_author,
-          old_author = change.old_author
-      ) }}
+        pkg_link=h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        new_author = change.new_author,
+        old_author = change.old_author
+        ) }}
 
     {% elif change.method == "add" %}
 
       {{ _('Set author of {pkg_link} to {new_author}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe,
-          new_author = change.new_author
-      ) }}
+        pkg_link=h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        new_author = change.new_author
+        ) }}
 
     {% elif change.method == "remove" %}
 
       {{ _('Removed author from {pkg_link}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe
-      ) }}
+        pkg_link=h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id)
+        ) }}
 
     {% else %}
 

--- a/ckan/templates/snippets/changes/author_email.html
+++ b/ckan/templates/snippets/changes/author_email.html
@@ -3,42 +3,23 @@
     {% if change.method == "change" %}
 
       {{ _('Set author email of {pkg_link} to {new_author_email} (previously {old_author_email})').format(
-            pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-              pkg_url = h.url_for(controller='dataset',
-                                  action='read', id=change.pkg_id),
-              pkg_name = change.title
-            )|safe,
-            new_author_email = '<a href="{new_email_link}">{new_email}</a>'.format(
-              new_email_link = "mailto:" + change.new_author_email,
-              new_email = change.new_author_email
-            )|safe,
-            old_author_email = '<a href="{old_email_link}">{old_email}</a>'.format(
-              old_email_link = "mailto:" + change.old_author_email,
-              old_email = change.old_author_email
-            )|safe
-          )}}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        new_author_email = h.link_to(change.new_author_email, "mailto:" + change.new_author_email),
+        old_author_email = h.link_to(change.old_author_email, "mailto:" + change.old_author_email)
+        )}}
 
     {% elif change.method == "add" %}
 
       {{ _('Set author email of {pkg_link} to {new_author_email}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset', action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe,
-          new_author_email = '<a href="{new_email_link}">{new_email}</a>'.format(
-            new_email_link = "mailto:" + change.new_author_email,
-            new_email = change.new_author_email
-          )|safe
-      ) }}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        new_author_email = h.link_to(change.new_author_email, "mailto:" + change.new_author_email)
+        ) }}
 
     {% elif change.method == "remove" %}
 
       {{ _('Removed author email from {pkg_link}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset', action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe
-      )}}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id)
+        )}}
 
     {% else %}
 

--- a/ckan/templates/snippets/changes/delete_resource.html
+++ b/ckan/templates/snippets/changes/delete_resource.html
@@ -1,18 +1,10 @@
 <li>
   <p>
     {{ _('Deleted resource {resource_link} from {pkg_link}').format(
-        resource_link = '<a href="{resource_url}">{resource_name}</a>'.format(
-          resource_url = h.url_for(qualified=True, controller='resource',
-                                    action='read', id=change.pkg_id,
-                                    resource_id = change.resource_id) +
-                                    "?activity_id=" + change.old_activity_id,
-          resource_name = change.resource_name
-        )|safe,
-        pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-          pkg_url = h.url_for(controller='dataset',
-                              action='read', id=change.pkg_id),
-          pkg_name = change.title
-        )|safe
-    ) }}
+      resource_link = h.nav_link(
+        change.resource_name, named_route='resource.read', qualified=True, id=change.pkg_id,
+        resource_id = change.resource_id, activity_id=change.old_activity_id),
+      pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+      ) }}
   </p>
 </li>

--- a/ckan/templates/snippets/changes/extension_fields.html
+++ b/ckan/templates/snippets/changes/extension_fields.html
@@ -1,13 +1,9 @@
 <li>
   <p>
     {{ _('Changed value of field <q>{key}</q> to <q>{value}</q> in {pkg_link}').format(
-        pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-          pkg_url = h.url_for(controller='dataset',
-                              action='read', id=change.pkg_id),
-          pkg_name = change.title
-        )|safe,
-        key = change.key,
-        value = change.value
-    )}}
+      pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+      key = change.key,
+      value = change.value
+      )}}
   </p>
 </li>

--- a/ckan/templates/snippets/changes/extra_fields.html
+++ b/ckan/templates/snippets/changes/extra_fields.html
@@ -3,35 +3,23 @@
     {% if change.method == "add_one_value" %}
 
       {{ _('Added field <q>{key}</q> with value <q>{value}</q> to {pkg_link}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe,
-          key = change.key,
-          value = change.value
-      )}}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        key = change.key,
+        value = change.value
+        )}}
 
     {% elif change.method == "add_one_no_value" %}
 
       {{ _('Added field <q>{key}</q> to {pkg_link}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe,
-          key = change.key
-      )}}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        key = change.key
+        )}}
 
     {% elif change.method == "add_multiple" %}
 
       {{ _('Added the following fields to {pkg_link}').format(
-        pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-          pkg_url = h.url_for(controller='dataset',
-                              action='read', id=change.pkg_id),
-          pkg_name = change.title
-        )|safe
-      )}}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id)
+        )}}
       <ul>
         {% for item in change.key_list %}
           <li>
@@ -39,11 +27,11 @@
               {{ _('{key} with value {value}').format(
                 key = item,
                 value = change.value_list[item]
-              )|safe }}
+                )|safe }}
             {% else %}
               {{ _('{key}').format(
                 key = item
-              )|safe }}
+                )|safe }}
             {% endif %}
           </li>
         {% endfor %}
@@ -52,48 +40,32 @@
     {% elif change.method == "change_with_old_value" %}
 
       {{ _('Changed value of field <q>{key}</q> to <q>{new_val}</q> (previously <q>{old_val}</q>) in {pkg_link}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe,
-          key = change.key,
-          new_val = change.new_value,
-          old_val = change.old_value
-      )}}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        key = change.key,
+        new_val = change.new_value,
+        old_val = change.old_value
+        )}}
 
     {% elif change.method == "change_no_old_value" %}
 
       {{ _('Changed value of field <q>{key}</q> to <q>{new_val}</q> in {pkg_link}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe,
-          key = change.key,
-          new_val = change.new_value,
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        key = change.key,
+        new_val = change.new_value,
         ) }}
 
     {% elif change.method == "remove_one" %}
 
       {{ _('Removed field <q>{key}</q> from {pkg_link}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe,
-          key = change.key,
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        key = change.key,
         ) }}
 
     {% elif change.method == "remove_multiple" %}
 
       {{ _('Removed the following fields from {pkg_link}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe
-      ) }}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id)
+        ) }}
       <ul>
         {% for item in change.key_list %}
           <li>

--- a/ckan/templates/snippets/changes/license.html
+++ b/ckan/templates/snippets/changes/license.html
@@ -4,65 +4,38 @@
     {% if change.new_url != "" and change.old_url != "" %}
 
       {{ _('Changed the license of {pkg_link} to {new_link} (previously {old_link})').format(
-            pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-              pkg_url = h.url_for(controller='dataset',
-                                  action='read', id=change.pkg_id),
-              pkg_name = change.title
-            )|safe,
-            new_link = '<a href={new_url}>{new_title}</a>'.format(
-              new_url = change.new_url,
-              new_title = change.new_title
-            )|safe,
-            old_link = '<a href={old_url}>{old_title}</a>'.format(
-              old_url = change.old_url,
-              old_title = change.old_title
-            )|safe
-      ) }}
 
-    {# if only the new one has a URL #}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        new_link = h.link_to(change.new_title, change.new_url)
+        old_link = h.link_to(change.old_title, change.old_url)
+        ) }}
+
+      {# if only the new one has a URL #}
     {% elif change.new_url != "" and change.old_url == "" %}
 
       {{ _('Changed the license of {pkg_link} to {new_link} (previously {old_title})').format(
-            pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-              pkg_url = h.url_for(controller='dataset',
-                                  action='read', id=change.pkg_id),
-              pkg_name = change.title
-            )|safe,
-            new_link = '<a href="{new_url}">{new_title}</a>'.format(
-              new_url = change.new_url,
-              new_title = change.new_title,
-            )|safe,
-            old_title = change.old_title
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        new_link = h.link_to(change.new_title, change.new_url)
+        old_title = change.old_title
         ) }}
 
-    {# if only the old one has a URL #}
+      {# if only the old one has a URL #}
     {% elif change.new_url == "" and change.old_url != "" %}
 
-    {{ _('Changed the license of {pkg_link} to {new_title} (previously {old_link})').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe,
-          new_title = change.new_title,
-          old_link = '<a href="{old_url}">{old_title}</a>'.format(
-            old_url = change.old_url,
-            old_title = change.old_title
-          )|safe
-      )}}
+      {{ _('Changed the license of {pkg_link} to {new_title} (previously {old_link})').format(
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        new_title = change.new_title,
+        old_link = h.link_to(change.old_title, change.old_url)
+        )}}
 
-    {# otherwise neither has a URL #}
+      {# otherwise neither has a URL #}
     {% else %}
 
 
       {{ _('Changed the license of {pkg_link} to {new_title} (previously {old_title})').format(
-            pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-              pkg_url = h.url_for(controller='dataset',
-                                  action='read', id=change.pkg_id),
-              pkg_name = change.title
-            )|safe,
-            new_title = change.new_title,
-            old_title = change.old_title
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        new_title = change.new_title,
+        old_title = change.old_title
         )|safe }}
 
     {% endif %}

--- a/ckan/templates/snippets/changes/maintainer.html
+++ b/ckan/templates/snippets/changes/maintainer.html
@@ -3,35 +3,23 @@
     {% if change.method == "change" %}
 
       {{ _('Set maintainer of {pkg_link} to {new_maintainer} (previously {old_maintainer})').format(
-            pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-              pkg_url = h.url_for(controller='dataset',
-                                  action='read', id=change.pkg_id),
-              pkg_name = change.title
-            )|safe,
-            new_maintainer = change.new_maintainer,
-            old_maintainer = change.old_maintainer
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),,
+        new_maintainer = change.new_maintainer,
+        old_maintainer = change.old_maintainer
         ) }}
 
     {% elif change.method == "add" %}
 
       {{ _('Set maintainer of {pkg_link} to {new_maintainer}').format(
-            pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-              pkg_url = h.url_for(controller='dataset',
-                                  action='read', id=change.pkg_id),
-              pkg_name = change.title
-            )|safe,
-            new_maintainer = change.new_maintainer
-      ) }}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),,
+        new_maintainer = change.new_maintainer
+        ) }}
 
     {% elif change.method == "remove" %}
 
       {{ _('Removed maintainer from {pkg_link}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe
-      ) }}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        ) }}
 
     {% else %}
 

--- a/ckan/templates/snippets/changes/maintainer_email.html
+++ b/ckan/templates/snippets/changes/maintainer_email.html
@@ -3,44 +3,23 @@
     {% if change.method == "change" %}
 
       {{ _('Set maintainer email of {pkg_link} to {new_email} (previously {old_email})').format(
-             pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-               pkg_url = h.url_for(controller='dataset',
-                                   action='read', id=change.pkg_id),
-               pkg_name = change.title
-             )|safe,
-             new_email = '<a href="{new_maintainer_email_link}">{new_maintainer_email}</a>'.format(
-               new_maintainer_email = change.new_maintainer_email,
-               new_maintainer_email_link = "mailto:" + change.new_maintainer_email
-             )|safe,
-             old_email = '<a href="{old_maintainer_email_link}">{old_maintainer_email}</a>'.format(
-               old_maintainer_email = change.old_maintainer_email,
-               old_maintainer_email_link = "mailto:" + change.old_maintainer_email
-             )|safe
-      ) }}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        new_email = h.link_to(change.new_maintainer_email, "mailto:" + change.new_maintainer_email),
+        old_email = h.link_to(change.old_maintainer_email, "mailto:" + change.old_maintainer_email)
+        ) }}
 
     {% elif change.method == "add" %}
 
       {{ _('Set maintainer email of {pkg_link} to {new_email}').format(
-            pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-              pkg_url = h.url_for(controller='dataset',
-                                  action='read', id=change.pkg_id),
-              pkg_name = change.title
-            )|safe,
-            new_email = '<a href="{new_maintainer_email_link}">{new_maintainer_email}</a>'.format(
-              new_maintainer_email = change.new_maintainer_email,
-              new_maintainer_email_link = "mailto:" + change.new_maintainer_email
-            )|safe
-      ) }}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        new_email = h.link_to(change.new_maintainer_email, "mailto:" + change.new_maintainer_email)
+        ) }}
 
     {% elif change.method == "remove" %}
 
       {{ _('Removed maintainer email from {pkg_link}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe
-      ) }}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id)
+        ) }}
 
     {% else %}
 

--- a/ckan/templates/snippets/changes/name.html
+++ b/ckan/templates/snippets/changes/name.html
@@ -1,19 +1,12 @@
 <li>
   <p>
+    {% set old_url = h.url_for('dataset.read', qualified=True, id=change.old_name) %}
+    {% set new_url = h.url_for('dataset.read', qualified=True, id=change.new_name) %}
+
     {{ _('Moved {pkg_link} from {old_link} to {new_link}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe,
-          old_link = '<a href="{old_url}">{old_url}</a>'.format(
-            old_url = h.url_for(qualified=True,
-              controller='dataset', action='read', id=change.old_name)
-          )|safe,
-          new_link = '<a href="{new_url}">{new_url}</a>'.format(
-            new_url = h.url_for(qualified=True,
-              controller='dataset', action='read', id=change.new_name)
-          )|safe
-    ) }}
+      pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+      old_link = h.link_to(old_url, old_url),
+      new_link = h.link_to(new_url, new_url),
+      ) }}
   </p>
 </li>

--- a/ckan/templates/snippets/changes/new_file.html
+++ b/ckan/templates/snippets/changes/new_file.html
@@ -1,17 +1,10 @@
 <li>
   <p>
     {{ _('Uploaded a new file to resource {resource_link} in {pkg_link}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe,
-          resource_link = '<a href="{resource_url}">{resource_name}</a>'.format(
-            resource_url = h.url_for(qualified=True, controller='resource',
-                                      action='read', id=change.pkg_id,
-                                      resource_id = change.resource_id),
-            resource_name = change.resource_name
-          )|safe
-    ) }}
+      pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+      resource_link = h.nav_link(
+        change.resource_name, named_route='resource.read', id=change.pkg_id,
+        resource_id=change.resource_id, qualified=True)
+      ) }}
   </p>
 </li>

--- a/ckan/templates/snippets/changes/notes.html
+++ b/ckan/templates/snippets/changes/notes.html
@@ -3,35 +3,23 @@
     {% if change.method == "change" %}
 
       {{ _('Updated description of {pkg_link} from <br class="line-height2"><blockquote>{old_notes}</blockquote> to <br class="line-height2"><blockquote>{new_notes}</blockquote>').format(
-              pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-                pkg_url = h.url_for(controller='dataset',
-                                    action='read', id=change.pkg_id),
-                pkg_name = change.title
-              )|safe,
-              old_notes = change.old_notes,
-              new_notes = change.new_notes
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        old_notes = change.old_notes,
+        new_notes = change.new_notes
         ) }}
 
     {% elif change.method == "add" %}
 
       {{ _('Updated description of {pkg_link} to <br class="line-height2"><blockquote>{new_notes}</blockquote>').format(
-              pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-                pkg_url = h.url_for(controller='dataset',
-                                    action='read', id=change.pkg_id),
-                pkg_name = change.title
-              )|safe,
-              new_notes = change.new_notes
-          ) }}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        new_notes = change.new_notes
+        ) }}
 
     {% elif change.method == "remove" %}
 
       {{ _('Removed description from {pkg_link}').format(
-            pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-              pkg_url = h.url_for(controller='dataset',
-                                  action='read', id=change.pkg_id),
-              pkg_name = change.title
-            )|safe
-          ) }}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id)
+        ) }}
 
     {% else %}
 

--- a/ckan/templates/snippets/changes/org.html
+++ b/ckan/templates/snippets/changes/org.html
@@ -3,51 +3,23 @@
     {% if change.method == "change" %}
 
       {{ _('Moved {pkg_link} from organization {old_org_link} to organization {new_org_link}').format(
-            pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-              pkg_url = h.url_for(controller='dataset',
-                                  action='read', id=change.pkg_id),
-              pkg_name = change.title
-            )|safe,
-            old_org_link = '<a href="{old_url}">{old_name}</a>'.format(
-              old_url = h.url_for(controller='organization', action='read',
-                id=change.old_org_id),
-              old_name = change.old_org_title
-            )|safe,
-            new_org_link = '<a href="{new_url}">{new_name}</a>'.format(
-              new_url = h.url_for(controller='organization', action='read',
-                id=change.new_org_id),
-              new_name = change.new_org_title
-            )|safe
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        old_org_link = h.nav_link(change.old_org_title, named_route='organization.read', id=change.old_org_id),
+        new_org_link = h.nav_link(change.new_org_title, named_route='organization.read', id=change.new_org_id)
         ) }}
 
-      {% elif change.method == "remove" %}
+    {% elif change.method == "remove" %}
 
-        {{ _('Removed {pkg_link} from organization {old_org_link}').format(
-              pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-                pkg_url = h.url_for(controller='dataset',
-                                    action='read', id=change.pkg_id),
-                pkg_name = change.title
-              )|safe,
-              old_org_link = '<a href="{old_url}">{old_name}</a>'.format(
-                old_url = h.url_for(controller='organization', action='read',
-                  id=change.old_org_id),
-                old_name = change.old_org_title
-              )|safe
-            ) }}
+      {{ _('Removed {pkg_link} from organization {old_org_link}').format(
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        old_org_link = h.nav_link(change.old_org_title, named_route='organization.read', id=change.old_org_id)
+        ) }}
 
-      {% elif change.method == "add" %}
+    {% elif change.method == "add" %}
 
-        {{ _('Added {pkg_link} to organization {new_org_link}').format(
-              pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-                pkg_url = h.url_for(controller='dataset',
-                                    action='read', id=change.pkg_id),
-                pkg_name = change.title
-              )|safe,
-              new_org_link = '<a href="{new_url}">{new_name}</a>'.format(
-                new_url = h.url_for(controller='organization', action='read',
-                  id=change.new_org_id),
-                new_name = change.new_org_title
-              )|safe
+      {{ _('Added {pkg_link} to organization {new_org_link}').format(
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        new_org_link = h.nav_link(change.new_org_title, named_route='organization.read', id=change.new_org_id)
         ) }}
       {% else %}
 

--- a/ckan/templates/snippets/changes/private.html
+++ b/ckan/templates/snippets/changes/private.html
@@ -1,12 +1,8 @@
 <li>
   <p>
     {{ _('Set visibility of {pkg_link} to {visibility}').format(
-            pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-              pkg_url = h.url_for(controller='dataset',
-                                  action='read', id=change.pkg_id),
-              pkg_name = change.title
-            )|safe,
-            visibility = change.new
-        ) }}
+      pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+      visibility = change.new
+      ) }}
   </p>
 </li>

--- a/ckan/templates/snippets/changes/resource_desc.html
+++ b/ckan/templates/snippets/changes/resource_desc.html
@@ -2,53 +2,32 @@
   <p>
     {% if change.method == "add" %}
 
-    {{ _('Updated description of resource {resource_link} in {pkg_link} to <br class="line-height2"><blockquote>{new_desc}</blockquote>').format(
-            pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-              pkg_url = h.url_for(controller='dataset',
-                                  action='read', id=change.pkg_id),
-              pkg_name = change.title
-            )|safe,
-            resource_link = '<a href="{resource_url}">{resource_name}</a>'.format(
-              resource_url = h.url_for(qualified=True, controller='resource',
-                                        action='read', id=change.pkg_id,
-                                        resource_id = change.resource_id),
-              resource_name = change.resource_name
-            )|safe,
-            new_desc = change.new_desc
-          ) }}
+      {{ _('Updated description of resource {resource_link} in {pkg_link} to <br class="line-height2"><blockquote>{new_desc}</blockquote>').format(
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        resource_link = h.nav_link(
+          change.resource_name, named_route='resource.read', id=change.pkg_id,
+          resource_id=change.resource_id, qualified=True),
+        new_desc = change.new_desc
+        ) }}
 
     {% elif change.method == "remove" %}
 
       {{ _('Removed description from resource {resource_link} in {pkg_link}').format(
-            pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-              pkg_url = h.url_for(controller='dataset',
-                                  action='read', id=change.pkg_id),
-              pkg_name = change.title
-            )|safe,
-            resource_link = '<a href="{resource_url}">{resource_name}</a>'.format(
-              resource_url = h.url_for(qualified=True, controller='resource',
-                                        action='read', id=change.pkg_id,
-                                        resource_id = change.resource_id),
-              resource_name = change.resource_name
-            )|safe
-      )}}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        resource_link = h.nav_link(
+          change.resource_name, named_route='resource.read', id=change.pkg_id,
+          resource_id=change.resource_id, qualified=True)
+        )}}
 
     {% elif change.method == "change" %}
 
-    {{ _('Updated description of resource {resource_link} in {pkg_link} from <br class="line-height2"><blockquote>{old_desc}</blockquote> to <br class="line-height2"><blockquote>{new_desc}</blockquote>').format(
-            pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-              pkg_url = h.url_for(controller='dataset',
-                                  action='read', id=change.pkg_id),
-              pkg_name = change.title
-            )|safe,
-            resource_link = '<a href="{resource_url}">{resource_name}</a>'.format(
-              resource_url = h.url_for(qualified=True, controller='resource',
-                                        action='read', id=change.pkg_id,
-                                        resource_id = change.resource_id),
-              resource_name = change.resource_name
-            )|safe,
-            new_desc = change.new_desc,
-            old_desc = change.old_desc
+      {{ _('Updated description of resource {resource_link} in {pkg_link} from <br class="line-height2"><blockquote>{old_desc}</blockquote> to <br class="line-height2"><blockquote>{new_desc}</blockquote>').format(
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        resource_link = h.nav_link(
+          change.resource_name, named_route='resource.read', id=change.pkg_id,
+          resource_id=change.resource_id, qualified=True),
+        new_desc = change.new_desc,
+        old_desc = change.old_desc
         ) }}
 
     {% else %}

--- a/ckan/templates/snippets/changes/resource_extras.html
+++ b/ckan/templates/snippets/changes/resource_extras.html
@@ -3,52 +3,31 @@
     {% if change.method == "add_one_value" %}
 
       {{ _('Added field <q>{key}</q> with value <q>{value}</q> to resource {resource_link} in {pkg_link}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe,
-          resource_link = '<a href="{resource_url}">{resource_name}</a>'.format(
-            resource_url = h.url_for(qualified=True, controller='resource',
-                                      action='read', id=change.pkg_id,
-                                      resource_id = change.resource_id),
-            resource_name = change.resource_name
-          )|safe,
-          key = change.key,
-          value = change.value
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        resource_link = h.nav_link(
+          change.resource_name, named_route='resource.read', id=change.pkg_id,
+          resource_id=change.resource_id, qualified=True),
+        key = change.key,
+        value = change.value
         ) }}
 
     {% elif change.method == "add_one_no_value" %}
 
       {{ _('Added field <q>{key}</q> to resource {resource_link} in {pkg_link}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe,
-          resource_link = '<a href="{resource_url}">{resource_name}</a>'.format(
-            resource_url = h.url_for(qualified=True, controller='resource',
-                                      action='read', id=change.pkg_id,
-                                      resource_id = change.resource_id),
-            resource_name = change.resource_name
-          )|safe,
-          key = change.key,
-      ) }}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        resource_link = h.nav_link(
+          change.resource_name, named_route='resource.read', id=change.pkg_id,
+          resource_id=change.resource_id, qualified=True),
+        key = change.key,
+        ) }}
 
     {% elif change.method == "add_multiple" %}
 
       {{ _('Added the following fields to resource {resource_link} in {pkg_link}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe,
-          resource_link = '<a href="{resource_url}">{resource_name}</a>'.format(
-            resource_url = h.url_for(qualified=True, controller='resource',
-                                      action='read', id=change.pkg_id,
-                                      resource_id = change.resource_id),
-            resource_name = change.resource_name
-          )|safe
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        resource_link = h.nav_link(
+          change.resource_name, named_route='resource.read', id=change.pkg_id,
+          resource_id=change.resource_id, qualified=True)
         ) }}
       <ul>
         {% for item in change.key_list %}
@@ -56,11 +35,11 @@
             {{ _('{key} with value {value}').format(
               key = item,
               value = change.value_list[item]
-            )|safe }}
+              )|safe }}
           {% else %}
             {{ _('{key}').format(
               key = item
-            )|safe }}
+              )|safe }}
           {% endif %}
         {% endfor %}
       </ul>
@@ -68,96 +47,61 @@
     {% elif change.method == "remove_one" %}
 
       {{ _('Removed field <q>{key}</q> from resource {resource_link} in {pkg_link}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe,
-          resource_link = '<a href="{resource_url}">{resource_name}</a>'.format(
-            resource_url = h.url_for(qualified=True, controller='resource',
-                                      action='read', id=change.pkg_id,
-                                      resource_id = change.resource_id),
-            resource_name = change.resource_name
-          )|safe,
-          key = change.key
-      ) }}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        resource_link = h.nav_link(
+          change.resource_name, named_route='resource.read', id=change.pkg_id,
+          resource_id=change.resource_id, qualified=True),
+        key = change.key
+        ) }}
 
     {% elif change.method == "remove_multiple" %}
 
       {{ _('Removed the following fields from resource {resource_link} in {pkg_link}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe,
-          resource_link = '<a href="{resource_url}">{resource_name}</a>'.format(
-            resource_url = h.url_for(qualified=True, controller='resource',
-                                      action='read', id=change.pkg_id,
-                                      resource_id = change.resource_id),
-            resource_name = change.resource_name
-          )|safe
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        resource_link = h.nav_link(
+          change.resource_name, named_route='resource.read', id=change.pkg_id,
+          resource_id=change.resource_id, qualified=True)
         ) }}
       <ul>
         {% for item in change.key_list %}
           {{ _('{key}').format(
             key = item
-          )|safe }}
+            )|safe }}
         {% endfor %}
       </ul>
 
     {% elif change.method == "change_value_with_old" %}
 
       {{ _('Changed value of field <q>{key}</q> of resource {resource_link} to <q>{new_val}</q> (previously <q>{old_val}</q>) in {pkg_link}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe,
-          resource_link = '<a href="{resource_url}">{resource_name}</a>'.format(
-            resource_url = h.url_for(qualified=True, controller='resource',
-                                      action='read', id=change.pkg_id,
-                                      resource_id = change.resource_id),
-            resource_name = change.resource_name
-          )|safe,
-          key = change.key,
-          new_val = change.new_value,
-          old_val = change.old_value
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        resource_link = h.nav_link(
+          change.resource_name, named_route='resource.read', id=change.pkg_id,
+          resource_id=change.resource_id, qualified=True),
+        key = change.key,
+        new_val = change.new_value,
+        old_val = change.old_value
         ) }}
 
     {% elif change.method == "change_value_no_old" %}
 
       {{ _('Changed value of field <q>{key}</q> to <q>{new_val}</q> in resource {resource_link} in {pkg_link}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe,
-          resource_link = '<a href="{resource_url}">{resource_name}</a>'.format(
-            resource_url = h.url_for(qualified=True, controller='resource',
-                                      action='read', id=change.pkg_id,
-                                      resource_id = change.resource_id),
-            resource_name = change.resource_name
-          )|safe,
-          key = change.key,
-          new_val = change.new_value
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        resource_link = h.nav_link(
+          change.resource_name, named_route='resource.read', id=change.pkg_id,
+          resource_id=change.resource_id, qualified=True),
+        key = change.key,
+        new_val = change.new_value
         ) }}
 
     {% elif change.method == "change_value_no_new" %}
 
       {{ _('Removed the value of field <q>{key}</q> in resource {resource_link} in {pkg_link}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe,
-          resource_link = '<a href="{resource_url}">{resource_name}</a>'.format(
-            resource_url = h.url_for(qualified=True, controller='resource',
-                                      action='read', id=change.pkg_id,
-                                      resource_id = change.resource_id),
-            resource_name = change.resource_name
-          )|safe,
-          key = change.key,
-          new_val = change.new_value
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        resource_link = h.nav_link(
+          change.resource_name, named_route='resource.read', id=change.pkg_id,
+          resource_id=change.resource_id, qualified=True),
+        key = change.key,
+        new_val = change.new_value
         ) }}
     {% else %}
 

--- a/ckan/templates/snippets/changes/resource_format.html
+++ b/ckan/templates/snippets/changes/resource_format.html
@@ -1,52 +1,29 @@
 <li>
   <p>
     {% set format_search_base_url = (
-       h.url_for(controller="organization", action="read", id=change.org_id)
-       if change.org_id else
-       h.url_for(controller="dataset", action="search")) %}
+      h.url_for(controller="organization", action="read", id=change.org_id)
+      if change.org_id else
+      h.url_for(controller="dataset", action="search")) %}
 
     {% if change.method == "add" %}
 
       {{ _('Set format of resource {resource_link} to {format_link} in {pkg_link}').format(
-            pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-              pkg_url = h.url_for(controller='dataset',
-                                  action='read', id=change.pkg_id),
-              pkg_name = change.title
-            )|safe,
-            resource_link = '<a href="{resource_url}">{resource_name}</a>'.format(
-              resource_url = h.url_for(qualified=True, controller='resource',
-                                        action='read', id=change.pkg_id,
-                                        resource_id = change.resource_id),
-              resource_name = change.resource_name
-            )|safe,
-            format_link = '<a href={format_url}>{format}</a>'.format(
-              format_url = format_search_base_url + "?res_format=" + change.format,
-              format = change.format
-            )|safe
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        resource_link = h.nav_link(
+          change.resource_name, named_route='resource.read', id=change.pkg_id,
+          resource_id=change.resource_id, qualified=True),
+        format_link = h.link_to(change.format, format_search_base_url + "?res_format=" + change.format)
         ) }}
 
     {% elif change.method == "change" %}
 
       {{ _('Set format of resource {resource_link} to {new_format_link} (previously {old_format_link}) in {pkg_link}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe,
-          resource_link = '<a href="{resource_url}">{resource_name}</a>'.format(
-            resource_url = h.url_for(qualified=True, controller='resource',
-                                      action='read', id=change.pkg_id,
-                                      resource_id = change.resource_id),
-            resource_name = change.resource_name
-          )|safe,
-          old_format_link = '<a href={format_url}>{format}</a>'.format(
-            format_url = format_search_base_url + "?res_format=" + change.old_format,
-            format = change.old_format
-          )|safe,
-          new_format_link = '<a href={format_url}>{format}</a>'.format(
-            format_url = format_search_base_url + "?res_format=" + change.new_format,
-            format = change.new_format
-          )|safe
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        resource_link = h.nav_link(
+          change.resource_name, named_route='resource.read', id=change.pkg_id,
+          resource_id=change.resource_id, qualified=True),
+        old_format_link = h.link_to(change.old_format, format_search_base_url + "?res_format=" + change.old_format),
+        new_format_link = h.link_to(change.new_format, format_search_base_url + "?res_format=" + change.new_format)
         ) }}
 
     {% else %}

--- a/ckan/templates/snippets/changes/resource_name.html
+++ b/ckan/templates/snippets/changes/resource_name.html
@@ -1,24 +1,13 @@
 <li>
   <p>
     {{ _('Renamed resource {old_resource_link} to {new_resource_link} in {pkg_link}').format(
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe,
-          old_resource_link = '<a href="{resource_url}">{resource_name}</a>'.format(
-            resource_url = h.url_for(qualified=True, controller='resource',
-                                          action='read', id=change.old_pkg_id,
-                                          resource_id=change.resource_id) +
-                                          "?activity_id=" + change.old_activity_id,
-            resource_name = change.old_resource_name
-          )|safe,
-          new_resource_link = '<a href="{resource_url}">{resource_name}</a>'.format(
-            resource_url = h.url_for(qualified=True, controller='resource',
-                                          action='read', id=change.new_pkg_id,
-                                          resource_id=change.resource_id),
-            resource_name = change.new_resource_name
-          )|safe
-        ) }}
+      pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+      old_resource_link = h.nav_link(
+        change.old_resource_name, named_route='resource.read', id=change.old_pkg_id,
+        resource_id=change.resource_id, activity_id=change.old_activity_id),
+      new_resource_link = h.nav_link(
+        change.new_resource_name, named_route='resource.read', id=change.new_pkg_id,
+        resource_id=change.resource_id),
+      ) }}
   </p>
 </li>

--- a/ckan/templates/snippets/changes/tags.html
+++ b/ckan/templates/snippets/changes/tags.html
@@ -3,38 +3,26 @@
     {% if change.method == "remove_one" %}
 
       {{ _('Removed tag {tag_link} from {pkg_link}').format(
-            tag_link = '<a href="{tag_url}">{tag}</a>'.format(
-              tag_url = h.url_for(controller='dataset', action='search') +
-              "?tags=" + change.tag,
-              tag = change.tag
-            )|safe,
-            pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-              pkg_url = h.url_for(controller='dataset',
-                                  action='read', id=change.pkg_id),
-              pkg_name = change.title
-            )|safe
-      ) }}
+        tag_link = '<a href="{tag_url}">{tag}</a>'.format(
+          tag_url = h.url_for(controller='dataset', action='search') +
+          "?tags=" + change.tag,
+          tag = change.tag
+        )|safe,
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        ) }}
 
     {% elif change.method == "remove_multiple" %}
 
       {{ _('Removed the following tags from {pkg_link}').format(
-            pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-              pkg_url = h.url_for(controller='dataset',
-                                  action='read', id=change.pkg_id),
-              pkg_name = change.title
-            )|safe
-      )|safe }}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        )|safe }}
 
       <ul>
         {% for item in change.tags %}
           <li>
             {{ _('{tag_link}').format(
-              tag_link = '<a href="{tag_url}">{tag}</a>'.format(
-                tag_url = h.url_for(controller='dataset', action='search') +
-                "?tags=" + item,
-                tag = item
-              )|safe
-            )}}
+              tag_link = h.nav_link(item, named_route='dataset.search', tags=item),
+              )}}
           </li>
         {% endfor %}
       </ul>
@@ -42,38 +30,22 @@
     {% elif change.method == "add_one" %}
 
       {{ _('Added tag {tag_link} to {pkg_link}').format(
-          tag_link = '<a href="{tag_url}">{tag}</a>'.format(
-            tag_url = h.url_for(controller='dataset', action='search') +
-            "?tags=" + change.tag,
-            tag = change.tag
-          )|safe,
-          pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-            pkg_url = h.url_for(controller='dataset',
-                                action='read', id=change.pkg_id),
-            pkg_name = change.title
-          )|safe
-      ) }}
+        tag_link = h.nav_link(change.tag, named_route='dataset.search', tags=change.tag),
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        ) }}
 
     {% elif change.method == "add_multiple" %}
 
       {{ _('Added the following tags to {pkg_link}').format(
-        pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-          pkg_url = h.url_for(controller='dataset',
-                              action='read', id=change.pkg_id),
-          pkg_name = change.title
-        )|safe
-      ) }}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        ) }}
       <ul>
         {% for item in change.tags %}
           <li>
             {# TODO: figure out which controller to actually use here #}
             {{ _('{tag_link}').format(
-              tag_link = '<a href="{tag_url}">{tag}</a>'.format(
-                tag_url = h.url_for(controller='dataset', action='search') +
-                "?tags=" + item,
-                tag = item
-              )|safe
-            )}}
+              tag_link = h.nav_link(item, named_route='dataset.search', tags=item),
+              )}}
           </li>
         {% endfor %}
       </ul>

--- a/ckan/templates/snippets/changes/title.html
+++ b/ckan/templates/snippets/changes/title.html
@@ -1,11 +1,8 @@
 <li>
   <p>
     {{ _('Changed title to {title_link} (previously {old_title})').format(
-          title_link = '<a href="{new_url}">{new_title}</a>'.format(
-            new_url = h.url_for(controller='dataset', action='read', id=change.id),
-            new_title = change.new_title
-          )|safe,
-          old_title = change.old_title
+      title_link = h.nav_link(change.new_title, named_route='dataset.read', id=change.id),
+      old_title = change.old_title
       ) }}
   </p>
 </li>

--- a/ckan/templates/snippets/changes/url.html
+++ b/ckan/templates/snippets/changes/url.html
@@ -3,44 +3,23 @@
     {% if change.method == "change" %}
 
       {{ _('Changed the source URL of {pkg_link} from {old_link} to {new_link}').format(
-            pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-              pkg_url = h.url_for(controller='dataset',
-                                  action='read', id=change.pkg_id),
-              pkg_name = change.title
-            )|safe,
-            old_link = '<a href="{old_url}">{old_url_name}</a>'.format(
-              old_url = "http://" + change.old_url if not change.old_url[0:4] == "http" else change.old_url,
-              old_url_name = change.old_url
-            )|safe,
-            new_link = '<a href="{new_url}">{new_url_name}</a>'.format(
-              new_url = "http://" + change.new_url if not change.new_url[0:4] == "http" else change.new_url,
-              new_url_name = change.new_url
-            )|safe
-      ) }}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        old_link = h.link_to(change.old_url, "http://" + change.old_url if not change.old_url[0:4] == "http" else change.old_url),
+        new_link = h.link_to(change.new_url, "http://" + change.new_url if not change.new_url[0:4] == "http" else change.new_url),
+        ) }}
 
     {% elif change.method == "remove" %}
 
       {{ _('Removed the source URL from {pkg_link}').format(
-            pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-              pkg_url = h.url_for(controller='dataset',
-                                  action='read', id=change.pkg_id),
-              pkg_name = change.title
-            )|safe
-      ) }}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        ) }}
 
     {% elif change.method == "add" %}
 
       {{ _('Changed the source URL of {pkg_link} to {new_link}').format(
-            pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-              pkg_url = h.url_for(controller='dataset',
-                                  action='read', id=change.pkg_id),
-              pkg_name = change.title
-            )|safe,
-            new_link = '<a href="{new_url}">{new_url_name}</a>'.format(
-              new_url = "http://" + change.new_url if not change.new_url[0:4] == "http" else change.new_url,
-              new_url_name = change.new_url
-            )|safe
-      ) }}
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        new_link = h.link_to(change.new_url, "http://" + change.new_url if not change.new_url[0:4] == "http" else change.new_url),
+        ) }}
 
     {% else %}
 

--- a/ckan/templates/snippets/changes/version.html
+++ b/ckan/templates/snippets/changes/version.html
@@ -3,34 +3,22 @@
     {% if change.method == "change" %}
 
       {{ _('Changed the version of {pkg_link} to {new_version} (previously {old_version})').format(
-            pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-              pkg_url = h.url_for(controller='dataset',
-                                  action='read', id=change.pkg_id),
-              pkg_name = change.title
-            )|safe,
-            old_version = change.old_version,
-            new_version = change.new_version
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        old_version = change.old_version,
+        new_version = change.new_version
         ) }}
 
     {% elif change.method == "remove" %}
 
       {{ _('Removed the version from {pkg_link}').format(
-            pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-              pkg_url = h.url_for(controller='dataset',
-                                  action='read', id=change.pkg_id),
-              pkg_name = change.title
-            )|safe
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
         ) }}
 
     {% elif change.method == "add" %}
 
       {{ _('Changed the version of {pkg_link} to {new_version}').format(
-            pkg_link = '<a href="{pkg_url}">{pkg_name}</a>'.format(
-              pkg_url = h.url_for(controller='dataset',
-                                  action='read', id=change.pkg_id),
-              pkg_name = change.title
-            )|safe,
-            new_version = change.new_version
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        new_version = change.new_version
         ) }}
 
     {% else %}


### PR DESCRIPTION
Fixes #5785

Use CKAN's link helpers (`nav_link` and `link_to`) instead of using `str.format`. This way templates become a bit simpler and all the possible issues handled by existing helpers.