### PR TITLE
[#6018] replaced package_read with package_show

### DIFF
--- a/ckan/views/feed.py
+++ b/ckan/views/feed.py
@@ -174,7 +174,7 @@ def output_feed(results, feed_title, feed_description, feed_link, feed_url,
             title=pkg.get(u'title', u''),
             link=h.url_for(
                 u'api.action',
-                logic_function=u'package_read',
+                logic_function=u'package_show',
                 id=pkg['id'],
                 ver=3,
                 _external=True),


### PR DESCRIPTION
Fixes #6018 

### Proposed fixes:
Updated feed.py to use package_show instead of package_read


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
