### PR TITLE
h.remove_url_param fail with minimal set of params

### DIFF
--- a/changes/6414.bugfix
+++ b/changes/6414.bugfix
@@ -1,0 +1,1 @@
+h.remove_url_param fail with minimal set of params

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1947,16 +1947,25 @@ def follow_count(obj_type, obj_id):
     return logic.get_action(action)(context, {'id': obj_id})
 
 
-def _create_url_with_params(params=None, controller=None, action=None,
-                            extras=None):
-    ''' internal function for building urls with parameters. '''
+def _create_url_with_params(
+    params=None, controller=None, action=None, extras=None
+):
+    """internal function for building urls with parameters."""
+    if extras is None:
+        if not controller and not action:
+            # it's an url for the current page. Let's keep all interlal params,
+            # like <package_type>
+            extras = dict(request.view_args)
+        else:
+            extras = {}
+
+    blueprint, view = p.toolkit.get_endpoint()
     if not controller:
-        controller = getattr(c, 'controller', False) or request.blueprint
+        controller = getattr(g, "controller", blueprint)
     if not action:
-        action = getattr(c, 'action', False) or p.toolkit.get_endpoint()[1]
-    if not extras:
-        extras = {}
-    endpoint = controller + '.' + action
+        action = getattr(g, "action", view)
+
+    endpoint = controller + "." + action
     url = url_for(endpoint, **extras)
     return _url_with_params(url, params)
 

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -522,21 +522,17 @@ For example: ``bar = toolkit.aslist(config.get('ckan.foo.bar', []))``
 
     @classmethod
     def _get_endpoint(cls):
-        """Returns tuple in format: (controller|blueprint, action|view).
-        """
-        import ckan.common as common
-        try:
-            # CKAN >= 2.8
-            endpoint = tuple(common.request.endpoint.split('.'))
-        except AttributeError:
-            try:
-                return common.c.controller, common.c.action
-            except AttributeError:
-                return (None, None)
+        """Returns tuple in format: (blueprint, view)."""
+        from ckan.common import request
+
+        if not request:
+            return None, None
+
+        blueprint, *rest = tuple(request.endpoint.split(".", 1))
         # service routes, like `static`
-        if len(endpoint) == 1:
-            return endpoint + ('index', )
-        return endpoint
+        if not rest:
+            rest = ("index",)
+        return blueprint, rest[0]
 
     def __getattr__(self, name):
         ''' return the function/object requested '''

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -528,11 +528,10 @@ For example: ``bar = toolkit.aslist(config.get('ckan.foo.bar', []))``
         if not request:
             return None, None
 
-        blueprint, *rest = tuple(request.endpoint.split(".", 1))
+        blueprint, *rest = request.endpoint.split(".", 1)
         # service routes, like `static`
-        if not rest:
-            rest = ("index",)
-        return blueprint, rest[0]
+        view = rest[0] if rest else "index"
+        return blueprint, view
 
     def __getattr__(self, name):
         ''' return the function/object requested '''

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -743,8 +743,15 @@ class TestActivityListSelect(object):
         assert str(html).startswith(u'<option value="&#34;&gt;" >')
 
 
-class TestAddUrlParam(object):
+class TestRemoveUrlParam:
+    def test_current_url(self, test_request_context):
+        base = "/organization/name"
+        with test_request_context(base + "?q=search"):
+            assert h.remove_url_param("q") == base
+            assert h.remove_url_param("q", replace="test") == base + "?q=test"
 
+
+class TestAddUrlParam(object):
     @pytest.mark.parametrize(u'url,params,expected', [
         (u'/dataset', {u'a': u'2'}, u'/dataset/?a=2'),
         (u'/dataset?a=1', {u'a': u'2'}, u'/dataset/?a=1&a=2'),

--- a/ckan/tests/plugins/test_toolkit.py
+++ b/ckan/tests/plugins/test_toolkit.py
@@ -107,3 +107,14 @@ def test_tk_helper_as_item_missing_helper():
     """Directly attempt access as item"""
     with pytest.raises(tk.HelperError):
         tk.h[u"nothere"]()
+
+
+def test_get_endpoint_without_context():
+    """Do not fail in CLI and tests."""
+    assert tk.get_endpoint() == (None, None)
+
+
+@pytest.mark.usefixtures("with_request_context")
+def test_get_endpoint_witho_context():
+    """with_request_context fixture mocks request to the homepage."""
+    assert tk.get_endpoint() == ("home", "index")


### PR DESCRIPTION
`h.remove_url_param` with the minimal set of parameters: 
```
h.remove_url_param("q")
```
will throw an error on the `organization.read` page(not only here). Because internally it gets current blueprint and view (`g.controller` and `g.action`) and tries to build the URL `h.url_for(blueprint + "." + view)`. And as long as the given blueprint requires extra arguments (`package_type` for dataset pages, `group_type`/`is_organization` for group pages, `id` for organization.read page, etc), this will fail. User has to do something like
```
h.remove_url_param("q", extras={"is_organization": group_dict.type, id=group_dict.id, "group_type": group_dict.type})
```

While it is perfectly ok from the clarity point of view, it requires every developer to know CKAN internals and these extra parameters. And it makes the given helper too fragile. In addition, the `extras` parameter is optional, so there may be some expectations, like 
**whenever I'm using `h.remove_url_param("q")` in the simplest form, I expect `q` to be removed from the CURRENT URL, whatever it is**

This PR takes all the extra parameters required to build the current URL and adds them **only when neither `controller` nor `action` nor `extras` argument is present**. I.e, only when the user trying to modify the current URL.

PS. And it also updates `toolkit.get_endpoint`. Now it won't raise RuntimeError in CLI. Instead, its returns `None, None`, which is quite safe, I think.
