### PR TITLE
Remove old pylons.h config

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -196,7 +196,6 @@ def update_config():
     app_globals.app_globals._init()
 
     helpers.load_plugin_helpers()
-    config['pylons.h'] = helpers.helper_functions
 
     # Templates and CSS loading from configuration
     valid_base_templates_folder_names = ['templates']


### PR DESCRIPTION
Removes an old config value that it is no longer needed.