### PR TITLE
Fix Recline Map views latlon selects

### DIFF
--- a/ckanext/reclineview/plugin.py
+++ b/ckanext/reclineview/plugin.py
@@ -210,7 +210,7 @@ class ReclineMapView(ReclineViewBase):
 
     datastore_fields = []
 
-    datastore_field_latlon_types = ['numeric']
+    datastore_field_latlon_types = ['numeric', 'text']
 
     datastore_field_geojson_types = ['text']
 


### PR DESCRIPTION
Fixes #
This is a pretty straightforward fix for CKAN 2.9+, due to changes done with xloader that by default parses all CSV files as text, asa result User cannot choose manually Latitude and Longitude.
Initial issue described in https://github.com/ckan/ckan/issues/5849

