### PR TITLE
Clean PluginMapperExtension (deprecated dependency)

### DIFF
--- a/changes/6648.removal
+++ b/changes/6648.removal
@@ -1,0 +1,2 @@
+The `PluginMapperExtension` has been removed since it was no longer used in core
+and it had a deprecated dependency.

--- a/ckan/model/extension.py
+++ b/ckan/model/extension.py
@@ -6,60 +6,12 @@ Provides bridges between the model and plugin PluginImplementationss
 import logging
 from operator import methodcaller
 
-from sqlalchemy.orm.interfaces import MapperExtension
 from sqlalchemy.orm.session import SessionExtension
 
 import ckan.plugins as plugins
 
 
 log = logging.getLogger(__name__)
-
-
-class PluginMapperExtension(MapperExtension):
-    """
-    Extension that calls plugins implementing IMapper on SQLAlchemy
-    MapperExtension events
-    """
-
-    def notify_observers(self, func):
-        """
-        Call func(observer) for all registered observers.
-
-        :param func: Any callable, which will be called for each observer
-        :returns: EXT_CONTINUE if no errors encountered, otherwise EXT_STOP
-        """
-        for observer in plugins.PluginImplementations(plugins.IMapper):
-            func(observer)
-
-    def before_insert(self, mapper, connection, instance):
-        return self.notify_observers(
-            methodcaller('before_insert', mapper, connection, instance)
-        )
-
-    def before_update(self, mapper, connection, instance):
-        return self.notify_observers(
-            methodcaller('before_update', mapper, connection, instance)
-        )
-
-    def before_delete(self, mapper, connection, instance):
-        return self.notify_observers(
-            methodcaller('before_delete', mapper, connection, instance)
-        )
-
-    def after_insert(self, mapper, connection, instance):
-        return self.notify_observers(
-            methodcaller('after_insert', mapper, connection, instance)
-        )
-
-    def after_update(self, mapper, connection, instance):
-        return self.notify_observers(
-            methodcaller('after_update', mapper, connection, instance)
-        )
-
-    def after_delete(self, mapper, connection, instance):
-        return self.notify_observers(
-            methodcaller('after_delete', mapper, connection, instance)
-        )
 
 
 class PluginSessionExtension(SessionExtension):

--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -489,16 +489,12 @@ meta.mapper(Package, package_table, properties={
     'package_tags':orm.relation(tag.PackageTag, backref='package',
         cascade='all, delete', #, delete-orphan',
         ),
-    },
-    extension=[extension.PluginMapperExtension()],
-    )
+    })
 
 meta.mapper(tag.PackageTag, tag.package_tag_table, properties={
     'pkg':orm.relation(Package, backref='package_tag_all',
         cascade='none',
         )
-    },
-    extension=[extension.PluginMapperExtension()],
-    )
+    })
 
 meta.mapper(PackageMember, package_member_table)

--- a/ckan/model/package_extra.py
+++ b/ckan/model/package_extra.py
@@ -40,8 +40,7 @@ meta.mapper(PackageExtra, package_extra_table, properties={
             cascade='all, delete, delete-orphan',
             ),
         ),
-    },
-    extension=[extension.PluginMapperExtension()],
+    }
 )
 
 

--- a/ckan/model/resource.py
+++ b/ckan/model/resource.py
@@ -147,9 +147,7 @@ meta.mapper(Resource, resource_table, properties={
                             cascade='all, delete'
                             ),
     )
-},
-extension=[extension.PluginMapperExtension()],
-)
+})
 
 
 def resource_identifier(obj):

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -13,7 +13,6 @@ from pyutilib.component.core import Interface as _pca_Interface
 
 __all__ = [
     u'Interface',
-    u'IMapper',
     u'ISession',
     u'IMiddleware',
     u'IAuthFunctions',
@@ -113,60 +112,6 @@ class IMiddleware(Interface):
         Pylons app.
         '''
         return app
-
-
-class IMapper(Interface):
-    u'''
-    A subset of the SQLAlchemy mapper extension hooks.
-    See `sqlalchemy MapperExtension`_
-
-    Example::
-
-        >>> class MyPlugin(SingletonPlugin):
-        ...
-        ...     implements(IMapper)
-        ...
-        ...     def after_update(self, mapper, connection, instance):
-        ...         log(u'Updated: %r', instance)
-
-    .. _sqlalchemy MapperExtension:\
-    http://docs.sqlalchemy.org/en/rel_0_9/orm/deprecated.html#sqlalchemy.orm.interfaces.MapperExtension
-    '''  # noqa
-
-    def before_insert(self, mapper, connection, instance):
-        u'''
-        Receive an object instance before that instance is INSERTed into
-        its table.
-        '''
-
-    def before_update(self, mapper, connection, instance):
-        u'''
-        Receive an object instance before that instance is UPDATEed.
-        '''
-
-    def before_delete(self, mapper, connection, instance):
-        u'''
-        Receive an object instance before that instance is PURGEd.
-        (whereas usually in ckan 'delete' means to change the state property to
-        deleted, so use before_update for that case.)
-        '''
-
-    def after_insert(self, mapper, connection, instance):
-        u'''
-        Receive an object instance after that instance is INSERTed.
-        '''
-
-    def after_update(self, mapper, connection, instance):
-        u'''
-        Receive an object instance after that instance is UPDATEed.
-        '''
-
-    def after_delete(self, mapper, connection, instance):
-        u'''
-        Receive an object instance after that instance is PURGEd.
-        (whereas usually in ckan 'delete' means to change the state property to
-        deleted, so use before_update for that case.)
-        '''
 
 
 class ISession(Interface):

--- a/ckan/tests/plugins/ckantestplugins.py
+++ b/ckan/tests/plugins/ckantestplugins.py
@@ -6,32 +6,6 @@ import ckan.plugins as p
 import ckan.tests.plugins.mock_plugin as mock_plugin
 
 
-class MapperPlugin(p.SingletonPlugin):
-    p.implements(p.IMapper, inherit=True)
-
-    def __init__(self, *args, **kw):
-        self.calls = []
-
-    def _get_instance_name(self, instance):
-        return getattr(instance, "name", None)
-
-    def before_insert(self, mapper, conn, instance):
-        self.calls.append(("before_insert", self._get_instance_name(instance)))
-
-    def after_insert(self, mapper, conn, instance):
-        self.calls.append(("after_insert", self._get_instance_name(instance)))
-
-    def before_delete(self, mapper, conn, instance):
-        self.calls.append(("before_delete", self._get_instance_name(instance)))
-
-    def after_delete(self, mapper, conn, instance):
-        self.calls.append(("after_delete", self._get_instance_name(instance)))
-
-
-class MapperPlugin2(MapperPlugin):
-    p.implements(p.IMapper)
-
-
 class SessionPlugin(p.SingletonPlugin):
     p.implements(p.ISession, inherit=True)
 

--- a/ckan/tests/plugins/test_core.py
+++ b/ckan/tests/plugins/test_core.py
@@ -7,7 +7,6 @@ import ckan.logic as logic
 import ckan.authz as authz
 import ckan.plugins as plugins
 from ckan.plugins.core import find_system_plugins
-from ckan.tests import factories
 
 
 def _make_calls(*args):

--- a/ckan/tests/plugins/test_core.py
+++ b/ckan/tests/plugins/test_core.py
@@ -173,38 +173,38 @@ class TestPlugins:
         config_plugins = config["ckan.plugins"]
         config[
             "ckan.plugins"
-        ] = "test_observer_plugin mapper_plugin mapper_plugin2"
+        ] = "test_observer_plugin action_plugin auth_plugin"
         plugins.load_all()
 
         observerplugin = plugins.get_plugin("test_observer_plugin")
 
         expected_order = _make_calls(
-            plugins.get_plugin("mapper_plugin"),
-            plugins.get_plugin("mapper_plugin2"),
+            plugins.get_plugin("action_plugin"),
+            plugins.get_plugin("auth_plugin"),
         )
 
         assert observerplugin.before_load.calls[:2] == expected_order
         expected_order = _make_calls(
             plugins.get_plugin("test_observer_plugin"),
-            plugins.get_plugin("mapper_plugin"),
-            plugins.get_plugin("mapper_plugin2"),
+            plugins.get_plugin("action_plugin"),
+            plugins.get_plugin("auth_plugin"),
         )
         assert observerplugin.after_load.calls[:3] == expected_order
 
         config[
             "ckan.plugins"
-        ] = "test_observer_plugin mapper_plugin2 mapper_plugin"
+        ] = "test_observer_plugin auth_plugin action_plugin"
         plugins.load_all()
 
         expected_order = _make_calls(
-            plugins.get_plugin("mapper_plugin2"),
-            plugins.get_plugin("mapper_plugin"),
+            plugins.get_plugin("auth_plugin"),
+            plugins.get_plugin("action_plugin"),
         )
         assert observerplugin.before_load.calls[:2] == expected_order
         expected_order = _make_calls(
             plugins.get_plugin("test_observer_plugin"),
-            plugins.get_plugin("mapper_plugin2"),
-            plugins.get_plugin("mapper_plugin"),
+            plugins.get_plugin("auth_plugin"),
+            plugins.get_plugin("action_plugin"),
         )
         assert observerplugin.after_load.calls[:3] == expected_order
         # cleanup

--- a/ckan/tests/plugins/test_core.py
+++ b/ckan/tests/plugins/test_core.py
@@ -142,16 +142,6 @@ def test_plugins_load(monkeypatch):
 
 
 @pytest.mark.ckan_config("ckan.plugins", "mapper_plugin")
-@pytest.mark.usefixtures("with_plugins")
-def test_only_configured_plugins_loaded():
-    plugin = plugins.get_plugin("mapper_plugin")
-    # MapperPlugin should be loaded as it is listed in
-    assert plugin in plugins.PluginImplementations(plugins.IMapper)
-    # MapperPlugin2 and RoutesPlugin should NOT be loaded
-    assert len(plugins.PluginImplementations(plugins.IMapper)) == 1
-
-
-@pytest.mark.ckan_config("ckan.plugins", "mapper_plugin")
 @pytest.mark.usefixtures("with_plugins", "clean_db")
 def test_mapper_plugin_fired_on_insert():
     plugin = plugins.get_plugin("mapper_plugin")

--- a/ckan/tests/plugins/test_core.py
+++ b/ckan/tests/plugins/test_core.py
@@ -138,6 +138,7 @@ def test_plugins_load(monkeypatch):
         ]
     )
     assert set(plugins.core._PLUGINS_SERVICE.values()) == current_plugins
+    plugins.unload_all()
 
 
 def test_action_plugin_override():

--- a/ckan/tests/plugins/test_interfaces.py
+++ b/ckan/tests/plugins/test_interfaces.py
@@ -12,7 +12,6 @@ def test_no_conflicts_in_method_names():
         "IOrganizationController",
         "IGroupController",
         "ITagController",
-        "IMapper",
         "IDomainObjectModification",
     }
     classes = dict(

--- a/setup.py
+++ b/setup.py
@@ -163,9 +163,7 @@ entry_points = {
         'domain_object_mods = ckan.model.modification:DomainObjectModificationExtension',
     ],
     'ckan.test_plugins': [
-        'mapper_plugin = tests.plugins.ckantestplugins:MapperPlugin',
         'session_plugin = tests.plugins.ckantestplugins:SessionPlugin',
-        'mapper_plugin2 = tests.plugins.ckantestplugins:MapperPlugin2',
         'authorizer_plugin = tests.plugins.ckantestplugins:AuthorizerPlugin',
         'test_observer_plugin = tests.plugins.ckantestplugins:PluginObserverPlugin',
         'action_plugin = tests.plugins.ckantestplugins:ActionPlugin',


### PR DESCRIPTION
This is part of the cleanup needed to update SQLAlchemy to it's latest version since MapperExtension has been removed.

This is part of the work being done as part of: #6243 

### Proposed fixes:

The PluginMapperExtension is not being used in our code, and for a quick search in the Organization repository it looks like it is not used in other extensions:

https://github.com/search?q=org%3Ackan+PluginMapperExtension&type=code



