### PR TITLE
Fix TemplateSyntaxError in snippets/changes/license.html

### DIFF
--- a/ckan/templates/snippets/changes/license.html
+++ b/ckan/templates/snippets/changes/license.html
@@ -6,7 +6,7 @@
       {{ _('Changed the license of {pkg_link} to {new_link} (previously {old_link})').format(
 
         pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
-        new_link = h.link_to(change.new_title, change.new_url)
+        new_link = h.link_to(change.new_title, change.new_url),
         old_link = h.link_to(change.old_title, change.old_url)
         ) }}
 
@@ -15,7 +15,7 @@
 
       {{ _('Changed the license of {pkg_link} to {new_link} (previously {old_title})').format(
         pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
-        new_link = h.link_to(change.new_title, change.new_url)
+        new_link = h.link_to(change.new_title, change.new_url),
         old_title = change.old_title
         ) }}
 


### PR DESCRIPTION
Fixes #
When the license of a package was changed, viewing these "changes" in Activity Stream lead to a jinja2.exceptions.TemplateSyntaxError .

Missing commas were added, now the template renders without error

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
