### PR TITLE
cast query string keys/values to string before passing to `quote()`

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -8,6 +8,7 @@ available to Controllers. This module is available to templates as 'h'.
 import email.utils
 import datetime
 import logging
+import numbers
 import re
 import os
 import pytz
@@ -383,6 +384,14 @@ def url_for(*args, **kw):
     return _local_url(my_url, locale=locale, **kw)
 
 
+def _coerce_for_querystring(value):
+    if value is None:
+        return 'null'
+    if isinstance(value, numbers.Number):
+        return str(value)
+    return value
+
+
 def _url_for_flask(*args, **kw):
     '''Build a URL using the Flask router
 
@@ -442,10 +451,18 @@ def _url_for_flask(*args, **kw):
                     if isinstance(val, (list, tuple)):
                         for value in val:
                             query_args.append(
-                                u'{}={}'.format(quote(key), quote(value)))
+                                u'{}={}'.format(
+                                    quote(_coerce_for_querystring(key)),
+                                    quote(_coerce_for_querystring(value))
+                                )
+                            )
                     else:
                         query_args.append(
-                            u'{}={}'.format(quote(key), quote(val)))
+                            u'{}={}'.format(
+                                quote(_coerce_for_querystring(key)),
+                                quote(_coerce_for_querystring(val))
+                            )
+                        )
                 my_url += '&'.join(query_args)
         else:
             raise

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -8,7 +8,6 @@ available to Controllers. This module is available to templates as 'h'.
 import email.utils
 import datetime
 import logging
-import numbers
 import re
 import os
 import pytz

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -384,14 +384,6 @@ def url_for(*args, **kw):
     return _local_url(my_url, locale=locale, **kw)
 
 
-def _coerce_for_querystring(value):
-    if value is None:
-        return 'null'
-    if isinstance(value, numbers.Number):
-        return str(value)
-    return value
-
-
 def _url_for_flask(*args, **kw):
     '''Build a URL using the Flask router
 
@@ -445,24 +437,29 @@ def _url_for_flask(*args, **kw):
             kw.pop('host', None)
             kw.pop('protocol', None)
             if kw:
-                my_url += '?'
                 query_args = []
                 for key, val in kw.items():
                     if isinstance(val, (list, tuple)):
                         for value in val:
+                            if value is None:
+                                continue
                             query_args.append(
                                 u'{}={}'.format(
-                                    quote(_coerce_for_querystring(key)),
-                                    quote(_coerce_for_querystring(value))
+                                    quote(str(key)),
+                                    quote(str(value))
                                 )
                             )
                     else:
+                        if val is None:
+                            continue
                         query_args.append(
                             u'{}={}'.format(
-                                quote(_coerce_for_querystring(key)),
-                                quote(_coerce_for_querystring(val))
+                                quote(str(key)),
+                                quote(str(val))
                             )
                         )
+                if query_args:
+                    my_url += '?'
                 my_url += '&'.join(query_args)
         else:
             raise

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -168,44 +168,24 @@ class TestHelpersUrlFor(BaseUrlFor):
             ({"param": 27}, "/dataset/my_dataset?param=27"),
             ({"param": 27.3}, "/dataset/my_dataset?param=27.3"),
             ({"param": True}, "/dataset/my_dataset?param=True"),
-            ({"param": None}, "/dataset/my_dataset?param=null"),
+            ({"param": None}, "/dataset/my_dataset"),
+            ({"param": {}}, "/dataset/my_dataset?param=%7B%7D"),
         ],
     )
-    def test_url_for_string_route_with_query_param_valid(self, extra, exp):
-        generated_url = h.url_for("/dataset/my_dataset", **extra)
-        assert generated_url == exp
-
-    @pytest.mark.parametrize(
-        "extra",
-        [
-            {"param": {}},
-            {"param": object()}
-        ]
-    )
-    def test_url_for_string_route_with_query_param_invalid(self, extra):
-        with pytest.raises(TypeError):
-            h.url_for("/dataset/my_dataset", **extra)
-
-    def test_url_for_string_route_with_list_query_params_valid(self):
-        generated_url = h.url_for(
-            "/dataset/my_dataset",
-            multi=['foo', 27, 27.3, True, None]
-        )
+    def test_url_for_string_route_with_query_param(self, extra, exp):
         assert (
-            generated_url ==
-            "/dataset/my_dataset?multi=foo&multi=27&multi=27.3&multi=True&multi=null"
+            h.url_for("/dataset/my_dataset", **extra) ==
+            h.url_for("dataset.read", id="my_dataset", **extra) ==
+            exp
         )
 
-    @pytest.mark.parametrize(
-        "extra",
-        [
-            {"param": [{}]},
-            {"param": [object()]}
-        ]
-    )
-    def test_url_for_string_route_with_list_query_params_invalid(self, extra):
-        with pytest.raises(TypeError):
-            h.url_for("/dataset/my_dataset", **extra)
+    def test_url_for_string_route_with_list_query_param(self):
+        extra = {'multi': ['foo', 27, 27.3, True, None]}
+        assert (
+            h.url_for("/dataset/my_dataset", **extra) ==
+            h.url_for("dataset.read", id="my_dataset", **extra) ==
+            "/dataset/my_dataset?multi=foo&multi=27&multi=27.3&multi=True"
+        )
 
 
 class TestHelpersUrlForFlaskandPylons(BaseUrlFor):

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -103,6 +103,7 @@ class TestHelpersUrlFor(BaseUrlFor):
                 {"qualified": True, "locale": "de"},
                 "http://example.com/de/dataset/my_dataset",
             ),
+            ({"__no_cache__": True}, "/dataset/my_dataset?__no_cache__=True"),
         ],
     )
     def test_url_for_default(self, extra, exp):
@@ -159,6 +160,52 @@ class TestHelpersUrlFor(BaseUrlFor):
         expected = "/my/custom/path/_debug_toolbar/static/test.js"
         url = url_for('_debug_toolbar.static', filename='test.js')
         assert url == expected
+
+    @pytest.mark.parametrize(
+        "extra,exp",
+        [
+            ({"param": "foo"}, "/dataset/my_dataset?param=foo"),
+            ({"param": 27}, "/dataset/my_dataset?param=27"),
+            ({"param": 27.3}, "/dataset/my_dataset?param=27.3"),
+            ({"param": True}, "/dataset/my_dataset?param=True"),
+            ({"param": None}, "/dataset/my_dataset?param=null"),
+        ],
+    )
+    def test_url_for_string_route_with_query_param_valid(self, extra, exp):
+        generated_url = h.url_for("/dataset/my_dataset", **extra)
+        assert generated_url == exp
+
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            {"param": {}},
+            {"param": object()}
+        ]
+    )
+    def test_url_for_string_route_with_query_param_invalid(self, extra):
+        with pytest.raises(TypeError):
+            h.url_for("/dataset/my_dataset", **extra)
+
+    def test_url_for_string_route_with_list_query_params_valid(self):
+        generated_url = h.url_for(
+            "/dataset/my_dataset",
+            multi=['foo', 27, 27.3, True, None]
+        )
+        assert (
+            generated_url ==
+            "/dataset/my_dataset?multi=foo&multi=27&multi=27.3&multi=True&multi=null"
+        )
+
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            {"param": [{}]},
+            {"param": [object()]}
+        ]
+    )
+    def test_url_for_string_route_with_list_query_params_invalid(self, extra):
+        with pytest.raises(TypeError):
+            h.url_for("/dataset/my_dataset", **extra)
 
 
 class TestHelpersUrlForFlaskandPylons(BaseUrlFor):


### PR DESCRIPTION
### Proposed fixes:

Cast query string keys/values to string before passing to `quote()`

This issue can cause us to throw `AttributeError: 'bool' object has no attribute 'rstrip'` calling something like

```py
url_for("/foo/bar", __no_cache__=True)
```

I've been hitting this problem on CKAN 2.9 so this should definitely be backported to 2.9. It might also be applicable to 2.8.

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

