### PR TITLE
Allow pager to optionally accept raw HTML symbols

### DIFF
--- a/ckan/lib/pagination.py
+++ b/ckan/lib/pagination.py
@@ -494,16 +494,20 @@ class BasePage(list):
                 u"last_item": self.last_item,
                 u"item_count": self.item_count,
                 u"link_first": self.page > self.first_page
-                and self._pagerlink(self.first_page, symbol_first, raw_text=raw_symbols)
+                and self._pagerlink(self.first_page, symbol_first,
+                                    raw_text=raw_symbols)
                 or u"",
                 u"link_last": self.page < self.last_page
-                and self._pagerlink(self.last_page, symbol_last, raw_text=raw_symbols)
+                and self._pagerlink(self.last_page, symbol_last,
+                                    raw_text=raw_symbols)
                 or u"",
                 u"link_previous": self.previous_page
-                and self._pagerlink(self.previous_page, symbol_previous, raw_text=raw_symbols)
+                and self._pagerlink(self.previous_page, symbol_previous,
+                                    raw_text=raw_symbols)
                 or u"",
                 u"link_next": self.next_page
-                and self._pagerlink(self.next_page, symbol_next, raw_text=raw_symbols)
+                and self._pagerlink(self.next_page, symbol_next,
+                                    raw_text=raw_symbols)
                 or u"",
             }
         )


### PR DESCRIPTION
Fixes #5733 

### Proposed fixes:
- Add optional keyword argument `raw_symbols` to `Page.pager` that allows disabling HTML escaping for `symbol_first`, `symbol_last`, `symbol_next` and `symbol_previous`. This makes it possible to customize the pager with a11y tags and icons.

### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport

Financed by Finland's open data portal opendata.fi. Find all Finnish open data at https://www.opendata.fi/en.
The Service is provided by the Digital and Population Data Services Agency (https://dvv.fi/en/).