### PR TITLE
[#6006] Fix auth error when deleting a group/org

### DIFF
--- a/ckan/tests/controllers/test_group.py
+++ b/ckan/tests/controllers/test_group.py
@@ -287,6 +287,7 @@ class TestGroupDelete(object):
             data={"delete": ""},
             extra_environ=initial_data["user_env"],
         )
+        assert response.status_code == 200
         group = helpers.call_action(
             "group_show", id=initial_data["group"]["id"]
         )
@@ -300,6 +301,7 @@ class TestGroupDelete(object):
             data={"delete": ""},
             extra_environ=extra_environ,
         )
+        assert response.status_code == 200
         group = helpers.call_action(
             "group_show", id=initial_data["group"]["id"]
         )

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -1036,7 +1036,6 @@ class DeleteGroupView(MethodView):
                 u'has been deleted') or _(u'Group')
             h.flash_notice(
                 _(u'%s has been deleted.') % _(group_label))
-            group_dict = _action(u'group_show')(context, {u'id': id})
         except NotAuthorized:
             base.abort(403, _(u'Unauthorized to delete group %s') % u'')
         except NotFound:
@@ -1046,8 +1045,6 @@ class DeleteGroupView(MethodView):
             return h.redirect_to(u'organization.read', id=id)
 
             return h.redirect_to(u'{}.read'.format(group_type), id=id)
-        # TODO: Remove
-        g.group_dict = group_dict
 
         return h.redirect_to(u'{}.index'.format(group_type))
 

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -1042,8 +1042,6 @@ class DeleteGroupView(MethodView):
             base.abort(404, _(u'Group not found'))
         except ValidationError as e:
             h.flash_error(e.error_dict['message'])
-            return h.redirect_to(u'organization.read', id=id)
-
             return h.redirect_to(u'{}.read'.format(group_type), id=id)
 
         return h.redirect_to(u'{}.index'.format(group_type))


### PR DESCRIPTION
Remove a group_show call that was failing for non-sysadmin users after the group/org being deleted

Fixes #6006