### PR TITLE
Remove Pylons reference in make_app method

### DIFF
--- a/ckan/config/middleware/__init__.py
+++ b/ckan/config/middleware/__init__.py
@@ -17,8 +17,7 @@ _internal_test_request_context = None
 
 def make_app(conf):
     '''
-    Initialise both the pylons and flask apps, and wrap them in dispatcher
-    middleware.
+    Initialise the Flask app and wrap it in dispatcher middleware.
     '''
 
     load_environment(conf)


### PR DESCRIPTION
Fixes a docstring referencing Pylons.

P.S: Also I'm testing github.dev with this PR :stuck_out_tongue: 