### PR TITLE
Accept empty string in one of validator

### DIFF
--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -951,9 +951,9 @@ def email_is_unique(key, data, errors, context):
 
 
 def one_of(list_of_value):
-    ''' Checks if the provided value is present in a list '''
+    ''' Checks if the provided value is present in a list or is an empty string'''
     def callable(value):
-        if value not in list_of_value:
+        if value == "" or value not in list_of_value:
             raise Invalid(_('Value must be one of {}'.format(list_of_value)))
         return value
     return callable

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -953,7 +953,7 @@ def email_is_unique(key, data, errors, context):
 def one_of(list_of_value):
     ''' Checks if the provided value is present in a list or is an empty string'''
     def callable(value):
-        if value == "" or value not in list_of_value:
+        if value != "" and value not in list_of_value:
             raise Invalid(_('Value must be one of {}'.format(list_of_value)))
         return value
     return callable

--- a/ckan/tests/logic/test_validators.py
+++ b/ckan/tests/logic/test_validators.py
@@ -869,6 +869,11 @@ class TestOneOfValidator(object):
         func = validators.one_of(cont)
         raises_invalid(func)(5)
 
+    def test_empty_val_accepted(self):
+        cont = [1, 2, 3, 4]
+        func = validators.one_of(cont)
+        assert func("") == ""
+
 
 def test_tag_string_convert():
     def convert(tag_string):


### PR DESCRIPTION
Fixes #6605 

### Proposed fixes:

Adds a simple check for empty string in OneOf validator. Previous implementation also accepted empty lists and everything except 0 value as empty: [link](https://github.com/bdoms/formencode/blob/3ee909d2dd0e304f195f7625dfb9cf642e8573da/validators.py#L408-L438), should this be also replicated or should this be handled in some other way ?


### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
