### PR TITLE
Clean _make_menu_item helper

### DIFF
--- a/changes/6263.removal
+++ b/changes/6263.removal
@@ -1,0 +1,2 @@
+`build_nav_main()`, `build_nav_icon()` and `build_nav()` helpers no longer support
+Pylons route syntax. eg use `dataset.search` instead of `controller=dataset, action=search`.

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -271,25 +271,6 @@ def make_flask_stack(conf):
     lib_plugins.register_package_blueprints(app)
     lib_plugins.register_group_blueprints(app)
 
-    # Set flask routes in named_routes
-    # TODO: refactor whatever helper is using this to not do it
-    if 'routes.named_routes' not in config:
-        config['routes.named_routes'] = {}
-    for rule in app.url_map.iter_rules():
-        if '.' not in rule.endpoint:
-            continue
-        controller, action = rule.endpoint.split('.')
-        needed = list(rule.arguments - set(rule.defaults or {}))
-        route = {
-            rule.endpoint: {
-                'action': action,
-                'controller': controller,
-                'highlight_actions': action,
-                'needed': needed
-            }
-        }
-        config['routes.named_routes'].update(route)
-
     # Start other middleware
     for plugin in PluginImplementations(IMiddleware):
         app = plugin.make_middleware(app, config)

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -797,7 +797,6 @@ def _link_to(text, *args, **kwargs):
             active = ' active'
         else:
             active = ''
-        kwargs.pop('highlight_actions', '')
         return kwargs.pop('class_', '') + active or None
 
     def _create_link_text(text, **kwargs):
@@ -1027,8 +1026,7 @@ def _make_menu_item(menu_item, title, **kw):
     controller, action = menu_item.split('.')
     item = {
         'action': action,
-        'controller': controller,
-        'highlight_actions': action
+        'controller': controller
     }
     item.update(kw)
     active = _link_active(item)

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1024,21 +1024,17 @@ def _make_menu_item(menu_item, title, **kw):
 
     This function is called by wrapper functions.
     '''
-    menu_item = map_pylons_to_flask_route_name(menu_item)
-    _menu_items = config['routes.named_routes']
-    if menu_item not in _menu_items:
-        raise Exception('menu item `%s` cannot be found' % menu_item)
-    item = copy.copy(_menu_items[menu_item])
+    controller, action = menu_item.split('.')
+    item = {
+        'action': action,
+        'controller': controller,
+        'highlight_actions': action
+    }
     item.update(kw)
     active = _link_active(item)
-
     # Remove highlight controllers so that they won't appear in generated urls.
     item.pop('highlight_controllers', False)
-    needed = item.pop('needed')
-    for need in needed:
-        if need not in kw:
-            raise Exception('menu item `%s` need parameter `%s`'
-                            % (menu_item, need))
+
     link = _link_to(title, menu_item, suppress_active_class=True, **item)
     if active:
         return literal('<li class="active">') + link + literal('</li>')

--- a/ckan/templates/package/search.html
+++ b/ckan/templates/package/search.html
@@ -4,7 +4,7 @@
 {% block subtitle %}{{ _(dataset_type.title()) }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{{ h.nav_link(_(dataset_type.title() + 's'), named_route='%s.search' % dataset_type, highlight_actions = 'new index') }}</li>
+  <li class="active">{{ h.nav_link(_(dataset_type.title() + 's'), named_route='%s.search' % dataset_type) }}</li>
 {% endblock %}
 
 {% block primary_content %}

--- a/ckan/templates/package/snippets/new_package_breadcrumb.html
+++ b/ckan/templates/package/snippets/new_package_breadcrumb.html
@@ -1,2 +1,2 @@
-<li>{% link_for _('Datasets'), named_route='dataset.search', highlight_actions = 'new index' %}</li>
+<li>{% link_for _('Datasets'), named_route='dataset.search' %}</li>
 <li class="active">{% link_for _('Create Dataset'), named_route='dataset.new' %}</li>

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -622,127 +622,16 @@ class TestBuildNavMain(object):
                 '<li><a href="/about">About</a></li>'
             )
 
-    def test_legacy_pylon_routes(self):
-        menu = (
-            ("home", "Home"),
-            ("search", "Datasets"),
-            ("organizations_index", "Organizations"),
-            ("group_index", "Groups"),
-            ("about", "About"),
-        )
-        assert h.build_nav_main(*menu) == (
-            '<li class="active"><a href="/">Home</a></li>'
-            '<li><a href="/dataset/">Datasets</a></li>'
-            '<li><a href="/organization/">Organizations</a></li>'
-            '<li><a href="/group/">Groups</a></li>'
-            '<li><a href="/about">About</a></li>'
-        )
+    def test_link_to(self):
+        link = h.link_to("Example Link", "https://www.example.com", cls='css-class', target='_blank')
+        assert link == '<a class="css-class" href="https://www.example.com" target="_blank">Example Link</a>'
 
-    def test_active_in_legacy_pylon_routes(self, test_request_context):
+        link2 =  h.link_to('display_name', h.url_for('dataset.search', tags='name'), class_='tag')
+        link2 == '<a class="tag" href="/dataset/?tags=name">display_name</a>'
 
-        with test_request_context(u'/organization'):
-            menu = (
-                ("home", "Home"),
-                ("search", "Datasets", ['dataset', 'resource']),
-                ("organizations_index", "Organizations"),
-                ("group_index", "Groups"),
-                ("about", "About"),
-            )
-            assert h.build_nav_main(*menu) == (
-                '<li><a href="/">Home</a></li>'
-                '<li><a href="/dataset/">Datasets</a></li>'
-                '<li class="active"><a href="/organization/">Organizations</a></li>'
-                '<li><a href="/group/">Groups</a></li>'
-                '<li><a href="/about">About</a></li>'
-            )
-
-    @pytest.mark.usefixtures("clean_db")
-    def test_active_in_resource_controller_legacy_pylon_routes(self, test_request_context):
-
-        dataset = factories.Dataset()
-        with test_request_context(u'/dataset/' + dataset['id']):
-            menu = (
-                ("home", "Home"),
-                ("search", "Datasets", ['dataset', 'resource']),
-                ("organizations_index", "Organizations"),
-                ("group_index", "Groups"),
-                ("about", "About"),
-            )
-            assert h.build_nav_main(*menu) == (
-                '<li><a href="/">Home</a></li>'
-                '<li class="active"><a href="/dataset/">Datasets</a></li>'
-                '<li><a href="/organization/">Organizations</a></li>'
-                '<li><a href="/group/">Groups</a></li>'
-                '<li><a href="/about">About</a></li>'
-            )
-
-        resource = factories.Resource(name="some_resource")
-        with test_request_context(u'/dataset/' + resource['package_id'] + '/resource/' + resource['id']):
-            menu = (
-                ("home", "Home"),
-                ("search", "Datasets", ['dataset', 'resource']),
-                ("organizations_index", "Organizations"),
-                ("group_index", "Groups"),
-                ("about", "About"),
-            )
-            assert h.build_nav_main(*menu) == (
-                '<li><a href="/">Home</a></li>'
-                '<li class="active"><a href="/dataset/">Datasets</a></li>'
-                '<li><a href="/organization/">Organizations</a></li>'
-                '<li><a href="/group/">Groups</a></li>'
-                '<li><a href="/about">About</a></li>'
-            )
-
-    def test_dataset_navigation_legacy_routes(self):
-        dataset_name = "test-dataset"
-        assert (
-            h.build_nav_icon("dataset_read", "Datasets", id=dataset_name)
-            == '<li><a href="/dataset/test-dataset">Datasets</a></li>'
-        )
-        assert (
-            h.build_nav_icon("dataset_groups", "Groups", id=dataset_name)
-            == '<li><a href="/dataset/groups/test-dataset">Groups</a></li>'
-        )
-        assert (
-            h.build_nav_icon(
-                "dataset_activity", "Activity Stream", id=dataset_name
-            )
-            == '<li><a href="/dataset/activity/test-dataset">Activity Stream</a></li>'
-        )
-
-    def test_group_navigation_legacy_routes(self):
-        group_name = "test-group"
-        assert (
-            h.build_nav_icon("group_read", "Datasets", id=group_name)
-            == '<li><a href="/group/test-group">Datasets</a></li>'
-        )
-        assert (
-            h.build_nav_icon(
-                "group_activity", "Activity Stream", id=group_name
-            )
-            == '<li><a href="/group/activity/test-group">Activity Stream</a></li>'
-        )
-        assert (
-            h.build_nav_icon("group_about", "About", id=group_name)
-            == '<li><a href="/group/about/test-group">About</a></li>'
-        )
-
-    def test_organization_navigation_legacy_routes(self):
-        org_name = "test-org"
-        assert (
-            h.build_nav_icon("organization_read", "Datasets", id=org_name)
-            == '<li><a href="/organization/test-org">Datasets</a></li>'
-        )
-        assert (
-            h.build_nav_icon(
-                "organization_activity", "Activity Stream", id=org_name
-            )
-            == '<li><a href="/organization/activity/test-org">Activity Stream</a></li>'
-        )
-        assert (
-            h.build_nav_icon("organization_about", "About", id=org_name)
-            == '<li><a href="/organization/about/test-org">About</a></li>'
-        )
+    def test_build_nav_icon(self):
+        link = h.build_nav_icon('organization.edit', 'Edit', id='org-id', icon='pencil-square-o')
+        assert link == '<li><a href="/organization/edit/org-id"><i class="fa fa-pencil-square-o"></i> Edit</a></li>'
 
 
 class TestHelpersPlugin(p.SingletonPlugin):

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -626,7 +626,7 @@ class TestBuildNavMain(object):
         link = h.link_to("Example Link", "https://www.example.com", cls='css-class', target='_blank')
         assert link == '<a class="css-class" href="https://www.example.com" target="_blank">Example Link</a>'
 
-        link2 =  h.link_to('display_name', h.url_for('dataset.search', tags='name'), class_='tag')
+        link2 = h.link_to('display_name', h.url_for('dataset.search', tags='name'), class_='tag')
         link2 == '<a class="tag" href="/dataset/?tags=name">display_name</a>'
 
     def test_build_nav_icon(self):


### PR DESCRIPTION
This PR aims to clean the helpers to build navigation bars and some old code and configs that are now obsolete.

- Removing `config['routes.named_routes']` should be straight forward since we don't require a mapping anymore. (assuming that all templates are updated to use flask routes when creating nav links._
- `_make_menu_item` will no longer raise an exception if the helper (in the template) is missing a required argument for the endpoint. I think this is an acceptable tradeoff aiming to clean lot of legacy code that it is still tied to old Pylons logic.