### PR TITLE
Clean breadcrumb code

### DIFF
--- a/ckan/public/base/less/toolbar.less
+++ b/ckan/public/base/less/toolbar.less
@@ -19,26 +19,6 @@
     border: none;
     background: none;
     font-size: @font-size-large;
-    // line-height: 1.3;
-}
-
-// .toolbar .breadcrumb li:after {
-//   content: " / ";
-// }
-// .toolbar .breadcrumb li.active:after {
-//   content: "";
-// }
-// Needs to be a separate declaration as IE chokes on the last-of-type.
-// .toolbar .breadcrumb li:last-of-type:after {
-//   content: "";
-// }
-
-.toolbar .home a {
-    text-decoration: none;
-}
-
-.toolbar .home span {
-    display: none;
 }
 
 .toolbar .breadcrumb a {
@@ -49,9 +29,6 @@
     .toolbar .breadcrumb {
         color: #fff;
         text-shadow: none;
-        // .home {
-        //     display: none;
-        // }
         a {
             color: #fff;
             text-shadow: none;

--- a/ckan/templates/admin/base.html
+++ b/ckan/templates/admin/base.html
@@ -2,7 +2,9 @@
 
 {% block subtitle %}{{ _('Administration') }}{% endblock %}
 
-{% block breadcrumb_content %}{% endblock %}
+{% block breadcrumb_content %}
+  <li class="breadcrumb-item active"><a href="{{ h.url_for('admin.index') }}" aria-current="page">{{ _('Administration') }}</a></li>
+{% endblock %}
 
 {% block content_primary_nav %}
   {{ h.build_nav_icon('admin.index', _('Sysadmins'), icon='gavel') }}

--- a/ckan/templates/development/primer.html
+++ b/ckan/templates/development/primer.html
@@ -1,11 +1,5 @@
 {% extends "page.html" %}
 
-{% block toolbar %}
-{% snippet 'development/snippets/breadcrumb.html', stage=1 %}
-{% snippet 'development/snippets/breadcrumb.html', stage=2 %}
-{% snippet 'development/snippets/breadcrumb.html', stage=3 %}
-{% endblock %}
-
 {% block actions_content %}
 {% snippet 'development/snippets/actions.html' %}
 {% endblock %}

--- a/ckan/templates/development/snippets/breadcrumb.html
+++ b/ckan/templates/development/snippets/breadcrumb.html
@@ -1,7 +1,0 @@
-<div class="toolbar">
-  <ol class="breadcrumb">
-    {% snippet 'snippets/home_breadcrumb_item.html' %}
-    {% if stage > 1 %}<li{% if stage == 2 %} class="active"{% endif %}><a href="#">{% if stage == 2 %}Active {% endif %}Breadcrumb Item</a></li>{% endif %}
-    {% if stage > 2 %}<li class="active"><a href="#">Active Breadcrumb Item</a></li>{% endif %}
-  </ol>
-</div>

--- a/ckan/templates/group/base_form_page.html
+++ b/ckan/templates/group/base_form_page.html
@@ -1,14 +1,14 @@
 {% extends "group/edit_base.html" %}
 
 {% block breadcrumb_content %}
-  <li>{{ h.nav_link(
+  <li>{% link_for
         h.humanize_entity_type('group', group_type, 'breadcrumb') or _('Groups'),
-        named_route=group_type+'.index') }}</li>
+        named_route=group_type+'.index' %}</li>
   <li class="active">
     {% block breadcrumb_link %}
-      {{ h.nav_link(
+      {% link_for
         h.humanize_entity_type('group', group_type, 'add link') or _('Add a Group'),
-        named_route=group_type~'.new') }}
+        named_route=group_type~'.new' %}
     {% endblock %}
   </li>
 {% endblock %}

--- a/ckan/templates/group/base_form_page.html
+++ b/ckan/templates/group/base_form_page.html
@@ -1,14 +1,16 @@
 {% extends "group/edit_base.html" %}
 
 {% block breadcrumb_content %}
-  <li>{% link_for
-        h.humanize_entity_type('group', group_type, 'breadcrumb') or _('Groups'),
-        named_route=group_type+'.index' %}</li>
-  <li class="active">
+  <li class="breadcrumb-item">
+    <a href="{{ h.url_for(group_type + '.index') }}">
+      {{ h.humanize_entity_type('group', group_type, 'breadcrumb') or _('Groups') }}
+    </a>
+  </li>
+  <li class="breadcrumb-item active">
     {% block breadcrumb_link %}
-      {% link_for
-        h.humanize_entity_type('group', group_type, 'add link') or _('Add a Group'),
-        named_route=group_type~'.new' %}
+      <a href="{{ h.url_for(group_type + '.new') }}" aria-current="page">
+        {{ h.humanize_entity_type('group', group_type, 'add link') or _('Add a Group') }}
+      </a>
     {% endblock %}
   </li>
 {% endblock %}

--- a/ckan/templates/group/changes.html
+++ b/ckan/templates/group/changes.html
@@ -2,10 +2,9 @@
 
 {% block subtitle %}{{ group_dict.name }} {{ g.template_title_delimiter }} Changes {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
-{% block breadcrumb_content_selected %}{% endblock %}
-
 {% block breadcrumb_content %}
-  {{ super() }}
+  <li>{% link_for h.humanize_entity_type('group', group_type, 'breadcrumb') or _('Groups'), named_route=group_type+'.index' %}</li>
+  <li>{% link_for group_dict.display_name|truncate(35), named_route=group_type+'.read', id=group_dict.name %}</li>
   <li>{% link_for _('Changes'), named_route='group.activity', id=group_dict.name %}</li>
   <li class="active">{% link_for activity_diffs[0].activities[1].id|truncate(30), named_route='group.changes', id=activity_diffs[0].activities[1].id %}</li>
 {% endblock %}

--- a/ckan/templates/group/changes.html
+++ b/ckan/templates/group/changes.html
@@ -3,10 +3,10 @@
 {% block subtitle %}{{ group_dict.name }} {{ g.template_title_delimiter }} Changes {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li>{% link_for h.humanize_entity_type('group', group_type, 'breadcrumb') or _('Groups'), named_route=group_type+'.index' %}</li>
-  <li>{% link_for group_dict.display_name|truncate(35), named_route=group_type+'.read', id=group_dict.name %}</li>
-  <li>{% link_for _('Changes'), named_route='group.activity', id=group_dict.name %}</li>
-  <li class="active">{% link_for activity_diffs[0].activities[1].id|truncate(30), named_route='group.changes', id=activity_diffs[0].activities[1].id %}</li>
+  <li class="breadcrumb-item"><a href="{{ h.url_for(group_type + '.index') }}"> {{ h.humanize_entity_type('group', group_type, 'breadcrumb') or _('Groups') }}</a></li>
+  <li class="breadcrumb-item"><a href="{{ h.url_for(group_type + '.read', id=group_dict.name) }}"> {{ group_dict.display_name|truncate(35) }}</a></li>
+  <li class="breadcrumb-item"><a href="{{ h.url_for('group.activity', id=group_dict.name) }}"> {{ _('Changes') }}</a></li>
+  <li class="breadcrumb-item active"><a href="{{ h.url_for('group.changes', id=activity_diffs[0].activities[1].id) }}" aria-current="page"> {{ activity_diffs[0].activities[1].id|truncate(8) }} </a></li>
 {% endblock %}
 
 {% block primary %}

--- a/ckan/templates/group/edit.html
+++ b/ckan/templates/group/edit.html
@@ -1,10 +1,10 @@
 {% extends "group/base_form_page.html" %}
 
 {% block breadcrumb_content %}
-  <li>{% link_for h.humanize_entity_type('group', group_type, 'breadcrumb') or _('Groups'), named_route=group_type+'.index' %}</li>
+  <li class="breadcrumb-item"><a href="{{ h.url_for(group_type + '.index') }}"> {{ h.humanize_entity_type('group', group_type, 'breadcrumb') or _('Groups') }}</a></li>
   {% block breadcrumb_content_inner %}
-    <li>{% link_for group.display_name|truncate(35), named_route=group_type+'.read', id=group.name %}</li>
-    <li class="active">{% link_for _('Manage'), named_route=group_type+'.edit', id=group.name %}</li>
+    <li class="breadcrumb-item"><a href="{{ h.url_for(group_type + '.read', id=group.name) }}"> {{ group.display_name|truncate(35) }}</a></li>
+    <li class="breadcrumb-item active"><a href="{{ h.url_for(group_type + '.edit', id=group.name) }}" aria-current="page"> {{ _('Manage') }}</a></li>
   {% endblock %}
 {% endblock %}
 

--- a/ckan/templates/group/edit_base.html
+++ b/ckan/templates/group/edit_base.html
@@ -5,10 +5,10 @@
 {% set group = group_dict %}
 
 {% block breadcrumb_content %}
-  <li>{% link_for h.humanize_entity_type('group', group_type, 'breadcrumb') or _('Groups'), named_route=group_type + '.index' %}</li>
+  <li class="breadcrumb-item"><a href="{{ h.url_for(group_type + '.index') }}"> {{ h.humanize_entity_type('group', group_type, 'breadcrumb') or _('Groups') }}</a></li>
   {% block breadcrumb_content_inner %}
-    <li>{% link_for group.display_name|truncate(35), named_route=group_type+'.read', id=group.name %}</li>
-    <li class="active">{% link_for _('Manage'), named_route=group_type+'.edit', id=group.name %}</li>
+    <li class="breadcrumb-item"><a href="{{ h.url_for(group_type + '.read', id=group_dict.name) }}"> {{ group_dict.display_name|truncate(35) }}</a></li>
+    <li class="breadcrumb-item active"><a href="{{ h.url_for(group_type + '.edit', id=group_dict.name) }}"  aria-current="page"> {{ _('Manage') }}</a></li>
   {% endblock %}
 {% endblock %}
 

--- a/ckan/templates/group/index.html
+++ b/ckan/templates/group/index.html
@@ -4,7 +4,7 @@
 {% block subtitle %}{{ h.humanize_entity_type('group', group_type, 'page title') or _('Groups') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{% link_for h.humanize_entity_type('group', group_type, 'breadcrumb') or _('Groups'), named_route=group_type+'.index' %}</li>
+  <li class="breadcrumb-item active"><a href="{{ h.url_for(group_type + '.index') }}" aria-current="page"> {{ h.humanize_entity_type('group', group_type, 'breadcrumb') or _('Groups') }}</a></li>
 {% endblock %}
 
 {% block page_header %}{% endblock %}

--- a/ckan/templates/group/new.html
+++ b/ckan/templates/group/new.html
@@ -5,7 +5,7 @@
 
 {% block subtitle %}{{ label }}{% endblock %}
 
-{% block breadcrumb_link %}{{ h.nav_link(label, named_route=group_type+'.new') }}{% endblock %}
+{% block breadcrumb_link %}{% link_for label, named_route=group_type+'.new' %}{% endblock %}
 
 {% block page_heading %}{{ label }}{% endblock %}
 

--- a/ckan/templates/group/read_base.html
+++ b/ckan/templates/group/read_base.html
@@ -3,8 +3,8 @@
 {% block subtitle %}{{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('group', group_type, 'page title') or _('Groups') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li>{% link_for h.humanize_entity_type('group', group_type, 'breadcrumb') or _('Groups'), named_route=group_type+'.index' %}</li>
-  <li class="active">{% link_for group_dict.display_name|truncate(35), named_route=group_type+'.read', id=group_dict.name %}</li>
+  <li class="breadcrumb-item"><a href="{{ h.url_for(group_type + '.index') }}"> {{ h.humanize_entity_type('group', group_type, 'breadcrumb') or _('Groups') }}</a></li>
+  <li class="breadcrumb-item active"><a href="{{ h.url_for(group_type + '.read', id=group_dict.name) }}" aria-current="page"> {{ group_dict.display_name|truncate(35) }}</a></li>
 {% endblock %}
 
 {% block content_action %}

--- a/ckan/templates/home/about.html
+++ b/ckan/templates/home/about.html
@@ -3,7 +3,7 @@
 {% block subtitle %}{{ _('About') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{% link_for _('About'), 'home.about' %}</li>
+  <li class="breadcrumb-item active"><a href="{{ h.url_for('home.about') }}" aria-current="page"> {{ _('About') }}</a></li>
 {% endblock %}
 
 {% block primary %}

--- a/ckan/templates/organization/base_form_page.html
+++ b/ckan/templates/organization/base_form_page.html
@@ -2,7 +2,7 @@
 
 {% block breadcrumb_content %}
   <li>{{ h.nav_link(h.humanize_entity_type('organization', group_type, 'breadcrumb') or _('Organizations'), named_route=group_type+'.index') }}</li>
-  <li class="active">{% block breadcrumb_link %}{{ h.nav_link(h.humanize_entity_type('organization', group_type, 'add link') or _('Add an Organization'), named_route=group_type+'.new') }}{% endblock %}</li>
+  <li class="active">{% block breadcrumb_link %}{% link_for h.humanize_entity_type('organization', group_type, 'add link') or _('Add an Organization'), named_route=group_type+'.new' %}{% endblock %}</li>
 {% endblock %}
 
 {% block primary_content_inner %}

--- a/ckan/templates/organization/base_form_page.html
+++ b/ckan/templates/organization/base_form_page.html
@@ -1,8 +1,8 @@
 {% extends "organization/edit_base.html" %}
 
 {% block breadcrumb_content %}
-  <li>{{ h.nav_link(h.humanize_entity_type('organization', group_type, 'breadcrumb') or _('Organizations'), named_route=group_type+'.index') }}</li>
-  <li class="active">{% block breadcrumb_link %}{% link_for h.humanize_entity_type('organization', group_type, 'add link') or _('Add an Organization'), named_route=group_type+'.new' %}{% endblock %}</li>
+  <li class="breadcrumb-item"><a href="{{ h.url_for(group_type + '.index') }}"> {{ h.humanize_entity_type('organization', group_type, 'breadcrumb') or _('Organizations') }}</a></li>
+  <li class="breadcrumb-item active">{% block breadcrumb_link %}<a href="{{ h.url_for(group_type + '.new') }}" aria-current="page"> {{ h.humanize_entity_type('organization', group_type, 'add link') or _('Add an Organization') }}</a>{% endblock %}</li>
 {% endblock %}
 
 {% block primary_content_inner %}

--- a/ckan/templates/organization/changes.html
+++ b/ckan/templates/organization/changes.html
@@ -2,10 +2,9 @@
 
 {% block subtitle %}{{ group_dict.name }} {{ g.template_title_delimiter }} Changes {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
-{% block breadcrumb_content_selected %}{% endblock %}
-
 {% block breadcrumb_content %}
-  {{ super() }}
+  <li>{% link_for h.humanize_entity_type('organization', group_type, 'breadcrumb') or _('Organizations'), named_route=group_type+'.index' %}</li>
+  <li>{% link_for group_dict.display_name|truncate(35), named_route=group_type+'.read', id=group_dict.name %}</li>
   <li>{% link_for _('Changes'), named_route='organization.activity', id=group_dict.name %}</li>
   <li class="active">{% link_for activity_diffs[0].activities[1].id|truncate(30), named_route='organization.changes', id=activity_diffs[0].activities[1].id %}</li>
 {% endblock %}

--- a/ckan/templates/organization/changes.html
+++ b/ckan/templates/organization/changes.html
@@ -3,10 +3,10 @@
 {% block subtitle %}{{ group_dict.name }} {{ g.template_title_delimiter }} Changes {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li>{% link_for h.humanize_entity_type('organization', group_type, 'breadcrumb') or _('Organizations'), named_route=group_type+'.index' %}</li>
-  <li>{% link_for group_dict.display_name|truncate(35), named_route=group_type+'.read', id=group_dict.name %}</li>
-  <li>{% link_for _('Changes'), named_route='organization.activity', id=group_dict.name %}</li>
-  <li class="active">{% link_for activity_diffs[0].activities[1].id|truncate(30), named_route='organization.changes', id=activity_diffs[0].activities[1].id %}</li>
+  <li class="breadcrumb-item"><a href="{{ h.url_for(group_type + '.index') }}"> {{ h.humanize_entity_type('organization', group_type, 'breadcrumb') or _('Organizations') }}</a></li>
+  <li class="breadcrumb-item"><a href="{{ h.url_for(group_type + '.read', id=group_dict.name) }}"> {{ group_dict.display_name|truncate(35) }}</a></li>
+  <li class="breadcrumb-item"><a href="{{ h.url_for('organization.activity', id=group_dict.name) }}"> {{ _('Changes') }}</a></li>
+  <li class="breadcrumb-item active"><a href="{{ h.url_for('organization.changes', id=activity_diffs[0].activities[1].id) }}" aria-current="page"> {{ activity_diffs[0].activities[1].id|truncate(8) }}</a></li>
 {% endblock %}
 
 {% block primary %}

--- a/ckan/templates/organization/edit_base.html
+++ b/ckan/templates/organization/edit_base.html
@@ -5,10 +5,10 @@
 {% block subtitle %}{{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('organization', group_type, 'page title') or _('Organizations') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li>{% link_for h.humanize_entity_type('organization', group_type, 'breadcrumb') or _('Organizations'), named_route=group_type+'.index' %}</li>
+  <li class="breadcrumb-item"><a href="{{ h.url_for(group_type + '.index') }}"> {{ h.humanize_entity_type('organization', group_type, 'breadcrumb') or _('Organizations') }}</a></li>
   {% block breadcrumb_content_inner %}
-    <li>{% link_for organization.display_name|truncate(35), named_route=group_type+'.read', id=organization.name %}</li>
-    <li class="active">{% link_for _('Manage'), named_route=group_type+'.edit', id=organization.name %}</li>
+  <li class="breadcrumb-item"><a href="{{ h.url_for(group_type + '.read', id=organization.name) }}"> {{ organization.display_name|truncate(35) }}</a></li>
+  <li class="breadcrumb-item active"><a href="{{ h.url_for(group_type + '.edit', id=organization.name) }}" aria-current="page"> {{ _('Manage') }}</a></li>
   {% endblock %}
 {% endblock %}
 

--- a/ckan/templates/organization/index.html
+++ b/ckan/templates/organization/index.html
@@ -3,7 +3,7 @@
 {% block subtitle %}{{ h.humanize_entity_type('organization', group_type, 'page title') or _('Organizations') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{% link_for h.humanize_entity_type('organization', group_type, 'breadcrumb') or _('Organizations'), named_route=group_type+'.index' %}</li>
+  <li class="breadcrumb-item active"><a href="{{ h.url_for(group_type + '.index') }}" aria-current="page"> {{ h.humanize_entity_type('organization', group_type, 'breadcrumb') or _('Organizations') }}</a></li>
 {% endblock %}
 
 {% block page_header %}{% endblock %}

--- a/ckan/templates/organization/new.html
+++ b/ckan/templates/organization/new.html
@@ -5,7 +5,7 @@
 
 {% block subtitle %}{{ title }}{% endblock %}
 
-{% block breadcrumb_link %}{{ h.nav_link(title, named_route=group_type+'.new') }}{% endblock %}
+{% block breadcrumb_link %}{% link_for title, named_route=group_type+'.new' %}{% endblock %}
 
 {% block page_heading %}{{ title }}{% endblock %}
 

--- a/ckan/templates/organization/read_base.html
+++ b/ckan/templates/organization/read_base.html
@@ -3,8 +3,8 @@
 {% block subtitle %}{{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('organization', group_type, 'page title') or _('Organizations') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li>{% link_for h.humanize_entity_type('organization', group_type, 'breadcrumb') or _('Organizations'), named_route=group_type+'.index' %}</li>
-  <li class="active">{% link_for group_dict.display_name|truncate(35), named_route=group_type+'.read', id=group_dict.name %}</li>
+  <li class="breadcrumb-item"><a href="{{ h.url_for(group_type + '.index') }}"> {{ h.humanize_entity_type('organization', group_type, 'breadcrumb') or _('Organizations') }}</a></li>
+  <li class="breadcrumb-item active"><a href="{{ h.url_for(group_type + '.read', id=group_dict.name) }}" aria-current="page"> {{ group_dict.display_name|truncate(35) }}</a></li>
 {% endblock %}
 
 {% block content_action %}

--- a/ckan/templates/package/base.html
+++ b/ckan/templates/package/base.html
@@ -3,8 +3,6 @@
 {% set pkg = pkg_dict %}
 {% set dataset_type = dataset_type or pkg.type or 'dataset' %}
 
-{% block breadcrumb_content_selected %} class="active"{% endblock %}
-
 {% block subtitle %}{{ _(dataset_type.title()) }}{% endblock %}
 
 {% block breadcrumb_content %}
@@ -18,7 +16,7 @@
     {% else %}
       <li>{% link_for _(dataset_type.title()), named_route=dataset_type ~ '.search' %}</li>
     {% endif %}
-    <li{{ self.breadcrumb_content_selected() }}>{% link_for dataset|truncate(30), named_route=pkg.type ~ '.read', id=pkg.id if is_activity_archive else pkg.name %}</li>
+    <li class="active">{% link_for dataset|truncate(30), named_route=pkg.type ~ '.read', id=pkg.id if is_activity_archive else pkg.name %}</li>
   {% else %}
     <li>{% link_for _(dataset_type.title()), named_route=dataset_type ~ '.search' %}</li>
     <li class="active"><a href="">{{ _('Create Dataset') }}</a></li>

--- a/ckan/templates/package/base.html
+++ b/ckan/templates/package/base.html
@@ -11,14 +11,14 @@
     {% if pkg.organization %}
       {% set organization = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
       {% set group_type = pkg.organization.type %}
-      <li>{% link_for h.humanize_entity_type('organization', group_type, 'breadcrumb') or _('Organizations'), named_route=group_type ~ '.index' %}</li>
-      <li>{% link_for organization|truncate(30), named_route=group_type ~ '.read', id=pkg.organization.name %}</li>
+      <li class="breadcrumb-item"><a href="{{ h.url_for(group_type + '.index') }}"> {{ h.humanize_entity_type('organization', group_type, 'breadcrumb') or _('Organizations') }}</a></li>
+      <li class="breadcrumb-item"><a href="{{ h.url_for(group_type + '.read', id=pkg.organization.name) }}"> {{ organization|truncate(30) }}</a></li>
     {% else %}
-      <li>{% link_for _(dataset_type.title()), named_route=dataset_type ~ '.search' %}</li>
+    <li class="breadcrumb-item"><a href="{{ h.url_for(dataset_type + '.search') }}"> {{ _(dataset_type.title()) }}</a></li>
     {% endif %}
-    <li class="active">{% link_for dataset|truncate(30), named_route=pkg.type ~ '.read', id=pkg.id if is_activity_archive else pkg.name %}</li>
+    <li class="breadcrumb-item active"><a href="{{ h.url_for(pkg.type + '.read', id=pkg.id if is_activity_archive else pkg.name) }}" aria-current="page"> {{ dataset|truncate(30) }}</a></li>
   {% else %}
-    <li>{% link_for _(dataset_type.title()), named_route=dataset_type ~ '.search' %}</li>
-    <li class="active"><a href="">{{ _('Create Dataset') }}</a></li>
+    <li class="breadcrumb-item"><a href="{{ h.url_for(dataset_type + '.search') }}"> {{ _(dataset_type.title()) }}</a></li>
+    <li class="breadcrumb-item active"><a href="#" aria-current="page"> {{ _('Create Dataset') }}</a></li>
   {% endif %}
 {% endblock %}

--- a/ckan/templates/package/changes.html
+++ b/ckan/templates/package/changes.html
@@ -4,8 +4,8 @@
 
 {% block breadcrumb_content %}
   {{ super() }}
-  <li>{% link_for _('Changes'), named_route=dataset_type ~ '.activity', id=pkg_dict.name %}</li>
-  <li class="active">{% link_for activity_diffs[0].activities[1].id|truncate(30), named_route=dataset_type ~ '.changes', id=activity_diffs[0].activities[1].id %}</li>
+  <li class="breadcrumb-item"><a href="{{ h.url_for(dataset_type ~ '.activity', id=pkg_dict.name) }}">{{ _('Changes') }}</a></li>
+  <li class="breadcrumb-item active"><a href="{{ h.url_for(dataset_type ~ '.changes', id=activity_diffs[0].activities[1].id) }}" aria-current="page">{{ activity_diffs[0].activities[1].id|truncate(8) }}</a></li>
 {% endblock %}
 
 {% block primary %}

--- a/ckan/templates/package/changes.html
+++ b/ckan/templates/package/changes.html
@@ -2,8 +2,6 @@
 
 {% block subtitle %}{{ pkg_dict.name }} {{ g.template_title_delimiter }} Changes {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
-{% block breadcrumb_content_selected %}{% endblock %}
-
 {% block breadcrumb_content %}
   {{ super() }}
   <li>{% link_for _('Changes'), named_route=dataset_type ~ '.activity', id=pkg_dict.name %}</li>

--- a/ckan/templates/package/edit_base.html
+++ b/ckan/templates/package/edit_base.html
@@ -3,7 +3,7 @@
 {% block breadcrumb_content %}
     {{ super() }}
     {% if pkg %}
-	<li class="active">{% link_for _('Edit'), named_route=pkg.type ~ '.edit', id=pkg.name %}</li>
+    <li class="breadcrumb-item active"><a href="{{ h.url_for(pkg.type ~ '.edit', id=pkg.name) }}" aria-current="page">{{ _('Edit') }}</a></li>
     {% endif %}
 {% endblock %}
 

--- a/ckan/templates/package/edit_base.html
+++ b/ckan/templates/package/edit_base.html
@@ -1,7 +1,5 @@
 {% extends 'package/base.html' %}
 
-{% block breadcrumb_content_selected %}{% endblock %}
-
 {% block breadcrumb_content %}
     {{ super() }}
     {% if pkg %}

--- a/ckan/templates/package/edit_view.html
+++ b/ckan/templates/package/edit_view.html
@@ -5,7 +5,7 @@
 
 {% block breadcrumb_content %}
   {{ super() }}
-  <li class="active"><a href="#">{{ _('Edit view') }}</a></li>
+  <li class="breadcrumb-item active"><a href="#" aria-current="page">{{ _('Edit view') }}</a></li>
 {% endblock %}
 
 {% block content_primary_nav %}

--- a/ckan/templates/package/new_resource.html
+++ b/ckan/templates/package/new_resource.html
@@ -4,7 +4,6 @@
 
 {% block subtitle %}{{ _('Add data to the dataset') }}{% endblock %}
 
-{% block breadcrumb_content_selected %}{% endblock %}
 {% block breadcrumb_content %}
   {{ super() }}
   {% if pkg %}

--- a/ckan/templates/package/new_resource.html
+++ b/ckan/templates/package/new_resource.html
@@ -7,7 +7,7 @@
 {% block breadcrumb_content %}
   {{ super() }}
   {% if pkg %}
-    <li class="active"><a href="#">{{ _('Add New Resource') }}</a></li>
+    <li class="breadcrumb-item active"><a href="#" aria-current="page">{{ _('Add New Resource') }}</a></li>
   {% endif %}
 {% endblock %}
 

--- a/ckan/templates/package/new_resource_not_draft.html
+++ b/ckan/templates/package/new_resource_not_draft.html
@@ -5,7 +5,7 @@
 
 {% block breadcrumb_content %}
   {{ super() }}
-  <li class="active"><a href="#">{{ _('Add New Resource') }}</a></li>
+  <li class="breadcrumb-item active"><a href="#" aria-current="page">{{ _('Add New Resource') }}</a></li>
 {% endblock %}
 
 {% block form %}

--- a/ckan/templates/package/new_view.html
+++ b/ckan/templates/package/new_view.html
@@ -5,7 +5,7 @@
 
 {% block breadcrumb_content %}
   {{ super() }}
-  <li class="active"><a href="#">{{ _('Add view') }}</a></li>
+  <li class="breadcrumb-item active"><a href="#" aria-current="page">{{ _('Add view') }}</a></li>
 {% endblock %}
 
 {% block content_primary_nav %}

--- a/ckan/templates/package/resource_edit_base.html
+++ b/ckan/templates/package/resource_edit_base.html
@@ -7,7 +7,7 @@
   {{ super() }}
   {% if res %}
       <li>{% link_for h.resource_display_name(res)|truncate(30), named_route=pkg.type ~ '_resource.read', id=pkg.name, resource_id=res.id %}</li>
-      <li{% block breadcrumb_edit_selected %} class="active"{% endblock %}><a href="">{{ _('Edit') }}</a></li>
+      <li class="active"><a href="">{{ _('Edit') }}</a></li>
   {% endif %}
 {% endblock %}
 

--- a/ckan/templates/package/resource_edit_base.html
+++ b/ckan/templates/package/resource_edit_base.html
@@ -6,8 +6,8 @@
 {% block breadcrumb_content %}
   {{ super() }}
   {% if res %}
-      <li>{% link_for h.resource_display_name(res)|truncate(30), named_route=pkg.type ~ '_resource.read', id=pkg.name, resource_id=res.id %}</li>
-      <li class="active"><a href="">{{ _('Edit') }}</a></li>
+  <li class="breadcrumb-item"><a href="{{ h.url_for(pkg.type + '_resource.read', id=pkg.name, resource_id=res.id) }}">{{  h.resource_display_name(res)|truncate(30) }}</a></li>
+  <li class="breadcrumb-item active"><a href="#" aria-current="page">{{ _('Edit') }}</a></li>
   {% endif %}
 {% endblock %}
 

--- a/ckan/templates/package/resource_edit_base.html
+++ b/ckan/templates/package/resource_edit_base.html
@@ -3,8 +3,6 @@
 {% set logged_in = true if c.userobj else false %}
 {% set res = resource %}
 
-{% block breadcrumb_content_selected %}{% endblock %}
-
 {% block breadcrumb_content %}
   {{ super() }}
   {% if res %}

--- a/ckan/templates/package/resource_read.html
+++ b/ckan/templates/package/resource_read.html
@@ -13,7 +13,7 @@
 
 {% block breadcrumb_content %}
   {{ super() }}
-  <li class="active"><a href="">{{ h.resource_display_name(res)|truncate(30) }}</a></li>
+  <li class="breadcrumb-item active"><a href="#" aria-current="page">{{ h.resource_display_name(res)|truncate(30) }}</a></li>
 {% endblock %}
 
 {% block pre_primary %}

--- a/ckan/templates/package/resource_read.html
+++ b/ckan/templates/package/resource_read.html
@@ -11,8 +11,6 @@
 
 {% block subtitle %}{{ h.dataset_display_name(package) }} {{ g.template_title_delimiter }} {{ h.resource_display_name(res) }}{% endblock %}
 
-{% block breadcrumb_content_selected %}{% endblock %}
-
 {% block breadcrumb_content %}
   {{ super() }}
   <li class="active"><a href="">{{ h.resource_display_name(res)|truncate(30) }}</a></li>

--- a/ckan/templates/package/search.html
+++ b/ckan/templates/package/search.html
@@ -4,7 +4,7 @@
 {% block subtitle %}{{ _(dataset_type.title()) }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{{ h.nav_link(_(dataset_type.title() + 's'), named_route='%s.search' % dataset_type, highlight_actions = 'new index') }}</li>
+  <li class="active">{% link_for _(dataset_type.title() + 's'), named_route='%s.search' % dataset_type  %}</li>
 {% endblock %}
 
 {% block primary_content %}

--- a/ckan/templates/package/search.html
+++ b/ckan/templates/package/search.html
@@ -4,7 +4,7 @@
 {% block subtitle %}{{ _(dataset_type.title()) }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{% link_for _(dataset_type.title() + 's'), named_route='%s.search' % dataset_type  %}</li>
+  <li class="breadcrumb-item active"><a href="{{ h.url_for('%s.search' % dataset_type) }}" aria-current="page"> {{ _(dataset_type.title() + 's') }}</a></li>
 {% endblock %}
 
 {% block primary_content %}

--- a/ckan/templates/package/view_edit_base.html
+++ b/ckan/templates/package/view_edit_base.html
@@ -3,8 +3,6 @@
 {% set logged_in = true if c.userobj else false %}
 {% set res = resource %}
 
-{% block breadcrumb_edit_selected %}{% endblock %}
-
 {% block content_action %}
   {% link_for _('All views'), named_route=pkg.type ~ '_resource.views', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='arrow-left' %}
   {% if res %}

--- a/ckan/templates/page.html
+++ b/ckan/templates/page.html
@@ -33,14 +33,14 @@
           {% endblock %}
 
           {% block toolbar %}
-            <div class="toolbar" role="navigation" aria-label="{{ _('Breadcrumb') }}">
+            <nav class="toolbar" aria-label="breadcrumb">
               {% block breadcrumb %}
                   <ol class="breadcrumb">
                     {% snippet 'snippets/home_breadcrumb_item.html' %}
                     {% block breadcrumb_content %}{% endblock %}
                   </ol>
               {% endblock %}
-            </div>
+            </nav>
           {% endblock %}
 
           <div class="row wrapper{% block wrapper_class %}{% endblock %}{% if self.secondary()|trim == '' or c.action=='resource_read' %} no-nav{% endif %}">

--- a/ckan/templates/page.html
+++ b/ckan/templates/page.html
@@ -35,12 +35,10 @@
           {% block toolbar %}
             <div class="toolbar" role="navigation" aria-label="{{ _('Breadcrumb') }}">
               {% block breadcrumb %}
-                {% if self.breadcrumb_content() | trim %}
                   <ol class="breadcrumb">
                     <li class="home"><a href="{{ h.url_for('home.index') }}" aria-label="{{ _('Home') }}"><i class="fa fa-home"></i><span> {{ _('Home') }}</span></a></li>
                     {% block breadcrumb_content %}{% endblock %}
                   </ol>
-                {% endif %}
               {% endblock %}
             </div>
           {% endblock %}

--- a/ckan/templates/page.html
+++ b/ckan/templates/page.html
@@ -36,7 +36,7 @@
             <div class="toolbar" role="navigation" aria-label="{{ _('Breadcrumb') }}">
               {% block breadcrumb %}
                   <ol class="breadcrumb">
-                    <li class="home"><a href="{{ h.url_for('home.index') }}" aria-label="{{ _('Home') }}"><i class="fa fa-home"></i><span> {{ _('Home') }}</span></a></li>
+                    {% snippet 'snippets/home_breadcrumb_item.html' %}
                     {% block breadcrumb_content %}{% endblock %}
                   </ol>
               {% endblock %}

--- a/ckan/templates/page.html
+++ b/ckan/templates/page.html
@@ -37,7 +37,7 @@
               {% block breadcrumb %}
                 {% if self.breadcrumb_content() | trim %}
                   <ol class="breadcrumb">
-                    {% snippet 'snippets/home_breadcrumb_item.html' %}
+                    <li class="home"><a href="{{ h.url_for('home.index') }}" aria-label="{{ _('Home') }}"><i class="fa fa-home"></i><span> {{ _('Home') }}</span></a></li>
                     {% block breadcrumb_content %}{% endblock %}
                   </ol>
                 {% endif %}

--- a/ckan/templates/snippets/home_breadcrumb_item.html
+++ b/ckan/templates/snippets/home_breadcrumb_item.html
@@ -1,2 +1,0 @@
-{# Used to insert the home icon into a breadcrumb #}
-<li class="home"><a href="{{ h.url_for('home.index') }}" aria-label="{{ _('Home') }}"><i class="fa fa-home"></i><span> {{ _('Home') }}</span></a></li>

--- a/ckan/templates/snippets/home_breadcrumb_item.html
+++ b/ckan/templates/snippets/home_breadcrumb_item.html
@@ -1,0 +1,2 @@
+{# Used to insert the home icon into a breadcrumb #}
+<li class="home"><a href="{{ h.url_for('home.index') }}" aria-label="{{ _('Home') }}"><i class="fa fa-home"></i><span> {{ _('Home') }}</span></a></li>

--- a/ckan/templates/snippets/home_breadcrumb_item.html
+++ b/ckan/templates/snippets/home_breadcrumb_item.html
@@ -1,2 +1,2 @@
 {# Used to insert the home icon into a breadcrumb #}
-<li class="home"><a href="{{ h.url_for('home.index') }}" aria-label="{{ _('Home') }}"><i class="fa fa-home"></i><span> {{ _('Home') }}</span></a></li>
+<li class="breadcrumb-item"><a href="{{ h.url_for('home.index') }}"><i class="fa fa-home"></i></a></li>

--- a/ckan/templates/tag/index.html
+++ b/ckan/templates/tag/index.html
@@ -3,7 +3,7 @@
 {% block subtitle %}{{ _('Tags') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active"><a href="">{{ _('Tags') }}</a></li>
+  <li class="breadcrumb-item active"><a href="#" aria-current="page">{{ _('Tags') }}</a></li>
 {% endblock %}
 
 {% block primary_content %}

--- a/ckan/templates/user/dashboard.html
+++ b/ckan/templates/user/dashboard.html
@@ -5,7 +5,7 @@
 {% set group_type = h.default_group_type('group') %}
 
 {% block breadcrumb_content %}
-  <li class="active"><a href="{{ h.url_for('dashboard.index') }}">{{ _('Dashboard') }}</a></li>
+  <li class="breadcrumb-item active"><a href="{{ h.url_for('dashboard.index') }}" aria-current="page">{{ _('Dashboard') }}</a></li>
 {% endblock %}
 
 {% block secondary %}{% endblock %}
@@ -17,14 +17,14 @@
         <div class="content_action">
           {% link_for _('Profile settings'), named_route='user.edit', id=user.name, class_='btn btn-default', icon='cog' %}
         </div>
-    {% block content_primary_nav %}    
+    {% block content_primary_nav %}
         <ul class="nav nav-tabs">
           {{ h.build_nav_icon('dashboard.index', _('News feed'), icon='list') }}
           {{ h.build_nav_icon('dashboard.datasets', _('My Datasets'), icon='sitemap') }}
           {{ h.build_nav_icon('dashboard.organizations', h.humanize_entity_type('organization', org_type, 'my label') or _('My Organizations'), icon='building-o') }}
           {{ h.build_nav_icon('dashboard.groups', h.humanize_entity_type('group', group_type, 'my label') or _('My Groups'), icon='users') }}
         </ul>
-     {% endblock %}   
+     {% endblock %}
       </header>
     {% endblock %}
     <div class="module-content">

--- a/ckan/templates/user/edit.html
+++ b/ckan/templates/user/edit.html
@@ -3,9 +3,9 @@
 {% block actions_content %}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li><a href="{{ h.url_for('user.index') }}">{{ _('Users') }}</a></li>
-  <li><a href="{{ h.url_for('user.read', id=user_dict.name) }}">{{ user_dict.display_name }}</a></li>
-  <li class="active"><a href="#">{{ _('Manage') }}</a></li>
+  <li class="breadcrumb-item"><a href="{{ h.url_for('user.index') }}">{{ _('Users') }}</a></li>
+  <li class="breadcrumb-item"><a href="{{ h.url_for('user.read', id=user_dict.name) }}">{{ user_dict.display_name }}</a></li>
+  <li class="breadcrumb-item active"><a href="{{ h.url_for('user.edit', id=user_dict.name) }}" aria-current="page">{{ _('Manage') }}</a></li>
 {% endblock %}
 
 {% block primary_content_inner %}

--- a/ckan/templates/user/list.html
+++ b/ckan/templates/user/list.html
@@ -3,7 +3,7 @@
 {% block subtitle %}{{ _('All Users') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{% link_for _('Users'), named_route='user.index' %}</li>
+  <li class="breadcrumb-item active"><a href="{{ h.url_for('user.index') }}" aria-current="page">{{ _('Users') }}</a></li>
 {% endblock %}
 
 {% block primary_content %}

--- a/ckan/templates/user/list.html
+++ b/ckan/templates/user/list.html
@@ -3,7 +3,7 @@
 {% block subtitle %}{{ _('All Users') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{{ h.nav_link(_('Users'), named_route='user.index') }}</li>
+  <li class="active">{% link_for _('Users'), named_route='user.index' %}</li>
 {% endblock %}
 
 {% block primary_content %}

--- a/ckan/templates/user/login.html
+++ b/ckan/templates/user/login.html
@@ -3,7 +3,7 @@
 {% block subtitle %}{{ _('Login') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{% link_for _('Login'), named_route='user.login' %}</li>
+  <li class="breadcrumb-item active"><a href="{{ h.url_for('user.login') }}" aria-current="page">{{ _('Login') }}</a></li>
 {% endblock %}
 
 {% block primary_content %}

--- a/ckan/templates/user/login.html
+++ b/ckan/templates/user/login.html
@@ -3,7 +3,7 @@
 {% block subtitle %}{{ _('Login') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{{ h.nav_link(_('Login'), named_route='user.login') }}</li>
+  <li class="active">{% link_for _('Login'), named_route='user.login' %}</li>
 {% endblock %}
 
 {% block primary_content %}

--- a/ckan/templates/user/new.html
+++ b/ckan/templates/user/new.html
@@ -3,7 +3,7 @@
 {% block subtitle %}{{ _('Register') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{% _('Registration'), named_route='user.register' %}</li>
+  <li class="active">{% link_for _('Registration'), named_route='user.register' %}</li>
 {% endblock %}
 
 {% block primary_content %}

--- a/ckan/templates/user/new.html
+++ b/ckan/templates/user/new.html
@@ -3,7 +3,7 @@
 {% block subtitle %}{{ _('Register') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{% link_for _('Registration'), named_route='user.register' %}</li>
+  <li class="breadcrumb-item active"><a href="{{ h.url_for('user.register') }}" aria-current="page">{{ _('Registration') }}</a></li>
 {% endblock %}
 
 {% block primary_content %}

--- a/ckan/templates/user/new.html
+++ b/ckan/templates/user/new.html
@@ -3,7 +3,7 @@
 {% block subtitle %}{{ _('Register') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{{ h.nav_link(_('Registration'), named_route='user.register') }}</li>
+  <li class="active">{% _('Registration'), named_route='user.register' %}</li>
 {% endblock %}
 
 {% block primary_content %}

--- a/ckan/templates/user/perform_reset.html
+++ b/ckan/templates/user/perform_reset.html
@@ -4,7 +4,7 @@
 {% block subtitle %}{{ _('Reset Your Password') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{{ _('Password Reset') }}</li>
+  <li class="breadcrumb-item active">{{ _('Password Reset') }}</li>
 {% endblock %}
 
 {% block primary_content %}

--- a/ckan/templates/user/read_base.html
+++ b/ckan/templates/user/read_base.html
@@ -5,8 +5,8 @@
 {% block subtitle %}{{ user.display_name }} {{ g.template_title_delimiter }} {{ _('Users') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  {{ h.build_nav('user.index', _('Users')) }}
-  {{ h.build_nav('user.read', user.display_name|truncate(35), id=user.name) }}
+  <li>{% link_for _('Users'), named_route='user.index' %}</li>
+  <li class="active">{% link_for user.display_name|truncate(35), named_route='user.read', id=user.name %}</li>
 {% endblock %}
 
 {% block content_action %}

--- a/ckan/templates/user/read_base.html
+++ b/ckan/templates/user/read_base.html
@@ -5,8 +5,8 @@
 {% block subtitle %}{{ user.display_name }} {{ g.template_title_delimiter }} {{ _('Users') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li>{% link_for _('Users'), named_route='user.index' %}</li>
-  <li class="active">{% link_for user.display_name|truncate(35), named_route='user.read', id=user.name %}</li>
+  <li class="breadcrumb-item"><a href="{{ h.url_for('user.index') }}">{{ _('Users') }}</a></li>
+  <li class="breadcrumb-item active"><a href="{{ h.url_for('user.read', id=user.name) }}" aria-current="page">{{ user.display_name|truncate(35) }}</a></li>
 {% endblock %}
 
 {% block content_action %}

--- a/ckan/templates/user/request_reset.html
+++ b/ckan/templates/user/request_reset.html
@@ -3,7 +3,7 @@
 {% block subtitle %}{{ _('Reset your password') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{% link_for _('Password Reset'), named_route='user.request_reset' %}</li>
+  <li class="breadcrumb-item active"><a href="{{ h.url_for('user.request_reset') }}" aria-current="page">{{ _('Password Reset') }}</a></li>
 {% endblock %}
 
 {% block primary_content %}

--- a/ckanext/stats/templates/ckanext/stats/index.html
+++ b/ckanext/stats/templates/ckanext/stats/index.html
@@ -1,7 +1,7 @@
 {% extends "page.html" %}
 
 {% block breadcrumb_content %}
-  <li class="active">{{ _('Statistics') }}</li>
+  <li class="breadcrumb-item active">{{ _('Statistics') }}</li>
 {% endblock %}
 
 {% block primary_content %}


### PR DESCRIPTION
This PR is a first step to clean the breadcrumb code overall the application for a modern approach on building it.

Changes:
 - Replace `h.nav_link()` for `{% link_for %}` to have a more consistent approach across the templates (Most of them currently are using the snippet
 - Clean old `breadcrumb.html` template in development folder.
 - Clean `breadcrumb_content_selected` block. Supposedly it is use to detect and set the `class="active"` but its hard to follow and it's currently buggy (Is not working for example in the dataset changes template). I cleaned it and replaced some `super()` call with duplicated code. This may seem counter intuitive but [we are currently using it](https://github.com/ckan/ckan/blob/53b9442509b46525d653f2f705e98319752ceb2d/ckan/templates/user/edit.html#L5-L9) and also it's the way [Django implements some of it's breadcrumbs](https://github.com/django/django/blob/012f38f9594b35743e9ab231757b7b62db638323/django/contrib/admin/templates/admin/delete_confirmation.html#L12-L20). I think is a good tradeoff to reduce complexity.

Finally:

This PR removes all the calls to `build_nav(...)` in the templates. It's still used in some other places but it's a good step forward to clean up the helpers library.
