### PR TITLE
Support for pdb and debuggers

### DIFF
--- a/ckan/cli/server.py
+++ b/ckan/cli/server.py
@@ -54,6 +54,12 @@ def run(ctx: click.Context, host: str, port: str, disable_reloader: bool,
     if config.get_value("debug"):
         warnings.filterwarnings("default", category=CkanDeprecationWarning)
 
+    # passthrough_errors overrides conflicting options
+    if passthrough_errors:
+        disable_reloader = False
+        threaded = False
+        processes = 1
+
     # Reloading
     use_reloader = not disable_reloader
     config_extra_files = config.get_value(u"ckan.devserver.watch_patterns")

--- a/ckan/cli/server.py
+++ b/ckan/cli/server.py
@@ -23,6 +23,8 @@ DEFAULT_PORT = 5000
 @click.option(u"-p", u"--port", help=u"Port number")
 @click.option(u"-r", u"--disable-reloader", is_flag=True,
               help=u"Disable reloader")
+@click.option(u"-E", u"--passthrough-errors", is_flag=True,
+              help=u"Disable error caching (useful to hook debuggers)")
 @click.option(
     u"-t", u"--threaded", is_flag=True,
     help=u"Handle each request in a separate thread"
@@ -45,8 +47,8 @@ DEFAULT_PORT = 5000
     " automatically generate a new one (on each server reload).")
 @click.pass_context
 def run(ctx: click.Context, host: str, port: str, disable_reloader: bool,
-        threaded: bool, extra_files: list[str], processes: int,
-        ssl_cert: Optional[str], ssl_key: Optional[str]):
+        passthrough_errors: bool, threaded: bool, extra_files: list[str],
+        processes: int, ssl_cert: Optional[str], ssl_key: Optional[str]):
     u"""Runs the Werkzeug development server"""
 
     if config.get_value("debug"):
@@ -99,4 +101,5 @@ def run(ctx: click.Context, host: str, port: str, disable_reloader: bool,
         processes=processes,
         extra_files=extra_files,
         ssl_context=ssl_context,
+        passthrough_errors=passthrough_errors,
     )

--- a/ckan/cli/server.py
+++ b/ckan/cli/server.py
@@ -56,7 +56,7 @@ def run(ctx: click.Context, host: str, port: str, disable_reloader: bool,
 
     # passthrough_errors overrides conflicting options
     if passthrough_errors:
-        disable_reloader = False
+        disable_reloader = True
         threaded = False
         processes = 1
 

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - POSTGRES_HOST=${POSTGRES_HOST}
     restart: unless-stopped
     # Debug with pdb (example) - Interact with `docker attach $(docker container ls -qf name=ckan)`
-    #command: "python -m pdb /usr/lib/ckan/venv/bin/ckan --config /etc/ckan/production.ini run --passthrough-errors"
+    #command: 'python -m pdb /usr/lib/ckan/venv/bin/ckan --config /etc/ckan/production.ini run --host 0.0.0.0 --passthrough-errors'
     #tty: true
     #stdin_open: true
 

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -36,6 +36,10 @@ services:
       - DS_RO_PASS=${DATASTORE_READONLY_PASSWORD}
       - POSTGRES_HOST=${POSTGRES_HOST}
     restart: unless-stopped
+    # Debug with pdb (example) - Interact with `docker attach $(docker container ls -qf name=ckan)`
+    #command: "python -m pdb /usr/lib/ckan/venv/bin/ckan --config /etc/ckan/production.ini run --passthrough-errors"
+    #tty: true
+    #stdin_open: true
 
     volumes:
       - ckan_config:/etc/ckan

--- a/doc/maintaining/cli.rst
+++ b/doc/maintaining/cli.rst
@@ -484,7 +484,22 @@ Usage
  ckan run --host (-h)                  - Set Host
  ckan run --port (-p)                  - Set Port
  ckan run --disable-reloader (-r)      - Use reloader
+ ckan run --passthrough_errors         - Crash instead of handling fatal errors
 
+Use ``--passthrough-errors`` to enable pdb
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Exceptions are caught and handled by CKAN. Sometimes, user needs to disable
+this error handling, to be able to use ``pdb`` or the debug capabilities of the
+most common IDE. This allows to use breakpoints, inspect the stack frames and
+evaluate arbitrary Python code.
+Running CKAN with ``--passthrough-errors`` will automatically disable CKAN
+reload capabilities and run everything in a single process, for the sake of
+simplicity.
+
+Example:
+
+ python -m pdb ckan run --passthrough-errors
 
 
 search-index: Search index commands


### PR DESCRIPTION
### Proposed fixes:

It is now possible to debug ckan with pdb/ipdb/PyCharm debugger and others, both outside Docker and inside Docker.
I just exposed a `werkzeug` option to the CKAN CLI, called `passthrough_errors`. Enabling that, together with `--disable-reloader` (which should be the default in my opinion, like it was in the past), allow to run pdb without making other changes to the source code.
`threads` should not be enabled and `processes` should be set to 1. These are the defaults already.

> passthrough_errors (bool) – set this to True to disable the error catching. This means that the server will die on errors but it can be useful to hook debuggers in (pdb etc.)
-- https://werkzeug.palletsprojects.com/en/2.0.x/serving/

Example:
```
$ cd contrib/docker
$ docker-compose up --build -d
$ # wait...
$ docker-compose exec ckan bash
root@f6a71d0b7686:/# python3 -m pdb /usr/lib/ckan/venv/bin/ckan -c /etc/ckan/production.ini run --host 0.0.0.0 -E --disable-reloader
> /usr/lib/ckan/venv/bin/ckan(3)<module>()
-> import re
(Pdb) b ckan/views/api.py:215
Breakpoint 1 at /usr/lib/ckan/venv/src/ckan/ckan/views/api.py:215
(Pdb) c
2021-11-01 17:00:50,832 INFO  [ckan.cli] Using configuration file /etc/ckan/production.ini
2021-11-01 17:00:50,832 INFO  [ckan.config.environment] Loading static files from public
2021-11-01 17:00:50,954 INFO  [ckan.config.environment] Loading templates from /usr/lib/ckan/venv/src/ckan/ckan/templates
2021-11-01 17:00:51,552 INFO  [ckan.config.environment] Loading templates from /usr/lib/ckan/venv/src/ckan/ckan/templates
2021-11-01 17:00:52,173 INFO  [ckan.cli.server] Running CKAN on http://0.0.0.0:5000
2021-11-01 17:00:52,174 WARNI [werkzeug]  * Running on all addresses.
   WARNING: This is a development server. Do not use it in a production deployment.
```

...then `http://localhost:5000/api/3/action/package_search` can be opened in the web browser to trigger the breakpoint:

```
> /usr/lib/ckan/venv/src/ckan/ckan/views/api.py(215)action()
-> try:
(Pdb)
```

### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport