### PR TITLE
Check if resource.size exists before trying to display it in the resource metadata tooltip

### DIFF
--- a/ckanext/datatablesview/templates/datatables/datatables_view.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_view.html
@@ -92,7 +92,6 @@
   {%- if res.size|int != 0 -%}
    ( {{ h.SI_number_span(res.size)|striptags }} )
   {%- endif -%}
-  &#10;"
 </div>
 {%- endblock -%}
 {%- block styles -%}

--- a/ckanext/datatablesview/templates/datatables/datatables_view.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_view.html
@@ -90,7 +90,7 @@
   {{- _('Created') }}: {{ local_friendly_datetime(res.created) }}&#10;
   {{- res.format or res.mimetype_inner or res.mimetype or _('unknown') -}}&nbsp;
   {%- if res.size|int != 0 -%}
-   ( {{ h.SI_number_span(res.size)|striptags }} )&#10;"
+   ( {{ h.SI_number_span(res.size)|striptags }} )
   {%- endif -%}
   &#10;"
 </div>

--- a/ckanext/datatablesview/templates/datatables/datatables_view.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_view.html
@@ -88,7 +88,11 @@
   {{- _('Data last updated') }}: {{ local_friendly_datetime(res.last_modified) }}&#10;
   {{- _('Metadata last updated') }}: {{ local_friendly_datetime(res.metadata_modified) }}&#10;
   {{- _('Created') }}: {{ local_friendly_datetime(res.created) }}&#10;
-  {{- res.format or res.mimetype_inner or res.mimetype or _('unknown') }} ( {{ h.SI_number_span(res.size)|striptags }} )&#10;"
+  {{- res.format or res.mimetype_inner or res.mimetype or _('unknown') -}}&nbsp;
+  {%- if res.size|int != 0 -%}
+   ( {{ h.SI_number_span(res.size)|striptags }} )&#10;"
+  {%- endif -%}
+  &#10;"
 </div>
 {%- endblock -%}
 {%- block styles -%}


### PR DESCRIPTION
Fixes #6060

### Proposed fixes:
Use the jinja2 int filter to ensure the resource.size is numeric and defined before trying to display it

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
