### PR TITLE
updated links to https

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -14,31 +14,31 @@ code that calls the CKAN API.  For example, using the CKAN API your app can:
 
 * Get JSON-formatted lists of a site's datasets, groups or other CKAN objects:
 
-  http://demo.ckan.org/api/3/action/package_list
+  https://demo.ckan.org/api/3/action/package_list
 
-  http://demo.ckan.org/api/3/action/group_list
+  https://demo.ckan.org/api/3/action/group_list
 
-  http://demo.ckan.org/api/3/action/tag_list
+  https://demo.ckan.org/api/3/action/tag_list
 
 * Get a full JSON representation of a dataset, resource or other object:
 
-  http://demo.ckan.org/api/3/action/package_show?id=adur_district_spending
+  https://demo.ckan.org/api/3/action/package_show?id=adur_district_spending
 
-  http://demo.ckan.org/api/3/action/tag_show?id=gold
+  https://demo.ckan.org/api/3/action/tag_show?id=gold
 
-  http://demo.ckan.org/api/3/action/group_show?id=data-explorer
+  https://demo.ckan.org/api/3/action/group_show?id=data-explorer
 
 * Search for packages or resources matching a query:
 
-  http://demo.ckan.org/api/3/action/package_search?q=spending
+  https://demo.ckan.org/api/3/action/package_search?q=spending
 
-  http://demo.ckan.org/api/3/action/resource_search?query=name:District%20Names
+  https://demo.ckan.org/api/3/action/resource_search?query=name:District%20Names
 
 * Create, update and delete datasets, resources and other objects
 
 * Get an activity stream of recently changed datasets on a site:
 
-  http://demo.ckan.org/api/3/action/recently_changed_packages_activity_list
+  https://demo.ckan.org/api/3/action/recently_changed_packages_activity_list
 
 .. note::
 
@@ -145,7 +145,7 @@ with this Python code::
     import pprint
 
     # Make the HTTP request.
-    response = urllib2.urlopen('http://demo.ckan.org/api/3/action/group_list',
+    response = urllib2.urlopen('https://demo.ckan.org/api/3/action/group_list',
             data_string)
     assert response.code == 200
 
@@ -222,12 +222,12 @@ API versions
 The CKAN APIs are versioned. If you make a request to an API URL without a
 version number, CKAN will choose the latest version of the API::
 
-    http://demo.ckan.org/api/action/package_list
+    https://demo.ckan.org/api/action/package_list
 
 Alternatively, you can specify the desired API version number in the URL that
 you request::
 
-    http://demo.ckan.org/api/3/action/package_list
+    https://demo.ckan.org/api/3/action/package_list
 
 Version 3 is currently the only version of the Action API.
 
@@ -299,12 +299,12 @@ Functions defined in `ckan.logic.action.get`_ can also be called with an HTTP
 GET request.  For example, to get the list of datasets (packages) from
 demo.ckan.org, open this URL in your browser:
 
-http://demo.ckan.org/api/3/action/package_list
+https://demo.ckan.org/api/3/action/package_list
 
 Or, to search for datasets (packages) matching the search query ``spending``,
 on demo.ckan.org, open this URL in your browser:
 
-http://demo.ckan.org/api/3/action/package_search?q=spending
+https://demo.ckan.org/api/3/action/package_search?q=spending
 
 .. tip::
 
@@ -316,12 +316,12 @@ The search query is given as a URL parameter ``?q=spending``. Multiple
 URL parameters can be appended, separated by ``&`` characters, for example
 to get only the first 10 matching datasets open this URL:
 
-http://demo.ckan.org/api/3/action/package_search?q=spending&rows=10
+https://demo.ckan.org/api/3/action/package_search?q=spending&rows=10
 
 When an action requires a list of strings as the value of a parameter, the
 value can be sent by giving the parameter multiple times in the URL:
 
-http://demo.ckan.org/api/3/action/term_translation_show?terms=russian&terms=romantic%20novel
+https://demo.ckan.org/api/3/action/term_translation_show?terms=russian&terms=romantic%20novel
 
 
 -------------
@@ -332,7 +332,7 @@ To cater for scripts from other sites that wish to access the API, the data can
 be returned in JSONP format, where the JSON data is 'padded' with a function
 call. The function is named in the 'callback' parameter. For example:
 
-http://demo.ckan.org/api/3/action/package_show?id=adur_district_spending&callback=myfunction
+https://demo.ckan.org/api/3/action/package_show?id=adur_district_spending&callback=myfunction
 
 .. note :: This only works for GET requests
 
@@ -349,30 +349,30 @@ Tags (not in a vocabulary)
 
 A list of all tags:
 
-* browser: http://demo.ckan.org/api/3/action/tag_list
-* curl: ``curl http://demo.ckan.org/api/3/action/tag_list``
-* ckanapi: ``ckanapi -r http://demo.ckan.org action tag_list``
+* browser: https://demo.ckan.org/api/3/action/tag_list
+* curl: ``curl https://demo.ckan.org/api/3/action/tag_list``
+* ckanapi: ``ckanapi -r https://demo.ckan.org action tag_list``
 
 Top 10 tags used by datasets:
 
-* browser: http://demo.ckan.org/api/action/package_search?facet.field=[%22tags%22]&facet.limit=10&rows=0
-* curl: ``curl 'http://demo.ckan.org/api/action/package_search?facet.field=\["tags"\]&facet.limit=10&rows=0'``
-* ckanapi: ``ckanapi -r http://demo.ckan.org action package_search facet.field='["tags"]' facet.limit=10 rows=0``
+* browser: https://demo.ckan.org/api/action/package_search?facet.field=[%22tags%22]&facet.limit=10&rows=0
+* curl: ``curl 'https://demo.ckan.org/api/action/package_search?facet.field=\["tags"\]&facet.limit=10&rows=0'``
+* ckanapi: ``ckanapi -r https://demo.ckan.org action package_search facet.field='["tags"]' facet.limit=10 rows=0``
 
 All datasets that have tag 'economy':
 
-* browser: http://demo.ckan.org/api/3/action/package_search?fq=tags:economy
-* curl: ``curl 'http://demo.ckan.org/api/3/action/package_search?fq=tags:economy'``
-* ckanapi: ``ckanapi -r http://demo.ckan.org action package_search fq='tags:economy'``
+* browser: https://demo.ckan.org/api/3/action/package_search?fq=tags:economy
+* curl: ``curl 'https://demo.ckan.org/api/3/action/package_search?fq=tags:economy'``
+* ckanapi: ``ckanapi -r https://demo.ckan.org action package_search fq='tags:economy'``
 
 Tag Vocabularies
 ================
 
 Top 10 tags and vocabulary tags used by datasets:
 
-* browser: http://demo.ckan.org/api/action/package_search?facet.field=[%22tags%22]&facet.limit=10&rows=0
-* curl: ``curl 'http://demo.ckan.org/api/action/package_search?facet.field=\["tags"\]&facet.limit=10&rows=0'``
-* ckanapi: ``ckanapi -r http://demo.ckan.org action package_search facet.field='["tags"]' facet.limit=10 rows=0``
+* browser: https://demo.ckan.org/api/action/package_search?facet.field=[%22tags%22]&facet.limit=10&rows=0
+* curl: ``curl 'https://demo.ckan.org/api/action/package_search?facet.field=\["tags"\]&facet.limit=10&rows=0'``
+* ckanapi: ``ckanapi -r https://demo.ckan.org action package_search facet.field='["tags"]' facet.limit=10 rows=0``
 
 e.g. Facet: `vocab_Topics` means there is a vocabulary called Topics, and its top tags are listed under it.
 


### PR DESCRIPTION
The examples didn't work for me using HTTPie,
e.g. http http://demo.ckan.org/api/3/action/group_list 
gave me the HTTP response "301 Moved Permanently"
changing url to https solved the problem

Fixes #

changed all http://demo.ckan.org/api... links to https
(not sure about link in line 195, so I didn't change that)

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
