### PR TITLE
[#6179] Fix exception when using solr_user and solr_password on Py3

### DIFF
--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -5,6 +5,7 @@ import logging
 import sys
 import cgitb
 import warnings
+import base64
 import xml.dom.minidom
 
 import requests
@@ -259,7 +260,7 @@ def _get_schema_from_solr(file_offset):
     http_auth = None
     if solr_user is not None and solr_password is not None:
         http_auth = solr_user + ':' + solr_password
-        http_auth = 'Basic ' + http_auth.encode('base64').strip()
+        http_auth = 'Basic {}'.format(base64.b64encode(http_auth.encode('utf8')).strip())
 
     url = solr_url.strip('/') + file_offset
 

--- a/ckan/tests/lib/search/test_common.py
+++ b/ckan/tests/lib/search/test_common.py
@@ -1,0 +1,11 @@
+import pytest
+
+from ckan.common import config
+
+
+@pytest.mark.ckan_config("solr_user", "solr")
+@pytest.mark.ckan_config("solr_password", "password")
+def test_solr_user_and_password(app):
+
+    assert config["solr_user"] == "solr"
+    assert config["solr_password"] == "password"

--- a/ckan/tests/lib/search/test_common.py
+++ b/ckan/tests/lib/search/test_common.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import pytest
 
 from ckan.common import config


### PR DESCRIPTION
Fixes #6179

Use the base64 module to encode the Solr Basic Auth header to avoid
bytes/str exception on Python 3

### Features:

- [x] includes bugfix for possible backport
