### PR TITLE
Prevent traceback of HTTP Exception

### DIFF
--- a/changes/6340.bugfix
+++ b/changes/6340.bugfix
@@ -1,0 +1,2 @@
+Prevent Traceback to logged for HTTP Exception until debug is true
+Add the HTTP status Code in logging for HTTP requests

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -396,6 +396,7 @@ def ckan_after_request(response):
     r_time = time.time() - g.__timer
     url = request.environ['PATH_INFO']
     status_code = response.status_code
+
     log.info(' %s %s render time %.3f seconds' % (status_code, url, r_time))
 
     return response

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -395,8 +395,8 @@ def ckan_after_request(response):
 
     r_time = time.time() - g.__timer
     url = request.environ['PATH_INFO']
-
-    log.info(' %s render time %.3f seconds' % (url, r_time))
+    status_code = response.status_code
+    log.info(' %s %s render time %.3f seconds' % (status_code, url, r_time))
 
     return response
 
@@ -525,8 +525,9 @@ def _register_error_handler(app):
     u'''Register error handler'''
 
     def error_handler(e):
-        log.error(e, exc_info=sys.exc_info)
+        debug = asbool(config.get('debug', config.get('DEBUG', False)))
         if isinstance(e, HTTPException):
+            log.error(e, exc_info=sys.exc_info) if debug else log.error(e)
             extra_vars = {
                 u'code': e.code,
                 u'content': e.description,
@@ -535,6 +536,7 @@ def _register_error_handler(app):
 
             return base.render(
                 u'error_document_template.html', extra_vars), e.code
+        log.error(e, exc_info=sys.exc_info)
         extra_vars = {u'code': [500], u'content': u'Internal server error'}
         return base.render(u'error_document_template.html', extra_vars), 500
 


### PR DESCRIPTION
Fixes #6340

### Proposed fixes:
- Added the Debug flag for the HTTP Exception and handled the logging traceback


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
