### PR TITLE
Fix status_show when no extensions are installed

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -2416,7 +2416,7 @@ def status_show(context, data_dict):
     '''
 
     plugins = config.get('ckan.plugins') 
-    extensions = "" if plugins == None else plugins.split()
+    extensions = plugins.split() if plugins else [] 
 
     return {
         'site_title': config.get('ckan.site_title'),

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -2416,7 +2416,7 @@ def status_show(context, data_dict):
     '''
 
     plugins = config.get('ckan.plugins') 
-    extensions = "" if plugins == None else config.get('ckan.plugins').split()
+    extensions = "" if plugins == None else plugins.split()
 
     return {
         'site_title': config.get('ckan.site_title'),

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -2414,6 +2414,10 @@ def status_show(context, data_dict):
     :rtype: dictionary
 
     '''
+
+    plugins = config.get('ckan.plugins') 
+    extensions = "" if plugins == None else config.get('ckan.plugins').split()
+
     return {
         'site_title': config.get('ckan.site_title'),
         'site_description': config.get('ckan.site_description'),
@@ -2421,7 +2425,7 @@ def status_show(context, data_dict):
         'ckan_version': ckan.__version__,
         'error_emails_to': config.get('email_to'),
         'locale_default': config.get('ckan.locale_default'),
-        'extensions': config.get('ckan.plugins').split(),
+        'extensions': extensions,
     }
 
 


### PR DESCRIPTION
Fixes #

### Proposed fixes:

Currently, `/api/3/action/status_show` returns a 500 error if there are no extensions, because `split()` is called on `None`. This fixes that issue.

Caveat: it's fixed in `ckan/logic/action/get.py`, which is where the NoneType is exposed; however, the return from `load(*plugins)` in `ckan/plugins/core.py` is actually

```
[<Plugin DomainObjectModificationExtension 'domain_object_mods'>, <Plugin SynchronousSearchPlugin 'synchronous_search'>]
```

so it seems these 2 plugins are removed from the output somewhere, but I didn't know where. It might be better to fix the issue at this point, rather than in `get.py`. Feel free to reject if you think this would be a better option

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
