### PR TITLE
Delete resource views if type changes

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -110,11 +110,21 @@ def resource_update(context, data_dict):
     resource = _get_action('resource_show')(context, {'id': id})
 
     if old_resource_format != resource['format']:
-        _get_action('resource_create_default_resource_views')(
-            {'model': context['model'], 'user': context['user'],
-             'ignore_auth': True},
-            {'package': updated_pkg_dict,
-             'resource': resource})
+        context_views = {
+            'model': context['model'],
+            'user': context['user'],
+            'ignore_auth': True
+            }
+        views = _get_action('resource_view_list')(context_views, {
+            'id': resource['id']
+        })
+        for view in views:
+            _get_action('resource_view_delete')(context_views, {
+            'id': view['id']
+            })
+        _get_action('resource_create_default_resource_views')(context_views, {
+            'package': updated_pkg_dict, 'resource': resource
+            })
 
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.after_update(context, resource)

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -1260,7 +1260,7 @@ class TestResourceUpdate(object):
             "resource_view_list", id=second_resource["id"]
         )
 
-        assert len(res_views) == 2
+        assert len(res_views) == 1
 
         third_resource = factories.Resource(
             package=dataset, url="http://localhost", name="Test2"


### PR DESCRIPTION
Currently when a resource is updated and it changes it format, it triggers the creation of new default resources views but it doesn't clean the current ones.

This may cause that a resource that changed from PDF to CSV to maintain 2 non-compatible views.

### Proposed fixes:
Remove the current resource_views if the format changes since it is fair to assume that different resource types will show different types of views.

I tried to create a new action to delete all the views of a resource (so it can be reused) but `resource_view_clean` is already taken and I cannot define a good name for it :facepalm:. Suggestions are welcome!