### PR TITLE
Delete render.py module

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -17,7 +17,6 @@ import ckan.lib.plugins as lib_plugins
 import ckan.lib.helpers as helpers
 import ckan.lib.app_globals as app_globals
 from ckan.lib.redis import is_redis_available
-import ckan.lib.render as render
 import ckan.lib.search as search
 import ckan.logic as logic
 import ckan.authz as authz

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -238,10 +238,6 @@ def update_config():
     for plugin in p.PluginImplementations(p.IConfigurable):
         plugin.configure(config)
 
-    # reset the template cache - we do this here so that when we load the
-    # environment it is clean
-    render.reset_template_info_cache()
-
     # clear other caches
     logic.clear_actions_cache()
     logic.clear_validators_cache()

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -18,7 +18,6 @@ from flask import (
 )
 
 import ckan.lib.i18n as i18n
-import ckan.lib.render as render_
 import ckan.lib.helpers as h
 import ckan.lib.app_globals as app_globals
 import ckan.plugins as p

--- a/ckan/lib/render.py
+++ b/ckan/lib/render.py
@@ -1,18 +1,4 @@
 # encoding: utf-8
 
-import os
-import logging
-
-from ckan.common import config
-
-log = logging.getLogger(__name__)
-
-_template_info_cache = {}
-
-def reset_template_info_cache():
-    '''Reset the template cache'''
-    _template_info_cache.clear()
-
-
 class TemplateNotFound(Exception):
     pass

--- a/ckan/lib/render.py
+++ b/ckan/lib/render.py
@@ -1,4 +1,0 @@
-# encoding: utf-8
-
-class TemplateNotFound(Exception):
-    pass

--- a/ckan/lib/render.py
+++ b/ckan/lib/render.py
@@ -26,23 +26,3 @@ def template_type(template_path):
 
 class TemplateNotFound(Exception):
     pass
-
-def template_info(template_name):
-    ''' Returns the path and type for a template '''
-
-    if template_name in _template_info_cache:
-        t_data = _template_info_cache[template_name]
-        return t_data['template_path'], t_data['template_type']
-
-    template_path = find_template(template_name)
-    if not template_path:
-        raise TemplateNotFound('Template %s cannot be found' % template_name)
-    t_type = template_type(template_path)
-
-    # if in debug mode we always want to search for templates so we
-    # don't want to store it.
-    if not config.get('debug', False):
-        t_data = {'template_path' : template_path,
-                  'template_type' : t_type,}
-        _template_info_cache[template_name] = t_data
-    return template_path, t_type

--- a/ckan/lib/render.py
+++ b/ckan/lib/render.py
@@ -13,16 +13,6 @@ def reset_template_info_cache():
     '''Reset the template cache'''
     _template_info_cache.clear()
 
-def find_template(template_name):
-    ''' looks through the possible template paths to find a template
-    returns the full path is it exists. '''
-    template_paths = config['computed_template_paths']
-    for path in template_paths:
-        if os.path.exists(os.path.join(path, template_name.encode('utf-8'))):
-            return os.path.join(path, template_name)
-
-def template_type(template_path):
-    return 'jinja2'
 
 class TemplateNotFound(Exception):
     pass

--- a/ckan/tests/legacy/test_coding_standards.py
+++ b/ckan/tests/legacy/test_coding_standards.py
@@ -319,7 +319,6 @@ class TestPep8(object):
         "ckan/lib/navl/validators.py",
         "ckan/lib/package_saver.py",
         "ckan/lib/plugins.py",
-        "ckan/lib/render.py",
         "ckan/lib/search/__init__.py",
         "ckan/lib/search/index.py",
         "ckan/lib/search/query.py",

--- a/ckan/tests/test_coding_standards.py
+++ b/ckan/tests/test_coding_standards.py
@@ -284,7 +284,6 @@ _STRING_LITERALS_WHITELIST = [
     u"ckan/lib/navl/dictization_functions.py",
     u"ckan/lib/navl/validators.py",
     u"ckan/lib/plugins.py",
-    u"ckan/lib/render.py",
     u"ckan/lib/search/__init__.py",
     u"ckan/lib/search/common.py",
     u"ckan/lib/search/index.py",

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 from flask import Blueprint
 from flask.views import MethodView
+from jinja2.exceptions import TemplateNotFound
 from werkzeug.datastructures import MultiDict
 from ckan.common import asbool
 
@@ -24,7 +25,6 @@ import ckan.authz as authz
 from ckan.common import _, config, g, request
 from ckan.views.home import CACHE_PARAMETERS
 from ckan.lib.plugins import lookup_package_plugin
-from ckan.lib.render import TemplateNotFound
 from ckan.lib.search import SearchError, SearchQueryError, SearchIndexError
 from ckan.views import LazyView
 


### PR DESCRIPTION
`render.py` module contains irrelevant code that it is no longer used in CKAN. Most of it was remove during `pylons` removal. 

For example: https://github.com/ckan/ckan/commit/4726519265f038f059862fb53d4c736f43172a21

#### More details:
 - `render.py` was imported as `render_` in `base.py` but it is no longer the case, it was removed in the example commit
 - `template_info(...)` was being used in an old `_pylons_prepare_renderer` function in `base.py` module
 - `find_template(...)` is only used in `template_info(...)`
 - `reset_template_info_cache(...)` only cleans a dict in `render.py` module that it is never updated so it has zero effect.
 - I standarized to use jinja2 `TemplateNotFound` exception in `dataset.py` views as we are currently using it other modules too

