### PR TITLE
[#5998] db init error in alembic (2.9 backport)

### DIFF
--- a/ckan/model/__init__.py
+++ b/ckan/model/__init__.py
@@ -266,7 +266,7 @@ class Repository():
         self.reset_alembic_output()
         alembic_config = AlembicConfig(self._alembic_ini)
         alembic_config.set_main_option(
-            "sqlalchemy.url", str(self.metadata.bind.url)
+            "sqlalchemy.url", config.get("sqlalchemy.url")
         )
         try:
             sqlalchemy_migrate_version = self.metadata.bind.execute(


### PR DESCRIPTION
Fixes #5998 in branch 2.9.

This is a cherrypick of 1a18632, since original PR #5999 on master is not present in branch 2.9.

### Proposed fixes:

Get `sqlalchemy.url` from original ckan config instead from mangled items.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
