### PR TITLE
Clean not accesed code

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1486,14 +1486,7 @@ def icon(name, alt=None, inline=True):
 
 @core_helper
 def resource_icon(res):
-    if False:
-        icon_name = 'page_white'
-        # if (res.is_404?): icon_name = 'page_white_error'
-        # also: 'page_white_gear'
-        # also: 'page_white_link'
-        return icon(icon_name)
-    else:
-        return icon(format_icon(res.get('format', '')))
+    return icon(format_icon(res.get('format', '')))
 
 
 @core_helper

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -748,21 +748,6 @@ def are_there_flash_messages():
 
 def _link_active(kwargs):
     ''' creates classes for the link_to calls '''
-    return _link_active_flask(kwargs)
-
-
-def _link_active_pylons(kwargs):
-    highlight_controllers = kwargs.get('highlight_controllers', [])
-    if highlight_controllers and c.controller in highlight_controllers:
-        return True
-
-    highlight_actions = kwargs.get('highlight_actions',
-                                   kwargs.get('action', '')).split()
-    return (c.controller == kwargs.get('controller')
-            and c.action in highlight_actions)
-
-
-def _link_active_flask(kwargs):
     blueprint, endpoint = p.toolkit.get_endpoint()
 
     highlight_controllers = kwargs.get('highlight_controllers', [])

--- a/ckan/tests/controllers/test_group.py
+++ b/ckan/tests/controllers/test_group.py
@@ -56,13 +56,6 @@ class TestGroupController(object):
             app.get(url=group_url)
 
 
-def _get_group_new_page(app):
-    user = factories.User()
-    env = {"REMOTE_USER": six.ensure_str(user["name"])}
-    response = app.get(url=url_for("group.new"), extra_environ=env)
-    return env, response
-
-
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 class TestGroupControllerNew(object):
     def test_not_logged_in(self, app):
@@ -126,17 +119,6 @@ class TestGroupControllerNew(object):
         assert form.select_one('[name=title]')['value'] == "title"
         assert form.select_one('[name=name]')['value'] == "name"
         assert form.select_one('[name=description]').text == "description"
-
-
-def _get_group_edit_page(app, group_name=None):
-    user = factories.User()
-    if group_name is None:
-        group = factories.Group(user=user)
-        group_name = group["name"]
-    env = {"REMOTE_USER": six.ensure_str(user["name"])}
-    url = url_for("group.edit", id=group_name)
-    response = app.get(url=url, extra_environ=env)
-    return env, response, group_name
 
 
 @pytest.mark.usefixtures("clean_db", "with_request_context")


### PR DESCRIPTION
### Proposed fixes:

- Removes `if False:` code block
- Removes old `_link_active_pylons` method that was not being used.
- Clean method sequence to execute directly `_link_active_flask` code when calling `_link_active`
- `_get_group_edit_page` and `_get_group_new_page` are not longer used in `test_group.py`. (They are used and duplicated in `test_controllers.py`)