### PR TITLE
Do not rely on error message when selecting validator signature

### DIFF
--- a/changes/6048.removal
+++ b/changes/6048.removal
@@ -1,0 +1,2 @@
+Only user-defined functions can be used as validators. Attempt to use
+mock-object, built-in function or class will cause TypeError.

--- a/ckan/lib/navl/dictization_functions.py
+++ b/ckan/lib/navl/dictization_functions.py
@@ -2,7 +2,6 @@
 
 import copy
 import json
-import inspect
 
 import six
 from six import text_type

--- a/ckan/lib/navl/dictization_functions.py
+++ b/ckan/lib/navl/dictization_functions.py
@@ -220,8 +220,12 @@ def augment_data(data, schema):
 
 
 def convert(converter, key, converted_data, errors, context):
-    signature = inspect.signature(converter)
-    nargs = len(signature.parameters)
+    try:
+        nargs = converter.__code__.co_argcount
+    except AttributeError:
+        raise TypeError(
+            f"{converter.__name__} cannot be used as validator "
+            "because it is not a user-defined function")
     if nargs == 1:
         params = (converted_data.get(key),)
     elif nargs == 2:
@@ -230,7 +234,8 @@ def convert(converter, key, converted_data, errors, context):
         params = (key, converted_data, errors, context)
     else:
         raise TypeError(
-            f"Wrong number of arguments(expected 1, 2 or 4): {nargs}")
+            "Wrong number of arguments for "
+            f"{converter.__name__}(expected 1, 2 or 4): {nargs}")
     try:
         value = converter(*params)
         # 4-args version sets value internally

--- a/ckan/lib/navl/dictization_functions.py
+++ b/ckan/lib/navl/dictization_functions.py
@@ -2,6 +2,7 @@
 
 import copy
 import json
+import inspect
 
 import six
 from six import text_type
@@ -219,35 +220,22 @@ def augment_data(data, schema):
 
 
 def convert(converter, key, converted_data, errors, context):
-
+    signature = inspect.signature(converter)
+    nargs = len(signature.parameters)
+    if nargs == 1:
+        params = (converted_data.get(key),)
+    elif nargs == 2:
+        params = (converted_data.get(key), context)
+    elif nargs == 4:
+        params = (key, converted_data, errors, context)
+    else:
+        raise TypeError(
+            f"Wrong number of arguments(expected 1, 2 or 4): {nargs}")
     try:
-        value = converter(converted_data.get(key))
-        converted_data[key] = value
-        return
-    except TypeError as e:
-        # hack to make sure the type error was caused by the wrong
-        # number of arguments given.
-        if converter.__name__ not in str(e):
-            raise
-    except Invalid as e:
-        errors[key].append(e.error)
-        return
-
-    try:
-        converter(key, converted_data, errors, context)
-        return
-    except Invalid as e:
-        errors[key].append(e.error)
-        return
-    except TypeError as e:
-        # hack to make sure the type error was caused by the wrong
-        # number of arguments given.
-        if converter.__name__ not in str(e):
-            raise
-
-    try:
-        value = converter(converted_data.get(key), context)
-        converted_data[key] = value
+        value = converter(*params)
+        # 4-args version sets value internally
+        if nargs != 4:
+            converted_data[key] = value
         return
     except Invalid as e:
         errors[key].append(e.error)

--- a/ckan/lib/navl/validators.py
+++ b/ckan/lib/navl/validators.py
@@ -15,6 +15,11 @@ Invalid = df.Invalid
 def identity_converter(key, data, errors, context):
     return
 
+
+def string(value):
+    return str(value)
+
+
 def keep_extras(key, data, errors, context):
 
     extras = data.pop(key, {})

--- a/ckan/lib/navl/validators.py
+++ b/ckan/lib/navl/validators.py
@@ -16,10 +16,6 @@ def identity_converter(key, data, errors, context):
     return
 
 
-def string(value):
-    return str(value)
-
-
 def keep_extras(key, data, errors, context):
 
     extras = data.pop(key, {})
@@ -80,7 +76,7 @@ def ignore(key, data, errors, context):
     raise StopOnError
 
 def default(default_value):
-    '''When key is missing or value is an empty string or None, replace it with
+    '''When key is missing or value is an empty strisng or None, replace it with
     a default value'''
 
     def callable(key, data, errors, context):

--- a/ckan/lib/navl/validators.py
+++ b/ckan/lib/navl/validators.py
@@ -76,7 +76,7 @@ def ignore(key, data, errors, context):
     raise StopOnError
 
 def default(default_value):
-    '''When key is missing or value is an empty strisng or None, replace it with
+    '''When key is missing or value is an empty string or None, replace it with
     a default value'''
 
     def callable(key, data, errors, context):

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -999,9 +999,10 @@ def term_translation_update(context, data_dict):
 
     _check_access('term_translation_update', context, data_dict)
 
-    schema = {'term': [validators.not_empty, text_type],
-              'term_translation': [validators.not_empty, text_type],
-              'lang_code': [validators.not_empty, text_type]}
+    schema = {'term': [validators.not_empty, validators.unicode_safe],
+              'term_translation': [
+                  validators.not_empty, validators.unicode_safe],
+              'lang_code': [validators.not_empty, validators.unicode_safe]}
 
     data, errors = _validate(data_dict, schema, context)
     if errors:

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -3,7 +3,6 @@
 from functools import wraps
 import inspect
 
-from six import text_type
 import ckan.model
 import ckan.plugins as plugins
 from ckan.logic import get_validator
@@ -419,9 +418,9 @@ def user_new_form_schema(
     schema = default_user_schema()
 
     schema['email'] = [email_is_unique]
-    schema['password1'] = [text_type, user_both_passwords_entered,
+    schema['password1'] = [unicode_safe, user_both_passwords_entered,
                            user_password_validator, user_passwords_match]
-    schema['password2'] = [text_type]
+    schema['password2'] = [unicode_safe]
 
     return schema
 
@@ -471,7 +470,7 @@ def default_generate_apikey_user_schema(
 def default_user_invite_schema(
         not_empty, unicode_safe):
     return {
-        'email': [not_empty, text_type],
+        'email': [not_empty, unicode_safe],
         'group_id': [not_empty],
         'role': [not_empty],
     }

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -412,15 +412,15 @@ def default_user_schema(
 
 @validator_args
 def user_new_form_schema(
-        string, user_both_passwords_entered,
+        unicode_safe, user_both_passwords_entered,
         user_password_validator, user_passwords_match,
         email_is_unique):
     schema = default_user_schema()
 
     schema['email'] = [email_is_unique]
-    schema['password1'] = [string, user_both_passwords_entered,
+    schema['password1'] = [unicode_safe, user_both_passwords_entered,
                            user_password_validator, user_passwords_match]
-    schema['password2'] = [string]
+    schema['password2'] = [unicode_safe]
 
     return schema
 
@@ -468,9 +468,9 @@ def default_generate_apikey_user_schema(
 
 @validator_args
 def default_user_invite_schema(
-        not_empty, string):
+        not_empty, unicode_safe):
     return {
-        'email': [not_empty, string],
+        'email': [not_empty, unicode_safe],
         'group_id': [not_empty],
         'role': [not_empty],
     }

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -412,15 +412,15 @@ def default_user_schema(
 
 @validator_args
 def user_new_form_schema(
-        unicode_safe, user_both_passwords_entered,
+        string, user_both_passwords_entered,
         user_password_validator, user_passwords_match,
         email_is_unique):
     schema = default_user_schema()
 
     schema['email'] = [email_is_unique]
-    schema['password1'] = [unicode_safe, user_both_passwords_entered,
+    schema['password1'] = [string, user_both_passwords_entered,
                            user_password_validator, user_passwords_match]
-    schema['password2'] = [unicode_safe]
+    schema['password2'] = [string]
 
     return schema
 
@@ -468,9 +468,9 @@ def default_generate_apikey_user_schema(
 
 @validator_args
 def default_user_invite_schema(
-        not_empty, unicode_safe):
+        not_empty, string):
     return {
-        'email': [not_empty, unicode_safe],
+        'email': [not_empty, string],
         'group_id': [not_empty],
         'role': [not_empty],
     }

--- a/ckan/tests/legacy/lib/test_navl.py
+++ b/ckan/tests/legacy/lib/test_navl.py
@@ -17,6 +17,7 @@ from pprint import pformat
 from ckan.lib.navl.validators import (
     identity_converter,
     empty,
+    unicode_safe,
     not_empty,
     ignore_missing,
     default,
@@ -346,8 +347,8 @@ def test_simple():
 
 def test_simple_converter_types():
     schema = {
-        "name": [not_empty, text_type],
-        "age": [ignore_missing, int],
+        "name": [not_empty, unicode_safe],
+        "age": [ignore_missing, convert_int],
         "gender": [default("female")],
     }
 

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -274,10 +274,13 @@ class TestUpdate(object):
         user = factories.User()
 
         # A mock validator method, it doesn't do anything but it records what
-        # params it gets called with and how many times. We are using lambda
+        # params it gets called with and how many times. We are using function
         # instead of MagicMock, because validator must have __code__ attribute
         calls = []
-        mock_validator = lambda v: calls.append(v) or v
+
+        def mock_validator(v):
+            calls.append(v)
+            return v
 
         # Build a custom schema by taking the default schema and adding our
         # mock method to its 'id' field.

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -274,8 +274,10 @@ class TestUpdate(object):
         user = factories.User()
 
         # A mock validator method, it doesn't do anything but it records what
-        # params it gets called with and how many times.
-        mock_validator = mock.MagicMock()
+        # params it gets called with and how many times. We are using lambda
+        # instead of MagicMock, because validator must have __code__ attribute
+        calls = []
+        mock_validator = lambda v: calls.append(v) or v
 
         # Build a custom schema by taking the default schema and adding our
         # mock method to its 'id' field.
@@ -294,6 +296,7 @@ class TestUpdate(object):
             password=factories.User.password,
             fullname="updated full name",
         )
+        assert calls == [user['id']]
 
     def test_user_update_multiple(self):
         """Test that updating multiple user attributes at once works."""

--- a/ckanext/audioview/plugin.py
+++ b/ckanext/audioview/plugin.py
@@ -4,6 +4,7 @@ from six import text_type
 import ckan.plugins as p
 
 ignore_empty = p.toolkit.get_validator('ignore_empty')
+unicode_safe = p.toolkit.get_validator('unicode_safe')
 
 DEFAULT_AUDIO_FORMATS = 'wav ogg mp3'
 
@@ -24,7 +25,7 @@ class AudioView(p.SingletonPlugin):
         return {'name': 'audio_view',
                 'title': p.toolkit._('Audio'),
                 'icon': 'file-audio-o',
-                'schema': {'audio_url': [ignore_empty, text_type]},
+                'schema': {'audio_url': [ignore_empty, unicode_safe]},
                 'iframed': False,
                 'always_available': True,
                 'default_title': p.toolkit._('Audio'),

--- a/ckanext/datapusher/logic/schema.py
+++ b/ckanext/datapusher/logic/schema.py
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-from six import text_type
-
 import ckan.plugins as p
 import ckanext.datastore.logic.schema as dsschema
 
@@ -12,11 +10,12 @@ not_empty = get_validator('not_empty')
 ignore_missing = get_validator('ignore_missing')
 empty = get_validator('empty')
 boolean_validator = get_validator('boolean_validator')
+unicode_safe = get_validator('unicode_safe')
 
 
 def datapusher_submit_schema():
     schema = {
-        'resource_id': [not_missing, not_empty, text_type],
+        'resource_id': [not_missing, not_empty, unicode_safe],
         'id': [ignore_missing],
         'set_url_type': [ignore_missing, boolean_validator],
         'ignore_hash': [ignore_missing, boolean_validator],

--- a/ckanext/datastore/logic/schema.py
+++ b/ckanext/datastore/logic/schema.py
@@ -24,7 +24,7 @@ default = get_validator('default')
 natural_number_validator = get_validator('natural_number_validator')
 configured_default = get_validator('configured_default')
 limit_to_configured_maximum = get_validator('limit_to_configured_maximum')
-string = get_validator('string')
+unicode_safe = get_validator('unicode_safe')
 
 
 def rename(old, new):
@@ -104,12 +104,12 @@ def unicode_or_json_validator(value, context):
 
 def datastore_create_schema():
     schema = {
-        'resource_id': [ignore_missing, string, resource_id_exists],
+        'resource_id': [ignore_missing, unicode_safe, resource_id_exists],
         'force': [ignore_missing, boolean_validator],
         'id': [ignore_missing],
         'aliases': [ignore_missing, list_of_strings_or_string],
         'fields': {
-            'id': [not_empty, string],
+            'id': [not_empty, unicode_safe],
             'type': [ignore_missing],
             'info': [ignore_missing],
         },
@@ -136,10 +136,10 @@ def datastore_create_schema():
 
 def datastore_upsert_schema():
     schema = {
-        'resource_id': [not_missing, not_empty, string],
+        'resource_id': [not_missing, not_empty, unicode_safe],
         'force': [ignore_missing, boolean_validator],
         'id': [ignore_missing],
-        'method': [ignore_missing, string, one_of(
+        'method': [ignore_missing, unicode_safe, one_of(
             ['upsert', 'insert', 'update'])],
         'calculate_record_count': [ignore_missing, default(False),
                                    boolean_validator],
@@ -152,7 +152,7 @@ def datastore_upsert_schema():
 
 def datastore_delete_schema():
     schema = {
-        'resource_id': [not_missing, not_empty, string],
+        'resource_id': [not_missing, not_empty, unicode_safe],
         'force': [ignore_missing, boolean_validator],
         'id': [ignore_missing],
         'calculate_record_count': [ignore_missing, default(False),
@@ -165,12 +165,12 @@ def datastore_delete_schema():
 
 def datastore_search_schema():
     schema = {
-        'resource_id': [not_missing, not_empty, string],
+        'resource_id': [not_missing, not_empty, unicode_safe],
         'id': [ignore_missing],
         'q': [ignore_missing, unicode_or_json_validator],
         'plain': [ignore_missing, boolean_validator],
         'filters': [ignore_missing, json_validator],
-        'language': [ignore_missing, string],
+        'language': [ignore_missing, unicode_safe],
         'limit': [
             configured_default('ckan.datastore.search.rows_default', 100),
             natural_number_validator,
@@ -214,5 +214,5 @@ def datastore_function_delete_schema():
 
 def datastore_analyze_schema():
     return {
-        'resource_id': [string, resource_id_exists],
+        'resource_id': [unicode_safe, resource_id_exists],
     }

--- a/ckanext/datastore/logic/schema.py
+++ b/ckanext/datastore/logic/schema.py
@@ -24,6 +24,7 @@ default = get_validator('default')
 natural_number_validator = get_validator('natural_number_validator')
 configured_default = get_validator('configured_default')
 limit_to_configured_maximum = get_validator('limit_to_configured_maximum')
+string = get_validator('string')
 
 
 def rename(old, new):
@@ -103,12 +104,12 @@ def unicode_or_json_validator(value, context):
 
 def datastore_create_schema():
     schema = {
-        'resource_id': [ignore_missing, text_type, resource_id_exists],
+        'resource_id': [ignore_missing, string, resource_id_exists],
         'force': [ignore_missing, boolean_validator],
         'id': [ignore_missing],
         'aliases': [ignore_missing, list_of_strings_or_string],
         'fields': {
-            'id': [not_empty, text_type],
+            'id': [not_empty, string],
             'type': [ignore_missing],
             'info': [ignore_missing],
         },
@@ -135,10 +136,10 @@ def datastore_create_schema():
 
 def datastore_upsert_schema():
     schema = {
-        'resource_id': [not_missing, not_empty, text_type],
+        'resource_id': [not_missing, not_empty, string],
         'force': [ignore_missing, boolean_validator],
         'id': [ignore_missing],
-        'method': [ignore_missing, text_type, one_of(
+        'method': [ignore_missing, string, one_of(
             ['upsert', 'insert', 'update'])],
         'calculate_record_count': [ignore_missing, default(False),
                                    boolean_validator],
@@ -151,7 +152,7 @@ def datastore_upsert_schema():
 
 def datastore_delete_schema():
     schema = {
-        'resource_id': [not_missing, not_empty, text_type],
+        'resource_id': [not_missing, not_empty, string],
         'force': [ignore_missing, boolean_validator],
         'id': [ignore_missing],
         'calculate_record_count': [ignore_missing, default(False),
@@ -164,12 +165,12 @@ def datastore_delete_schema():
 
 def datastore_search_schema():
     schema = {
-        'resource_id': [not_missing, not_empty, text_type],
+        'resource_id': [not_missing, not_empty, string],
         'id': [ignore_missing],
         'q': [ignore_missing, unicode_or_json_validator],
         'plain': [ignore_missing, boolean_validator],
         'filters': [ignore_missing, json_validator],
-        'language': [ignore_missing, text_type],
+        'language': [ignore_missing, string],
         'limit': [
             configured_default('ckan.datastore.search.rows_default', 100),
             natural_number_validator,
@@ -213,5 +214,5 @@ def datastore_function_delete_schema():
 
 def datastore_analyze_schema():
     return {
-        'resource_id': [text_type, resource_id_exists],
+        'resource_id': [string, resource_id_exists],
     }

--- a/ckanext/example_iconfigurer/plugin.py
+++ b/ckanext/example_iconfigurer/plugin.py
@@ -41,6 +41,7 @@ class ExampleIConfigurerPlugin(plugins.SingletonPlugin):
     def update_config_schema(self, schema):
 
         ignore_missing = toolkit.get_validator(u'ignore_missing')
+        unicode_safe = toolkit.get_validator(u'unicode_safe')
         is_positive_integer = toolkit.get_validator(u'is_positive_integer')
 
         schema.update({
@@ -50,7 +51,7 @@ class ExampleIConfigurerPlugin(plugins.SingletonPlugin):
 
             # This is a custom configuration option
             u'ckanext.example_iconfigurer.test_conf': [
-                ignore_missing, text_type
+                ignore_missing, unicode_safe
             ],
         })
 

--- a/ckanext/example_iconfigurer/plugin_v1.py
+++ b/ckanext/example_iconfigurer/plugin_v1.py
@@ -15,6 +15,7 @@ class ExampleIConfigurerPlugin(plugins.SingletonPlugin):
     def update_config_schema(self, schema):
 
         ignore_missing = toolkit.get_validator('ignore_missing')
+        unicode_safe = toolkit.get_validator('unicode_safe')
         is_positive_integer = toolkit.get_validator('is_positive_integer')
 
         schema.update({
@@ -24,7 +25,7 @@ class ExampleIConfigurerPlugin(plugins.SingletonPlugin):
 
             # This is a custom configuration option
             'ckanext.example_iconfigurer.test_conf': [ignore_missing,
-                                                      text_type],
+                                                      unicode_safe],
         })
 
         return schema

--- a/ckanext/example_iconfigurer/plugin_v2.py
+++ b/ckanext/example_iconfigurer/plugin_v2.py
@@ -18,6 +18,7 @@ class ExampleIConfigurerPlugin(plugins.SingletonPlugin):
     def update_config_schema(self, schema):
 
         ignore_missing = toolkit.get_validator('ignore_missing')
+        unicode_safe = toolkit.get_validator('unicode_safe')
         is_positive_integer = toolkit.get_validator('is_positive_integer')
 
         schema.update({
@@ -27,7 +28,7 @@ class ExampleIConfigurerPlugin(plugins.SingletonPlugin):
 
             # This is a custom configuration option
             'ckanext.example_iconfigurer.test_conf': [ignore_missing,
-                                                      text_type],
+                                                      unicode_safe],
         })
 
         return schema

--- a/ckanext/imageview/plugin.py
+++ b/ckanext/imageview/plugin.py
@@ -6,6 +6,7 @@ import ckan.plugins as p
 
 log = logging.getLogger(__name__)
 ignore_empty = p.toolkit.get_validator('ignore_empty')
+unicode_safe = p.toolkit.get_validator('unicode_safe')
 
 DEFAULT_IMAGE_FORMATS = 'png jpeg jpg gif'
 
@@ -26,7 +27,7 @@ class ImageView(p.SingletonPlugin):
         return {'name': 'image_view',
                 'title': p.toolkit._('Image'),
                 'icon': 'picture-o',
-                'schema': {'image_url': [ignore_empty, text_type]},
+                'schema': {'image_url': [ignore_empty, unicode_safe]},
                 'iframed': False,
                 'always_available': True,
                 'default_title': p.toolkit._('Image'),

--- a/ckanext/videoview/plugin.py
+++ b/ckanext/videoview/plugin.py
@@ -4,6 +4,7 @@ from six import text_type
 import ckan.plugins as p
 
 ignore_empty = p.toolkit.get_validator('ignore_empty')
+unicode_safe = p.toolkit.get_validator('unicode_safe')
 
 DEFAULT_VIDEO_FORMATS = 'mp4 ogg webm'
 
@@ -24,8 +25,8 @@ class VideoView(p.SingletonPlugin):
         return {'name': 'video_view',
                 'title': p.toolkit._('Video'),
                 'icon': 'file-video-o',
-                'schema': {'video_url': [ignore_empty, text_type],
-                           'poster_url': [ignore_empty, text_type]},
+                'schema': {'video_url': [ignore_empty, unicode_safe],
+                           'poster_url': [ignore_empty, unicode_safe]},
                 'iframed': False,
                 'always_available': True,
                 'default_title': p.toolkit._('Video'),

--- a/ckanext/webpageview/plugin.py
+++ b/ckanext/webpageview/plugin.py
@@ -6,6 +6,7 @@ import ckan.plugins as p
 
 log = logging.getLogger(__name__)
 ignore_empty = p.toolkit.get_validator('ignore_empty')
+unicode_safe = p.toolkit.get_validator('unicode_safe')
 
 
 class WebPageView(p.SingletonPlugin):
@@ -20,7 +21,7 @@ class WebPageView(p.SingletonPlugin):
     def info(self):
         return {'name': 'webpage_view',
                 'title': p.toolkit._('Website'),
-                'schema': {'page_url': [ignore_empty, text_type]},
+                'schema': {'page_url': [ignore_empty, unicode_safe]},
                 'iframed': False,
                 'icon': 'link',
                 'always_available': True,

--- a/doc/extensions/adding-custom-fields.rst
+++ b/doc/extensions/adding-custom-fields.rst
@@ -214,13 +214,20 @@ of a custom dataset, group or organization schema. CKAN's validation
 code will check for and attempt to use them in this order:
 
 
-1. a callable object taking a single parameter: ``validator(value)``
+1. a function taking a single parameter: ``validator(value)``
 
-2. a callable object taking four parameters:
+2. a function taking four parameters:
    ``validator(key, flattened_data, errors, context)``
 
-3. a callable object taking two parameters
+3. a function taking two parameters
    ``validator(value, context)``
+
+.. note::
+
+   Object constructors(including str, int, etc.) and some built-in functions
+   cannot be used as validators. In order to use them, create a thin wrapper
+   which passes values into these callables and converts expected exceptions
+   into :py:exc:`ckan.plugins.toolkit.Invalid`.
 
 
 ``validator(value)``
@@ -276,9 +283,9 @@ Otherwise this is the same as the single-parameter form above.
 Validators that need to access or update multiple fields
 may be written as a callable taking four parameters.
 
-All fields and errors in a ``flattened`` form are passed to the 
-validator. The validator must fetch values from ``flattened_data`` 
-and may replace values in ``flattened_data``. The return value 
+All fields and errors in a ``flattened`` form are passed to the
+validator. The validator must fetch values from ``flattened_data``
+and may replace values in ``flattened_data``. The return value
 from this function is ignored.
 
 ``key`` is the flattened key for the field to which this validator was

--- a/doc/extensions/adding-custom-fields.rst
+++ b/doc/extensions/adding-custom-fields.rst
@@ -229,6 +229,14 @@ code will check for and attempt to use them in this order:
    which passes values into these callables and converts expected exceptions
    into :py:exc:`ckan.plugins.toolkit.Invalid`.
 
+   Example::
+
+     def int_validator(value):
+         try:
+             return int(value)
+         except ValueError:
+             raise Invalid(f"Invalid literal for integer: {value}")
+
 
 ``validator(value)``
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The current implementation of validators relies on error messages when validators applied. 

Instead, it will be more obvious to check the number of arguments that are expected by the validator - after migration to py3 it's possible via `inspect.signature`.