### PR TITLE
Make datastore search whitelist case insensitive

### DIFF
--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1588,7 +1588,10 @@ def search_sql(context, data_dict):
         context['check_access'](table_names)
 
         for f in function_names:
-            if f not in backend.allowed_sql_functions:
+            for name_variant in [f.lower(), '"{}"'.format(f)]:
+                if name_variant in backend.allowed_sql_functions:
+                    break
+            else:
                 raise toolkit.NotAuthorized({
                     'permissions': [
                         'Not authorized to call function {}'.format(f)]
@@ -1731,8 +1734,21 @@ class DatastorePostgresqlBackend(DatastoreBackend):
                 _SQL_FUNCTIONS_ALLOWLIST_FILE
             )
 
+            def format_entry(line):
+                '''Prepare an entry from the 'allowed_functions' file
+                to be used in the whitelist.
+
+                Leading and trailing whitespace is removed, and the
+                entry is lowercased unless enclosed in "double quotes".
+                '''
+                entry = line.strip()
+                if not entry.startswith('"'):
+                    entry = entry.lower()
+                return entry
+
             with open(allowed_sql_functions_file, 'r') as f:
-                self.allowed_sql_functions = set(line.strip() for line in f)
+                self.allowed_sql_functions = set(format_entry(line)
+                                                 for line in f)
 
         # Check whether we are running one of the paster commands which means
         # that we should ignore the following tests.

--- a/ckanext/datastore/tests/allowed_functions.txt
+++ b/ckanext/datastore/tests/allowed_functions.txt
@@ -1,0 +1,2 @@
+upper
+"count"

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -1656,6 +1656,8 @@ class TestDatastoreSQLFunctional(object):
         with pytest.raises(p.toolkit.NotAuthorized):
             helpers.call_action("datastore_search_sql", sql=sql)
 
+    @pytest.mark.ckan_config("ckan.plugins", "datastore")
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_allowed_functions_are_case_insensitive(self):
         resource = factories.Resource()
         data = {
@@ -1670,6 +1672,8 @@ class TestDatastoreSQLFunctional(object):
         )
         helpers.call_action("datastore_search_sql", sql=sql)
 
+    @pytest.mark.ckan_config("ckan.plugins", "datastore")
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_quoted_allowed_functions_are_case_sensitive(self):
         resource = factories.Resource()
         data = {

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -1656,6 +1656,40 @@ class TestDatastoreSQLFunctional(object):
         with pytest.raises(p.toolkit.NotAuthorized):
             helpers.call_action("datastore_search_sql", sql=sql)
 
+    def test_allowed_functions_are_case_insensitive(self):
+        resource = factories.Resource()
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "records": [{"author": "bob"}, {"author": "jane"}],
+        }
+        helpers.call_action("datastore_create", **data)
+
+        sql = 'SELECT UpPeR(author) from "{}"'.format(
+            resource["id"]
+        )
+        helpers.call_action("datastore_search_sql", sql=sql)
+
+    def test_quoted_allowed_functions_are_case_sensitive(self):
+        resource = factories.Resource()
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "records": [{"author": "bob"}, {"author": "jane"}],
+        }
+        helpers.call_action("datastore_create", **data)
+
+        sql = 'SELECT count(*) from "{}"'.format(
+            resource["id"]
+        )
+        helpers.call_action("datastore_search_sql", sql=sql)
+
+        sql = 'SELECT CoUnT(*) from "{}"'.format(
+            resource["id"]
+        )
+        with pytest.raises(p.toolkit.NotAuthorized):
+            helpers.call_action("datastore_search_sql", sql=sql)
+
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_invalid_statement(self):

--- a/test-core.ini
+++ b/test-core.ini
@@ -29,6 +29,7 @@ sqlalchemy.url = postgresql://ckan_default:pass@localhost/ckan_test
 ckan.datastore.write_url = postgresql://ckan_default:pass@localhost/datastore_test
 ckan.datastore.read_url = postgresql://datastore_default:pass@localhost/datastore_test
 ckan.datastore.sqlsearch.enabled = true
+ckan.datastore.sqlsearch.allowed_functions_file = %(here)s/ckanext/datastore/tests/allowed_functions.txt
 
 ckan.datapusher.url = http://datapusher.ckan.org/
 ckan.datapusher.formats = csv xls xlsx tsv application/csv application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet


### PR DESCRIPTION
### Proposed fixes:

Make the datastore search SQL function whitelist case-insensitive, since PostgreSQL function calls are typically case-insensitive.

If case-sensitivity is desired, it can be achieved by enclosing a whitelist entry in "double quotes".

### Features:

- [X] includes tests covering changes
- [X] includes bug fix for possible backport
