### PR TITLE
update the python 3.6 to 3.7 in doc.

### DIFF
--- a/doc/maintaining/installing/index.rst
+++ b/doc/maintaining/installing/index.rst
@@ -9,7 +9,7 @@ There are three ways to install CKAN:
 #. Install from source
 #. Install from Docker Compose
 
-CKAN 2.9 supports Python 3.7. The next version of CKAN
+CKAN 2.9 supports Python 3.7  and Python 3.8 The next version of CKAN
 will support Python 3 only.
 
 Installing from package is the quickest and easiest way to install CKAN, but it requires
@@ -17,7 +17,7 @@ Ubuntu 18.04 64-bit or Ubuntu 20.04 64-bit.
 
 **You should install CKAN from package if**:
 
-* You want to install CKAN on an Ubuntu 18.04 or 20.04, 64-bit server, *and*
+* You want to install CKAN on an Ubuntu 18.04  or 20.04, 64-bit server, *and*
 * You only want to run one CKAN website per server
 
 See :doc:`install-from-package`.

--- a/doc/maintaining/installing/index.rst
+++ b/doc/maintaining/installing/index.rst
@@ -9,7 +9,7 @@ There are three ways to install CKAN:
 #. Install from source
 #. Install from Docker Compose
 
-CKAN 2.9 supports Python 3.6 or higher and Python 2.7. The next version of CKAN
+CKAN 2.9 supports Python 3.7. The next version of CKAN
 will support Python 3 only.
 
 Installing from package is the quickest and easiest way to install CKAN, but it requires

--- a/doc/maintaining/installing/install-from-package.rst
+++ b/doc/maintaining/installing/install-from-package.rst
@@ -5,7 +5,7 @@ Installing CKAN from package
 ============================
 
 This section describes how to install CKAN from package. This is the quickest
-and easiest way to install CKAN, but it requires **Ubuntu 18.04 (Python 2) or 20.04 (Python 3 or Python 2) 64-bit**. If
+and easiest way to install CKAN, but it requires **Ubuntu 18.04 (Python 3) or 20.04 (Python 3) 64-bit**. If
 you're not using any of these Ubuntu versions, or if you're installing CKAN for
 development, you should follow :doc:`install-from-source` instead.
 
@@ -13,10 +13,10 @@ At the end of the installation process you will end up with two running web
 applications, CKAN itself and the DataPusher, a separate service for automatically
 importing data to CKAN's :doc:`/maintaining/datastore`. Additionally, there will be a process running the worker for running :doc:`/maintaining/background-tasks`. All these processes will be managed by `Supervisor <https://supervisord.org/>`_.
 
-For Python 3 installations, the minimum Python version required is 3.6.
+For Python 3 installations, the minimum Python version required is 3.7.
 
 * **Ubuntu 20.04** includes **Python 3.8** as part of its distribution
-* **Ubuntu 18.04** includes **Python 3.6** as part of its distribution
+* **Ubuntu 18.04** includes **Python 3.7** as part of its distribution
 
 
 Host ports requirements:

--- a/doc/maintaining/installing/install-from-package.rst
+++ b/doc/maintaining/installing/install-from-package.rst
@@ -5,7 +5,7 @@ Installing CKAN from package
 ============================
 
 This section describes how to install CKAN from package. This is the quickest
-and easiest way to install CKAN, but it requires **Ubuntu 18.04 (Python 3) or 20.04 (Python 3) 64-bit**. If
+and easiest way to install CKAN, but it requires **Ubuntu 18.04 (Python 3.7) or 20.04 (Python 3.8) 64-bit**. If
 you're not using any of these Ubuntu versions, or if you're installing CKAN for
 development, you should follow :doc:`install-from-source` instead.
 

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -12,10 +12,10 @@ If you install CKAN from source on your own operating system, please share your
 experiences on our `How to Install CKAN <https://github.com/ckan/ckan/wiki/How-to-Install-CKAN>`_
 wiki page.
 
-**For Python 3 installations, the minimum Python version required is 3.6**
+**For Python 3 installations, the minimum Python version required is 3.7**
 
 * **Ubuntu 20.04** includes **Python 3.8** as part of its distribution
-* **Ubuntu 18.04** includes **Python 3.6** as part of its distribution
+* **Ubuntu 18.04** includes **Python 3.7** as part of its distribution
 
 From source is also the right installation method for developers who want to
 work on CKAN.
@@ -37,7 +37,7 @@ wiki page for help):
 =====================  ===============================================
 Package                Description
 =====================  ===============================================
-Python                 `The Python programming language, v3.6 or newer <https://www.python.org/getit/>`_
+Python                 `The Python programming language, v3.7 or newer <https://www.python.org/getit/>`_
 |postgres|             `The PostgreSQL database system, v9.5 or newer <https://www.postgresql.org/docs/9.5/libpq.html>`_
 libpq                  `The C programmer's interface to PostgreSQL <http://www.postgresql.org/docs/8.1/static/libpq.html>`_
 pip                    `A tool for installing and managing Python packages <https://pip.pypa.io/en/stable/>`_


### PR DESCRIPTION
Fixes #6549 

### Proposed fixes:
 3.6 end of life date  in a month , update python version 3.6 to 3.7 in  documents.
and  update the docs to reflect that master requires Python 3.7
### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
