### PR TITLE
Improve and fixes to stats extension

### DIFF
--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -11306,58 +11306,6 @@ h4 small {
   margin-bottom: 10px;
 }
 
-.table-chunky td,
-.table-chunky th {
-  padding: 12px 15px;
-  font-size: 12px;
-}
-
-.table-chunky thead th,
-.table-chunky thead td {
-  color: #fff;
-  background-color: #aaa;
-  padding-top: 10px;
-  padding-bottom: 10px;
-}
-
-.table-striped tbody tr:nth-child(odd) td,
-.table-striped tbody tr:nth-child(odd) th {
-  background-color: transparent;
-}
-.table-striped tbody tr:nth-child(even) td,
-.table-striped tbody tr:nth-child(even) th {
-  background-color: #f2f2f2;
-}
-
-.table-chunky.table-bordered {
-  border-radius: 2px;
-}
-.table-chunky.table-bordered thead:first-child tr:first-child th:first-child,
-.table-chunky.table-bordered tbody:first-child tr:first-child td:first-child {
-  -webkit-border-top-left-radius: 2px;
-  -moz-border-radius-topleft: 2px;
-  border-top-left-radius: 2px;
-}
-.table-chunky.table-bordered thead:first-child tr:first-child th:last-child,
-.table-chunky.table-bordered tbody:first-child tr:first-child td:last-child {
-  -webkit-border-top-right-radius: 2px;
-  -moz-border-radius-topright: 2px;
-  border-top-right-radius: 2px;
-}
-.table-chunky.table-bordered thead:last-child tr:last-child th:first-child,
-.table-chunky.table-bordered tbody:last-child tr:last-child td:first-child {
-  border-radius: 0 0 0 2px;
-  -webkit-border-bottom-left-radius: 2px;
-  -moz-border-radius-bottomleft: 2px;
-  border-bottom-left-radius: 2px;
-}
-.table-chunky.table-bordered thead:last-child tr:last-child th:last-child,
-.table-chunky.table-bordered tbody:last-child tr:last-child td:last-child {
-  -webkit-border-bottom-right-radius: 2px;
-  -moz-border-radius-bottomright: 2px;
-  border-bottom-right-radius: 2px;
-}
-
 .ellipsis {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -9378,58 +9378,6 @@ h4 small {
   margin-bottom: 10px;
 }
 
-.table-chunky td,
-.table-chunky th {
-  padding: 12px 15px;
-  font-size: 12px;
-}
-
-.table-chunky thead th,
-.table-chunky thead td {
-  color: #fff;
-  background-color: #aaa;
-  padding-top: 10px;
-  padding-bottom: 10px;
-}
-
-.table-striped tbody tr:nth-child(odd) td,
-.table-striped tbody tr:nth-child(odd) th {
-  background-color: transparent;
-}
-.table-striped tbody tr:nth-child(even) td,
-.table-striped tbody tr:nth-child(even) th {
-  background-color: #f2f2f2;
-}
-
-.table-chunky.table-bordered {
-  border-radius: 2px;
-}
-.table-chunky.table-bordered thead:first-child tr:first-child th:first-child,
-.table-chunky.table-bordered tbody:first-child tr:first-child td:first-child {
-  -webkit-border-top-left-radius: 2px;
-  -moz-border-radius-topleft: 2px;
-  border-top-left-radius: 2px;
-}
-.table-chunky.table-bordered thead:first-child tr:first-child th:last-child,
-.table-chunky.table-bordered tbody:first-child tr:first-child td:last-child {
-  -webkit-border-top-right-radius: 2px;
-  -moz-border-radius-topright: 2px;
-  border-top-right-radius: 2px;
-}
-.table-chunky.table-bordered thead:last-child tr:last-child th:first-child,
-.table-chunky.table-bordered tbody:last-child tr:last-child td:first-child {
-  border-radius: 0 0 0 2px;
-  -webkit-border-bottom-left-radius: 2px;
-  -moz-border-radius-bottomleft: 2px;
-  border-bottom-left-radius: 2px;
-}
-.table-chunky.table-bordered thead:last-child tr:last-child th:last-child,
-.table-chunky.table-bordered tbody:last-child tr:last-child td:last-child {
-  -webkit-border-bottom-right-radius: 2px;
-  -moz-border-radius-bottomright: 2px;
-  border-bottom-right-radius: 2px;
-}
-
 .ellipsis {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/ckan/public/base/scss/_prose.scss
+++ b/ckan/public/base/scss/_prose.scss
@@ -36,66 +36,6 @@ h4 {
     }
 }
 
-.table-chunky td,
-.table-chunky th {
-    padding: 12px 15px;
-    font-size: 12px;
-}
-
-.table-chunky thead th,
-.table-chunky thead td {
-    color: $chunkyTableHeaderTextColor;
-    background-color: $chunkyTableHeaderBackgroundColor;
-    padding-top: 10px;
-    padding-bottom: 10px;
-}
-
-.table-striped {
-    tbody {
-        tr:nth-child(odd) td,
-        tr:nth-child(odd) th {
-            background-color: transparent;
-        }
-        tr:nth-child(even) td,
-        tr:nth-child(even) th {
-            background-color: $chunkyTableStripeBackgroundColor;
-        }
-    }
-}
-
-// Oh boy.
-.table-chunky.table-bordered {
-    $radius: 2px;
-    @include border-radius($radius);
-    // For first th or td in the first row in the first thead or tbody
-    thead:first-child tr:first-child th:first-child,
-    tbody:first-child tr:first-child td:first-child {
-        -webkit-border-top-left-radius: $radius;
-        -moz-border-radius-topleft: $radius;
-        border-top-left-radius: $radius;
-    }
-    thead:first-child tr:first-child th:last-child,
-    tbody:first-child tr:first-child td:last-child {
-        -webkit-border-top-right-radius: $radius;
-        -moz-border-radius-topright: $radius;
-        border-top-right-radius: $radius;
-    }
-    // For first th or td in the first row in the first thead or tbody
-    thead:last-child tr:last-child th:first-child,
-    tbody:last-child tr:last-child td:first-child {
-        @include border-radius(0 0 0 $radius);
-        -webkit-border-bottom-left-radius: $radius;
-        -moz-border-radius-bottomleft: $radius;
-        border-bottom-left-radius: $radius;
-    }
-    thead:last-child tr:last-child th:last-child,
-    tbody:last-child tr:last-child td:last-child {
-        -webkit-border-bottom-right-radius: $radius;
-        -moz-border-radius-bottomright: $radius;
-        border-bottom-right-radius: $radius;
-    }
-}
-
 .ellipsis {
     overflow: hidden;
     text-overflow: ellipsis;

--- a/ckan/public/base/scss/_variables.scss
+++ b/ckan/public/base/scss/_variables.scss
@@ -99,12 +99,6 @@ $codeTextColor: #000;
 $listingHeadingTextColor: #333;
 $resourceFormatBackground: #6e6e6e;
 
-// Table
-
-$chunkyTableHeaderTextColor: #fff;
-$chunkyTableHeaderBackgroundColor: #aaa;
-$chunkyTableStripeBackgroundColor: #f2f2f2;
-
 // Twitter Bootstrap Overrides
 $bodyBackground: $layoutBackgroundColor;
 $btnBackground: #ffffff;

--- a/ckanext/stats/templates/ckanext/stats/index.html
+++ b/ckanext/stats/templates/ckanext/stats/index.html
@@ -9,7 +9,7 @@
 
     <section id="stats-largest-groups" class="module-content tab-content">
       <h2>{{ _('Largest Groups') }}</h2>
-      {% if c.largest_groups %}
+      {% if largest_groups %}
         <table class="table table-chunky table-bordered table-striped">
           <thead>
             <tr>
@@ -18,9 +18,9 @@
             </tr>
           </thead>
           <tbody>
-            {% for group, num_packages in c.largest_groups %}
+            {% for group, num_packages in largest_groups %}
               <tr>
-                <td>{{ h.link_to(group.title or group.name, h.url_for(group.type + 'read', id=group.name)) }}</td>
+                <td>{{ h.link_to(group.title or group.name, h.url_for(group.type + '.read', id=group.name)) }}</td>
                 <td class="metric">{{ num_packages }}</td>
               </tr>
             {% endfor %}
@@ -41,7 +41,7 @@
           </tr>
         </thead>
         <tbody>
-          {% for tag, num_packages in c.top_tags %}
+          {% for tag, num_packages in top_tags %}
             <tr>
               <td>{{ h.link_to(tag.name, h.url_for('dataset.search', tags=tag.name)) }}</td>
               <td class="metric">{{ num_packages }}</td>
@@ -61,7 +61,7 @@
           </tr>
         </thead>
         <tbody>
-          {% for user, num_packages in c.top_package_creators %}
+          {% for user, num_packages in top_package_creators %}
             <tr>
               <td class="media">{{ h.linked_user(user) }}</td>
               <td class="metric">{{ num_packages }}</td>

--- a/ckanext/stats/templates/ckanext/stats/index.html
+++ b/ckanext/stats/templates/ckanext/stats/index.html
@@ -10,18 +10,18 @@
     <section id="stats-largest-groups" class="module-content tab-content">
       <h2>{{ _('Largest Groups') }}</h2>
       {% if largest_groups %}
-        <table class="table table-chunky table-bordered table-striped">
+        <table class="table table-striped table-bordered table-condensed">
           <thead>
             <tr>
-              <th>{{ _('Group') }}</th>
-              <th class="metric">{{ _('Number of datasets') }}</th>
+              <th class="col-md-9">{{ _('Group') }}</th>
+              <th class="col-md-3">{{ _('Number of datasets') }}</th>
             </tr>
           </thead>
           <tbody>
             {% for group, num_packages in largest_groups %}
               <tr>
                 <td>{{ h.link_to(group.title or group.name, h.url_for(group.type + '.read', id=group.name)) }}</td>
-                <td class="metric">{{ num_packages }}</td>
+                <td>{{ num_packages }}</td>
               </tr>
             {% endfor %}
           </tbody>
@@ -33,18 +33,18 @@
 
     <section id="stats-top-tags" class="module-content tab-content">
       <h2>{{ _('Top Tags') }}</h2>
-      <table class="table table-chunky table-bordered table-striped">
+      <table class="table table-striped table-bordered table-condensed">
         <thead>
           <tr>
-            <th>{{ _('Tag Name') }}</th>
-            <th class="metric">{{ _('Number of Datasets') }}</th>
+            <th class="col-md-9">{{ _('Tag Name') }}</th>
+            <th class="col-md-3">{{ _('Number of Datasets') }}</th>
           </tr>
         </thead>
         <tbody>
           {% for tag, num_packages in top_tags %}
             <tr>
               <td>{{ h.link_to(tag.name, h.url_for('dataset.search', tags=tag.name)) }}</td>
-              <td class="metric">{{ num_packages }}</td>
+              <td>{{ num_packages }}</td>
             </tr>
           {% endfor %}
         </tbody>
@@ -53,18 +53,18 @@
 
     <section id="stats-most-create" class="module-content tab-content">
       <h2>{{ _('Users Creating Most Datasets') }}</h2>
-      <table class="table table-chunky table-bordered table-striped">
+      <table class="table table-striped table-bordered table-condensed">
         <thead>
           <tr>
-            <th>{{ _('User') }}</th>
-            <th class="metric">{{ _('Number of Datasets') }}</th>
+            <th class="col-md-9">{{ _('User') }}</th>
+            <th class="col-md-3">{{ _('Number of Datasets') }}</th>
           </tr>
         </thead>
         <tbody>
           {% for user, num_packages in top_package_creators %}
             <tr>
-              <td class="media">{{ h.linked_user(user) }}</td>
-              <td class="metric">{{ num_packages }}</td>
+              <td>{{ h.linked_user(user) }}</td>
+              <td>{{ num_packages }}</td>
             </tr>
           {% endfor %}
         </tbody>


### PR DESCRIPTION
Issues:
 - The extension was not showing any data since the variables were incorrectly accessed.
 - The extension uses some old CSS styles and doesn't follow Bootstrap best practices.

Fixes:
 - Access variables directly and not through `c` object (as they are rendered as `extra_vars`)
 - Re design of the tables following Bootstrap best practices simplifying our CSS files.

Previous design:
![image](https://user-images.githubusercontent.com/6672339/127930833-69338b63-ba61-426f-9414-9fd89bc3a8ab.png)


Current design:
![image](https://user-images.githubusercontent.com/6672339/127930746-24b13faa-f19c-4092-a376-5b5838f8bddd.png)
