### PR TITLE
Make `CKAN_*` envvars available as variables in config

### DIFF
--- a/changes/6192.misc
+++ b/changes/6192.misc
@@ -1,0 +1,1 @@
+Environment variables prefixed with `CKAN_` can be used as variables inside config file via `option = %(CKAN_***)s`

--- a/ckan/cli/__init__.py
+++ b/ckan/cli/__init__.py
@@ -18,7 +18,10 @@ class CKANConfigLoader(object):
         self.config = dict()
         self.parser = ConfigParser()
         self.section = u'app:main'
-        defaults = {u'__file__': os.path.abspath(self.config_file)}
+        defaults = dict(
+            (k, v) for k, v in os.environ.items()
+            if k.startswith("CKAN_"))
+        defaults['__file__'] = os.path.abspath(self.config_file)
         self._update_defaults(defaults)
         self._create_config_object()
 

--- a/ckan/tests/cli/data/test-env-var.ini
+++ b/ckan/tests/cli/data/test-env-var.ini
@@ -1,0 +1,3 @@
+[app:main]
+use = egg:ckan
+var = %(CKAN_TEST_ENV_VAR)s

--- a/ckan/tests/cli/data/test-no-env-var.ini
+++ b/ckan/tests/cli/data/test-no-env-var.ini
@@ -1,0 +1,3 @@
+[app:main]
+use = egg:ckan
+var = %(TEST_ENV_VAR)s

--- a/ckan/tests/cli/test_cli.py
+++ b/ckan/tests/cli/test_cli.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from configparser import InterpolationMissingOptionError
 import pytest
 import os
 
@@ -114,6 +115,26 @@ def test_ckan_config_loader_parse_two_files():
     assert conf[u'global_conf'][u'__file__'] == filename
     assert conf[u'global_conf'][u'here'] == tpl_dir
     assert conf[u'global_conf'][u'debug'] == u'false'
+
+
+def test_ckan_env_vars_in_config(monkeypatch):
+    """CKAN_ prefixed environment variables can be used in config.
+    """
+    filename = os.path.join(
+        os.path.dirname(__file__), u'data', u'test-env-var.ini')
+    monkeypatch.setenv("CKAN_TEST_ENV_VAR", "value")
+    conf = CKANConfigLoader(filename).get_config()
+    assert conf["var"] == "value"
+
+
+def test_other_env_vars_ignored(monkeypatch):
+    """Non-CKAN_ environment variables are ignored
+    """
+    filename = os.path.join(
+        os.path.dirname(__file__), u'data', u'test-no-env-var.ini')
+    monkeypatch.setenv("TEST_ENV_VAR", "value")
+    with pytest.raises(InterpolationMissingOptionError):
+        CKANConfigLoader(filename).get_config()
 
 
 def test_chain_loading():


### PR DESCRIPTION
Add all `CKAN_*` environment variables to the `[DEFAULT]` section of the config. We already doing something similar [for the subset of config options](https://github.com/ckan/ckan/blob/master/ckan/config/environment.py#L97-L115). But existing functionality is aggressive and unconditionally replaces config values with the ones that came from the environment. Probably it was done mainly for docker.

This PR provides this sort of functionality for any env variable with the name `CKAN_*` but in a less aggressive manner. Variable can be specified explicitly in the config file and then can be overridden with the static value if the current config file is extended by another one (#6192)