### PR TITLE
Updated python-magic to version 0.4.24

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ Markdown==3.3.3
 passlib==1.7.3
 polib==1.0.7
 psycopg2==2.8.2
-python-magic==0.4.15
+python-magic==0.4.24
 pysolr==3.6.0
 python-dateutil>=1.5.0
 pytz==2016.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ pyparsing==2.4.7          # via packaging
 pysolr==3.6.0             # via -r requirements.in
 python-dateutil==2.8.1    # via -r requirements.in, alembic, feedgen
 python-editor==1.0.4      # via alembic
-python-magic==0.4.15      # via -r requirements.in
+python-magic==0.4.24      # via -r requirements.in
 pytz==2016.7              # via -r requirements.in, babel, flask-babel, tzlocal
 pyutilib==5.7.1           # via -r requirements.in
 pyyaml==5.4.1             # via -r requirements.in


### PR DESCRIPTION
# Fixes
Hi,
we're running CKAN in a Docker container that is based on Alpine 3. This leads to the exceptions when sending files to the Datastore for some formats (e.g. GeoJSON). The exception states that `python-magic` could not find libmagic. (`ImportError: failed to find libmagic.  Check your installation`)
This is a known problem in `python-magic` and was fixed in version 0.4.24, see this [issue here](https://github.com/ahupp/python-magic/issues/247). CKAN uses `python-magic` version 0.4.15 at the moment.
If I'm not mistaken this problem already occurred once about 3 years ago in the CKAN repo, [see this issue](https://github.com/ckan/ckan/issues/4098).

### Proposed fixes:
This PR updates the `python-magic` package to to version 0.4.24 (latest as of writing this). We already patched this for building our CKAN instance, which solved the issue and did not lead to any problems.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
