### PR TITLE
Refactor task_status_delete authz method

### DIFF
--- a/ckan/logic/auth/delete.py
+++ b/ckan/logic/auth/delete.py
@@ -108,12 +108,6 @@ def organization_delete(context, data_dict):
     else:
         return {'success': True}
 
-def revision_undelete(context, data_dict):
-    return {'success': False, 'msg': 'Not implemented yet in the auth refactor'}
-
-def revision_delete(context, data_dict):
-    return {'success': False, 'msg': 'Not implemented yet in the auth refactor'}
-
 def task_status_delete(context, data_dict):
     # sysadmins only
     return {'success': False}

--- a/ckan/logic/auth/delete.py
+++ b/ckan/logic/auth/delete.py
@@ -116,8 +116,7 @@ def revision_delete(context, data_dict):
 
 def task_status_delete(context, data_dict):
     # sysadmins only
-    user = context['user']
-    return {'success': False, 'msg': _('User %s not authorized to delete task_status') % user}
+    return {'success': False}
 
 def vocabulary_delete(context, data_dict):
     # sysadmins only

--- a/ckan/tests/legacy/test_coding_standards.py
+++ b/ckan/tests/legacy/test_coding_standards.py
@@ -542,8 +542,6 @@ class TestActionAuth(object):
 
     AUTH_NO_ACTION_BLACKLIST = [
         "create: file_upload",
-        "delete: revision_delete",
-        "delete: revision_undelete",
         "get: activity_list",
         "get: group_list_available",
         "get: sysadmin",


### PR DESCRIPTION
- Sanitize `task_status_delete` to behave as other sysadmin authz functions
- Remove old revision authz functions that are no longer used