### PR TITLE
Remove not accessed variables in update.py

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -897,8 +897,6 @@ def user_generate_apikey(context, data_dict):
     :rtype: dictionary
     '''
     model = context['model']
-    user = context['user']
-    session = context['session']
     schema = context.get('schema') or schema_.default_generate_apikey_user_schema()
     context['schema'] = schema
     # check if user id in data_dict
@@ -1175,7 +1173,6 @@ def package_owner_org_update(context, data_dict):
     :type organization_id: string
     '''
     model = context['model']
-    user = context['user']
     name_or_id = data_dict.get('id')
     organization_id = data_dict.get('organization_id')
 


### PR DESCRIPTION
- `user` and `session` objects are not used in the methods so there is no need to get them from the context object.