### PR TITLE
Remove unused Jinja2 `Environment.get_attr patch`

### DIFF
--- a/ckan/lib/jinja_extensions.py
+++ b/ckan/lib/jinja_extensions.py
@@ -9,7 +9,6 @@ from jinja2 import loaders
 from jinja2 import ext
 from jinja2.exceptions import TemplateNotFound
 from jinja2.utils import open_if_exists, escape
-from jinja2 import Environment
 
 from six import text_type
 from six.moves import xrange
@@ -350,37 +349,3 @@ class AssetExtension(BaseExtension):
         assert len(kwargs) == 0
         h.include_asset(args[0])
         return ''
-
-
-'''
-The following function is based on jinja2 code
-
-Provides a class that holds runtime and parsing time options.
-
-:copyright: (c) 2010 by the Jinja Team.
-:license: BSD, see LICENSE for more details.
-'''
-
-def jinja2_getattr(self, obj, attribute):
-    """Get an item or attribute of an object but prefer the attribute.
-    Unlike :meth:`getitem` the attribute *must* be a bytestring.
-
-    This is a customised version to work with properties
-    """
-    try:
-        value = getattr(obj, attribute)
-        if isinstance(value, property):
-            value = value.fget()
-        return value
-    except AttributeError:
-        pass
-    try:
-        value = obj[attribute]
-        if isinstance(value, property):
-            value = value.fget()
-        return value
-    except (TypeError, LookupError, AttributeError):
-        return self.undefined(obj=obj, name=attribute)
-
-setattr(Environment, 'get_attr', jinja2_getattr)
-del jinja2_getattr


### PR DESCRIPTION
This code was written 10 years ago and since then Jinja2's `Environment` has changed quite a bit. Now this patch has no effect at all 