### PR TITLE
Documentation: Update solr.rst with correct solr port

### DIFF
--- a/doc/maintaining/installing/solr.rst
+++ b/doc/maintaining/installing/solr.rst
@@ -67,7 +67,7 @@ Installing Solr manually
 Next steps with Solr
 ====================
 
-To check that Solr started you can visit the web interface at http://localhost:8989/solr
+To check that Solr started you can visit the web interface at http://localhost:8983/solr
 
 .. warning:: The two installation methods above will leave you with a setup that is fine for local development, but Solr should never be exposed publicly in a production site. Pleaser refer to the `Solr documentation <https://solr.apache.org/guide/securing-solr.html>`_ to learn how to secure your Solr instance.
 


### PR DESCRIPTION

### Proposed fixes:
new Solr documentation has an incorrect port number (8989) - changed to 8983


### Features:

- [ ] includes tests covering changes
- [x ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
