### PR TITLE
Datatables linkification truncation refactor

### DIFF
--- a/ckanext/datatablesview/public/datatables_view.css
+++ b/ckanext/datatablesview/public/datatables_view.css
@@ -46,7 +46,7 @@ table.dataTable td {
 
 /* but show the data on hover */
 table.dataTable td:hover {
-   white-space: normal;
+   white-space: break-spaces;  /* normal; */
    word-break: break-all;
    overflow: visible;
    text-overflow: visible;

--- a/ckanext/datatablesview/public/datatablesview.js
+++ b/ckanext/datatablesview/public/datatablesview.js
@@ -241,21 +241,21 @@ function initFilterObserver () {
 // helper for converting links in text into clickable links
 const linkify = (input) => {
   let text = input
-  const linksFound = text.match(/(\b(www|https?)[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig)
+  const linksFound = text.match(/(\b(https?)[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig)
   const links = []
   if (linksFound != null) {
     if (linksFound.length === 1 && input.match(/\.(jpeg|jpg|gif|png|svg|apng|webp|avif)$/)) {
       // the whole text is just one link and its a picture, create a thumbnail
       text = '<div class="thumbnail zoomthumb"><a href="' + linksFound[0] + '" target="_blank"><img src="' + linksFound[0] + '"></a></div>'
-      return text
+      return { text: text, links: linksFound }
     }
     for (let i = 0; i < linksFound.length; i++) {
       links.push('<a href="' + linksFound[i] + '" target="_blank">' + linksFound[i] + '</a>')
       text = text.split(linksFound[i]).map(item => { return item }).join(links[i])
     }
-    return text
+    return { text: text, links: linksFound }
   } else {
-    return input
+    return { text: input, links: [] }
   }
 }
 
@@ -283,7 +283,7 @@ this.ckan.module('datatables_view', function (jQuery) {
       const stateduration = parseInt(dtprv.data('state-duration'))
       const ellipsislength = parseInt(dtprv.data('ellipsis-length'))
       const dateformat = dtprv.data('date-format').trim()
-      const formatdateflag = dateformat.toUpperCase() === 'NONE' ? false : true
+      const formatdateflag = dateformat.toUpperCase() !== 'NONE'
       const packagename = dtprv.data('package-name')
       const responsiveflag = dtprv.data('responsive-flag')
       const pagelengthchoices = dtprv.data('page-length-choices')
@@ -330,36 +330,53 @@ this.ckan.module('datatables_view', function (jQuery) {
             break
           default:
             colDict.type = 'html'
-            if (ellipsislength) {
-              colDict.render = function (data, type, row, meta) {
-                // Order, search and type get the original data
-                if (type !== 'display') {
-                  return data
-                }
-                if (typeof data !== 'number' && typeof data !== 'string') {
-                  return data
-                }
-                data = data.toString() // cast numbers
-                const linkifiedData = linkify(data)
-                // if there are no http links, see if we need to apply ellipsis truncation logic
-                if (linkifiedData === data) {
-                  if (data.length <= ellipsislength) {
-                    return data
-                  }
-                  const shortened = data.substr(0, ellipsislength - 1)
-                  return '<span class="ellipsis" title="' + esc(data) + '">' + shortened + '&#8230;</span>'
-                } else {
-                  // there are links
-                  const strippedData = linkifiedData.replace(/(<([^>]+)>)/gi, '')
-                  if (strippedData.length <= ellipsislength) {
-                    return linkifiedData
-                  }
-                  const shortened = linkifiedData.substr(0, ellipsislength - 1)
-                  return '<span class="ellipsis" title="' + esc(strippedData) + '">' + shortened + '&#8230;</span>'
-                }
-              }
-            } else {
+            if (!ellipsislength) {
               colDict.className = 'wrapcell'
+            }
+            colDict.render = function (data, type, row, meta) {
+              // Order, search and type get the original data
+              if (type !== 'display') {
+                return data
+              }
+              if (typeof data !== 'number' && typeof data !== 'string') {
+                return data
+              }
+              data = data.toString() // cast numbers
+
+              const linkifiedData = linkify(data)
+              // if there are no http links, see if we need to apply ellipsis truncation logic
+              if (!linkifiedData.links) {
+                // no links, just do simple truncation if ellipsislength is defined
+                if (!ellipsislength || data.length <= ellipsislength) {
+                  return data
+                }
+                const shortened = data.substr(0, ellipsislength - 1).trimEnd()
+                return '<span class="ellipsis" title="' + esc(data) + '">' + shortened + '&#8230;</span>'
+              } else {
+                // there are links
+                const strippedData = linkifiedData.text.replace(/(<([^>]+)>)/gi, '')
+                if (!ellipsislength || strippedData.length <= ellipsislength) {
+                  return linkifiedData.text
+                }
+                let linkpos = ellipsislength
+                let lastpos = ellipsislength
+                let lastlink = ''
+                let addLen = 0
+                // check if truncation point is in the middle of a link
+                for (const aLink of linkifiedData.links) {
+                  linkpos = data.indexOf(aLink)
+                  if (linkpos + aLink.length >= ellipsislength) {
+                    // truncation point is in the middle of a link, truncate to where the link started
+                    break
+                  } else {
+                    addLen = addLen + lastlink.length ? (lastlink.length) + 31 : 0 // 31 is the number of other chars in the full anchor tag
+                    lastpos = linkpos
+                    lastlink = aLink
+                  }
+                }
+                const shortened = linkifiedData.text.substr(0, lastpos + addLen).trimEnd()
+                return '<span class="ellipsis" title="' + esc(strippedData) + '">' + shortened + '&#8230;</span>'
+              }
             }
         }
         dynamicCols.push(colDict)
@@ -411,14 +428,15 @@ this.ckan.module('datatables_view', function (jQuery) {
             // render the Record Details in a modal dialog box
             // do not render the _colspacer column, which has the 'none' class
             // the none class in responsive mode forces the _colspacer column to be hidden
-            // guaranteeing the green display record button is always displayed, even for narrow tables
+            // guaranteeing the blue record details button is always displayed, even for narrow tables
+            // also, when a column's content has been truncated with an ellipsis, show the untruncated content
             renderer: function (api, rowIdx, columns) {
               const data = $.map(columns, function (col, i) {
                 return col.className !== 'none'
                   ? '<tr class="dt-body-right" data-dt-row="' + col.rowIndex + '" data-dt-column="' + col.columnIndex + '">' +
-                    '<td>' + col.title + ':' + '</td> ' +
-                    '<td>' + col.data + '</td>' +
-                    '</tr>'
+                    '<td>' + col.title + ':' + '</td><td>' +
+                    (col.data.startsWith('<span class="ellipsis"') ? col.data.substr(30, col.data.indexOf('">') - 30) : col.data) +
+                    '</td></tr>'
                   : ''
               }).join('')
               return data ? $('<table class="dtr-details" width="100%"/>').append(data) : false
@@ -824,12 +842,12 @@ this.ckan.module('datatables_view', function (jQuery) {
       // EVENT HANDLERS
       // called before making AJAX request
       datatable.on('preXhr', function (e, settings, data) {
-        gstartTime = performance.now()
+        gstartTime = window.performance.now()
       })
 
       // called after getting an AJAX response from CKAN
       datatable.on('xhr', function (e, settings, json, xhr) {
-        gelaspedTime = performance.now() - gstartTime
+        gelaspedTime = window.performance.now() - gstartTime
       })
 
       // save state of table when row selection is changed

--- a/ckanext/datatablesview/public/vendor/DataTables/datatables.css
+++ b/ckanext/datatablesview/public/vendor/DataTables/datatables.css
@@ -4,10 +4,10 @@
  *
  * To rebuild or modify this file with the latest versions of the included
  * software please visit:
- *   https://datatables.net/download/#bs/dt-1.10.24/b-1.7.0/b-colvis-1.7.0/b-html5-1.7.0/b-print-1.7.0/cr-1.5.3/fc-3.3.2/kt-2.6.1/r-2.2.7/sl-1.3.2
+ *   https://datatables.net/download/#bs/dt-1.10.24/b-1.7.0/b-colvis-1.7.0/b-html5-1.7.0/b-print-1.7.0/cr-1.5.3/fc-3.3.2/kt-2.6.1/r-2.2.7/sl-1.3.3
  *
  * Included libraries:
- *   DataTables 1.10.24, Buttons 1.7.0, Column visibility 1.7.0, HTML5 export 1.7.0, Print view 1.7.0, ColReorder 1.5.3, FixedColumns 3.3.2, KeyTable 2.6.1, Responsive 2.2.7, Select 1.3.2
+ *   DataTables 1.10.24, Buttons 1.7.0, Column visibility 1.7.0, HTML5 export 1.7.0, Print view 1.7.0, ColReorder 1.5.3, FixedColumns 3.3.2, KeyTable 2.6.1, Responsive 2.2.7, Select 1.3.3
  */
 
 @charset "UTF-8";
@@ -667,7 +667,6 @@ div.dtr-bs-modal table.table tr:first-child td {
 }
 
 
-@charset "UTF-8";
 table.dataTable tbody > tr.selected,
 table.dataTable tbody > tr > .selected {
   background-color: #08C;

--- a/ckanext/datatablesview/public/vendor/DataTables/datatables.js
+++ b/ckanext/datatablesview/public/vendor/DataTables/datatables.js
@@ -4,10 +4,10 @@
  *
  * To rebuild or modify this file with the latest versions of the included
  * software please visit:
- *   https://datatables.net/download/#bs/dt-1.10.24/b-1.7.0/b-colvis-1.7.0/b-html5-1.7.0/b-print-1.7.0/cr-1.5.3/fc-3.3.2/kt-2.6.1/r-2.2.7/sl-1.3.2
+ *   https://datatables.net/download/#bs/dt-1.10.24/b-1.7.0/b-colvis-1.7.0/b-html5-1.7.0/b-print-1.7.0/cr-1.5.3/fc-3.3.2/kt-2.6.1/r-2.2.7/sl-1.3.3
  *
  * Included libraries:
- *   DataTables 1.10.24, Buttons 1.7.0, Column visibility 1.7.0, HTML5 export 1.7.0, Print view 1.7.0, ColReorder 1.5.3, FixedColumns 3.3.2, KeyTable 2.6.1, Responsive 2.2.7, Select 1.3.2
+ *   DataTables 1.10.24, Buttons 1.7.0, Column visibility 1.7.0, HTML5 export 1.7.0, Print view 1.7.0, ColReorder 1.5.3, FixedColumns 3.3.2, KeyTable 2.6.1, Responsive 2.2.7, Select 1.3.3
  */
 
 /*! DataTables 1.10.24
@@ -13971,7 +13971,7 @@
 		 *
 		 *  @type string
 		 */
-		build:"bs/dt-1.10.24/b-1.7.0/b-colvis-1.7.0/b-html5-1.7.0/b-print-1.7.0/cr-1.5.3/fc-3.3.2/kt-2.6.1/r-2.2.7/sl-1.3.2",
+		build:"bs/dt-1.10.24/b-1.7.0/b-colvis-1.7.0/b-html5-1.7.0/b-print-1.7.0/cr-1.5.3/fc-3.3.2/kt-2.6.1/r-2.2.7/sl-1.3.3",
 	
 	
 		/**
@@ -25684,7 +25684,7 @@ return Responsive;
 }));
 
 
-/*! Select for DataTables 1.3.2
+/*! Select for DataTables 1.3.3
  * 2015-2021 SpryMedia Ltd - datatables.net/license/mit
  */
 
@@ -25692,7 +25692,7 @@ return Responsive;
  * @summary     Select for DataTables
  * @description A collection of API methods, events and buttons for DataTables
  *   that provides selection options of the items in a DataTable
- * @version     1.3.2
+ * @version     1.3.3
  * @file        dataTables.select.js
  * @author      SpryMedia Ltd (www.sprymedia.co.uk)
  * @contact     datatables.net/forums
@@ -25740,7 +25740,7 @@ var DataTable = $.fn.dataTable;
 // Version information for debugger
 DataTable.select = {};
 
-DataTable.select.version = '1.3.2';
+DataTable.select.version = '1.3.3';
 
 DataTable.select.init = function ( dt ) {
 	var ctx = dt.settings()[0];


### PR DESCRIPTION
Fixes #6013 and some minor tweaks.

### Proposed fixes:
- linkification/truncation now works properly when truncating near a link as per expected behavior in #6013 
- only linkify links with `http/s` prefix. Do not linkify `www` links anymore as it complicates the logic for this truncation/linkification fix
- cell content is no longer truncated in modal Details display in list/responsive mode

Also, some minor tweaks:
 - simplified conditional operator for formatdateflag
 - fully qualified performance function (used for displaying search time in Filter Info tooltip)
 - bumped datatables select plugin to 1.3.3
 -  change table cell hover white-space CSS from `normal` to `break-spaces`. More of a preference given the data I'm using for testing, that's why I left the `normal` comment (https://developer.mozilla.org/en-US/docs/Web/CSS/white-space#in_action)

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
