### PR TITLE
Allow to set path to INI file in the WSGI script

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -4,9 +4,17 @@ import os
 from ckan.config.middleware import make_app
 from ckan.cli import CKANConfigLoader
 from logging.config import fileConfig as loggingFileConfig
-config_filepath = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), u'ckan.ini')
-abspath = os.path.join(os.path.dirname(os.path.abspath(__file__)))
-loggingFileConfig(config_filepath)
-config = CKANConfigLoader(config_filepath).get_config()
+
+if os.environ.get('CKAN_INI'):
+    config_path = os.environ['CKAN_INI']
+else:
+    config_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), u'ckan.ini')
+
+if not os.path.exists(config_path):
+    raise RuntimeError('CKAN config option not found: {}'.format(config_path))
+
+loggingFileConfig(config_path)
+config = CKANConfigLoader(config_path).get_config()
+
 application = make_app(config)


### PR DESCRIPTION
The wsgi script that we include as example to be used with uwsgi or gunicorn expects a `ckan.ini` file in the same folder. This adds support for the `CKAN_INI` env var which is already supported when running the CLI.

### Features:

- [x] includes bugfix for possible backport

