### PR TITLE
Replace __import__ with importlib

### DIFF
--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -3,6 +3,9 @@
 import functools
 import logging
 import re
+import importlib
+import inspect
+
 from collections import defaultdict
 
 from werkzeug.local import LocalProxy
@@ -390,30 +393,21 @@ def get_action(action):
         if action not in _actions:
             raise KeyError("Action '%s' not found" % action)
         return _actions.get(action)
-    # Otherwise look in all the plugins to resolve all possible
-    # First get the default ones in the ckan/logic/action directory
-    # Rather than writing them out in full will use __import__
+    # Otherwise look in all the plugins to resolve all possible First
+    # get the default ones in the ckan/logic/action directory Rather
+    # than writing them out in full will use importlib.import_module
     # to load anything from ckan.logic.action that looks like it might
     # be an action
     for action_module_name in ['get', 'create', 'update', 'delete', 'patch']:
-        module_path = 'ckan.logic.action.' + action_module_name
-        module = __import__(module_path)
-        for part in module_path.split('.')[1:]:
-            module = getattr(module, part)
-        for k, v in module.__dict__.items():
-            if not k.startswith('_') and not isinstance(v, LocalProxy):
-                # Only load functions from the action module or already
-                # replaced functions.
-                if (hasattr(v, '__call__') and
-                        (v.__module__ == module_path or
-                         hasattr(v, '__replaced'))):
-                    _actions[k] = v
-
-                    # Whitelist all actions defined in logic/action/get.py as
-                    # being side-effect free.
-                    if action_module_name == 'get' and \
-                       not hasattr(v, 'side_effect_free'):
-                        v.side_effect_free = True
+        module = importlib.import_module(
+            '.' + action_module_name, 'ckan.logic.action')
+        for k, v in authz.get_local_public_functions(module):
+            _actions[k] = v
+            # Whitelist all actions defined in logic/action/get.py as
+            # being side-effect free.
+            if action_module_name == 'get' and \
+               not hasattr(v, 'side_effect_free'):
+                v.side_effect_free = True
 
     # Then overwrite them with any specific ones in the plugins:
     resolved_action_plugins = {}
@@ -491,12 +485,6 @@ def get_action(action):
                     pass
                 return result
             return wrapped
-
-        # If we have been called multiple times for example during tests then
-        # we need to make sure that we do not rewrap the actions.
-        if hasattr(_action, '__replaced'):
-            _actions[action_name] = _action.__replaced
-            continue
 
         fn = make_wrapped(_action, action_name)
         # we need to mirror the docstring
@@ -715,16 +703,8 @@ def model_name_to_class(model_module, model_name):
 
 def _import_module_functions(module_path):
     '''Import a module and get the functions and return them in a dict'''
-    functions_dict = {}
-    module = __import__(module_path)
-    for part in module_path.split('.')[1:]:
-        module = getattr(module, part)
-    for k, v in module.__dict__.items():
-
-        try:
-            if v.__module__ != module_path:
-                continue
-            functions_dict[k] = v
-        except AttributeError:
-            pass
-    return functions_dict
+    module = importlib.import_module(module_path)
+    return {
+        k: v
+        for k, v in authz.get_local_public_functions(module)
+    }

--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -401,7 +401,7 @@ def get_action(action):
     for action_module_name in ['get', 'create', 'update', 'delete', 'patch']:
         module = importlib.import_module(
             '.' + action_module_name, 'ckan.logic.action')
-        for k, v in authz.get_local_public_functions(module):
+        for k, v in authz.get_local_functions(module):
             _actions[k] = v
             # Whitelist all actions defined in logic/action/get.py as
             # being side-effect free.
@@ -706,5 +706,5 @@ def _import_module_functions(module_path):
     module = importlib.import_module(module_path)
     return {
         k: v
-        for k, v in authz.get_local_public_functions(module)
+        for k, v in authz.get_local_functions(module)
     }

--- a/ckan/model/core.py
+++ b/ckan/model/core.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
-log = __import__('logging').getLogger(__name__)
+import logging
+log = logging.getLogger(__name__)
 
 
 class State(object):

--- a/ckan/model/license.py
+++ b/ckan/model/license.py
@@ -2,7 +2,7 @@
 
 import datetime
 import re
-
+import logging
 import requests
 
 from ckan.common import config
@@ -13,7 +13,7 @@ from six import text_type, string_types
 from ckan.common import _, json
 import ckan.lib.maintain as maintain
 
-log = __import__('logging').getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 class License(object):

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -397,10 +397,7 @@ content type, cookies, etc.
         assert config_var in ('extra_template_paths', 'extra_public_paths')
         # we want the filename that of the function caller but they will
         # have used one of the available helper functions
-        # TODO: starting from python 3.5, `inspect.stack` returns list
-        # of named tuples `FrameInfo`. Don't forget to remove
-        # `getframeinfo` wrapper after migration.
-        filename = inspect.getframeinfo(inspect.stack()[2][0]).filename
+        filename = inspect.stack()[2].filename
 
         this_dir = os.path.dirname(filename)
         absolute_path = os.path.join(this_dir, relative_path)
@@ -431,7 +428,7 @@ content type, cookies, etc.
         # TODO: starting from python 3.5, `inspect.stack` returns list
         # of named tuples `FrameInfo`. Don't forget to remove
         # `getframeinfo` wrapper after migration.
-        filename = inspect.getframeinfo(inspect.stack()[1][0]).filename
+        filename = inspect.stack()[1].filename
 
         this_dir = os.path.dirname(filename)
         absolute_path = os.path.join(this_dir, path)

--- a/ckan/tests/controllers/test_organization.py
+++ b/ckan/tests/controllers/test_organization.py
@@ -5,6 +5,7 @@ import six
 from bs4 import BeautifulSoup
 from unittest.mock import patch
 
+import ckan.authz as authz
 from ckan import model
 from ckan.lib.helpers import url_for
 from ckan.tests import factories, helpers
@@ -54,14 +55,14 @@ class TestOrganizationNew(object):
 
 @pytest.mark.usefixtures("with_request_context")
 class TestOrganizationList(object):
-    @patch(
-        "ckan.logic.auth.get.organization_list",
-        return_value={"success": False},
-    )
     @pytest.mark.usefixtures("clean_db")
     def test_error_message_shown_when_no_organization_list_permission(
-        self, mock_check_access, app
+        self, monkeypatch, app
     ):
+        authz._AuthFunctions.get('organization_list')
+        monkeypatch.setitem(
+            authz._AuthFunctions._functions, 'organization_list',
+            lambda *args: {'success': False})
         self.user = factories.User()
         self.user_env = {"REMOTE_USER": six.ensure_str(self.user["name"])}
         self.organization_list_url = url_for("organization.index")

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -4,6 +4,7 @@ from bs4 import BeautifulSoup
 from werkzeug.routing import BuildError
 import unittest.mock as mock
 
+import ckan.authz as authz
 from ckan.lib.helpers import url_for
 import pytest
 import six
@@ -55,16 +56,18 @@ class TestPackageNew(object):
 
     @pytest.mark.ckan_config("ckan.auth.create_unowned_dataset", "false")
     @pytest.mark.ckan_config("ckan.auth.user_create_organizations", "false")
-    @mock.patch("ckan.logic.auth.create.package_create")
     def test_needs_organization_but_no_organizations_no_button(
-        self, mock_p_create, app
+        self, monkeypatch, app
     ):
         """ Scenario: The settings say every dataset needs an organization
         but there are no organizations. If the user is not allowed to create an
         organization they should be told to ask the admin but no link should be
         presented. Note: This cannot happen with the default ckan and requires
         a plugin to overwrite the package_create behavior"""
-        mock_p_create.return_value = {"success": True}
+        authz._AuthFunctions.get('package_create')
+        monkeypatch.setitem(
+            authz._AuthFunctions._functions, 'package_create',
+            lambda *args: {'success': True})
 
         user = factories.User()
 

--- a/ckan/tests/legacy/test_coding_standards.py
+++ b/ckan/tests/legacy/test_coding_standards.py
@@ -19,6 +19,7 @@ are legitimate reasons for the failure.
 from __future__ import print_function
 import inspect
 import itertools
+import importlib
 import os
 import re
 import sys
@@ -571,6 +572,7 @@ class TestActionAuth(object):
     @classmethod
     def process(cls):
         def get_functions(module_root):
+            import ckan.authz as authz
             fns = {}
             for auth_module_name in [
                 "get",
@@ -580,22 +582,12 @@ class TestActionAuth(object):
                 "patch",
             ]:
                 module_path = "%s.%s" % (module_root, auth_module_name)
-                try:
-                    module = __import__(module_path)
-                except ImportError:
-                    print('No auth module for action "%s"' % auth_module_name)
-
-                for part in module_path.split(".")[1:]:
-                    module = getattr(module, part)
-
-                for key, v in module.__dict__.items():
-                    if not hasattr(v, "__call__"):
-                        continue
-                    if v.__module__ != module_path:
-                        continue
-                    if not key.startswith("_"):
-                        name = "%s: %s" % (auth_module_name, key)
-                        fns[name] = v
+                module = importlib.import_module(module_path)
+                members = inspect.getmembers(
+                    module, lambda f: authz.is_local_public_function(f, module))
+                for key, v in members:
+                    name = "%s: %s" % (auth_module_name, key)
+                    fns[name] = v
             return fns
 
         cls.actions = get_functions("logic.action")

--- a/ckan/tests/legacy/test_coding_standards.py
+++ b/ckan/tests/legacy/test_coding_standards.py
@@ -583,8 +583,7 @@ class TestActionAuth(object):
             ]:
                 module_path = "%s.%s" % (module_root, auth_module_name)
                 module = importlib.import_module(module_path)
-                members = inspect.getmembers(
-                    module, lambda f: authz.is_local_public_function(f, module))
+                members = authz.get_local_functions(module)
                 for key, v in members:
                     name = "%s: %s" % (auth_module_name, key)
                     fns[name] = v

--- a/ckan/tests/test_authz.py
+++ b/ckan/tests/test_authz.py
@@ -76,3 +76,12 @@ def test_get_user_inside_web_request_returns_user_obj():
 def test_get_user_inside_web_request_not_found():
 
     assert auth._get_user('example') is None
+
+
+@pytest.mark.usefixtures('with_request_context', 'app')
+def test_no_attributes_set_on_imported_auth_members():
+    import ckan.logic.auth.get as auth_get
+    import ckan.plugins.toolkit as tk
+    tk.check_access('site_read', {})
+    assert hasattr(auth_get.package_show, 'auth_allow_anonymous_access')
+    assert not hasattr(auth_get.config, 'auth_allow_anonymous_access')

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 import logging
+import inspect
 from collections import OrderedDict
 from functools import partial
 from six.moves.urllib.parse import urlencode
@@ -57,11 +58,10 @@ def _setup_template_variables(context, data_dict, package_type=None):
 def _get_pkg_template(template_type, package_type=None):
     pkg_plugin = lookup_package_plugin(package_type)
     method = getattr(pkg_plugin, template_type)
-    try:
+    signature = inspect.signature(method)
+    if len(signature.parameters):
         return method(package_type)
-    except TypeError as err:
-        if u'takes 1' not in str(err) and u'takes exactly 1' not in str(err):
-            raise
+    else:
         return method()
 
 

--- a/ckanext/stats/__init__.py
+++ b/ckanext/stats/__init__.py
@@ -1,1 +1,3 @@
 # encoding: utf-8
+
+__import__('pkg_resources').declare_namespace(__name__)

--- a/ckanext/stats/__init__.py
+++ b/ckanext/stats/__init__.py
@@ -1,3 +1,1 @@
 # encoding: utf-8
-
-__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
1. Use `importlib.import_module` instead of `__import__`. It saves us few lines of code
2. Filter out all non-local members when adding `auth_allow_anonymous_access` attribute to auth functions. Right now this attribute is assigned to every variable imported by `auth.{get,update,create,delete,patch}` including `config`, `_`, etc.
3. Update a bit code for `add_template/add_resource` toolkit functions. Now we can rely on py3 functionality of `inspect` module
4. Check the number of arguments accepted by `ckan.views.dataset:_get_pkg_template` instead of testing text of raised exception