### PR TITLE
fix edit member role of organization

### DIFF
--- a/ckan/templates/organization/member_new.html
+++ b/ckan/templates/organization/member_new.html
@@ -2,7 +2,7 @@
 
 {% import 'macros/form.html' as form %}
 
-{% set user = user_dict %}
+{% set user = g.user_dict %}
 
 {% block subtitle %}{{ _('Edit Member') if user else _('Add Member') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 


### PR DESCRIPTION

Fixes #
On the organization member's page, the member edit button is linked to create a new organization member instead of edit the member role.

### Proposed fixes:


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
