### PR TITLE
[6546]validation error on resource subfields

### DIFF
--- a/ckan/lib/navl/dictization_functions.py
+++ b/ckan/lib/navl/dictization_functions.py
@@ -245,6 +245,18 @@ def convert(converter, key, converted_data, errors, context):
         return
 
 
+def _remove_blank_keys_nested(schema_copy, key, value):
+
+    if schema_copy['resources'][0]:
+        resource_item = [i for i in schema_copy['resources'][0]]
+        resource_item = resource_item[0]
+        if not any(value[0][resource_item]):
+            schema_copy.pop(key)
+    else:
+        if not any(value[0]):
+            schema_copy.pop(key)
+
+
 def _remove_blank_keys(schema):
 
     schema_copy = copy.copy(schema)
@@ -253,7 +265,10 @@ def _remove_blank_keys(schema):
         if isinstance(value[0], dict):
             for item in value:
                 _remove_blank_keys(item)
-            if not any(value):
+                if key == 'resources':
+                    _remove_blank_keys_nested(schema_copy, key, value)
+                    break
+            if not any(value) and key != 'resources':
                 schema_copy.pop(key)
 
     return schema_copy


### PR DESCRIPTION
Fixes #6546 #6559

Added comment in #6546 that explains what causes the error.

### Proposed fixes:
Added helper function for `_remove_blank_keys()` which will deal against nested data e.g (`'resources': [{'schedule': [{}, {}, {}]}, {}]}`)

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
