### PR TITLE
Replace old mailing list with google groups

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ If you find a potential security vulnerability please email security@ckan.org,
 rather than creating a public issue on GitHub.
 
 .. _CKAN tag on Stack Overflow: http://stackoverflow.com/questions/tagged/ckan
-.. _archives: https://www.google.com/search?q=%22%5Bckan-dev%5D%22+site%3Alists.okfn.org.
+.. _archives: https://groups.google.com/a/ckan.org/g/ckan-dev
 .. _GitHub Issues: https://github.com/ckan/ckan/issues
 .. _CKAN chat on Gitter: https://gitter.im/ckan/chat
 

--- a/doc/_templates/footer.html
+++ b/doc/_templates/footer.html
@@ -30,7 +30,7 @@
     &mdash;
     <a href="https://github.com/ckan/ckan/issues">Issues</a>
     &mdash;
-    <a href="http://lists.okfn.org/mailman/listinfo/ckan-dev">Mailing List</a>
+    <a href="https://groups.google.com/a/ckan.org/g/ckan-dev">Mailing List</a>
     &mdash;
     <a href="http://twitter.com/CKANProject">Twitter @CKANProject</a>
   </p>

--- a/doc/contributing/release-process.rst
+++ b/doc/contributing/release-process.rst
@@ -329,10 +329,10 @@ Leading up to the release
 #. A week before the actual release, announce the upcoming release(s).
 
    Send an email to the
-   `ckan-announce mailing list <http://lists.okfn.org/mailman/listinfo/ckan-announce>`_,
+   `ckan-announce mailing list <https://groups.google.com/a/ckan.org/g/ckan-announce>`_,
    so CKAN instance maintainers can be aware of the upcoming releases. List any
    patch releases that will be also available. Here's an `example
-   <https://lists.okfn.org/pipermail/ckan-announce/2015-July/000013.html>`_ email.
+   <https://groups.google.com/a/ckan.org/g/ckan-announce/c/BcDR7Guzb44>`_ email.
 
 -----------------------
 Doing the final release
@@ -435,8 +435,8 @@ a release.
 
    CKAN blog here: <http://ckan.org/wp-admin>`_
 
-   * `Example blog <http://ckan.org/2015/07/22/ckan-2-4-release-and-patch-releases/>`_
-   * `Example email <https://lists.okfn.org/pipermail/ckan-dev/2015-July/009141.html>`_
+   * `Example blog <https://ckan.org/2021/02/10/new-patch-releases-available-upgrade-now-your-ckan-site/>`_
+   * `Example email <https://groups.google.com/a/ckan.org/g/ckan-announce/c/BcDR7Guzb44>`_
 
    Tweet from @CKANproject
 

--- a/doc/contributing/simple-code-contributions.rst
+++ b/doc/contributing/simple-code-contributions.rst
@@ -3,21 +3,21 @@ Projects for beginner CKAN developers
 =====================================
 
 The `'Good for Contribution' <https://github.com/ckan/ckan/issues?labels=Good+for+Contribution&state=open>`_
-label on Github lists issues which are feasible for people who aren't 
+label on Github lists issues which are feasible for people who aren't
 intimately familiar with CKAN's internals. Many of them are things which would
 be extremely helpful if they got done, but the core team never seems to get
-around to them. They're all busy wrestling with the problems that do require 
+around to them. They're all busy wrestling with the problems that do require
 familiarity with the internals. We hope this will make it easier for more
 people to assist the CKAN project, by giving new developers places to jump in.
 
 These issues vary from simple text changes to more complicated code changes
-that require more knowledge of Python and CKAN. Do not despair if any 
+that require more knowledge of Python and CKAN. Do not despair if any
 individual task seems daunting; there's probably an easier one. If you have no
-programming skills, we can still use your help with documentation or 
+programming skills, we can still use your help with documentation or
 translation.
 
 If you wish to take up an issue make sure to keep in touch with the team on
 the Github issue itself, the `ckan-dev mailing list`_, or the `CKAN chat on Gitter`_.
 
 .. _CKAN chat on Gitter: https://gitter.im/ckan/chat
-.. _ckan-dev mailing list: http://lists.okfn.org/mailman/listinfo/ckan-dev
+.. _ckan-dev mailing list: https://groups.google.com/a/ckan.org/g/ckan-dev

--- a/doc/maintaining/upgrading/index.rst
+++ b/doc/maintaining/upgrading/index.rst
@@ -68,7 +68,7 @@ Patch Releases
    CKAN 2.0.1 will no longer be supported.
 
 Releases are announced on the
-`ckan-announce mailing list <http://lists.okfn.org/mailman/listinfo/ckan-announce>`_,
+`ckan-announce mailing list <https://groups.google.com/a/ckan.org/g/ckan-announce>`_,
 a low-volume list that CKAN instance maintainers can subscribe to in order to
 be up to date with upcoming releases.
 


### PR DESCRIPTION
Fixes #5609 

### Proposed fixes:
Replaces all lists.ofkn.org entries in the docs with google groups links.


### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
