### PR TITLE
Remove leftover merge conflict text

### DIFF
--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -205,11 +205,7 @@ This task of automatically parsing and then adding data to the DataStore is
 performed by the `DataPusher`_, a service that runs asynchronously and can be installed
 alongside CKAN.
 
-<<<<<<< HEAD
-To install this please look at the docs here: http://docs.ckan.org/projects/datapusher
-=======
 To install this please look at the docs here: https://github.com/ckan/datapusher
->>>>>>> 4013dff64... Update references to DataPusher documentation
 
 .. note:: The DataPusher only imports the first worksheet of a spreadsheet. It also does
    not support duplicate column headers. That includes blank column headings.


### PR DESCRIPTION
I don't think this needs the PR template. This just removes some leftover text from a merge conflict.
