### PR TITLE
Show job title on job start/finish log messages

### DIFF
--- a/ckan/lib/jobs.py
+++ b/ckan/lib/jobs.py
@@ -271,13 +271,19 @@ class Worker(rq.Worker):
 
         # The original implementation performs the actual fork
         queue = remove_queue_name_prefix(job.origin)
+
+        if job.meta.get('title'):
+            job_id = '{} ({})'.format(job.id, job.meta['title'])
+        else:
+            job_id = job.id
+
         log.info(u'Worker {} starts job {} from queue "{}"'.format(
-                 self.key, job.id, queue))
+                 self.key, job_id, queue))
         for plugin in plugins.PluginImplementations(plugins.IForkObserver):
             plugin.before_fork()
         result = super(Worker, self).execute_job(job, *args, **kwargs)
         log.info(u'Worker {} has finished job {} from queue "{}"'.format(
-                 self.key, job.id, queue))
+                 self.key, job_id, queue))
 
         return result
 


### PR DESCRIPTION
To make it easier to debug background job calls.

Before:

```
INFO  [ckan.lib.jobs] Worker rq:worker:f0792c8bd67344f288b5704d39c43124 starts job 2baa42e5-4582-4103-92e5-b4a384d0b1da from queue "default"
```

After:

```
INFO  [ckan.lib.jobs] Worker rq:worker:f0792c8bd67344f288b5704d39c43124 starts job 2baa42e5-4582-4103-92e5-b4a384d0b1da (Process data fields) from queue "default"
```

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
