### PR TITLE
reorder resource view button: allow translation

### DIFF
--- a/ckan/i18n/ckan.pot
+++ b/ckan/i18n/ckan.pot
@@ -2451,6 +2451,10 @@ msgstr ""
 msgid "Select a field"
 msgstr ""
 
+#: ckan/public/base/javascript/modules/resource-view-reorder.js:41
+msgid "Reorder resource view"
+msgstr ""
+
 #: ckan/public/base/javascript/modules/slug-preview.js:57
 #: ckan/public/base/javascript/modules/slug-preview.min.js:2
 #: ckan/templates/group/edit_base.html:20 ckan/templates/group/members.html:28

--- a/ckan/i18n/fr/LC_MESSAGES/ckan.po
+++ b/ckan/i18n/fr/LC_MESSAGES/ckan.po
@@ -2561,6 +2561,10 @@ msgstr "Ajouter un filtre"
 msgid "Select a field"
 msgstr "Sélectionnez un champ"
 
+#: ckan/public/base/javascript/modules/resource-view-reorder.js:41
+msgid "Reorder resource view"
+msgstr "Réorganiser la vue des ressources"
+
 #: ckan/public/base/javascript/modules/slug-preview.js:57
 #: ckan/public/base/javascript/modules/slug-preview.min.js:2
 #: ckan/templates/group/edit_base.html:20 ckan/templates/group/members.html:28

--- a/ckan/public/base/javascript/modules/resource-view-reorder.js
+++ b/ckan/public/base/javascript/modules/resource-view-reorder.js
@@ -3,8 +3,7 @@
 this.ckan.module('resource-view-reorder', function($) {
   return {
     options: {
-      id: false,
-      labelText: 'Reorder resource view'
+      id: false
     },
     template: {
       title: '<h1></h1>',
@@ -38,7 +37,7 @@ this.ckan.module('resource-view-reorder', function($) {
     initialize: function() {
       jQuery.proxyAll(this, /_on/);
 
-      var labelText = this._(this.options.labelText);
+      var labelText = this._('Reorder resource view');
       this.html_title = $(this.template.title)
         .text(labelText)
         .insertBefore(this.el)


### PR DESCRIPTION
Fixes untranslatable "Reorder resource view" string

### Proposed fixes:

Removes `labelText` from the module options list so that it can be captured by `extract_messages` and added to the .pot file so that it is exported as a translation available to JS.

Note: this is my first foray into updating a JS module for a translated string, so I've probably done everything wrong. 

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport