### PR TITLE
[2317] fix default ordering consuming resouce content from datastore

### DIFF
--- a/changes/2317.bugfix
+++ b/changes/2317.bugfix
@@ -1,0 +1,1 @@
+Fixed default ordering when consuming resource content from datastore

--- a/changes/2317.bugfix
+++ b/changes/2317.bugfix
@@ -1,1 +1,1 @@
-Fixed default ordering when consuming resource content from datastore
+Stable default ordering when consuming resource content from datastore

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1296,7 +1296,7 @@ def search_data(context, data_dict):
 
     query_dict = {
         'select': [],
-        'sort': ['_id'],
+        'sort': [],
         'where': []
     }
 
@@ -1318,6 +1318,9 @@ def search_data(context, data_dict):
         distinct = 'DISTINCT'
     else:
         distinct = ''
+
+    if not sort:
+        sort = ['_id']
 
     if sort:
         sort_clause = 'ORDER BY %s' % (', '.join(sort)).replace('%', '%%')

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1319,7 +1319,7 @@ def search_data(context, data_dict):
     else:
         distinct = ''
 
-    if not sort:
+    if not sort and not distinct:
         sort = ['_id']
 
     if sort:

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1296,7 +1296,7 @@ def search_data(context, data_dict):
 
     query_dict = {
         'select': [],
-        'sort': [],
+        'sort': ['_id'],
         'where': []
     }
 


### PR DESCRIPTION

Fixes #2317 

### Proposed fixes:

Fixed default ordering when consuming resource content from datastore

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
