### PR TITLE
[#6288] Replace python3.6 with python3.8 as 3.6 is not supported by Ubuntu Focal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN update-locale LANG=${LC_ALL}
 RUN apt-get -q -y update \
     && DEBIAN_FRONTEND=noninteractive apt-get -q -y upgrade \
     && apt-get -q -y install \
-        python3.6 \
+        python3.8 \
         python3-dev \
         python3-pip \
         python3-venv \


### PR DESCRIPTION
Fixes #6288

### Proposed fixes:
Use right Python version on Ubuntu 20.04, as current Dockerfile is misleading, it's already using Python 3.8 but Dockerfile suggests it's 3.6


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
