### PR TITLE
Add select2 features

### DIFF
--- a/ckan/public/base/javascript/modules/autocomplete.js
+++ b/ckan/public/base/javascript/modules/autocomplete.js
@@ -29,7 +29,8 @@ this.ckan.module('autocomplete', function (jQuery) {
       tokensep: ',',
       interval: 300,
       dropdownClass: '',
-      containerClass: ''
+      containerClass: '',
+      minimumInputLength: 0
     },
 
     /* Sets up the module, binding methods, creating elements etc. Called
@@ -42,7 +43,7 @@ this.ckan.module('autocomplete', function (jQuery) {
       this.setupAutoComplete();
     },
 
-    /* Sets up the auto complete plugin.
+    /* Sets up the auto complete plugin. 
      *
      * Returns nothing.
      */
@@ -54,7 +55,8 @@ this.ckan.module('autocomplete', function (jQuery) {
         formatInputTooShort: this.formatInputTooShort,
         dropdownCssClass: this.options.dropdownClass,
         containerCssClass: this.options.containerClass,
-        tokenSeparators: this.options.tokensep.split('')
+        tokenSeparators: this.options.tokensep.split(''),
+        minimumInputLength: this.options.minimumInputLength
       };
 
       // Different keys are required depending on whether the select is
@@ -154,10 +156,10 @@ this.ckan.module('autocomplete', function (jQuery) {
       // Kills previous timeout
       clearTimeout(this._debounced);
 
-      // OK, wipe the dropdown before we start ajaxing the completions
-      fn({results:[]});
-
-      if (string) {
+      if (!string) {
+        // Wipe the dropdown for empty calls.
+        fn({results:[]});
+      } else {
         // Set a timer to prevent the search lookup occurring too often.
         this._debounced = setTimeout(function () {
           var term = module._lastTerm;
@@ -224,12 +226,6 @@ this.ckan.module('autocomplete', function (jQuery) {
       );
     },
 
-    /* Takes a string and converts it into an object used by the select2 plugin.
-     *
-     * term - The term to convert.
-     *
-     * Returns an object for use in select2.
-     */
     formatTerm: function (term) {
       term = jQuery.trim(term || '');
 

--- a/ckan/public/base/vendor/select2/select2.js
+++ b/ckan/public/base/vendor/select2/select2.js
@@ -1929,7 +1929,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 return;
             }
 
-            if (opts.formatSearching) {
+            if (opts.formatSearching && this.findHighlightableChoices().length === 0) {
                 render("<li class='select2-searching'>" + evaluate(opts.formatSearching, opts.element) + "</li>");
             }
 

--- a/ckan/public/base/vendor/select2/select2.js
+++ b/ckan/public/base/vendor/select2/select2.js
@@ -1929,7 +1929,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 return;
             }
 
-            if (opts.formatSearching && this.findHighlightableChoices().length === 0) {
+            if (opts.formatSearching) {
                 render("<li class='select2-searching'>" + evaluate(opts.formatSearching, opts.element) + "</li>");
             }
 

--- a/cypress/integration/modules/autocomplete.spec.js
+++ b/cypress/integration/modules/autocomplete.spec.js
@@ -74,7 +74,8 @@ describe('ckan.modules.AutocompleteModule()', function () {
         formatInputTooShort: this.module.formatInputTooShort,
         createSearchChoice: this.module.formatTerm, // Not used by tags.
         initSelection: this.module.formatInitialValue,
-	      tokenSeparators: [',']
+	      tokenSeparators: [','],
+        minimumInputLength: 0
       });
     });
 
@@ -92,7 +93,8 @@ describe('ckan.modules.AutocompleteModule()', function () {
         formatNoMatches: this.module.formatNoMatches,
         formatInputTooShort: this.module.formatInputTooShort,
         initSelection: this.module.formatInitialValue,
-        tokenSeparators: [',']
+        tokenSeparators: [','],
+        minimumInputLength: 0
       });
     })
     it('should watch the keydown event on the select2 input');
@@ -112,7 +114,8 @@ describe('ckan.modules.AutocompleteModule()', function () {
         formatInputTooShort: this.module.formatInputTooShort,
         createSearchChoice: this.module.formatTerm, // Not used by tags.
         initSelection: this.module.formatInitialValue,
-        tokenSeparators: [',']
+        tokenSeparators: [','],
+        minimumInputLength: 0
       });
     });
 
@@ -131,9 +134,31 @@ describe('ckan.modules.AutocompleteModule()', function () {
         formatInputTooShort: this.module.formatInputTooShort,
         createSearchChoice: this.module.formatTerm, // Not used by tags.
         initSelection: this.module.formatInitialValue,
-        tokenSeparators: [',']
+        tokenSeparators: [','],
+        minimumInputLength: 0
       });
     });
+
+    it('should allow a changing minimumInputLength', function () {
+      this.module.options.minimumInputLength = 3;
+      this.module.setupAutoComplete();
+
+      expect(this.select2).to.be.called;
+      expect(this.select2).to.be.calledWith({
+        width: 'resolve',
+        query: this.module._onQuery,
+        dropdownCssClass: '',
+        containerCssClass: '',
+        formatResult: this.module.formatResult,
+        formatNoMatches: this.module.formatNoMatches,
+        formatInputTooShort: this.module.formatInputTooShort,
+        createSearchChoice: this.module.formatTerm, // Not used by tags.
+        initSelection: this.module.formatInitialValue,
+        tokenSeparators: [','],
+        minimumInputLength: 3
+      });
+    });
+
   });
 
   describe('.getCompletions(term, fn)', function () {


### PR DESCRIPTION
### Proposed new features

 - Start using the `minimumInputLength` select2 option. Useful for heavy API call from an external `source`
 - Start showing the `Searching ...` label when select2 have a search in progress. We are (by mistake) wiping results before searching so select2 doesn't know we are searching.

https://user-images.githubusercontent.com/3237309/143074534-6cf0025b-3d66-45bf-9ace-285e03c6a2b6.mp4

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply

Related to [UNHCR#738](https://github.com/okfn/ckanext-unhcr/issues/738)
