### PR TITLE
Fix datetime formatting when listing user tokens on Python 2.

### DIFF
--- a/ckan/cli/user.py
+++ b/ckan/cli/user.py
@@ -4,6 +4,7 @@ import logging
 import six
 import click
 from six import text_type
+from datetime import datetime
 
 import ckan.logic as logic
 import ckan.plugins as plugin
@@ -226,9 +227,21 @@ def list_tokens(username):
     for token in tokens:
         last_access = token[u"last_access"]
         if last_access:
-            accessed = plugin.toolkit.h.date_str_to_datetime(
-                last_access
-            ).isoformat(u" ", u"seconds")
+            accessed = plugin.toolkit.h.date_str_to_datetime(last_access)
+            if six.PY2:
+                """
+                Strip out microseconds to force formatting as isoformat doesnt
+                have a timespec param on Python 2.
+                """
+                accessed = datetime(
+                    accessed.year,
+                    accessed.month,
+                    accessed.day,
+                    accessed.hour,
+                    accessed.minute,
+                    accessed.second).isoformat(" ")
+            else:
+                accessed = accessed.isoformat(u" ", u"seconds")
 
         else:
             accessed = u"Never"


### PR DESCRIPTION
Fixes #6319 

### Proposed fixes:

Fixes the formatting of last access time field when listing used tokens on Python 2. Previously a traceback was generated because of differences between Python 2 and Python 3 `datetime.isoformat`. See #6319 for details.

This seams like the cleanest solution to me however I'm happy to modify it if you think there is a more appropriate way to do this. One other option I considered was to add a parameter to the `plugin.toolkit.h.date_str_to_datetime` methods to allow the control of precision. However, I decided to do it this way as its easier to identify that its dead code once Python 2 support is removed.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply 
