### PR TITLE
Remove werkzeug hardcoded logging level

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -164,8 +164,6 @@ def make_flask_stack(conf):
         from werkzeug.debug import DebuggedApplication
         app.wsgi_app = DebuggedApplication(app.wsgi_app, True)
 
-        log = logging.getLogger('werkzeug')
-        log.setLevel(logging.DEBUG)
 
     # Use Beaker as the Flask session interface
     class BeakerSessionInterface(SessionInterface):

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -164,7 +164,6 @@ def make_flask_stack(conf):
         from werkzeug.debug import DebuggedApplication
         app.wsgi_app = DebuggedApplication(app.wsgi_app, True)
 
-
     # Use Beaker as the Flask session interface
     class BeakerSessionInterface(SessionInterface):
         def open_session(self, app, request):


### PR DESCRIPTION
The current configuration option to handle werkzeug logging level is being overridden when executing the server in debug mode. 

This allows the werkzeug logging level to be managed in the configuration file while working in the development server:
https://github.com/ckan/ckan/blob/58d165235a9c53dfcbfd5f196d55ebb0faaf27d1/ckan/config/deployment.ini_tmpl#L226-L230
