### PR TITLE
[#6531] Py2/py3 compatible version of open

### DIFF
--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -3,6 +3,7 @@
 import os
 import logging
 import html
+import io
 
 from flask import Blueprint, make_response
 
@@ -449,7 +450,7 @@ def i18n_js_translations(lang, ver=API_REST_DEFAULT_VERSION):
                              u'base', u'i18n', u'{0}.js'.format(lang)))
     if not os.path.exists(source):
         return u'{}'
-    translations = json.load(open(source, u'r', encoding='utf-8'))
+    translations = json.load(io.open(source, u'r', encoding='utf-8'))
     return _finish_ok(translations)
 
 


### PR DESCRIPTION
Fixes #6531

### Proposed fixes:
Use `io.open` instead of `open` like in b2b92a478f9a96c908e214d33d7d8141c73343c7.
