### PR TITLE
Fix runaway preview height

### DIFF
--- a/ckan/public/base/javascript/modules/data-viewer.js
+++ b/ckan/public/base/javascript/modules/data-viewer.js
@@ -28,7 +28,7 @@ this.ckan.module('data-viewer', function (jQuery) {
       // see if page is in part of the same domain
       if (this.el.attr('src').substring(0, loc.length) === loc) {
         this._recalibrate();
-        setInterval(function() {
+        setTimeout(function() {
           self._recalibrate();
         }, this.options.timeout);
       } else {


### PR DESCRIPTION
### Proposed fixes:

On a relatively complicated 2.9.3 site, with ckanext-pdfview #0.0.7, `setInterval` fires repeatedly, slowly increasing the height of the datapreview window to tens of thousands of pixels.

I'm not 100% clear that this would happen on a less complicated site, but I don't generally see why the height of the iframe should change more than once, ever.  

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
