### PR TITLE
[2.9 backport] Add timeout= parameter to all requests.* calls

### DIFF
--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -62,6 +62,10 @@ ckan.datastore.default_fts_index_method = gist
 ckan.site_url =
 #ckan.use_pylons_response_cleanup_middleware = true
 
+# Default timeout for Requests
+#ckan.requests.timeout = 10
+
+
 ## Authorization Settings
 
 ckan.auth.anon_create_dataset = false
@@ -186,6 +190,8 @@ ckan.feeds.author_link =
 #ckan.resource_proxy.max_file_size = 1048576
 # Size of chunks to read/write.
 #ckan.resource_proxy.chunk_size = 4096
+# Default timeout for fetching proxied items
+#ckan.resource_proxy.timeout = 10
 
 ## Activity Streams Settings
 

--- a/ckan/lib/captcha.py
+++ b/ckan/lib/captcha.py
@@ -1,9 +1,10 @@
 # encoding: utf-8
 
-from ckan.common import config
+from ckan.common import config, asint
 
 import requests
 
+TIMEOUT = asint(config.get('ckan.requests.timeout', 10))
 
 def check_recaptcha(request):
     '''Check a user\'s recaptcha submission is valid, and raise CaptchaError
@@ -28,7 +29,7 @@ def check_recaptcha(request):
         remoteip=client_ip_address,
         response=recaptcha_response_field.encode('utf8')
     )
-    response = requests.get(recaptcha_server_name, params)
+    response = requests.get(recaptcha_server_name, params, timeout=TIMEOUT)
     data = response.json()
 
     try:

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -9,7 +9,7 @@ import xml.dom.minidom
 
 import requests
 
-from ckan.common import asbool, config
+from ckan.common import asbool, asint, config
 import ckan.model as model
 import ckan.plugins as p
 import ckan.logic as logic
@@ -27,6 +27,7 @@ from ckan.lib.search.query import (
 
 log = logging.getLogger(__name__)
 
+TIMEOUT = asint(config.get('ckan.requests.timeout', 10))
 
 def text_traceback():
     with warnings.catch_warnings():
@@ -265,9 +266,11 @@ def _get_schema_from_solr(file_offset):
 
     if http_auth:
         response = requests.get(
-            url, headers={'Authorization': http_auth})
+            url,
+            timeout=TIMEOUT,
+            headers={'Authorization': http_auth})
     else:
-        response = requests.get(url)
+        response = requests.get(url, timeout=TIMEOUT)
 
     return response
 

--- a/ckan/model/license.py
+++ b/ckan/model/license.py
@@ -6,7 +6,7 @@ import re
 import requests
 
 from ckan.common import config
-from ckan.common import asbool
+from ckan.common import asbool, asint
 import six
 from six import text_type, string_types
 
@@ -15,6 +15,7 @@ import ckan.lib.maintain as maintain
 
 log = __import__('logging').getLogger(__name__)
 
+TIMEOUT = asint(config.get('ckan.requests.timeout', 10))
 
 class License(object):
     """Domain object for a license."""
@@ -130,7 +131,7 @@ class LicenseRegister(object):
                 with open(license_url.replace('file://', ''), 'r') as f:
                     license_data = json.load(f)
             else:
-                response = requests.get(license_url)
+                response = requests.get(license_url, timeout=TIMEOUT)
                 license_data = response.json()
         except requests.RequestException as e:
             msg = "Couldn't get the licenses file {}: {}".format(license_url, e)

--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -14,13 +14,15 @@ import ckan.lib.helpers as h
 import ckan.lib.navl.dictization_functions
 import ckan.logic as logic
 import ckan.plugins as p
-from ckan.common import config
+from ckan.common import config, asint
 import ckanext.datapusher.logic.schema as dpschema
 import ckanext.datapusher.interfaces as interfaces
 
 log = logging.getLogger(__name__)
 _get_or_bust = logic.get_or_bust
 _validate = ckan.lib.navl.dictization_functions.validate
+
+TIMEOUT = asint(config.get('ckan.requests.timeout', 10))
 
 
 def datapusher_submit(context, data_dict):
@@ -130,6 +132,7 @@ def datapusher_submit(context, data_dict):
             headers={
                 'Content-Type': 'application/json'
             },
+            timeout=TIMEOUT,
             data=json.dumps({
                 'api_key': site_user['apikey'],
                 'job_type': 'push_to_datastore',
@@ -296,8 +299,10 @@ def datapusher_status(context, data_dict):
     if job_id:
         url = urljoin(datapusher_url, 'job' + '/' + job_id)
         try:
-            r = requests.get(url, headers={'Content-Type': 'application/json',
-                                           'Authorization': job_key})
+            r = requests.get(url,
+                             timeout=TIMEOUT,
+                             headers={'Content-Type': 'application/json',
+                                      'Authorization': job_key})
             r.raise_for_status()
             job_detail = r.json()
             for log in job_detail['logs']:

--- a/ckanext/resourceproxy/blueprint.py
+++ b/ckanext/resourceproxy/blueprint.py
@@ -17,6 +17,7 @@ MAX_FILE_SIZE = asint(
     config.get(u'ckan.resource_proxy.max_file_size', 1024**2)
 )
 CHUNK_SIZE = asint(config.get(u'ckan.resource_proxy.chunk_size', 4096))
+TIMEOUT = asint(config.get(u'ckan.resource_proxy.timeout', 10))
 
 resource_proxy = Blueprint(u'resource_proxy', __name__)
 
@@ -45,13 +46,13 @@ def proxy_resource(context, data_dict):
     try:
         # first we try a HEAD request which may not be supported
         did_get = False
-        r = requests.head(url)
+        r = requests.head(url, timeout=TIMEOUT)
         # Servers can refuse HEAD requests. 405 is the appropriate
         # response, but 400 with the invalid method mentioned in the
         # text, or a 403 (forbidden) status is also possible (#2412,
         # #2530)
         if r.status_code in (400, 403, 405):
-            r = requests.get(url, stream=True)
+            r = requests.get(url, timeout=TIMEOUT, stream=True)
             did_get = True
         r.raise_for_status()
 
@@ -65,7 +66,7 @@ def proxy_resource(context, data_dict):
             )
 
         if not did_get:
-            r = requests.get(url, stream=True)
+            r = requests.get(url, timeout=TIMEOUT, stream=True)
 
         response.headers[u'content-type'] = r.headers[u'content-type']
         response.charset = r.encoding

--- a/ckanext/resourceproxy/tests/test_proxy.py
+++ b/ckanext/resourceproxy/tests/test_proxy.py
@@ -70,7 +70,7 @@ class TestProxyPrettyfied(object):
             body=six.ensure_binary(JSON_STRING))
 
         url = self.data_dict['resource']['url']
-        result = requests.get(url)
+        result = requests.get(url, timeout=30)
         assert result.status_code == 200, result.status_code
         assert "yes, I'm proxied" in six.ensure_str(result.content)
 
@@ -83,7 +83,7 @@ class TestProxyPrettyfied(object):
             status=404)
 
         url = self.data_dict['resource']['url']
-        result = requests.get(url)
+        result = requests.get(url, timeout=30)
         assert result.status_code == 404, result.status_code
 
         proxied_url = proxy.get_proxified_resource_url(self.data_dict)
@@ -134,7 +134,7 @@ class TestProxyPrettyfied(object):
 
         def f1():
             url = self.data_dict['resource']['url']
-            requests.get(url)
+            requests.get(url, timeout=30)
 
         with pytest.raises(requests.ConnectionError):
             f1()


### PR DESCRIPTION
### Proposed fixes:

See #6408 

Requests will block forever if the remote server hangs and there's no
timeout.

* Two new config variables:
  - ckan.resource_proxy.timeout -- specifically for resourceproxy
  - ckan.requests.timeout -- for all other uses of requests in the
  code base.
* All timeouts currently defaulting to 10 sec


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes backport for possible bugfix

Please [X] all the boxes above that apply
