### PR TITLE
Remove support for SQLALchemy 0.4 in Repository class

### DIFF
--- a/ckan/model/__init__.py
+++ b/ckan/model/__init__.py
@@ -7,7 +7,7 @@ import re
 from time import sleep
 from os.path import splitext
 
-from sqlalchemy import MetaData, __version__ as sqav, Table
+from sqlalchemy import MetaData, Table
 from sqlalchemy.exc import ProgrammingError
 
 from alembic.command import (
@@ -236,10 +236,7 @@ class Repository():
         self.session.remove()
         ## use raw connection for performance
         connection = self.session.connection()
-        if sqav.startswith("0.4"):
-            tables = self.metadata.table_iterator()
-        else:
-            tables = reversed(self.metadata.sorted_tables)
+        tables = reversed(self.metadata.sorted_tables)
         for table in tables:
             if table.name == 'alembic_version':
                 continue


### PR DESCRIPTION
This piece of logic is for supporting SQLAlchemy 0.4 so it is safe to remove it.