### PR TITLE
purge user if invitation fails

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -1168,10 +1168,9 @@ def user_invite(context, data_dict):
     try:
         mailer.send_invite(user, group_dict, data['role'])
     except (socket_error, mailer.MailerException) as error:
-        # Email could not be sent, delete the pending user
-
-        _get_action('user_delete')(context, {'id': user.id})
-
+        # Email could not be sent, purge the pending user
+        user.purge()
+        user.commit()
         msg = _('Error sending the invite email, ' +
                 'the user was not created: {0}').format(error)
         raise ValidationError({'message': msg}, error_summary=msg)

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -120,7 +120,7 @@ class TestUserInvite(object):
             .all()
         )
 
-        assert user[0].state == "deleted"
+        assert not user
 
     def _invite_user_to_group(
         self, email="user@email.com", group=None, role="member"


### PR DESCRIPTION
Curently, if an error occurs during the invitation to group, the user state will be changed to 'deleted. The problem will appear on second try. Because user was already created we will face the validation error: `The email address 'examle@gmail.com' belongs to a registered user.`

I propose to purge these users, because there is no sense to keep them. As I understand, there is no data associated with such user that could prevent us from purging them. Also, the validation error message states that the user was not created, but it was actually :)

### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
