### PR TITLE
Improve resource_show error message

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1072,7 +1072,7 @@ def resource_show(context, data_dict):
         if resource_dict['id'] == id:
             break
     else:
-        log.error('Could not find resource %s after all', id)
+        log.error('Resource %s exists but it is not found in the package it should belong to.', id)
         raise NotFound(_('Resource was not found.'))
 
     return resource_dict


### PR DESCRIPTION
This exception is raised when the the resource exists in the database but it cannot be found in the Dataset it should belong to.

This PR improves the error message of `resource_show` to give a clearer idea of what is happening.

This is more related to an "integrity" issue. Do we have an exception for this kind of errors?

