### PR TITLE
FIx issues references in CHANGELOG.rst

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -493,7 +493,7 @@ Fixes:
 * Fix tracking.js module preventing links to be opened in new tabs (`#6386 <https://github.com/ckan/ckan/pull/6384>`_)
 * Fix deleted org/group feeds (`#6368 <https://github.com/ckan/ckan/pull/6368>`_)
 * Fix runaway preview height (`#6284 <https://github.com/ckan/ckan/pull/6283>`_)
-* Fix unreliable ordering of DataStore results (`#2318 <https://github.com/ckan/ckan/pull/2317>`_)
+* Fix unreliable ordering of DataStore results (`#2317 <https://github.com/ckan/ckan/pull/2317>`_)
 
 
 v.2.8.8 2021-05-19
@@ -831,10 +831,10 @@ v.2.7.12 2021-09-22
 
 Fixes:
 
-* Fix tracking.js module preventing links to be opened in new tabs (`#6384 <https://github.com/ckan/ckan/pull/6088>`_)
-* Fix deleted org/group feeds (`#6367 <https://github.com/ckan/ckan/pull/6088>`_)
-* Fix runaway preview height (`#6283 <https://github.com/ckan/ckan/pull/6088>`_)
-* Fix unreliable ordering of DataStore results (`#2317 <https://github.com/ckan/ckan/pull/6088>`_)
+* Fix tracking.js module preventing links to be opened in new tabs (`#6384 <https://github.com/ckan/ckan/pull/6384>`_)
+* Fix deleted org/group feeds (`#6367 <https://github.com/ckan/ckan/pull/6367>`_)
+* Fix runaway preview height (`#6283 <https://github.com/ckan/ckan/pull/6283>`_)
+* Fix unreliable ordering of DataStore results (`#2317 <https://github.com/ckan/ckan/pull/2317>`_)
 
 v.2.7.11 2021-05-19
 ===================


### PR DESCRIPTION
This PR is an attempt to fix the following error when building the docs:
```
1 test failed  out of 2690

    test_building_the_docs - ckan.tests.test_coding_standards

AssertionError: Don't add any new warnings to the Sphinx build: [b'/root/project/doc/changelog.rst:827: WARNING: Bullet list ends without a blank line; unexpected unindent.', b'/root/project/doc/changelog.rst:8: WARNING: Duplicate explicit target name: "#2317".']
assert False
def test_building_the_docs():
        u"""There should be no warnings or errors when building the Sphinx docs.
    
        This test will also fail is build_sphinx exits with non-zero status.
    
        """
        try:
            output = subprocess.check_output(
                [b"python", b"setup.py", b"build_sphinx"], stderr=subprocess.STDOUT
            )
        except subprocess.CalledProcessError as err:
            assert (
                False
            ), u"Building the docs failed with return code: {code}".format(
                code=err.returncode
            )
        output_lines = output.split(six.b(u"\n"))
    
        errors = [line for line in output_lines if six.b(u"ERROR") in line]
        if errors:
            assert False, (
                u"Don't add any errors to the Sphinx build: "
                u"{errors}".format(errors=errors)
            )
    
        warnings = [line for line in output_lines if six.b(u"WARNING") in line]
    
        # Some warnings have been around for a long time and aren't easy to fix.
        # These are allowed, but no more should be added.
        allowed_warnings = [
            u"WARNING: duplicate label ckan.auth.create_user_via_web",
            u"WARNING: duplicate label ckan.auth.create_unowned_dataset",
            u"WARNING: duplicate label ckan.auth.user_create_groups",
            u"WARNING: duplicate label ckan.auth.anon_create_dataset",
            u"WARNING: duplicate label ckan.auth.user_delete_organizations",
            u"WARNING: duplicate label ckan.auth.create_user_via_api",
            u"WARNING: duplicate label ckan.auth.create_dataset_if_not_in_organization",
            u"WARNING: duplicate label ckan.auth.user_delete_groups",
            u"WARNING: duplicate label ckan.auth.user_create_organizations",
            u"WARNING: duplicate label ckan.auth.roles_that_cascade_to_sub_groups",
            u"WARNING: duplicate label ckan.auth.public_user_details",
            u"WARNING: duplicate label ckan.auth.public_activity_stream_detail",
            u"WARNING: duplicate label ckan.auth.allow_dataset_collaborators",
            u"WARNING: duplicate label ckan.auth.allow_admin_collaborators",
            u"WARNING: duplicate label ckan.auth.allow_collaborators_to_change_owner_org",
            u"WARNING: duplicate label ckan.auth.create_default_api_keys",
        ]
    
        # Remove the allowed warnings from the list of collected warnings.
        # Be sure to only remove one warning for each allowed warning.
        warnings_to_remove = []
        for allowed_warning in allowed_warnings:
            for warning in warnings:
                if six.b(allowed_warning) in warning:
                    warnings_to_remove.append(warning)
                    break
        new_warnings = [
            warning for warning in warnings if warning not in warnings_to_remove
        ]
    
        if new_warnings:
>           assert False, (
                u"Don't add any new warnings to the Sphinx build: "
                u"{warnings}".format(warnings=new_warnings)
            )
E           AssertionError: Don't add any new warnings to the Sphinx build: [b'/root/project/doc/changelog.rst:827: WARNING: Bullet list ends without a blank line; unexpected unindent.', b'/root/project/doc/changelog.rst:8: WARNING: Duplicate explicit target name: "#2317".']
E           assert False

ckan/tests/test_coding_standards.py:291: AssertionError
```