### PR TITLE
DataPusher and XLoader documented in Source docs

### DIFF
--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -277,9 +277,10 @@ Follow the instructions in :doc:`/maintaining/datastore` to create the required
 databases and users, set the right permissions and set the appropriate values
 in your CKAN config file.
 
-After setting up the DataStore, configure DataPusher or XLoader to add data to DataStore.
-To install the DataPusher refer this docs: https://github.com/ckan/datapusher or refer this
-docs: https://github.com/ckan/ckanext-xloader to install the XLoader.
+Once you have set up the DataStore, you may then wish to configure either the DataPusher or XLoader
+extensions to add data to the DataStore. To install DataPusher refer to this link:
+https://github.com/ckan/datapusher and to install XLoader refer to this link:
+https://github.com/ckan/ckanext-xloader
 
 ---------------
 9. You're done!

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -277,6 +277,10 @@ Follow the instructions in :doc:`/maintaining/datastore` to create the required
 databases and users, set the right permissions and set the appropriate values
 in your CKAN config file.
 
+After setting up the DataStore, configure DataPusher or XLoader to add data to DataStore.
+To install the DataPusher refer this docs: https://github.com/ckan/datapusher or refer this
+docs: https://github.com/ckan/ckanext-xloader to install the XLoader.
+
 ---------------
 9. You're done!
 ---------------


### PR DESCRIPTION
Fixes #6269 

### Proposed fixes:
DataStore and XLoader are documented in CKAN source installing document.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
