### PR TITLE
replace uses of @helpers.change_config with @pytest.mark.ckan_config

### DIFF
--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -1208,7 +1208,7 @@ class TestResourceUpdate(object):
         assert "extras" not in resource
         assert "someotherkey" not in resource
 
-    @helpers.change_config(
+    @pytest.mark.ckan_config(
         "ckan.views.default_views", "image_view recline_view"
     )
     def test_resource_format_update(self):

--- a/ckanext/example_idatastorebackend/test/test_plugin.py
+++ b/ckanext/example_idatastorebackend/test/test_plugin.py
@@ -20,7 +20,7 @@ class_to_patch = (
 
 
 @pytest.mark.ckan_config(u"ckan.plugins",
-                         u"datastore example_idatastorebackend")
+                         u"example_idatastorebackend datastore")
 @pytest.mark.usefixtures(u"with_plugins", u"clean_db", u"app")
 class TestExampleIDatastoreBackendPlugin():
 

--- a/ckanext/example_idatastorebackend/test/test_plugin.py
+++ b/ckanext/example_idatastorebackend/test/test_plugin.py
@@ -44,8 +44,8 @@ class TestExampleIDatastoreBackendPlugin():
             with pytest.raises(AssertionError):
                 DatastoreBackend.set_active_backend(config)
 
-    @helpers.change_config(u"ckan.datastore.write_url", u"sqlite://x")
-    @helpers.change_config(u"ckan.datastore.read_url", u"sqlite://x")
+    @pytest.mark.ckan_config(u"ckan.datastore.write_url", u"sqlite://x")
+    @pytest.mark.ckan_config(u"ckan.datastore.read_url", u"sqlite://x")
     def test_sqlite_engine(self):
         DatastoreBackend.set_active_backend(config)
         assert isinstance(
@@ -53,8 +53,8 @@ class TestExampleIDatastoreBackendPlugin():
             DatastoreExampleSqliteBackend,
         )
 
-    @helpers.change_config(u"ckan.datastore.write_url", u"sqlite://x")
-    @helpers.change_config(u"ckan.datastore.read_url", u"sqlite://x")
+    @pytest.mark.ckan_config(u"ckan.datastore.write_url", u"sqlite://x")
+    @pytest.mark.ckan_config(u"ckan.datastore.read_url", u"sqlite://x")
     @patch(class_to_patch + u"._get_engine")
     def test_backend_functionality(self, get_engine):
         engine = get_engine()


### PR DESCRIPTION
### Proposed fixes:

Replace a couple of remaining uses of `@helpers.change_config` with `@pytest.mark.ckan_config`
Should the `change_config` function itself also be removed in this PR?

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
