### PR TITLE
Allow indexing deleted packages

### DIFF
--- a/ckan/cli/search_index.py
+++ b/ckan/cli/search_index.py
@@ -43,7 +43,7 @@ def rebuild(
                 only_missing=only_missing,
                 force=force,
                 defer_commit=(not commit_each),
-                quiet=quiet,
+                quiet=quiet and not verbose,
                 clear=clear)
     except Exception as e:
         error_shout(e)

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -649,6 +649,16 @@ groups:
 
       - key: solr_user
       - key: solr_password
+      - key: ckan.search.remove_deleted_packages
+        type: bool
+        default: true
+        description: |
+          By default, deleted datasets are removed from the search index so are no
+          longer available in searches. To keep them in the search index, set this
+          setting to ``False``. This will enable the  ``include_deleted``
+          parameter in the  :py:func:`ckan.logic.action.get.package_search`
+          API action.
+
       - key: ckan.search.solr_commit
         type: bool
         default: true

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -219,8 +219,12 @@ def rebuild(package_id: Optional[str] = None,
             log.info('Indexing just package %r...', pkg_dict['name'])
             package_index.update_dict(pkg_dict, True)
     else:
-        package_ids = [r[0] for r in model.Session.query(model.Package.id).
-                       filter(model.Package.state != 'deleted').all()]
+        packages = model.Session.query(model.Package.id)
+        if config.get_value('ckan.search.remove_deleted_packages'):
+            packages = packages.filter(model.Package.state != 'deleted')
+        
+        package_ids = [r[0] for r in packages.all()]
+        
         if only_missing:
             log.info('Indexing only missing packages...')
             package_query = query_for(model.Package)

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -136,7 +136,7 @@ class PackageSearchIndex(SearchIndex):
 
         if config.get_value('ckan.search.remove_deleted_packages'):
             # delete the package if there is no state, or the state is `deleted`
-            if (not pkg_dict.get('state') or 'deleted' in pkg_dict.get('state')):
+            if pkg_dict.get('state', 'deleted') == 'deleted':
                 return self.delete_package(pkg_dict)
 
         index_fields = RESERVED_FIELDS + list(pkg_dict.keys())

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -134,9 +134,10 @@ class PackageSearchIndex(SearchIndex):
         if title:
             pkg_dict['title_string'] = title
 
-        # delete the package if there is no state, or the state is `deleted`
-        if (not pkg_dict.get('state') or 'deleted' in pkg_dict['state']):
-            return self.delete_package(pkg_dict)
+        if config.get_value('ckan.search.remove_deleted_packages'):
+            # delete the package if there is no state, or the state is `deleted`
+            if (not pkg_dict.get('state') or 'deleted' in pkg_dict.get('state')):
+                return self.delete_package(pkg_dict)
 
         index_fields = RESERVED_FIELDS + list(pkg_dict.keys())
 

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -136,7 +136,7 @@ class PackageSearchIndex(SearchIndex):
 
         if config.get_value('ckan.search.remove_deleted_packages'):
             # delete the package if there is no state, or the state is `deleted`
-            if pkg_dict.get('state', 'deleted') == 'deleted':
+            if pkg_dict.get('state') in [None, 'deleted']:
                 return self.delete_package(pkg_dict)
 
         index_fields = RESERVED_FIELDS + list(pkg_dict.keys())

--- a/ckan/templates/admin/snippets/data_type.html
+++ b/ckan/templates/admin/snippets/data_type.html
@@ -17,6 +17,8 @@
       </button>
     </h2>
 
+{# entities list can be of different types #}
+{% set items = [] %}
 
     <!-- expanded by default to prevent problems with disabled js -->
     <div id="{{ ent_type }}" class="accordion-collapse collapse show p-2" aria-labelledby="heading-{{ ent_type }}"
@@ -24,6 +26,7 @@
       <ul class="{{ ent_type }}-list">
         {% for entity in entities %}
         {% set title = entity.title or entity.name %}
+          {% do items.append(title) %}
         <li>
           <a href="{{ h.url_for(entity.type + '.read', id=entity.name) }}">
             {{ title|truncate(80) }}
@@ -37,7 +40,7 @@
       </ul>
 
       <!-- show button only if there is entity to purge -->
-      {% if entities.first() %}
+      {% if items|length > 0 %}
       <form method="POST" class="d-flex justify-content-end" action="{{ h.url_for('admin.trash') }}"
         id="form-purge-{{ ent_type }}">
         <input type="hidden" name="action" value="{{ent_type}}">

--- a/ckan/tests/cli/test_search_index.py
+++ b/ckan/tests/cli/test_search_index.py
@@ -91,15 +91,23 @@ class TestSearchIndex(object):
         org1 = factories.Organization(user=user1)
         org2 = factories.Organization(user=user2)
         dataset1 = factories.Dataset(
-            user=user1, private=True, owner_org=org1["name"], state="deleted"
+            name="dataset-user-1",
+            user=user1,
+            private=True,
+            owner_org=org1["name"],
+            state="deleted"
         )
         dataset2 = factories.Dataset(
-            user=user2, private=True, owner_org=org2["name"], state="deleted"
+            name="dataset-user-2",
+            user=user2,
+            private=True,
+            owner_org=org2["name"],
+            state="deleted"
         )
 
         search_results_1 = helpers.call_action(
             "package_search",
-            {"user": user1["name"]},
+            {"user": user1["name"], "ignore_auth": False},
             include_private=True,
             include_deleted=True
         )
@@ -109,7 +117,7 @@ class TestSearchIndex(object):
 
         search_results_2 = helpers.call_action(
             "package_search",
-            {"user": user2["name"]},
+            {"user": user2["name"], "ignore_auth": False},
             include_private=True,
             include_deleted=True
         )

--- a/ckan/views/admin.py
+++ b/ckan/views/admin.py
@@ -184,19 +184,17 @@ class TrashView(MethodView):
         )
 
     def _get_deleted_datasets_from_search_index(self) -> List[Any]:
-        query = search.query_for(model.Package)
+        package_search = logic.get_action('package_search')
         search_params = {
             'fq': '+state:deleted',
-            'df': 'text',
-            'fl': 'id name title dataset_type',
+            'include_private': True,
         }
-        query.run(search_params)
+        base_results = package_search(
+            {'ignore_auth': True},
+            search_params
+        )
 
-        results = []
-        for result in query.results:
-            result['type'] = result['dataset_type']
-            results.append(result)
-        return results
+        return base_results['results']
 
     def get(self) -> str:
         ent_type = request.args.get(u'name')

--- a/ckan/views/admin.py
+++ b/ckan/views/admin.py
@@ -12,7 +12,6 @@ import ckan.lib.app_globals as app_globals
 import ckan.lib.base as base
 import ckan.lib.helpers as h
 import ckan.lib.navl.dictization_functions as dict_fns
-import ckan.lib.search as search
 import ckan.logic as logic
 import ckan.model as model
 import ckan.logic.schema

--- a/ckan/views/admin.py
+++ b/ckan/views/admin.py
@@ -191,7 +191,11 @@ class TrashView(MethodView):
         }
         query.run(search_params)
 
-        return query.results
+        results = []
+        for result in query.results:
+            result['type'] = result['dataset_type']
+            results.append(result)
+        return results
 
     def get(self) -> str:
         ent_type = request.args.get(u'name')


### PR DESCRIPTION
Related to [UNHCR#287](https://github.com/okfn/ckanext-unhcr/issues/287)

### Proposed fixes:

CKAN remove all deleted packages from the search index.
This PR propose to make this behavior, optional (by adding the `ckan.search.remove_deleted_packages` new config value)

Deleted data sets will not be visible until an extension adds the `include_deleted` parameter to the `before_search` function.

The purge dataset form is also updated to list deleted from search index instead DB

Also proposed fix: Start to take into account the value of `verbose` param for the `search-index rebuild` command.
### Features:

- [x] includes tests covering changes
- [x] includes updated documentation
- [x] includes user-visible changes
- [x] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
