### PR TITLE
Support for setting host and port in the ini file

### DIFF
--- a/ckan/cli/server.py
+++ b/ckan/cli/server.py
@@ -10,10 +10,13 @@ from ckan.common import config
 
 log = logging.getLogger(__name__)
 
+DEFAULT_HOST = "localhost"
+DEFAULT_PORT = 5000
+
 
 @click.command(u"run", short_help=u"Start development server")
-@click.option(u"-H", u"--host", default=u"localhost", help=u"Set host")
-@click.option(u"-p", u"--port", default=5000, help=u"Set port")
+@click.option(u"-H", u"--host", help=u"Host name")
+@click.option(u"-p", u"--port", help=u"Port number")
 @click.option(u"-r", u"--disable-reloader", is_flag=True,
               help=u"Disable reloader")
 @click.option(
@@ -70,6 +73,14 @@ def run(ctx, host, port, disable_reloader, threaded, extra_files, processes,
             ssl_context = (ssl_cert, ssl_key)
     else:
         ssl_context = None
+
+    host = host or config.get('ckan.devserver.host', DEFAULT_HOST)
+    port = port or config.get('ckan.devserver.port', DEFAULT_PORT)
+    try:
+        port = int(port)
+    except ValueError:
+        tk.error_shout(u"Server port must be an integer, not {}".format(port))
+        raise click.Abort()
 
     log.info(u"Running CKAN on {scheme}://{host}:{port}".format(
         scheme='https' if ssl_context else 'http', host=host, port=port))

--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -17,14 +17,15 @@
 # With debug mode enabled, a visitor to your site could execute malicious commands.
 debug = false
 
-[server:main]
-use = egg:Paste#http
-host = 0.0.0.0
-port = 5000
-
 [app:main]
 use = egg:ckan
-full_stack = true
+
+## Development settings
+ckan.devserver.host = localhost
+ckan.devserver.port = 5000
+
+
+## Session settings
 cache_dir = /tmp/%(ckan.site_id)s/
 beaker.session.key = ckan
 

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -147,6 +147,34 @@ maintain compatibility.
 Development Settings
 --------------------
 
+.. _ckan.devserver.host:
+
+ckan.devserver.host
+^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+  ckan.devserver.host = 0.0.0.0
+
+Default value: localhost
+
+Host name to use when running the development server.
+
+
+.. _ckan.devserver.port:
+
+ckan.devserver.port
+^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+  ckan.devserver.port = 5005
+
+Default value: 5000
+
+Port to use when running the development server.
+
+
 .. _ckan.devserver.threaded:
 
 ckan.devserver.threaded


### PR DESCRIPTION
It's useful to be able to set these on your local ini file and not have to provide them each time when running `ckan run`, specially when you have multiple instances installed locally. Paster used to support this in the `[server:main]` section of the ini file.

Added `ckan.devserver.host` and `ckan.devserver.port` support, plus some value checks for the port.
I also cleaned a bit the ini template to remove paster specific stuff.