### PR TITLE
Documentation - update for supervisor ckan worker.log

### DIFF
--- a/doc/maintaining/background-tasks.rst
+++ b/doc/maintaining/background-tasks.rst
@@ -207,7 +207,7 @@ via
 
     ckan -c |ckan.ini| jobs test
 
-The worker's log files (``/var/log/ckan/ckan-worker.stdout.log`` and ``/var/log/ckan/ckan-worker.stderr.log``) 
+The worker's log files (``/var/log/ckan/ckan-worker.stdout.log`` and/or ``/var/log/ckan/ckan-worker.stderr.log``) 
 should then show how the job was processed by the worker.
 
 In case you run into problems, make sure to check the logs of Supervisor and

--- a/doc/maintaining/background-tasks.rst
+++ b/doc/maintaining/background-tasks.rst
@@ -173,6 +173,10 @@ First install Supervisor::
 Next copy the configuration file template::
 
     sudo cp /usr/lib/ckan/default/src/ckan/ckan/config/supervisor-ckan-worker.conf /etc/supervisor/conf.d
+    
+Next make sure the ``/var/log/ckan/`` directory exists, if not then it needs to be created::
+
+    sudo mkdir /var/log/ckan
 
 Open ``/etc/supervisor/conf.d/supervisor-ckan-worker.conf`` in your favourite
 text editor and make sure all the settings suit your needs. If you installed
@@ -203,14 +207,15 @@ via
 
     ckan -c |ckan.ini| jobs test
 
-The worker's log (``/var/log/ckan-worker.log``) should then show how the job
-was processed by the worker.
+The worker's log files (``/var/log/ckan/ckan-worker.stdout.log`` and ``/var/log/ckan/ckan-worker.stderr.log``) 
+should then show how the job was processed by the worker.
 
 In case you run into problems, make sure to check the logs of Supervisor and
 the worker::
 
     cat /var/log/supervisor/supervisord.log
-    cat /var/log/ckan-worker.log
+    cat /var/log/ckan/ckan-worker.stdout.log
+    cat /var/log/ckan/ckan-worker.sterr.log
 
 
 


### PR DESCRIPTION
Fixes: https://github.com/ckan/ckan/issues/6587

### Proposed fixes:
Update the background-tasks.rst documentation file to reference the correct location and names of the
CKAN Worker log files:  `/var/log/ckan/ckan-worker.stdout.log` and `/var/log/ckan/ckan-worker.stderr.log`

The template file: `https://github.com/ckan/ckan/blob/master/ckan/config/supervisor-ckan-worker.conf` has the correct
correct location and names of the log files. The doco didn't.


### Features:

- [ ] includes tests covering changes
- [ x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
