### PR TITLE
Clean datastore purge command

### DIFF
--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -124,10 +124,9 @@ def purge():
     action, which drops tables when called without filters.'''
 
     site_user = logic.get_action(u'get_site_user')({u'ignore_auth': True}, {})
-    context = {u'user': site_user[u'name']}
 
     result = logic.get_action(u'datastore_search')(
-        context,
+        {u'user': site_user[u'name']},
         {u'resource_id': u'_table_metadata'}
     )
 
@@ -139,13 +138,8 @@ def purge():
             if record[u'alias_of']:
                 continue
 
-            # we need to do this to trigger resource_show auth function
-            site_user = logic.get_action(u'get_site_user')(
-                {u'ignore_auth': True}, {})
-            context = {u'user': site_user[u'name']}
-
             logic.get_action(u'resource_show')(
-                context,
+                {u'user': site_user[u'name']},
                 {u'id': record[u'name']}
             )
         except logic.NotFound:
@@ -168,7 +162,7 @@ def purge():
     drop_count = 0
     for resource_id in resource_id_list:
         logic.get_action(u'datastore_delete')(
-            context,
+            {u'user': site_user[u'name']},
             {u'resource_id': resource_id, u'force': True}
         )
         click.echo(u"Table '%s' dropped)" % resource_id)

--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -116,59 +116,59 @@ def _parse_db_config(config_key=u'sqlalchemy.url'):
 
 
 @datastore.command(
-    u'purge',
-    short_help=u'purge orphaned resources from the datastore.'
+    'purge',
+    short_help='purge orphaned resources from the datastore.'
 )
 def purge():
-    u'''Purge orphaned resources from the datastore using the datastore_delete
+    '''Purge orphaned resources from the datastore using the datastore_delete
     action, which drops tables when called without filters.'''
 
-    site_user = logic.get_action(u'get_site_user')({u'ignore_auth': True}, {})
+    site_user = logic.get_action('get_site_user')({'ignore_auth': True}, {})
 
-    result = logic.get_action(u'datastore_search')(
-        {u'user': site_user[u'name']},
-        {u'resource_id': u'_table_metadata'}
+    result = logic.get_action('datastore_search')(
+        {'user': site_user['name']},
+        {'resource_id': '_table_metadata'}
     )
 
     resource_id_list = []
-    for record in result[u'records']:
+    for record in result['records']:
         try:
             # ignore 'alias' records (views) as they are automatically
             # deleted when the parent resource table is dropped
-            if record[u'alias_of']:
+            if record['alias_of']:
                 continue
 
-            logic.get_action(u'resource_show')(
-                {u'user': site_user[u'name']},
-                {u'id': record[u'name']}
+            logic.get_action('resource_show')(
+                {'user': site_user['name']},
+                {'id': record['name']}
             )
         except logic.NotFound:
-            resource_id_list.append(record[u'name'])
-            click.echo(u"Resource '%s' orphaned - queued for drop" %
+            resource_id_list.append(record['name'])
+            click.echo("Resource '%s' orphaned - queued for drop" %
                        record[u'name'])
         except KeyError:
             continue
 
     orphaned_table_count = len(resource_id_list)
-    click.echo(u'%d orphaned tables found.' % orphaned_table_count)
+    click.echo('%d orphaned tables found.' % orphaned_table_count)
 
     if not orphaned_table_count:
         return
 
-    click.confirm(u'Proceed with purge?', abort=True)
+    click.confirm('Proceed with purge?', abort=True)
 
     # Drop the orphaned datastore tables. When datastore_delete is called
     # without filters, it does a drop table cascade
     drop_count = 0
     for resource_id in resource_id_list:
-        logic.get_action(u'datastore_delete')(
-            {u'user': site_user[u'name']},
-            {u'resource_id': resource_id, u'force': True}
+        logic.get_action('datastore_delete')(
+            {'user': site_user['name']},
+            {'resource_id': resource_id, 'force': True}
         )
-        click.echo(u"Table '%s' dropped)" % resource_id)
+        click.echo("Table '%s' dropped)" % resource_id)
         drop_count += 1
 
-    click.echo(u'Dropped %s tables' % drop_count)
+    click.echo('Dropped %s tables' % drop_count)
 
 
 def get_commands():


### PR DESCRIPTION
This PR simplifies the logic by:
 - Avoiding calling twice to `get_site_user` by reusing `site_user` variable
 - Avoiding the reuse of `context` object (not a good practice)

The commit to review is: https://github.com/ckan/ckan/commit/26219d29f95db1c952dbffbe081e31f762a242ff the other is just cleaning literal prefixes.