### PR TITLE
Update CKAN Docker - 20_postgis_permissions.sql

### DIFF
--- a/contrib/docker/postgresql/docker-entrypoint-initdb.d/20_postgis_permissions.sql
+++ b/contrib/docker/postgresql/docker-entrypoint-initdb.d/20_postgis_permissions.sql
@@ -1,3 +1,2 @@
-CREATE EXTENSION POSTGIS;
 ALTER VIEW geometry_columns OWNER TO ckan;
 ALTER TABLE spatial_ref_sys OWNER TO ckan;


### PR DESCRIPTION
Fixes #6231

### Proposed fixes:
The 20_postgis_permissions.sql script is used when the db container is built during runtime. The base image is now postgis/postgis:11-3.1 which includes the postgis extension - therefore the `CREATE EXTENSION POSTGIS;` line is no longer needed in this script


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
