### PR TITLE
Remove leftover merge conflict text in CKAN 2.7 DataPusher docs

### DIFF
--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -228,11 +228,7 @@ This task of automatically parsing and then adding data to the DataStore is
 performed by the `DataPusher`_, a service that runs asynchronously and can be installed
 alongside CKAN.
 
-<<<<<<< HEAD
-To install this please look at the docs here: http://docs.ckan.org/projects/datapusher
-=======
 To install this please look at the docs here: https://github.com/ckan/datapusher
->>>>>>> 4013dff64... Update references to DataPusher documentation
 
 
 .. _data_dictionary:


### PR DESCRIPTION
This removes leftover text from a merge conflict in CKAN 2.7 DataPusher docs.