### PR TITLE
Add --no-config CLI flag

### DIFF
--- a/changes/6402.feature
+++ b/changes/6402.feature
@@ -1,0 +1,2 @@
+`--no-config` / `-C` CLI flag that skips app initialization and config parsing. This means that commands registered via `IClick` interface are not available. It can be used only with the commands registered inside the setup.py as long as such commands do not read config options and do not interact with CKAN application(DB interactions, API calls, etc)
+

--- a/ckan/cli/cli.py
+++ b/ckan/cli/cli.py
@@ -70,8 +70,9 @@ class ExtendableGroup(click.Group):
         # manually.
         if not ctx.obj:
             _add_service_commands(ctx)
-            _add_ctx_object(ctx)
-            _add_external_commands(ctx)
+            if not ctx.meta.get("no_config"):
+                _add_ctx_object(ctx)
+                _add_external_commands(ctx)
 
         commands = []
         ext_commands = defaultdict(lambda: defaultdict(list))
@@ -123,6 +124,7 @@ def _set_no_config(ctx, param, value):
 
 
 def _init_ckan_config(ctx, param, value):
+    _remove_stale_commands(ctx)
     _add_service_commands(ctx)
 
     if ctx.meta["no_config"]:
@@ -146,6 +148,8 @@ def _add_ctx_object(ctx, path=None):
 
     ctx.meta["flask_app"] = ctx.obj.app._wsgi_app
 
+
+def _remove_stale_commands(ctx):
     # Remove all commands that were registered by extensions before
     # adding new ones. Such situation is possible only during tests,
     # because we are using singleton as main entry point, so it
@@ -153,6 +157,7 @@ def _add_ctx_object(ctx, path=None):
     for key, cmd in list(ctx.command.commands.items()):
         if hasattr(cmd, META_ATTR):
             ctx.command.commands.pop(key)
+
 
 
 def _add_service_commands(ctx):


### PR DESCRIPTION
New `--no-config` / `-C` flag for CKAN CLI that disables parsing config file and skips app initialization. 

As the config file is not parsed when the flag is provided, there will be no plugin commands(IClick). But all the entrypoint-commands (setup.py) are still available, as well as core CKAN commands.