### PR TITLE
Clean old resource method

### DIFF
--- a/ckan/model/resource.py
+++ b/ckan/model/resource.py
@@ -132,25 +132,6 @@ class Resource(core.StatefulObjectMixin,
                 setattr(cls, field, DictProxy(field, 'extras'))
         return cls.extra_columns
 
-    @classmethod
-    def get_all_without_views(cls, formats=[]):
-        '''Returns all resources that have no resource views
-
-        :param formats: if given, returns only resources that have no resource
-            views and are in any of the received formats
-        :type formats: list
-
-        :rtype: list of ckan.model.Resource objects
-        '''
-        query = meta.Session.query(cls).outerjoin(ckan.model.ResourceView) \
-                    .filter(ckan.model.ResourceView.id == None)
-
-        if formats:
-            lowercase_formats = [f.lower() for f in formats]
-            query = query.filter(func.lower(cls.format).in_(lowercase_formats))
-
-        return query.all()
-
     def related_packages(self):
         return [self.package]
 

--- a/ckan/tests/model/test_resource.py
+++ b/ckan/tests/model/test_resource.py
@@ -27,32 +27,6 @@ class TestReousrce(object):
         res = Resource.get(res_dict["id"])
         assert res.extras["newfield"] == "second"
 
-    def test_get_all_without_views_returns_all_resources_without_views(self):
-        # Create resource with resource_view
-        factories.ResourceView()
-
-        expected_resources = [
-            factories.Resource(format="format"),
-            factories.Resource(format="other_format"),
-        ]
-
-        resources = Resource.get_all_without_views()
-
-        expected_resources_ids = [r["id"] for r in expected_resources]
-        resources_ids = [r.id for r in resources]
-
-        assert expected_resources_ids.sort() == resources_ids.sort()
-
-    def test_get_all_without_views_accepts_list_of_formats_ignoring_case(self):
-        factories.Resource(format="other_format")
-        resource_id = factories.Resource(format="format")["id"]
-
-        resources = Resource.get_all_without_views(["FORMAT"])
-
-        length = len(resources)
-        assert length == 1, "Expected 1 resource, but got %d" % length
-        assert [resources[0].id] == [resource_id]
-
     def test_resource_count(self):
         """Resource.count() should return a count of instances of Resource
         class"""

--- a/ckan/tests/model/test_resource.py
+++ b/ckan/tests/model/test_resource.py
@@ -10,7 +10,7 @@ Resource = model.Resource
 
 @pytest.mark.ckan_config("ckan.plugins", "image_view")
 @pytest.mark.usefixtures("clean_db", "with_plugins")
-class TestReousrce(object):
+class TestResource(object):
     def test_edit_url(self):
         res_dict = factories.Resource(url="http://first")
         res = Resource.get(res_dict["id"])


### PR DESCRIPTION
The Resource's model method `get_all_without_views` is not used in the repository neither in any of the main extensions in the CKAN organization.

- The code using this method was removed years ago in this PR: https://github.com/ckan/ckan/pull/2204
- None of the extensions in the CKAN organization is using it: https://github.com/search?q=org%3Ackan+get_all_without_views&type=code

This is related to the clean of resource_view code we are doing in this PR: https://github.com/ckan/ckan/pull/6205/files

I'm not sure how's the process to maintain, clean the code or deprecate functions but I think it's safe to remove if is not actually used.