### PR TITLE
Remove blogspam link from the documentation footer

### DIFF
--- a/doc/_templates/footer.html
+++ b/doc/_templates/footer.html
@@ -37,8 +37,6 @@
 
   <p>
     Related Projects:
-    <a href="http://thedatahub.org/">The DataHub</a>
-    &mdash;
     <a href="http://datacatalogs.org">DataCatalogs.org</a>
     &mdash;
     <a href="http://openspending.org">OpenSpending.org</a>


### PR DESCRIPTION
While reading the documentation, I stumbled over the "The DataHub" link in the footer of each page. It seems like that this was an OKFN project that is no longer active in the form that was meant there - and actually got its domain taken over and replaced by blogspam.

### Proposed fixes:
Remove the Link.

### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
