### PR TITLE
Better callback url base management (behind reverse proxy)

### DIFF
--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -130,6 +130,10 @@ def datapusher_submit(context, data_dict):
         'get_site_user')({'ignore_auth': True}, {})
 
     try:
+        original_url_base = ''
+        if callback_url_base:
+            original_url_base = config.get_value("ckan.site_url")
+
         r = requests.post(
             urljoin(datapusher_url, 'job'),
             headers={
@@ -146,6 +150,9 @@ def datapusher_submit(context, data_dict):
                     'set_url_type': data_dict.get('set_url_type', False),
                     'task_created': task['last_updated'],
                     'original_url': resource_dict.get('url'),
+                    # added to replace the base url behind reverse proxy with the internal base url
+                    # in datapusher job.py
+                    'original_url_base': original_url_base,
                 }
             }))
         r.raise_for_status()


### PR DESCRIPTION
# Fixes #

When behind reverse proxy datapusher try to reach ckan using the external url (ckan.site_url) instead of using ckan.datapusher.callback_url_base. This fix send original_url_base (the external url) to datapusher to make it replace with callback_url_base.

See datapusher pull request.
