### PR TITLE
Update install-from-docker-compose.rst

### DIFF
--- a/doc/maintaining/installing/install-from-docker-compose.rst
+++ b/doc/maintaining/installing/install-from-docker-compose.rst
@@ -174,7 +174,7 @@ a. Configure datastore database
 
 With running CKAN containers, execute the built-in setup script against the ``db`` container::
 
-    docker exec ckan /usr/local/bin/ckan-paster --plugin=ckan datastore set-permissions -c /etc/ckan/production.ini | docker exec -i db psql -U ckan
+    docker exec ckan ckan -c /etc/ckan/production.ini datastore set-permissions | docker exec -i db psql -U ckan
 
 The script pipes in the output of ``paster ckan set-permissions`` - however,
 as this output can change in future versions of CKAN, we set the permissions directly.


### PR DESCRIPTION
Old instruction:
$ docker exec ckan /usr/local/bin/ckan-paster --plugin=ckan datastore set-permissions -c /etc/ckan/production.ini

Fails with:
Command 'datastore' not known (you may need to run setup.py egg_info)

Changing to use below could get pass it
$ docker exec ckan ckan -c /etc/ckan/production.ini datastore set-permissions | docker exec -i db psql -U ckan

tested on ckan2.9.2 only

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
