### PR TITLE
Use correct auth function when editing organizations

### DIFF
--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -1064,7 +1064,7 @@ class EditGroupView(MethodView):
 
         try:
             _action(u'group_show')(context, data_dict)
-            check_access(u'group_update', context)
+            _check_access(u'group_update', context, {u'id': id})
         except NotAuthorized:
             base.abort(403, _(u'Unauthorized to create a group'))
         except NotFound:


### PR DESCRIPTION
Fixes #6621

### Proposed fixes:
- Use `_check_access` in EditGroupView like the rest of the views


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply

Financed by Finland's open data portal opendata.fi. Find all Finnish open data at https://www.opendata.fi/en.
The Service is provided by the Digital and Population Data Services Agency (https://dvv.fi/en/).