### PR TITLE
Print list declarations as strings

### DIFF
--- a/ckan/config/declaration/option.py
+++ b/ckan/config/declaration/option.py
@@ -58,6 +58,9 @@ class Option(Generic[T]):
         self.default = default
 
     def __str__(self):
+        as_list = "as_list" in self.get_validators()
+        if isinstance(self.default, list) and as_list:
+            return " ".join(self.default)
         return str(self.default)
 
     def _unset_flag(self, flag: Flag):


### PR DESCRIPTION
`ckan config declaration --core` CLI command that prints example of configuration prints lists like this:

```
ckan.i18n.rtl_languages = ['he', 'ar', 'fa_IR']
```

But it should be printed as
```
ckan.i18n.rtl_languages = he ar fa_IR
```