### PR TITLE
Clean remaining resource jinja extension code

### DIFF
--- a/ckan/lib/jinja_extensions.py
+++ b/ckan/lib/jinja_extensions.py
@@ -27,7 +27,6 @@ def _get_extensions():
             CkanExtend,
             CkanInternationalizationExtension,
             LinkForExtension,
-            ResourceExtension,
             UrlForStaticExtension,
             UrlForExtension,
             AssetExtension]
@@ -314,24 +313,6 @@ class LinkForExtension(BaseExtension):
     @classmethod
     def _call(cls, args, kwargs):
         return h.nav_link(*args, **kwargs)
-
-class ResourceExtension(BaseExtension):
-    ''' Deprecated. Custom include_resource tag.
-
-    {% resource <resource_name> %}
-
-    see lib.helpers.include_resource() for more details.
-    '''
-
-    tags = set(['resource'])
-
-    @classmethod
-    def _call(cls, args, kwargs):
-        assert len(args) == 1
-        assert len(kwargs) == 0
-        h.include_resource(args[0], **kwargs)
-        return ''
-
 
 class AssetExtension(BaseExtension):
     ''' Custom include_asset tag.

--- a/ckan/templates/base.html
+++ b/ckan/templates/base.html
@@ -107,7 +107,7 @@
 
     {#
     DO NOT USE THIS BLOCK FOR ADDING SCRIPTS
-    Scripts should be loaded by the {% resource %} tag except in very special
+    Scripts should be loaded by the {% assets %} tag except in very special
     circumstances
     #}
     {%- block scripts %}

--- a/ckanext/example_theme_docs/v22_webassets/templates/base.html
+++ b/ckanext/example_theme_docs/v22_webassets/templates/base.html
@@ -4,5 +4,4 @@
   {{ super() }}
 
   {% asset 'example_theme/scripts' %}
-  {% resource 'example_theme/scripts' %}
 {% endblock %}

--- a/doc/contributing/frontend/javascript-module-tutorial.rst
+++ b/doc/contributing/frontend/javascript-module-tutorial.rst
@@ -51,8 +51,8 @@ translation object.
 
 .. Note::
     In order to include a module for page render inclusion within an
-    extension it is recommended that you use ``{% resource %}`` within
-    your templates. See the `Resource Documentation <./resources.html>`_
+    extension it is recommended that you use ``{% asset %}`` within
+    your templates. See the `Assets Documentation <./assets.html>`_
 
 Initialisation
 ~~~~~~~~~~~~~~

--- a/doc/contributing/frontend/template-tutorial.rst
+++ b/doc/contributing/frontend/template-tutorial.rst
@@ -85,21 +85,14 @@ it is useful to provide additional actions that a related to the page.
 Scripts and Stylesheets
 -----------------------
 
-Currently scripts and stylesheets can be added by extending the
-``styles`` and ``scripts`` blocks. This is soon to be replaced with the
-``{% resource %}`` tag which manages script loading for us.
+Currently scripts and stylesheets can be added by using the
+``{% asset %}`` tag which manages script loading for us.
 
 ::
 
-    {% block styles %}
-      {{ super() }}
-      <link rel="stylesheet" href="{% url_for_static "my-style.css" %}" />
-    {% endblock %}
+{% asset 'my-extension/main-css' %}
+{% asset 'my-extension/main-js' %}
 
-    {% block scripts %}
-      {{ super() }}
-      <script src="{% url_for_static "my-script.js" %}"></script>
-    {% endblock %}
 
 Summary
 -------

--- a/doc/theming/javascript.rst
+++ b/doc/theming/javascript.rst
@@ -243,7 +243,7 @@ JavaScript module using ``data-module-*`` attributes:
 .. literalinclude:: /../ckanext/example_theme_docs/v18_snippet_api/templates/snippets/package_item.html
    :language: django
 
-We've also added a second ``{% resource %}`` tag to the snippet above, to
+We've also added a second ``{% asset %}`` tag to the snippet above, to
 include a custom CSS file. We'll see the contents of that CSS file later.
 
 Next, we need to add a new template snippet to our extension that will be used
@@ -308,7 +308,7 @@ going on:
    :language: javascript
 
 Finally, we need some custom CSS to make the HTML from our new snippet look
-nice. In ``package_item.html`` above we added a ``{% resource %}`` tag to
+nice. In ``package_item.html`` above we added a ``{% asset %}`` tag to
 include a custom CSS file. Now we need to create that file,
 ``ckanext-example_theme/ckanext/example_theme/assets/example_theme_popover.css``:
 
@@ -500,7 +500,7 @@ a single expression by chaining our jQuery method with another method:
 
 Before we can use our ``greenify()`` method in CKAN, we need to import the
 ``jquery.greenify.js`` file into the CKAN page. To do this, add a
-``{% resource %}`` tag to a template file, just as you would do to include any
+``{% asset %}`` tag to a template file, just as you would do to include any
 other JavaScript or CSS file in CKAN. Edit the ``package_item.html`` file:
 
 .. literalinclude:: /../ckanext/example_theme_docs/v21_custom_jquery_plugin/templates/snippets/package_item.html


### PR DESCRIPTION
This PR cleans some remaining code from the old `{% resources %}` tag.