### PR TITLE
Self user details for logged in user

### DIFF
--- a/changes/5490.bugfix
+++ b/changes/5490.bugfix
@@ -1,1 +1,0 @@
-Add functionality for the user_show to fetch own details when logged in without passing id or user_obj

--- a/changes/5490.bugfix
+++ b/changes/5490.bugfix
@@ -1,0 +1,1 @@
+Add functionality for the user_show to fetch own details when logged in without passing id or user_obj

--- a/changes/5490.feature
+++ b/changes/5490.feature
@@ -1,0 +1,1 @@
+Add functionality for the user_show to fetch own details when logged in without passing id

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1354,7 +1354,9 @@ def tag_show(context, data_dict):
 def user_show(context, data_dict):
     '''Return a user account.
 
-    Either the ``id`` or the ``user_obj`` parameter must be given.
+    Either the ``id`` or the ``user_obj`` parameter should be given.
+    If the ``id`` or the ``user_obj`` is not given and user is logged in then
+    the user object will be returned otherwise not found will be returned.
 
     :param id: the id or name of the user (optional)
     :type id: string
@@ -1385,6 +1387,9 @@ def user_show(context, data_dict):
 
     '''
     model = context['model']
+
+    if 'user' in context and 'id' not in data_dict:
+        data_dict['id'] = context.get('user')
 
     id = data_dict.get('id', None)
     provided_user = data_dict.get('user_obj', None)

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1388,7 +1388,9 @@ def user_show(context, data_dict):
     '''
     model = context['model']
 
-    if 'user' in context and 'id' not in data_dict:
+    if 'user' in context and \
+       'id' not in data_dict and \
+       'user_obj' not in data_dict:
         data_dict['id'] = context.get('user')
 
     id = data_dict.get('id', None)

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1354,14 +1354,10 @@ def tag_show(context, data_dict):
 def user_show(context, data_dict):
     '''Return a user account.
 
-    Either the ``id`` or the ``user_obj`` parameter should be given.
-    If the ``id`` or the ``user_obj`` is not given and user is logged in then
-    the user object will be returned otherwise not found will be returned.
+    Either the ``id`` should be passed or the user should be logged in.
 
     :param id: the id or name of the user (optional)
     :type id: string
-    :param user_obj: the user dictionary of the user (optional)
-    :type user_obj: user dictionary
     :param include_datasets: Include a list of datasets the user has created.
         If it is the same user or a sysadmin requesting, it includes datasets
         that are draft or private.
@@ -1388,18 +1384,13 @@ def user_show(context, data_dict):
     '''
     model = context['model']
 
-    if 'user' in context and \
-       'id' not in data_dict and \
-       'user_obj' not in data_dict:
+    if 'user' in context and 'id' not in data_dict:
         data_dict['id'] = context.get('user')
 
     id = data_dict.get('id', None)
-    provided_user = data_dict.get('user_obj', None)
     if id:
         user_obj = model.User.get(id)
         context['user_obj'] = user_obj
-    elif provided_user:
-        context['user_obj'] = user_obj = provided_user
     else:
         raise NotFound
 

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -1207,6 +1207,19 @@ class TestUserShow(object):
         assert dataset_deleted["name"] not in datasets_got
         assert got_user["number_created_packages"] == 3
 
+    def test_user_show_for_myself_without_passing_id(self):
+
+        user = factories.User()
+
+        got_user = helpers.call_action(
+            "user_show", context={"user": user["name"]}
+        )
+
+        assert got_user["name"] == user["name"]
+        assert got_user["email"] == user["email"]
+        assert got_user["apikey"] == user["apikey"]
+        assert "password" not in got_user
+        assert "reset_key" not in got_user
 
 @pytest.mark.usefixtures("clean_db", "clean_index", "with_request_context")
 class TestCurrentPackageList(object):

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -1221,6 +1221,7 @@ class TestUserShow(object):
         assert "password" not in got_user
         assert "reset_key" not in got_user
 
+
 @pytest.mark.usefixtures("clean_db", "clean_index", "with_request_context")
 class TestCurrentPackageList(object):
     def test_current_package_list(self):


### PR DESCRIPTION
Fixes #5490 

### Proposed fixes:
As discussed in https://github.com/ckan/ckan/pull/5504#issuecomment-760974628, we are not creating an extra action but adding the functionality in the current `user_show` action. So added the check to validate whether the user is logged in and if logged in return the user details.

### Features:

- [x] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [x] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
