### PR TITLE
Refactor some global variables

### DIFF
--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -21,8 +21,6 @@ MB = 1 << 20
 log = logging.getLogger(__name__)
 
 _storage_path = None
-_max_resource_size = None
-_max_image_size = None
 
 
 def _copy_file(input_file, output_file, max_size):
@@ -95,17 +93,11 @@ def get_storage_path():
 
 
 def get_max_image_size():
-    global _max_image_size
-    if _max_image_size is None:
-        _max_image_size = config.get_value('ckan.max_image_size')
-    return _max_image_size
+    return config.get_value('ckan.max_image_size', 2)
 
 
 def get_max_resource_size():
-    global _max_resource_size
-    if _max_resource_size is None:
-        _max_resource_size = config.get_value('ckan.max_resource_size')
-    return _max_resource_size
+    return config.get_value('ckan.max_resource_size', 10)
 
 
 class Upload(object):

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -84,11 +84,11 @@ def get_storage_path():
 
 
 def get_max_image_size():
-    return config.get_value('ckan.max_image_size', 2)
+    return config.get_value('ckan.max_image_size')
 
 
 def get_max_resource_size():
-    return config.get_value('ckan.max_resource_size', 10)
+    return config.get_value('ckan.max_resource_size')
 
 
 class Upload(object):

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -20,9 +20,6 @@ MB = 1 << 20
 
 log = logging.getLogger(__name__)
 
-_storage_path = None
-
-
 def _copy_file(input_file, output_file, max_size):
     input_file.seek(0)
     current_size = 0
@@ -76,20 +73,13 @@ def get_resource_uploader(data_dict):
 
 
 def get_storage_path():
-    '''Function to cache storage path'''
-    global _storage_path
+    '''Function to get the storage path from config file.'''
+    storage_path = config.get_value('ckan.storage_path')
+    if not storage_path:
+        log.critical('''Please specify a ckan.storage_path in your config
+                        for your uploads''')
 
-    # None means it has not been set. False means not in config.
-    if _storage_path is None:
-        storage_path = config.get_value('ckan.storage_path')
-        if storage_path:
-            _storage_path = storage_path
-        else:
-            log.critical('''Please specify a ckan.storage_path in your config
-                         for your uploads''')
-            _storage_path = False
-
-    return _storage_path
+    return storage_path
 
 
 def get_max_image_size():

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -20,6 +20,7 @@ MB = 1 << 20
 
 log = logging.getLogger(__name__)
 
+
 def _copy_file(input_file, output_file, max_size):
     input_file.seek(0)
     current_size = 0

--- a/ckan/tests/controllers/test_api.py
+++ b/ckan/tests/controllers/test_api.py
@@ -65,7 +65,6 @@ class TestApiController(object):
         self, app, monkeypatch, tmpdir, ckan_config
     ):
         monkeypatch.setitem(ckan_config, u"ckan.storage_path", str(tmpdir))
-        monkeypatch.setattr(ckan_uploader, u"_storage_path", str(tmpdir))
 
         user = factories.User()
         pkg = factories.Dataset(creator_user_id=user["id"])

--- a/ckan/tests/controllers/test_api.py
+++ b/ckan/tests/controllers/test_api.py
@@ -12,7 +12,6 @@ from io import BytesIO
 from ckan.lib.helpers import url_for
 import ckan.tests.helpers as helpers
 from ckan.tests import factories
-from ckan.lib import uploader as ckan_uploader
 
 
 @pytest.mark.parametrize(

--- a/ckan/tests/lib/test_uploader.py
+++ b/ckan/tests/lib/test_uploader.py
@@ -11,7 +11,6 @@ class TestInitResourceUpload(object):
     def test_resource_without_upload_with_old_werkzeug(
             self, ckan_config, monkeypatch, tmpdir):
         monkeypatch.setitem(ckan_config, u'ckan.storage_path', str(tmpdir))
-        monkeypatch.setattr(ckan.lib.uploader, u'_storage_path', str(tmpdir))
 
         # this test data is based on real observation using a browser
         # and werkzeug 0.14.1
@@ -30,7 +29,6 @@ class TestInitResourceUpload(object):
     def test_resource_without_upload(
             self, ckan_config, monkeypatch, tmpdir):
         monkeypatch.setitem(ckan_config, u'ckan.storage_path', str(tmpdir))
-        monkeypatch.setattr(ckan.lib.uploader, u'_storage_path', str(tmpdir))
         # this test data is based on real observation using a browser
         res = {u'clear_upload': u'true',
                u'format': u'PNG',
@@ -47,7 +45,6 @@ class TestInitResourceUpload(object):
     def test_resource_with_upload(
             self, ckan_config, monkeypatch, tmpdir):
         monkeypatch.setitem(ckan_config, u'ckan.storage_path', str(tmpdir))
-        monkeypatch.setattr(ckan.lib.uploader, u'_storage_path', str(tmpdir))
         # this test data is based on real observation using a browser
         res = {u'clear_upload': u'',
                u'format': u'PNG',
@@ -70,7 +67,6 @@ class TestUpload(object):
 
         """
         monkeypatch.setitem(ckan_config, u'ckan.storage_path', str(tmpdir))
-        monkeypatch.setattr(ckan.lib.uploader, u'_storage_path', str(tmpdir))
         group = {u'clear_upload': u'',
                  u'upload': FileStorage(
                      BytesIO(six.ensure_binary(u'hello')),

--- a/ckan/tests/lib/test_uploader.py
+++ b/ckan/tests/lib/test_uploader.py
@@ -3,7 +3,6 @@ import six
 from io import BytesIO
 from werkzeug.datastructures import FileStorage
 
-import ckan.lib.uploader
 from ckan.lib.uploader import ResourceUpload, Upload
 
 

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -407,7 +407,7 @@ class TestResourceCreate:
 
         assert not stored_resource["url"]
 
-    def test_mimetype_by_url(self, monkeypatch, tmpdir):
+    def test_mimetype_by_url(self, monkeypatch, ckan_config, tmpdir):
         """The mimetype is guessed from the url
 
         Real world usage would be externally linking the resource and
@@ -420,7 +420,7 @@ class TestResourceCreate:
             "url": "http://localhost/data.csv",
             "name": "A nice resource",
         }
-        monkeypatch.setattr(ckan.lib.uploader, "_storage_path", str(tmpdir))
+        monkeypatch.setitem(ckan_config, u'ckan.storage_path', str(tmpdir))
         result = helpers.call_action("resource_create", context, **params)
 
         mimetype = result.pop("mimetype")

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -8,7 +8,6 @@ import unittest.mock as mock
 import pytest
 
 
-import ckan
 import ckan.logic as logic
 import ckan.model as model
 import ckan.tests.factories as factories

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -1051,7 +1051,7 @@ class TestResourceUpdate(object):
 
         assert "datastore_active" not in res_returned
 
-    def test_mimetype_by_url(self, monkeypatch, tmpdir):
+    def test_mimetype_by_url(self, monkeypatch, ckan_config, tmpdir):
         """The mimetype is guessed from the url
 
         Real world usage would be externally linking the resource and
@@ -1062,7 +1062,7 @@ class TestResourceUpdate(object):
         resource = factories.Resource(
             package=dataset, url="http://localhost/data.csv", name="Test"
         )
-        monkeypatch.setattr(ckan.lib.uploader, "_storage_path", str(tmpdir))
+        monkeypatch.setitem(ckan_config, u'ckan.storage_path', str(tmpdir))
         res_update = helpers.call_action(
             "resource_update",
             id=resource["id"],

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -6,7 +6,6 @@ import time
 import unittest.mock as mock
 import pytest
 
-import ckan
 import ckan.lib.app_globals as app_globals
 import ckan.logic as logic
 import ckan.plugins as p

--- a/ckan/tests/pytest_ckan/fixtures.py
+++ b/ckan/tests/pytest_ckan/fixtures.py
@@ -364,7 +364,6 @@ def create_with_upload(clean_db, ckan_config, monkeypatch, tmpdir):
 
     """
     monkeypatch.setitem(ckan_config, u'ckan.storage_path', str(tmpdir))
-    monkeypatch.setattr(ckan.lib.uploader, u'_storage_path', str(tmpdir))
 
     def factory(data, filename, context={}, **kwargs):
         action = kwargs.pop(u"action", u"resource_create")

--- a/ckanext/example_iuploader/test/test_plugin.py
+++ b/ckanext/example_iuploader/test/test_plugin.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 from ckan.lib.helpers import url_for
 
 from urllib.parse import urlparse
-import ckan.lib.uploader
 import ckan.model as model
 
 import ckan.tests.factories as factories

--- a/ckanext/example_iuploader/test/test_plugin.py
+++ b/ckanext/example_iuploader/test/test_plugin.py
@@ -31,7 +31,6 @@ def test_resource_download_iuploader_called(
         send_file, app, monkeypatch, tmpdir, ckan_config
 ):
     monkeypatch.setitem(ckan_config, u'ckan.storage_path', str(tmpdir))
-    monkeypatch.setattr(ckan.lib.uploader, u'_storage_path', str(tmpdir))
 
     user = factories.User()
     env = {"REMOTE_USER": six.ensure_str(user["name"])}


### PR DESCRIPTION
This PR cleans some old global variables from the `uploader` code:
 - Using global variables is not recommended
 - They belonged to an old legacy logic no longer available in our codebase.