### PR TITLE
Replace glyphicons with fontawesome

### DIFF
--- a/ckanext/datatablesview/public/datatablesview.js
+++ b/ckanext/datatablesview/public/datatablesview.js
@@ -454,7 +454,7 @@ this.ckan.module('datatables_view', function (jQuery) {
         const colname = thecol.textContent
         const colid = 'dtcol-' + validateId(colname) + '-' + i
         const coltype = $(thecol).data('type')
-        const placeholderText = formatdateflag && coltype.substr(0, 9) === 'timestamp' ? ' placeholder="yyyy-mm-dd"' : ''  
+        const placeholderText = formatdateflag && coltype.substr(0, 9) === 'timestamp' ? ' placeholder="yyyy-mm-dd"' : ''
         $('<input id="' + colid + '" name="' + colid + '" autosave="' + colid + '"' +
                 placeholderText +
                 ' class="fhead form-control input-sm" type="search" results="10" autocomplete="on" style="width:100%"/>')
@@ -880,8 +880,8 @@ this.ckan.module('datatables_view', function (jQuery) {
           const colText = datatable.column(sortcol[0]).name()
           gsortInfo = gsortInfo + colText +
                       (sortcol[1] === 'asc'
-                        ? ' <span class="glyphicon glyphicon-sort-by-attributes"></span> '
-                        : ' <span class="glyphicon glyphicon-sort-by-attributes-alt"></span> ')
+                        ? ' <span class="fa fa-sort-amount-asc"></span> '
+                        : ' <span class="fa fa-sort-amount-desc"></span> ')
         })
         $('div.sortinfo').html(gsortInfo)
       })

--- a/ckanext/reclineview/theme/public/vendor/recline/recline.js
+++ b/ckanext/reclineview/theme/public/vendor/recline/recline.js
@@ -3981,7 +3981,7 @@ my.Fields = Backbone.View.extend({
     {{#fields}} \
       <div class="panel panel-default field"> \
         <div class="panel-heading"> \
-          <i class="glyphicon glyphicon-file"></i> \
+          <i class="fa fa-file"></i> \
           <h4> \
             {{label}} \
             <small> \
@@ -4314,7 +4314,7 @@ my.QueryEditor = Backbone.View.extend({
       <div class="form-group"> \
         <div class="input-group text-query"> \
           <div class="input-group-addon"> \
-            <i class="glyphicon glyphicon-search"></i> \
+            <i class="fa fa-search"></i> \
           </div> \
           <label for="q">Search</label> \
           <input class="form-control search-query" type="text" id="q" name="q" value="{{q}}" placeholder="Search data ..."> \


### PR DESCRIPTION
Bootstrap 4 dropped the Glyphicons icon font: https://getbootstrap.com/docs/4.6/migration/#components

This are the only uses I found in the codebase, so one less thing to do when migrating Bootstrap to a newer version.