### PR TITLE
Remove unused action call in download blueprint

### DIFF
--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -1087,6 +1087,22 @@ class TestResourceDownload(object):
 
         assert response.headers[u"Content-Type"] == u"text/csv"
 
+    def test_not_found_if_not_in_package(self, create_with_upload, app):
+        dataset = factories.Dataset()
+        resource = create_with_upload(
+            u"hello,world", u"file.csv",
+            package_id=dataset[u"id"]
+        )
+        dataset2 = factories.Dataset()
+
+        url = url_for(
+            u"{}_resource.download".format(dataset[u"type"]),
+            id=dataset2[u"id"],
+            resource_id=resource[u"id"],
+        )
+
+        response = app.get(url, status=404)
+
 
 @pytest.mark.ckan_config("ckan.plugins", "image_view")
 @pytest.mark.usefixtures("clean_db", "with_plugins", "with_request_context")

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -165,7 +165,6 @@ def download(package_type, id, resource_id, filename=None):
 
     try:
         rsc = get_action(u'resource_show')(context, {u'id': resource_id})
-        get_action(u'package_show')(context, {u'id': id})
     except (NotFound, NotAuthorized):
         return base.abort(404, _(u'Resource not found'))
 

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -165,6 +165,11 @@ def download(package_type, id, resource_id, filename=None):
 
     try:
         rsc = get_action(u'resource_show')(context, {u'id': resource_id})
+        if rsc['package_id'] != id:
+            return base.abort(
+                    404,
+                    _(u'The resource found does not belong to the package.')
+                )
     except (NotFound, NotAuthorized):
         return base.abort(404, _(u'Resource not found'))
 

--- a/ckanext/example_idatasetform/tests/test_example_idatasetform.py
+++ b/ckanext/example_idatasetform/tests/test_example_idatasetform.py
@@ -276,7 +276,7 @@ class TestUrlsForCustomDatasetType(object):
             assert page_header.find(
                 href=url_for("fancy_type." + action, id=pkg["name"])
             )
-        # import ipdb; ipdb.set_trace()
+
         assert page.find(id="dataset-resources").find(
             href=url_for(
                 "fancy_type_resource.read",


### PR DESCRIPTION
This call to `get_action(u'package_show')` is not used for anything in the download blueprint.
