### PR TITLE
Remove context objects from resource_view_delete auth

### DIFF
--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -225,9 +225,7 @@ def resource_view_delete(context, data_dict):
     if not resource_view:
         raise NotFound
 
-    context["resource_view"] = resource_view
-    context['resource'] = model.Resource.get(resource_view.resource_id)
-    _check_access('resource_view_delete', context, data_dict)
+    _check_access('resource_view_delete', context, {'id': id})
 
     resource_view.delete()
     model.repo.commit()

--- a/ckan/logic/auth/delete.py
+++ b/ckan/logic/auth/delete.py
@@ -43,18 +43,12 @@ def resource_delete(context, data_dict):
 
 
 def resource_view_delete(context, data_dict):
+    model = context['model']
 
-    if context.get('resource'):
-        return authz.is_authorized('resource_delete', context, {})
-    if context.get('resource_view'):
-        return authz.is_authorized('resource_delete', context, {'id': context['resource_view'].resource_id})
-
-    resource_id = data_dict.get('resource_id')
-    if not resource_id:
-        resource_view = context['model'].ResourceView.get(data_dict['id'])
-        if not resource_view:
-            raise logic.NotFound(_('Resource view not found, cannot check auth.'))
-        resource_id = resource_view.resource_id
+    resource_view = model.ResourceView.get(data_dict['id'])
+    if not resource_view:
+        raise logic.NotFound(_('Resource view not found, cannot check auth.'))
+    resource_id = resource_view.resource_id
 
     return authz.is_authorized('resource_delete', context, {'id': resource_id})
 


### PR DESCRIPTION
This PR cleans the `resource_view_delete` authz method and avoids adding extra objects into the context that can cause side effects on other methods.

[resource_view_dict_save(...)](https://github.com/ckan/ckan/blob/3bca47492878b13dfac8338893a1b35b8f1311c7/ckan/lib/dictization/model_save.py#L588-L597) method forces an update if there is a `resource_view` object in the context. Adding a `resource_view` to the context before checking the authorization, and not cleaning it, can cause some buggy behavior down the pipe of actions.

Specifically, the following logic will not delete and create but delete and then edit since the `resource_view` object will remain in the context:
```python
...
toolkit.get_action('resource_view_delete')(context, data_dict)
...
toolkit.get_action('resource_view_create')(context, data_dict)
...
```
