### PR TITLE
Clean old session CkanCacheExtension

### DIFF
--- a/ckan/model/meta.py
+++ b/ckan/model/meta.py
@@ -10,26 +10,6 @@ from ckan.model import extension
 __all__ = ['Session', 'engine_is_sqlite', 'engine_is_pg']
 
 
-class CkanCacheExtension(SessionExtension):
-    ''' This extension checks what tables have been affected by
-    database access and allows us to act on them. Currently this is
-    used by the page cache to flush the cache when data in the database
-    is altered. '''
-
-    def __init__(self, *args, **kw):
-        super(CkanCacheExtension, self).__init__(*args, **kw)
-
-    def after_commit(self, session):
-        if hasattr(session, '_object_cache'):
-            oc = session._object_cache
-            oc_list = oc['new']
-            oc_list.update(oc['changed'])
-            oc_list.update(oc['deleted'])
-            objs = set()
-            for item in oc_list:
-                objs.add(item.__class__.__name__)
-
-
 class CkanSessionExtension(SessionExtension):
 
     def before_flush(self, session, flush_context, instances):
@@ -70,8 +50,7 @@ Session = orm.scoped_session(orm.sessionmaker(
     autoflush=False,
     autocommit=False,
     expire_on_commit=False,
-    extension=[CkanCacheExtension(),
-               CkanSessionExtension(),
+    extension=[CkanSessionExtension(),
                extension.PluginSessionExtension(),
     ],
 ))
@@ -80,8 +59,7 @@ create_local_session = orm.sessionmaker(
     autoflush=False,
     autocommit=False,
     expire_on_commit=False,
-    extension=[CkanCacheExtension(),
-               CkanSessionExtension(),
+    extension=[CkanSessionExtension(),
                extension.PluginSessionExtension(),
     ],
 )


### PR DESCRIPTION
`CkanCacheExtension` was used by `PageCacheExtension` which is no longer in the codebase. ([see commit](https://github.com/ckan/ckan/commit/bc29a8df0a440f0c091ae7aba91b30c175f43f37))

As it says in the docstring: **Currently this is used by the page cache to flush the cache when data in the database is altered.**

This is a cleanup PR that's part of #6243 since SessionExtension is deprecated in SQLAlchemy 1.4.