### PR TITLE
Always add "user" to context

### DIFF
--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -235,17 +235,20 @@ def _prepopulate_context(context):
         context = {}
     context.setdefault('model', model)
     context.setdefault('session', model.Session)
+
     try:
-        context.setdefault('user', c.user)
+        user = c.user
     except AttributeError:
         # c.user not set
-        pass
+        user = ""
     except RuntimeError:
         # Outside of request context
-        pass
+        user = ""
     except TypeError:
         # c not registered
-        pass
+        user = ""
+
+    context.setdefault('user', user)
     return context
 
 
@@ -295,32 +298,26 @@ def check_access(action, context, data_dict=None):
     if audit and audit[0] == action:
         context['__auth_audit'].pop()
 
-    user = context.get('user')
+    if 'auth_user_obj' not in context:
+        context['auth_user_obj'] = None
 
+    context = _prepopulate_context(context)
+    if not context.get('ignore_auth'):
+        if not context.get('__auth_user_obj_checked'):
+            if context["user"] and not context["auth_user_obj"]:
+                context['auth_user_obj'] = model.User.by_name(context['user'])
+            context['__auth_user_obj_checked'] = True
     try:
-        if 'auth_user_obj' not in context:
-            context['auth_user_obj'] = None
-
-        if not context.get('ignore_auth'):
-            if not context.get('__auth_user_obj_checked'):
-                if context.get('user') and not context.get('auth_user_obj'):
-                    context['auth_user_obj'] = \
-                        model.User.by_name(context['user'])
-                context['__auth_user_obj_checked'] = True
-
-        context = _prepopulate_context(context)
-
-        logic_authorization = authz.is_authorized(action, context,
-                                                  data_dict)
+        logic_authorization = authz.is_authorized(action, context, data_dict)
         if not logic_authorization['success']:
             msg = logic_authorization.get('msg', '')
             raise NotAuthorized(msg)
     except NotAuthorized as e:
         log.debug(u'check access NotAuthorized - %s user=%s "%s"',
-                  action, user, str(e))
+                  action, context["user"], str(e))
         raise
 
-    log.debug('check access OK - %s user=%s', action, user)
+    log.debug('check access OK - %s user=%s', action, context["user"])
     return True
 
 

--- a/ckan/tests/logic/test_logic.py
+++ b/ckan/tests/logic/test_logic.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from unittest import mock
 import pytest
 from ckan import logic, model
 import ckan.tests.factories as factories
@@ -46,3 +47,17 @@ def test_check_access_auth_user_obj_is_not_set_when_ignoring_auth():
     assert result
     assert "__auth_user_obj_checked" not in context
     assert context["auth_user_obj"] is None
+
+
+@mock.patch("ckan.authz.is_authorized")
+def test_user_inside_context_of_check_access(is_authorized: mock.Mock):
+    logic.check_access("site_read", {})
+    is_authorized.assert_called_once()
+    context = is_authorized.call_args[0][1]
+    assert context["user"] == ""
+
+    is_authorized.reset_mock()
+
+    logic.check_access("site_read", {"user": "test"})
+    context = is_authorized.call_args[0][1]
+    assert context["user"] == "test"


### PR DESCRIPTION
At the moment, the "user" key is missing from the context when `check_access/get_action` is called outside request context. This happens during the tests without the `with_request_context` fixture and inside CLI commands. 

I think that setting "user" to an empty string is much more expected behavior. Usually, it means that the user is anonymous and it makes perfect sense for tests and CLI commands when `get_action` is called without an explicit "user" inside context.