### PR TITLE
Clean not accesed variables and methods in get.py

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -764,7 +764,7 @@ def tag_list(context, data_dict):
     _check_access('tag_list', context, data_dict)
 
     if query:
-        tags, _ = _tag_search(context, data_dict)
+        tags, count = _tag_search(context, data_dict)
     else:
         tags = model.Tag.all(vocab_id_or_name)
 
@@ -1021,7 +1021,7 @@ def package_show(context, data_dict):
         else:
             schema = package_plugin.show_package_schema()
         if schema and context.get('validate', True):
-            package_dict, _ = lib_plugins.plugin_validate(
+            package_dict, errors = lib_plugins.plugin_validate(
                 package_plugin, context, package_dict, schema,
                 'package_show')
 
@@ -1199,7 +1199,7 @@ def _group_or_org_show(context, data_dict, is_org=False):
 
     if schema is None:
         schema = logic.schema.default_show_group_schema()
-    group_dict, _ = lib_plugins.plugin_validate(
+    group_dict, errors = lib_plugins.plugin_validate(
         group_plugin, context, group_dict, schema,
         'organization_show' if is_org else 'group_show')
     return group_dict
@@ -2254,7 +2254,7 @@ def tag_autocomplete(context, data_dict):
 
     '''
     _check_access('tag_autocomplete', context, data_dict)
-    matching_tags, _ = _tag_search(context, data_dict)
+    matching_tags, count = _tag_search(context, data_dict)
     if matching_tags:
         return [tag.name for tag in matching_tags]
     else:

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -44,30 +44,10 @@ ValidationError = logic.ValidationError
 _get_or_bust = logic.get_or_bust
 
 _select = sqlalchemy.sql.select
-_aliased = sqlalchemy.orm.aliased
 _or_ = sqlalchemy.or_
 _and_ = sqlalchemy.and_
 _func = sqlalchemy.func
-_desc = sqlalchemy.desc
 _case = sqlalchemy.case
-_text = sqlalchemy.text
-
-
-def _activity_stream_get_filtered_users():
-    '''
-    Get the list of users from the :ref:`ckan.hide_activity_from_users` config
-    option and return a list of their ids. If the config is not specified,
-    returns the id of the site user.
-    '''
-    users = config.get('ckan.hide_activity_from_users')
-    if users:
-        users_list = users.split()
-    else:
-        context = {'model': model, 'ignore_auth': True}
-        site_user = logic.get_action('get_site_user')(context)
-        users_list = [site_user.get('name')]
-
-    return model.User.user_ids_for_name_or_id(users_list)
 
 
 def site_read(context, data_dict=None):
@@ -141,7 +121,6 @@ def current_package_list_with_resources(context, data_dict):
     :rtype: list of dictionaries
 
     '''
-    model = context["model"]
     limit = data_dict.get('limit')
     offset = data_dict.get('offset', 0)
     user = context['user']
@@ -3270,7 +3249,6 @@ def activity_show(context, data_dict):
     :rtype: dictionary
     '''
     model = context['model']
-    user = context['user']
     activity_id = _get_or_bust(data_dict, 'id')
     include_data = asbool(_get_or_bust(data_dict, 'include_data'))
 
@@ -3301,7 +3279,6 @@ def activity_data_show(context, data_dict):
     :rtype: dictionary
     '''
     model = context['model']
-    user = context['user']
     activity_id = _get_or_bust(data_dict, 'id')
     object_type = data_dict.get('object_type')
 
@@ -3340,7 +3317,6 @@ def activity_diff(context, data_dict):
     import difflib
 
     model = context['model']
-    user = context['user']
     activity_id = _get_or_bust(data_dict, 'id')
     object_type = _get_or_bust(data_dict, 'object_type')
     diff_type = data_dict.get('diff_type', 'unified')

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -764,7 +764,7 @@ def tag_list(context, data_dict):
     _check_access('tag_list', context, data_dict)
 
     if query:
-        tags, count = _tag_search(context, data_dict)
+        tags, _ = _tag_search(context, data_dict)
     else:
         tags = model.Tag.all(vocab_id_or_name)
 
@@ -1021,7 +1021,7 @@ def package_show(context, data_dict):
         else:
             schema = package_plugin.show_package_schema()
         if schema and context.get('validate', True):
-            package_dict, errors = lib_plugins.plugin_validate(
+            package_dict, _ = lib_plugins.plugin_validate(
                 package_plugin, context, package_dict, schema,
                 'package_show')
 
@@ -1199,7 +1199,7 @@ def _group_or_org_show(context, data_dict, is_org=False):
 
     if schema is None:
         schema = logic.schema.default_show_group_schema()
-    group_dict, errors = lib_plugins.plugin_validate(
+    group_dict, _ = lib_plugins.plugin_validate(
         group_plugin, context, group_dict, schema,
         'organization_show' if is_org else 'group_show')
     return group_dict
@@ -2254,7 +2254,7 @@ def tag_autocomplete(context, data_dict):
 
     '''
     _check_access('tag_autocomplete', context, data_dict)
-    matching_tags, count = _tag_search(context, data_dict)
+    matching_tags, _ = _tag_search(context, data_dict)
     if matching_tags:
         return [tag.name for tag in matching_tags]
     else:


### PR DESCRIPTION
Clean some variables that are not accessed anywhere in the module nor the code:

- some unused `sqlalchemy` functions
- `_activity_stream_get_filtered_users` now lives in [model/activity.py](https://github.com/ckan/ckan/blob/9640287cf829cb8c6b723d79c7fa6e4db4f43b63/ckan/model/activity.py#L484-L499)
- some `users` and `model` variables that were not being used in the methods.