### PR TITLE
Delete a resource in dataset from the `Explore` drop-down button

### DIFF
--- a/ckan/templates/package/snippets/resource_item.html
+++ b/ckan/templates/package/snippets/resource_item.html
@@ -71,6 +71,16 @@
         </a>
       </li>
       {% endif %}
+       {% if res.id %}
+        {% if h.check_access('resource_delete', {'id': res.id})  %}
+        <li>
+	       <a href="{{ h.url_for(pkg.type ~ '_resource.delete', id=pkg.name, resource_id=res.id) }}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this resource?') }}" >
+	         <i class="fa fa-trash-o"></i>
+            {{ _('Delete') }}
+	       </a>
+        </li>  
+       {% endif %}
+      {% endif %}
       {% endblock %}
     </ul>
   </div>


### PR DESCRIPTION
Sometimes users create wrong views for the resource, and  CKAN creates the view for the resource and gives a Server Error for the view. If the user wants to delete the view, that is not possible since deleting is only available in the view edit form, which can't be opened since there is a Server Error. This PR will allow a user to delete a resource from the `Explore` drop-down button.

Fixes #5159 

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
