### PR TITLE
Fix page render errors when search facets are not defined

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1178,8 +1178,9 @@ def get_facet_items_dict(
     if search_facets is None:
         search_facets = getattr(c, u'search_facets', None)
 
-    if not search_facets or not search_facets.get(
-            facet, {}).get('items'):
+    if not search_facets \
+       or not isinstance(c.search_facets, dict) \
+       or not search_facets.get(facet, {}).get('items'):
         return []
     facets = []
     for facet_item in search_facets.get(facet)['items']:

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1179,7 +1179,7 @@ def get_facet_items_dict(
         search_facets = getattr(c, u'search_facets', None)
 
     if not search_facets \
-       or not isinstance(c.search_facets, dict) \
+       or not isinstance(search_facets, dict) \
        or not search_facets.get(facet, {}).get('items'):
         return []
     facets = []

--- a/ckan/templates/snippets/search_form.html
+++ b/ckan/templates/snippets/search_form.html
@@ -57,7 +57,7 @@
     {% if facets %}
       <p class="filter-list">
         {% for field in facets.fields %}
-          {% set search_facets_items = facets.search.get(field)['items'] %}
+          {% set search_facets_items = facets.search.get(field)['items'] if facets.search and field in facets.search else [] %}
           <span class="facet">{{ facets.titles.get(field) }}:</span>
           {% for value in facets.fields[field] %}
             <span class="filtered pill">


### PR DESCRIPTION
Partially fixes #5025

### Proposed fixes:
- Handle non-dict `search_facets` value in `get_facet_items_dict`
  - Manifests currently only with the old pylons implementation, but should still be checked
- Handle missing or invalid `search_facets` value in `snippets/search_form.html`

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply

Financed by Finland's open data portal opendata.fi. Find all Finnish open data at https://www.opendata.fi/en.
The Service is provided by the Digital and Population Data Services Agency (https://dvv.fi/en/).