### PR TITLE
Migrate url_for calls to Flask syntax

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1825,8 +1825,7 @@ def group_link(group):
 
 @core_helper
 def organization_link(organization):
-    url = url_for(controller='organization', action='read',
-                  id=organization['name'])
+    url = url_for('organization.read', id=organization['name'])
     return link_to(organization['title'], url)
 
 
@@ -1949,8 +1948,8 @@ def _create_url_with_params(params=None, controller=None, action=None,
         action = getattr(c, 'action', False) or p.toolkit.get_endpoint()[1]
     if not extras:
         extras = {}
-
-    url = url_for(controller=controller, action=action, **extras)
+    endpoint = controller + '.' + action
+    url = url_for(endpoint, **extras)
     return _url_with_params(url, params)
 
 

--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -166,8 +166,7 @@ def get_invite_body(user, group_dict=None, role=None):
 
 
 def get_reset_link(user):
-    return h.url_for(controller='user',
-                     action='perform_reset',
+    return h.url_for('user.perform_reset',
                      id=user.id,
                      key=user.reset_key,
                      qualified=True)

--- a/ckan/templates/activity_streams/activity_stream_items.html
+++ b/ckan/templates/activity_streams/activity_stream_items.html
@@ -6,7 +6,7 @@
     <ul class="activity" data-module="activity-stream" data-module-more="{{ has_more }}" data-module-context="{{ controller }}" data-module-id="{{ id }}" data-module-offset="{{ offset }}">
       {% block activity_stream_inner %}
         {% if offset > 0 %}
-          <li class="load-less"><a href="{{ h.url_for(controller=controller, action=action, id=id, offset=(offset-30 if offset-30 > 0 else 0)) }}" class="btn btn-default btn-rounded">{{ _('Load less') }}</a></li>
+          <li class="load-less"><a href="{{ h.url_for(controller + '.' + action, id=id, offset=(offset-30 if offset-30 > 0 else 0)) }}" class="btn btn-default btn-rounded">{{ _('Load less') }}</a></li>
         {% endif %}
         {% for activity in activities %}
           {% if loop.index <= has_more_length %}
@@ -14,7 +14,7 @@
           {% endif %}
         {% endfor %}
         {% if has_more %}
-          <li class="load-more"><a href="{{ h.url_for(controller=controller, action=action, id=id, offset=offset+30) }}" class="btn btn-default btn-rounded">{{ _('Load more') }}</a></li>
+          <li class="load-more"><a href="{{ h.url_for(controller + '.' + action, id=id, offset=offset+30) }}" class="btn btn-default btn-rounded">{{ _('Load more') }}</a></li>
         {% endif %}
       {% endblock %}
     </ul>

--- a/ckan/templates/admin/config.html
+++ b/ckan/templates/admin/config.html
@@ -46,8 +46,8 @@
     </h2>
     <div class="module-content">
       {% block admin_form_help %}
-        {% set about_url = h.url_for(controller='home', action='about') %}
-        {% set home_url = h.url_for(controller='home', action='index') %}
+        {% set about_url = h.url_for('home.about') %}
+        {% set home_url = h.url_for('home.index') %}
         {% set docs_url = "http://docs.ckan.org/en/{0}/theming".format(g.ckan_doc_version) %}
         {% trans %}
           <p><strong>Site Title:</strong> This is the title of this CKAN instance

--- a/ckan/templates/base.html
+++ b/ckan/templates/base.html
@@ -89,7 +89,7 @@
   </head>
 
   {# Allows custom attributes to be added to the <body> tag #}
-  <body{% block bodytag %} data-site-root="{{ h.url_for('/', locale='default', qualified=true) }}" data-locale-root="{{ h.url_for('/', qualified=true) }}" {% endblock %}>
+  <body{% block bodytag %} data-site-root="{{ h.url_for('home.index', locale='default', qualified=true) }}" data-locale-root="{{ h.url_for('home.index', qualified=true) }}" {% endblock %}>
 
     {#
     The page block allows you to add content to the page. Most of the time it is

--- a/ckan/templates/footer.html
+++ b/ckan/templates/footer.html
@@ -6,7 +6,7 @@
         {% block footer_nav %}
           <ul class="list-unstyled">
             {% block footer_links %}
-              <li><a href="{{ h.url_for(controller='home', action='about') }}">{{ _('About {0}').format(g.site_title) }}</a></li>
+              <li><a href="{{ h.url_for('home.about') }}">{{ _('About {0}').format(g.site_title) }}</a></li>
             {% endblock %}
           </ul>
           <ul class="list-unstyled">

--- a/ckan/templates/header.html
+++ b/ckan/templates/header.html
@@ -7,7 +7,7 @@
           <ul class="list-unstyled">
             {% block header_account_logged %} {% if c.userobj.sysadmin %}
               <li>
-                <a href="{{ h.url_for(controller='admin', action='index') }}" title="{{ _('Sysadmin settings') }}">
+                <a href="{{ h.url_for('admin.index') }}" title="{{ _('Sysadmin settings') }}">
                   <i class="fa fa-gavel" aria-hidden="true"></i>
                   <span class="text">{{ _('Admin') }}</span>
                 </a>
@@ -38,7 +38,7 @@
               </li>
             {% endblock %} {% block header_account_log_out_link %}
               <li>
-                <a href="{{ h.url_for('/user/_logout') }}" title="{{ _('Log out') }}">
+                <a href="{{ h.url_for('user.logout') }}" title="{{ _('Log out') }}">
                   <i class="fa fa-sign-out" aria-hidden="true"></i>
                   <span class="text">{{ _('Log out') }}</span>
                 </a>

--- a/ckan/templates/home/about.html
+++ b/ckan/templates/home/about.html
@@ -3,7 +3,7 @@
 {% block subtitle %}{{ _('About') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{% link_for _('About'), 'home.about' %}</li>
+  <li class="active">{% link_for _('About'), named_route='home.about' %}</li>
 {% endblock %}
 
 {% block primary %}

--- a/ckan/templates/home/snippets/stats.html
+++ b/ckan/templates/home/snippets/stats.html
@@ -12,13 +12,13 @@
         </a>
       </li>
       <li>
-        <a href="{{ h.url_for(controller='organization', action='index') }}">
+        <a href="{{ h.url_for('organization.index') }}">
           <strong>{{ h.SI_number_span(stats.organization_count) }}</strong>
           {{ _('organization') if stats.organization_count == 1 else _('organizations') }}
         </a>
       </li>
       <li>
-        <a href="{{ h.url_for(controller='group', action='index') }}">
+        <a href="{{ h.url_for('group.index') }}">
           <strong>{{ h.SI_number_span(stats.group_count) }}</strong>
           {{ _('group') if stats.group_count == 1 else _('groups') }}
         </a>

--- a/ckan/templates/package/search.html
+++ b/ckan/templates/package/search.html
@@ -49,7 +49,7 @@
       <div class="module-content">
         {% block package_search_results_api_inner %}
           <small>
-            {% set api_link = h.link_to(_('API'), h.url_for(controller='api', action='get_api', ver=3)) %}
+            {% set api_link = h.link_to(_('API'), h.url_for('api.get_api', ver=3)) %}
             {% set api_doc_link = h.link_to(_('API Docs'), 'http://docs.ckan.org/en/{0}/api/'.format(g.ckan_doc_version)) %}
             {% if g.dumps_url -%}
               {% set dump_link = h.link_to(_('full {format} dump').format(format=g.dumps_format), g.dumps_url) %}

--- a/ckan/templates/package/snippets/cannot_create_package.html
+++ b/ckan/templates/package/snippets/cannot_create_package.html
@@ -9,7 +9,7 @@
               {%  if h.check_access('organization_create') %}
                 <div class="alert alert-warning">{{ _('Before you can create a dataset you need to create an organization.') }}</div>
 
-                  <a class='btn btn-primary' href="{{ h.url_for(controller='organization', action='new') }}">
+                  <a class='btn btn-primary' href="{{ h.url_for('organization.new') }}">
                     {{ _('Create a new organization') }}
                   </a>
 

--- a/ckan/templates/snippets/changes/resource_format.html
+++ b/ckan/templates/snippets/changes/resource_format.html
@@ -1,9 +1,9 @@
 <li>
   <p>
     {% set format_search_base_url = (
-      h.url_for(controller="organization", action="read", id=change.org_id)
+      h.url_for("organization.read", id=change.org_id)
       if change.org_id else
-      h.url_for(controller="dataset", action="search")) %}
+      h.url_for("dataset.search")) %}
 
     {% if change.method == "add" %}
 

--- a/ckan/templates/snippets/changes/tags.html
+++ b/ckan/templates/snippets/changes/tags.html
@@ -4,7 +4,7 @@
 
       {{ _('Removed tag {tag_link} from {pkg_link}').format(
         tag_link = '<a href="{tag_url}">{tag}</a>'.format(
-          tag_url = h.url_for(controller='dataset', action='search') +
+          tag_url = h.url_for('dataset.search') +
           "?tags=" + change.tag,
           tag = change.tag
         )|safe,

--- a/ckan/templates/snippets/group.html
+++ b/ckan/templates/snippets/group.html
@@ -10,7 +10,7 @@ Example:
     {% snippet 'snippets/group, group=c.group_dict %}
 
 #}
-{% with truncate=truncate or 0, url=h.url_for(controller='group', action='read', id=group.name) %}
+{% with truncate=truncate or 0, url=h.url_for('group.read', id=group.name) %}
   <section class="module module-narrow module-shallow group">
     <div class="module-content media media-vertical">
       <a class="media-image" href="{{ url }}">

--- a/ckan/templates/tag/index.html
+++ b/ckan/templates/tag/index.html
@@ -28,7 +28,7 @@
 
 {% block secondary_content %}
   <section class="module module-narrow module-shallow simple-input">
-    <form class="module-content field-bordered" action="{% url_for controller='tag', action='index' %}" method="get">
+    <form class="module-content field-bordered" action="{% url_for 'tag.index' %}" method="get">
       <div class="field">
         <label for="field-tag-search">{{ _('Search Tags') }}</label>
         <input id="field-tag-search" type="text" class="field form-control" name="q" placeholder="{{ _('Search Tags') }}" />

--- a/ckan/tests/controllers/test_api.py
+++ b/ckan/tests/controllers/test_api.py
@@ -26,10 +26,9 @@ class TestApiController(object):
         pkg = factories.Dataset(creator_user_id=user["id"])
 
         url = url_for(
-            controller="api",
-            action="action",
+            "api.action",
             logic_function="resource_create",
-            ver="/3",
+            ver=3,
         )
         env = {"REMOTE_USER": six.ensure_str(user["name"])}
 
@@ -63,9 +62,7 @@ class TestApiController(object):
     @pytest.mark.usefixtures("clean_index")
     def test_dataset_autocomplete_name(self, app):
         dataset = factories.Dataset(name="rivers")
-        url = url_for(
-            controller="api", action="dataset_autocomplete", ver="/2"
-        )
+        url = url_for("api.dataset_autocomplete", ver=2)
         assert url == "/api/2/util/dataset/autocomplete"
 
         response = app.get(url=url, query_string={"incomplete": u"rive"}, status=200)
@@ -91,9 +88,7 @@ class TestApiController(object):
     @pytest.mark.usefixtures("clean_index")
     def test_dataset_autocomplete_title(self, app):
         dataset = factories.Dataset(name="test_ri", title="Rivers")
-        url = url_for(
-            controller="api", action="dataset_autocomplete", ver="/2"
-        )
+        url = url_for("api.dataset_autocomplete", ver=2)
         assert url == "/api/2/util/dataset/autocomplete"
 
         response = app.get(url=url, query_string={"incomplete": u"riv"}, status=200)
@@ -118,7 +113,7 @@ class TestApiController(object):
 
     def test_tag_autocomplete(self, app):
         factories.Dataset(tags=[{"name": "rivers"}])
-        url = url_for(controller="api", action="tag_autocomplete", ver="/2")
+        url = url_for("api.tag_autocomplete", ver=2)
         assert url == "/api/2/util/tag/autocomplete"
 
         response = app.get(url=url, query_string={"incomplete": u"rive"}, status=200)
@@ -132,7 +127,7 @@ class TestApiController(object):
 
     def test_group_autocomplete_by_name(self, app):
         org = factories.Group(name="rivers", title="Bridges")
-        url = url_for(controller="api", action="group_autocomplete", ver="/2")
+        url = url_for("api.group_autocomplete", ver=2)
         assert url == "/api/2/util/group/autocomplete"
 
         response = app.get(url=url, query_string={"q": u"rive"}, status=200)
@@ -148,7 +143,7 @@ class TestApiController(object):
 
     def test_group_autocomplete_by_title(self, app):
         org = factories.Group(name="frogs", title="Bugs")
-        url = url_for(controller="api", action="group_autocomplete", ver="/2")
+        url = url_for("api.group_autocomplete", ver=2)
 
         response = app.get(url=url, query_string={"q": u"bug"}, status=200)
 
@@ -158,9 +153,7 @@ class TestApiController(object):
 
     def test_organization_autocomplete_by_name(self, app):
         org = factories.Organization(name="simple-dummy-org")
-        url = url_for(
-            controller="api", action="organization_autocomplete", ver="/2"
-        )
+        url = url_for("api.organization_autocomplete", ver=2)
         assert url == "/api/2/util/organization/autocomplete"
 
         response = app.get(url=url, query_string={"q": u"simple"}, status=200)
@@ -176,9 +169,7 @@ class TestApiController(object):
 
     def test_organization_autocomplete_by_title(self, app):
         org = factories.Organization(title="Simple dummy org")
-        url = url_for(
-            controller="api", action="organization_autocomplete", ver="/2"
-        )
+        url = url_for("api.organization_autocomplete", ver=2)
 
         response = app.get(url=url, query_string={"q": u"simple dum"}, status=200)
 
@@ -189,10 +180,9 @@ class TestApiController(object):
     def test_config_option_list_access_sysadmin(self, app):
         user = factories.Sysadmin()
         url = url_for(
-            controller="api",
-            action="action",
+            "api.action",
             logic_function="config_option_list",
-            ver="/3",
+            ver=3,
         )
 
         app.get(
@@ -205,10 +195,9 @@ class TestApiController(object):
     def test_config_option_list_access_sysadmin_jsonp(self, app):
         user = factories.Sysadmin()
         url = url_for(
-            controller="api",
-            action="action",
+            "api.action",
             logic_function="config_option_list",
-            ver="/3",
+            ver=3,
         )
 
         app.get(
@@ -224,10 +213,9 @@ class TestApiController(object):
         dataset2 = factories.Dataset()
 
         url = url_for(
-            controller="api",
-            action="action",
+            "api.action",
             logic_function="package_list",
-            ver="/3",
+            ver=3,
         )
 
         res = app.get(url=url, query_string={"callback": "my_callback"})
@@ -243,10 +231,9 @@ class TestApiController(object):
 
     def test_jsonp_returns_javascript_content_type(self, app):
         url = url_for(
-            controller="api",
-            action="action",
+            "api.action",
             logic_function="status_show",
-            ver="/3",
+            ver=3,
         )
 
         res = app.get(url=url, query_string={"callback": "my_callback"})
@@ -258,10 +245,9 @@ class TestApiController(object):
         dataset2 = factories.Dataset()
 
         url = url_for(
-            controller="api",
-            action="action",
+            "api.action",
             logic_function="package_list",
-            ver="/3",
+            ver=3,
             callback="my_callback",
         )
 

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -52,7 +52,7 @@ class TestPackageNew(object):
 
         env = {"REMOTE_USER": six.ensure_str(sysadmin["name"])}
         response = app.get(url=url_for("dataset.new"), extra_environ=env)
-        assert url_for(controller="organization", action="new") in response
+        assert url_for("organization.new") in response
 
     @pytest.mark.ckan_config("ckan.auth.create_unowned_dataset", "false")
     @pytest.mark.ckan_config("ckan.auth.user_create_organizations", "false")
@@ -74,7 +74,7 @@ class TestPackageNew(object):
         env = {"REMOTE_USER": six.ensure_str(user["name"])}
         response = app.get(url=url_for("dataset.new"), extra_environ=env)
 
-        assert url_for(controller="organization", action="new") not in response
+        assert url_for("organization.new") not in response
         assert "Ask a system administrator" in response
 
     def test_name_required(self, app, user_env):

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -361,8 +361,7 @@ class TestUser(object):
         key = user_obj.reset_key
 
         offset = url_for(
-            controller="user",
-            action="perform_reset",
+            "user.perform_reset",
             id=user_obj.id,
             key=user_obj.reset_key,
         )
@@ -411,8 +410,7 @@ class TestUser(object):
         user_two = factories.User()
 
         env = {"REMOTE_USER": six.ensure_str(user_one["name"])}
-        follow_url = url_for(
-            controller="user", action="follow", id=user_two["id"]
+        follow_url = url_for("user.follow", id=user_two["id"]
         )
         response = app.post(follow_url, extra_environ=env)
         assert (
@@ -426,7 +424,7 @@ class TestUser(object):
         user_one = factories.User()
 
         env = {"REMOTE_USER": six.ensure_str(user_one["name"])}
-        follow_url = url_for(controller="user", action="follow", id="not-here")
+        follow_url = url_for("user.follow", id="not-here")
         response = app.post(follow_url, extra_environ=env)
 
         assert response.status_code == 404
@@ -437,9 +435,7 @@ class TestUser(object):
         user_two = factories.User()
 
         env = {"REMOTE_USER": six.ensure_str(user_one["name"])}
-        follow_url = url_for(
-            controller="user", action="follow", id=user_two["id"]
-        )
+        follow_url = url_for("user.follow", id=user_two["id"])
         app.post(follow_url, extra_environ=env)
 
         unfollow_url = url_for("user.unfollow", id=user_two["id"])
@@ -475,8 +471,7 @@ class TestUser(object):
         user_one = factories.User()
 
         env = {"REMOTE_USER": six.ensure_str(user_one["name"])}
-        unfollow_url = url_for(
-            controller="user", action="unfollow", id="not-here")
+        unfollow_url = url_for("user.unfollow", id="not-here")
         response = app.post(unfollow_url, extra_environ=env)
 
         assert response.status_code == 404
@@ -488,9 +483,7 @@ class TestUser(object):
         user_two = factories.User()
 
         env = {"REMOTE_USER": six.ensure_str(user_one["name"])}
-        follow_url = url_for(
-            controller="user", action="follow", id=user_two["id"]
-        )
+        follow_url = url_for("user.follow", id=user_two["id"])
         app.post(follow_url, extra_environ=env)
 
         followers_url = url_for("user.followers", id=user_two["id"])

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -410,8 +410,7 @@ class TestUser(object):
         user_two = factories.User()
 
         env = {"REMOTE_USER": six.ensure_str(user_one["name"])}
-        follow_url = url_for("user.follow", id=user_two["id"]
-        )
+        follow_url = url_for("user.follow", id=user_two["id"])
         response = app.post(follow_url, extra_environ=env)
         assert (
             "You are now following {0}".format(user_two["display_name"])

--- a/ckan/tests/legacy/functional/api/test_user.py
+++ b/ckan/tests/legacy/functional/api/test_user.py
@@ -17,7 +17,7 @@ class TestUserApi(ControllerTestCase):
 
     def test_autocomplete(self):
         response = self.app.get(
-            url=url_for(controller="api", action="user_autocomplete", ver=2),
+            url=url_for("api.user_autocomplete", ver=2),
             params={"q": u"sysadmin"},
             status=200,
         )
@@ -30,7 +30,7 @@ class TestUserApi(ControllerTestCase):
 
     def test_autocomplete_multiple(self):
         response = self.app.get(
-            url=url_for(controller="api", action="user_autocomplete", ver=2),
+            url=url_for("api.user_autocomplete", ver=2),
             params={"q": u"tes"},
             status=200,
         )
@@ -38,7 +38,7 @@ class TestUserApi(ControllerTestCase):
 
     def test_autocomplete_limit(self):
         response = self.app.get(
-            url=url_for(controller="api", action="user_autocomplete", ver=2),
+            url=url_for("api.user_autocomplete", ver=2),
             params={"q": u"tes", "limit": 1},
             status=200,
         )

--- a/ckan/tests/legacy/functional/test_group.py
+++ b/ckan/tests/legacy/functional/test_group.py
@@ -82,7 +82,7 @@ def test_sorting():
 @pytest.mark.usefixtures("clean_db")
 def test_read_non_existent(app):
     name = u"group_does_not_exist"
-    offset = url_for(controller="group", action="read", id=name)
+    offset = url_for("group.read", id=name)
     app.get(offset, status=404)
 
 
@@ -93,7 +93,7 @@ def test_member_new_invites_user_if_received_email(_mail_user, app):
     group_name = "a_group"
     CreateTestData.create_groups([{"name": group_name}], user.name)
     group = model.Group.get(group_name)
-    url = url_for(controller="group", action="member_new", id=group.id)
+    url = url_for("group.member_new", id=group.id)
     email = "invited_user@mailinator.com"
     role = "member"
 

--- a/ckan/tests/legacy/functional/test_pagination.py
+++ b/ckan/tests/legacy/functional/test_pagination.py
@@ -136,7 +136,7 @@ def test_package_search_p1(app):
 
 @pytest.mark.usefixtures("clean_index", "clean_db", "fake_packages")
 def test_group_datasets_read_p1(app):
-    res = app.get(url_for(controller="group", action="read", id="group_00"))
+    res = app.get(url_for("group.read", id="group_00"))
     assert 'href="/group/group_00?page=2' in res, res
     pkg_numbers = scrape_search_results(res.data, "group_dataset")
     assert [
@@ -162,9 +162,7 @@ def test_group_datasets_read_p1(app):
         "31",
     ] == pkg_numbers
 
-    res = app.get(
-        url_for(controller="group", action="read", id="group_00", page=2)
-    )
+    res = app.get(url_for("group.read", id="group_00", page=2))
     assert 'href="/group/group_00?page=1' in res, res
     pkg_numbers = scrape_search_results(res.data, "group_dataset")
     assert [

--- a/ckan/tests/legacy/functional/test_tag.py
+++ b/ckan/tests/legacy/functional/test_tag.py
@@ -14,53 +14,35 @@ def initial_data(clean_db):
 
 
 def test_autocomplete(app):
-    controller = "api"
-    action = "tag_autocomplete"
-    offset = url_for(controller=controller, action=action, ver=2)
+    offset = url_for("api.tag_autocomplete", ver=2)
     res = app.get(offset)
     assert "[]" in res
-    offset = url_for(
-        controller=controller, action=action, incomplete="russian", ver=2
-    )
+    offset = url_for("api.tag_autocomplete", incomplete="russian", ver=2)
     res = app.get(offset)
     assert "russian" in res
     assert "tolstoy" not in res
-    offset = url_for(
-        controller=controller, action=action, incomplete="tolstoy", ver=2
-    )
+    offset = url_for("api.tag_autocomplete", incomplete="tolstoy", ver=2)
     res = app.get(offset)
     assert "russian" not in res
     assert "tolstoy" in res
 
 
 def test_autocomplete_with_capital_letter_in_search_term(app):
-    controller = "api"
-    action = "tag_autocomplete"
-    offset = url_for(
-        controller=controller, action=action, incomplete="Flex", ver=2
-    )
+    offset = url_for("api.tag_autocomplete", incomplete="Flex", ver=2)
     res = app.get(offset)
     data = json.loads(res.body)
     assert u"Flexible \u30a1" in data["ResultSet"]["Result"][0].values()
 
 
 def test_autocomplete_with_space_in_search_term(app):
-    controller = "api"
-    action = "tag_autocomplete"
-    offset = url_for(
-        controller=controller, action=action, incomplete="Flexible ", ver=2
-    )
+    offset = url_for("api.tag_autocomplete", incomplete="Flexible ", ver=2)
     res = app.get(offset)
     data = json.loads(res.body)
     assert u"Flexible \u30a1" in data["ResultSet"]["Result"][0].values()
 
 
 def test_autocomplete_with_unicode_in_search_term(app):
-    controller = "api"
-    action = "tag_autocomplete"
-    offset = url_for(
-        controller=controller, action=action, incomplete=u"ible \u30a1", ver=2
-    )
+    offset = url_for("api.tag_autocomplete", incomplete=u"ible \u30a1", ver=2)
     res = app.get(offset)
     data = json.loads(res.body)
     assert u"Flexible \u30a1" in data["ResultSet"]["Result"][0].values()

--- a/ckan/tests/legacy/functional/test_user.py
+++ b/ckan/tests/legacy/functional/test_user.py
@@ -90,18 +90,14 @@ def test_perform_reset_user_password_link_key_incorrect(app):
     CreateTestData.create_user(name="jack", password="TestPassword1")
     # Make up a key - i.e. trying to hack this
     user = model.User.by_name(u"jack")
-    offset = url_for(
-        controller="user", action="perform_reset", id=user.id, key="randomness"
-    )  # i.e. incorrect
+    offset = url_for("user.perform_reset", id=user.id, key="randomness")  # i.e. incorrect
     res = app.get(offset, status=403)  # error
 
 
 def test_perform_reset_user_password_link_key_missing(app):
     CreateTestData.create_user(name="jack", password="TestPassword1")
     user = model.User.by_name(u"jack")
-    offset = url_for(
-        controller="user", action="perform_reset", id=user.id
-    )  # not, no key specified
+    offset = url_for("user.perform_reset", id=user.id)  # not, no key specified
     res = app.get(offset, status=403)  # error
 
 
@@ -109,8 +105,7 @@ def test_perform_reset_user_password_link_user_incorrect(app):
     # Make up a key - i.e. trying to hack this
     user = model.User.by_name(u"jack")
     offset = url_for(
-        controller="user",
-        action="perform_reset",
+        "user.perform_reset",
         id="randomness",  # i.e. incorrect
         key="randomness",
     )
@@ -128,8 +123,7 @@ def test_perform_reset_activates_pending_user(app):
     assert user.is_pending(), user.state
 
     offset = url_for(
-        controller="user",
-        action="perform_reset",
+        "user.perform_reset",
         id=user.id,
         key=user.reset_key,
     )
@@ -150,8 +144,7 @@ def test_perform_reset_doesnt_activate_deleted_user(app):
     assert user.is_deleted(), user.state
 
     offset = url_for(
-        controller="user",
-        action="perform_reset",
+        "user.perform_reset",
         id=user.id,
         key=user.reset_key,
     )

--- a/ckan/views/feed.py
+++ b/ckan/views/feed.py
@@ -426,7 +426,8 @@ def _feed_url(query, controller, action, **kwargs):
     """
     for item in six.iteritems(query):
         kwargs['query'] = item
-    return h.url_for(controller=controller, action=action, **kwargs)
+    endpoint = controller + '.' + action
+    return h.url_for(endpoint, **kwargs)
 
 
 def _navigation_urls(query, controller, action, item_count, limit, **kwargs):

--- a/ckan/views/home.py
+++ b/ckan/views/home.py
@@ -67,7 +67,7 @@ def index():
         g.package_count = 0
 
     if g.userobj and not g.userobj.email:
-        url = h.url_for(controller=u'user', action=u'edit')
+        url = h.url_for('user.edit')
         msg = _(u'Please <a href="%s">update your profile</a>'
                 u' and add your email address. ') % url + \
             _(u'%s uses your email address'

--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -67,7 +67,7 @@ def datapusher_submit(context, data_dict):
         callback_url = urljoin(
             callback_url_base.rstrip('/'), '/api/3/action/datapusher_hook')
     else:
-        site_url = h.url_for('/', qualified=True)
+        site_url = h.url_for('home.index', qualified=True)
         callback_url = h.url_for(
             '/api/3/action/datapusher_hook', qualified=True)
 

--- a/ckanext/datastore/templates/ajax_snippets/api_info.html
+++ b/ckanext/datastore/templates/ajax_snippets/api_info.html
@@ -11,7 +11,7 @@ Example
 #}
 
 {% set resource_id = h.sanitize_id(resource_id) %}
-{% set sql_example_url = h.url_for(controller='api', action='action', ver=3, logic_function='datastore_search_sql', qualified=True) + '?sql=SELECT * from "' + resource_id + '" WHERE title LIKE \'jones\'' %}
+{% set sql_example_url = h.url_for('api.action', ver=3, logic_function='datastore_search_sql', qualified=True) + '?sql=SELECT * from "' + resource_id + '" WHERE title LIKE \'jones\'' %}
 {# not urlencoding the sql because its clearer #}
 <div{% if not embedded %} class="modal fade"{% endif %}>
   <div class="modal-dialog">
@@ -42,19 +42,19 @@ Example
                   <tbody>
                     <tr>
                       <th scope="row">{{ _('Create') }}</th>
-                      <td><code>{{ h.url_for(controller='api', action='action', ver=3, logic_function='datastore_create', qualified=True) }}</code></td>
+                      <td><code>{{ h.url_for('api.action', ver=3, logic_function='datastore_create', qualified=True) }}</code></td>
                     </tr>
                     <tr>
                       <th scope="row">{{ _('Update / Insert') }}</th>
-                      <td><code>{{ h.url_for(controller='api', action='action', ver=3, logic_function='datastore_upsert', qualified=True) }}</code></td>
+                      <td><code>{{ h.url_for('api.action', ver=3, logic_function='datastore_upsert', qualified=True) }}</code></td>
                     </tr>
                     <tr>
                       <th scope="row">{{ _('Query') }}</th>
-                      <td><code>{{ h.url_for(controller='api', action='action', ver=3, logic_function='datastore_search', qualified=True) }}</code></td>
+                      <td><code>{{ h.url_for('api.action', ver=3, logic_function='datastore_search', qualified=True) }}</code></td>
                     </tr>
                     <tr>
                       <th scope="row">{{ _('Query (via SQL)') }}</th>
-                      <td><code>{{ h.url_for(controller='api', action='action', ver=3, logic_function='datastore_search_sql', qualified=True) }}</code></td>
+                      <td><code>{{ h.url_for('api.action', ver=3, logic_function='datastore_search_sql', qualified=True) }}</code></td>
                     </tr>
 
                   </tbody>
@@ -71,12 +71,12 @@ Example
               <div class="panel-body">
                 <strong>{{ _('Query example (first 5 results)') }}</strong>
                 <p>
-                <code><a href="{{ h.url_for(controller='api', action='action', ver=3, logic_function='datastore_search', resource_id=resource_id, limit=5, qualified=True) }}" target="_blank" rel="noreferrer">{{ h.url_for(controller='api', action='action', ver=3, logic_function='datastore_search', resource_id=resource_id, limit=5, qualified=True) }}</a></code>
+                <code><a href="{{ h.url_for('api.action', ver=3, logic_function='datastore_search', resource_id=resource_id, limit=5, qualified=True) }}" target="_blank" rel="noreferrer">{{ h.url_for('api.action', ver=3, logic_function='datastore_search', resource_id=resource_id, limit=5, qualified=True) }}</a></code>
                 </p>
 
                 <strong>{{ _('Query example (results containing \'jones\')') }}</strong>
                 <p>
-                <code><a href="{{ h.url_for(controller='api', action='action', ver=3, logic_function='datastore_search', resource_id=resource_id, q='jones', qualified=True) }}" target="_blank" rel="noreferrer">{{ h.url_for(controller='api', action='action', ver=3, logic_function='datastore_search', resource_id=resource_id, q='jones', qualified=True) }}</a></code>
+                <code><a href="{{ h.url_for('api.action', ver=3, logic_function='datastore_search', resource_id=resource_id, q='jones', qualified=True) }}" target="_blank" rel="noreferrer">{{ h.url_for('api.action', ver=3, logic_function='datastore_search', resource_id=resource_id, q='jones', qualified=True) }}</a></code>
                 </p>
 
                 <strong>{{ _('Query example (via SQL statement)') }}</strong>
@@ -102,7 +102,7 @@ Example
           q: 'jones' // query for 'jones'
         };
         $.ajax({
-          url: '{{ h.url_for(controller='api', action='action', ver=3, logic_function='datastore_search', qualified=True) }}',
+          url: '{{ h.url_for('api.action', ver=3, logic_function='datastore_search', qualified=True) }}',
           data: data,
           dataType: 'jsonp',
           success: function(data) {
@@ -121,7 +121,7 @@ Example
               <div class="panel-body">
                 <pre>
       import urllib
-      url = '{{ h.url_for(qualified=True, controller='api', action='action', ver=3, logic_function='datastore_search', resource_id=resource_id, limit=5) + '&q=title:jones' }}'  {# not urlencoding the ":" because its clearer #}
+      url = '{{ h.url_for('api.action', qualified=True, ver=3, logic_function='datastore_search', resource_id=resource_id, limit=5) + '&q=title:jones' }}'  {# not urlencoding the ":" because its clearer #}
       fileobj = urllib.urlopen(url)
       print fileobj.read()
       </pre>

--- a/ckanext/datastore/templates/package/snippets/data_api_button.html
+++ b/ckanext/datastore/templates/package/snippets/data_api_button.html
@@ -5,6 +5,6 @@ resource: the resource
 #}
 {% if resource.datastore_active %}
   {% set loading_text = _('Loading...') %}
-  {% set api_info_url = h.url_for(controller='api', action='snippet', ver=1, snippet_path='api_info.html', resource_id=resource.id) %}
+  {% set api_info_url = h.url_for('api.snippet', ver=1, snippet_path='api_info.html', resource_id=resource.id) %}
   <a class="btn btn-success" href="{{ api_info_url }}" data-module="api-info" data-module-template="{{ api_info_url }}" data-loading-text="{{ loading_text }}"><i class="fa fa-flask fa-lg"></i> {{ _('Data API') }}</a>
 {% endif %}

--- a/ckanext/datastore/tests/test_info.py
+++ b/ckanext/datastore/tests/test_info.py
@@ -66,8 +66,7 @@ def test_api_info(app):
     # the 'API info' is seen on the resource_read page, a snippet loaded by
     # javascript via data_api_button.html
     url = template_helpers.url_for(
-        controller="api",
-        action="snippet",
+        "api.snippet",
         ver=1,
         snippet_path="api_info.html",
         resource_id=resource["id"],

--- a/ckanext/stats/templates/ckanext/stats/index.html
+++ b/ckanext/stats/templates/ckanext/stats/index.html
@@ -20,7 +20,7 @@
           <tbody>
             {% for group, num_packages in c.largest_groups %}
               <tr>
-                <td>{{ h.link_to(group.title or group.name, h.url_for(controller=group.type, action='read', id=group.name)) }}</td>
+                <td>{{ h.link_to(group.title or group.name, h.url_for(group.type + 'read', id=group.name)) }}</td>
                 <td class="metric">{{ num_packages }}</td>
               </tr>
             {% endfor %}


### PR DESCRIPTION
This PR migrates some leftovers of `url_for` method calls using the old Pylons syntax.