### PR TITLE
Migrate CkanSessionExtension to sqlalchemty events

### DIFF
--- a/ckan/model/meta.py
+++ b/ckan/model/meta.py
@@ -1,68 +1,73 @@
 # encoding: utf-8
 
 """SQLAlchemy Metadata and Session object"""
-from sqlalchemy import MetaData
+from sqlalchemy import MetaData, event
 import sqlalchemy.orm as orm
-from sqlalchemy.orm.session import SessionExtension
 
 from ckan.model import extension
 
 __all__ = ['Session', 'engine_is_sqlite', 'engine_is_pg']
 
 
-class CkanSessionExtension(SessionExtension):
-
-    def before_flush(self, session, flush_context, instances):
-        if not hasattr(session, '_object_cache'):
-            session._object_cache= {'new': set(),
-                                    'deleted': set(),
-                                    'changed': set()}
-
-        changed = [obj for obj in session.dirty if
-            session.is_modified(obj, include_collections=False, passive=True)]
-
-        session._object_cache['new'].update(session.new)
-        session._object_cache['deleted'].update(session.deleted)
-        session._object_cache['changed'].update(changed)
-
-
-    def before_commit(self, session):
-        session.flush()
-        try:
-            obj_cache = session._object_cache
-        except AttributeError:
-            return
-
-    def after_commit(self, session):
-        if hasattr(session, '_object_cache'):
-            del session._object_cache
-
-    def after_rollback(self, session):
-        if hasattr(session, '_object_cache'):
-            del session._object_cache
-
-# __all__ = ['Session', 'engine', 'metadata', 'mapper']
-
 # SQLAlchemy database engine. Updated by model.init_model()
 engine = None
+
 
 Session = orm.scoped_session(orm.sessionmaker(
     autoflush=False,
     autocommit=False,
     expire_on_commit=False,
-    extension=[CkanSessionExtension(),
-               extension.PluginSessionExtension(),
-    ],
+    extension=[extension.PluginSessionExtension(),],
 ))
+
 
 create_local_session = orm.sessionmaker(
     autoflush=False,
     autocommit=False,
     expire_on_commit=False,
-    extension=[CkanSessionExtension(),
-               extension.PluginSessionExtension(),
-    ],
+    extension=[extension.PluginSessionExtension(),],
 )
+
+
+@event.listens_for(create_local_session, 'after_commit')
+@event.listens_for(Session, 'after_commit')
+def ckan_after_commit(session):
+    "listen for the 'after_commit' event"
+    if hasattr(session, '_object_cache'):
+        del session._object_cache
+
+
+@event.listens_for(create_local_session, 'before_flush')
+@event.listens_for(Session, 'before_flush')
+def ckan_before_flush(session, flush_context, instances):
+    if not hasattr(session, '_object_cache'):
+        session._object_cache= {'new': set(),
+                                'deleted': set(),
+                                'changed': set()}
+
+    changed = [obj for obj in session.dirty if
+        session.is_modified(obj, include_collections=False, passive=True)]
+
+    session._object_cache['new'].update(session.new)
+    session._object_cache['deleted'].update(session.deleted)
+    session._object_cache['changed'].update(changed)
+
+
+@event.listens_for(create_local_session, 'before_commit')
+@event.listens_for(Session, 'before_commit')
+def ckan_before_commit(session):
+    session.flush()
+    try:
+        session._object_cache
+    except AttributeError:
+        return
+
+@event.listens_for(create_local_session, 'after_rollback')
+@event.listens_for(Session, 'after_rollback')
+def ckan_after_rollback(session):
+    if hasattr(session, '_object_cache'):
+        del session._object_cache
+
 
 #mapper = Session.mapper
 mapper = orm.mapper


### PR DESCRIPTION
As part of the migration to SQLAlchemy 1.4 we need to migrate our extensions to events: #6243 

This PR only migrates our current logic to events, however, as I pointed out in #6243 this logic should be refactored and simplified in another PR. A summary of the issues with the current implementation:
 - It forces `autoflush=False` but later adds `session.flush()` in `before_commit()`
 - Having `Session` and `create_local_session` is confusing and it shouldn't be needed.
 - This whole `_object_cache` in the `Session` object is an anti-pattern forced so we can index a document before comiting it to the database.
 - More info in #6243 