### PR TITLE
[#6028] Fix performance bottleneck in activities queries

### DIFF
--- a/changes/6028.bugfix
+++ b/changes/6028.bugfix
@@ -1,0 +1,1 @@
+Fix performance bottleneck in activity queries

--- a/ckan/model/activity.py
+++ b/ckan/model/activity.py
@@ -225,8 +225,7 @@ def _group_activity_query(group_id, include_hidden_activity=False):
     ).outerjoin(
         model.Package,
         and_(
-            or_(model.Package.id == model.Member.table_id,
-                model.Package.owner_org == group_id),
+            model.Package.id == model.Member.table_id,
             model.Package.private == False,
         )
     ).filter(


### PR DESCRIPTION
Fixes #6028, #5765

As it happens often with these kind of issues, many hours of debugging and false leads end up condensed in a single line change :man_shrugging: . 
The fix is in 73c1ffc. The issue was located in `_group_activity_query()`, which apart from activities in the group itself looks for activities in datasets belonging to the group / org. When performing the join between the activity + member and package tables we were joining both the `package.id`  with the `member.table_id` (which makes sense and it's fast) but also `package.owner_org` with the provided `group_id`, which is *really* slow and also unnecessary, because we are adding an explicit member.group_id filter later on.

I fixed a test which was supposed to be testing that you got activities from datasets belonging to a group you were following, and added another specific one for datasets in organizations you are following.

Testing the `dashboard_activity_list` endpoint with this patch drastically reduced the load times from several seconds to milliseconds.

To reproduce:

```
# Create a test org, a test user and assign it as editor in the org
ckanapi action organization_create name=my-org
ckanapi action user_create name=my-user email=hi@example.com password=testtest
ckanapi action member_create id=my-org object=my-user object_type='user' capacity=editor

# Follow the org
ckanapi action follow_group -u my-user id=my-org

# Create loads of datasets belonging to the org (from @wardi in #2008)

(for a in `seq 3000` 
     do echo '{"name": "test-dataset-'$a'", "owner_org": "my-org"}'
done) | ckanapi load datasets -u my-user
```

You can then use a tool like [siege]() to measure loading time, eg

```
siege http://localhost:5010/api/action/dashboard_activity_list -H "Authorization:`cat api_token_my-user.txt`" -d1 -c10 -r1
```


| version | lowest dashboard_activity_list time | vs. master |
| --- | --- | --- |
| ckan master | 4.36s | 1.00 |
| PR #6028 | 0.05s | 0.0115 |

