### PR TITLE
Show function name on job start/finish log messages

### DIFF
--- a/ckan/lib/jobs.py
+++ b/ckan/lib/jobs.py
@@ -272,18 +272,18 @@ class Worker(rq.Worker):
         # The original implementation performs the actual fork
         queue = remove_queue_name_prefix(job.origin)
 
-        if job.func_name:
-            function_name = job.func_name.split('.')[-1]
+        if job.meta.get('title'):
+            job_id = '{} ({})'.format(job.id, job.meta['title'])
         else:
-            function_name = ''
+            job_id = job.id
 
-        log.info(u'Worker {} starts job {} ({}) from queue "{}"'.format(
-                 self.key, job.id, function_name, queue))
+        log.info(u'Worker {} starts job {} from queue "{}"'.format(
+                 self.key, job_id, queue))
         for plugin in plugins.PluginImplementations(plugins.IForkObserver):
             plugin.before_fork()
         result = super(Worker, self).execute_job(job, *args, **kwargs)
-        log.info(u'Worker {} has finished job {} ({}) from queue "{}"'.format(
-                 self.key, job.id, function_name, queue))
+        log.info(u'Worker {} has finished job {} from queue "{}"'.format(
+                 self.key, job_id, queue))
 
         return result
 

--- a/ckan/lib/jobs.py
+++ b/ckan/lib/jobs.py
@@ -271,13 +271,19 @@ class Worker(rq.Worker):
 
         # The original implementation performs the actual fork
         queue = remove_queue_name_prefix(job.origin)
-        log.info(u'Worker {} starts job {} from queue "{}"'.format(
-                 self.key, job.id, queue))
+
+        if job.func_name:
+            function_name = job.func_name.split('.')[-1]
+        else:
+            function_name = ''
+
+        log.info(u'Worker {} starts job {} ({}) from queue "{}"'.format(
+                 self.key, job.id, function_name, queue))
         for plugin in plugins.PluginImplementations(plugins.IForkObserver):
             plugin.before_fork()
         result = super(Worker, self).execute_job(job, *args, **kwargs)
-        log.info(u'Worker {} has finished job {} from queue "{}"'.format(
-                 self.key, job.id, queue))
+        log.info(u'Worker {} has finished job {} ({}) from queue "{}"'.format(
+                 self.key, job.id, function_name, queue))
 
         return result
 

--- a/ckan/views/home.py
+++ b/ckan/views/home.py
@@ -28,10 +28,21 @@ def before_request():
     except logic.NotAuthorized:
         abort(403)
 
+import logging
+
+log = logging.getLogger(__name__)
+
+def hi(msg):
+    log.critical(f'Hey {msg}')
+
 
 def index():
     u'''display home page'''
     try:
+        from ckan.plugins import toolkit
+
+        toolkit.enqueue_job(hi, ['koko'], title="Calling Hi job")
+
         context = {u'model': model, u'session': model.Session,
                    u'user': g.user, u'auth_user_obj': g.userobj}
         data_dict = {u'q': u'*:*',


### PR DESCRIPTION
To make it easier to debug background job calls.

Before:

```
INFO  [ckan.lib.jobs] Worker rq:worker:f0792c8bd67344f288b5704d39c43124 starts job 2baa42e5-4582-4103-92e5-b4a384d0b1da from queue "default"
```

After:

```
INFO  [ckan.lib.jobs] Worker rq:worker:f0792c8bd67344f288b5704d39c43124 starts job 2baa42e5-4582-4103-92e5-b4a384d0b1da (process_data_fields) from queue "default"
```


### Features:

- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
