### PR TITLE
Remove unused session objects

### DIFF
--- a/ckan/lib/dictization/__init__.py
+++ b/ckan/lib/dictization/__init__.py
@@ -30,9 +30,6 @@ def table_dictize(obj, context, **kw):
 
     result_dict = {}
 
-    model = context["model"]
-    session = model.Session
-
     if isinstance(obj, RowProxy):
         fields = obj.keys()
     else:

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -1447,7 +1447,6 @@ def _group_or_org_member_create(context, data_dict, is_org=False):
     # this needs to be after the repo.commit or else revisions break
     model = context['model']
     user = context['user']
-    session = context['session']
 
     schema = ckan.logic.schema.member_schema()
     data, errors = _validate(data_dict, schema, context)
@@ -1478,7 +1477,6 @@ def _group_or_org_member_create(context, data_dict, is_org=False):
     member_create_context = {
         'model': model,
         'user': user,
-        'session': session,
         'ignore_auth': context.get('ignore_auth'),
     }
     return logic.get_action('member_create')(member_create_context,


### PR DESCRIPTION
- `session` is not used in `_group_or_org_member_create`
- action `member_create` does not use a session object (neither the authz calls) so no need to add it to the context.
- `table_dictize` gets `model` and then `model.Session` from context but it is not used in the method.

