### PR TITLE
fix email validation regexp pattern

### DIFF
--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -871,9 +871,9 @@ def empty_if_not_sysadmin(key, data, errors, context):
 email_pattern = re.compile(
                             # additional pattern to reject malformed dots usage
                             r"^(?!\.)(?!.*\.$)(?!.*?\.\.)"\
-                            "[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9]"\
-                            "(?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9]"\
-                            "(?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
+                            r"[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9]"\
+                            r"(?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9]"\
+                            r"(?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$"
                         )
 
 

--- a/ckan/tests/logic/test_validators.py
+++ b/ckan/tests/logic/test_validators.py
@@ -267,6 +267,7 @@ def test_email_validator_with_invalid_value():
         "test..test@example.com",
         "test.test...@example.com",
         "...test@example.com",
+        "test@example"
     ]
 
     for invalid_value in invalid_values:


### PR DESCRIPTION
I was working on some issue with inviting user to group and found out that email validation is weird. `test@example` - this email is invalid, but it passes the validation.


### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
