### PR TITLE
Remove obsolete context key: return_type

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -289,9 +289,7 @@ def resource_create(context, data_dict):
     if not data_dict.get('url'):
         data_dict['url'] = ''
 
-    pkg_dict = _get_action('package_show')(
-        dict(context, return_type='dict'),
-        {'id': package_id})
+    pkg_dict = _get_action('package_show')(context, {'id': package_id})
 
     _check_access('resource_create', context, data_dict)
 

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -79,8 +79,7 @@ def resource_update(context, data_dict):
     del context["resource"]
 
     package_id = resource.package.id
-    pkg_dict = _get_action('package_show')(dict(context, return_type='dict'),
-        {'id': package_id})
+    pkg_dict = _get_action('package_show')(context, {'id': package_id})
 
     for n, p in enumerate(pkg_dict['resources']):
         if p['id'] == id:

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -79,8 +79,7 @@ def resource_update(context, data_dict):
     del context["resource"]
 
     package_id = resource.package.id
-    pkg_dict = _get_action('package_show')(dict(context, return_type='dict'),
-        {'id': package_id})
+    pkg_dict = _get_action('package_show')(context, {'id': package_id})
 
     for n, p in enumerate(pkg_dict['resources']):
         if p['id'] == id:
@@ -460,12 +459,8 @@ def package_revise(context, data_dict):
     if name_or_id is None:
         raise ValidationError({'match__id': _('Missing value')})
 
-    package_show_context = dict(
-        context,
-        return_type='dict',
-        for_update=True)
     orig = _get_action('package_show')(
-        package_show_context,
+        dict(context, for_update=True),
         {'id': name_or_id})
 
     pkg = package_show_context['package']  # side-effect of package_show

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -79,7 +79,8 @@ def resource_update(context, data_dict):
     del context["resource"]
 
     package_id = resource.package.id
-    pkg_dict = _get_action('package_show')(context, {'id': package_id})
+    pkg_dict = _get_action('package_show')(dict(context, return_type='dict'),
+        {'id': package_id})
 
     for n, p in enumerate(pkg_dict['resources']):
         if p['id'] == id:
@@ -459,8 +460,11 @@ def package_revise(context, data_dict):
     if name_or_id is None:
         raise ValidationError({'match__id': _('Missing value')})
 
+    package_show_context = dict(
+        context,
+        for_update=True)
     orig = _get_action('package_show')(
-        dict(context, for_update=True),
+        package_show_context,
         {'id': name_or_id})
 
     pkg = package_show_context['package']  # side-effect of package_show


### PR DESCRIPTION
`package_show` method does not handle any `return_type` parameter, neither the context object anywhere in the code.
