### PR TITLE
Clean not accessed variables in delete.py

### DIFF
--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -266,7 +266,6 @@ def package_relationship_delete(context, data_dict):
 
     '''
     model = context['model']
-    user = context['user']
     id, id2, rel = _get_or_bust(data_dict, ['subject', 'object', 'type'])
 
     pkg1 = model.Package.get(id)
@@ -281,7 +280,6 @@ def package_relationship_delete(context, data_dict):
         raise NotFound
 
     relationship = existing_rels[0]
-    revisioned_details = 'Package Relationship: %s %s %s' % (id, rel, id2)
 
     context['relationship'] = relationship
     _check_access('package_relationship_delete', context, data_dict)
@@ -398,8 +396,6 @@ def _group_or_org_delete(context, data_dict, is_org=False):
     if group is None:
         raise NotFound('Group was not found.')
 
-    revisioned_details = 'Group: %s' % group.name
-
     if is_org:
         _check_access('organization_delete', context, data_dict)
     else:
@@ -451,7 +447,6 @@ def _group_or_org_delete(context, data_dict, is_org=False):
     }
     activity_create_context = {
         'model': model,
-        'user': user,
         'defer_commit': True,
         'ignore_auth': True,
         'session': context['session']


### PR DESCRIPTION
- Clean some variables that are not used in the method
- Removing `user` field from `activity_create_context` since it is not needed down in the chain.