### PR TITLE
fix for render_datetime()

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -247,6 +247,7 @@ def make_flask_stack(conf):
     app.config[u'BABEL_TRANSLATION_DIRECTORIES'] = ';'.join(i18n_dirs)
     app.config[u'BABEL_DOMAIN'] = 'ckan'
     app.config[u'BABEL_MULTIPLE_DOMAINS'] = ';'.join(i18n_domains)
+    app.config[u'BABEL_DEFAULT_TIMEZONE'] = str(helpers.get_display_timezone())
 
     babel = CKANBabel(app)
 

--- a/ckan/lib/formatters.py
+++ b/ckan/lib/formatters.py
@@ -51,7 +51,7 @@ def localised_nice_date(datetime_, show_date=False, with_hours=False,
     if with_seconds:
         return format_datetime(datetime_, format or 'long')
     elif with_hours:
-        fmt_str = "MMMM d, YYYY, HH:mm (ZZZZ)"
+        fmt_str = "MMMM d, YYYY, HH:mm (z)"
         return format_datetime(datetime_, format or fmt_str, rebase=False)
     else:
         return format_date(datetime_, format or 'long')

--- a/ckan/lib/formatters.py
+++ b/ckan/lib/formatters.py
@@ -51,8 +51,8 @@ def localised_nice_date(datetime_, show_date=False, with_hours=False,
     if with_seconds:
         return format_datetime(datetime_, format or 'long')
     elif with_hours:
-        fmt_str = "MMMM d, YYYY, HH:mm (z)"
-        return format_datetime(datetime_, format or fmt_str)
+        fmt_str = "MMMM d, YYYY, HH:mm (ZZZZ)"
+        return format_datetime(datetime_, format or fmt_str, rebase=False)
     else:
         return format_date(datetime_, format or 'long')
 

--- a/ckan/lib/formatters.py
+++ b/ckan/lib/formatters.py
@@ -52,7 +52,7 @@ def localised_nice_date(datetime_, show_date=False, with_hours=False,
         return format_datetime(datetime_, format or 'long')
     elif with_hours:
         fmt_str = "MMMM d, YYYY, HH:mm (z)"
-        return format_datetime(datetime_, format or fmt_str, rebase=False)
+        return format_datetime(datetime_, format or fmt_str)
     else:
         return format_date(datetime_, format or 'long')
 


### PR DESCRIPTION
Fixes #5946

### Proposed fixes:
passing rebase=False to format_datetime() will make render_datetime to respect ckan.display_timezone configuration


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
