### PR TITLE
Add resource_revision index

### DIFF
--- a/ckan/migration/versions/101_7ab0d120f411_add_resource_indexes.py
+++ b/ckan/migration/versions/101_7ab0d120f411_add_resource_indexes.py
@@ -1,0 +1,28 @@
+"""add resource indexes
+
+Revision ID: 7ab0d120f411
+Revises: ccd38ad5fced
+Create Date: 2021-11-11 14:12:09.088843
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '7ab0d120f411'
+down_revision = 'ccd38ad5fced'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if skip_based_on_legacy_engine_version(op, __name__):
+        return
+    op.create_index(
+        'idx_package_resource_revision_period', 'resource_revision', ['package_id', 'revision_timestamp', 'expired_timestamp']
+    )
+
+
+def downgrade():
+    op.drop_index('idx_resource_continuity_id', 'resource_revision')


### PR DESCRIPTION

Not related to a current bug, found in the wild when using CKAN on US data.gov system.

### Proposed fixes:
When updating a package, the CKAN system searches the current resources from [here](https://github.com/ckan/ckan/blob/2.8/ckan/lib/dictization/model_dictize.py#L137).
When you have many records, this query can take multiple seconds to run which
slows down the update considerably. This index increased
speed for the given query by > 90%, and helped cut time for package updates.

This goes in line with [resource index](https://github.com/ckan/ckan/blob/master/ckan/migration/versions/092_01afcadbd8c0_resource_package_id_index.py), which we also had to implement.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
