### PR TITLE
Emit warnings on deprecation calls

### DIFF
--- a/ckan/cli/server.py
+++ b/ckan/cli/server.py
@@ -1,6 +1,8 @@
 # encoding: utf-8
 
+from ckan.exceptions import CkanDeprecationWarning
 import logging
+import warnings
 
 import click
 from werkzeug.serving import run_simple
@@ -43,6 +45,9 @@ DEFAULT_PORT = 5000
 def run(ctx, host, port, disable_reloader, threaded, extra_files, processes,
         ssl_cert, ssl_key):
     u"""Runs the Werkzeug development server"""
+
+    if tk.asbool(config.get("debug")):
+        warnings.filterwarnings("default", category=CkanDeprecationWarning)
 
     # Reloading
     use_reloader = not disable_reloader

--- a/ckan/exceptions.py
+++ b/ckan/exceptions.py
@@ -32,3 +32,7 @@ class HelperError(Exception):
     Normally, this would be a subclass of AttributeError, but Jinja2 will
     catch and ignore them. We want this to be an explicit failure re #2908.
     """
+
+
+class CkanDeprecationWarning(DeprecationWarning):
+    pass

--- a/ckan/lib/maintain.py
+++ b/ckan/lib/maintain.py
@@ -1,11 +1,14 @@
 # encoding: utf-8
 
 ''' This module contains code that helps in maintaining the Ckan codebase. '''
+
 import inspect
 import time
 import logging
 import re
+import warnings
 
+from ckan.exceptions import CkanDeprecationWarning
 
 log = logging.getLogger(__name__)
 
@@ -31,9 +34,15 @@ def deprecated(message='', since=None):
 
         def wrapped(*args, **kw):
             since_msg = f'since CKAN v{since}' if since else ''
-            log.warning('Function %s() in module %s has been deprecated %s'
-                        'and will be removed in a later release of ckan. %s'
-                        % (fn.__name__, fn.__module__, since_msg, message))
+            msg = (
+                'Function %s() in module %s has been deprecated %s'
+                ' and will be removed in a later release of ckan. %s'
+                % (fn.__name__, fn.__module__, since_msg, message)
+            )
+
+            log.warning(msg)
+            warnings.warn(msg, CkanDeprecationWarning, stacklevel=2)
+
             return fn(*args, **kw)
         return wrapped
     return decorator


### PR DESCRIPTION
Just noticed that deprecation messages are logged with no hints as to what part of the code had used the deprecated function. While it's not a problem for the production instances, during development it would be much nicer to signal about the actual file that uses deprecated functionality.

With this change, **only when dev-server is used AND debug mode is active**, extra warning line will be added to the logs.
This is how deprecation call looked before:
```
2021-09-02 12:19:00,887 WARNI [ckan.lib.maintain] Function auth_is_registered_user() in module ckan.authz has been deprecated since CKAN v2.2.0 and will be removed in a later release of ckan. Use auth_is_loggedin_user instead
```
Who has called `auth_is_registered_user`?

And this is how it looks now:
```
2021-09-02 12:19:00,887 WARNI [ckan.lib.maintain] Function auth_is_registered_user() in module ckan.authz has been deprecated since CKAN v2.2.0 and will be removed in a later release of ckan. Use auth_is_loggedin_user instead
/home/sergey/Projects/core/ckan/ckan/config/middleware/../../views/user.py:56: CkanDeprecationWarning: Function auth_is_registered_user() in module ckan.authz has been deprecated since CKAN v2.2.0 and will be removed in a later release of ckan. Use auth_is_loggedin_user instead
```
Now we can see that `auth_is_registered_user` was called inside `views/user.py` on the line 56.