### PR TITLE
Remove obsolete config automatic_index

### DIFF
--- a/changes/6639.removal
+++ b/changes/6639.removal
@@ -1,0 +1,1 @@
+Remove ckan.search.automatic_indexing config

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -305,9 +305,6 @@ groups:
         required: true
       - key: solr_user
       - key: solr_password
-      - key: ckan.search.automatic_indexing
-        type: bool
-        default: true
       - key: ckan.search.solr_commit
         type: bool
         default: true

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -119,8 +119,7 @@ class SynchronousSearchPlugin(p.SingletonPlugin):
     p.implements(p.IDomainObjectModification, inherit=True)
 
     def notify(self, entity, operation):
-        if (not isinstance(entity, model.Package) or
-                not config.get_value('ckan.search.automatic_indexing')):
+        if not isinstance(entity, model.Package):
             return
         if operation != model.domain_object.DomainObjectOperation.deleted:
             dispatch_by_operation(

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -1188,8 +1188,6 @@ Optionally, ``solr_user`` and ``solr_password`` can also be configured to specif
 
 .. note::  If you change this value, you need to rebuild the search index.
 
-.. _ckan.search.automatic_indexing:
-
 solr_timeout
 ^^^^^^^^^^^^
 
@@ -1200,21 +1198,6 @@ Example::
 Default value: |config:solr_timeout|
 
 The option defines the timeout in seconds until giving up on a request. Raising this value might help you if you encounter a timeout exception.
-
-ckan.search.automatic_indexing
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Example::
-
- ckan.search.automatic_indexing = true
-
-Default value: |config:ckan.search.automatic_indexing|
-
-Make all changes immediately available via the search after editing or
-creating a dataset. Default is true. If for some reason you need the indexing
-to occur asynchronously, set this option to false.
-
-.. note:: This is equivalent to explicitly load the ``synchronous_search`` plugin.
 
 .. _ckan.search.solr_commit:
 


### PR DESCRIPTION
Currently CKAN depends on `ckan.search.automatic_indexing` to be `True` to be fully functional. 

I'm removing this config variable to cleanup the code since it cannot be set to `False`.