### PR TITLE
Clean group get view

### DIFF
--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -213,7 +213,6 @@ def index(group_type, is_organization):
 
 
 def _read(id, limit, group_type):
-    u'''Internal call used in group.read blueprint '''
     extra_vars = {}
     context = {
         u'model': model,

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -863,14 +863,11 @@ class BulkProcessView(MethodView):
             # FIXME: better error
             raise Exception(u'Must be an organization')
 
-        # If no action then just show the datasets
-        limit = 500
         # TODO: Remove
         # ckan 2.9: Adding variables that were removed from c object for
         # compatibility with templates in existing extensions
         g.group_dict = group_dict
         g.group = group
-        extra_vars = _read(id, limit, group_type)
         g.packages = g.page.items
 
         extra_vars = {

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -213,7 +213,7 @@ def index(group_type, is_organization):
 
 
 def _read(id, limit, group_type):
-    u''' This is common code used by both read and bulk_process'''
+    u'''Internal call used in group.read blueprint '''
     extra_vars = {}
     context = {
         u'model': model,


### PR DESCRIPTION
This PR cleans an unnecessary assignment since `extra_vars` is overridden three lines after by a clean new dictionary.