### PR TITLE
remove extra comma

### DIFF
--- a/ckan/templates/snippets/changes/maintainer.html
+++ b/ckan/templates/snippets/changes/maintainer.html
@@ -3,7 +3,7 @@
     {% if change.method == "change" %}
 
       {{ _('Set maintainer of {pkg_link} to {new_maintainer} (previously {old_maintainer})').format(
-        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),,
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
         new_maintainer = change.new_maintainer,
         old_maintainer = change.old_maintainer
         ) }}
@@ -11,7 +11,7 @@
     {% elif change.method == "add" %}
 
       {{ _('Set maintainer of {pkg_link} to {new_maintainer}').format(
-        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),,
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
         new_maintainer = change.new_maintainer
         ) }}
 


### PR DESCRIPTION
Because typo of additional comma we see: 
`jinja2.exceptions.TemplateSyntaxError: invalid syntax for function call expression`

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
