### PR TITLE
Update Links in About Snippet

### DIFF
--- a/ckan/templates/home/snippets/about_text.html
+++ b/ckan/templates/home/snippets/about_text.html
@@ -9,12 +9,12 @@ companies and organizations) wanting to make their data open and available.</p>
 
 <p>CKAN is used by governments and user groups worldwide and powers a variety
 of official and community data portals including portals for local, national
-and international government, such as the UK’s <a href="http://data.gov.uk">data.gov.uk</a> and the
-European Union’s <a href="http://publicdata.eu/">publicdata.eu</a>, the Brazilian <a href="http://dados.gov.br/">dados.gov.br</a>, Dutch and
+and international government, such as the UK’s <a href="https://data.gov.uk">data.gov.uk</a> and the
+European Union’s <a href="https://data.europa.eu/">data.europa.eu</a>, the Brazilian <a href="https://dados.gov.br/">dados.gov.br</a>, Dutch and
 Netherland government portals, as well as city and municipal sites in the US,
 UK, Argentina, Finland and elsewhere.</p>
 
-<p>CKAN: <a href="http://ckan.org/">http://ckan.org/</a><br />
-CKAN Tour: <a href="http://ckan.org/tour/">http://ckan.org/tour/</a><br />
-Features overview: <a href="http://ckan.org/features/">http://ckan.org/features/</a></p>
+<p>CKAN: <a href="https://ckan.org/">https://ckan.org/</a><br />
+CKAN Showcases: <a href="https://ckan.org/showcase">https://ckan.org/showcase</a><br />
+Features overview: <a href="https://ckan.org/features/">https://ckan.org/features/</a></p>
 {% endtrans %}


### PR DESCRIPTION
Fixes:
I noticed that in the default about page snippet, CKAN refers to sites which do not exist anymore.
Therefore I fixed it without creating an issue.

### Proposed fixes:
Changes link of EU data partal, replaces CKAN tour with CKAN showcases and adds https to urls.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
