### PR TITLE
Remove unused imports in stats extension

### DIFF
--- a/ckanext/stats/blueprint.py
+++ b/ckanext/stats/blueprint.py
@@ -2,9 +2,9 @@
 
 from flask import Blueprint
 
-from ckan.plugins.toolkit import c, render
+from ckan.plugins.toolkit import render
 import ckanext.stats.stats as stats_lib
-import ckan.lib.helpers as h
+
 
 stats = Blueprint(u'stats', __name__)
 


### PR DESCRIPTION
This PR removes some unused imports in `stats` blueprint.
