### PR TITLE
enh: make web app more verbose on NotAuthorized dataset edits

### DIFF
--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -746,8 +746,8 @@ class EditView(MethodView):
             return _form_save_redirect(
                 pkg_dict[u'name'], u'edit', package_type=package_type
             )
-        except NotAuthorized:
-            return base.abort(403, _(u'Unauthorized to read package %s') % id)
+        except NotAuthorized as e:
+            return base.abort(403, _(u'Unauthorized to edit package %s (%s)') % (id, str(e)))
         except NotFound as e:
             return base.abort(404, _(u'Dataset not found'))
         except SearchIndexError as e:


### PR DESCRIPTION
I have a plugin that does not allow setting the visibility of a dataset to private if it has been public before. The CKAN API returns the correct error message. The web app does not do that - it just prints "Unauthorized to read package XYZ". With this change, the web app will print e.g.  "Unauthorized to edit package b8 (Changing visibility to private not allowed)".

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes **(more verbose error message)**
- [ ] includes API changes
- [ ] includes bugfix for possible backport
