### PR TITLE
Catch TypeError from invalid dates thrown by dateutils

### DIFF
--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -249,7 +249,8 @@ class PackageSearchIndex(SearchIndex):
                         # The date field was empty, so dateutil filled it with
                         # the default bogus date
                         value = None
-                except (ValueError, IndexError):
+                except (IndexError, TypeError, ValueError):
+                    log.error('%r: %r value of %r is not a valid date', pkg_dict['id'], key, value)
                     continue
             new_dict[key] = value
         pkg_dict = new_dict

--- a/ckan/tests/lib/search/test_index.py
+++ b/ckan/tests/lib/search/test_index.py
@@ -142,6 +142,8 @@ class TestSearchIndex(object):
                 "extras": [
                     {"key": "test_wrong_date", "value": "Not a date"},
                     {"key": "test_another_wrong_date", "value": "2014-13-01"},
+                    {"key": "test_yet_another_wrong_date", "value": "2014-15"},
+                    {"key": "test_yet_another_very_wrong_date", "value": "30/062012"},
                 ]
             }
         )
@@ -154,6 +156,8 @@ class TestSearchIndex(object):
 
         assert "test_wrong_date" not in response.docs[0]
         assert "test_another_wrong_date" not in response.docs[0]
+        assert "test_yet_another_wrong_date" not in response.docs[0]
+        assert "test_yet_another_very_wrong_date" not in response.docs[0]
 
     def test_index_date_field_empty_value(self):
 


### PR DESCRIPTION
## Fixes

Problem with catching TypeErrors thrown when an invalid date like `20/062012` and `2014-15` are passed in as date strings.

### Proposed fixes:

Catch TypeError and provide an error log so that devs can investigate any issues.

### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
