### PR TITLE
Fix minor typo

### DIFF
--- a/doc/contributing/python.rst
+++ b/doc/contributing/python.rst
@@ -60,7 +60,7 @@ Imports
 
   Most of the current CKAN code base imports just the modules and
   then accesses names with ``module.name``. This allows circular
-  imports in some cases and may still be necessary for exsiting
+  imports in some cases and may still be necessary for existing
   code, but is not recommended for new code.
 
 - Make all imports at the start of the file, after the module docstring.


### PR DESCRIPTION
Fixes a minor typo in [contributing/python](https://docs.ckan.org/en/2.9/contributing/python.html) page. On
> This allows circular imports in some cases and may still be necessary for exsiting code