### PR TITLE
Fix #6568: add "restart: unless-stopped" to docker-compose

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ defaults:
     name: ckan-redis
 
   solr_image: &solr_image
-    image: ckan/ckan-solr-dev:master
+    image: ckan/ckan-solr-dev:2.9
     name: ckan-solr
 
 jobs:

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - CKAN_MAX_UPLOAD_SIZE_MB=${CKAN_MAX_UPLOAD_SIZE_MB}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - DS_RO_PASS=${DATASTORE_READONLY_PASSWORD}
+    restart: unless-stopped
 
     volumes:
       - ckan_config:/etc/ckan
@@ -45,6 +46,7 @@ services:
     image: clementmouchet/datapusher
     ports:
       - "8800:8800"
+    restart: unless-stopped
 
   db:
     container_name: db
@@ -59,6 +61,7 @@ services:
       - pg_data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "ckan"]
+    restart: unless-stopped
 
   solr:
     container_name: solr
@@ -67,8 +70,9 @@ services:
       dockerfile: contrib/docker/solr/Dockerfile
     volumes:
       - solr_data:/opt/solr/server/solr/ckan/data
-
+    restart: unless-stopped
 
   redis:
     container_name: redis
     image: redis:6.2
+    restart: unless-stopped


### PR DESCRIPTION
Fixes #6568

### Proposed fixes:
In a default Ubuntu VM, this will cause services run with `docker-compose up -d` to restart after system reboot.
This PR uses a more cautious "unless stopped" restart policy to preserve the state of running services across a host reboot. 
The more aggressive "restart: always" discussed in the issue changes the system state after a reboot, which may not be intended.

This particular fix will not require changes to documentation.
Related, the docs chapter on docker-compose could be updated with a few other details. I'll send a separate PR once I've worked freshly through a docker-compose setup.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
