### PR TITLE
[QOL-8368] fix race condition in creating the default site user

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -227,6 +227,9 @@ def update_config():
     except (sqlalchemy.exc.ProgrammingError, sqlalchemy.exc.OperationalError):
         # The database is not yet initialised. It happens in `ckan db init`
         pass
+    except sqlalchemy.exc.IntegrityError:
+        # Race condition, user already exists.
+        pass
 
     # Close current session and open database connections to ensure a clean
     # clean environment even if an error occurs later on


### PR DESCRIPTION
Fixes #6631 

### Proposed fixes:

Ignore duplicate key errors (caused by race conditions) when creating the site user, since it's an idempotent operation.

### Features:

- [X] includes bugfix for possible backport

Could be backported to earlier 2.9 versions. Doesn't appear to affect 2.8.