### PR TITLE
added missed url_type

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -99,6 +99,7 @@ def resource_update(context, data_dict):
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.before_update(context, pkg_dict['resources'][n], data_dict)
 
+    data_dict['url_type'] = resource.url_type
     pkg_dict['resources'][n] = data_dict
 
     try:


### PR DESCRIPTION
Fixes #6404

### Proposed fixes:
I added the missed `url_type` to `data_dict`


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
