### PR TITLE
Pagination removes repeated params

### DIFF
--- a/changes/6084.bugfix
+++ b/changes/6084.bugfix
@@ -1,0 +1,1 @@
+Keep repeatable facets inside pagination links

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -1567,6 +1567,25 @@ class TestSearch(object):
         assert len(ds_titles) == 1
         assert "Dataset One" in ds_titles
 
+    @pytest.mark.ckan_config('ckan.datasets_per_page', 1)
+    def test_repeatable_params(self, app):
+        """Searching for datasets returns expected results."""
+
+        factories.Dataset(name="dataset-one", title="Test Dataset One")
+        factories.Dataset(name="dataset-two", title="Test Dataset Two")
+
+        search_url = url_for("dataset.search", title=['Test', 'Dataset'])
+        search_results = app.get(search_url)
+        html = BeautifulSoup(search_results.data)
+        links = html.select('.pagination a')
+        # first, second and "Next" pages
+        assert len(links) == 3
+
+        params = [set(urlparse(a['href']).query.split('&')) for a in links]
+        for group in params:
+            assert 'title=Test' in group
+            assert 'title=Dataset' in group
+
     def test_search_page_no_results(self, app):
         """Search with non-returning phrase returns no results."""
 

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -223,7 +223,8 @@ def search(package_type):
     limit = int(config.get(u'ckan.datasets_per_page', 20))
 
     # most search operations should reset the page counter:
-    params_nopage = [(k, v) for k, v in request.args.items(multi=True) if k != u'page']
+    params_nopage = [(k, v) for k, v in request.args.items(multi=True)
+                     if k != u'page']
 
     extra_vars[u'drill_down_url'] = drill_down_url
     extra_vars[u'remove_field'] = partial(remove_field, package_type)

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -223,7 +223,7 @@ def search(package_type):
     limit = int(config.get(u'ckan.datasets_per_page', 20))
 
     # most search operations should reset the page counter:
-    params_nopage = [(k, v) for k, v in request.args.items() if k != u'page']
+    params_nopage = [(k, v) for k, v in request.args.items(multi=True) if k != u'page']
 
     extra_vars[u'drill_down_url'] = drill_down_url
     extra_vars[u'remove_field'] = partial(remove_field, package_type)

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -247,7 +247,8 @@ def _read(id, limit, group_type):
     page = h.get_page_number(request.params)
 
     # most search operations should reset the page counter:
-    params_nopage = [(k, v) for k, v in request.params.items(multi=True) if k != u'page']
+    params_nopage = [(k, v) for k, v in request.params.items(multi=True)
+                     if k != u'page']
     sort_by = request.params.get(u'sort', None)
 
     def search_url(params):

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -247,7 +247,7 @@ def _read(id, limit, group_type):
     page = h.get_page_number(request.params)
 
     # most search operations should reset the page counter:
-    params_nopage = [(k, v) for k, v in request.params.items() if k != u'page']
+    params_nopage = [(k, v) for k, v in request.params.items(multi=True) if k != u'page']
     sort_by = request.params.get(u'sort', None)
 
     def search_url(params):


### PR DESCRIPTION
Whenever the same parameter appears in the search query multiple times, only the first occurrence stays in the links generated by the pager. It happens because we are not passing `multi=True` while collecting "nopage"-params for `pager_url` function.