### PR TITLE
Set logging level to error in error mail handler

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -551,6 +551,7 @@ def _setup_error_mail_handler(app):
         secure=secure
     )
 
+    mail_handler.setLevel(logging.ERROR)
     mail_handler.setFormatter(logging.Formatter('''
 Time:               %(asctime)s
 URL:                %(url)s


### PR DESCRIPTION
### Proposed fixes:

Error email handler sends an email for example Permission denied errors, it doesn't have a stack trace as those where removed in #6345, it just produces following email:

```
Time:               2021-12-07 08:13:21,716
URL:                /user/activity/test-user
Method:             GET
IP:                 127.0.0.1
Headers:            Cookie: _pk_id.19.5949=9a0143ef0e614333.1638863250.; _pk_ses.19.5949=1
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36
Connection: close
Host: vagrant.avoindata.fi
Upgrade-Insecure-Requests: 1
Cache-Control: max-age=0
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
X-Url-Scheme: http
Accept-Language: fi-FI,fi;q=0.9
Accept-Encoding: gzip, deflate
```

This PR sets logging level in mail handler to error so that these won't get logged and emailed to admins.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
