### PR TITLE
CKAN 2.8 Dockerfile: pin pip version to lower than 21 where python2 is still supported

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN mkdir -p $CKAN_VENV $CKAN_CONFIG $CKAN_STORAGE_PATH && \
 
 # Setup CKAN
 ADD . $CKAN_VENV/src/ckan/
-RUN ckan-pip install -U pip && \
+RUN ckan-pip install -U 'pip<21' && \
     ckan-pip install --upgrade --no-cache-dir -r $CKAN_VENV/src/ckan/requirement-setuptools.txt && \
     ckan-pip install --upgrade --no-cache-dir -r $CKAN_VENV/src/ckan/requirements.txt && \
     ckan-pip install -e $CKAN_VENV/src/ckan/ && \


### PR DESCRIPTION
Fixes #5925

pip 21 dropped support for Python2 which breaks the docker build, this pins it to a version lower than 21 where Python2 is still supported