### PR TITLE
Improve translation logging

### DIFF
--- a/ckan/lib/i18n.py
+++ b/ckan/lib/i18n.py
@@ -348,8 +348,9 @@ def build_js_translations():
 
         latest = max(os.path.getmtime(fn) for fn in po_files)
         dest_file = os.path.join(_JS_TRANSLATIONS_DIR, lang + u'.js')
-        if os.path.isfile(dest_file) and os.path.getmtime(dest_file) > latest:
-            log.debug(u'JS translation for "{}" is up to date'.format(lang))
-        else:
-            log.debug(u'Generating JS translation for "{}"'.format(lang))
+
+        if not (os.path.isfile(dest_file) and os.path.getmtime(dest_file) > latest):
+            log.debug('Generating JS translation for "{}"'.format(lang))
             _build_js_translation(lang, po_files, js_entries, dest_file)
+
+    log.debug('All JS translation are up to date')

--- a/ckan/lib/i18n.py
+++ b/ckan/lib/i18n.py
@@ -350,7 +350,7 @@ def build_js_translations():
         dest_file = os.path.join(_JS_TRANSLATIONS_DIR, lang + u'.js')
 
         if (not os.path.isfile(dest_file) or
-            os.path.getmtime(dest_file) < latest):
+                os.path.getmtime(dest_file) < latest):
             log.debug('Generating JS translation for "{}"'.format(lang))
             _build_js_translation(lang, po_files, js_entries, dest_file)
 

--- a/ckan/lib/i18n.py
+++ b/ckan/lib/i18n.py
@@ -349,7 +349,8 @@ def build_js_translations():
         latest = max(os.path.getmtime(fn) for fn in po_files)
         dest_file = os.path.join(_JS_TRANSLATIONS_DIR, lang + u'.js')
 
-        if not (os.path.isfile(dest_file) and os.path.getmtime(dest_file) > latest):
+        if (not os.path.isfile(dest_file) or
+            os.path.getmtime(dest_file) < latest):
             log.debug('Generating JS translation for "{}"'.format(lang))
             _build_js_translation(lang, po_files, js_entries, dest_file)
 


### PR DESCRIPTION
Currently, the translation logs when running CKAN are really noisy and looks like a 'every-works-fine' alarm.

![image](https://user-images.githubusercontent.com/6672339/147937309-a861810a-eb26-47ef-97f8-ffa03faeae93.png)


I'm simplifying the logic to make the logs less noisy to the developer:
![image](https://user-images.githubusercontent.com/6672339/147937408-03691bef-68b7-418b-af71-deaccb1d15f2.png)
