### PR TITLE
Allow children for select2

### DIFF
--- a/ckan/public/base/javascript/client.js
+++ b/ckan/public/base/javascript/client.js
@@ -172,18 +172,37 @@
         var key = typeof options.key != 'undefined' ? item[options.key] : false;
         var label = typeof options.label != 'undefined' ? item[options.label] : false;
 
+        let children = item.children;
         item = typeof item === 'string' ? item : item.name || item.Name || item.Format || '';
         item = jQuery.trim(item);
 
         key = key ? key : item;
         label = label ? label : item;
 
+        /* Having the "ID" mark an element as selectable
+           Group labels should not be selectable
+           Children should include its own IDs and TEXTs
+        */
+        let ret = {text: label};
+        if (children !== null) {
+          // This is a group. Children need ID and TEXT
+          // "key" and "label" should be defined
+          for (i = 0, l = children.length; i < l; i = i + 1) {
+            children[i].id = children[i][options.key];
+            children[i].text = children[i][options.label];
+          }
+          ret.children = children;
+        } else {
+          // This is a regular element without children
+          ret.id = key;
+        }
+
         var lowercased = item.toLowerCase();
         var returnObject = options && options.objects === true;
 
         if (lowercased && !map[lowercased]) {
           map[lowercased] = 1;
-          return returnObject ? {id: key, text: label} : item;
+          return returnObject ? ret : item;
         }
 
         return null;

--- a/ckan/public/base/javascript/client.js
+++ b/ckan/public/base/javascript/client.js
@@ -184,7 +184,10 @@
            Children should include its own IDs and TEXTs
         */
         let ret = {text: label};
-        if (children !== null) {
+        if (children === undefined) {
+          // This is a regular element without children
+          ret.id = key;
+        } else {
           // This is a group. Children need ID and TEXT
           // "key" and "label" should be defined
           for (i = 0, l = children.length; i < l; i = i + 1) {
@@ -192,9 +195,6 @@
             children[i].text = children[i][options.label];
           }
           ret.children = children;
-        } else {
-          // This is a regular element without children
-          ret.id = key;
         }
 
         var lowercased = item.toLowerCase();


### PR DESCRIPTION
### Proposed fixes:
Allow using [grouped data](https://select2.org/data-sources/formats#grouped-data) from `select2`.

This PR add the ability to detect if an autocomplete endpoint include _children_ elements and shows them.
Using the feature:

![image](https://user-images.githubusercontent.com/3237309/139111992-de9073cf-f226-4123-80e3-798878c7df1c.png)

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport
