### PR TITLE
Documentation - i18n directory permissions

### DIFF
--- a/doc/maintaining/installing/install-from-package.rst
+++ b/doc/maintaining/installing/install-from-package.rst
@@ -196,3 +196,12 @@ your CKAN site.
     You should check the :doc:`/maintaining/authorization` documentation, configure CKAN accordingly
     and grant other users the relevant permissions using the :ref:`sysadmin account <create-admin-user>`.
 
+.. note::
+
+   There may be a ``PermissionError: [Errno 13] Permission denied:`` message when restarting supervisor or 
+   accessing CKAN via a browser for the first time. This happens when a different user is used to execute 
+   the web server than the user who installed CKAN and the support software. A workaround would be to 
+   open up the permissions on the ``/path/to/ckan/lib/default/src/ckan/ckan/public/base/i18n/`` directory 
+   to be world-readable ie: ``chmod 777 /path/to/ckan/lib/default/src/ckan/ckan/public/base/i18n/`` 
+   before starting/accessing CKAN. Once all the .js files have been generated in this directory the 
+   permissions could be changed back to what they were previously.

--- a/doc/maintaining/installing/install-from-package.rst
+++ b/doc/maintaining/installing/install-from-package.rst
@@ -200,8 +200,7 @@ your CKAN site.
 
    There may be a ``PermissionError: [Errno 13] Permission denied:`` message when restarting supervisor or 
    accessing CKAN via a browser for the first time. This happens when a different user is used to execute 
-   the web server than the user who installed CKAN and the support software. A workaround would be to 
+   the web server process than the user who installed CKAN and the support software. A workaround would be to 
    open up the permissions on the ``/path/to/ckan/lib/default/src/ckan/ckan/public/base/i18n/`` directory 
-   to be world-readable ie: ``chmod 777 /path/to/ckan/lib/default/src/ckan/ckan/public/base/i18n/`` 
-   before starting/accessing CKAN. Once all the .js files have been generated in this directory the 
-   permissions could be changed back to what they were previously.
+   so that this user could write the .js files into it. Accessing CKAN will generate these files for a new 
+   install, or you could run ``ckan -c /path/to/ckan.ini translation js`` to explicitly generate them.

--- a/doc/maintaining/installing/install-from-package.rst
+++ b/doc/maintaining/installing/install-from-package.rst
@@ -201,6 +201,6 @@ your CKAN site.
    There may be a ``PermissionError: [Errno 13] Permission denied:`` message when restarting supervisor or 
    accessing CKAN via a browser for the first time. This happens when a different user is used to execute 
    the web server process than the user who installed CKAN and the support software. A workaround would be to 
-   open up the permissions on the ``/path/to/ckan/lib/default/src/ckan/ckan/public/base/i18n/`` directory 
+   open up the permissions on the ``/usr/lib/ckan/default/src/ckan/ckan/public/base/i18n/`` directory 
    so that this user could write the .js files into it. Accessing CKAN will generate these files for a new 
-   install, or you could run ``ckan -c /path/to/ckan.ini translation js`` to explicitly generate them.
+   install, or you could run ``ckan -c /etc/ckan/default/ckan.ini translation js`` to explicitly generate them.


### PR DESCRIPTION
Fixes https://github.com/ckan/ckan/issues/6347

### Proposed fixes:
Added a note to the Install CKAN (via the package method) documentation describing a "**workaround**" to an issue with using 2 different users to _install_ CKAN and _run_ CKAN.

There is also a Rockstar ticket : https://github.com/ckan/ckan/issues/6278 that describes this issue


### Features:

- [ ] includes tests covering changes
- [ x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
