### PR TITLE
Fix underscore error for datastore field names

### DIFF
--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -40,16 +40,17 @@ def _fix_bad_field_names(data_dict, prefix):
             new_fields.append(field)
         data_dict['fields'] = new_fields
 
-        new_records = []
-        for record in data_dict.get('records'):
-            new_record = {}
-            for field, value in record.items():
-                if field.startswith('_'):
-                    new_record['{}{}'.format(prefix, field)] = value
-                else:
-                    new_record[field] = record[field]
-            new_records.append(new_record)
-        data_dict['records'] = new_records
+        if data_dict.get('records'):
+            new_records = []
+            for record in data_dict.get('records'):
+                new_record = {}
+                for field, value in record.items():
+                    if field.startswith('_'):
+                        new_record['{}{}'.format(prefix, field)] = value
+                    else:
+                        new_record[field] = record[field]
+                new_records.append(new_record)
+            data_dict['records'] = new_records
 
     return data_dict
 

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -26,6 +26,34 @@ _validate = ckan.lib.navl.dictization_functions.validate
 WHITELISTED_RESOURCES = ['_table_metadata']
 
 
+def _fix_bad_field_names(data_dict, prefix):
+    """ fix bad fields names.
+        Datastore do not allow "_" before field names
+        """
+    if data_dict.get('fields'):
+        new_fields = []
+        for field in data_dict.get('fields'):
+            if field['id'].startswith('_'):
+                new_field_name = '{}{}'.format(prefix, field['id'])
+                log.warn('Datastore field name starts with _: %s, replaced as %s', field['id'], new_field_name)
+                field['id'] = new_field_name
+            new_fields.append(field)
+        data_dict['fields'] = new_fields
+
+        new_records = []
+        for record in data_dict.get('records'):
+            new_record = {}
+            for field, value in record.items():
+                if field.startswith('_'):
+                    new_record['{}{}'.format(prefix, field)] = value
+                else:
+                    new_record[field] = record[field]
+            new_records.append(new_record)
+        data_dict['records'] = new_records
+
+    return data_dict
+
+
 def datastore_create(context, data_dict):
     '''Adds a new table to the DataStore.
 
@@ -92,6 +120,8 @@ def datastore_create(context, data_dict):
     '''
     backend = DatastoreBackend.get_active_backend()
     schema = context.get('schema', dsschema.datastore_create_schema())
+
+    data_dict = _fix_bad_field_names(data_dict, prefix=p.toolkit.config.get("ckanext.datastore.field_prefix", "dstore"))
     records = data_dict.pop('records', None)
     resource = data_dict.pop('resource', None)
     data_dict, errors = _validate(data_dict, schema, context)

--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -68,6 +68,21 @@ class TestDatastoreCreateNewTests(object):
 
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    def test_underescored_field_name(self):
+        package = factories.Dataset()
+        data = {
+            "resource": {"package_id": package["id"]},
+            "fields": [
+                {"id": "_id", "type": "text"},
+                {"id": "movie", "type": "text"},
+            ],
+            "records": [{"movie": "sideways", "_id": "99"}],
+        }
+        result = helpers.call_action("datastore_create", **data)
+        assert result["resource_id"] is not None
+
+    @pytest.mark.ckan_config("ckan.plugins", "datastore")
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_create_works_with_empty_object_in_json_field(self):
         package = factories.Dataset()
         data = {

--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -510,7 +510,6 @@ class TestDatastoreCreate(object):
         resource = model.Package.get("annakarenina").resources[0]
         auth = {"Authorization": self.sysadmin_token}
         invalid_names = [
-            "_author",
             '"author',
             "",
             " author",


### PR DESCRIPTION
Fixes [UNHCR#698](https://github.com/okfn/ckanext-unhcr/issues/698)

### Proposed fixes:
Datastore do not allow field names starting with "_". This PR propose to add a prefix (from `p.toolkit.config.get("ckanext.datastore.field_prefix", "dstore")`)

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [x] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
