### PR TITLE
filter activities that user should not be authorized to view

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -17,6 +17,7 @@ import ckan.lib.dictization
 import ckan.logic as logic
 import ckan.logic.action
 import ckan.logic.schema
+import ckan.lib.helpers as h
 import ckan.lib.dictization.model_dictize as model_dictize
 import ckan.lib.jobs as jobs
 import ckan.lib.navl.dictization_functions
@@ -2469,6 +2470,11 @@ def user_activity_list(context, data_dict):
     # FIXME: Filter out activities whose subject or object the user is not
     # authorized to read.
     data_dict['include_data'] = False
+
+    auth_user_obj_ = context['auth_user_obj']
+    if auth_user_obj_ is None or not auth_user_obj_.sysadmin:
+        data_dict['include_data'] = True
+
     _check_access('user_activity_list', context, data_dict)
 
     model = context['model']
@@ -2525,6 +2531,11 @@ def package_activity_list(context, data_dict):
     # FIXME: Filter out activities whose subject or object the user is not
     # authorized to read.
     data_dict['include_data'] = False
+
+    org_member = h.user_in_org_or_group(context['package'].owner_org)
+    if not org_member:
+        data_dict['include_data'] = True
+
     include_hidden_activity = data_dict.get('include_hidden_activity', False)
     activity_types = data_dict.pop('activity_types', None)
     exclude_activity_types = data_dict.pop('exclude_activity_types', None)
@@ -2586,6 +2597,11 @@ def group_activity_list(context, data_dict):
     # FIXME: Filter out activities whose subject or object the user is not
     # authorized to read.
     data_dict = dict(data_dict, include_data=False)
+
+    group_member = h.user_in_org_or_group(data_dict.get('id'))
+    if not group_member:
+        data_dict['include_data'] = True
+
     include_hidden_activity = data_dict.get('include_hidden_activity', False)
     _check_access('group_activity_list', context, data_dict)
 
@@ -2637,6 +2653,11 @@ def organization_activity_list(context, data_dict):
     # FIXME: Filter out activities whose subject or object the user is not
     # authorized to read.
     data_dict['include_data'] = False
+
+    org_member = h.user_in_org_or_group(data_dict.get('id'))
+    if not org_member:
+        data_dict['include_data'] = True
+
     include_hidden_activity = data_dict.get('include_hidden_activity', False)
     _check_access('organization_activity_list', context, data_dict)
 

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -474,15 +474,12 @@ def activity(id, group_type, is_organization, offset=0):
         u'user': g.user,
         u'for_view': True
     }
-    try:
-        group_dict = _get_group_dict(id, group_type)
-    except (NotFound, NotAuthorized):
-        base.abort(404, _(u'Group not found'))
 
     try:
         # Add the group's activity stream (already rendered to HTML) to the
         # template context for the group/read.html
         # template to retrieve later.
+        group_dict = _get_group_dict(id, group_type)
         extra_vars["activity_stream"] = \
             _action(u'organization_activity_list'
                     if group_dict.get(u'is_organization')
@@ -494,6 +491,10 @@ def activity(id, group_type, is_organization, offset=0):
 
     except ValidationError as error:
         base.abort(400, error.message)
+    except NotFound:
+        base.abort(404, _('Group not found'))
+    except NotAuthorized:
+        base.abort(403, _('Unauthorized to read activity stream for %s') % id)
 
     # TODO: Remove
     # ckan 2.9: Adding variables that were removed from c object for

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -570,14 +570,11 @@ def activity(id, offset=0):
         u'user_obj': g.userobj,
         u'include_num_followers': True
     }
-    try:
-        logic.check_access(u'user_show', context, data_dict)
-    except logic.NotAuthorized:
-        base.abort(403, _(u'Not authorized to see this page'))
 
     extra_vars = _extra_template_variables(context, data_dict)
 
     try:
+        logic.check_access(u'user_show', context, data_dict)
         extra_vars['user_activity_stream'] = \
             logic.get_action(u'user_activity_list')(
                 context, {
@@ -586,6 +583,9 @@ def activity(id, offset=0):
                 })
     except logic.ValidationError:
         base.abort(400)
+    except logic.NotAuthorized:
+        base.abort(403, _(u'Not authorized to see this page'))
+        
     extra_vars['id'] = id
 
     return base.render(u'user/activity_stream.html', extra_vars)


### PR DESCRIPTION
Fixes #6107

### Proposed fixes:
I filtered the activities that user should not be authorized to read: 
-user can see activity list  for himself only
-only user who is member in particular organization/group should be able to see the activity stream for that organization.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
