### PR TITLE
make password reset landing page configurable

### DIFF
--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -661,14 +661,18 @@ class RequestResetView(MethodView):
                 h.flash_error(_(u'Error sending the email. Try again later '
                                 'or contact an administrator for help'))
                 log.exception(e)
-                return h.redirect_to(u'home.index')
+                return h.redirect_to(config.get(
+                    u'ckan.user_reset_landing_page',
+                    u'home.index'))
 
         # always tell the user it succeeded, because otherwise we reveal
         # which accounts exist or not
         h.flash_success(
             _(u'A reset link has been emailed to you '
               '(unless the account specified does not exist)'))
-        return h.redirect_to(u'home.index')
+        return h.redirect_to(config.get(
+            u'ckan.user_reset_landing_page',
+            u'home.index'))
 
     def get(self):
         self._prepare()
@@ -734,7 +738,9 @@ class PerformResetView(MethodView):
             mailer.create_reset_key(context[u'user_obj'])
 
             h.flash_success(_(u'Your password has been reset.'))
-            return h.redirect_to(u'home.index')
+            return h.redirect_to(config.get(
+                u'ckan.user_reset_landing_page',
+                u'home.index'))
         except logic.NotAuthorized:
             h.flash_error(_(u'Unauthorized to edit user %s') % id)
         except logic.NotFound:

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -1760,7 +1760,7 @@ Default value: ``7200``
 Duration (in seconds) for which the saved state information is considered valid. After this period has elapsed, the table's state will
 be returned to the default, and the state cleared from the browser's localStorage.
 
-.. note:: The value ``0`` is a special value as it indicates that the state can be stored and retrieved indefinitely with no time limit. 
+.. note:: The value ``0`` is a special value as it indicates that the state can be stored and retrieved indefinitely with no time limit.
 
 .. _ckan.datatables.data_dictionary_labels:
 
@@ -1774,7 +1774,7 @@ Example::
 Default value: ``True``
 
 Enable or disable data dictionary integration. When enabled, a column's data dictionary label will be used in the table header. A tooltip for each
-column with data dictionary information will also be integrated into the header. 
+column with data dictionary information will also be integrated into the header.
 
 .. _ckan.datatables.ellipsis_length:
 
@@ -2103,6 +2103,19 @@ Default value: ``20``
 
 This controls the number of users to show in the Users list. By default, it shows 20 users.
 
+.. _ckan.user_reset_landing_page:
+
+ckan.user_reset_landing_page
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+  ckan.user_reset_landing_page = dataset
+
+Default value: ``home.index``
+
+This controls the page where users will be sent after requesting a password reset.
+This is ordinarily the home page, but specific sites may prefer somewhere else.
 
 Activity Streams Settings
 -------------------------


### PR DESCRIPTION
Fixes #6030

### Proposed fixes:

Add an optional configuration entry for controlling the landing page after requesting a password reset.

### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport
