### PR TITLE
user_list[return_query] returns `about` instead of `email`

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -817,7 +817,7 @@ def user_list(context, data_dict):
             model.User.name.label('name'),
             model.User.fullname.label('fullname'),
             model.User.about.label('about'),
-            model.User.about.label('email'),
+            model.User.email.label('email'),
             model.User.created.label('created'),
             _select([_func.count(model.Package.id)],
                     _and_(

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -912,6 +912,19 @@ class TestUserList(object):
         got_user = got_users[0]
         assert got_user == user["name"]
 
+    def test_user_list_return_query(self):
+        user_a = factories.User(email="a@example.com")
+        query = helpers.call_action(
+            "user_list",
+            {"return_query": True},
+            email="a@example.com"
+        )
+        user = query.one()
+
+        expected = ["name", "fullname", "about", "email"]
+        for prop in expected:
+            assert user_a[prop] == getattr(user, prop), prop
+
     def test_user_list_filtered_by_email(self):
 
         user_a = factories.User(email="a@example.com")


### PR DESCRIPTION
There is a possibility to get an SQLAlchemy query from the `user_list` action if `return_query=True` is passed inside the context. But in this case, the query contains the user's `about` field labeled as `email`. 

This query also contains the whole user object, so it's definitely not a security measure, just a typo. 