### PR TITLE
Fix typo in wsgi.py

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -12,7 +12,7 @@ else:
         os.path.dirname(os.path.abspath(__file__)), u'ckan.ini')
 
 if not os.path.exists(config_path):
-    raise RuntimeError('CKAN config option not found: {}'.format(config_path))
+    raise RuntimeError('CKAN config file not found: {}'.format(config_path))
 
 loggingFileConfig(config_path)
 config = CKANConfigLoader(config_path).get_config()


### PR DESCRIPTION
When config file does not exists error message from wsgi.py says that *config **option** not found*. Replace **option** with **file**