### PR TITLE
Support file attachments in emails, refactor email module

### DIFF
--- a/changes/6535.misc
+++ b/changes/6535.misc
@@ -1,0 +1,1 @@
+Support including file attachments when sending emails

--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -5,6 +5,7 @@ import os
 import smtplib
 import socket
 import logging
+import mimetypes
 from time import time
 
 from email.message import EmailMessage
@@ -64,9 +65,18 @@ def _mail_recipient(recipient_name, recipient_email,
         msg['Reply-to'] = reply_to
 
     for attachment in attachments:
-        name, _file, media_type = attachment
+        if len(attachment) == 3:
+            name, _file, media_type = attachment
+        else:
+            name, _file = attachment
+            media_type = None
+
+        if not media_type:
+            media_type, encoding = mimetypes.guess_type(name)
         if media_type:
             main_type, sub_type = media_type.split('/')
+        else:
+            main_type = sub_type = None
 
         msg.add_attachment(
             _file.read(), filename=name, maintype=main_type, subtype=sub_type)

--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -130,7 +130,7 @@ def mail_recipient(
         body_html=None, headers=None, attachments=None):
     '''Sends an email to a an email address.
 
-    .. note:: You need to set up the :ref:`email_settings` to able to send emails.
+    .. note:: You need to set up the :ref:`email-settings` to able to send emails.
 
     :param recipient_name: the name of the recipient
     :type recipient: string
@@ -174,7 +174,7 @@ def mail_user(
         body_html=None, headers=None, attachments=None):
     '''Sends an email to a CKAN user.
 
-    You need to set up the :ref:`email_settings` to able to send emails.
+    You need to set up the :ref:`email-settings` to able to send emails.
 
     :param recipient: a CKAN user object
     :type recipient: a model.User object

--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -189,12 +189,12 @@ def send_invite(user, group_dict=None, role=None):
 
 
 def create_reset_key(user):
-    user.reset_key = str(make_key())
+    user.reset_key = make_key()
     model.repo.commit_and_remove()
 
 
 def make_key():
-    return codecs.encode(os.urandom(16), 'hex')
+    return codecs.encode(os.urandom(16), 'hex').decode()
 
 
 def verify_reset_link(user, key):

--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -128,7 +128,39 @@ def _mail_recipient(recipient_name, recipient_email,
 def mail_recipient(
         recipient_name, recipient_email, subject, body,
         body_html=None, headers=None, attachments=None):
-    '''Sends an email'''
+    '''Sends an email to a an email address.
+
+    .. note:: You need to set up the :ref:`email_settings` to able to send emails.
+
+    :param recipient_name: the name of the recipient
+    :type recipient: string
+    :param recipient_email: the email address of the recipient
+    :type recipient: string
+
+    :param subject: the email subject
+    :type subject: string
+    :param body: the email body, in plain text
+    :type body: string
+    :param body_html: the email body, in html format (optional)
+    :type body_html: string
+    :headers: extra headers to add to email, in the form {'Header name': 'Header value'}
+    :type: dict
+    :attachments: a list of tuples containing file attachments to add to the email.
+        Tuples should contain the file name and a file-like object pointing to the file
+        contents::
+
+            [
+                ('some_report.csv', file_object),
+            ]
+
+        Optionally, you can add a third element to the tuple containing the media type.
+        If not provided, it will be guessed using the ``mimetypes`` module::
+
+            [
+                ('some_report.csv', file_object, 'text/csv'),
+            ]
+    :type: list
+    '''
     site_title = config.get_value('ckan.site_title')
     site_url = config.get_value('ckan.site_url')
     return _mail_recipient(
@@ -140,7 +172,17 @@ def mail_recipient(
 def mail_user(
         recipient, subject, body,
         body_html=None, headers=None, attachments=None):
-    '''Sends an email to a CKAN user'''
+    '''Sends an email to a CKAN user.
+
+    You need to set up the :ref:`email_settings` to able to send emails.
+
+    :param recipient: a CKAN user object
+    :type recipient: a model.User object
+
+    For further parameters see
+    :py:func:`~ckan.lib.mailer.mail_recipient`.
+    '''
+
     if (recipient.email is None) or not len(recipient.email):
         raise MailerException(_("No recipient email address available!"))
     mail_recipient(

--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -130,7 +130,8 @@ def mail_recipient(
         body_html=None, headers=None, attachments=None):
     '''Sends an email to a an email address.
 
-    .. note:: You need to set up the :ref:`email-settings` to able to send emails.
+    .. note:: You need to set up the :ref:`email-settings` to able to send
+        emails.
 
     :param recipient_name: the name of the recipient
     :type recipient: string
@@ -143,18 +144,20 @@ def mail_recipient(
     :type body: string
     :param body_html: the email body, in html format (optional)
     :type body_html: string
-    :headers: extra headers to add to email, in the form {'Header name': 'Header value'}
+    :headers: extra headers to add to email, in the form
+        {'Header name': 'Header value'}
     :type: dict
-    :attachments: a list of tuples containing file attachments to add to the email.
-        Tuples should contain the file name and a file-like object pointing to the file
-        contents::
+    :attachments: a list of tuples containing file attachments to add to the
+        email. Tuples should contain the file name and a file-like object
+        pointing to the file contents::
 
             [
                 ('some_report.csv', file_object),
             ]
 
-        Optionally, you can add a third element to the tuple containing the media type.
-        If not provided, it will be guessed using the ``mimetypes`` module::
+        Optionally, you can add a third element to the tuple containing the
+        media type. If not provided, it will be guessed using
+        the ``mimetypes`` module::
 
             [
                 ('some_report.csv', file_object, 'text/csv'),

--- a/ckan/tests/lib/test_mailer.py
+++ b/ckan/tests/lib/test_mailer.py
@@ -41,7 +41,7 @@ class TestMailer(MailerBase):
             "recipient_name": "Bob",
             "recipient_email": user["email"],
             "subject": "Meeting",
-            "body": "The meeting is cancelled.",
+            "body": "The meeting is cancelled.\n",
             "headers": {"header1": "value1"},
         }
         mailer.mail_recipient(**test_email)
@@ -72,8 +72,8 @@ class TestMailer(MailerBase):
             "recipient_name": "Bob",
             "recipient_email": user["email"],
             "subject": "Meeting",
-            "body": "The meeting is cancelled.",
-            "body_html": "The <a href=\"meeting\">meeting</a> is cancelled.",
+            "body": "The meeting is cancelled.\n",
+            "body_html": "The <a href=\"meeting\">meeting</a> is cancelled.\n",
             "headers": {"header1": "value1"},
         }
         mailer.mail_recipient(**test_email)
@@ -87,7 +87,7 @@ class TestMailer(MailerBase):
         assert list(test_email["headers"].keys())[0] in msg[3], msg[3]
         assert list(test_email["headers"].values())[0] in msg[3], msg[3]
         assert test_email["subject"] in msg[3], msg[3]
-        assert msg[3].startswith('Content-Type: multipart'), msg[3]
+        assert 'Content-Type: multipart' in msg[3]
         expected_plain_body = self.mime_encode(
             test_email["body"], test_email["recipient_name"],
             subtype='plain'
@@ -111,7 +111,7 @@ class TestMailer(MailerBase):
         test_email = {
             "recipient": user_obj,
             "subject": "Meeting",
-            "body": "The meeting is cancelled.",
+            "body": "The meeting is cancelled.\n",
             "headers": {"header1": "value1"},
         }
         mailer.mail_user(**test_email)
@@ -185,7 +185,7 @@ class TestMailer(MailerBase):
         assert msg[2] == [user["email"]]
         assert "Reset" in msg[3], msg[3]
         test_msg = mailer.get_reset_link_body(user_obj)
-        expected_body = self.mime_encode(test_msg, user["name"])
+        expected_body = self.mime_encode(test_msg + '\n', user["name"])
 
         assert expected_body in msg[3]
 
@@ -204,7 +204,7 @@ class TestMailer(MailerBase):
         assert msg[1] == config["smtp.mail_from"]
         assert msg[2] == [user["email"]]
         test_msg = mailer.get_invite_body(user_obj)
-        expected_body = self.mime_encode(test_msg, user["name"])
+        expected_body = self.mime_encode(test_msg + '\n', user["name"])
 
         assert expected_body in msg[3]
         assert user_obj.reset_key is not None, user

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -642,10 +642,7 @@ class TestSendEmailNotifications(object):
     def check_email(self, email, address, name, subject):
         assert email[1] == "info@test.ckan.net"
         assert email[2] == [address]
-        encoded_subject = "Subject: =?utf-8?q?{subject}".format(
-            subject=subject.replace(" ", "_")
-        )
-        assert encoded_subject in email[3]
+        assert subject in email[3]
         # TODO: Check that body contains link to dashboard and email prefs.
 
     def test_fresh_setupnotifications(self, mail_server):

--- a/ckanext/example_theme_docs/custom_emails/test_custom_emails.py
+++ b/ckanext/example_theme_docs/custom_emails/test_custom_emails.py
@@ -41,7 +41,7 @@ class TestExampleCustomEmailsPlugin(MailerBase):
         )
         expected = expected.split("\n")[0]
 
-        subject = self.get_email_subject(msg[3]).decode()
+        subject = self.get_email_subject(msg[3])
         assert expected == subject
         assert "**test**" in subject
 
@@ -58,7 +58,7 @@ class TestExampleCustomEmailsPlugin(MailerBase):
         extra_vars = {"reset_link": mailer.get_reset_link(user_obj)}
         expected = render("emails/reset_password.txt", extra_vars)
         body = self.get_email_body(msg[3]).decode()
-        assert expected == body
+        assert expected == body.strip()
         assert "**test**" in body
 
     def test_invite_user_custom_subject(self, mail_server):
@@ -77,7 +77,7 @@ class TestExampleCustomEmailsPlugin(MailerBase):
         expected = render("emails/invite_user_subject.txt", extra_vars)
         expected = expected.split("\n")[0]
 
-        subject = self.get_email_subject(msg[3]).decode()
+        subject = self.get_email_subject(msg[3])
         assert expected == subject
         assert "**test**" in subject
 
@@ -98,5 +98,5 @@ class TestExampleCustomEmailsPlugin(MailerBase):
         }
         expected = render("emails/invite_user.txt", extra_vars)
         body = self.get_email_body(msg[3]).decode()
-        assert expected == body
+        assert expected == body.strip()
         assert "**test**" in body


### PR DESCRIPTION
Allow `mail_user()` or `mail_recipient()` to support a new `attachments` parameter. This should be a list of tuples in the form:

```
    [
        (file_name, file_object, media_type)
    ]
```

While working on this and to make the changes easier I refactored the email sending function to use the `email.message` module instead of the legacy `email.mime`, which simplifies significantly the code.

Note that the existing base64 encoding has been kept on, although in the future we might consider adding an option to
support the default "quoted-printable" one which is more human friendly.