### PR TITLE
snippet names rendered in non-debug mode

### DIFF
--- a/changes/6406.bugfix
+++ b/changes/6406.bugfix
@@ -1,0 +1,1 @@
+Snippet names rendered into HTML as comments in non-debug mode.

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -65,7 +65,7 @@ def render_snippet(*template_names, **kw):
     for template_name in template_names:
         try:
             output = render(template_name, extra_vars=kw)
-            if config.get('debug'):
+            if asbool(config.get('debug')):
                 output = (
                     '\n<!-- Snippet %s start -->\n%s\n<!-- Snippet %s end -->'
                     '\n' % (template_name, output, template_name))


### PR DESCRIPTION
Depending on `config["debug"]` option, CKAN adds comments with the name of rendered snippet into HTML. But as `config["debug"]` is used directly, without conversion to `bool`, it works in both, debug and non-debug modes:)