### PR TITLE
Clean ckan.validated_data_dict config

### DIFF
--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -311,9 +311,6 @@ groups:
       - key: ckan.search.solr_commit
         type: bool
         default: true
-      - key: ckan.cache_validated_datasets
-        type: bool
-        default: true
       - key: ckan.search.show_all_types
         default: dataset
       - key: ckan.search.default_include_private

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -111,19 +111,17 @@ class PackageSearchIndex(SearchIndex):
         for r in pkg_dict.get('resources', []):
             r.pop('tracking_summary', None)
 
+        # Index validated data-dict
+        package_plugin = lib_plugins.lookup_package_plugin(
+            pkg_dict.get('type'))
+        schema = package_plugin.show_package_schema()
+        validated_pkg_dict, errors = lib_plugins.plugin_validate(
+            package_plugin, {'model': model, 'session': model.Session},
+            pkg_dict, schema, 'package_show')
+        pkg_dict['validated_data_dict'] = json.dumps(validated_pkg_dict,
+            cls=ckan.lib.navl.dictization_functions.MissingNullEncoder)
+
         data_dict_json = json.dumps(pkg_dict)
-
-        if config.get_value('ckan.cache_validated_datasets'):
-            package_plugin = lib_plugins.lookup_package_plugin(
-                pkg_dict.get('type'))
-
-            schema = package_plugin.show_package_schema()
-            validated_pkg_dict, errors = lib_plugins.plugin_validate(
-                package_plugin, {'model': model, 'session': model.Session},
-                pkg_dict, schema, 'package_show')
-            pkg_dict['validated_data_dict'] = json.dumps(validated_pkg_dict,
-                cls=ckan.lib.navl.dictization_functions.MissingNullEncoder)
-
         pkg_dict['data_dict'] = data_dict_json
 
         # add to string field for sorting


### PR DESCRIPTION
Currently CKAN has a strong dependency on `validated_data_dict` so `config.get_value('ckan.cache_validated_datasets')` option is now mandatory and cannot be set to `False`.

I'm removing the config to avoid confusion.