### PR TITLE
Add typing-extensions dependency

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -29,6 +29,7 @@ rq==1.10.0
 simplejson==3.17.5
 SQLAlchemy==1.3.5
 sqlparse==0.4.2
+typing_extensions==4.0.0
 tzlocal==3.0
 webassets==2.0
 Werkzeug[watchdog]==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -117,6 +117,8 @@ sqlalchemy==1.3.5
     #   alembic
 sqlparse==0.4.2
     # via -r requirements.in
+typing_extensions==4.0.0
+    # via -r requirements.in
 tzlocal==3.0
     # via -r requirements.in
 urllib3==1.26.7


### PR DESCRIPTION
`typing-extensions` library [is used by config declarations module](https://github.com/ckan/ckan/blob/master/ckan/config/declaration/load.py#L6). It is installed indirectly as a dependency of some dev-requirement. But it is missing when doing basic setup, so we need to require it explicitly

PS this library will be anyway added by the TypingPR, that's why I don't see any sense changing the code and not using it