### PR TITLE
removed pg_buffercache from datastore_search

### DIFF
--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1317,6 +1317,7 @@ def search_data(context, data_dict):
     sort = query_dict['sort']
     limit = query_dict['limit']
     offset = query_dict['offset']
+    where = query_dict['where']
 
     if query_dict.get('distinct'):
         distinct = 'DISTINCT'
@@ -1325,6 +1326,10 @@ def search_data(context, data_dict):
 
     if not sort and not distinct:
         sort = ['_id']
+
+    if not where:
+        where_clause = 'WHERE %s' % (''.join("name != 'pg_buffercache'"))\
+            .replace('%', '%%')
 
     if sort:
         sort_clause = 'ORDER BY %s' % (', '.join(sort)).replace('%', '%%')
@@ -2183,7 +2188,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
     def get_all_ids(self):
         resources_sql = sqlalchemy.text(
             u'''SELECT name FROM "_table_metadata"
-            WHERE alias_of IS NULL''')
+            WHERE alias_of IS NULL and name != "pg_buffercache"''')
         query = self._get_read_engine().execute(resources_sql)
         return [q[0] for q in query.fetchall()]
 


### PR DESCRIPTION
Fixes #6354

### Proposed fixes:
I  installed few more extensions and i saw they are not included in _table_metadata... somehow only pg_buffercache is..  and i think thats because it has reference in pg_class, pg_depend and pg_rewrite as we query it when creating the table.

![image](https://user-images.githubusercontent.com/72216462/132675794-07bed0d0-44b4-4c5a-901c-e2a2ba5f274b.png)



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
