### PR TITLE
Use ugettext for all NotFound exception messages

### DIFF
--- a/ckan/lib/render.py
+++ b/ckan/lib/render.py
@@ -1,18 +1,20 @@
 # encoding: utf-8
 
 import os
-import re
 import logging
 
-from ckan.common import config
+from ckan.common import config, _
+
 
 log = logging.getLogger(__name__)
 
 _template_info_cache = {}
 
+
 def reset_template_info_cache():
     '''Reset the template cache'''
     _template_info_cache.clear()
+
 
 def find_template(template_name):
     ''' looks through the possible template paths to find a template
@@ -22,11 +24,14 @@ def find_template(template_name):
         if os.path.exists(os.path.join(path, template_name.encode('utf-8'))):
             return os.path.join(path, template_name)
 
+
 def template_type(template_path):
     return 'jinja2'
 
+
 class TemplateNotFound(Exception):
     pass
+
 
 def template_info(template_name):
     ''' Returns the path and type for a template '''
@@ -37,7 +42,10 @@ def template_info(template_name):
 
     template_path = find_template(template_name)
     if not template_path:
-        raise TemplateNotFound('Template %s cannot be found' % template_name)
+        raise TemplateNotFound(
+            _('Template {template_name} cannot be found').format(
+                template_name=template_name
+            ))
     t_type = template_type(template_path)
 
     # if in debug mode we always want to search for templates so we

--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -5,9 +5,9 @@ import logging
 import re
 from collections import defaultdict
 
-from werkzeug.local import LocalProxy
 import six
 from six import string_types, text_type
+from werkzeug.local import LocalProxy
 
 import ckan.model as model
 import ckan.authz as authz
@@ -15,6 +15,7 @@ import ckan.lib.navl.dictization_functions as df
 import ckan.plugins as p
 
 from ckan.common import _, c
+
 
 log = logging.getLogger(__name__)
 _validate = df.validate
@@ -439,8 +440,10 @@ def get_action(action):
     for name, func_list in six.iteritems(chained_actions):
         if name not in fetched_actions and name not in _actions:
             # nothing to override from plugins or core
-            raise NotFound('The action %r is not found for chained action' % (
-                name))
+            raise NotFound(
+                _('The action {name} is not found for chained action').format(
+                    name=name
+                ))
         for func in reversed(func_list):
             # try other plugins first, fall back to core
             prev_func = fetched_actions.get(name, _actions.get(name))

--- a/ckan/logic/action/__init__.py
+++ b/ckan/logic/action/__init__.py
@@ -1,7 +1,6 @@
 # encoding: utf-8
-
-from copy import deepcopy
 import re
+from copy import deepcopy
 
 import six
 
@@ -45,7 +44,8 @@ def get_domain_object(model, domain_object_ref):
     user = model.User.get(domain_object_ref)
     if user:
         return user
-    raise NotFound('Domain object %r not found' % domain_object_ref)
+    raise NotFound(_('Domain object {domain_object_ref} not found').format(
+        domain_object_ref=domain_object_ref))
 
 
 def error_summary(error_dict):

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -7,15 +7,14 @@ import datetime
 import time
 import json
 
-from ckan.common import config
-import ckan.common as converters
 import six
 from six import text_type
 
-import ckan.lib.helpers as h
+import ckan.common as converters
 import ckan.plugins as plugins
 import ckan.logic as logic
 import ckan.logic.schema as schema_
+import ckan.lib.helpers as h
 import ckan.lib.dictization as dictization
 import ckan.lib.dictization.model_dictize as model_dictize
 import ckan.lib.dictization.model_save as model_save
@@ -27,9 +26,8 @@ import ckan.lib.search as search
 import ckan.lib.uploader as uploader
 import ckan.lib.datapreview
 import ckan.lib.app_globals as app_globals
+from ckan.common import _, request, config
 
-
-from ckan.common import _, request
 
 log = logging.getLogger(__name__)
 
@@ -61,7 +59,6 @@ def resource_update(context, data_dict):
 
     '''
     model = context['model']
-    user = context['user']
     id = _get_or_bust(data_dict, "id")
 
     if not data_dict.get('url'):
@@ -608,14 +605,14 @@ def package_relationship_update(context, data_dict):
     schema = context.get('schema') \
         or schema_.default_update_relationship_schema()
 
-    id, id2, rel = _get_or_bust(data_dict, ['subject', 'object', 'type'])
+    id1, id2, rel = _get_or_bust(data_dict, ['subject', 'object', 'type'])
 
-    pkg1 = model.Package.get(id)
+    pkg1 = model.Package.get(id1)
     pkg2 = model.Package.get(id2)
     if not pkg1:
-        raise NotFound('Subject package %r was not found.' % id)
+        raise NotFound(_('Subject package {id1} was not found.').format(id1=id1))
     if not pkg2:
-        return NotFound('Object package %r was not found.' % id2)
+        return NotFound(_('Object package {id2} was not found.').format(id2=id2))
 
     data, errors = _validate(data_dict, schema, context)
     if errors:
@@ -626,7 +623,7 @@ def package_relationship_update(context, data_dict):
 
     existing_rels = pkg1.get_relationships_with(pkg2, rel)
     if not existing_rels:
-        raise NotFound('This relationship between the packages was not found.')
+        raise NotFound(_('This relationship between the packages was not found.'))
     entity = existing_rels[0]
     comment = data_dict.get('comment', u'')
     context['relationship'] = entity
@@ -642,7 +639,7 @@ def _group_or_org_update(context, data_dict, is_org=False):
     group = model.Group.get(id)
     context["group"] = group
     if group is None:
-        raise NotFound('Group was not found.')
+        raise NotFound(_('Group was not found.'))
 
     data_dict['type'] = group.type
 
@@ -819,7 +816,7 @@ def user_update(context, data_dict):
     user_obj = model.User.get(id)
     context['user_obj'] = user_obj
     if user_obj is None:
-        raise NotFound('User was not found.')
+        raise NotFound(_('User was not found.'))
 
     _check_access('user_update', context, data_dict)
 
@@ -890,7 +887,7 @@ def user_generate_apikey(context, data_dict):
     user_obj = model.User.get(id)
     context['user_obj'] = user_obj
     if user_obj is None:
-        raise NotFound('User was not found.')
+        raise NotFound(_('User was not found.'))
 
     # check permission
     _check_access('user_generate_apikey', context, data_dict)

--- a/ckan/model/tag.py
+++ b/ckan/model/tag.py
@@ -1,20 +1,21 @@
 # encoding: utf-8
 
 from sqlalchemy.orm import relation
-from sqlalchemy import types, Column, Table, ForeignKey, and_, UniqueConstraint
+from sqlalchemy import types, Column, Table, ForeignKey, UniqueConstraint
 
+import ckan  # this import is needed
+import ckan.model
+import ckan.lib.dictization
+import ckan.lib.maintain as maintain
+from ckan.common import _
 from ckan.model import (
     core,
     meta,
     types as _types,
     domain_object,
     vocabulary,
-    extension as _extension,
 )
-import ckan  # this import is needed
-import ckan.model
-import ckan.lib.dictization
-import ckan.lib.maintain as maintain
+
 
 __all__ = ['tag_table', 'package_tag_table', 'Tag', 'PackageTag',
            'MAX_TAG_LENGTH', 'MIN_TAG_LENGTH']
@@ -129,8 +130,10 @@ class Tag(domain_object.DomainObject):
                 vocab = vocabulary.Vocabulary.get(vocab_id_or_name)
                 if vocab is None:
                     # The user specified an invalid vocab.
-                    raise ckan.logic.NotFound("could not find vocabulary '%s'"
-                            % vocab_id_or_name)
+                    raise ckan.logic.NotFound(
+                        _("Could not find vocabulary '{vocab_id_or_name}'").format(
+                            vocab_id_or_name=vocab_id_or_name
+                        ))
             else:
                 vocab = None
             tag = Tag.by_name(tag_id_or_name, vocab=vocab)
@@ -191,8 +194,10 @@ class Tag(domain_object.DomainObject):
             vocab = vocabulary.Vocabulary.get(vocab_id_or_name)
             if vocab is None:
                 # The user specified an invalid vocab.
-                raise ckan.logic.NotFound("could not find vocabulary '%s'"
-                        % vocab_id_or_name)
+                raise ckan.logic.NotFound(
+                    _("Could not find vocabulary '{vocab_id_or_name}'").format(
+                        vocab_id_or_name=vocab_id_or_name
+                    ))
             query = meta.Session.query(Tag).filter(Tag.vocabulary_id==vocab.id)
         else:
             query = meta.Session.query(Tag).filter(Tag.vocabulary_id == None)


### PR DESCRIPTION
There are a many strings in CKAN that aren't wrapped with **ugettext**. I've started from NotFound exception (I don't know why:)
Also, few unused vars and imports were deleted in files where I made changes for translation.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
