### PR TITLE
removed deprcated API-keys

### DIFF
--- a/changes/6247.removal
+++ b/changes/6247.removal
@@ -1,0 +1,5 @@
+-Renamed methods/vars from api_key -> api_token
+-Removed the API key snippet and "Regenerate API key" button from the user profile templates
+-Removed the endpoint used to regenerate the API key and the user_generate_apikey action and auth function
+-Removed apikey from the user schema
+-Created factory.APIToken() for the tests and we use it for Authorization instead of user's api_key

--- a/ckan/lib/create_test_data.py
+++ b/ckan/lib/create_test_data.py
@@ -52,8 +52,7 @@ class CreateTestData(object):
     def create_test_user(cls):
         tester = model.User.by_name(u'tester')
         if tester is None:
-            tester = model.User(name=u'tester', apikey=u'tester',
-                password=u'tester')
+            tester = model.User(name=u'tester', password=u'tester')
             model.Session.add(tester)
             model.Session.commit()
         model.Session.remove()
@@ -458,7 +457,7 @@ left arrow <
         sysadmin = model.User(name=u'testsysadmin', password=u'testsysadmin')
         sysadmin.sysadmin = True
         model.Session.add_all([
-            model.User(name=u'tester', apikey=u'tester', password=u'tester'),
+            model.User(name=u'tester', password=u'tester'),
             model.User(name=u'joeadmin', password=u'joeadmin'),
             model.User(name=u'annafan', about=u'I love reading Annakarenina. My site: http://datahub.io', password=u'annafan'),
             model.User(name=u'russianfan', password=u'russianfan'),

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -886,37 +886,6 @@ def user_update(context, data_dict):
     return user_dict
 
 
-def user_generate_apikey(context, data_dict):
-    '''Cycle a user's API key
-
-    :param id: the name or id of the user whose key needs to be updated
-    :type id: string
-
-    :returns: the updated user
-    :rtype: dictionary
-    '''
-    model = context['model']
-    schema = context.get('schema') or schema_.default_generate_apikey_user_schema()
-    context['schema'] = schema
-    # check if user id in data_dict
-    id = _get_or_bust(data_dict, 'id')
-
-    # check if user exists
-    user_obj = model.User.get(id)
-    context['user_obj'] = user_obj
-    if user_obj is None:
-        raise NotFound('User was not found.')
-
-    # check permission
-    _check_access('user_generate_apikey', context, data_dict)
-
-    # change key
-    old_data = _get_action('user_show')(context, data_dict)
-    old_data['apikey'] = model.types.make_uuid()
-    data_dict = old_data
-    return _get_action('user_update')(context, data_dict)
-
-
 def task_status_update(context, data_dict):
     '''Update a task status.
 

--- a/ckan/logic/auth/update.py
+++ b/ckan/logic/auth/update.py
@@ -215,16 +215,6 @@ def user_update(context, data_dict):
                         (user, user_obj.id)}
 
 
-def user_generate_apikey(context, data_dict):
-    user = context['user']
-    user_obj = logic_auth.get_user_object(context, data_dict)
-    if user == user_obj.name:
-        # Allow users to update only their own user accounts.
-        return {'success': True}
-    return {'success': False, 'msg': _('User {0} not authorized to update user'
-            ' {1}'.format(user, user_obj.id))}
-
-
 def task_status_update(context, data_dict):
     # sysadmins only
     user = context['user']

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -402,7 +402,6 @@ def default_user_schema(
         'about': [ignore_missing, user_about_validator, unicode_safe],
         'created': [ignore],
         'sysadmin': [ignore_missing, ignore_not_sysadmin],
-        'apikey': [ignore],
         'reset_key': [ignore],
         'activity_streams_email_notifications': [ignore_missing,
                                                  boolean_validator],
@@ -457,15 +456,6 @@ def default_update_user_schema(
     schema['password'] = [
         user_password_validator, ignore_missing, unicode_safe]
 
-    return schema
-
-
-@validator_args
-def default_generate_apikey_user_schema(
-        not_empty, unicode_safe):
-    schema = default_update_user_schema()
-
-    schema['apikey'] = [not_empty, unicode_safe]
     return schema
 
 

--- a/ckan/templates/user/edit_user_form.html
+++ b/ckan/templates/user/edit_user_form.html
@@ -83,11 +83,6 @@
             <a class="btn btn-danger pull-left" href="{% url_for 'user_delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this User?') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
           {% endif %}
         {% endblock %}
-        {% block generate_button %}
-          {% if h.check_access('user_generate_apikey', {'id': data.id})  %}
-            <a class="btn btn-warning" href="{% url_for 'user.generate_apikey', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to regenerate the API key?') }}">{% block generate_button_text %}{{ _('Regenerate API Key') }}{% endblock %}</a>
-          {% endif %}
-        {% endblock %}
         {{ form.required_message() }}
         <button class="btn btn-primary" type="submit" name="save">{{ _('Update Profile') }}</button>
       {% endblock %}

--- a/ckan/tests/factories.py
+++ b/ckan/tests/factories.py
@@ -401,6 +401,32 @@ class SystemInfo(factory.Factory):
         return obj
 
 
+class APIToken(factory.Factory):
+    """A factory class for creating CKAN API Tokens"""
+
+    class Meta:
+        model = ckan.model.ApiToken
+
+    name = "first token"
+    user = factory.LazyAttribute(lambda _: User()["name"])
+
+    @classmethod
+    def _build(cls, target_class, *args, **kwargs):
+        raise NotImplementedError(".build() isn't supported in CKAN")
+
+    @classmethod
+    def _create(cls, target_class, *args, **kwargs):
+        if args:
+            assert False, "Positional args aren't supported, use keyword args."
+
+        context = {"user": kwargs["user"]}
+
+        token_create = helpers.call_action(
+            'api_token_create', context=context, **kwargs
+        )
+        return token_create["token"]
+
+
 def validator_data_dict():
     """Return a data dict with some arbitrary data in it, suitable to be passed
     to validator functions for testing.

--- a/ckan/tests/factories.py
+++ b/ckan/tests/factories.py
@@ -408,7 +408,6 @@ class APIToken(factory.Factory):
         model = ckan.model.ApiToken
 
     name = "first token"
-    user = factory.LazyAttribute(lambda _: User()["name"])
 
     @classmethod
     def _build(cls, target_class, *args, **kwargs):
@@ -419,10 +418,11 @@ class APIToken(factory.Factory):
         if args:
             assert False, "Positional args aren't supported, use keyword args."
 
-        context = {"user": kwargs["user"]}
+        context = {"user": _get_action_user_name(kwargs)}
+        data_dict = {"name": kwargs["name"], "user": kwargs["user"]["name"]}
 
         token_create = helpers.call_action(
-            'api_token_create', context=context, **kwargs
+            'api_token_create', context=context, **data_dict
         )
         return token_create["token"]
 

--- a/ckan/tests/factories.py
+++ b/ckan/tests/factories.py
@@ -418,11 +418,12 @@ class APIToken(factory.Factory):
         if args:
             assert False, "Positional args aren't supported, use keyword args."
 
-        context = {"user": _get_action_user_name(kwargs)}
-        data_dict = {"name": kwargs["name"], "user": kwargs["user"]["name"]}
+        target_user_name = _get_action_user_name(kwargs)
+        context = {"user": target_user_name}
+        kwargs["user"] = target_user_name
 
         token_create = helpers.call_action(
-            'api_token_create', context=context, **data_dict
+            'api_token_create', context=context, **kwargs
         )
         return token_create["token"]
 

--- a/ckan/tests/lib/test_base.py
+++ b/ckan/tests/lib/test_base.py
@@ -4,6 +4,8 @@ import six
 import pytest
 
 import ckan.tests.factories as factories
+import ckan.model as model
+import ckan.tests.helpers as h
 
 
 @pytest.mark.ckan_config("debug", True)
@@ -18,31 +20,45 @@ def test_comment_absent_if_debug_false(app):
     assert "<!-- Snippet " not in response
 
 
-def test_apikey_missing(app):
+def test_apitoken_missing(app):
     request_headers = {}
 
     app.get("/dataset/new", headers=request_headers, status=403)
 
 
 @pytest.mark.usefixtures("clean_db", "with_request_context")
-def test_apikey_in_authorization_header(app):
+def test_apitoken_in_authorization_header(app):
     user = factories.Sysadmin()
-    request_headers = {"Authorization": str(user["apikey"])}
+    user_token = h.call_action(
+        "api_token_create",
+        context={"model": model, "user": user["name"]},
+        user=user["name"],
+        name="first token",
+    )
+    request_headers = {
+        "Authorization": user_token["token"]
+    }
 
     app.get("/dataset/new", headers=request_headers)
 
 
 @pytest.mark.usefixtures("clean_db", "with_request_context")
-def test_apikey_in_x_ckan_header(app):
+def test_apitoken_in_x_ckan_header(app):
     user = factories.Sysadmin()
+    user_token = h.call_action(
+        "api_token_create",
+        context={"model": model, "user": user["name"]},
+        user=user["name"],
+        name="first token",
+    )
     # non-standard header name is defined in test-core.ini
-    request_headers = {"X-Non-Standard-CKAN-API-Key": str(user["apikey"])}
+    request_headers = {"X-Non-Standard-CKAN-API-Key": user_token["token"]}
 
     app.get("/dataset/new", headers=request_headers)
 
 
-def test_apikey_contains_unicode(app):
-    # there is no valid apikey containing unicode, but we should fail
+def test_apitoken_contains_unicode(app):
+    # there is no valid apitoken containing unicode, but we should fail
     # nicely if unicode is supplied
     request_headers = {"Authorization": "\xc2\xb7"}
 

--- a/ckan/tests/lib/test_base.py
+++ b/ckan/tests/lib/test_base.py
@@ -29,7 +29,7 @@ def test_apitoken_missing(app):
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 def test_apitoken_in_authorization_header(app):
     user = factories.Sysadmin()
-    user_token = factories.APIToken(user=user["name"])
+    user_token = factories.APIToken(user=user)
     request_headers = {
         "Authorization": user_token
     }
@@ -40,7 +40,7 @@ def test_apitoken_in_authorization_header(app):
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 def test_apitoken_in_x_ckan_header(app):
     user = factories.Sysadmin()
-    user_token = factories.APIToken(user=user["name"])
+    user_token = factories.APIToken(user=user)
     # non-standard header name is defined in test-core.ini
     request_headers = {"X-Non-Standard-CKAN-API-Key": user_token}
 

--- a/ckan/tests/lib/test_base.py
+++ b/ckan/tests/lib/test_base.py
@@ -29,14 +29,9 @@ def test_apitoken_missing(app):
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 def test_apitoken_in_authorization_header(app):
     user = factories.Sysadmin()
-    user_token = h.call_action(
-        "api_token_create",
-        context={"model": model, "user": user["name"]},
-        user=user["name"],
-        name="first token",
-    )
+    user_token = factories.APIToken(user=user["name"])
     request_headers = {
-        "Authorization": user_token["token"]
+        "Authorization": user_token
     }
 
     app.get("/dataset/new", headers=request_headers)
@@ -45,14 +40,9 @@ def test_apitoken_in_authorization_header(app):
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 def test_apitoken_in_x_ckan_header(app):
     user = factories.Sysadmin()
-    user_token = h.call_action(
-        "api_token_create",
-        context={"model": model, "user": user["name"]},
-        user=user["name"],
-        name="first token",
-    )
+    user_token = factories.APIToken(user=user["name"])
     # non-standard header name is defined in test-core.ini
-    request_headers = {"X-Non-Standard-CKAN-API-Key": user_token["token"]}
+    request_headers = {"X-Non-Standard-CKAN-API-Key": user_token}
 
     app.get("/dataset/new", headers=request_headers)
 

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -57,45 +57,6 @@ class TestUpdate(object):
 
     # END-BEFORE
 
-    def test_user_generate_apikey(self):
-        user = factories.User()
-        context = {"user": user["name"]}
-        result = helpers.call_action(
-            "user_generate_apikey", context=context, id=user["id"]
-        )
-        updated_user = helpers.call_action(
-            "user_show", context=context, id=user["id"]
-        )
-
-        assert updated_user["apikey"] != user["apikey"]
-        assert result["apikey"] == updated_user["apikey"]
-
-    def test_user_generate_apikey_sysadmin_user(self):
-        user = factories.User()
-        sysadmin = factories.Sysadmin()
-        context = {"user": sysadmin["name"], "ignore_auth": False}
-        result = helpers.call_action(
-            "user_generate_apikey", context=context, id=user["id"]
-        )
-        updated_user = helpers.call_action(
-            "user_show", context=context, id=user["id"]
-        )
-
-        assert updated_user["apikey"] != user["apikey"]
-        assert result["apikey"] == updated_user["apikey"]
-
-    def test_user_generate_apikey_nonexistent_user(self):
-        user = {
-            "id": "nonexistent",
-            "name": "nonexistent",
-            "email": "does@notexist.com",
-        }
-        context = {"user": user["name"]}
-        with pytest.raises(logic.NotFound):
-            helpers.call_action(
-                "user_generate_apikey", context=context, id=user["id"]
-            )
-
     def test_user_update_with_id_that_does_not_exist(self):
         user_dict = factories.User()
         user_dict["id"] = "there's no user with this id"
@@ -338,43 +299,6 @@ class TestUpdate(object):
 
         updated_user = helpers.call_action("user_update", **params)
         assert "password" not in updated_user
-
-    def test_user_update_does_not_return_apikey(self):
-        """The user dict that user_update returns should not include the user's
-        API key."""
-
-        user = factories.User()
-        params = {
-            "id": user["id"],
-            "fullname": "updated full name",
-            "about": "updated about",
-            "email": user["email"],
-            "password": factories.User.password,
-        }
-
-        updated_user = helpers.call_action("user_update", **params)
-        assert "apikey" not in updated_user
-
-    def test_user_update_does_not_return_reset_key(self):
-        """The user dict that user_update returns should not include the user's
-        reset key."""
-
-        import ckan.lib.mailer
-        import ckan.model
-
-        user = factories.User()
-        ckan.lib.mailer.create_reset_key(ckan.model.User.get(user["id"]))
-
-        params = {
-            "id": user["id"],
-            "fullname": "updated full name",
-            "about": "updated about",
-            "email": user["email"],
-            "password": factories.User.password,
-        }
-
-        updated_user = helpers.call_action("user_update", **params)
-        assert "reset_key" not in updated_user
 
     def test_resource_reorder(self):
         resource_urls = ["http://a.html", "http://b.html", "http://c.html"]

--- a/ckan/tests/logic/auth/test_update.py
+++ b/ckan/tests/logic/auth/test_update.py
@@ -129,52 +129,6 @@ def test_user_update_with_no_user_in_context():
         helpers.call_auth("user_update", context=context, **params)
 
 
-@pytest.mark.usefixtures("with_request_context")
-def test_user_generate_own_apikey():
-    fred = factories.MockUser(name="fred")
-    mock_model = mock.MagicMock()
-    mock_model.User.get.return_value = fred
-    # auth_user_obj shows user as logged in for non-anonymous auth
-    # functions
-    context = {"model": mock_model, "auth_user_obj": fred}
-    context["user"] = fred.name
-    params = {"id": fred.id}
-
-    result = helpers.call_auth(
-        "user_generate_apikey", context=context, **params
-    )
-    assert result is True
-
-
-@pytest.mark.usefixtures("with_request_context")
-def test_user_generate_apikey_without_logged_in_user():
-    fred = factories.MockUser(name="fred")
-    mock_model = mock.MagicMock()
-    mock_model.User.get.return_value = fred
-    context = {"model": mock_model}
-    context["user"] = None
-    params = {"id": fred.id}
-
-    with pytest.raises(logic.NotAuthorized):
-        helpers.call_auth("user_generate_apikey", context=context, **params)
-
-
-@pytest.mark.usefixtures("with_request_context")
-def test_user_generate_apikey_for_another_user():
-    fred = factories.MockUser(name="fred")
-    bob = factories.MockUser(name="bob")
-    mock_model = mock.MagicMock()
-    mock_model.User.get.return_value = fred
-    # auth_user_obj shows user as logged in for non-anonymous auth
-    # functions
-    context = {"model": mock_model, "auth_user_obj": bob}
-    context["user"] = bob.name
-    params = {"id": fred.id}
-
-    with pytest.raises(logic.NotAuthorized):
-        helpers.call_auth("user_generate_apikey", context=context, **params)
-
-
 @pytest.mark.ckan_config("ckan.plugins", "image_view")
 @pytest.mark.usefixtures("clean_db", "with_plugins", "with_request_context")
 class TestUpdateWithView(object):

--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -186,34 +186,33 @@ def _identify_user_default():
                               u'logout_handler_path')
                 redirect(pth)
     else:
-        g.userobj = _get_user_for_apikey()
+        g.userobj = _get_user_for_apitoken()
         if g.userobj is not None:
             g.user = g.userobj.name
 
 
-def _get_user_for_apikey():
-    apikey_header_name = config.get(APIKEY_HEADER_NAME_KEY,
-                                    APIKEY_HEADER_NAME_DEFAULT)
-    apikey = request.headers.get(apikey_header_name, u'')
-    if not apikey:
-        apikey = request.environ.get(apikey_header_name, u'')
-    if not apikey:
+def _get_user_for_apitoken():
+    apitoken_header_name = config.get(
+        APIKEY_HEADER_NAME_KEY, APIKEY_HEADER_NAME_DEFAULT
+    )
+    apitoken = request.headers.get(apitoken_header_name, u'')
+    if not apitoken:
+        apitoken = request.environ.get(apitoken_header_name, u'')
+    if not apitoken:
         # For misunderstanding old documentation (now fixed).
-        apikey = request.environ.get(u'HTTP_AUTHORIZATION', u'')
-    if not apikey:
-        apikey = request.environ.get(u'Authorization', u'')
+        apitoken = request.environ.get(u'HTTP_AUTHORIZATION', u'')
+    if not apitoken:
+        apitoken = request.environ.get(u'Authorization', u'')
         # Forget HTTP Auth credentials (they have spaces).
-        if u' ' in apikey:
-            apikey = u''
-    if not apikey:
+        if u' ' in apitoken:
+            apitoken = u''
+    if not apitoken:
         return None
-    apikey = six.ensure_text(apikey, errors=u"ignore")
-    log.debug(u'Received API Key: %s' % apikey)
-    query = model.Session.query(model.User)
-    user = query.filter_by(apikey=apikey).first()
+    apitoken = six.ensure_text(apitoken, errors=u"ignore")
+    log.debug(u'Received API Token: %s' % apitoken)
 
-    if not user:
-        user = api_token.get_user_from_token(apikey)
+    user = api_token.get_user_from_token(apitoken)
+
     return user
 
 

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -550,32 +550,6 @@ def delete(id):
         return h.redirect_to(user_index)
 
 
-def generate_apikey(id=None):
-    u'''Cycle the API key of a user'''
-    context = {
-        u'model': model,
-        u'session': model.Session,
-        u'user': g.user,
-        u'auth_user_obj': g.userobj,
-    }
-    if id is None:
-        if g.userobj:
-            id = g.userobj.id
-        else:
-            base.abort(400, _(u'No user specified'))
-    data_dict = {u'id': id}
-
-    try:
-        result = logic.get_action(u'user_generate_apikey')(context, data_dict)
-    except logic.NotAuthorized:
-        base.abort(403, _(u'Unauthorized to edit user %s') % u'')
-    except logic.NotFound:
-        base.abort(404, _(u'User not found'))
-
-    h.flash_success(_(u'Profile updated'))
-    return h.redirect_to(u'user.read', id=result[u'name'])
-
-
 def activity(id, offset=0):
     u'''Render this user's public activity stream page.'''
 
@@ -906,11 +880,6 @@ user.add_url_rule(u'/logged_out', view_func=logged_out)
 user.add_url_rule(u'/logged_out_redirect', view_func=logged_out_page)
 
 user.add_url_rule(u'/delete/<id>', view_func=delete, methods=(u'POST', ))
-
-user.add_url_rule(
-    u'/generate_key', view_func=generate_apikey, methods=(u'POST', ))
-user.add_url_rule(
-    u'/generate_key/<id>', view_func=generate_apikey, methods=(u'POST', ))
 
 user.add_url_rule(u'/activity/<id>', view_func=activity)
 user.add_url_rule(u'/activity/<id>/<int:offset>', view_func=activity)

--- a/ckanext/datapusher/tests/test.py
+++ b/ckanext/datapusher/tests/test.py
@@ -181,7 +181,7 @@ class TestDatastoreCreate(object):
 
         data = {"status": "success", "metadata": {"resource_id": resource.id}}
 
-        if user["sysadmin"] == True:
+        if user["sysadmin"]:
             auth = {"Authorization": self.sysadmin_token}
         else:
             auth = {"Authorization": self.normal_user_token}

--- a/ckanext/datapusher/tests/test.py
+++ b/ckanext/datapusher/tests/test.py
@@ -24,8 +24,10 @@ class TestDatastoreCreate(object):
     @pytest.fixture(autouse=True)
     def initial_data(self, clean_db, clean_index, test_request_context):
         ctd.CreateTestData.create()
-        self.sysadmin_user = model.User.get("testsysadmin")
-        self.normal_user = model.User.get("annafan")
+        self.sysadmin_user = factories.Sysadmin()
+        self.sysadmin_token = factories.APIToken(user=self.sysadmin_user)
+        self.normal_user = factories.User()
+        self.normal_user_token = factories.APIToken(user=self.normal_user)
         engine = db.get_write_engine()
         self.Session = orm.scoped_session(orm.sessionmaker(bind=engine))
         with test_request_context():
@@ -38,7 +40,7 @@ class TestDatastoreCreate(object):
     def test_create_ckan_resource_in_package(self, app):
         package = model.Package.get("annakarenina")
         data = {"resource": {"package_id": package.id}}
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -114,7 +116,7 @@ class TestDatastoreCreate(object):
             "resource": {"package_id": package.id},
         }
 
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -139,7 +141,7 @@ class TestDatastoreCreate(object):
         package = model.Package.get("annakarenina")
         resource = package.resources[0]
 
-        context = {"ignore_auth": True, "user": self.sysadmin_user.name}
+        context = {"ignore_auth": True, "user": self.sysadmin_user["name"]}
         with test_request_context():
             p.toolkit.get_action("datapusher_submit")(
                 context, {"resource_id": resource.id}
@@ -162,7 +164,7 @@ class TestDatastoreCreate(object):
         package = model.Package.get("annakarenina")
         resource = package.resources[0]
 
-        context = {"user": self.sysadmin_user.name}
+        context = {"user": self.sysadmin_user["name"]}
 
         p.toolkit.get_action("task_status_update")(
             context,
@@ -179,7 +181,10 @@ class TestDatastoreCreate(object):
 
         data = {"status": "success", "metadata": {"resource_id": resource.id}}
 
-        auth = {"Authorization": str(user.apikey)}
+        if user["sysadmin"] == True:
+            auth = {"Authorization": self.sysadmin_token}
+        else:
+            auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datapusher_hook",
             json=data,

--- a/ckanext/datastore/tests/helpers.py
+++ b/ckanext/datastore/tests/helpers.py
@@ -51,7 +51,7 @@ def rebuild_all_dbs(Session):
 
 
 def set_url_type(resources, user):
-    context = {"user": user.name}
+    context = {"user": user["name"]}
     for resource in resources:
         resource = p.toolkit.get_action("resource_show")(
             context, {"id": resource.id}

--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -346,7 +346,19 @@ class TestDatastoreCreate(object):
     def create_test_data(self, clean_datastore, test_request_context):
         ctd.CreateTestData.create()
         self.sysadmin_user = model.User.get("testsysadmin")
+        self.sysadmin_token = helpers.call_action(
+            "api_token_create",
+            context={"model": model, "user": self.sysadmin_user.name},
+            user=self.sysadmin_user.name,
+            name="first token",
+        )
         self.normal_user = model.User.get("annafan")
+        self.normal_user_token = helpers.call_action(
+            "api_token_create",
+            context={"model": model, "user": self.normal_user.name},
+            user=self.normal_user.name,
+            name="first token",
+        )
         engine = db.get_write_engine()
         self.Session = orm.scoped_session(orm.sessionmaker(bind=engine))
         with test_request_context():
@@ -371,7 +383,7 @@ class TestDatastoreCreate(object):
     @pytest.mark.usefixtures("with_plugins")
     def test_create_empty_fails(self, app):
         data = {}
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             data=data,
@@ -394,7 +406,7 @@ class TestDatastoreCreate(object):
             ],
         }
 
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -411,7 +423,7 @@ class TestDatastoreCreate(object):
                 {"id": "author", "type": "text"},
             ],
         }
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -426,7 +438,7 @@ class TestDatastoreCreate(object):
     def test_create_duplicate_alias_name(self, app):
         resource = model.Package.get("annakarenina").resources[0]
         data = {"resource_id": resource.id, "aliases": u"myalias"}
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             data=data,
@@ -439,7 +451,7 @@ class TestDatastoreCreate(object):
         # try to create another table with the same alias
         resource = model.Package.get("annakarenina").resources[1]
         data = {"resource_id": resource.id, "aliases": u"myalias"}
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             data=data,
@@ -456,7 +468,7 @@ class TestDatastoreCreate(object):
             "resource_id": resource.id,
             "aliases": model.Package.get("annakarenina").resources[0].id,
         }
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             data=data,
@@ -477,7 +489,7 @@ class TestDatastoreCreate(object):
                 {"id": "author", "type": "INVALID"},
             ],
         }
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -491,7 +503,7 @@ class TestDatastoreCreate(object):
     @pytest.mark.usefixtures("with_plugins")
     def test_create_invalid_field_name(self, app):
         resource = model.Package.get("annakarenina").resources[0]
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         invalid_names = [
             "_author",
             '"author',
@@ -534,7 +546,7 @@ class TestDatastoreCreate(object):
                 {"book": "warandpeace", "published": "1869"},
             ],
         }
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -556,7 +568,7 @@ class TestDatastoreCreate(object):
             ],
             "records": ["bad"],  # treat author as null
         }
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -581,7 +593,7 @@ class TestDatastoreCreate(object):
                 {"book": "warandpeace"},
             ],  # treat author as null
         }
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -605,7 +617,7 @@ class TestDatastoreCreate(object):
                 {"id": "author", "type": "text"},
             ],
         }
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -627,7 +639,7 @@ class TestDatastoreCreate(object):
                 {"id": "author", "type": "text"},
             ],
         }
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -649,7 +661,7 @@ class TestDatastoreCreate(object):
                 {"id": "author", "type": "text"},
             ],
         }
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -664,7 +676,7 @@ class TestDatastoreCreate(object):
             "aliases": "new_alias",
             "fields": [{"id": "more books", "type": "text"}],
         }
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -681,7 +693,7 @@ class TestDatastoreCreate(object):
         aliases = [u"great_list_of_books", u"another_list_of_b\xfcks"]
         ### Firstly test to see whether resource has no datastore table yet
         data = {"id": resource.id}
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/resource_show", data=data, extra_environ=auth
         )
@@ -702,7 +714,7 @@ class TestDatastoreCreate(object):
             ],  # treat author as null
         }
 
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -769,7 +781,7 @@ class TestDatastoreCreate(object):
         self.Session.remove()
 
         # check to test to see if resource now has a datastore table
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/resource_show", data={"id": resource.id}, extra_environ=auth
         )
@@ -782,7 +794,7 @@ class TestDatastoreCreate(object):
             "records": [{"boo%k": "hagji murat", "author": ["tolstoy"]}],
         }
 
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             json=data2,
@@ -829,7 +841,7 @@ class TestDatastoreCreate(object):
             "indexes": ["rating"],
         }
 
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             json=data3,
@@ -870,7 +882,7 @@ class TestDatastoreCreate(object):
             "primary_key": "boo%k",
         }
 
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             json=data4,
@@ -890,7 +902,7 @@ class TestDatastoreCreate(object):
             "primary_key": "",
         }
 
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             json=data5,
@@ -934,7 +946,7 @@ class TestDatastoreCreate(object):
             "indexes": ["characters"],
         }
 
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             json=data6,
@@ -964,7 +976,7 @@ class TestDatastoreCreate(object):
             "indexes": ["characters"],
         }
 
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             json=data7,
@@ -981,7 +993,7 @@ class TestDatastoreCreate(object):
             "records": [{"boo%k": "warandpeace", "author": "99% good"}],
         }
 
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             json=data8,
@@ -1010,7 +1022,7 @@ class TestDatastoreCreate(object):
             ],  # treat author as null
         }
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": str(self.normal_user_token["token"])}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -1035,7 +1047,7 @@ class TestDatastoreCreate(object):
         resource = model.Package.get("annakarenina").resources[1]
 
         data = {"resource_id": resource.id}
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_delete",
             data=data,
@@ -1063,7 +1075,7 @@ class TestDatastoreCreate(object):
                 {"book": "warandpeace"},
             ],  # treat author as null
         }
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -1122,7 +1134,7 @@ class TestDatastoreCreate(object):
             ],
         }
 
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -1177,7 +1189,7 @@ class TestDatastoreCreate(object):
             ],
         }
 
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -1208,7 +1220,7 @@ class TestDatastoreCreate(object):
             ],
             "method": "insert",
         }
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create",
             json=data_dict,

--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -346,19 +346,9 @@ class TestDatastoreCreate(object):
     def create_test_data(self, clean_datastore, test_request_context):
         ctd.CreateTestData.create()
         self.sysadmin_user = model.User.get("testsysadmin")
-        self.sysadmin_token = helpers.call_action(
-            "api_token_create",
-            context={"model": model, "user": self.sysadmin_user.name},
-            user=self.sysadmin_user.name,
-            name="first token",
-        )
+        self.sysadmin_token = factories.APIToken(user=self.sysadmin_user.name)
         self.normal_user = model.User.get("annafan")
-        self.normal_user_token = helpers.call_action(
-            "api_token_create",
-            context={"model": model, "user": self.normal_user.name},
-            user=self.normal_user.name,
-            name="first token",
-        )
+        self.normal_user_token = factories.APIToken(user=self.normal_user.name)
         engine = db.get_write_engine()
         self.Session = orm.scoped_session(orm.sessionmaker(bind=engine))
         with test_request_context():
@@ -383,7 +373,7 @@ class TestDatastoreCreate(object):
     @pytest.mark.usefixtures("with_plugins")
     def test_create_empty_fails(self, app):
         data = {}
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             data=data,
@@ -406,7 +396,7 @@ class TestDatastoreCreate(object):
             ],
         }
 
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -423,7 +413,7 @@ class TestDatastoreCreate(object):
                 {"id": "author", "type": "text"},
             ],
         }
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -438,7 +428,7 @@ class TestDatastoreCreate(object):
     def test_create_duplicate_alias_name(self, app):
         resource = model.Package.get("annakarenina").resources[0]
         data = {"resource_id": resource.id, "aliases": u"myalias"}
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             data=data,
@@ -451,7 +441,7 @@ class TestDatastoreCreate(object):
         # try to create another table with the same alias
         resource = model.Package.get("annakarenina").resources[1]
         data = {"resource_id": resource.id, "aliases": u"myalias"}
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             data=data,
@@ -468,7 +458,7 @@ class TestDatastoreCreate(object):
             "resource_id": resource.id,
             "aliases": model.Package.get("annakarenina").resources[0].id,
         }
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             data=data,
@@ -489,7 +479,7 @@ class TestDatastoreCreate(object):
                 {"id": "author", "type": "INVALID"},
             ],
         }
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -503,7 +493,7 @@ class TestDatastoreCreate(object):
     @pytest.mark.usefixtures("with_plugins")
     def test_create_invalid_field_name(self, app):
         resource = model.Package.get("annakarenina").resources[0]
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         invalid_names = [
             "_author",
             '"author',
@@ -546,7 +536,7 @@ class TestDatastoreCreate(object):
                 {"book": "warandpeace", "published": "1869"},
             ],
         }
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -568,7 +558,7 @@ class TestDatastoreCreate(object):
             ],
             "records": ["bad"],  # treat author as null
         }
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -593,7 +583,7 @@ class TestDatastoreCreate(object):
                 {"book": "warandpeace"},
             ],  # treat author as null
         }
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -617,7 +607,7 @@ class TestDatastoreCreate(object):
                 {"id": "author", "type": "text"},
             ],
         }
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -639,7 +629,7 @@ class TestDatastoreCreate(object):
                 {"id": "author", "type": "text"},
             ],
         }
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -661,7 +651,7 @@ class TestDatastoreCreate(object):
                 {"id": "author", "type": "text"},
             ],
         }
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -676,7 +666,7 @@ class TestDatastoreCreate(object):
             "aliases": "new_alias",
             "fields": [{"id": "more books", "type": "text"}],
         }
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -693,7 +683,7 @@ class TestDatastoreCreate(object):
         aliases = [u"great_list_of_books", u"another_list_of_b\xfcks"]
         ### Firstly test to see whether resource has no datastore table yet
         data = {"id": resource.id}
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/resource_show", data=data, extra_environ=auth
         )
@@ -714,7 +704,7 @@ class TestDatastoreCreate(object):
             ],  # treat author as null
         }
 
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -781,7 +771,7 @@ class TestDatastoreCreate(object):
         self.Session.remove()
 
         # check to test to see if resource now has a datastore table
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/resource_show", data={"id": resource.id}, extra_environ=auth
         )
@@ -794,7 +784,7 @@ class TestDatastoreCreate(object):
             "records": [{"boo%k": "hagji murat", "author": ["tolstoy"]}],
         }
 
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data2,
@@ -841,7 +831,7 @@ class TestDatastoreCreate(object):
             "indexes": ["rating"],
         }
 
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data3,
@@ -882,7 +872,7 @@ class TestDatastoreCreate(object):
             "primary_key": "boo%k",
         }
 
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data4,
@@ -902,7 +892,7 @@ class TestDatastoreCreate(object):
             "primary_key": "",
         }
 
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data5,
@@ -946,7 +936,7 @@ class TestDatastoreCreate(object):
             "indexes": ["characters"],
         }
 
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data6,
@@ -976,7 +966,7 @@ class TestDatastoreCreate(object):
             "indexes": ["characters"],
         }
 
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data7,
@@ -993,7 +983,7 @@ class TestDatastoreCreate(object):
             "records": [{"boo%k": "warandpeace", "author": "99% good"}],
         }
 
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data8,
@@ -1022,7 +1012,7 @@ class TestDatastoreCreate(object):
             ],  # treat author as null
         }
 
-        auth = {"Authorization": str(self.normal_user_token["token"])}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -1047,7 +1037,7 @@ class TestDatastoreCreate(object):
         resource = model.Package.get("annakarenina").resources[1]
 
         data = {"resource_id": resource.id}
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_delete",
             data=data,
@@ -1075,7 +1065,7 @@ class TestDatastoreCreate(object):
                 {"book": "warandpeace"},
             ],  # treat author as null
         }
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -1134,7 +1124,7 @@ class TestDatastoreCreate(object):
             ],
         }
 
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -1189,7 +1179,7 @@ class TestDatastoreCreate(object):
             ],
         }
 
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data,
@@ -1220,7 +1210,7 @@ class TestDatastoreCreate(object):
             ],
             "method": "insert",
         }
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create",
             json=data_dict,

--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -345,10 +345,10 @@ class TestDatastoreCreate(object):
     @pytest.fixture(autouse=True)
     def create_test_data(self, clean_datastore, test_request_context):
         ctd.CreateTestData.create()
-        self.sysadmin_user = model.User.get("testsysadmin")
-        self.sysadmin_token = factories.APIToken(user=self.sysadmin_user.name)
-        self.normal_user = model.User.get("annafan")
-        self.normal_user_token = factories.APIToken(user=self.normal_user.name)
+        self.sysadmin_user = factories.Sysadmin()
+        self.sysadmin_token = factories.APIToken(user=self.sysadmin_user)
+        self.normal_user = factories.User()
+        self.normal_user_token = factories.APIToken(user=self.normal_user)
         engine = db.get_write_engine()
         self.Session = orm.scoped_session(orm.sessionmaker(bind=engine))
         with test_request_context():

--- a/ckanext/datastore/tests/test_delete.py
+++ b/ckanext/datastore/tests/test_delete.py
@@ -131,19 +131,9 @@ class TestDatastoreDeleteLegacy(object):
         self.app = app
         ctd.CreateTestData.create()
         self.sysadmin_user = model.User.get("testsysadmin")
-        self.sysadmin_token = helpers.call_action(
-            "api_token_create",
-            context={"model": model, "user": self.sysadmin_user.name},
-            user=self.sysadmin_user.name,
-            name="first token",
-        )
+        self.sysadmin_token = factories.APIToken(user=self.sysadmin_user.name)
         self.normal_user = model.User.get("annafan")
-        self.normal_user_token = helpers.call_action(
-            "api_token_create",
-            context={"model": model, "user": self.normal_user.name},
-            user=self.normal_user.name,
-            name="first token",
-        )
+        self.normal_user_token = factories.APIToken(user=self.normal_user.name)
         resource = model.Package.get("annakarenina").resources[0]
         self.data = {
             "resource_id": resource.id,
@@ -176,7 +166,7 @@ class TestDatastoreDeleteLegacy(object):
             )
 
     def _create(self):
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = self.app.post(
             "/api/action/datastore_create",
             json=self.data,
@@ -189,7 +179,7 @@ class TestDatastoreDeleteLegacy(object):
     def _delete(self):
         data = {"resource_id": self.data["resource_id"]}
         postparams = "%s=1" % json.dumps(data)
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = self.app.post(
             "/api/action/datastore_delete",
             data=data,
@@ -264,7 +254,7 @@ class TestDatastoreDeleteLegacy(object):
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_delete_invalid_resource_id(self, app):
         data = {"resource_id": "bad"}
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_delete",
             data=data,
@@ -282,7 +272,7 @@ class TestDatastoreDeleteLegacy(object):
 
         # try and delete just the 'warandpeace' row
         data = {"resource_id": resource_id, "filters": {"book": "warandpeace"}}
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_delete",
             json=data,
@@ -304,7 +294,7 @@ class TestDatastoreDeleteLegacy(object):
             "filters": {"book": "annakarenina", "author": "bad"},
         }
 
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_delete",
             json=data,
@@ -325,7 +315,7 @@ class TestDatastoreDeleteLegacy(object):
             "id": resource_id,
             "filters": {"book": "annakarenina", "author": "tolstoy"},
         }
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_delete",
             json=data,
@@ -354,7 +344,7 @@ class TestDatastoreDeleteLegacy(object):
             "filters": {"invalid-column-name": "value"},
         }
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_delete",
             json=data,
@@ -375,7 +365,7 @@ class TestDatastoreDeleteLegacy(object):
         self._create()
 
         data = {"resource_id": self.data["resource_id"], "filters": []}
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_delete",
             json=data,
@@ -396,7 +386,7 @@ class TestDatastoreDeleteLegacy(object):
         res = app.post(
             "/api/action/datastore_delete",
             json={"resource_id": self.data["resource_id"], "filters": {}},
-            environ_overrides={"Authorization": self.normal_user_token["token"]},
+            environ_overrides={"Authorization": self.normal_user_token},
         )
         assert res.status_code == 200
         results = json.loads(res.data)
@@ -405,7 +395,7 @@ class TestDatastoreDeleteLegacy(object):
         res = app.post(
             "/api/action/datastore_search",
             json={"resource_id": self.data["resource_id"]},
-            environ_overrides={"Authorization": self.normal_user_token["token"]},
+            environ_overrides={"Authorization": self.normal_user_token},
         )
         assert res.status_code == 200
         results = json.loads(res.data)

--- a/ckanext/datastore/tests/test_delete.py
+++ b/ckanext/datastore/tests/test_delete.py
@@ -130,10 +130,10 @@ class TestDatastoreDeleteLegacy(object):
     def initial_data(self, clean_datastore, app, test_request_context):
         self.app = app
         ctd.CreateTestData.create()
-        self.sysadmin_user = model.User.get("testsysadmin")
-        self.sysadmin_token = factories.APIToken(user=self.sysadmin_user.name)
-        self.normal_user = model.User.get("annafan")
-        self.normal_user_token = factories.APIToken(user=self.normal_user.name)
+        self.sysadmin_user = factories.Sysadmin()
+        self.sysadmin_token = factories.APIToken(user=self.sysadmin_user)
+        self.normal_user = factories.User()
+        self.normal_user_token = factories.APIToken(user=self.normal_user)
         resource = model.Package.get("annakarenina").resources[0]
         self.data = {
             "resource_id": resource.id,

--- a/ckanext/datastore/tests/test_dictionary.py
+++ b/ckanext/datastore/tests/test_dictionary.py
@@ -9,6 +9,7 @@ import ckan.tests.helpers as helpers
 @pytest.mark.usefixtures(u"clean_datastore", u"with_plugins", u"with_request_context")
 def test_read(app):
     user = factories.User()
+    user_token = factories.APIToken(user=user["name"])
     dataset = factories.Dataset(creator_user_id=user["id"])
     resource = factories.Resource(
         package_id=dataset["id"], creator_user_id=user["id"]
@@ -22,7 +23,7 @@ def test_read(app):
         ],
     }
     helpers.call_action(u"datastore_create", **data)
-    auth = {u"Authorization": str(user["apikey"])}
+    auth = {u"Authorization": user_token}
     app.get(
         url=u"/dataset/{id}/dictionary/{resource_id}".format(
             id=str(dataset["name"]), resource_id=str(resource["id"])

--- a/ckanext/datastore/tests/test_dictionary.py
+++ b/ckanext/datastore/tests/test_dictionary.py
@@ -9,7 +9,7 @@ import ckan.tests.helpers as helpers
 @pytest.mark.usefixtures(u"clean_datastore", u"with_plugins", u"with_request_context")
 def test_read(app):
     user = factories.User()
-    user_token = factories.APIToken(user=user["name"])
+    user_token = factories.APIToken(user=user)
     dataset = factories.Dataset(creator_user_id=user["id"])
     resource = factories.Resource(
         package_id=dataset["id"], creator_user_id=user["id"]

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -463,19 +463,9 @@ class TestDatastoreSearchLegacyTests(object):
     def initial_data(self, clean_datastore, app):
         ctd.CreateTestData.create()
         self.sysadmin_user = model.User.get("testsysadmin")
-        self.sysadmin_token = helpers.call_action(
-            "api_token_create",
-            context={"model": model, "user": self.sysadmin_user.name},
-            user=self.sysadmin_user.name,
-            name="first token",
-        )
+        self.sysadmin_token = factories.APIToken(user=self.sysadmin_user.name)
         self.normal_user = model.User.get("annafan")
-        self.normal_user_token = helpers.call_action(
-            "api_token_create",
-            context={"model": model, "user": self.normal_user.name},
-            user=self.normal_user.name,
-            name="first token",
-        )
+        self.normal_user_token = factories.APIToken(user=self.normal_user.name)
         self.dataset = model.Package.get("annakarenina")
         self.resource = self.dataset.resources[0]
         self.data = {
@@ -506,7 +496,7 @@ class TestDatastoreSearchLegacyTests(object):
                 },
             ],
         }
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create", json=self.data, extra_environ=auth,
         )
@@ -548,7 +538,7 @@ class TestDatastoreSearchLegacyTests(object):
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_search_basic(self, app):
         data = {"resource_id": self.data["resource_id"]}
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -560,7 +550,7 @@ class TestDatastoreSearchLegacyTests(object):
 
         # search with parameter id should yield the same results
         data = {"id": self.data["resource_id"]}
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -598,7 +588,7 @@ class TestDatastoreSearchLegacyTests(object):
         )
         helpers.call_action("datastore_create", resource_id=resource["id"], force=True)
         data = {"resource_id": resource["id"]}
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
 
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
@@ -610,7 +600,7 @@ class TestDatastoreSearchLegacyTests(object):
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_search_alias(self, app):
         data = {"resource_id": self.data["aliases"]}
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -626,7 +616,7 @@ class TestDatastoreSearchLegacyTests(object):
             "resource_id": self.data["resource_id"],
             "fields": [{"id": "bad"}],
         }
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search",
             json=data,
@@ -640,7 +630,7 @@ class TestDatastoreSearchLegacyTests(object):
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_search_fields(self, app):
         data = {"resource_id": self.data["resource_id"], "fields": [u"b\xfck"]}
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -657,7 +647,7 @@ class TestDatastoreSearchLegacyTests(object):
             "resource_id": self.data["resource_id"],
             "fields": u"b\xfck, author",
         }
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -679,7 +669,7 @@ class TestDatastoreSearchLegacyTests(object):
             "distinct": True,
         }
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -697,7 +687,7 @@ class TestDatastoreSearchLegacyTests(object):
             "filters": {u"b\xfck": "annakarenina"},
         }
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -715,7 +705,7 @@ class TestDatastoreSearchLegacyTests(object):
             "filters": {u"characters": [u"Princess Anna", u"Sergius"]},
         }
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -733,7 +723,7 @@ class TestDatastoreSearchLegacyTests(object):
             "filters": {u"b\xfck": [u"annakarenina", u"warandpeace"]},
         }
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -753,7 +743,7 @@ class TestDatastoreSearchLegacyTests(object):
             "filters": {u"b\xfck": [u"annakarenina", u"warandpeace"]},
         }
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -787,7 +777,7 @@ class TestDatastoreSearchLegacyTests(object):
             "filters": {u"author": 42},
         }
 
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_search",
             json=data,
@@ -804,7 +794,7 @@ class TestDatastoreSearchLegacyTests(object):
             "resource_id": self.data["resource_id"],
             "sort": u"b\xfck asc, author desc",
         }
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -836,7 +826,7 @@ class TestDatastoreSearchLegacyTests(object):
             "resource_id": self.data["resource_id"],
             "sort": u"f\xfc\xfc asc",
         }
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_search",
             json=data,
@@ -859,7 +849,7 @@ class TestDatastoreSearchLegacyTests(object):
             "offset": 1,
         }
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -874,7 +864,7 @@ class TestDatastoreSearchLegacyTests(object):
     def test_search_invalid_offset(self, app):
         data = {"resource_id": self.data["resource_id"], "offset": "bad"}
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search",
             json=data,
@@ -886,7 +876,7 @@ class TestDatastoreSearchLegacyTests(object):
 
         data = {"resource_id": self.data["resource_id"], "offset": -1}
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search",
             json=data,
@@ -901,7 +891,7 @@ class TestDatastoreSearchLegacyTests(object):
     def test_search_full_text(self, app):
         data = {"resource_id": self.data["resource_id"], "q": "annakarenina"}
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -1003,7 +993,7 @@ class TestDatastoreSearchLegacyTests(object):
             "q": {u"b\xfck": "annakarenina"},
         }
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -1025,7 +1015,7 @@ class TestDatastoreSearchLegacyTests(object):
             "q": u'{"b\xfck": "annakarenina"}',
         }
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -1045,7 +1035,7 @@ class TestDatastoreSearchLegacyTests(object):
             "q": {"invalid_field_name": "value"},
         }
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search",
             json=data,
@@ -1063,7 +1053,7 @@ class TestDatastoreSearchLegacyTests(object):
             "q": {"author": ["invalid", "value"]},
         }
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search",
             json=data,
@@ -1078,7 +1068,7 @@ class TestDatastoreSearchLegacyTests(object):
     def test_search_table_metadata(self, app):
         data = {"resource_id": "_table_metadata"}
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -1095,7 +1085,7 @@ class TestDatastoreSearchLegacyTests(object):
             "filters": "the-filter",
         }
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search",
             json=data,
@@ -1116,7 +1106,7 @@ class TestDatastoreSearchLegacyTests(object):
             "filters": {"invalid-column-name": "value"},
         }
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search",
             json=data,
@@ -1135,7 +1125,7 @@ class TestDatastoreSearchLegacyTests(object):
             "fields": ["invalid-column-name"],
         }
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search",
             json=data,
@@ -1152,19 +1142,9 @@ class TestDatastoreFullTextSearchLegacyTests(object):
     def initial_data(self, clean_datastore, app):
         ctd.CreateTestData.create()
         self.sysadmin_user = model.User.get("testsysadmin")
-        self.sysadmin_token = helpers.call_action(
-            "api_token_create",
-            context={"model": model, "user": self.sysadmin_user.name},
-            user=self.sysadmin_user.name,
-            name="first token",
-        )
+        self.sysadmin_token = factories.APIToken(user=self.sysadmin_user.name)
         self.normal_user = model.User.get("annafan")
-        self.normal_user_token = helpers.call_action(
-            "api_token_create",
-            context={"model": model, "user": self.normal_user.name},
-            user=self.normal_user.name,
-            name="first token",
-        )
+        self.normal_user_token = factories.APIToken(user=self.normal_user.name)
         resource = model.Package.get("annakarenina").resources[0]
         self.data = dict(
             resource_id=resource.id,
@@ -1249,7 +1229,7 @@ class TestDatastoreFullTextSearchLegacyTests(object):
                 },
             ],
         )
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_create", json=self.data, extra_environ=auth,
         )
@@ -1261,7 +1241,7 @@ class TestDatastoreFullTextSearchLegacyTests(object):
     def test_search_full_text(self, app):
         data = {"resource_id": self.data["resource_id"], "q": "DE"}
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -1277,7 +1257,7 @@ class TestDatastoreFullTextSearchLegacyTests(object):
             "q": "DE | UK",
         }
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -1289,7 +1269,7 @@ class TestDatastoreFullTextSearchLegacyTests(object):
     def test_full_text_search_on_integers_within_text_strings(self, app):
         data = {"resource_id": self.data["resource_id"], "q": "99"}
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -1301,7 +1281,7 @@ class TestDatastoreFullTextSearchLegacyTests(object):
     def test_full_text_search_on_integers(self, app):
         data = {"resource_id": self.data["resource_id"], "q": "4"}
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -1313,7 +1293,7 @@ class TestDatastoreFullTextSearchLegacyTests(object):
     def test_full_text_search_on_decimal_within_text_strings(self, app):
         data = {"resource_id": self.data["resource_id"], "q": "53.56"}
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -1325,7 +1305,7 @@ class TestDatastoreFullTextSearchLegacyTests(object):
     def test_full_text_search_on_decimal(self, app):
         data = {"resource_id": self.data["resource_id"], "q": "52.56"}
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -1337,7 +1317,7 @@ class TestDatastoreFullTextSearchLegacyTests(object):
     def test_full_text_search_on_date(self, app):
         data = {"resource_id": self.data["resource_id"], "q": "2011-01-01"}
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -1349,7 +1329,7 @@ class TestDatastoreFullTextSearchLegacyTests(object):
     def test_full_text_search_on_json_like_string_succeeds(self, app):
         data = {"resource_id": self.data["resource_id"], "q": '"{}"'}
 
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -1365,19 +1345,9 @@ class TestDatastoreSQLLegacyTests(object):
     def initial_data(self, clean_datastore, app):
         ctd.CreateTestData.create()
         self.sysadmin_user = model.User.get("testsysadmin")
-        self.sysadmin_token = helpers.call_action(
-            "api_token_create",
-            context={"model": model, "user": self.sysadmin_user.name},
-            user=self.sysadmin_user.name,
-            name="first token",
-        )
+        self.sysadmin_token = factories.APIToken(user=self.sysadmin_user.name)
         self.normal_user = model.User.get("annafan")
-        self.normal_user_token = helpers.call_action(
-            "api_token_create",
-            context={"model": model, "user": self.normal_user.name},
-            user=self.normal_user.name,
-            name="first token",
-        )
+        self.normal_user_token = factories.APIToken(user=self.normal_user.name)
         self.dataset = model.Package.get("annakarenina")
         resource = self.dataset.resources[0]
         self.data = {
@@ -1403,7 +1373,7 @@ class TestDatastoreSQLLegacyTests(object):
                 },
             ],
         }
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_create", json=self.data, extra_environ=auth,
         )
@@ -1456,7 +1426,7 @@ class TestDatastoreSQLLegacyTests(object):
             self.data["resource_id"]
         )
         data = {"sql": query}
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         res = app.post(
             "/api/action/datastore_search_sql", json=data, extra_environ=auth,
         )
@@ -1486,7 +1456,7 @@ class TestDatastoreSQLLegacyTests(object):
             """.format(
             self.data["resource_id"]
         )
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search_sql",
             json={"sql": query},
@@ -1528,7 +1498,7 @@ class TestDatastoreSQLLegacyTests(object):
             },
         )
 
-        auth = {"Authorization": self.sysadmin_token["token"]}
+        auth = {"Authorization": self.sysadmin_token}
         helpers.call_action(
             "datastore_create", resource_id=resource["id"], force=True
         )
@@ -1536,7 +1506,7 @@ class TestDatastoreSQLLegacyTests(object):
         # new resource should be private
         query = 'SELECT * FROM "{0}"'.format(resource["id"])
         data = {"sql": query}
-        auth = {"Authorization": self.normal_user_token["token"]}
+        auth = {"Authorization": self.normal_user_token}
         res = app.post(
             "/api/action/datastore_search_sql",
             json=data,

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -463,7 +463,19 @@ class TestDatastoreSearchLegacyTests(object):
     def initial_data(self, clean_datastore, app):
         ctd.CreateTestData.create()
         self.sysadmin_user = model.User.get("testsysadmin")
+        self.sysadmin_token = helpers.call_action(
+            "api_token_create",
+            context={"model": model, "user": self.sysadmin_user.name},
+            user=self.sysadmin_user.name,
+            name="first token",
+        )
         self.normal_user = model.User.get("annafan")
+        self.normal_user_token = helpers.call_action(
+            "api_token_create",
+            context={"model": model, "user": self.normal_user.name},
+            user=self.normal_user.name,
+            name="first token",
+        )
         self.dataset = model.Package.get("annakarenina")
         self.resource = self.dataset.resources[0]
         self.data = {
@@ -494,7 +506,7 @@ class TestDatastoreSearchLegacyTests(object):
                 },
             ],
         }
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create", json=self.data, extra_environ=auth,
         )
@@ -536,7 +548,7 @@ class TestDatastoreSearchLegacyTests(object):
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_search_basic(self, app):
         data = {"resource_id": self.data["resource_id"]}
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -548,7 +560,7 @@ class TestDatastoreSearchLegacyTests(object):
 
         # search with parameter id should yield the same results
         data = {"id": self.data["resource_id"]}
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -586,7 +598,7 @@ class TestDatastoreSearchLegacyTests(object):
         )
         helpers.call_action("datastore_create", resource_id=resource["id"], force=True)
         data = {"resource_id": resource["id"]}
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
 
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
@@ -598,7 +610,7 @@ class TestDatastoreSearchLegacyTests(object):
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_search_alias(self, app):
         data = {"resource_id": self.data["aliases"]}
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -614,7 +626,7 @@ class TestDatastoreSearchLegacyTests(object):
             "resource_id": self.data["resource_id"],
             "fields": [{"id": "bad"}],
         }
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search",
             json=data,
@@ -628,7 +640,7 @@ class TestDatastoreSearchLegacyTests(object):
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_search_fields(self, app):
         data = {"resource_id": self.data["resource_id"], "fields": [u"b\xfck"]}
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -645,7 +657,7 @@ class TestDatastoreSearchLegacyTests(object):
             "resource_id": self.data["resource_id"],
             "fields": u"b\xfck, author",
         }
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -667,7 +679,7 @@ class TestDatastoreSearchLegacyTests(object):
             "distinct": True,
         }
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -685,7 +697,7 @@ class TestDatastoreSearchLegacyTests(object):
             "filters": {u"b\xfck": "annakarenina"},
         }
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -703,7 +715,7 @@ class TestDatastoreSearchLegacyTests(object):
             "filters": {u"characters": [u"Princess Anna", u"Sergius"]},
         }
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -721,7 +733,7 @@ class TestDatastoreSearchLegacyTests(object):
             "filters": {u"b\xfck": [u"annakarenina", u"warandpeace"]},
         }
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -741,7 +753,7 @@ class TestDatastoreSearchLegacyTests(object):
             "filters": {u"b\xfck": [u"annakarenina", u"warandpeace"]},
         }
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -775,7 +787,7 @@ class TestDatastoreSearchLegacyTests(object):
             "filters": {u"author": 42},
         }
 
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_search",
             json=data,
@@ -792,7 +804,7 @@ class TestDatastoreSearchLegacyTests(object):
             "resource_id": self.data["resource_id"],
             "sort": u"b\xfck asc, author desc",
         }
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -824,7 +836,7 @@ class TestDatastoreSearchLegacyTests(object):
             "resource_id": self.data["resource_id"],
             "sort": u"f\xfc\xfc asc",
         }
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_search",
             json=data,
@@ -847,7 +859,7 @@ class TestDatastoreSearchLegacyTests(object):
             "offset": 1,
         }
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -862,7 +874,7 @@ class TestDatastoreSearchLegacyTests(object):
     def test_search_invalid_offset(self, app):
         data = {"resource_id": self.data["resource_id"], "offset": "bad"}
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search",
             json=data,
@@ -874,7 +886,7 @@ class TestDatastoreSearchLegacyTests(object):
 
         data = {"resource_id": self.data["resource_id"], "offset": -1}
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search",
             json=data,
@@ -889,7 +901,7 @@ class TestDatastoreSearchLegacyTests(object):
     def test_search_full_text(self, app):
         data = {"resource_id": self.data["resource_id"], "q": "annakarenina"}
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -991,7 +1003,7 @@ class TestDatastoreSearchLegacyTests(object):
             "q": {u"b\xfck": "annakarenina"},
         }
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -1013,7 +1025,7 @@ class TestDatastoreSearchLegacyTests(object):
             "q": u'{"b\xfck": "annakarenina"}',
         }
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -1033,7 +1045,7 @@ class TestDatastoreSearchLegacyTests(object):
             "q": {"invalid_field_name": "value"},
         }
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search",
             json=data,
@@ -1051,7 +1063,7 @@ class TestDatastoreSearchLegacyTests(object):
             "q": {"author": ["invalid", "value"]},
         }
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search",
             json=data,
@@ -1066,7 +1078,7 @@ class TestDatastoreSearchLegacyTests(object):
     def test_search_table_metadata(self, app):
         data = {"resource_id": "_table_metadata"}
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -1083,7 +1095,7 @@ class TestDatastoreSearchLegacyTests(object):
             "filters": "the-filter",
         }
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search",
             json=data,
@@ -1104,7 +1116,7 @@ class TestDatastoreSearchLegacyTests(object):
             "filters": {"invalid-column-name": "value"},
         }
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search",
             json=data,
@@ -1123,7 +1135,7 @@ class TestDatastoreSearchLegacyTests(object):
             "fields": ["invalid-column-name"],
         }
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search",
             json=data,
@@ -1140,7 +1152,19 @@ class TestDatastoreFullTextSearchLegacyTests(object):
     def initial_data(self, clean_datastore, app):
         ctd.CreateTestData.create()
         self.sysadmin_user = model.User.get("testsysadmin")
+        self.sysadmin_token = helpers.call_action(
+            "api_token_create",
+            context={"model": model, "user": self.sysadmin_user.name},
+            user=self.sysadmin_user.name,
+            name="first token",
+        )
         self.normal_user = model.User.get("annafan")
+        self.normal_user_token = helpers.call_action(
+            "api_token_create",
+            context={"model": model, "user": self.normal_user.name},
+            user=self.normal_user.name,
+            name="first token",
+        )
         resource = model.Package.get("annakarenina").resources[0]
         self.data = dict(
             resource_id=resource.id,
@@ -1225,7 +1249,7 @@ class TestDatastoreFullTextSearchLegacyTests(object):
                 },
             ],
         )
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_create", json=self.data, extra_environ=auth,
         )
@@ -1237,7 +1261,7 @@ class TestDatastoreFullTextSearchLegacyTests(object):
     def test_search_full_text(self, app):
         data = {"resource_id": self.data["resource_id"], "q": "DE"}
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -1253,7 +1277,7 @@ class TestDatastoreFullTextSearchLegacyTests(object):
             "q": "DE | UK",
         }
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -1265,7 +1289,7 @@ class TestDatastoreFullTextSearchLegacyTests(object):
     def test_full_text_search_on_integers_within_text_strings(self, app):
         data = {"resource_id": self.data["resource_id"], "q": "99"}
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -1277,7 +1301,7 @@ class TestDatastoreFullTextSearchLegacyTests(object):
     def test_full_text_search_on_integers(self, app):
         data = {"resource_id": self.data["resource_id"], "q": "4"}
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -1289,7 +1313,7 @@ class TestDatastoreFullTextSearchLegacyTests(object):
     def test_full_text_search_on_decimal_within_text_strings(self, app):
         data = {"resource_id": self.data["resource_id"], "q": "53.56"}
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -1301,7 +1325,7 @@ class TestDatastoreFullTextSearchLegacyTests(object):
     def test_full_text_search_on_decimal(self, app):
         data = {"resource_id": self.data["resource_id"], "q": "52.56"}
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -1313,7 +1337,7 @@ class TestDatastoreFullTextSearchLegacyTests(object):
     def test_full_text_search_on_date(self, app):
         data = {"resource_id": self.data["resource_id"], "q": "2011-01-01"}
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -1325,7 +1349,7 @@ class TestDatastoreFullTextSearchLegacyTests(object):
     def test_full_text_search_on_json_like_string_succeeds(self, app):
         data = {"resource_id": self.data["resource_id"], "q": '"{}"'}
 
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search", json=data, extra_environ=auth,
         )
@@ -1341,7 +1365,19 @@ class TestDatastoreSQLLegacyTests(object):
     def initial_data(self, clean_datastore, app):
         ctd.CreateTestData.create()
         self.sysadmin_user = model.User.get("testsysadmin")
+        self.sysadmin_token = helpers.call_action(
+            "api_token_create",
+            context={"model": model, "user": self.sysadmin_user.name},
+            user=self.sysadmin_user.name,
+            name="first token",
+        )
         self.normal_user = model.User.get("annafan")
+        self.normal_user_token = helpers.call_action(
+            "api_token_create",
+            context={"model": model, "user": self.normal_user.name},
+            user=self.normal_user.name,
+            name="first token",
+        )
         self.dataset = model.Package.get("annakarenina")
         resource = self.dataset.resources[0]
         self.data = {
@@ -1367,7 +1403,7 @@ class TestDatastoreSQLLegacyTests(object):
                 },
             ],
         }
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_create", json=self.data, extra_environ=auth,
         )
@@ -1420,7 +1456,7 @@ class TestDatastoreSQLLegacyTests(object):
             self.data["resource_id"]
         )
         data = {"sql": query}
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         res = app.post(
             "/api/action/datastore_search_sql", json=data, extra_environ=auth,
         )
@@ -1450,7 +1486,7 @@ class TestDatastoreSQLLegacyTests(object):
             """.format(
             self.data["resource_id"]
         )
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search_sql",
             json={"sql": query},
@@ -1492,7 +1528,7 @@ class TestDatastoreSQLLegacyTests(object):
             },
         )
 
-        auth = {"Authorization": str(self.sysadmin_user.apikey)}
+        auth = {"Authorization": self.sysadmin_token["token"]}
         helpers.call_action(
             "datastore_create", resource_id=resource["id"], force=True
         )
@@ -1500,7 +1536,7 @@ class TestDatastoreSQLLegacyTests(object):
         # new resource should be private
         query = 'SELECT * FROM "{0}"'.format(resource["id"])
         data = {"sql": query}
-        auth = {"Authorization": str(self.normal_user.apikey)}
+        auth = {"Authorization": self.normal_user_token["token"]}
         res = app.post(
             "/api/action/datastore_search_sql",
             json=data,

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -462,10 +462,10 @@ class TestDatastoreSearchLegacyTests(object):
     @pytest.fixture(autouse=True)
     def initial_data(self, clean_datastore, app):
         ctd.CreateTestData.create()
-        self.sysadmin_user = model.User.get("testsysadmin")
-        self.sysadmin_token = factories.APIToken(user=self.sysadmin_user.name)
-        self.normal_user = model.User.get("annafan")
-        self.normal_user_token = factories.APIToken(user=self.normal_user.name)
+        self.sysadmin_user = factories.Sysadmin()
+        self.sysadmin_token = factories.APIToken(user=self.sysadmin_user)
+        self.normal_user = factories.User()
+        self.normal_user_token = factories.APIToken(user=self.normal_user)
         self.dataset = model.Package.get("annakarenina")
         self.resource = self.dataset.resources[0]
         self.data = {
@@ -506,7 +506,7 @@ class TestDatastoreSearchLegacyTests(object):
         # Make an organization, because private datasets must belong to one.
         self.organization = helpers.call_action(
             "organization_create",
-            {"user": self.sysadmin_user.name},
+            {"user": self.sysadmin_user["name"]},
             name="test_org",
         )
 
@@ -565,7 +565,7 @@ class TestDatastoreSearchLegacyTests(object):
     def test_search_private_dataset(self, app):
         group = self.dataset.get_groups()[0]
         context = {
-            "user": self.sysadmin_user.name,
+            "user": self.sysadmin_user["name"],
             "ignore_auth": True,
             "model": model,
         }
@@ -1141,10 +1141,10 @@ class TestDatastoreFullTextSearchLegacyTests(object):
     @pytest.fixture(autouse=True)
     def initial_data(self, clean_datastore, app):
         ctd.CreateTestData.create()
-        self.sysadmin_user = model.User.get("testsysadmin")
-        self.sysadmin_token = factories.APIToken(user=self.sysadmin_user.name)
-        self.normal_user = model.User.get("annafan")
-        self.normal_user_token = factories.APIToken(user=self.normal_user.name)
+        self.sysadmin_user = factories.Sysadmin()
+        self.sysadmin_token = factories.APIToken(user=self.sysadmin_user)
+        self.normal_user = factories.User()
+        self.normal_user_token = factories.APIToken(user=self.normal_user)
         resource = model.Package.get("annakarenina").resources[0]
         self.data = dict(
             resource_id=resource.id,
@@ -1344,10 +1344,10 @@ class TestDatastoreSQLLegacyTests(object):
     @pytest.fixture(autouse=True)
     def initial_data(self, clean_datastore, app):
         ctd.CreateTestData.create()
-        self.sysadmin_user = model.User.get("testsysadmin")
-        self.sysadmin_token = factories.APIToken(user=self.sysadmin_user.name)
-        self.normal_user = model.User.get("annafan")
-        self.normal_user_token = factories.APIToken(user=self.normal_user.name)
+        self.sysadmin_user = factories.Sysadmin()
+        self.sysadmin_token = factories.APIToken(user=self.sysadmin_user)
+        self.normal_user = factories.User()
+        self.normal_user_token = factories.APIToken(user=self.normal_user)
         self.dataset = model.Package.get("annakarenina")
         resource = self.dataset.resources[0]
         self.data = {
@@ -1383,7 +1383,7 @@ class TestDatastoreSQLLegacyTests(object):
         # Make an organization, because private datasets must belong to one.
         self.organization = helpers.call_action(
             "organization_create",
-            {"user": self.sysadmin_user.name},
+            {"user": self.sysadmin_user["name"]},
             name="test_org",
         )
 
@@ -1476,7 +1476,7 @@ class TestDatastoreSQLLegacyTests(object):
         # make a private CKAN resource
         group = self.dataset.get_groups()[0]
         context = {
-            "user": self.sysadmin_user.name,
+            "user": self.sysadmin_user["name"],
             "ignore_auth": True,
             "model": model,
         }

--- a/test-core.ini
+++ b/test-core.ini
@@ -23,11 +23,11 @@ testing = true
 
 
 # Specify the Postgres database for SQLAlchemy to use
-sqlalchemy.url = postgresql://ckan_default:pass@localhost/ckan_test
+sqlalchemy.url = postgresql://ckan_local:pass@localhost/ckan_test
 
 ## Datastore
-ckan.datastore.write_url = postgresql://ckan_default:pass@localhost/datastore_test
-ckan.datastore.read_url = postgresql://datastore_default:pass@localhost/datastore_test
+ckan.datastore.write_url = postgresql://ckan_local:pass@localhost/datastore_test
+ckan.datastore.read_url = postgresql://ckan_local:pass@localhost/datastore_test
 ckan.datastore.sqlsearch.enabled = true
 ckan.datastore.sqlsearch.allowed_functions_file = %(here)s/ckanext/datastore/tests/allowed_functions.txt
 

--- a/test-core.ini
+++ b/test-core.ini
@@ -23,11 +23,11 @@ testing = true
 
 
 # Specify the Postgres database for SQLAlchemy to use
-sqlalchemy.url = postgresql://ckan_local:pass@localhost/ckan_test
+sqlalchemy.url = postgresql://ckan_default:pass@localhost/ckan_test
 
 ## Datastore
-ckan.datastore.write_url = postgresql://ckan_local:pass@localhost/datastore_test
-ckan.datastore.read_url = postgresql://ckan_local:pass@localhost/datastore_test
+ckan.datastore.write_url = postgresql://ckan_default:pass@localhost/datastore_test
+ckan.datastore.read_url = postgresql://datastore_default:pass@localhost/datastore_test
 ckan.datastore.sqlsearch.enabled = true
 ckan.datastore.sqlsearch.allowed_functions_file = %(here)s/ckanext/datastore/tests/allowed_functions.txt
 


### PR DESCRIPTION
Fixes #6247

### Proposed fixes:
-Renamed methods/vars from api_key -> api_token 
-Removed the  API key snippet and "Regenerate API key" button from the user profile templates
-Removed the endpoint used to regenerate the API key and the `user_generate_apikey` action and auth function
-Removed apikey from the user schema
-Instead of [api key](https://github.com/ckan/ckan/blob/94194d43667d122bc5a55a45e16b07b4430f3405/ckanext/datastore/tests/test_search.py#L498) i created API Token and used it for authorization.


### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
