### PR TITLE
Updated Docstrings for after_update/after_delete

### DIFF
--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -494,6 +494,11 @@ class IPackageController(Interface):
         u'''
         Extensions will receive the validated data dict after the dataset
         has been updated.
+
+        Note that bulk dataset update actions (`bulk_update_private`,
+        `bulk_update_public`) will bypass this callback. See
+        ``ckan.plugins.toolkit.chained_action`` to wrap those actions
+        if required.
         '''
         pass
 
@@ -502,6 +507,10 @@ class IPackageController(Interface):
         u'''
         Extensions will receive the data dict (typically containing
         just the dataset id) after the dataset has been deleted.
+
+        Note that the `bulk_update_delete` action will bypass this
+        callback. See ``ckan.plugins.toolkit.chained_action`` to wrap
+        that action if required.
         '''
         pass
 

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -640,6 +640,10 @@ class IResourceController(Interface):
             dictionary ``url_type`` which is set to ``upload`` when the
             resource file is uploaded instead of linked.
         :type resource: dictionary
+
+        Note that the datastore will bypass this callback when updating
+        the ``datastore_active`` flag on a resource that has been added
+        to the datastore.
         '''
         pass
 


### PR DESCRIPTION
Fixes / Related to #6159

### Proposed fixes:

The after_update and after_delete callbacks aren't always called
when the underlying dataset changes. This enumerates the cases where
it happens, and what to do about it.

Not having this documentation led to some headscratching on a site where we're doing some special work with permissions. 

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
