### PR TITLE
Add organization_list env variables to 2.8 docs

### DIFF
--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -781,6 +781,41 @@ Default value: ``None``
 
 List of the extra resource fields that would be used when searching.
 
+.. _ckan.group_and_organization_list_max:
+
+ckan.group_and_organization_list_max
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+  ckan.group_and_organization_list_max = 1000
+
+Default value: ``1000``
+
+Maximum number of groups/organizations returned when listing them. Specifically this limits:
+
+* ``group_list``'s ``limit`` when ``all_fields=false``
+* ``organization_list``'s ``limit`` when ``all_fields=false``
+
+.. note:: This is only available in CKAN versions 2.8.7 and newer.
+
+.. _ckan.group_and_organization_list_all_fields_max:
+
+ckan.group_and_organization_list_all_fields_max
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+  ckan.group_and_organization_list_all_fields_max = 100
+
+Default value: ``25``
+
+Maximum number of groups/organizations returned when listing them in detail. Specifically this limits:
+
+* ``group_list``'s ``limit`` when ``all_fields=true``
+* ``organization_list``'s ``limit`` when ``all_fields=true``
+
+.. note:: This is only available in CKAN versions 2.8.7 and newer.
 
 Redis Settings
 ---------------

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -797,7 +797,7 @@ Maximum number of groups/organizations returned when listing them. Specifically 
 * ``group_list``'s ``limit`` when ``all_fields=false``
 * ``organization_list``'s ``limit`` when ``all_fields=false``
 
-.. note:: This is only available in CKAN versions 2.8.7 and newer.
+.. note:: This is only available in CKAN version 2.8.7 and newer.
 
 .. _ckan.group_and_organization_list_all_fields_max:
 
@@ -815,7 +815,7 @@ Maximum number of groups/organizations returned when listing them in detail. Spe
 * ``group_list``'s ``limit`` when ``all_fields=true``
 * ``organization_list``'s ``limit`` when ``all_fields=true``
 
-.. note:: This is only available in CKAN versions 2.8.7 and newer.
+.. note:: This is only available in CKAN version 2.8.7 and newer.
 
 Redis Settings
 ---------------


### PR DESCRIPTION
### Proposed fixes:

This adds `ckan.group_and_organization_list_max` and `ckan.group_and_organization_list_all_fields_max` to the CKAN 2.8 configuration docs with a note that they're only available on CKAN 2.8.7+.

### Features:

- [x] includes updated documentation