### PR TITLE
tracking.js module prevent links to be opened in new tabs

### DIFF
--- a/ckan/public/base/javascript/tracking.js
+++ b/ckan/public/base/javascript/tracking.js
@@ -9,7 +9,7 @@ $(function (){
           type : 'POST',
           data : {url:url, type:'page'},
           timeout : 300 });
-  $('a.resource-url-analytics').click(function (e){
+  $('a.resource-url-analytics').on('click', function (e){
     var url = $(e.target).closest('a').attr('href');
     $.ajax({url : $('body').data('site-root') + '_tracking',
             data : {url:url, type:'resource'},

--- a/ckan/public/base/javascript/tracking.js
+++ b/ckan/public/base/javascript/tracking.js
@@ -14,8 +14,6 @@ $(function (){
     $.ajax({url : $('body').data('site-root') + '_tracking',
             data : {url:url, type:'resource'},
             type : 'POST',
-            complete : function () {location.href = url;},
             timeout : 30});
-    e.preventDefault();
   });
 });


### PR DESCRIPTION
The current module overrides the default action of `click()` events with a `location.href = url;` call when the ajax call is completed. This implementation will cause some buggy behavior if the user wants to open the link in a new tab. 

### Example

```html
<!-- This will open the link in a new tab -->
<a href="http://www.example.org/" target="_blank">Useless Link</a>

<!-- This will open the link in the current tab -->
<a class="resource-url-analytics" href="http://www.example.org/" target="_blank">Useless Link</a>
```