### PR TITLE
#6086 fix sqlalchemy configuration for datastore

### DIFF
--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -119,7 +119,7 @@ def _get_engine_from_url(connection_url):
     engine = _engines.get(connection_url)
     if not engine:
         extras = {'url': connection_url}
-        config.setdefault('pool_pre_ping', True)
+        config.setdefault('ckan.datastore.sqlalchemy.pool_pre_ping', True)
         engine = sqlalchemy.engine_from_config(config,
                                                'ckan.datastore.sqlalchemy.',
                                                **extras)


### PR DESCRIPTION
Fixes #6086

### Proposed fixes:

Fix mistyped configuration key.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
