### PR TITLE
redesign sysadmin password field

### DIFF
--- a/ckan/templates/user/edit_user_form.html
+++ b/ckan/templates/user/edit_user_form.html
@@ -32,12 +32,36 @@
     {% block extra_fields %}
     {% endblock %}
 
+    {% if is_sysadmin and g.user != data.name %}
+    {% block sysadmin_password %}
+      <fieldset>
+      <legend>{{ _('Change ' + data.name|capitalize + "'s" + ' password') }}</legend>
+      {{ form.input('password1', type='password', label=_('Password'), id='field-password', value=data.password1, error=errors.password1, classes=['control-medium'], attrs={'autocomplete': 'off', 'class': 'form-control'} ) }}
+      {{ form.input('password2', type='password', label=_('Confirm Password'), id='field-password-confirm', value=data.password2, error=errors.password2, classes=['control-medium'], attrs={'autocomplete': 'off', 'class': 'form-control'}) }}
+    </fieldset>
+
+    <fieldset>
+      <legend>{{ _('Sysadmin password') }}</legend>
+        {{ form.input('old_password',
+                      type='password',
+                      label=_('Sysadmin Password'),
+                      id='field-password-old',
+                      value=data.oldpassword,
+                      error=errors.oldpassword,
+                      classes=['control-medium'],
+                      attrs={'autocomplete': 'off', 'class': 'form-control'}
+                      ) }}
+        
+      </fieldset>
+    {% endblock %}
+
+    {% else %}
     {% block change_password %}
       <fieldset>
         <legend>{{ _('Change password') }}</legend>
         {{ form.input('old_password',
                       type='password',
-                      label=_('Sysadmin Password') if is_sysadmin else _('Old Password'),
+                      label=_('Old Password'),
                       id='field-password-old',
                       value=data.oldpassword,
                       error=errors.oldpassword,
@@ -50,6 +74,7 @@
         {{ form.input('password2', type='password', label=_('Confirm Password'), id='field-password-confirm', value=data.password2, error=errors.password2, classes=['control-medium'], attrs={'autocomplete': 'off', 'class': 'form-control'}) }}
       </fieldset>
     {% endblock %}
+    {% endif %}
 
     <div class="form-actions">
       {% block form_actions %}


### PR DESCRIPTION
Fixes #6142
Sysadmin password field is no longer part of the user password changing block.

### Proposed fixes:
I added new sysadmin_block for optional extensibility and moved sysadmin password field into this block.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
