### PR TITLE
users can able to login with both username and email

### DIFF
--- a/ckan/lib/authenticator.py
+++ b/ckan/lib/authenticator.py
@@ -19,10 +19,10 @@ class UsernamePasswordAuthenticator(object):
             return None
 
         login = identity['login']
-        user = User.by_name(login)
+        user = User.by_name(login) or User.by_email(login)[0]
 
         if user is None:
-            log.debug('Login failed - username %r not found', login)
+            log.debug('Login failed - username or email %r not found', login)
         elif not user.is_active():
             log.debug('Login as %r failed - user isn\'t active', login)
         elif not user.validate_password(identity['password']):

--- a/ckan/templates/user/snippets/login_form.html
+++ b/ckan/templates/user/snippets/login_form.html
@@ -17,7 +17,7 @@ Example:
 <form action="{{ action }}" method="post">
   {{ form.errors(errors=error_summary) }}
 
-  {{ form.input('login', label=_("Username"), id='field-login', value="", error=username_error, classes=["control-medium"]) }}
+  {{ form.input('login', label=_("Username or Email"), id='field-login', value="", error=username_error, classes=["control-medium"]) }}
 
   {{ form.input('password', label=_("Password"), id='field-password', type="password", value="", error=password_error, classes=["control-medium"]) }}
 

--- a/ckan/tests/legacy/lib/test_authenticator.py
+++ b/ckan/tests/legacy/lib/test_authenticator.py
@@ -22,6 +22,16 @@ class TestUsernamePasswordAuthenticator(object):
         username = self.authenticate(environ, identity)
         assert username == user.name, username
 
+    def test_authenticate_succeeds_if_user_login_with_email_passowrd(self):
+        environ = {}
+        email = "someuser@xyz.com"
+        password = "somepass"
+        user = CreateTestData.create_user(
+            "a_user", **{"password": password, "email": email})
+        identity = {"login": email, "password": password}
+        username = self.authenticate(environ, identity)
+        assert username == user.name, username
+
     def test_authenticate_fails_if_user_is_deleted(self):
         environ = {}
         password = "somepass"


### PR DESCRIPTION
Fixes #6165

### Proposed fixes:
- Allow users to login using their registered email. 


### Features:

- [X ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
