### PR TITLE
fix: replace nonexistent UWSGI option "guid" with "gid"

### DIFF
--- a/ckan-uwsgi.ini
+++ b/ckan-uwsgi.ini
@@ -2,7 +2,7 @@
 
 http            =  127.0.0.1:8080
 uid             =  www-data
-guid            =  www-data
+gid             =  www-data
 wsgi-file       =  /etc/ckan/default/wsgi.py
 virtualenv      =  /usr/lib/ckan/default
 module          =  wsgi:application
@@ -13,3 +13,4 @@ max-requests    =  5000
 vacuum          =  true
 callable        =  application
 buffer-size     =  32768
+strict          =  true

--- a/doc/maintaining/installing/deployment.rst
+++ b/doc/maintaining/installing/deployment.rst
@@ -83,7 +83,7 @@ The uwsgi configuration file can be copied from the CKAN distribution:
 
     http            =  127.0.0.1:8080
     uid             =  www-data
-    guid            =  www-data
+    gid             =  www-data
     wsgi-file       =  /etc/ckan/default/wsgi.py
     virtualenv      =  /usr/lib/ckan/default
     module          =  wsgi:application
@@ -93,6 +93,7 @@ The uwsgi configuration file can be copied from the CKAN distribution:
     max-requests    =  5000
     vacuum          =  true
     callable        =  application  
+    strict          =  true
 
 
 -----------------------------------


### PR DESCRIPTION
The "guid" option does not exist. I also added the "strict" option to make sure such things don't happen again.

Reference:

https://uwsgi-docs.readthedocs.io/en/latest/Options.html#gid

### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
