### PR TITLE
Remove unnecesary hack

### DIFF
--- a/ckan/lib/dictization/__init__.py
+++ b/ckan/lib/dictization/__init__.py
@@ -61,11 +61,6 @@ def table_dictize(obj, context, **kw):
 
     result_dict.update(kw)
 
-    ##HACK For optimisation to get metadata_modified created faster.
-
-    context['metadata_modified'] = max(result_dict.get('revision_timestamp', ''),
-                                       context.get('metadata_modified', ''))
-
     return result_dict
 
 


### PR DESCRIPTION
This hack doesn't make any sense since nowhere in the code we are using the value stored in `context['metadata_modified']`.