### PR TITLE
Typo in default_package_sort config example

### DIFF
--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -1097,7 +1097,7 @@ ckan.search.default_package_sort
 
 Example::
 
- ckan.search.default_package_sort = "name asc"
+ ckan.search.default_package_sort = name asc
 
 Default value:  ``score desc, metadata_modified desc``
 


### PR DESCRIPTION
Example of the `ckan.search.default_package_sort` has double quotes, producing invalid value