### PR TITLE
Clean old legacy_template config

### DIFF
--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -391,9 +391,6 @@ groups:
         default: /base/css/main.css
       - key: ckan.favicon
         default: /base/images/ckan.ico
-      - key: ckan.legacy_templates
-        ignored: true
-        type: bool
       - key: ckan.datasets_per_page
         type: int
         default: 20

--- a/ckan/lib/app_globals.py
+++ b/ckan/lib/app_globals.py
@@ -58,7 +58,6 @@ app_globals_from_config_details = {
     # bool
     'debug': {'default': 'false', 'type' : 'bool'},
     'ckan.debug_supress_header' : {'default': 'false', 'type' : 'bool'},
-    'ckan.legacy_templates' : {'default': 'false', 'type' : 'bool'},
     'ckan.tracking_enabled' : {'default': 'false', 'type' : 'bool'},
 
     # int

--- a/ckan/tests/helpers.py
+++ b/ckan/tests/helpers.py
@@ -266,7 +266,6 @@ def _get_test_app():
     Unit tests shouldn't need this.
 
     """
-    config["ckan.legacy_templates"] = False
     config["testing"] = True
     app = ckan.config.middleware.make_app(config)
     app = CKANTestApp(app)

--- a/ckanext/reclineview/tests/test_view.py
+++ b/ckanext/reclineview/tests/test_view.py
@@ -11,7 +11,6 @@ import ckan.lib.create_test_data as create_test_data
 from ckan.tests import helpers, factories
 
 
-@pytest.mark.ckan_config('ckan.legacy_templates', 'false')
 @pytest.mark.usefixtures("with_plugins", "with_request_context")
 class BaseTestReclineViewBase(object):
 
@@ -69,7 +68,6 @@ class TestReclineView(BaseTestReclineViewBase):
             assert not self.p.can_view(data_dict)
 
 
-@pytest.mark.ckan_config('ckan.legacy_templates', 'false')
 @pytest.mark.ckan_config('ckan.plugins', 'recline_view datastore')
 @pytest.mark.ckan_config('ckan.views.default_views', 'recline_view')
 @pytest.mark.usefixtures("clean_db", "with_plugins")

--- a/doc/contributing/string-i18n.rst
+++ b/doc/contributing/string-i18n.rst
@@ -355,7 +355,7 @@ the quality of CKAN's translations:
 * Try not to make translators translate strings that don't need to be
   translated.
 
-  For example, ``'legacy_templates'`` is the name of a directory, it doesn't
+  For example, ``'templates'`` is the name of a directory, it doesn't
   need to be marked for translation.
 
 * Mark singular and plural forms of strings correctly.

--- a/test-core.ini
+++ b/test-core.ini
@@ -62,9 +62,6 @@ package_new_return_url = http://localhost/dataset/<NAME>?test=new
 package_edit_return_url = http://localhost/dataset/<NAME>?test=edit
 ckan.extra_resource_fields = alt_url
 
-# we need legacy templates for many tests to pass
-ckan.legacy_templates = yes
-
 # Change API key HTTP header to something non-standard.
 apikey_header_name = X-Non-Standard-CKAN-API-Key
 


### PR DESCRIPTION
This config was using when migrating from Genshi to Jinja2 and it's no longer useful.