### PR TITLE
[2.8 Backport] Add timeout= parameter to all requests.* calls

### DIFF
--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -60,6 +60,10 @@ ckan.datastore.default_fts_index_method = gist
 ckan.site_url =
 #ckan.use_pylons_response_cleanup_middleware = true
 
+# Default timeout for Requests
+#ckan.requests.timeout = 10
+
+
 ## Authorization Settings
 
 ckan.auth.anon_create_dataset = false
@@ -171,6 +175,8 @@ ckan.feeds.author_link =
 #ckan.resource_proxy.max_file_size = 1048576
 # Size of chunks to read/write.
 #ckan.resource_proxy.chunk_size = 4096
+# Default timeout for fetching proxied items
+#ckan.resource_proxy.timeout = 10
 
 ## Activity Streams Settings
 

--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -14,13 +14,15 @@ import ckan.lib.helpers as h
 import ckan.lib.navl.dictization_functions
 import ckan.logic as logic
 import ckan.plugins as p
-from ckan.common import config
+from ckan.common import config, asint
 import ckanext.datapusher.logic.schema as dpschema
 import ckanext.datapusher.interfaces as interfaces
 
 log = logging.getLogger(__name__)
 _get_or_bust = logic.get_or_bust
 _validate = ckan.lib.navl.dictization_functions.validate
+
+TIMEOUT = asint(config.get('ckan.requests.timeout', 10))
 
 
 def datapusher_submit(context, data_dict):
@@ -127,6 +129,7 @@ def datapusher_submit(context, data_dict):
             headers={
                 'Content-Type': 'application/json'
             },
+            timeout=TIMEOUT,
             data=json.dumps({
                 'api_key': user['apikey'],
                 'job_type': 'push_to_datastore',
@@ -291,8 +294,10 @@ def datapusher_status(context, data_dict):
     if job_id:
         url = urlparse.urljoin(datapusher_url, 'job' + '/' + job_id)
         try:
-            r = requests.get(url, headers={'Content-Type': 'application/json',
-                                           'Authorization': job_key})
+            r = requests.get(url,
+                             timeout=TIMEOUT,
+                             headers={'Content-Type': 'application/json',
+                                      'Authorization': job_key})
             r.raise_for_status()
             job_detail = r.json()
             for log in job_detail['logs']:

--- a/ckanext/resourceproxy/tests/test_proxy.py
+++ b/ckanext/resourceproxy/tests/test_proxy.py
@@ -82,7 +82,7 @@ class TestProxyPrettyfied(unittest.TestCase):
             body=JSON_STRING)
 
         url = self.data_dict['resource']['url']
-        result = requests.get(url)
+        result = requests.get(url, timeout=30)
         assert result.status_code == 200, result.status_code
         assert "yes, I'm proxied" in result.content, result.content
 
@@ -95,7 +95,7 @@ class TestProxyPrettyfied(unittest.TestCase):
             status=404)
 
         url = self.data_dict['resource']['url']
-        result = requests.get(url)
+        result = requests.get(url, timeout=30)
         assert result.status_code == 404, result.status_code
 
         proxied_url = proxy.get_proxified_resource_url(self.data_dict)
@@ -145,7 +145,7 @@ class TestProxyPrettyfied(unittest.TestCase):
 
         def f1():
             url = self.data_dict['resource']['url']
-            requests.get(url)
+            requests.get(url, timeout=30)
 
         self.assertRaises(requests.ConnectionError, f1)
 


### PR DESCRIPTION
### Proposed fixes:

See #6408

Requests will block forever if the remote server hangs and there's no
timeout.

* Two new config variables:
  - ckan.resource_proxy.timeout -- specifically for resourceproxy
  - ckan.requests.timeout -- for all other uses of requests in the
  code base.
* All timeouts currently defaulting to 10 sec


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
