### PR TITLE
Docker - Redis version pinned to 6.2

### DIFF
--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -76,4 +76,4 @@ services:
 
   redis:
     container_name: redis
-    image: redis:latest
+    image: redis:6.2


### PR DESCRIPTION
Fixes https://github.com/ckan/ckan/issues/6418

### Proposed fixes:
The Redis image specified in the `docker-compose.yml` file is currently: `redis:latest`. Best practice for specifying Docker images is to be more granular than that. After some discussion within https://github.com/ckan/ckan/issues/6418, it was decided to use version 6.2 of the Redis image in DockerHub as this pins the version down to be more specific.



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
