### PR TITLE
Docker - remove ARG: lines from docker-compose.yml

### DIFF
--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -14,8 +14,6 @@ services:
     container_name: ckan
     build:
       context: ../../
-      args:
-          - CKAN_SITE_URL=${CKAN_SITE_URL}
     links:
       - db
       - solr
@@ -52,10 +50,7 @@ services:
     container_name: db
     build:
       context: ../../
-      dockerfile: contrib/docker/postgresql/Dockerfile
-      args:
-        - DS_RO_PASS=${DATASTORE_READONLY_PASSWORD}
-        - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      dockerfile: contrib/docker/postgresql/Dockerfile  
     environment:
       - DS_RO_PASS=${DATASTORE_READONLY_PASSWORD}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}


### PR DESCRIPTION
Fixes https://github.com/ckan/ckan/issues/6419

### Proposed fixes:
The following docker-compose-yml file args: lines can be removed:
`- CKAN_SITE_URL=${CKAN_SITE_URL}`
`- DS_RO_PASS=${DATASTORE_READONLY_PASSWORD}`
`- POSTGRES_PASSWORD=${POSTGRES_PASSWORD}`

These ARG’s are not assigned **directly** to environment variables (which are subsequently used during the deployment of the containers). They seem to be passed through during the image build but not used. 


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
