### PR TITLE
Include extra files into ckanext distribution

### DIFF
--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/MANIFEST.in
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
 include LICENSE
 include requirements.txt
-recursive-include ckanext/{{ cookiecutter.project_shortname }} *.html *.json *.js *.less *.css *.mo
+recursive-include ckanext/{{ cookiecutter.project_shortname }} *.html *.json *.js *.less *.css *.mo *.yml
+recursive-include ckanext/{{ cookiecutter.project_shortname }}/migration *.ini *.py *.mako

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/ckanext/{{cookiecutter.project_shortname}}/assets/webassets.yml
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/ckanext/{{cookiecutter.project_shortname}}/assets/webassets.yml
@@ -1,0 +1,14 @@
+# {{ cookiecutter.project_shortname }}-js:
+#   filter: rjsmin
+#   output: ckanext-{{ cookiecutter.project_shortname }}/%(version)s-{{ cookiecutter.project_shortname }}.js
+#   contents:
+#     - js/{{ cookiecutter.project_shortname }}.js
+#   extra:
+#     preload:
+#       - base/main
+
+# {{ cookiecutter.project_shortname }}-css:
+#   filter: cssrewrite
+#   output: ckanext-{{ cookiecutter.project_shortname }}/%(version)s-{{ cookiecutter.project_shortname }}.css
+#   contents:
+#     - css/{{ cookiecutter.project_shortname }}.css


### PR DESCRIPTION
Currently, 'webassets.yml` and all the alembic migration files are missing when source distribution created using the default setup.py\manifest.in. This PR includes those files and creates webassets.yml with commented basic examples of asset definition