### PR TITLE
Use anonymous references in changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,7 +45,7 @@ Bugfixes
 - Fix deleted org/group feeds (`#6368 <https://github.com/ckan/ckan/pull/6368>`_)
 - Fix runaway preview height (`#6284 <https://github.com/ckan/ckan/pull/6283>`_)
 - Stable default ordering when consuming resource content from datastore
-  (`#2317 <https://github.com/ckan/ckan/pull/2317>`_)
+  (`#2317 <https://github.com/ckan/ckan/pull/2317>`__)
 - Several documentation fixes and improvements
 
 v.2.9.3 2021-05-19
@@ -824,7 +824,7 @@ Changes and deprecations:
    This change is aimed to reduce usage of global variables in context. For a while, it has default value
    of None, in which case, `c.search_facets` will be used. But all template designers are strongly advised
    to specify this argument explicitly, as in future it'll become required.
-  * The ``ckan.recaptcha.version`` config option is now removed, since v2 is the only valid version now (#4061)
+ * The ``ckan.recaptcha.version`` config option is now removed, since v2 is the only valid version now (#4061)
 
 v.2.7.12 2021-09-22
 ===================
@@ -834,7 +834,7 @@ Fixes:
 * Fix tracking.js module preventing links to be opened in new tabs (`#6384 <https://github.com/ckan/ckan/pull/6088>`_)
 * Fix deleted org/group feeds (`#6367 <https://github.com/ckan/ckan/pull/6088>`_)
 * Fix runaway preview height (`#6283 <https://github.com/ckan/ckan/pull/6088>`_)
-* Fix unreliable ordering of DataStore results (`#2317 <https://github.com/ckan/ckan/pull/6088>`_)
+* Fix unreliable ordering of DataStore results (`#2317 <https://github.com/ckan/ckan/pull/6088>`__)
 
 v.2.7.11 2021-05-19
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,7 +45,7 @@ Bugfixes
 - Fix deleted org/group feeds (`#6368 <https://github.com/ckan/ckan/pull/6368>`_)
 - Fix runaway preview height (`#6284 <https://github.com/ckan/ckan/pull/6283>`_)
 - Stable default ordering when consuming resource content from datastore
-  (`#2317 <https://github.com/ckan/ckan/pull/2317>`__)
+  (`#2317 <https://github.com/ckan/ckan/pull/2317>`_)
 - Several documentation fixes and improvements
 
 v.2.9.3 2021-05-19

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ directory = "changes"
 package = "ckan"
 filename = "CHANGELOG.rst"
 title_format = "v.{version} {project_date}"
-issue_format = "`#{issue} <https://github.com/ckan/ckan/pull/{issue}>`_"
+issue_format = "`#{issue} <https://github.com/ckan/ckan/pull/{issue}>`__"
 wrap = true
 
 [[tool.towncrier.type]]


### PR DESCRIPTION
The changelog contains links to the corresponding GitHub issues/PRs.

Sometimes it happens that the same fix was backported to a number of CKAN patch releases. In this case, we have multiple links of form `#ID <link>_`. 
From the RST point of view, it's an incorrect markdown, because `_`(single underscore) denotes **named** reference, which must be unique. And in that way, Sphinx reports build warnings and tests are not passing anymore.
This can be fixed by using anonymous references - `__`(double underscore)