### PR TITLE
docs: use HTTPS for installation links

### DIFF
--- a/doc/contributing/release-process.rst
+++ b/doc/contributing/release-process.rst
@@ -264,7 +264,7 @@ Turn this file into a github issue with a checklist using this command::
 
      aws s3 cp python-ckan_2.5.0-precisebeta1_amd64.deb s3://packaging.ckan.org/build/python-ckan_2.5.0-precisebeta1_amd64.deb
 
-   Now the .deb files are available at http://packaging.ckan.org/build/ invite
+   Now the .deb files are available at https://packaging.ckan.org/build/ invite
    people on ckan-dev to test them.
 
 -------------------------
@@ -378,7 +378,7 @@ a release.
 #. Create and deploy the final deb package.
 
    Move it to the root of the
-   `publicly accessible folder <http://packaging.ckan.org/>`_ of
+   `publicly accessible folder <https://packaging.ckan.org/>`_ of
    the packaging server from the `/build` folder.
 
    Make sure to rename it so it follows the deb packages name convention::
@@ -530,7 +530,7 @@ Doing the patch releases
    Note that we drop the patch version and iteration number from the package name.
 
    Move it to the root of the
-   `publicly accessible folder <http://packaging.ckan.org/>`_ of
+   `publicly accessible folder <https://packaging.ckan.org/>`_ of
    the packaging server from the `/build` folder, replacing the existing file
    for this minor version.
 

--- a/doc/maintaining/installing/install-from-package.rst
+++ b/doc/maintaining/installing/install-from-package.rst
@@ -72,19 +72,19 @@ CKAN:
 
        .. parsed-literal::
 
-           wget \http://packaging.ckan.org/|latest_package_name_bionic|
+           wget \https://packaging.ckan.org/|latest_package_name_bionic|
 
      - On Ubuntu 20.04, for Python 3 (recommended):
 
        .. parsed-literal::
 
-           wget \http://packaging.ckan.org/|latest_package_name_focal_py3|
+           wget \https://packaging.ckan.org/|latest_package_name_focal_py3|
 
      - On Ubuntu 20.04, for Python 2:
 
        .. parsed-literal::
 
-           wget \http://packaging.ckan.org/|latest_package_name_focal_py2|
+           wget \https://packaging.ckan.org/|latest_package_name_focal_py2|
 
 #. Install the CKAN package:
 

--- a/doc/maintaining/upgrading/upgrade-package-to-minor-release.rst
+++ b/doc/maintaining/upgrading/upgrade-package-to-minor-release.rst
@@ -16,7 +16,7 @@ respectively.
 #. Download the CKAN package for the new minor release you want to upgrade
    to (replace the version number with the relevant one)::
 
-    wget http://packaging.ckan.org/python-ckan_2.1_amd64.deb
+    wget https://packaging.ckan.org/python-ckan_2.1_amd64.deb
 
 #. Install the package with the following command::
 

--- a/doc/maintaining/upgrading/upgrade-package-to-patch-release.rst
+++ b/doc/maintaining/upgrading/upgrade-package-to-patch-release.rst
@@ -15,7 +15,7 @@ minor release they belong to, so for example CKAN ``2.0``, ``2.0.1``,
 
 #. Download the CKAN package::
 
-    wget http://packaging.ckan.org/python-ckan_2.0_amd64.deb
+    wget https://packaging.ckan.org/python-ckan_2.0_amd64.deb
 
    You can check the actual CKAN version from a package running the following
    command::

--- a/doc/maintaining/upgrading/upgrade-postgres.rst
+++ b/doc/maintaining/upgrading/upgrade-postgres.rst
@@ -271,7 +271,7 @@ Upgrading
 #. Download the CKAN package for the new minor release you want to upgrade
    to (replace the version number with the relevant one)::
 
-     On Ubuntu 16.04: wget http://packaging.ckan.org/python-ckan_2.9-xenial_amd64.deb
-     On Ubuntu 18.04: wget http://packaging.ckan.org/python-ckan_2.9-bionic_amd64.deb
-     On Ubuntu 20.04: wget http://packaging.ckan.org/python-ckan_2.9-py3-focal_amd64.deb (for Python 3)
+     On Ubuntu 16.04: wget https://packaging.ckan.org/python-ckan_2.9-xenial_amd64.deb
+     On Ubuntu 18.04: wget https://packaging.ckan.org/python-ckan_2.9-bionic_amd64.deb
+     On Ubuntu 20.04: wget https://packaging.ckan.org/python-ckan_2.9-py3-focal_amd64.deb (for Python 3)
 


### PR DESCRIPTION
### Proposed fixes:
Use htttps for links to ckan package in docs.


### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
