### PR TITLE
generally improve formatting of resource item metadata

### DIFF
--- a/changes/6356.bugfix
+++ b/changes/6356.bugfix
@@ -1,0 +1,2 @@
+
+Improve rendering data types in resource view

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2291,7 +2291,11 @@ def format_resource_items(items):
     reg_ex_int = r'^-?\d{1,}$'
     reg_ex_float = r'^-?\d{1,}\.\d{1,}$'
     for key, value in items:
-        if not value or key in blacklist:
+        if key in blacklist or (not isinstance(value, bool) and not value):
+            # Ignore blocked keys and values that evaluate to
+            # `bool(value) == False` (e.g. `""`, `[]` or `{}`),
+            # with the exception of boolean-valued keys (keep `False`
+            # values just like `True` values).
             continue
         # size is treated specially as we want to show in MiB etc
         if key == 'size':

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2292,7 +2292,8 @@ def format_resource_items(items):
     reg_ex_int = r'^-?\d{1,}$'
     reg_ex_float = r'^-?\d{1,}\.\d{1,}$'
     for key, value in items:
-        if key in blacklist or (not isinstance(value, numbers.Number) and not value):
+        if (key in blacklist
+                or (not isinstance(value, numbers.Number) and not value)):
             # Ignore blocked keys and values that evaluate to
             # `bool(value) == False` (e.g. `""`, `[]` or `{}`),
             # with the exception of numbers such as `False`, `0`,`0.0`.

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -8,6 +8,7 @@ available to Controllers. This module is available to templates as 'h'.
 import email.utils
 import datetime
 import logging
+import numbers
 import re
 import os
 import pytz
@@ -2291,11 +2292,10 @@ def format_resource_items(items):
     reg_ex_int = r'^-?\d{1,}$'
     reg_ex_float = r'^-?\d{1,}\.\d{1,}$'
     for key, value in items:
-        if key in blacklist or (not isinstance(value, bool) and not value):
+        if key in blacklist or (not isinstance(value, numbers.Number) and not value):
             # Ignore blocked keys and values that evaluate to
             # `bool(value) == False` (e.g. `""`, `[]` or `{}`),
-            # with the exception of boolean-valued keys (keep `False`
-            # values just like `True` values).
+            # with the exception of numbers such as `False`, `0`,`0.0`.
             continue
         # size is treated specially as we want to show in MiB etc
         if key == 'size':
@@ -2314,8 +2314,9 @@ def format_resource_items(items):
                 value = formatters.localised_number(float(value))
             elif re.search(reg_ex_int, value):
                 value = formatters.localised_number(int(value))
-        elif ((isinstance(value, int) or isinstance(value, float))
-                and value not in (True, False)):
+        elif isinstance(value, bool):
+            value = str(value)
+        elif isinstance(value, numbers.Number):
             value = formatters.localised_number(value)
         key = key.replace('_', ' ')
         output.append((key, value))

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -8,6 +8,7 @@ import os
 import pytz
 import tzlocal
 from babel import Locale
+import flask_babel
 
 import pytest
 
@@ -912,6 +913,25 @@ def test_date_str_to_datetime_valid(string, date):
 def test_date_str_to_datetime_invalid(string):
     with pytest.raises(ValueError):
         h.date_str_to_datetime(string)
+
+
+@pytest.mark.parametrize("dict_in,dict_out", [
+    ({"number_bool": True}, {"number bool": "True"}),
+    ({"number_bool": False}, {"number bool": "False"}),
+    ({"number_int": 0}, {"number int": "0"}),
+    ({"number_int": 42}, {"number int": "42"}),
+    ({"number_float": 0.0}, {"number float": "0"}),
+    ({"number_float": 0.1}, {"number float": "0.1"}),
+    ({"number_float": "0.10"}, {"number float": "0.1"}),
+    ({"string_basic": "peter"}, {"string basic": "peter"}),
+    ({"string_empty": ""}, {}),  # empty strings are ignored
+    ({"name": "hans"}, {}),  # blocked string
+])
+def test_format_resource_items_data_types(dict_in, dict_out, monkeypatch):
+    # set locale to en (formatting of decimals)
+    monkeypatch.setattr(flask_babel, "get_locale", lambda: "en")
+    items_out = h.format_resource_items(dict_in.items())
+    assert items_out == list(dict_out.items())
 
 
 def test_gravatar():


### PR DESCRIPTION
Fixes #6350 and improves handling of numbers in general.

### Proposed fixes:
Initially I thought that the issue described in #6350 only affects `False` booleans, but it also affects all numbers that are 0 (integer and float). This PR makes `ckan.lib.helpers.format_resource_items` properly format (as in format as a string) numbers. Previously, booleans and zero-valued numbers were not converted to a string. I added a parametrized test function.

### Features:

- [X] includes tests covering changes (as far as I can see there were no tests for that function before)
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
