### PR TITLE
Update deprecated code

### DIFF
--- a/ckan/lib/datapreview.py
+++ b/ckan/lib/datapreview.py
@@ -132,7 +132,7 @@ def get_default_view_plugins(get_datastore_views=False):
         view_plugin = get_view_plugin(view_type)
 
         if not view_plugin:
-            log.warn('Plugin for view {0} could not be found'
+            log.warning('Plugin for view {0} could not be found'
                      .format(view_type))
             # We should probably check on startup if the default
             # view types exist

--- a/ckan/lib/dictization/__init__.py
+++ b/ckan/lib/dictization/__init__.py
@@ -34,7 +34,7 @@ def table_dictize(obj, context, **kw):
         fields = obj.keys()
     else:
         ModelClass = obj.__class__
-        table = class_mapper(ModelClass).mapped_table
+        table = class_mapper(ModelClass).persist_selectable
         fields = [field.name for field in table.c]
 
     for field in fields:
@@ -120,7 +120,7 @@ def table_dict_save(table_dict, ModelClass, context, extra_attrs=()):
     model = context["model"]
     session = context["session"]
 
-    table = class_mapper(ModelClass).mapped_table
+    table = class_mapper(ModelClass).persist_selectable
 
     obj = None
 

--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -28,7 +28,7 @@ def resource_dict_save(res_dict, context):
     else:
         new = False
 
-    table = class_mapper(model.Resource).mapped_table
+    table = class_mapper(model.Resource).persist_selectable
     fields = [field.name for field in table.c]
 
     # Strip the full url for resources of type 'upload'

--- a/ckan/lib/formatters.py
+++ b/ckan/lib/formatters.py
@@ -4,7 +4,7 @@ import datetime
 import pytz
 
 from flask_babel import (
-    format_number,
+    format_decimal,
     format_datetime,
     format_date,
     format_timedelta
@@ -59,7 +59,7 @@ def localised_nice_date(datetime_, show_date=False, with_hours=False,
 
 def localised_number(number):
     ''' Returns a localised unicode representation of number '''
-    return format_number(number)
+    return format_decimal(number)
 
 
 def localised_filesize(number):

--- a/ckan/lib/jinja_extensions.py
+++ b/ckan/lib/jinja_extensions.py
@@ -8,7 +8,8 @@ from jinja2 import nodes
 from jinja2 import loaders
 from jinja2 import ext
 from jinja2.exceptions import TemplateNotFound
-from jinja2.utils import open_if_exists, escape
+from jinja2.utils import open_if_exists
+from markupsafe import escape
 
 import ckan.lib.base as base
 import ckan.lib.helpers as h

--- a/ckan/model/domain_object.py
+++ b/ckan/model/domain_object.py
@@ -96,7 +96,7 @@ class DomainObject(object):
         are converted to strings for json compatibilty
         """
         _dict = OrderedDict()
-        table = orm.class_mapper(self.__class__).mapped_table
+        table = orm.class_mapper(self.__class__).persist_selectable
         for col in table.c:
             val = getattr(self, col.name)
             if isinstance(val, datetime.date):
@@ -122,7 +122,7 @@ class DomainObject(object):
         """
         changed = set()
         skipped = dict(_dict)
-        table = orm.class_mapper(self.__class__).mapped_table
+        table = orm.class_mapper(self.__class__).persist_selectable
         for col in table.c:
             if col.name.startswith('_'):
                 continue
@@ -151,7 +151,7 @@ class DomainObject(object):
 
     def __unicode__(self):
         repr = u'<%s' % self.__class__.__name__
-        table = orm.class_mapper(self.__class__).mapped_table
+        table = orm.class_mapper(self.__class__).persist_selectable
         for col in table.c:
             try:
                 repr += u' %s=%s' % (col.name, getattr(self, col.name))

--- a/ckan/model/meta.py
+++ b/ckan/model/meta.py
@@ -43,7 +43,7 @@ def ckan_before_flush(session, flush_context, instances):
                                 'changed': set()}
 
     changed = [obj for obj in session.dirty if
-        session.is_modified(obj, include_collections=False, passive=True)]
+        session.is_modified(obj, include_collections=False)]
 
     session._object_cache['new'].update(session.new)
     session._object_cache['deleted'].update(session.deleted)


### PR DESCRIPTION
Accidentally turned off warnings filter and noticed a number of deprecations:

* [sqlalchemy.orm.Mapper.mapped_table](https://docs.sqlalchemy.org/en/14/orm/mapping_api.html#sqlalchemy.orm.Mapper.mapped_table)
* [babel.numbers.format_number](http://babel.pocoo.org/en/latest/api/numbers.html#babel.numbers.format_number)
* [Session.is_modified.passive](https://docs.sqlalchemy.org/en/14/orm/session_api.html#sqlalchemy.orm.Session.is_modified)
* [jinja2.escape](https://github.com/pallets/jinja/blob/main/src/jinja2/utils.py#L847)
* [logging.warn](https://docs.python.org/3/library/logging.html#logging.warning)
