### PR TITLE
[6471] Resources Activities

### DIFF
--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -649,14 +649,27 @@ def vocabulary_list_dictize(vocabulary_list, context):
 
 def activity_dictize(activity, context, include_data=False):
     activity_dict = d.table_dictize(activity, context)
+
     if not include_data:
+        if 'resource' in activity_dict['activity_type']:
+            import ckan.model as model
+            for key, value in activity_dict['data'].items():
+                if isinstance(value, dict) and 'name' and 'package_id' in value:
+                    activity_dict['data'] = {key: {
+                        'name': value['name'], 'package_id': value['package_id']
+                    }}
+            if 'package' in activity_dict['data']:
+                pkg_id = activity_dict['data']['package']['package_id']
+                pkg_obj = model.Package.get(pkg_id)
+                activity_dict['data']['package']['title'] = pkg_obj.title or pkg_obj.name
         # replace the data with just a {'title': title} and not the rest of
         # the dataset/group/org/custom obj. we need the title to display it
         # in the activity stream.
-        activity_dict['data'] = {
-            key: {'title': val['title']}
-            for (key, val) in activity_dict['data'].items()
-            if isinstance(val, dict) and 'title' in val}
+        else:
+            activity_dict['data'] = {
+                key: {'title': val['title']}
+                for (key, val) in activity_dict['data'].items()
+                if isinstance(val, dict) and 'title' in val}
     return activity_dict
 
 

--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -47,9 +47,11 @@ def resource_dict_save(res_dict, context):
 
     if changed or obj.extras != skipped:
         obj.metadata_modified = datetime.datetime.utcnow()
-    obj.state = u'active'
-    obj.extras = skipped
 
+    if not obj.state == 'deleted':
+        obj.state = u'active'
+
+    obj.extras = skipped
     session.add(obj)
     return obj
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2138,6 +2138,7 @@ def dashboard_activity_stream(user_id, filter_type=None, filter_id=None,
     if filter_type:
         action_functions = {
             'dataset': 'package_activity_list',
+            'resource': 'resource_activity_list',
             'user': 'user_activity_list',
             'group': 'group_activity_list',
             'organization': 'organization_activity_list',
@@ -2823,9 +2824,10 @@ def compare_pkg_dicts(old, new, old_activity_id):
     from ckan.lib.changes import check_metadata_changes, check_resource_changes
     change_list = []
 
-    check_metadata_changes(change_list, old, new)
-
-    check_resource_changes(change_list, old, new, old_activity_id)
+    if old.get('type') or new.get('type'):
+        check_metadata_changes(change_list, old, new)
+    else:
+        check_resource_changes(change_list, old, new, old_activity_id)
 
     # if the dataset was updated but none of the fields we check were changed,
     # display a message stating that
@@ -2944,3 +2946,10 @@ def can_update_owner_org(package_dict, user_orgs=None):
         return True
 
     return False
+
+
+@core_helper
+def get_pkg_title_from_id(id):
+    if id:
+        obj = model.Session.query(model.Package).get(id)
+        return obj.title if obj.title else None

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -14,6 +14,7 @@ import ckan.plugins as plugins
 import ckan.lib.dictization as dictization
 import ckan.lib.api_token as api_token
 from ckan import authz
+from ckan.model.core import State
 
 from ckan.common import _
 
@@ -177,6 +178,8 @@ def resource_delete(context, data_dict):
 
     '''
     model = context['model']
+    session = context['session']
+    user = context['user']
     id = _get_or_bust(data_dict, 'id')
 
     entity = model.Resource.get(id)
@@ -190,16 +193,30 @@ def resource_delete(context, data_dict):
 
     pkg_dict = _get_action('package_show')(context, {'id': package_id})
 
+    if not pkg_dict['private']:
+        user_obj = model.User.by_name(user)
+        if user_obj:
+            user_id = user_obj.id
+        else:
+            user_id = 'not logged in'
+        entity.state = State.DELETED
+        activity = entity.activity_stream_item('changed', user_id)
+        session.add(activity)
+
     for plugin in plugins.PluginImplementations(plugins.IResourceController):
         plugin.before_delete(context, data_dict,
                              pkg_dict.get('resources', []))
 
-    pkg_dict = _get_action('package_show')(context, {'id': package_id})
+    package_show_context = dict(context, for_update=True)
+    pkg_dict = _get_action('package_show')(package_show_context, {'id': package_id})
 
     if pkg_dict.get('resources'):
-        pkg_dict['resources'] = [r for r in pkg_dict['resources'] if not
-                r['id'] == id]
+        for res in pkg_dict['resources']:
+            if res['id'] == id:
+                res['state'] = 'deleted'
+                break
     try:
+        context['resource'] = entity
         pkg_dict = _get_action('package_update')(context, pkg_dict)
     except ValidationError as e:
         errors = e.error_dict['resources'][-1]

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -2554,6 +2554,70 @@ def package_activity_list(context, data_dict):
 
 
 @logic.validate(logic.schema.default_activity_list_schema)
+def resource_activity_list(context, data_dict):
+    '''Return a resource activity stream (not including detail)
+
+    You must be authorized to view the resource.
+
+    :param id: the id or name of the resource
+    :type id: string
+    :param offset: where to start getting activity items from
+        (optional, default: ``0``)
+    :type offset: int
+    :param limit: the maximum number of activities to return
+        (optional, default: ``31`` unless set in site's configuration
+        ``ckan.activity_list_limit``, upper limit: ``100`` unless set in
+        site's configuration ``ckan.activity_list_limit_max``)
+    :type limit: int
+    :param include_hidden_activity: whether to include 'hidden' activity, which
+        is not shown in the Activity Stream page. Hidden activity includes
+        activity done by the site_user, such as harvests, which are not shown
+        in the activity stream because they can be too numerous, or activity by
+        other users specified in config option `ckan.hide_activity_from_users`.
+        NB Only sysadmins may set include_hidden_activity to true.
+        (default: false)
+    :type include_hidden_activity: bool
+    :param activity_types: A list of activity types to include in the response
+    :type activity_types: list
+
+    :param exclude_activity_types: A list of activity types to exclude from the response
+    :type exclude_activity_types: list
+
+    :rtype: list of dictionaries
+
+    '''
+    data_dict['include_data'] = False
+    include_hidden_activity = data_dict.get('include_hidden_activity', False)
+    activity_types = data_dict.pop('activity_types', None)
+    exclude_activity_types = data_dict.pop('exclude_activity_types', None)
+
+    if activity_types is not None and exclude_activity_types is not None:
+        raise ValidationError({'activity_types': ['Cannot be used together with `exclude_activity_types']})
+
+    _check_access('resource_activity_list', context, data_dict)
+
+    model = context['model']
+
+    resource_ref = data_dict.get('id')  # May be name or ID.
+    resource = model.Resource.get(resource_ref)
+    if resource is None:
+        raise logic.NotFound
+
+    offset = int(data_dict.get('offset', 0))
+    limit = data_dict['limit']  # defaulted, limited & made an int by schema
+
+    activity_objects = model.activity.resource_activity_list(
+        resource.id, limit=limit, offset=offset,
+        include_hidden_activity=include_hidden_activity,
+        activity_types=activity_types,
+        exclude_activity_types=exclude_activity_types
+    )
+
+    return model_dictize.activity_list_dictize(
+        activity_objects, context, include_data=data_dict['include_data'])
+
+
+@logic.validate(logic.schema.default_activity_list_schema)
 def group_activity_list(context, data_dict):
     '''Return a group's activity stream.
 

--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -296,6 +296,11 @@ def package_activity_list(context, data_dict):
     return activity_list(context, data_dict)
 
 
+def resource_activity_list(context, data_dict):
+    data_dict['object_type'] = 'package'
+    return activity_list(context, data_dict)
+
+
 def group_activity_list(context, data_dict):
     data_dict['object_type'] = 'group'
     return activity_list(context, data_dict)

--- a/ckan/model/activity.py
+++ b/ckan/model/activity.py
@@ -209,6 +209,40 @@ def package_activity_list(
     return _activities_at_offset(q, limit, offset)
 
 
+def _resource_activity_query(resource_id):
+    import ckan.model as model
+    q = model.Session.query(model.Activity) \
+        .filter_by(object_id=resource_id)
+    return q
+
+def resource_activity_list(
+    resource_id, limit, offset, include_hidden_activity=False,
+    activity_types=None, exclude_activity_types=None):
+    '''Return the given resource public activity stream.
+
+    activity_types, exclude_activity_types: Optional. list of strings for activity types
+
+    Returns activities about the given resource, i.e. where the given
+    resource is the object of the activity, e.g.:
+
+    "{USER} added the resource {RESOURCE} to the dataset {DATASET}"
+    "{USER} updated the resource {RESOURCE} in the dataset {DATASET}"
+    etc.
+
+    '''
+    q = _resource_activity_query(resource_id)
+
+    if not include_hidden_activity:
+        q = _filter_activitites_from_users(q)
+
+    if activity_types:
+        q = _filter_activitites_from_type(q, include=True, types=activity_types)
+    elif exclude_activity_types:
+        q = _filter_activitites_from_type(q, include=False, types=exclude_activity_types)
+
+    return _activities_at_offset(q, limit, offset)
+
+
 def _group_activity_query(group_id, include_hidden_activity=False):
     '''Return an SQLAlchemy query for all activities about group_id.
 

--- a/ckan/templates/package/activity_resource.html
+++ b/ckan/templates/package/activity_resource.html
@@ -1,0 +1,12 @@
+{% extends "package/read_base.html" %}
+
+{% block subtitle %}{{ _('Resource Activity Stream') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
+
+{% block primary_content_inner %}
+  <h1 class="hide-heading">
+    {% block page_heading %}
+      {{ _('Activity Stream') }}
+    {% endblock %}
+  </h1>
+  {% snippet 'snippets/activity_stream.html', activity_stream=res_activity_stream, id=id %}
+{% endblock %}

--- a/ckan/templates/package/read_base.html
+++ b/ckan/templates/package/read_base.html
@@ -23,6 +23,8 @@
   {{ h.build_nav_icon(dataset_type ~ '.read', _('Dataset'), id=pkg.id if is_activity_archive else pkg.name, icon='sitemap') }}
   {{ h.build_nav_icon(dataset_type ~ '.groups', h.humanize_entity_type('group', default_group_type, 'content tab') or _('Groups'), id=pkg.id if is_activity_archive else pkg.name, icon='users') }}
   {{ h.build_nav_icon(dataset_type ~ '.activity', _('Activity Stream'), id=pkg.id if is_activity_archive else pkg.name, icon='clock-o') }}
+  {{ h.build_nav_icon('resource.activity', _('Resource Activity Stream'), id=pkg.id if is_activity_archive else pkg.name,  icon='clock-o') }}
+
 {% endblock %}
 
 {% block secondary_content %}

--- a/ckan/templates/snippets/activities/changed_resource.html
+++ b/ckan/templates/snippets/activities/changed_resource.html
@@ -1,14 +1,26 @@
 <li class="item {{ activity.activity_type|replace(' ', '-')|lower }}">
   <i class="fa icon fa-file"></i>
   <p>
-    {{ _('{actor} updated the resource {resource} in the dataset {dataset}').format(
+     {{ _('{actor} updated the resource {resource} in the dataset ').format(
       actor=ah.actor(activity),
-      resource=ah.resource(activity),
-      dataset=ah.datset(activity)
-    )|safe }}
+      resource=ah.resource(activity)
+    ) |safe }}
+    <a href="{{ h.url_for('dataset.read', id=activity.data.package.package_id) }}">
+      {{activity.data.package.title}}
+    </a>
     <br />
     <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
+      {% if can_show_activity_detail %}
+        &nbsp;|&nbsp;
+        <a href="{{ h.url_for('resource.read', package_type='dataset', id=activity.data.package.package_id, resource_id=activity.object_id, activity_id=activity.id) }}">
+          {{ _('View this version') }}
+        </a>
+        &nbsp;|&nbsp;
+        <a href="{{ h.url_for('resource.changes', id=activity.data.package.package_id, activity_id=activity.id, resource_id=activity.object_id) }}">
+          {{ _('Changes') }}
+        </a>
+      {% endif %}
     </span>
   </p>
 </li>

--- a/ckan/templates/snippets/activities/deleted_resource.html
+++ b/ckan/templates/snippets/activities/deleted_resource.html
@@ -1,14 +1,21 @@
 <li class="item {{ activity.activity_type|replace(' ', '-')|lower }}">
   <i class="fa icon fa-file"></i>
   <p>
-    {{ _('{actor} deleted the resource {resource} from the dataset {dataset}').format(
+    {{ _('{actor} deleted the resource {resource} from the dataset ').format(
       actor=ah.actor(activity),
-      resource=ah.resource(activity),
-      dataset=ah.dataset(activity)
-    )|safe }}
+      resource=ah.resource(activity)
+    ) |safe }}
+    <a href="{{ h.url_for('dataset.read', id=activity.data.package.package_id) }}">
+      {{activity.data.package.title}}
+    </a>
     <br />
     <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
+      {% if can_show_activity_detail %}
+        &nbsp;|&nbsp;
+        <a href="{{ h.url_for('resource.read', package_type='dataset', id=activity.data.package.package_id, resource_id=activity.object_id, activity_id=activity.id) }}">
+          {{ _('View this version') }}
+      {% endif %}
     </span>
   </p>
 </li>

--- a/ckan/templates/snippets/activities/new_resource.html
+++ b/ckan/templates/snippets/activities/new_resource.html
@@ -1,14 +1,26 @@
 <li class="item {{ activity.activity_type|replace(' ', '-')|lower }}">
   <i class="fa icon fa-file"></i>
   <p>
-    {{ _('{actor} added the resource {resource} to the dataset {dataset}').format(
+    {{ _('{actor} added the resource {resource} to the dataset ').format(
       actor=ah.actor(activity),
       resource=ah.resource(activity),
-      dataset=ah.dataset(activity)
     )|safe }}
+    <a href="{{ h.url_for('dataset.read', id=activity.data.package.package_id) }}">
+      {{activity.data.package.title}}
+    </a>
     <br />
     <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
+      {% if can_show_activity_detail %}
+        &nbsp;|&nbsp;
+        <a href="{{ h.url_for('resource.read', package_type='dataset', id=activity.data.package.package_id, resource_id=activity.object_id, activity_id=activity.id) }}">
+          {{ _('View this version') }}
+        </a>
+        &nbsp;|&nbsp;
+     
+          {{ _('Changes') }}
+        </a>
+      {% endif %}
     </span>
   </p>
 </li>

--- a/ckan/templates/snippets/activity_stream.html
+++ b/ckan/templates/snippets/activity_stream.html
@@ -36,6 +36,15 @@
 </span>
 {% endmacro %}
 
+{% macro resource(activity) %}
+<span class="resource">
+  <a href="{{ h.url_for('resource.read', package_type='dataset', id=activity.data.package.package_id, resource_id=activity.object_id) }}">
+    {{ activity.data.package.name if activity.data.package else _('unknown') }}
+  </a>
+    {# object_id because the object_name may be out of date) #}
+</span>
+{% endmacro %}
+
 {# Displays an activity stream
 
 activity_stream - the activity data. e.g. the output from package_activity_list
@@ -56,6 +65,7 @@ object_type - 'package', 'organization', 'group', 'user'
         'organization': organization,
         'user': user,
         'group': group,
+        'resource': resource,
       }, id=id
     -%}
   {% endfor %}

--- a/ckan/templates/snippets/changes/new_file.html
+++ b/ckan/templates/snippets/changes/new_file.html
@@ -1,7 +1,8 @@
 <li>
   <p>
+    {% set title = h.get_pkg_title_from_id(change.pkg_id) %}
     {{ _('Uploaded a new file to resource {resource_link} in {pkg_link}').format(
-      pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+      pkg_link = h.nav_link(title, named_route='dataset.read', id=change.pkg_id),
       resource_link = h.nav_link(
         change.resource_name, named_route='resource.read', id=change.pkg_id,
         resource_id=change.resource_id, qualified=True)

--- a/ckan/templates/snippets/changes/resource_desc.html
+++ b/ckan/templates/snippets/changes/resource_desc.html
@@ -1,9 +1,10 @@
 <li>
   <p>
+    {% set title = h.get_pkg_title_from_id(change.pkg_id) %}
     {% if change.method == "add" %}
 
       {{ _('Updated description of resource {resource_link} in {pkg_link} to <br class="line-height2"><blockquote>{new_desc}</blockquote>').format(
-        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        pkg_link = h.nav_link(title, named_route='dataset.read', id=change.pkg_id),
         resource_link = h.nav_link(
           change.resource_name, named_route='resource.read', id=change.pkg_id,
           resource_id=change.resource_id, qualified=True),
@@ -13,7 +14,7 @@
     {% elif change.method == "remove" %}
 
       {{ _('Removed description from resource {resource_link} in {pkg_link}').format(
-        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        pkg_link = h.nav_link(title, named_route='dataset.read', id=change.pkg_id),
         resource_link = h.nav_link(
           change.resource_name, named_route='resource.read', id=change.pkg_id,
           resource_id=change.resource_id, qualified=True)
@@ -22,7 +23,7 @@
     {% elif change.method == "change" %}
 
       {{ _('Updated description of resource {resource_link} in {pkg_link} from <br class="line-height2"><blockquote>{old_desc}</blockquote> to <br class="line-height2"><blockquote>{new_desc}</blockquote>').format(
-        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        pkg_link = h.nav_link(title, named_route='dataset.read', id=change.pkg_id),
         resource_link = h.nav_link(
           change.resource_name, named_route='resource.read', id=change.pkg_id,
           resource_id=change.resource_id, qualified=True),

--- a/ckan/templates/snippets/changes/resource_extras.html
+++ b/ckan/templates/snippets/changes/resource_extras.html
@@ -1,9 +1,10 @@
 <li>
   <p>
+  {% set title = h.get_pkg_title_from_id(change.pkg_id) %}
     {% if change.method == "add_one_value" %}
 
       {{ _('Added field <q>{key}</q> with value <q>{value}</q> to resource {resource_link} in {pkg_link}').format(
-        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        pkg_link = h.nav_link(title, named_route='dataset.read', id=change.pkg_id),
         resource_link = h.nav_link(
           change.resource_name, named_route='resource.read', id=change.pkg_id,
           resource_id=change.resource_id, qualified=True),
@@ -14,7 +15,7 @@
     {% elif change.method == "add_one_no_value" %}
 
       {{ _('Added field <q>{key}</q> to resource {resource_link} in {pkg_link}').format(
-        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        pkg_link = h.nav_link(title, named_route='dataset.read', id=change.pkg_id),
         resource_link = h.nav_link(
           change.resource_name, named_route='resource.read', id=change.pkg_id,
           resource_id=change.resource_id, qualified=True),
@@ -24,7 +25,7 @@
     {% elif change.method == "add_multiple" %}
 
       {{ _('Added the following fields to resource {resource_link} in {pkg_link}').format(
-        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        pkg_link = h.nav_link(title, named_route='dataset.read', id=change.pkg_id),
         resource_link = h.nav_link(
           change.resource_name, named_route='resource.read', id=change.pkg_id,
           resource_id=change.resource_id, qualified=True)
@@ -47,7 +48,7 @@
     {% elif change.method == "remove_one" %}
 
       {{ _('Removed field <q>{key}</q> from resource {resource_link} in {pkg_link}').format(
-        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        pkg_link = h.nav_link(title, named_route='dataset.read', id=change.pkg_id),
         resource_link = h.nav_link(
           change.resource_name, named_route='resource.read', id=change.pkg_id,
           resource_id=change.resource_id, qualified=True),
@@ -57,7 +58,7 @@
     {% elif change.method == "remove_multiple" %}
 
       {{ _('Removed the following fields from resource {resource_link} in {pkg_link}').format(
-        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        pkg_link = h.nav_link(title, named_route='dataset.read', id=change.pkg_id),
         resource_link = h.nav_link(
           change.resource_name, named_route='resource.read', id=change.pkg_id,
           resource_id=change.resource_id, qualified=True)
@@ -73,7 +74,7 @@
     {% elif change.method == "change_value_with_old" %}
 
       {{ _('Changed value of field <q>{key}</q> of resource {resource_link} to <q>{new_val}</q> (previously <q>{old_val}</q>) in {pkg_link}').format(
-        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        pkg_link = h.nav_link(title, named_route='dataset.read', id=change.pkg_id),
         resource_link = h.nav_link(
           change.resource_name, named_route='resource.read', id=change.pkg_id,
           resource_id=change.resource_id, qualified=True),
@@ -85,7 +86,7 @@
     {% elif change.method == "change_value_no_old" %}
 
       {{ _('Changed value of field <q>{key}</q> to <q>{new_val}</q> in resource {resource_link} in {pkg_link}').format(
-        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        pkg_link = h.nav_link(title, named_route='dataset.read', id=change.pkg_id),
         resource_link = h.nav_link(
           change.resource_name, named_route='resource.read', id=change.pkg_id,
           resource_id=change.resource_id, qualified=True),
@@ -96,7 +97,7 @@
     {% elif change.method == "change_value_no_new" %}
 
       {{ _('Removed the value of field <q>{key}</q> in resource {resource_link} in {pkg_link}').format(
-        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+        pkg_link = h.nav_link(title, named_route='dataset.read', id=change.pkg_id),
         resource_link = h.nav_link(
           change.resource_name, named_route='resource.read', id=change.pkg_id,
           resource_id=change.resource_id, qualified=True),

--- a/ckan/templates/snippets/changes/resource_name.html
+++ b/ckan/templates/snippets/changes/resource_name.html
@@ -1,7 +1,8 @@
 <li>
   <p>
+    {% set title = h.get_pkg_title_from_id(change.new_pkg_id) %}
     {{ _('Renamed resource {old_resource_link} to {new_resource_link} in {pkg_link}').format(
-      pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
+      pkg_link = h.nav_link(title, named_route='dataset.read', id=change.pkg_id),
       old_resource_link = h.nav_link(
         change.old_resource_name, named_route='resource.read', id=change.old_pkg_id,
         resource_id=change.resource_id, activity_id=change.old_activity_id),

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -3126,37 +3126,39 @@ class TestPackageActivityList(object):
         resource = factories.Resource(package_id=dataset["id"], user=user)
 
         activities = helpers.call_action(
-            "package_activity_list", id=dataset["id"]
+            "resource_activity_list", id=resource["id"]
         )
         assert [activity["activity_type"] for activity in activities] == [
-            "changed package"
+            "new resource"
         ]
         assert activities[0]["user_id"] == user["id"]
-        assert activities[0]["object_id"] == dataset["id"]
+        assert activities[0]["object_id"] == resource["id"]
         assert activities[0]["data"]["package"]["title"] == dataset["title"]
         # NB the detail is not included - that is only added in by
         # activity_list_to_html()
 
     def test_change_dataset_change_resource(self):
+        import uuid
         user = factories.User()
-        dataset = factories.Dataset(
-            user=user,
-            resources=[dict(url="https://example.com/foo.csv", format="csv")],
+        dataset = factories.Dataset(user=user)
+        resource = factories.Resource(
+            package_id=dataset["id"],
+            url="https://example.com/foo.csv",
+            format="csv"
         )
         _clear_activities()
-        dataset["resources"][0]["format"] = "pdf"
+        resource["format"] = "pdf"
         helpers.call_action(
-            "package_update", context={"user": user["name"]}, **dataset
+            "resource_update", context={"user": user["name"]}, **resource
         )
-
         activities = helpers.call_action(
-            "package_activity_list", id=dataset["id"]
+            "resource_activity_list", id=resource["id"]
         )
         assert [activity["activity_type"] for activity in activities] == [
-            "changed package"
+            "changed resource"
         ]
         assert activities[0]["user_id"] == user["id"]
-        assert activities[0]["object_id"] == dataset["id"]
+        assert activities[0]["object_id"] == resource["id"]
         assert activities[0]["data"]["package"]["title"] == dataset["title"]
 
     def test_change_dataset_delete_resource(self):
@@ -3342,7 +3344,7 @@ class TestPackageActivityList(object):
             model.Activity(
                 user_id=user["id"],
                 object_id=dataset["id"],
-                activity_type=None,
+                activity_type="changed package",
                 data=None,
             )
             for i in range(count)
@@ -3578,7 +3580,7 @@ class TestUserActivityList(object):
             model.Activity(
                 user_id=user["id"],
                 object_id=None,
-                activity_type=None,
+                activity_type="changed user",
                 data=None,
             )
             for i in range(count)
@@ -3794,7 +3796,7 @@ class TestGroupActivityList(object):
             model.Activity(
                 user_id=user["id"],
                 object_id=group["id"],
-                activity_type=None,
+                activity_type="changed group",
                 data=None,
             )
             for i in range(count)
@@ -4027,7 +4029,7 @@ class TestOrganizationActivityList(object):
             model.Activity(
                 user_id=user["id"],
                 object_id=org["id"],
-                activity_type=None,
+                activity_type="changed organization",
                 data=None,
             )
             for i in range(count)
@@ -4306,7 +4308,7 @@ class TestDashboardActivityList(object):
             model.Activity(
                 user_id=user["id"],
                 object_id=None,
-                activity_type=None,
+                activity_type="changed package",
                 data=None,
             )
             for i in range(count)

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -47,70 +47,30 @@ prefixed_resource = Blueprint(
 )
 
 
-def read(package_type, id, resource_id):
-    context = {
-        u'model': model,
-        u'session': model.Session,
-        u'user': g.user,
-        u'auth_user_obj': g.userobj,
-        u'for_view': True
-    }
-
-    try:
-        package = get_action(u'package_show')(context, {u'id': id})
-    except (NotFound, NotAuthorized):
-        return base.abort(404, _(u'Dataset not found'))
-    activity_id = request.params.get(u'activity_id')
-    if activity_id:
-        # view an 'old' version of the package, as recorded in the
-        # activity stream
-        current_pkg = package
-        try:
-            package = context['session'].query(model.Activity).get(
-                activity_id
-            ).data['package']
-        except AttributeError:
-            base.abort(404, _(u'Dataset not found'))
-
-        if package['id'] != current_pkg['id']:
-            log.info(u'Mismatch between pkg id in activity and URL {} {}'
-                     .format(package['id'], current_pkg['id']))
-            # the activity is not for the package in the URL - don't allow
-            # misleading URLs as could be malicious
-            base.abort(404, _(u'Activity not found'))
-        # The name is used lots in the template for links, so fix it to be
-        # the current one. It's not displayed to the user anyway.
-        package['name'] = current_pkg['name']
-
-        # Don't crash on old (unmigrated) activity records, which do not
-        # include resources or extras.
-        package.setdefault(u'resources', [])
-
-    resource = None
-    for res in package.get(u'resources', []):
-        if res[u'id'] == resource_id:
-            resource = res
-            break
-    if not resource:
-        return base.abort(404, _(u'Resource not found'))
-
-    # get package license info
+def _read(context, data_dict):
+    package = data_dict.get('package')
+    resource = data_dict.get('resource')
+    resource_id = data_dict.get('resource_id')
+    view_id = data_dict.get('view_id')
+    activity_id = package.get('activity_id', None)
     license_id = package.get(u'license_id')
+
     try:
-        package[u'isopen'] = model.Package.get_license_register()[license_id
-                                                                  ].isopen()
+        package[u'isopen'] = model.Package.get_license_register()[
+            license_id
+        ].isopen()
     except KeyError:
         package[u'isopen'] = False
 
     resource_views = get_action(u'resource_view_list')(
         context, {
-            u'id': resource_id
+            u'id': resource["id"]
         }
     )
     resource[u'has_views'] = len(resource_views) > 0
 
     current_resource_view = None
-    view_id = request.args.get(u'view_id')
+
     if resource[u'has_views']:
         if view_id:
             current_resource_view = [
@@ -123,15 +83,8 @@ def read(package_type, id, resource_id):
         else:
             current_resource_view = resource_views[0]
 
-    # required for nav menu
     pkg = context[u'package']
-    dataset_type = pkg.type or package_type
-
-    # TODO: remove
-    g.package = package
-    g.resource = resource
-    g.pkg = pkg
-    g.pkg_dict = package
+    dataset_type = pkg.type or data_dict.get('package_type')
 
     extra_vars = {
         u'resource_views': resource_views,
@@ -145,9 +98,174 @@ def read(package_type, id, resource_id):
                       # backward compatibility
         u'is_activity_archive': bool(activity_id),
     }
+    return extra_vars
 
-    template = _get_pkg_template(u'resource_template', dataset_type)
-    return base.render(template, extra_vars)
+
+def read(package_type, id, resource_id):
+    context = {
+        u'model': model,
+        u'session': model.Session,
+        u'user': g.user,
+        u'auth_user_obj': g.userobj,
+        u'for_view': True
+    }
+
+    try:
+        package = get_action(u'package_show')(context, {u'id': id})
+    except (NotFound, NotAuthorized):
+        return base.abort(404, _(u'Dataset not found'))
+
+    resource = None
+    activity_id = request.params.get(u'activity_id')
+    view_id = request.args.get(u'view_id')
+    data_dict = {
+        'resource': resource, 'package': package, 'view_id': view_id,
+        'activity_id': activity_id, 'package_type': package_type,
+        'resource_id': resource_id
+    }
+    if activity_id:
+        # view an 'old' version of the package, as recorded in the
+        # activity stream
+        try:
+            resource = context['session'].query(model.Activity).get(
+                activity_id
+            ).data['package']
+        except AttributeError:
+            base.abort(404, _('Resource not found'))
+        if resource['id'] != resource_id:
+            log.info(
+                'Mismatch between resource id in activity and URL {} {}'.format
+                    (resource['id'], resource_id)
+            )
+            # the activity is not for the package in the URL - don't allow
+            # misleading URLs as could be malicious
+            base.abort(404, _(u'Activity not found'))
+        # The name is used lots in the template for links, so fix it to be
+        # the current one. It's not displayed to the user anyway.
+        # resource['name'] = current_res['name']
+
+        # Don't crash on old (unmigrated) activity records, which do not
+        # include resources or extras.
+        package.setdefault(u'resources', [])
+
+        data_dict['resource'] = resource
+        extra_vars = _read(context, data_dict)
+
+        template = _get_pkg_template(
+            u'resource_template', extra_vars['dataset_type']
+        )
+        return base.render(template, extra_vars)
+
+    else:
+        for res in package.get('resources', []):
+            if res['id'] == resource_id:
+                resource = res
+                break
+        if not resource:
+            return base.abort(404, _(u'Resource not found'))
+        data_dict['resource'] = resource
+        extra_vars = _read(context, data_dict)
+
+        template = _get_pkg_template(
+            u'resource_template', extra_vars['dataset_type']
+        )
+        return base.render(template, extra_vars)
+
+
+def activity(package_type, id):
+    """Render this package's public activity stream page.
+    """
+    context = {
+        u'model': model,
+        u'session': model.Session,
+        u'user': g.user,
+        u'for_view': True,
+        u'auth_user_obj': g.userobj
+    }
+    data_dict = {u'id': id}
+    try:
+        pkg_dict = get_action(u'package_show')(context, data_dict)
+        pkg = context[u'package']
+        package_activity_stream = get_action(
+            u'package_activity_list')(
+            context, {u'id': id})
+
+        res_activity_list = []
+        for res in pkg.resources_all:
+            resource_activity_stream = get_action(
+                'resource_activity_list')(
+                context, {'id': res.id}
+            )
+            res_activity_list.append(resource_activity_stream)
+
+        dataset_type = pkg_dict[u'type'] or u'dataset'
+    except NotFound:
+        return base.abort(404, _(u'Dataset not found'))
+    except NotAuthorized:
+        return base.abort(403, _(u'Unauthorized to read dataset %s') % id)
+
+    # TODO: remove
+    g.pkg_dict = pkg_dict
+    g.pkg = pkg
+
+    import itertools
+    from operator import itemgetter
+    activity_list = [list(itertools.chain.from_iterable(res_activity_list))]
+    activity_list = sorted(
+        activity_list[0], key=itemgetter('timestamp'), reverse=True
+    )
+    return base.render(
+        u'package/activity_resource.html', {
+            u'dataset_type': dataset_type,
+            u'pkg_dict': pkg_dict,
+            u'pkg': pkg,
+            u'activity_stream': package_activity_stream,
+            u'res_activity_stream': activity_list,
+            u'id': id,  # i.e. package's current name
+        }
+    )
+
+
+def changes(resource_id, id, activity_id, package_type=None):
+    '''
+    Shows the changes to a resource in one particular activity stream item.
+    '''
+    activity_id = activity_id
+    context = {
+        u'model': model, u'session': model.Session,
+        u'user': g.user, u'auth_user_obj': g.userobj
+    }
+
+    try:
+        activity_diff = get_action(u'activity_diff')(
+            context, {u'id': activity_id, u'object_type': u'package',
+                      u'diff_type': u'html'})
+    except NotFound as e:
+        log.info(u'Activity not found: {} - {}'.format(str(e), activity_id))
+        return base.abort(404, _(u'Activity not found'))
+    except NotAuthorized:
+        return base.abort(403, _(u'Unauthorized to view activity data'))
+
+    # 'pkg_dict' needs to go to the templates for page title & breadcrumbs.
+    # Use the current version of the package, in case the name/title have
+    # changed, and we need a link to it which works
+    pkg_id = activity_diff['activities'][1]['data']['package']['package_id']
+    current_pkg_dict = get_action('package_show')(context, {'id': pkg_id})
+    resource_activity_list = get_action('resource_activity_list')(
+        context, {
+            'id': resource_id,
+            'limit': 100
+        }
+    )
+
+    return base.render(
+        u'package/changes.html', {
+            u'activity_diffs': [activity_diff],
+            u'pkg_dict': current_pkg_dict,
+            u'pkg_activity_list': resource_activity_list,
+            u'dataset_type': current_pkg_dict[u'type'],
+        }
+    )
 
 
 def download(package_type, id, resource_id, filename=None):
@@ -903,7 +1021,6 @@ def register_dataset_plugin_rules(blueprint):
     blueprint.add_url_rule(
         u'/<resource_id>/download/<filename>', view_func=download
     )
-
     _edit_view = EditResourceViewView.as_view(str(u'edit_view'))
     blueprint.add_url_rule(u'/<resource_id>/new_view', view_func=_edit_view)
     blueprint.add_url_rule(
@@ -919,6 +1036,9 @@ def register_dataset_plugin_rules(blueprint):
             u'height': u"800"
         }
     )
+    blueprint.add_url_rule(u'/activity', view_func=activity)
+    blueprint.add_url_rule(
+        u'<resource_id>/changes/<activity_id>', view_func=changes)
 
 
 register_dataset_plugin_rules(resource)


### PR DESCRIPTION
Fixes #6471 

### Proposed fixes:
I divided the activities into:
1.) Dataset Activity Stream: Only shows the activities from dataset fields 
2.) Resource Activity Stream: Only shows the activities from resource fields. 
for eg: 
- {actor} added the resource {resource_name} in the dataset {dataset}
- {actor} updated the resource {resource_name} in the dataset {dataset}
- {actor} deleted the resource {resource_name} in the dataset {dataset}
- "View this version" and "changes" both  works fine
- You  can "View this version" even for deleted resources.

If you have any suggestions on how to make these changes even better I m happy to hear and to work on that.
Thanks


### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
