### PR TITLE
Fix unquoted attributes

### DIFF
--- a/ckan/templates/snippets/group.html
+++ b/ckan/templates/snippets/group.html
@@ -17,7 +17,7 @@ Example:
         <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" class="img-responsive" width="200" height="125" alt="{{ group.name }}" />
       </a>
       <div class="media-content">
-        <h3 class="media-heading"><a href={{ url }}>{{ group.title or group.name }}</a></h3>
+        <h3 class="media-heading"><a href="{{ url }}">{{ group.title or group.name }}</a></h3>
         {% if group.description %}
           <p>{{ h.markdown_extract(group.description, truncate) }}</p>
         {% endif %}

--- a/ckan/templates/snippets/organization_item.html
+++ b/ckan/templates/snippets/organization_item.html
@@ -10,7 +10,7 @@
         </a>
         {% endblock %}
         {% block organization_item_header_title %}
-          <h3 class="media-heading"><a href={{ url }}>{{ organization.title or organization.name }}</a></h3>
+          <h3 class="media-heading"><a href="{{ url }}">{{ organization.title or organization.name }}</a></h3>
         {% endblock %}
         {% block organization_item_header_description %}
           {% if organization.description %}


### PR DESCRIPTION
Jinja2 templates attributes should always be quoted to avoid XSS: https://flask.palletsprojects.com/en/2.0.x/security/#cross-site-scripting-xss