### PR TITLE
fix pagination links for custom org types

### DIFF
--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -252,10 +252,9 @@ def _read(id, limit, group_type):
     sort_by = request.params.get(u'sort', None)
 
     def search_url(params):
-        controller = lookup_group_controller(group_type)
         action = u'bulk_process' if getattr(
             g, u'action', u'') == u'bulk_process' else u'read'
-        url = h.url_for(u'.'.join([controller, action]), id=id)
+        url = h.url_for(u'.'.join([group_type, action]), id=id)
         params = [(k, v.encode(u'utf-8')
                    if isinstance(v, string_types) else str(v))
                   for k, v in params]


### PR DESCRIPTION
### Proposed fixes:

This PR fixes the pagination links for custom group/org types

Currently, if you are on `/fancy-type/my-org?page=1` the page 2 link will be `/organization/my-org?page=2`
This fixes it so it will be `/fancy-type/my-org?page=2`

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport (2.9 please)
