### PR TITLE
Removed Ubuntu 16.04 (and 14.04) references in documentation

### DIFF
--- a/doc/maintaining/installing/install-from-docker-compose.rst
+++ b/doc/maintaining/installing/install-from-docker-compose.rst
@@ -22,7 +22,7 @@ taken to use this setup in production.
 --------------
 1. Environment
 --------------
-This tutorial was tested on Ubuntu 16.04 LTS.
+This tutorial was tested on Ubuntu 20.04 LTS.
 The hosts can be local environments or cloud VMs. It is assumed that the user has direct access
 (via terminal / ssh) to the systems and root permissions.
 

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -14,8 +14,8 @@ wiki page.
 
 **For Python 3 installations, the minimum Python version required is 3.6**
 
+* **Ubuntu 20.04** includes **Python 3.8** as part of its distribution
 * **Ubuntu 18.04** includes **Python 3.6** as part of its distribution
-* **Ubuntu 16.04** includes **Python 3.5** as part of its distribution
 
 From source is also the right installation method for developers who want to
 work on CKAN.

--- a/doc/maintaining/upgrading/upgrade-package-ckan-1-to-2.rst
+++ b/doc/maintaining/upgrading/upgrade-package-ckan-1-to-2.rst
@@ -9,7 +9,7 @@ Upgrading a CKAN 1 package install to CKAN 2.x
    `documentation <http://docs.ckan.org/en/ckan-1.8/install-from-package.html#upgrading-a-package-install>`_
    relevant to the old CKAN packaging system.
 
-The CKAN 2.x packages require Ubuntu 16.04 64-bit or 14.04 64-bit, whereas previous CKAN
+The CKAN 2.x packages require Ubuntu 20.04 64-bit or 18.04 64-bit, whereas previous CKAN
 packages used Ubuntu 10.04. CKAN 2.x also introduces many
 backwards-incompatible feature changes (see :doc:`the changelog </changelog>`).
 So it's not possible to automatically upgrade to a CKAN 2.x package install.
@@ -28,7 +28,7 @@ database and any custom configuration, extensions or templates to your new CKAN
 
 #. Install CKAN 2.x, either from a
    :doc:`package install </maintaining/installing/install-from-package>`
-   if you have Ubuntu 16.04 or 14.04 64-bit, or from a
+   if you have Ubuntu 20.04 or 18.04 64-bit, or from a
    :doc:`source install </maintaining/installing/install-from-source>`
    otherwise.
 

--- a/doc/maintaining/upgrading/upgrade-postgres.rst
+++ b/doc/maintaining/upgrading/upgrade-postgres.rst
@@ -271,7 +271,6 @@ Upgrading
 #. Download the CKAN package for the new minor release you want to upgrade
    to (replace the version number with the relevant one)::
 
-     On Ubuntu 16.04: wget https://packaging.ckan.org/python-ckan_2.9-xenial_amd64.deb
      On Ubuntu 18.04: wget https://packaging.ckan.org/python-ckan_2.9-bionic_amd64.deb
      On Ubuntu 20.04: wget https://packaging.ckan.org/python-ckan_2.9-py3-focal_amd64.deb (for Python 3)
 


### PR DESCRIPTION
Fixes #6016 

### Proposed fixes:
Ubuntu 16.04 will reach end-of-life April 30, 2021. The documentation that references  Ubuntu 16.04 has been removed. Also, the CKAN Docker installation was tested on Ubuntu 20.04


### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
