### PR TITLE
Remove control characters from package.notes

### DIFF
--- a/ckan/tests/controllers/test_feed.py
+++ b/ckan/tests/controllers/test_feed.py
@@ -24,11 +24,18 @@ class TestFeeds(object):
         ), res
 
     def test_general_atom_feed_works(self, app):
-        dataset = factories.Dataset()
+        dataset = factories.Dataset(notes="Test\x0c Notes")
         offset = url_for(u"feeds.general")
         res = app.get(offset)
-
         assert helpers.body_contains(res, u"<title>{0}</title>".format(dataset["title"]))
+        assert helpers.body_contains(res, u"<content>Test Notes</content>")
+
+    def test_general_atom_feed_works_with_no_notes(self, app):
+        dataset = factories.Dataset(notes=None)
+        offset = url_for(u"feeds.general")
+        res = app.get(offset)
+        assert helpers.body_contains(res, u"<title>{0}</title>".format(dataset["title"]))
+        assert helpers.body_contains(res, u"<content/>")
 
     def test_group_atom_feed_works(self, app):
         group = factories.Group()

--- a/ckan/views/feed.py
+++ b/ckan/views/feed.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 import logging
-import re
+import unicodedata
 
 from urllib.parse import urlparse
 from flask import Blueprint, make_response
@@ -145,7 +145,11 @@ def output_feed(results, feed_title, feed_description, feed_link, feed_url,
     author_name = config.get(u'ckan.feeds.author_name', u'').strip() or \
         config.get(u'ckan.site_id', u'').strip()
 
-    CTRL_CHARS = r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\xff]'
+    def remove_control_characters(s):
+        if not s:
+            return ""
+
+        return "".join(ch for ch in s if unicodedata.category(ch)[0] != "C")
 
     # TODO: language
     feed_class = CKANFeed
@@ -181,7 +185,7 @@ def output_feed(results, feed_title, feed_description, feed_link, feed_url,
                 id=pkg['id'],
                 ver=3,
                 _external=True),
-            description=re.sub(CTRL_CHARS, '', pkg.get(u'notes', u'') or ''),
+            description=remove_control_characters(pkg.get(u'notes', u'')),
             updated=h.date_str_to_datetime(pkg.get(u'metadata_modified')),
             published=h.date_str_to_datetime(pkg.get(u'metadata_created')),
             unique_id=_create_atom_id(u'/dataset/%s' % pkg['id']),

--- a/ckan/views/feed.py
+++ b/ckan/views/feed.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 import logging
+import re
 
 from urllib.parse import urlparse
 from flask import Blueprint, make_response
@@ -144,6 +145,8 @@ def output_feed(results, feed_title, feed_description, feed_link, feed_url,
     author_name = config.get(u'ckan.feeds.author_name', u'').strip() or \
         config.get(u'ckan.site_id', u'').strip()
 
+    CTRL_CHARS = r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\xff]'
+
     # TODO: language
     feed_class = CKANFeed
     for plugin in plugins.PluginImplementations(plugins.IFeed):
@@ -178,7 +181,7 @@ def output_feed(results, feed_title, feed_description, feed_link, feed_url,
                 id=pkg['id'],
                 ver=3,
                 _external=True),
-            description=pkg.get(u'notes', u''),
+            description=re.sub(CTRL_CHARS, '', pkg.get(u'notes', u'') or ''),
             updated=h.date_str_to_datetime(pkg.get(u'metadata_modified')),
             published=h.date_str_to_datetime(pkg.get(u'metadata_created')),
             unique_id=_create_atom_id(u'/dataset/%s' % pkg['id']),


### PR DESCRIPTION
## What

Control characters are causing a problem for lxml parsing as strings must be XML compatible.
Control characters cause the `feedgen` module to throw an error leading to an Internal Server error.
Also have to pass empty string to the regex when no notes in the dataset as when there are no notes it returns a `None` not the expected ''.

Fixes #

Problem with control characters in package.notes which will throw this error - 

`ValueError: All strings must be XML compatible: Unicode or ASCII, no NULL bytes or control characters` which is called by `writeStriing` function in `views/feed.py`

Test it out by reverting back to the original https://github.com/ckan/ckan/pull/6371/files#diff-9e26466d662dfbb08832a2f76bd00a0ef6f52c3bfbc7edf6b2eca0115e3b345fL181 and then run the test to see the error raised when control characters are not removed.

### Proposed fixes:

Remove control characters from the package notes before pushing it to `feedgen` module.

### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
