### PR TITLE
add jinja2 loop control extensions

### DIFF
--- a/ckan/lib/jinja_extensions.py
+++ b/ckan/lib/jinja_extensions.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 
 
 def _get_extensions():
-    return ['jinja2.ext.do', 'jinja2.ext.with_',
+    return ['jinja2.ext.do', 'jinja2.ext.loopcontrols',
             SnippetExtension,
             CkanExtend,
             CkanInternationalizationExtension,


### PR DESCRIPTION
Fixes #5968

### Proposed fixes:
Add jinja2.ext.loopcontrols : support for break and continue statements in jinja templates.

The with_ extension is no longer needed as its built-in as of jinja2 2.9.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
