### PR TITLE
Remove unnecessary block

### DIFF
--- a/ckan/templates/package/snippets/additional_info.html
+++ b/ckan/templates/package/snippets/additional_info.html
@@ -8,7 +8,6 @@
       </tr>
     </thead>
     <tbody>
-      {% block package_additional_info %}
         {% if pkg_dict.url %}
           <tr>
             <th scope="row" class="dataset-label">{{ _('Source') }}</th>
@@ -22,8 +21,6 @@
               <td class="dataset-details" property="foaf:homepage">{{ pkg_dict.url }}</td>
             {% endif %}
           </tr>
-        {% endif %}
-
         {% if pkg_dict.author_email %}
           <tr>
             <th scope="row" class="dataset-label">{{ _("Author") }}</th>


### PR DESCRIPTION
Fixes #

### Proposed fixes:

The `read.html` file for packages already includes a block called `package_additional_info`

```
  {% block package_additional_info %}
    {% snippet "package/snippets/additional_info.html", pkg_dict=pkg %}
  {% endblock %}
```
The proposed block for deletion exists inside a block with the same name.
This probably it's an error and fail to use this block from extensions


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
