### PR TITLE
Clean lib/base.py

### DIFF
--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -5,29 +5,18 @@
 Provides the BaseController class for subclassing.
 """
 import logging
-import time
-import inspect
-import sys
 
 from jinja2.exceptions import TemplateNotFound
 
-import six
 from flask import (
     render_template as flask_render_template,
     abort as flask_abort
 )
 
-import ckan.lib.i18n as i18n
-import ckan.lib.render as render_
 import ckan.lib.helpers as h
-import ckan.lib.app_globals as app_globals
 import ckan.plugins as p
-import ckan.model as model
-from ckan.views import (identify_user,
-                        set_cors_headers_for_response,
-                        check_session_cookie,
-                        )
-from ckan.common import (c, request, config,
+
+from ckan.common import (request, config,
                          session, asbool)
 
 

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -94,12 +94,6 @@ def render_snippet(*template_names, **kw):
         raise last_exc or TemplateNotFound
 
 
-def render_jinja2(template_name, extra_vars):
-    env = config['pylons.app_globals'].jinja_env
-    template = env.get_template(template_name)
-    return template.render(**extra_vars)
-
-
 def render(template_name, extra_vars=None):
     '''Render a template and return the output.
 

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -100,7 +100,7 @@ def render_jinja2(template_name, extra_vars):
     return template.render(**extra_vars)
 
 
-def render(template_name, extra_vars=None, *pargs, **kwargs):
+def render(template_name, extra_vars=None):
     '''Render a template and return the output.
 
     This is CKAN's main template rendering function.
@@ -109,19 +109,8 @@ def render(template_name, extra_vars=None, *pargs, **kwargs):
     :type template_name: str
     :params extra_vars: additional variables available in template
     :type extra_vars: dict
-    :params pargs: DEPRECATED
-    :type pargs: tuple
-    :params kwargs: DEPRECATED
-    :type kwargs: dict
 
     '''
-    if pargs or kwargs:
-        tb = inspect.getframeinfo(sys._getframe(1))
-        log.warning(
-            'Extra arguments to `base.render` are deprecated: ' +
-            '<{0.filename}:{0.lineno}>'.format(tb)
-        )
-
     if extra_vars is None:
         extra_vars = {}
 

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -165,7 +165,3 @@ def _is_valid_session_cookie_data():
             break
 
     return is_valid_cookie_data
-
-
-class ValidationException(Exception):
-    pass

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -40,7 +40,7 @@ APIKEY_HEADER_NAME_DEFAULT = 'X-CKAN-API-Key'
 def abort(status_code=None, detail='', headers=None, comment=None):
     '''Abort the current request immediately by returning an HTTP exception.
 
-    This is a wrapper for :py:func:`pylons.controllers.util.abort` that adds
+    This is a wrapper for :py:func:`flask.abort` that adds
     some CKAN custom behavior, including allowing
     :py:class:`~ckan.plugins.interfaces.IAuthenticator` plugins to alter the
     abort response, and showing flash messages in the web interface.

--- a/ckanext/example_theme_docs/custom_emails/tests.py
+++ b/ckanext/example_theme_docs/custom_emails/tests.py
@@ -6,7 +6,7 @@ from ckan import plugins
 import ckan.model as model
 import ckan.lib.mailer as mailer
 from ckan.tests import factories
-from ckan.lib.base import render_jinja2
+from ckan.lib.base import render
 from ckan.common import config
 
 from ckan.tests.lib.test_mailer import MailerBase
@@ -43,7 +43,7 @@ class TestExampleCustomEmailsPlugin(MailerBase):
         assert len(msgs) == 1
         msg = msgs[0]
         extra_vars = {"site_title": config.get("ckan.site_title")}
-        expected = render_jinja2(
+        expected = render(
             "emails/reset_password_subject.txt", extra_vars
         )
         expected = expected.split("\n")[0]
@@ -63,7 +63,7 @@ class TestExampleCustomEmailsPlugin(MailerBase):
         assert len(msgs) == 1
         msg = msgs[0]
         extra_vars = {"reset_link": mailer.get_reset_link(user_obj)}
-        expected = render_jinja2("emails/reset_password.txt", extra_vars)
+        expected = render("emails/reset_password.txt", extra_vars)
         body = self.get_email_body(msg[3])
         assert expected == body
         assert "**test**" in body
@@ -81,7 +81,7 @@ class TestExampleCustomEmailsPlugin(MailerBase):
         extra_vars = {
             "site_title": config.get("ckan.site_title"),
         }
-        expected = render_jinja2("emails/invite_user_subject.txt", extra_vars)
+        expected = render("emails/invite_user_subject.txt", extra_vars)
         expected = expected.split("\n")[0]
 
         subject = self.get_email_subject(msg[3])
@@ -103,7 +103,7 @@ class TestExampleCustomEmailsPlugin(MailerBase):
             "user_name": user["name"],
             "site_title": config.get("ckan.site_title"),
         }
-        expected = render_jinja2("emails/invite_user.txt", extra_vars)
+        expected = render("emails/invite_user.txt", extra_vars)
         body = self.get_email_body(msg[3])
         assert expected == body
         assert "**test**" in body

--- a/ckanext/resourceproxy/blueprint.py
+++ b/ckanext/resourceproxy/blueprint.py
@@ -6,7 +6,7 @@ import requests
 from six.moves.urllib.parse import urlsplit
 from flask import Blueprint, make_response
 
-import ckan.lib.base as base
+import ckan.model as model
 import ckan.logic as logic
 from ckan.common import config, _
 from ckan.plugins.toolkit import (asint, abort, get_action, c)
@@ -100,8 +100,8 @@ def proxy_resource(context, data_dict):
 def proxy_view(id, resource_id):
     data_dict = {u'resource_id': resource_id}
     context = {
-        u'model': base.model,
-        u'session': base.model.Session,
+        u'model': model,
+        u'session': model.Session,
         u'user': c.user
     }
     return proxy_resource(context, data_dict)


### PR DESCRIPTION
This PR cleans the `base.py` module:
- Fixes docstring on `abort` method
- Clean old deprecated arguments from `render`
- Removes `render_jinja2` function since it depends on the no longer existing `pylons.app_globals` config
- Cleans unused imports
- Edit `custom_emails` example to use `render` instead of `render_jinja2`