### PR TITLE
WIP failing test case for validation error list position

### DIFF
--- a/ckan/tests/legacy/lib/test_navl.py
+++ b/ckan/tests/legacy/lib/test_navl.py
@@ -345,6 +345,39 @@ def test_simple():
     assert errors == {"numbers": [{"code": [u"Missing value"]}]}
 
 
+def test_error_list_position():
+    data = {
+        "name": "fred",
+        "numbers": [
+            {"number": "432423432", "code": "+44"},
+            {"number": "13221312"},
+            {"number": "432423432", "code": "+44"},
+            {"number": "13221312"},
+            {"number": "432423432", "code": "+44"},
+        ],
+    }
+
+    schema = {
+        "name": [not_empty],
+        "numbers": {
+            "number": [convert_int],
+            "code": [not_empty],
+            "__extras": [ignore],
+        },
+    }
+
+    converted_data, errors = validate(data, schema)
+
+    assert errors == {"numbers": [
+            {},
+            {"code": [u"Missing value"]},
+            {},
+            {"code": [u"Missing value"]},
+            {},
+        ]
+    }
+
+
 def test_simple_converter_types():
     schema = {
         "name": [not_empty, unicode_safe],


### PR DESCRIPTION
cc @amercader 
My reading of the validation changes for CKAN 2.9 is that if `validate()` is working correctly this test case should pass

i.e: lists of dicts should generate
- error dicts at the corresponding list index for dicts with an error and
- empty objects at the corresponding list index for dicts with no error

Currently this returns `{'numbers': [{'code': ['Missing value']}, {'code': ['Missing value']}]}`

hopefully this makes things a bit quicker to solve :crossed_fingers: 

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport (2.9)
