### PR TITLE
Allow package activity migration on py3

### DIFF
--- a/ckan/migration/migrate_package_activity.py
+++ b/ckan/migration/migrate_package_activity.py
@@ -273,8 +273,11 @@ if __name__ == u'__main__':
                         u'dataset - specify its name')
     args = parser.parse_args()
     assert args.config, u'You must supply a --config'
+    print(u'Loading config')
     try:
-        from ckan.lib.cli import load_config
+        from ckan.cli import load_config
+        from ckan.config.middleware import make_app
+        make_app(load_config(args.config))
     except ImportError:
         # for CKAN 2.6 and earlier
         def load_config(config):
@@ -287,9 +290,7 @@ if __name__ == u'__main__':
             cmd.options.config = config
             cmd._load_config()
             return
-
-    print(u'Loading config')
-    load_config(args.config)
+        load_config(args.config)
     if not args.dataset:
         migrate_all_datasets()
         wipe_activity_detail(delete_activity_detail=args.delete)


### PR DESCRIPTION
Fixes #5650

When running activity migration script,  initialize the app without touching old CLI files because they contain paste references and prevent the script from execution