### PR TITLE
Allow multi-level config inheritance

### DIFF
--- a/changes/6000.bugfix
+++ b/changes/6000.bugfix
@@ -1,0 +1,1 @@
+Allow multi-level config inheritance

--- a/ckan/cli/__init__.py
+++ b/ckan/cli/__init__.py
@@ -51,7 +51,7 @@ class CKANConfigLoader(object):
 
         self._update_config()
 
-        loaded_files = {use_config_path}
+        loaded_files = [use_config_path]
 
         while True:
             schema, path = self.parser.get(self.section, u'use').split(u':')
@@ -60,8 +60,12 @@ class CKANConfigLoader(object):
                     os.path.dirname(os.path.abspath(use_config_path)), path)
                 # Avoid circular references
                 if use_config_path in loaded_files:
-                    break
-                loaded_files.add(use_config_path)
+                    chain = ' -> '.join(loaded_files + [use_config_path])
+                    raise CkanConfigurationException(
+                        'Circular dependency located in '
+                        f'the configuration chain: {chain}'
+                    )
+                loaded_files.append(use_config_path)
 
                 self._read_config_file(use_config_path)
                 self._update_config()

--- a/ckan/cli/__init__.py
+++ b/ckan/cli/__init__.py
@@ -42,7 +42,8 @@ class CKANConfigLoader(object):
                     self.config[u'global_conf'][option] = value
 
     def _create_config_object(self):
-        self._read_config_file(self.config_file)
+        use_config_path = self.config_file
+        self._read_config_file(use_config_path)
 
         # # The global_config key is to keep compatibility with Pylons.
         # # It can be safely removed when the Flask migration is completed.
@@ -50,12 +51,26 @@ class CKANConfigLoader(object):
 
         self._update_config()
 
-        schema, path = self.parser.get(self.section, u'use').split(u':')
-        if schema == u'config':
-            use_config_path = os.path.join(
-                os.path.dirname(os.path.abspath(self.config_file)), path)
-            self._read_config_file(use_config_path)
-            self._update_config()
+        loaded_files = {use_config_path}
+
+        while True:
+            schema, path = self.parser.get(self.section, u'use').split(u':')
+            if schema == u'config':
+                use_config_path = os.path.join(
+                    os.path.dirname(os.path.abspath(use_config_path)), path)
+                # Avoid circular references
+                if use_config_path in loaded_files:
+                    break
+                loaded_files.add(use_config_path)
+
+                self._read_config_file(use_config_path)
+                self._update_config()
+            else:
+                break
+        log.debug(
+            u'Loaded configuration from the following files: %s',
+            loaded_files
+        )
 
     def get_config(self):
         return self.config.copy()

--- a/ckan/tests/cli/data/sub/test-two-recursive.ini
+++ b/ckan/tests/cli/data/sub/test-two-recursive.ini
@@ -1,0 +1,5 @@
+[app:main]
+use = config:../test-three-recursive.ini
+
+key1 =two
+key2 =two

--- a/ckan/tests/cli/data/sub/test-two.ini
+++ b/ckan/tests/cli/data/sub/test-two.ini
@@ -1,0 +1,5 @@
+[app:main]
+use = config:../test-three.ini
+
+key1 =two
+key2 =two

--- a/ckan/tests/cli/data/test-one-recursive.ini
+++ b/ckan/tests/cli/data/test-one-recursive.ini
@@ -1,0 +1,4 @@
+[app:main]
+use = config:sub/test-two-recursive.ini
+
+key1 = one

--- a/ckan/tests/cli/data/test-one.ini
+++ b/ckan/tests/cli/data/test-one.ini
@@ -1,0 +1,4 @@
+[app:main]
+use = config:sub/test-two.ini
+
+key1 = one

--- a/ckan/tests/cli/data/test-three-recursive.ini
+++ b/ckan/tests/cli/data/test-three-recursive.ini
@@ -1,0 +1,6 @@
+[app:main]
+use = config:test-one-recursive.ini
+
+key1 = three
+key2 = three
+key3 = three

--- a/ckan/tests/cli/data/test-three.ini
+++ b/ckan/tests/cli/data/test-three.ini
@@ -1,5 +1,5 @@
 [app:main]
-use = config:test-one.ini
+use = egg:ckan
 
 key1 = three
 key2 = three

--- a/ckan/tests/cli/data/test-three.ini
+++ b/ckan/tests/cli/data/test-three.ini
@@ -1,0 +1,6 @@
+[app:main]
+use = config:test-one.ini
+
+key1 = three
+key2 = three
+key3 = three

--- a/ckan/tests/cli/test_cli.py
+++ b/ckan/tests/cli/test_cli.py
@@ -110,3 +110,19 @@ def test_ckan_config_loader_parse_two_files():
     assert conf[u'global_conf'][u'__file__'] == filename
     assert conf[u'global_conf'][u'here'] == tpl_dir
     assert conf[u'global_conf'][u'debug'] == u'false'
+
+
+def test_recursive_loading():
+    """Load chains of config files via `use = config:...`.
+
+    Make sure we still remember main config file.
+    If there are circular dependencies, don't fall into infinite recursion.
+    """
+    filename = os.path.join(
+        os.path.dirname(__file__), u'data', u'test-one.ini')
+    conf = CKANConfigLoader(filename).get_config()
+
+    assert conf[u'__file__'] == filename
+    assert conf[u'key1'] == u'one'
+    assert conf[u'key2'] == u'two'
+    assert conf[u'key3'] == u'three'

--- a/ckan/tests/cli/test_cli.py
+++ b/ckan/tests/cli/test_cli.py
@@ -5,6 +5,7 @@ import os
 
 from ckan.cli.cli import ckan
 from ckan.cli import CKANConfigLoader
+from ckan.exceptions import CkanConfigurationException
 
 
 def test_without_args(cli):
@@ -112,17 +113,24 @@ def test_ckan_config_loader_parse_two_files():
     assert conf[u'global_conf'][u'debug'] == u'false'
 
 
-def test_recursive_loading():
+def test_chain_loading():
     """Load chains of config files via `use = config:...`.
-
-    Make sure we still remember main config file.
-    If there are circular dependencies, don't fall into infinite recursion.
     """
     filename = os.path.join(
         os.path.dirname(__file__), u'data', u'test-one.ini')
     conf = CKANConfigLoader(filename).get_config()
-
     assert conf[u'__file__'] == filename
     assert conf[u'key1'] == u'one'
     assert conf[u'key2'] == u'two'
     assert conf[u'key3'] == u'three'
+
+
+def test_recursive_loading():
+    """ Make sure we still remember main config file.
+
+    If there are circular dependencies, make sure the user knows about it.
+    """
+    filename = os.path.join(
+        os.path.dirname(__file__), u'data', u'test-one-recursive.ini')
+    with pytest.raises(CkanConfigurationException):
+        CKANConfigLoader(filename).get_config()


### PR DESCRIPTION
Currently `use = config:...` option in the main config file allows us to parse referenced config file. But if this referenced file also contains a reference to yet another config file, the latest one will be ignored. I.e, it impossible to create chains of config files.

This PR provides the ability to extend config with an arbitrary depth(unless there is a recursion, in which case we stop as soon as we see a file that was already parsed)