### PR TITLE
add tqdm progressbar helper and use for search-index progressbar

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -17,6 +17,7 @@ import copy
 import uuid
 import functools
 
+from tqdm import tqdm
 from collections import defaultdict
 
 import dominate.tags as dom_tags
@@ -2935,3 +2936,62 @@ def can_update_owner_org(package_dict, user_orgs=None):
         return True
 
     return False
+
+
+@core_helper
+def progressbar(*args, **kwargs):
+    """
+    Customisable progressbar decorator for iterators.
+    
+    This is a wrapper for `tqdm` library.
+
+    Usage::
+
+        for user in h.progressbar(users, desc='Notifying users', unit='user'):
+            mailer.mail_user(...)
+            # Do what you need in loop and progressbar will do the rest
+
+
+    :param n: Number of finished iterations
+    :type n: int or float
+
+    :param total: The expected total number of iterations. If meaningless (None), only basic progress statistics are displayed (no ETA)
+    :type total: int or float
+    
+    :param elapsed: Number of seconds passed since start
+    :type elapsed: float
+    
+    :param ncols: The width of the entire output message. If specified, dynamically resizes {bar} to stay within this bound [default: None]. If 0, will not print any bar (only stats). The fallback is {bar:10}
+    :type ncols: int, optional
+    
+    :param prefix: Prefix message (included in total width) [default: '']. Use as {desc} in bar_format string
+    :type prefix: str, optional
+    
+    :param ascii: If not set, use unicode (smooth blocks) to fill the meter [default: False]. The fallback is to use ASCII characters " 123456789#"
+    :type ascii: bool, optional or str, optional
+    
+    :param unit: The iteration unit [default: 'it'].
+    :type unit: str, optional
+    
+    :param unit_scale: If 1 or True, the number of iterations will be printed with an appropriate SI metric prefix (k = 10^3, M = 10^6, etc.) [default: False]. If any other non-zero number, will scale total and n
+    :type unit_scale: bool or int or float, optional
+    
+    :param rate: Manual override for iteration rate. If [default: None], uses n/elapsed
+    :type rate: float, optional
+    
+    :param bar_format: Specify a custom bar string formatting. May impact performance. [default: '{l_bar}{bar}{r_bar}'], where l_bar='{desc}: {percentage:3.0f}%|' and r_bar='| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, ' '{rate_fmt}{postfix}]' Possible vars: l_bar, bar, r_bar, n, n_fmt, total, total_fmt, percentage, elapsed, elapsed_s, ncols, nrows, desc, unit, rate, rate_fmt, rate_noinv, rate_noinv_fmt, rate_inv, rate_inv_fmt, postfix, unit_divisor, remaining, remaining_s, eta. Note that a trailing ": " is automatically removed after {desc} if the latter is empty
+    :type bar_format: str, optional
+    
+    :param postfix: Similar to prefix, but placed at the end (e.g. for additional stats). Note: postfix is usually a string (not a dict) for this method, and will if possible be set to postfix = ', ' + postfix. However other types are supported (382)
+    :type postfix: *, optional
+    
+    :param unit_divisor: [default: 1000], ignored unless unit_scale is True
+    :type unit_divisor: float, optional
+    
+    :param initial: The initial counter value [default: 0]
+    :type initial: int or float, optional
+    
+    :param colour: Bar colour (valid choices: [hex (#00ff00), BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE)
+    :type colour: str, optional
+    """
+    return tqdm(*args, **kwargs)

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2940,9 +2940,8 @@ def can_update_owner_org(package_dict, user_orgs=None):
 
 @core_helper
 def progressbar(*args, **kwargs):
-    """
-    Customisable progressbar decorator for iterators.
-    
+    '''Customisable progressbar decorator for iterators
+
     This is a wrapper for `tqdm` library.
 
     Usage::
@@ -2951,47 +2950,69 @@ def progressbar(*args, **kwargs):
             mailer.mail_user(...)
             # Do what you need in loop and progressbar will do the rest
 
-
     :param n: Number of finished iterations
     :type n: int or float
 
-    :param total: The expected total number of iterations. If meaningless (None), only basic progress statistics are displayed (no ETA)
+    :param total: The expected total number of iterations.
+        If meaningless (None), only basic progress statistics are
+        displayed (no ETA)
     :type total: int or float
-    
+
     :param elapsed: Number of seconds passed since start
     :type elapsed: float
-    
-    :param ncols: The width of the entire output message. If specified, dynamically resizes {bar} to stay within this bound [default: None]. If 0, will not print any bar (only stats). The fallback is {bar:10}
+
+    :param ncols: The width of the entire output message.
+        If specified, dynamically resizes {bar} to stay within
+        this bound [default: None]. If 0, will not print any bar
+        (only stats). The fallback is {bar:10}
     :type ncols: int, optional
-    
-    :param prefix: Prefix message (included in total width) [default: '']. Use as {desc} in bar_format string
+
+    :param prefix: Prefix message (included in total width) [default: ''].
+        Use as {desc} in bar_format string
     :type prefix: str, optional
-    
-    :param ascii: If not set, use unicode (smooth blocks) to fill the meter [default: False]. The fallback is to use ASCII characters " 123456789#"
+
+    :param ascii: If not set, use unicode (smooth blocks) to fill the meter
+        [default: False]. The fallback is to use ASCII characters " 123456789#"
     :type ascii: bool, optional or str, optional
-    
+
     :param unit: The iteration unit [default: 'it'].
     :type unit: str, optional
-    
-    :param unit_scale: If 1 or True, the number of iterations will be printed with an appropriate SI metric prefix (k = 10^3, M = 10^6, etc.) [default: False]. If any other non-zero number, will scale total and n
+
+    :param unit_scale: If 1 or True, the number of iterations will be printed
+        with an appropriate SI metric prefix (k = 10^3, M = 10^6, etc.)
+        [default: False]. If any other non-zero number, will scale total and n
     :type unit_scale: bool or int or float, optional
-    
-    :param rate: Manual override for iteration rate. If [default: None], uses n/elapsed
+
+    :param rate: Manual override for iteration rate.
+        If [default: None], uses n/elapsed
     :type rate: float, optional
-    
-    :param bar_format: Specify a custom bar string formatting. May impact performance. [default: '{l_bar}{bar}{r_bar}'], where l_bar='{desc}: {percentage:3.0f}%|' and r_bar='| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, ' '{rate_fmt}{postfix}]' Possible vars: l_bar, bar, r_bar, n, n_fmt, total, total_fmt, percentage, elapsed, elapsed_s, ncols, nrows, desc, unit, rate, rate_fmt, rate_noinv, rate_noinv_fmt, rate_inv, rate_inv_fmt, postfix, unit_divisor, remaining, remaining_s, eta. Note that a trailing ": " is automatically removed after {desc} if the latter is empty
+
+    :param bar_format: Specify a custom bar string formatting.
+        May impact performance. [default: '{l_bar}{bar}{r_bar}'], where
+        l_bar='{desc}: {percentage:3.0f}%|' and r_bar='| {n_fmt}/{total_fmt}
+        [{elapsed}<{remaining}, ' '{rate_fmt}{postfix}]' Possible vars:
+        l_bar, bar, r_bar, n, n_fmt, total, total_fmt, percentage, elapsed,
+        elapsed_s, ncols, nrows, desc, unit, rate, rate_fmt, rate_noinv,
+        rate_noinv_fmt, rate_inv, rate_inv_fmt, postfix, unit_divisor,
+        remaining, remaining_s, eta. Note that a trailing ": " is automatically
+        removed after {desc} if the latter is empty
     :type bar_format: str, optional
-    
-    :param postfix: Similar to prefix, but placed at the end (e.g. for additional stats). Note: postfix is usually a string (not a dict) for this method, and will if possible be set to postfix = ', ' + postfix. However other types are supported (382)
-    :type postfix: *, optional
-    
+
+    :param postfix: Similar to prefix, but placed at the end (e.g. for
+        additional stats). Note: postfix is usually a string (not a dict) for
+        this method, and will if possible be set to postfix = ', ' + postfix.
+        However other types are supported (382)
+    :type postfix: any, optional
+
     :param unit_divisor: [default: 1000], ignored unless unit_scale is True
     :type unit_divisor: float, optional
-    
+
     :param initial: The initial counter value [default: 0]
     :type initial: int or float, optional
-    
-    :param colour: Bar colour (valid choices: [hex (#00ff00), BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE)
+
+    :param colour: Bar colour (valid choices: [
+        hex (#00ff00), BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE)
     :type colour: str, optional
-    """
+
+    '''
     return tqdm(*args, **kwargs)

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -14,6 +14,7 @@ from ckan.common import asbool, config
 import ckan.model as model
 import ckan.plugins as p
 import ckan.logic as logic
+import ckan.lib.helpers as h
 
 from ckan.lib.search.common import (
     SearchIndexError, SearchError, SearchQueryError,
@@ -187,14 +188,7 @@ def rebuild(package_id=None, only_missing=False, force=False, defer_commit=False
             if clear:
                 package_index.clear()
 
-        total_packages = len(package_ids)
-        for counter, pkg_id in enumerate(package_ids):
-            if not quiet:
-                sys.stdout.write(
-                    "\rIndexing dataset {0}/{1}".format(
-                        counter +1, total_packages)
-                )
-                sys.stdout.flush()
+        for pkg_id in h.progressbar(package_ids, disable=quiet, desc='Indexing datasets', unit=' package'):
             try:
                 package_index.update_dict(
                     logic.get_action('package_show')(context,

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -148,6 +148,8 @@ class _Toolkit(object):
         import enum
 
         import six
+        from tqdm import tqdm
+
         import ckan
         import ckan.logic as logic
 
@@ -306,6 +308,7 @@ For example: ``bar = toolkit.aslist(config.get('ckan.foo.bar', []))``
 
         t['redirect_to'] = h.redirect_to
         t['url_for'] = h.url_for
+        t['progressbar'] = h.progressbar
         t['get_or_bust'] = logic.get_or_bust
         t['side_effect_free'] = logic.side_effect_free
         t['auth_sysadmins_check'] = logic.auth_sysadmins_check

--- a/requirements.in
+++ b/requirements.in
@@ -29,6 +29,7 @@ rq==1.9.0
 simplejson==3.17.2
 SQLAlchemy==1.3.5
 sqlparse==0.4.1
+tqdm==4.62.1
 tzlocal==2.1
 webassets==2.0
 Werkzeug[watchdog]==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -115,6 +115,8 @@ sqlalchemy==1.3.5
     #   alembic
 sqlparse==0.4.1
     # via -r requirements.in
+tqdm==4.62.1
+    # via -r requirements.in
 tzlocal==2.1
     # via -r requirements.in
 urllib3==1.26.6


### PR DESCRIPTION
Replaces search-index rebuild progressbar with an external module `tqdm`. It has many useful features, including the duration estimate that could be useful dealing with thousands of datasets.


### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
