### PR TITLE
Clean old IRoutes interface

### DIFF
--- a/changes/6594.removal
+++ b/changes/6594.removal
@@ -1,0 +1,2 @@
+The `IRoutes` interface has been removed since it was part of the old Pylons
+architecture.

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -13,7 +13,6 @@ from pyutilib.component.core import Interface as _pca_Interface
 
 __all__ = [
     u'Interface',
-    u'IRoutes',
     u'IMapper',
     u'ISession',
     u'IMiddleware',
@@ -114,32 +113,6 @@ class IMiddleware(Interface):
         Pylons app.
         '''
         return app
-
-
-class IRoutes(Interface):
-    u'''
-    Plugin into the setup of the routes map creation.
-
-    '''
-    def before_map(self, map):
-        u'''
-        Called before the routes map is generated. ``before_map`` is before any
-        other mappings are created so can override all other mappings.
-
-        :param map: Routes map object
-        :returns: Modified version of the map object
-        '''
-        return map
-
-    def after_map(self, map):
-        u'''
-        Called after routes map is set up. ``after_map`` can be used to
-        add fall-back handlers.
-
-        :param map: Routes map object
-        :returns: Modified version of the map object
-        '''
-        return map
 
 
 class IMapper(Interface):

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -12,7 +12,6 @@ from babel import Locale
 import pytest
 
 import ckan.lib.helpers as h
-import ckan.plugins as p
 import ckan.exceptions
 from ckan.tests import helpers, factories
 

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -660,41 +660,6 @@ class TestBuildNavMain(object):
         assert link == '<li><a href="/organization/edit/org-id"><i class="fa fa-pencil-square-o"></i> Edit</a></li>'
 
 
-class HelpersTestPlugin(p.SingletonPlugin):
-
-    p.implements(p.IRoutes, inherit=True)
-
-    controller = "ckan.tests.lib.test_helpers:TestHelperController"
-
-    def after_map(self, _map):
-
-        _map.connect(
-            "/broken_helper_as_attribute",
-            controller=self.controller,
-            action="broken_helper_as_attribute",
-        )
-
-        _map.connect(
-            "/broken_helper_as_item",
-            controller=self.controller,
-            action="broken_helper_as_item",
-        )
-
-        _map.connect(
-            "/helper_as_attribute",
-            controller=self.controller,
-            action="helper_as_attribute",
-        )
-
-        _map.connect(
-            "/helper_as_item",
-            controller=self.controller,
-            action="helper_as_item",
-        )
-
-        return _map
-
-
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 class TestActivityListSelect(object):
     def test_simple(self):

--- a/ckan/tests/plugins/ckantestplugins.py
+++ b/ckan/tests/plugins/ckantestplugins.py
@@ -46,21 +46,6 @@ class SessionPlugin(p.SingletonPlugin):
         self.deleted.append(instance)
 
 
-class RoutesPlugin(p.SingletonPlugin):
-    p.implements(p.IRoutes, inherit=True)
-
-    def __init__(self, *args, **kw):
-        self.calls_made = []
-
-    def before_map(self, map):
-        self.calls_made.append("before_map")
-        return map
-
-    def after_map(self, map):
-        self.calls_made.append("after_map")
-        return map
-
-
 class PluginObserverPlugin(mock_plugin.MockSingletonPlugin):
     p.implements(p.IPluginObserver)
 

--- a/ckan/tests/plugins/test_core.py
+++ b/ckan/tests/plugins/test_core.py
@@ -128,13 +128,13 @@ def reset_observer():
 
 
 def test_plugins_load(monkeypatch):
-    monkeypatch.setitem(config, "ckan.plugins", "mapper_plugin routes_plugin")
+    monkeypatch.setitem(config, "ckan.plugins", "mapper_plugin action_plugin")
     plugins.load_all()
     # synchronous_search automatically gets loaded
     current_plugins = set(
         [
             plugins.get_plugin(p)
-            for p in ["mapper_plugin", "routes_plugin", "synchronous_search"]
+            for p in ["mapper_plugin", "action_plugin", "synchronous_search"]
             + find_system_plugins()
         ]
     )

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -37,7 +37,6 @@ class DatastorePlugin(p.SingletonPlugin):
     p.implements(p.IConfigurer)
     p.implements(p.IActions)
     p.implements(p.IAuthFunctions)
-    p.implements(p.IRoutes, inherit=True)
     p.implements(p.IResourceController, inherit=True)
     p.implements(p.ITemplateHelpers)
     p.implements(p.IForkObserver, inherit=True)

--- a/doc/contributing/architecture.rst
+++ b/doc/contributing/architecture.rst
@@ -10,17 +10,14 @@ of CKAN.
      :alt: CKAN architecture diagram
 
 
-------
-Routes
-------
+----------
+Blueprints
+----------
 
-Routes define the connection between CKAN URLs and views that process
-requests and provide responses.
+CKAN is based on Flask and built using Blueprints.
 
-Default routes are defined in ``ckan.config.routing`` and extended with the
-:class:`ckan.plugins.interfaces.IRoutes` plugin interface.
-
-.. FIXME: talk about flask
+Default blueprints are defined along views in ``ckan.views`` and extended with the
+:class:`ckan.plugins.interfaces.IBlueprint` plugin interface.
 
 
 -----
@@ -29,7 +26,7 @@ Views
 
 Views process requests by reading and updating data with action
 function and return a response by rendering Jinja2 templates.
-CKAN views are defined in ``ckan.controllers`` and templates in
+CKAN views are defined in ``ckan.views`` and templates in
 ``ckan.templates``.
 
 Views and templates may use ``logic.check_access`` or

--- a/setup.py
+++ b/setup.py
@@ -163,7 +163,6 @@ entry_points = {
         'domain_object_mods = ckan.model.modification:DomainObjectModificationExtension',
     ],
     'ckan.test_plugins': [
-        'routes_plugin = tests.plugins.ckantestplugins:RoutesPlugin',
         'mapper_plugin = tests.plugins.ckantestplugins:MapperPlugin',
         'session_plugin = tests.plugins.ckantestplugins:SessionPlugin',
         'mapper_plugin2 = tests.plugins.ckantestplugins:MapperPlugin2',


### PR DESCRIPTION
This Interface is no longer used since it was part of the Pylons architecture.