### PR TITLE
removed deprecated API keys

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -886,37 +886,6 @@ def user_update(context, data_dict):
     return user_dict
 
 
-def user_generate_apikey(context, data_dict):
-    '''Cycle a user's API key
-
-    :param id: the name or id of the user whose key needs to be updated
-    :type id: string
-
-    :returns: the updated user
-    :rtype: dictionary
-    '''
-    model = context['model']
-    schema = context.get('schema') or schema_.default_generate_apikey_user_schema()
-    context['schema'] = schema
-    # check if user id in data_dict
-    id = _get_or_bust(data_dict, 'id')
-
-    # check if user exists
-    user_obj = model.User.get(id)
-    context['user_obj'] = user_obj
-    if user_obj is None:
-        raise NotFound('User was not found.')
-
-    # check permission
-    _check_access('user_generate_apikey', context, data_dict)
-
-    # change key
-    old_data = _get_action('user_show')(context, data_dict)
-    old_data['apikey'] = model.types.make_uuid()
-    data_dict = old_data
-    return _get_action('user_update')(context, data_dict)
-
-
 def task_status_update(context, data_dict):
     '''Update a task status.
 

--- a/ckan/logic/auth/update.py
+++ b/ckan/logic/auth/update.py
@@ -215,16 +215,6 @@ def user_update(context, data_dict):
                         (user, user_obj.id)}
 
 
-def user_generate_apikey(context, data_dict):
-    user = context['user']
-    user_obj = logic_auth.get_user_object(context, data_dict)
-    if user == user_obj.name:
-        # Allow users to update only their own user accounts.
-        return {'success': True}
-    return {'success': False, 'msg': _('User {0} not authorized to update user'
-            ' {1}'.format(user, user_obj.id))}
-
-
 def task_status_update(context, data_dict):
     # sysadmins only
     user = context['user']

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -402,7 +402,6 @@ def default_user_schema(
         'about': [ignore_missing, user_about_validator, unicode_safe],
         'created': [ignore],
         'sysadmin': [ignore_missing, ignore_not_sysadmin],
-        'apikey': [ignore],
         'reset_key': [ignore],
         'activity_streams_email_notifications': [ignore_missing,
                                                  boolean_validator],
@@ -457,15 +456,6 @@ def default_update_user_schema(
     schema['password'] = [
         user_password_validator, ignore_missing, unicode_safe]
 
-    return schema
-
-
-@validator_args
-def default_generate_apikey_user_schema(
-        not_empty, unicode_safe):
-    schema = default_update_user_schema()
-
-    schema['apikey'] = [not_empty, unicode_safe]
     return schema
 
 

--- a/ckan/templates/user/edit_user_form.html
+++ b/ckan/templates/user/edit_user_form.html
@@ -58,11 +58,6 @@
             <a class="btn btn-danger pull-left" href="{% url_for 'user_delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this User?') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
           {% endif %}
         {% endblock %}
-        {% block generate_button %}
-          {% if h.check_access('user_generate_apikey', {'id': data.id})  %}
-            <a class="btn btn-warning" href="{% url_for 'user.generate_apikey', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to regenerate the API key?') }}">{% block generate_button_text %}{{ _('Regenerate API Key') }}{% endblock %}</a>
-          {% endif %}
-        {% endblock %}
         {{ form.required_message() }}
         <button class="btn btn-primary" type="submit" name="save">{{ _('Update Profile') }}</button>
       {% endblock %}

--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -16,8 +16,8 @@ import ckan.plugins as p
 import logging
 log = logging.getLogger(__name__)
 
-APIKEY_HEADER_NAME_KEY = u'apikey_header_name'
-APIKEY_HEADER_NAME_DEFAULT = u'X-CKAN-API-Key'
+APIKEY_HEADER_NAME_KEY = u'apitoken_header_name'
+APIKEY_HEADER_NAME_DEFAULT = u'X-CKAN-API-Token'
 
 
 def check_session_cookie(response):
@@ -185,34 +185,32 @@ def _identify_user_default():
                               u'logout_handler_path')
                 redirect(pth)
     else:
-        g.userobj = _get_user_for_apikey()
+        g.userobj = _get_user_for_apitoken()
         if g.userobj is not None:
             g.user = g.userobj.name
 
 
-def _get_user_for_apikey():
-    apikey_header_name = config.get(APIKEY_HEADER_NAME_KEY,
-                                    APIKEY_HEADER_NAME_DEFAULT)
-    apikey = request.headers.get(apikey_header_name, u'')
-    if not apikey:
-        apikey = request.environ.get(apikey_header_name, u'')
-    if not apikey:
+def _get_user_for_apitoken():
+    api_token_header_name = config.get(APIKEY_HEADER_NAME_KEY,
+                                       APIKEY_HEADER_NAME_DEFAULT)
+    api_token = request.headers.get(api_token_header_name, u'')
+    if not api_token:
+        api_token = request.environ.get(api_token_header_name, u'')
+    if not api_token:
         # For misunderstanding old documentation (now fixed).
-        apikey = request.environ.get(u'HTTP_AUTHORIZATION', u'')
-    if not apikey:
-        apikey = request.environ.get(u'Authorization', u'')
+        api_token = request.environ.get(u'HTTP_AUTHORIZATION', u'')
+    if not api_token:
+        apitoken = request.environ.get(u'Authorization', u'')
         # Forget HTTP Auth credentials (they have spaces).
-        if u' ' in apikey:
-            apikey = u''
-    if not apikey:
+        if u' ' in api_token:
+            api_token = u''
+    if not api_token:
         return None
-    apikey = six.ensure_text(apikey, errors=u"ignore")
-    log.debug(u'Received API Key: %s' % apikey)
-    query = model.Session.query(model.User)
-    user = query.filter_by(apikey=apikey).first()
+    api_token = six.ensure_text(api_token, errors=u"ignore")
+    log.debug(u'Received API Key: %s' % api_token)
 
-    if not user:
-        user = api_token.get_user_from_token(apikey)
+    user = api_token.get_user_from_token(apitoken)
+
     return user
 
 

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -529,32 +529,6 @@ def delete(id):
         return h.redirect_to(user_index)
 
 
-def generate_apikey(id=None):
-    u'''Cycle the API key of a user'''
-    context = {
-        u'model': model,
-        u'session': model.Session,
-        u'user': g.user,
-        u'auth_user_obj': g.userobj,
-    }
-    if id is None:
-        if g.userobj:
-            id = g.userobj.id
-        else:
-            base.abort(400, _(u'No user specified'))
-    data_dict = {u'id': id}
-
-    try:
-        result = logic.get_action(u'user_generate_apikey')(context, data_dict)
-    except logic.NotAuthorized:
-        base.abort(403, _(u'Unauthorized to edit user %s') % u'')
-    except logic.NotFound:
-        base.abort(404, _(u'User not found'))
-
-    h.flash_success(_(u'Profile updated'))
-    return h.redirect_to(u'user.read', id=result[u'name'])
-
-
 def activity(id, offset=0):
     u'''Render this user's public activity stream page.'''
 
@@ -885,11 +859,6 @@ user.add_url_rule(u'/logged_out', view_func=logged_out)
 user.add_url_rule(u'/logged_out_redirect', view_func=logged_out_page)
 
 user.add_url_rule(u'/delete/<id>', view_func=delete, methods=(u'POST', ))
-
-user.add_url_rule(
-    u'/generate_key', view_func=generate_apikey, methods=(u'POST', ))
-user.add_url_rule(
-    u'/generate_key/<id>', view_func=generate_apikey, methods=(u'POST', ))
 
 user.add_url_rule(u'/activity/<id>', view_func=activity)
 user.add_url_rule(u'/activity/<id>/<int:offset>', view_func=activity)

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -495,7 +495,9 @@ class TestDatastoreSearchLegacyTests(object):
                 },
             ],
         }
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        query = model.Session.query(model.ApiToken)
+        token = query.filter_by(user_id=self.sysadmin_user.id).first()
+        auth = {"Authorization": str(token.id)}
         res = app.post(
             "/api/action/datastore_create", json=self.data, extra_environ=auth,
         )


### PR DESCRIPTION
Fixes #6247

### Proposed fixes:
-Renamed methods/vars from api_key -> api_token 
-Removed the  API key snippet and "Regenerate API key" button from the user profile templates
-Removed the endpoint used to regenerate the API key and the `user_generate_apikey` action and auth function
-Removed apikey from the user schema
-Instead of [api key](https://github.com/ckan/ckan/blob/94194d43667d122bc5a55a45e16b07b4430f3405/ckanext/datastore/tests/test_search.py#L498) i created API Token and used it for authorization.

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
