### PR TITLE
update docstring for package/resource_item snippet

### DIFF
--- a/ckan/templates/package/snippets/resource_item.html
+++ b/ckan/templates/package/snippets/resource_item.html
@@ -9,7 +9,7 @@
 
   Example:
 
-    {% snippet "package/snippets/resource_item.html", res=resource, pkg_dict=pkg_dict, can_edit=True, url_is_edit=False %}
+    {% snippet "package/snippets/resource_item.html", res=resource, pkg=pkg, can_edit=True, url_is_edit=False %}
 
 #}
 {% set url_action = pkg.type ~ ('_resource.edit' if url_is_edit and can_edit else '_resource.read') %}


### PR DESCRIPTION
### Fixes
Example in docstring of package/snippets/resource_item.html file is incorrect since `pkg_dict` is not a valid parameter

### Proposed fixes:
Change `pkg_dict` for `pkg`

### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
