### PR TITLE
render activity timestamps with title= attribute

### DIFF
--- a/ckan/templates/snippets/activities/added_tag.html
+++ b/ckan/templates/snippets/activities/added_tag.html
@@ -7,7 +7,7 @@
       tag=ah.tag(activity)
     )|safe }}
     <br />
-    <span class="date">
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
     </span>
   </p>

--- a/ckan/templates/snippets/activities/changed_group.html
+++ b/ckan/templates/snippets/activities/changed_group.html
@@ -6,7 +6,7 @@
       group=ah.group(activity)
     )|safe }}
     <br />
-    <span class="date">
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
     </span>
   </p>

--- a/ckan/templates/snippets/activities/changed_organization.html
+++ b/ckan/templates/snippets/activities/changed_organization.html
@@ -6,7 +6,7 @@
       organization=ah.organization(activity)
     )|safe }}
     <br />
-    <span class="date">
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
       {% if can_show_activity_detail %}
 	      &nbsp;|&nbsp;

--- a/ckan/templates/snippets/activities/changed_package.html
+++ b/ckan/templates/snippets/activities/changed_package.html
@@ -8,7 +8,7 @@
       dataset=ah.dataset(activity)
     )|safe }}
     <br />
-    <span class="date">
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
       {% if can_show_activity_detail %}
         &nbsp;|&nbsp;

--- a/ckan/templates/snippets/activities/changed_resource.html
+++ b/ckan/templates/snippets/activities/changed_resource.html
@@ -7,7 +7,7 @@
       dataset=ah.datset(activity)
     )|safe }}
     <br />
-    <span class="date">
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
     </span>
   </p>

--- a/ckan/templates/snippets/activities/changed_user.html
+++ b/ckan/templates/snippets/activities/changed_user.html
@@ -5,7 +5,7 @@
       actor=ah.actor(activity)
     )|safe }}
     <br />
-    <span class="date">
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
     </span>
   </p>

--- a/ckan/templates/snippets/activities/deleted_group.html
+++ b/ckan/templates/snippets/activities/deleted_group.html
@@ -6,7 +6,7 @@
       group=ah.group(activity)
     )|safe }}
     <br />
-    <span class="date">
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
     </span>
   </p>

--- a/ckan/templates/snippets/activities/deleted_organization.html
+++ b/ckan/templates/snippets/activities/deleted_organization.html
@@ -6,7 +6,7 @@
       organization=ah.organization(activity)
     )|safe }}
     <br />
-    <span class="date">
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
     </span>
   </p>

--- a/ckan/templates/snippets/activities/deleted_package.html
+++ b/ckan/templates/snippets/activities/deleted_package.html
@@ -6,7 +6,7 @@
       dataset=ah.dataset(activity)
     )|safe }}
     <br />
-    <span class="date">
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
     </span>
   </p>

--- a/ckan/templates/snippets/activities/deleted_resource.html
+++ b/ckan/templates/snippets/activities/deleted_resource.html
@@ -7,7 +7,7 @@
       dataset=ah.dataset(activity)
     )|safe }}
     <br />
-    <span class="date">
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
     </span>
   </p>

--- a/ckan/templates/snippets/activities/fallback.html
+++ b/ckan/templates/snippets/activities/fallback.html
@@ -30,7 +30,7 @@
         {% endif %}
       {% endif %}
       <br />
-      <span class="date">
+      <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
         {{ h.time_ago_from_timestamp(activity.timestamp) }}
       </span>
     </p>

--- a/ckan/templates/snippets/activities/follow_dataset.html
+++ b/ckan/templates/snippets/activities/follow_dataset.html
@@ -6,7 +6,7 @@
       dataset=ah.dataset(activity)
     )|safe }}
     <br />
-    <span class="date">
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
     </span>
   </p>

--- a/ckan/templates/snippets/activities/follow_group.html
+++ b/ckan/templates/snippets/activities/follow_group.html
@@ -6,7 +6,7 @@
       group=ah.group(activity)
     )|safe }}
     <br />
-    <span class="date">
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
     </span>
   </p>

--- a/ckan/templates/snippets/activities/follow_user.html
+++ b/ckan/templates/snippets/activities/follow_user.html
@@ -6,7 +6,7 @@
       user=ah.user(activity)
     )|safe }}
     <br />
-    <span class="date">
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
     </span>
   </p>

--- a/ckan/templates/snippets/activities/new_group.html
+++ b/ckan/templates/snippets/activities/new_group.html
@@ -6,7 +6,7 @@
       group=ah.group(activity)
     )|safe }}
     <br />
-    <span class="date">
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
     </span>
   </p>

--- a/ckan/templates/snippets/activities/new_organization.html
+++ b/ckan/templates/snippets/activities/new_organization.html
@@ -6,7 +6,7 @@
       organization=ah.organization(activity)
     )|safe }}
     <br />
-    <span class="date">
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
     </span>
   </p>

--- a/ckan/templates/snippets/activities/new_package.html
+++ b/ckan/templates/snippets/activities/new_package.html
@@ -7,7 +7,7 @@
       dataset=ah.dataset(activity)
     )|safe }}
     <br />
-    <span class="date">
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
       {% if can_show_activity_detail %}
         &nbsp;|&nbsp;

--- a/ckan/templates/snippets/activities/new_resource.html
+++ b/ckan/templates/snippets/activities/new_resource.html
@@ -7,7 +7,7 @@
       dataset=ah.dataset(activity)
     )|safe }}
     <br />
-    <span class="date">
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
     </span>
   </p>

--- a/ckan/templates/snippets/activities/new_user.html
+++ b/ckan/templates/snippets/activities/new_user.html
@@ -5,7 +5,7 @@
       actor=ah.actor(activity)
     )|safe }}
     <br />
-    <span class="date">
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
     </span>
   </p>

--- a/ckan/templates/snippets/activities/removed_tag.html
+++ b/ckan/templates/snippets/activities/removed_tag.html
@@ -7,7 +7,7 @@
       dataset=ah.dataset(dataset)
     )|safe }}
     <br />
-    <span class="date">
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
     </span>
   </p>


### PR DESCRIPTION
### Proposed fixes:

In CKAN 2.8, activites rendered timestamps with a `title=` attribute showing the full formatted timestamp. This meant that you would see the "fuzzy" timestamp (e.g: `2 days ago`) but in most browsers you can also hover over it to view the formatted datetime (e.g: `May 19, 2021, 11:17 (UTC)`). This was useful, but it was removed in CKAN 2.9 (presumably though oversight rather than intent?). In this PR I propose adding it back in.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport (2.9)
