### PR TITLE
add solr_timeout option

### DIFF
--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -91,6 +91,7 @@ expire_api_token.default_lifetime = 3600
 
 ckan.site_id = default
 #solr_url = http://127.0.0.1:8983/solr
+solr_timeout = 60
 
 
 ## Redis Settings

--- a/ckan/lib/search/common.py
+++ b/ckan/lib/search/common.py
@@ -9,6 +9,8 @@ import simplejson
 from six import string_types
 from six.moves.urllib.parse import quote_plus
 
+import ckan.plugins.toolkit as tk
+
 log = logging.getLogger(__name__)
 
 
@@ -77,11 +79,13 @@ def make_connection(decode_dates=True):
                                        quote_plus(solr_password),
                                        solr_url)
 
+    timeout = tk.asint(tk.config.get('solr_timeout', 60))
+
     if decode_dates:
         decoder = simplejson.JSONDecoder(object_hook=solr_datetime_decoder)
-        return pysolr.Solr(solr_url, decoder=decoder)
+        return pysolr.Solr(solr_url, decoder=decoder, timeout=timeout)
     else:
-        return pysolr.Solr(solr_url)
+        return pysolr.Solr(solr_url, timeout=timeout)
 
 
 def solr_datetime_decoder(d):

--- a/ckan/lib/search/common.py
+++ b/ckan/lib/search/common.py
@@ -9,7 +9,7 @@ import simplejson
 from six import string_types
 from six.moves.urllib.parse import quote_plus
 
-import ckan.plugins.toolkit as tk
+from ckan.common import config, asint
 
 log = logging.getLogger(__name__)
 
@@ -79,7 +79,7 @@ def make_connection(decode_dates=True):
                                        quote_plus(solr_password),
                                        solr_url)
 
-    timeout = tk.asint(tk.config.get('solr_timeout', 60))
+    timeout = asint(config.get('solr_timeout', 60))
 
     if decode_dates:
         decoder = simplejson.JSONDecoder(object_hook=solr_datetime_decoder)

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -971,6 +971,17 @@ Optionally, ``solr_user`` and ``solr_password`` can also be configured to specif
 
 .. _ckan.search.automatic_indexing:
 
+solr_timeout
+^^^^^^^^^^^^
+
+Example::
+
+ solr_timeout = 120
+
+Default value:  ``60``
+
+The option defines the timeout in seconds until giving up on a request. Raising this value might help you if you encounter a timeout exception.
+
 ckan.search.automatic_indexing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
We've recently encountered a problem with SOLR timeout. And seems like we don't have a possibility to configure timeout for SOLR connection. The default value in pysolr is 60 sec. So I've decided to add config option. I've added it to default production.ini template and to documentation also.


### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
