### PR TITLE
Clean old deprecated License methods

### DIFF
--- a/ckan/model/license.py
+++ b/ckan/model/license.py
@@ -19,16 +19,6 @@ class License(object):
     """Domain object for a license."""
 
     def __init__(self, data):
-        # convert old keys if necessary
-        if 'is_okd_compliant' in data:
-            data['od_conformance'] = 'approved' \
-                if asbool(data['is_okd_compliant']) else ''
-            del data['is_okd_compliant']
-        if 'is_osi_compliant' in data:
-            data['osd_conformance'] = 'approved' \
-                if asbool(data['is_osi_compliant']) else ''
-            del data['is_osi_compliant']
-
         self._data = data
         for (key, value) in self._data.items():
             if key == 'date_created':
@@ -40,14 +30,6 @@ class License(object):
                 self._data[key] = value
 
     def __getattr__(self, name):
-        if name == 'is_okd_compliant':
-            log.warn('license.is_okd_compliant is deprecated - use '
-                     'od_conformance instead.')
-            return self._data['od_conformance'] == 'approved'
-        if name == 'is_osi_compliant':
-            log.warn('license.is_osi_compliant is deprecated - use '
-                     'osd_conformance instead.')
-            return self._data['osd_conformance'] == 'approved'
         try:
             return self._data[name]
         except KeyError as e:

--- a/ckan/model/license.py
+++ b/ckan/model/license.py
@@ -55,41 +55,11 @@ class License(object):
             # behavior of `hasattr`
             raise AttributeError(*e.args)
 
-    @maintain.deprecated("License.__getitem__() is deprecated and will be "
-                         "removed in a future version of CKAN. Instead, "
-                         "please use attribute access.", since="2.4.0")
-    def __getitem__(self, key):
-        '''NB This method is deprecated and will be removed in a future version
-        of CKAN. Instead, please use attribute access.
-        '''
-        return self.__getattr__(key)
-
     def isopen(self):
         if not hasattr(self, '_isopen'):
             self._isopen = self.od_conformance == 'approved' or \
                 self.osd_conformance == 'approved'
         return self._isopen
-
-    @maintain.deprecated("License.as_dict() is deprecated and will be "
-                         "removed in a future version of CKAN. Instead, "
-                         "please use attribute access.", since="2.4.0")
-    def as_dict(self):
-        '''NB This method is deprecated and will be removed in a future version
-        of CKAN. Instead, please use attribute access.
-        '''
-        data = self._data.copy()
-        if 'date_created' in data:
-            value = data['date_created']
-            value = value.isoformat()
-            data['date_created'] = value
-
-        # deprecated keys
-        if 'od_conformance' in data:
-            data['is_okd_compliant'] = data['od_conformance'] == 'approved'
-        if 'osd_conformance' in data:
-            data['is_osi_compliant'] = data['osd_conformance'] == 'approved'
-
-        return data
 
 
 class LicenseRegister(object):

--- a/ckan/tests/model/licenses.v1
+++ b/ckan/tests/model/licenses.v1
@@ -5,10 +5,10 @@
     "family": "",
     "title": "Creative Commons Attribution",
     "domain_data": "False",
-    "is_okd_compliant": "True",
+    "od_conformance": "approved",
     "is_generic": "False",
     "url": "http://www.opendefinition.org/licenses/cc-by",
-    "is_osi_compliant": "False",
+    "osd_conformance": "approved",
     "domain_content": "False",
     "domain_software": "False",
     "id": "cc-by"

--- a/ckan/tests/model/test_license.py
+++ b/ckan/tests/model/test_license.py
@@ -89,6 +89,6 @@ def test_access_via_attribute():
 
 def test_access_via_attribute_2():
     license = LicenseRegister()["cc-by"]
-    assert license.is_okd_compliant
-    assert not license.is_osi_compliant
+    assert license.od_conformance
+    assert license.osd_conformance == "not reviewed"
 

--- a/ckan/tests/model/test_license.py
+++ b/ckan/tests/model/test_license.py
@@ -87,32 +87,8 @@ def test_access_via_attribute():
     assert license.od_conformance == "approved"
 
 
-def test_access_via_key():
-    license = LicenseRegister()["cc-by"]
-    assert license["od_conformance"] == "approved"
-
-
-def test_access_via_dict():
-    license = LicenseRegister()["cc-by"]
-    license_dict = license.as_dict()
-    assert license_dict["od_conformance"] == "approved"
-    assert license_dict["osd_conformance"] == "not reviewed"
-
-
 def test_access_via_attribute_2():
     license = LicenseRegister()["cc-by"]
     assert license.is_okd_compliant
     assert not license.is_osi_compliant
 
-
-def test_access_via_key_2():
-    license = LicenseRegister()["cc-by"]
-    assert license["is_okd_compliant"]
-    assert not license["is_osi_compliant"]
-
-
-def test_access_via_dict_2():
-    license = LicenseRegister()["cc-by"]
-    license_dict = license.as_dict()
-    assert license_dict["is_okd_compliant"]
-    assert not license_dict["is_osi_compliant"]


### PR DESCRIPTION
This attributes and methods were deprecated in CKAN 2.4.0 so it should be safe to clean the code now.