### PR TITLE
Update cookiecutter to 1.7.3

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,7 +12,7 @@ pycodestyle==2.5.0
 pip-tools==5.1.2
 Sphinx==1.8.5
 sphinx-rtd-theme==0.4.3
-cookiecutter==1.7.2
+cookiecutter==1.7.3
 
 pytest==6.2.2
 pytest-split-tests==1.0.9


### PR DESCRIPTION
Right now `cookiecutter` has a conflicting dependency on `markupsafe` which produces warnings when installing `dev-requirements.txt`. 
The only change in this release ([from cookie-cutter changelog](https://github.com/cookiecutter/cookiecutter/releases/tag/1.7.3))
```
1.7.3
@ssbarnea ssbarnea released this on May 14

Fixed jinja2 and markupsafe dependencies
```