### PR TITLE
Migrate SessionExtension to events

### DIFF
--- a/ckan/model/extension.py
+++ b/ckan/model/extension.py
@@ -7,7 +7,6 @@ import logging
 from operator import methodcaller
 
 from sqlalchemy.orm.interfaces import MapperExtension
-from sqlalchemy.orm.session import SessionExtension
 
 import ckan.plugins as plugins
 
@@ -59,51 +58,4 @@ class PluginMapperExtension(MapperExtension):
     def after_delete(self, mapper, connection, instance):
         return self.notify_observers(
             methodcaller('after_delete', mapper, connection, instance)
-        )
-
-
-class PluginSessionExtension(SessionExtension):
-    """
-    Class that calls plugins implementing ISession on SQLAlchemy
-    SessionExtension events
-    """
-
-    def notify_observers(self, func):
-        """
-        Call func(observer) for all registered observers.
-
-        :param func: Any callable, which will be called for each observer
-        :returns: EXT_CONTINUE if no errors encountered, otherwise EXT_STOP
-        """
-        for observer in plugins.PluginImplementations(plugins.ISession):
-            func(observer)
-
-    def after_begin(self, session, transaction, connection):
-        return self.notify_observers(
-            methodcaller('after_begin', session, transaction, connection)
-        )
-
-    def before_flush(self, session, flush_context, instances):
-        return self.notify_observers(
-            methodcaller('before_flush', session, flush_context, instances)
-        )
-
-    def after_flush(self, session, flush_context):
-        return self.notify_observers(
-            methodcaller('after_flush', session, flush_context)
-        )
-
-    def before_commit(self, session):
-        return self.notify_observers(
-            methodcaller('before_commit', session)
-        )
-
-    def after_commit(self, session):
-        return self.notify_observers(
-            methodcaller('after_commit', session)
-        )
-
-    def after_rollback(self, session):
-        return self.notify_observers(
-            methodcaller('after_rollback', session)
         )

--- a/ckan/model/meta.py
+++ b/ckan/model/meta.py
@@ -17,7 +17,6 @@ Session = orm.scoped_session(orm.sessionmaker(
     autoflush=False,
     autocommit=False,
     expire_on_commit=False,
-    extension=[extension.PluginSessionExtension(),],
 ))
 
 
@@ -25,7 +24,6 @@ create_local_session = orm.sessionmaker(
     autoflush=False,
     autocommit=False,
     expire_on_commit=False,
-    extension=[extension.PluginSessionExtension(),],
 )
 
 


### PR DESCRIPTION
Fixes #6243 

### Proposed fixes:
This migrates our current PluginSessionExtension from SessionExtension (deprecated) to EventListeners.