### PR TITLE
cors: "no content"+access-control-allow-headers response

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -399,6 +399,12 @@ def ckan_after_request(response):
 
     log.info(' %s render time %.3f seconds' % (url, r_time))
 
+    # 204 "No content" response required for CORS OPTIONS calls
+    if not response.data and response.status_code == 200:
+        response.status_code = 204
+        response.headers.pop('Content-Type', None)
+        response.headers['Access-Control-Allow-Headers'] = 'Authorization, Content-Type, Accept'
+
     return response
 
 


### PR DESCRIPTION
Fixes #6292 

### Proposed fixes:

respond with "no content" on empty responses and include access-control-allow-headers to make post requests to the API from other sites possible

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport