### PR TITLE
DataTables configuration

### DIFF
--- a/ckanext/datatablesview/plugin.py
+++ b/ckanext/datatablesview/plugin.py
@@ -11,6 +11,7 @@ ignore_missing = toolkit.get_validator(u'ignore_missing')
 # see https://datatables.net/examples/advanced_init/length_menu.html
 DEFAULT_PAGE_LENGTH_CHOICES = [10, 25, 50, 100]
 
+
 class DataTablesView(p.SingletonPlugin):
     u'''
     DataTables table view plugin
@@ -32,8 +33,11 @@ class DataTablesView(p.SingletonPlugin):
         template directory for the view
         '''
 
-        self.page_length_choices = config.get(u'ckan.datatables.page_length_choices', DEFAULT_PAGE_LENGTH_CHOICES)
-        self.top_pagination_controls = config.get(u'ckan.datatables.top_pagination_controls', False)
+        self.page_length_choices = config.get(
+            u'ckan.datatables.page_length_choices',
+            DEFAULT_PAGE_LENGTH_CHOICES)
+        self.top_pagination_controls = config.get(
+            u'ckan.datatables.top_pagination_controls', False)
 
         toolkit.add_template_directory(config, u'templates')
         toolkit.add_resource(u'public', u'ckanext-datatablesview')

--- a/ckanext/datatablesview/plugin.py
+++ b/ckanext/datatablesview/plugin.py
@@ -8,6 +8,8 @@ default = toolkit.get_validator(u'default')
 boolean_validator = toolkit.get_validator(u'boolean_validator')
 ignore_missing = toolkit.get_validator(u'ignore_missing')
 
+# see https://datatables.net/examples/advanced_init/length_menu.html
+DEFAULT_PAGE_LENGTH_CHOICES = [10, 25, 50, 100]
 
 class DataTablesView(p.SingletonPlugin):
     u'''
@@ -29,6 +31,10 @@ class DataTablesView(p.SingletonPlugin):
         Set up the resource library, public directory and
         template directory for the view
         '''
+
+        self.page_length_choices = config.get(u'ckan.datatables.page_length_choices', DEFAULT_PAGE_LENGTH_CHOICES)
+        self.top_pagination_controls = config.get(u'ckan.datatables.top_pagination_controls', False)
+
         toolkit.add_template_directory(config, u'templates')
         toolkit.add_resource(u'public', u'ckanext-datatablesview')
 
@@ -37,6 +43,10 @@ class DataTablesView(p.SingletonPlugin):
     def can_view(self, data_dict):
         resource = data_dict['resource']
         return resource.get(u'datastore_active')
+
+    def setup_template_variables(self, context, data_dict):
+        return {u'page_length_choices': self.page_length_choices,
+                u'top_pagination_controls': self.top_pagination_controls}
 
     def view_template(self, context, data_dict):
         return u'datatables/datatables_view.html'

--- a/ckanext/datatablesview/templates/datatables/datatables_view.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_view.html
@@ -23,7 +23,12 @@
       {% endif %}
       data-fixed-header="true"
       data-fixed-columns="true"
-      data-dom='"Blifrtip"'
+      data-length-menu="{{ page_length_choices }}"
+      {% if top_pagination_controls %}
+        data-dom='"Blifrptip"'
+      {% else %}
+        data-dom='"Blifrtip"'
+      {% endif %}
       data-buttons='[
         {
           "extend": "colvis",


### PR DESCRIPTION
adds DataTables configuration parameters:
* `ckan.datatables.page_length_choices` - sets default page size and page size choices, with the  first value in the list as the default page size - e.g,
``
ckan.datatables.page_length_choices=[20,50,100,1000]
``

* `ckan.datatables.top_pagination_controls` - to add a pagination control on top in addition to the default bottom pagination control - e.g.
``
ckan.datatables.top_pagination_controls=True
``

Will add details to DataTables documentation once #5902 is merged.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
