### PR TITLE
Clean global variable

### DIFF
--- a/ckan/lib/redis.py
+++ b/ckan/lib/redis.py
@@ -16,10 +16,6 @@ from ckan.common import config
 
 log = logging.getLogger(__name__)
 
-# Redis connection pool. Do not use this directly, use ``connect_to_redis``
-# instead.
-_connection_pool = None
-
 
 def connect_to_redis():
     u'''
@@ -33,11 +29,9 @@ def connect_to_redis():
 
     .. seealso:: :py:func:`is_redis_available`
     '''
-    global _connection_pool
-    if _connection_pool is None:
-        url = config.get_value('ckan.redis.url')
-        log.debug(u'Using Redis at {}'.format(url))
-        _connection_pool = ConnectionPool.from_url(url)
+    url = config.get_value('ckan.redis.url')
+    log.debug(u'Using Redis at {}'.format(url))
+    _connection_pool = ConnectionPool.from_url(url)
     return Redis(connection_pool=_connection_pool)
 
 


### PR DESCRIPTION
This PR cleans the `_connection_pool` global variable from the Redis module.