### PR TITLE
Update dev-requirements

### DIFF
--- a/ckan/tests/controllers/test_group.py
+++ b/ckan/tests/controllers/test_group.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-import mock
+import unittest.mock as mock
 from bs4 import BeautifulSoup
 import pytest
 import six

--- a/ckan/tests/controllers/test_organization.py
+++ b/ckan/tests/controllers/test_organization.py
@@ -3,7 +3,7 @@
 import pytest
 import six
 from bs4 import BeautifulSoup
-from mock import patch
+from unittest.mock import patch
 
 from ckan import model
 from ckan.lib.helpers import url_for

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -2,7 +2,7 @@
 
 from bs4 import BeautifulSoup
 from werkzeug.routing import BuildError
-import mock
+import unittest.mock as mock
 
 from ckan.lib.helpers import url_for
 import pytest

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
-import mock
+import unittest.mock as mock
 import pytest
 import six
 from bs4 import BeautifulSoup

--- a/ckan/tests/factories.py
+++ b/ckan/tests/factories.py
@@ -41,7 +41,7 @@ Usage::
 import random
 import string
 import factory
-import mock
+import unittest.mock as mock
 
 import ckan.model
 import ckan.logic

--- a/ckan/tests/helpers.py
+++ b/ckan/tests/helpers.py
@@ -32,7 +32,7 @@ from flask.testing import Client as FlaskClient
 from flask.wrappers import Response
 from click.testing import CliRunner
 import pytest
-import mock
+import unittest.mock as mock
 import rq
 import six
 

--- a/ckan/tests/legacy/functional/test_group.py
+++ b/ckan/tests/legacy/functional/test_group.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 import pytest
-import mock
+import unittest.mock as mock
 
 import ckan.model as model
 

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -3,7 +3,7 @@
 
 """
 import datetime
-import mock
+import unittest.mock as mock
 import pytest
 
 import ckan

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -2,7 +2,7 @@
 """Unit tests for ckan/logic/action/update.py."""
 import datetime
 
-import mock
+import unittest.mock as mock
 import pytest
 import six
 

--- a/ckan/tests/logic/auth/test_create.py
+++ b/ckan/tests/logic/auth/test_create.py
@@ -3,7 +3,7 @@
 
 """
 
-import mock
+import unittest.mock as mock
 import pytest
 from six import string_types
 

--- a/ckan/tests/logic/auth/test_update.py
+++ b/ckan/tests/logic/auth/test_update.py
@@ -2,7 +2,7 @@
 """Unit tests for ckan/logic/auth/update.py.
 
 """
-import mock
+import unittest.mock as mock
 import pytest
 from six import string_types
 

--- a/ckan/tests/logic/test_validators.py
+++ b/ckan/tests/logic/test_validators.py
@@ -7,7 +7,7 @@ import warnings
 import copy
 import decimal
 import fractions
-import mock
+import unittest.mock as mock
 import pytest
 
 import ckan.lib.navl.dictization_functions as df

--- a/ckan/tests/test_authz.py
+++ b/ckan/tests/test_authz.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 import six
-import mock
+import unittest.mock as mock
 import pytest
 
 from ckan import authz as auth

--- a/ckanext/datapusher/tests/test_action.py
+++ b/ckanext/datapusher/tests/test_action.py
@@ -2,7 +2,7 @@
 
 import datetime
 
-import mock
+import unittest.mock as mock
 import pytest
 from ckan.logic import _actions
 

--- a/ckanext/datastore/tests/test_db.py
+++ b/ckanext/datastore/tests/test_db.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-import mock
+import unittest.mock as mock
 import pytest
 import sqlalchemy.exc
 

--- a/ckanext/datastore/tests/test_dump.py
+++ b/ckanext/datastore/tests/test_dump.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-import mock
+import unittest.mock as mock
 import json
 import pytest
 import six

--- a/ckanext/datastore/tests/test_plugin.py
+++ b/ckanext/datastore/tests/test_plugin.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-import mock
+import unittest.mock as mock
 import pytest
 
 import ckan.plugins as p

--- a/ckanext/example_idatastorebackend/test/test_plugin.py
+++ b/ckanext/example_idatastorebackend/test/test_plugin.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 
-from mock import patch, Mock, call
+from unittest.mock import patch, Mock, call
 import pytest
 
 from ckan.common import config

--- a/ckanext/example_iuploader/test/test_plugin.py
+++ b/ckanext/example_iuploader/test/test_plugin.py
@@ -3,7 +3,7 @@
 import flask
 import pytest
 import six
-from mock import patch
+from unittest.mock import patch
 from ckan.lib.helpers import url_for
 
 from six.moves.urllib.parse import urlparse

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,23 +2,21 @@
 
 beautifulsoup4==4.9.1
 coveralls   #Let Unpinned - Requires latest coveralls
-docutils==0.12
+docutils==0.16
 factory-boy==2.12.0
 Flask-DebugToolbar==0.11.0
-freezegun==0.3.15
-ipdb==0.13.2
-responses==0.10.14
-mock==2.0.0
+freezegun==1.1.0
+ipdb==0.13.7
+responses==0.13.1
 pycodestyle==2.5.0
 pip-tools==5.1.2
-pyfakefs==3.2
 Sphinx==1.8.5
 sphinx-rtd-theme==0.4.3
-cookiecutter==1.7.0
+cookiecutter==1.7.2
 
-pytest==4.6.5
+pytest==6.2.2
 pytest-split-tests==1.0.9
-pytest-cov==2.7.1
-pytest-freezegun==0.4.1
-pytest-rerunfailures==8.0
+pytest-cov==2.11.1
+pytest-freezegun==0.4.2
+pytest-rerunfailures==9.1.1
 towncrier==19.2.0

--- a/doc/contributing/testing.rst
+++ b/doc/contributing/testing.rst
@@ -317,7 +317,7 @@ code will always get another mock object back:
 
 .. code-block:: python
 
-    >>> import mock
+    >>> import unittest.mock as mock
     >>> my_mock = mock.MagicMock()
     >>> my_mock.foo
     <MagicMock name='mock.foo' id='56032400'>

--- a/doc/maintaining/background-tasks.rst
+++ b/doc/maintaining/background-tasks.rst
@@ -297,7 +297,7 @@ synchronously instead of asynchronously:
 
 .. code-block:: python
 
-    import mock
+    import unittest.mock as mock
 
     from ckan.tests import helpers
 
@@ -431,4 +431,3 @@ Use that function as follows for enqueuing a job::
     compat_enqueue(u'my_extension.echofunction',
                    ckanext.my_extension.plugin.echo,
                    [u'Hello World'])
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,17 @@ showcontent = true
 
 [tool.black]
 line-length = 79
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore::sqlalchemy.exc.SADeprecationWarning",
+    "ignore::sqlalchemy.exc.SAWarning",
+    "ignore::DeprecationWarning"
+]
+markers = [
+    "ckan_config: patch configuration used by other fixtures via (key, value) pair.",
+    "ckan_pytest: test case that is explicitely was rewriten from `nose` style"
+]
+
+testpaths = ["ckan", "ckanext"]
+addopts = "--strict-markers  --pdbcls=IPython.terminal.debugger:TerminalPdb"

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,14 +29,3 @@ previous = true
 
 [upload_sphinx]
 upload-dir = build/sphinx/html
-
-[tool:pytest]
-filterwarnings =
-        ignore::sqlalchemy.exc.SADeprecationWarning
-        ignore::sqlalchemy.exc.SAWarning
-        ignore::DeprecationWarning
-markers =
-        ckan_config: patch configuration used by other fixtures via (key, value) pair.
-        ckan_pytest: test case that is explicitely was rewriten from `nose` style
-testpaths = ckan ckanext
-addopts = --strict-markers  --pdbcls=IPython.terminal.debugger:TerminalPdb

--- a/setup.py
+++ b/setup.py
@@ -240,6 +240,7 @@ setup(
     entry_points=entry_points,
     # setup.py test command needs a TestSuite so does not work with py.test
     # tests_require=[ 'py >= 0.8.0-alpha2' ]
+    python_requires=">=3.7",
     extras_require=extras_require,
     classifiers=[
         # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
* Update `pytest` because the current version does not contain types information
* Store `pytest` configuration inside `pyproject.toml` instead of `setup.cfg`(recommended by `pytest` maintainers)
* Update `docutils`. Not critical, but it required for packaging CKAN extensions
* Use built-in `unittest.mock` instead of external `mock`
* Update minor for other dev-requirements when it's possible
* Pin minimal python version in `setup.py`