### PR TITLE
Consistent CLI behavior

### DIFF
--- a/changes/6120.bugfix
+++ b/changes/6120.bugfix
@@ -1,0 +1,1 @@
+Consistent CLI behavior when when no command provided and when using `--help` options

--- a/ckan/cli/asset.py
+++ b/ckan/cli/asset.py
@@ -12,10 +12,9 @@ from ckan.cli import error_shout
 log = logging.getLogger(__name__)
 
 
-@click.group()
+@click.group(short_help=u"WebAssets commands.")
 def asset():
     """WebAssets commands.
-
     """
     pass
 

--- a/ckan/cli/cli.py
+++ b/ckan/cli/cli.py
@@ -32,6 +32,10 @@ from ckan.cli import (
 
 from ckan.cli import seed
 
+META_ATTR = u'_ckan_meta'
+CMD_TYPE_PLUGIN = u'plugin'
+CMD_TYPE_ENTRY = u'entry_point'
+
 log = logging.getLogger(__name__)
 
 _no_config_commands = [
@@ -41,7 +45,7 @@ _no_config_commands = [
 ]
 
 
-class CkanCommand(object):
+class CtxObject(object):
 
     def __init__(self, conf=None):
         # Don't import `load_config` by itself, rather call it using
@@ -50,17 +54,123 @@ class CkanCommand(object):
         self.app = make_app(self.config)
 
 
+class ExtendableGroup(click.Group):
+    _section_titles = {
+        CMD_TYPE_PLUGIN: u'Plugins',
+        CMD_TYPE_ENTRY: u'Entry points',
+    }
+
+    def format_commands(self, ctx, formatter):
+        """Print help message.
+
+        Includes information about commands that were registered by extensions.
+        """
+        # click won't parse config file from envvar if no other options
+        # provided, except for `--help`. In this case it has to be done
+        # manually.
+        if not ctx.obj:
+            _add_ctx_object(ctx)
+            _add_external_commands(ctx)
+
+        commands = []
+        ext_commands = defaultdict(lambda: defaultdict(list))
+
+        for subcommand in self.list_commands(ctx):
+            cmd = self.get_command(ctx, subcommand)
+            if cmd is None:
+                continue
+            if cmd.hidden:
+                continue
+            help = cmd.short_help or u''
+
+            meta = getattr(cmd, META_ATTR, None)
+            if meta:
+                ext_commands[meta[u'type']][meta[u'name']].append(
+                    (subcommand, help))
+            else:
+                commands.append((subcommand, help))
+
+        if commands:
+            with formatter.section(u'Commands'):
+                formatter.write_dl(commands)
+
+        for section, group in ext_commands.items():
+            with formatter.section(self._section_titles.get(section, section)):
+                for rows in group.values():
+                    formatter.write_dl(rows)
+
+    def parse_args(self, ctx, args):
+        """Preprocess options and arguments.
+
+        As long as at least one option is provided, click won't fallback to
+        printing help message. That means that `ckan -c config.ini` will be
+        executed as command, instead of just printing help message(as `ckan -c
+        config.ini --help`).
+        In order to fix it, we have to check whether there is at least one
+        argument. If no, let's print help message manually
+
+        """
+        result = super().parse_args(ctx, args)
+        if not ctx.protected_args and not ctx.args:
+            click.echo(ctx.get_help(), color=ctx.color)
+            ctx.exit()
+        return result
+
+
+def _init_ckan_config(ctx, param, value):
+    if any(sys.argv[1:len(cmd) + 1] == cmd for cmd in _no_config_commands):
+        return
+    _add_ctx_object(ctx, value)
+    _add_external_commands(ctx)
+
+
+def _add_ctx_object(ctx, path=None):
+    """Initialize CKAN App using config file available under provided path.
+
+    """
+    try:
+        ctx.obj = CtxObject(path)
+    except CkanConfigurationException as e:
+        p.toolkit.error_shout(e)
+        ctx.abort()
+
+    if six.PY2:
+        ctx.meta["flask_app"] = ctx.obj.app.apps["flask_app"]._wsgi_app
+    else:
+        ctx.meta["flask_app"] = ctx.obj.app._wsgi_app
+
+
+def _add_external_commands(ctx):
+    for cmd in _get_commands_from_entry_point():
+        ctx.command.add_command(cmd)
+
+    plugins = p.PluginImplementations(p.IClick)
+    for cmd in _get_commands_from_plugins(plugins):
+        ctx.command.add_command(cmd)
+
+
+def _command_with_ckan_meta(cmd, name, type_):
+    """Mark command as one retrived from CKAN extension.
+
+    This information is used when CLI help text is generated.
+    """
+    setattr(cmd, META_ATTR, {u'name': name, u'type': type_})
+    return cmd
+
+
 def _get_commands_from_plugins(plugins):
+    """Register commands that are available when plugin enabled.
+
+    """
     for plugin in plugins:
         for cmd in plugin.get_commands():
-            cmd._ckan_meta = {
-                u'name': plugin.name,
-                u'type': u'plugin'
-            }
-            yield cmd
+            yield _command_with_ckan_meta(cmd, plugin.name, CMD_TYPE_PLUGIN)
 
 
 def _get_commands_from_entry_point(entry_point=u'ckan.click_command'):
+    """Register commands that are available even if plugin is not enabled.
+
+    """
     registered_entries = {}
     for entry in iter_entry_points(entry_point):
         if entry.name in registered_entries:
@@ -77,95 +187,15 @@ def _get_commands_from_entry_point(entry_point=u'ckan.click_command'):
             raise click.Abort()
         registered_entries[entry.name] = entry
 
-        cmd = entry.load()
-        cmd._ckan_meta = {
-            u'name': entry.name,
-            u'type': u'entry_point'
-        }
-        yield cmd
+        yield _command_with_ckan_meta(entry.load(), entry.name, CMD_TYPE_ENTRY)
 
 
-def _init_ckan_config(ctx, param, value):
-    is_help = u'--help' in sys.argv
-    no_config = False
-    if len(sys.argv) > 1:
-        for cmd in _no_config_commands:
-            if sys.argv[1:len(cmd) + 1] == cmd:
-                no_config = True
-                break
-    if no_config or is_help:
-        return
-
-    try:
-        ctx.obj = CkanCommand(value)
-    except CkanConfigurationException as e:
-        p.toolkit.error_shout(e)
-        raise click.Abort()
-
-    if six.PY2:
-        ctx.meta["flask_app"] = ctx.obj.app.apps["flask_app"]._wsgi_app
-    else:
-        ctx.meta["flask_app"] = ctx.obj.app._wsgi_app
-
-    for cmd in _get_commands_from_entry_point():
-        ctx.command.add_command(cmd)
-
-    plugins = p.PluginImplementations(p.IClick)
-    for cmd in _get_commands_from_plugins(plugins):
-        ctx.command.add_command(cmd)
-
-
-click_config_option = click.option(
-    u'-c',
-    u'--config',
-    default=None,
-    metavar=u'CONFIG',
-    help=u'Config file to use (default: development.ini)',
-    is_eager=True,
-    callback=_init_ckan_config
-)
-
-
-class CustomGroup(click.Group):
-    _section_titles = {
-        u'plugin': u'Plugins',
-        u'entry_point': u'Entry points',
-    }
-
-    def format_commands(self, ctx, formatter):
-        # Without any arguments click skips option callbacks.
-        self.parse_args(ctx, [u'help'])
-
-        commands = []
-        ext_commands = defaultdict(lambda: defaultdict(list))
-
-        for subcommand in self.list_commands(ctx):
-            cmd = self.get_command(ctx, subcommand)
-            if cmd is None:
-                continue
-            help = cmd.short_help or u''
-
-            meta = getattr(cmd, u'_ckan_meta', None)
-            if meta:
-                ext_commands[meta[u'type']][meta[u'name']].append(
-                    (subcommand, help))
-            else:
-                commands.append((subcommand, help))
-
-        if commands:
-            with formatter.section(u'Commands'):
-                formatter.write_dl(commands)
-
-        for section, group in ext_commands.items():
-            with formatter.section(self._section_titles.get(section, section)):
-                for _ext, rows in group.items():
-                    formatter.write_dl(rows)
-
-
-@click.group(cls=CustomGroup)
+@click.group(cls=ExtendableGroup)
+@click.option(u'-c', u'--config', metavar=u'CONFIG',
+              is_eager=True, callback=_init_ckan_config, expose_value=False,
+              help=u'Config file to use (default: ckan.ini)')
 @click.help_option(u'-h', u'--help')
-@click_config_option
-def ckan(config, *args, **kwargs):
+def ckan():
     pass
 
 

--- a/ckan/cli/dataset.py
+++ b/ckan/cli/dataset.py
@@ -18,6 +18,7 @@ def dataset():
     """
     pass
 
+
 @dataset.command()
 @click.argument(u'package')
 def show(package):

--- a/ckan/cli/dataset.py
+++ b/ckan/cli/dataset.py
@@ -12,11 +12,11 @@ import ckan.model as model
 log = logging.getLogger(__name__)
 
 
-@click.group()
+@click.group(short_help=u"Manage datasets")
 def dataset():
-    u'''Manage datasets
-    '''
-
+    """Manage datasets.
+    """
+    pass
 
 @dataset.command()
 @click.argument(u'package')

--- a/ckan/cli/db.py
+++ b/ckan/cli/db.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 applies_to_plugin = click.option(u"-p", u"--plugin", help=u"Affected plugin.")
 
 
-@click.group()
+@click.group(short_help=u"Database management commands.")
 def db():
     """Database management commands.
     """

--- a/ckan/cli/generate.py
+++ b/ckan/cli/generate.py
@@ -23,7 +23,7 @@ class CKANAlembicConfig(AlembicConfig):
                             u"../contrib/alembic")
 
 
-@click.group()
+@click.group(short_help=u"Scaffolding for regular development tasks.")
 def generate():
     """Scaffolding for regular development tasks.
     """

--- a/ckan/cli/views.py
+++ b/ckan/cli/views.py
@@ -19,7 +19,7 @@ from ckan.lib.datapreview import (
 _page_size = 100
 
 
-@click.group()
+@click.group(short_help=u"Manage resource views.")
 def views():
     """Manage resource views.
     """

--- a/ckan/tests/cli/test_cli.py
+++ b/ckan/tests/cli/test_cli.py
@@ -24,11 +24,11 @@ def test_incorrect_config(cli):
 
 
 def test_correct_config(cli, ckan_config):
-    """Presense of config file disables default printing of help message.
+    """With explicit config file user still sees help message.
     """
     result = cli.invoke(ckan, [u'-c', ckan_config[u'__file__']])
-    assert u'Error: Missing command.' in result.output
-    assert result.exit_code
+    assert u'Usage: ckan' in result.output
+    assert not result.exit_code
 
 
 def test_correct_config_with_help(cli, ckan_config):
@@ -54,6 +54,9 @@ def test_command_from_extension_shown_in_help_when_enabled(cli):
     """Extra commands shown in help when plugin enabled.
     """
     result = cli.invoke(ckan, [])
+    assert u'example-iclick-hello' in result.output
+
+    result = cli.invoke(ckan, [u'--help'])
     assert u'example-iclick-hello' in result.output
 
 

--- a/ckanext/datapusher/cli.py
+++ b/ckanext/datapusher/cli.py
@@ -29,10 +29,11 @@ def confirm(yes):
     click.confirm(question, abort=True)
 
 
-@click.group()
+@click.group(short_help=u"Perform commands in the datapusher.")
 def datapusher():
-    u'''Perform commands in the datapusher.
-    '''
+    """Perform commands in the datapusher.
+    """
+    pass
 
 
 @datapusher.command()

--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -22,6 +22,7 @@ def datastore():
     """
     pass
 
+
 @datastore.command(
     u'set-permissions',
     short_help=u'Generate SQL for permission configuration.'

--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -16,11 +16,11 @@ from ckanext.datastore.blueprint import DUMP_FORMATS, dump_to
 log = logging.getLogger(__name__)
 
 
-@click.group()
+@click.group(short_help=u"Perform commands to set up the datastore.")
 def datastore():
-    u'''Perform commands to set up the datastore.
-    '''
-
+    """Perform commands to set up the datastore.
+    """
+    pass
 
 @datastore.command(
     u'set-permissions',


### PR DESCRIPTION
Fixes #6120 and #5755

Predictable behavior when no command provided(print help message) or when `-h`/`--help` option is specified(print help message as well)
