### PR TITLE
Remove non-existing keys from the toolkit

### DIFF
--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -76,10 +76,6 @@ class _Toolkit(object):
         'StopOnError',
         # validation invalid exception
         'Invalid',
-        # old class for providing CLI interfaces
-        'CkanCommand',
-        # function for initializing CLI interfaces
-        'load_config',
         # function to promt the exception in CLI command
         'error_shout',
         # base class for IDatasetForm plugins
@@ -88,10 +84,6 @@ class _Toolkit(object):
         'DefaultGroupForm',
         # base class for IGroupForm plugins for orgs
         'DefaultOrganizationForm',
-        # response object for cookies etc
-        'response',
-        # Allow controllers to be created
-        'BaseController',
         # abort actions
         'abort',
         # allow redirections


### PR DESCRIPTION
These keys are no longer present in the CKAN codebase but were left in the toolkit definition. These caused the following error when running the tests:

    pytest --ckan-ini=test-core-custom.ini -v -s --disable-warnings ckan/tests/lib/test_mailer.py

                errors = set(t).symmetric_difference(set(self.contents))
                if errors:
    >               raise Exception('Plugin toolkit error %s not matching' % errors)
    E               Exception: Plugin toolkit error {'BaseController', 'load_config', 'CkanCommand', 'response'} not matching

    ckan/plugins/toolkit.py:334: Exception

Not sure why this does not happen more widely but in any case it makes sense to get rid of those keys.
