### PR TITLE
Use bullseye and python 3.8 in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ defaults:
 jobs:
   test-python-3:
     docker:
-      - image: python:3.8-bullseye
+      - image: python:3.7-bullseye
         <<: *ckan_env
       - <<: *pg_image
       - <<: *redis_image


### PR DESCRIPTION
### Proposed fixes:
Let's encrypt had one root certificate expired https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/ which results in failing installation of nodejs. As circle ci used debian stretch which had EoL in 2020, it does not update the certificates. This PR replaces the image with debian bullseye and locks python to 3.8 as ckan does not work on 3.10. Tests themselves fail for now as it has problems in master.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
