### PR TITLE
Cleanup non necessary fixtures

### DIFF
--- a/ckan/tests/lib/dictization/test_dictization.py
+++ b/ckan/tests/lib/dictization/test_dictization.py
@@ -99,7 +99,6 @@ class TestBasicDictize:
         assert got["id"]
         assert got["timestamp"]
 
-    @pytest.mark.usefixtures("with_request_context")
     def test_user_dictize_as_sysadmin(self):
         """Sysadmins should be allowed to see certain sensitive data."""
         CreateTestData.create()
@@ -125,7 +124,6 @@ class TestBasicDictize:
         assert "password" not in user_dict
         assert "reset_key" not in user_dict
 
-    @pytest.mark.usefixtures("with_request_context")
     def test_user_dictize_as_same_user(self):
         """User should be able to see their own sensitive data."""
         CreateTestData.create()
@@ -147,7 +145,6 @@ class TestBasicDictize:
         assert "password" not in user_dict
         assert "reset_key" not in user_dict
 
-    @pytest.mark.usefixtures("with_request_context")
     def test_user_dictize_as_other_user(self):
         """User should not be able to see other's sensitive data."""
         CreateTestData.create()
@@ -234,7 +231,6 @@ class TestDictizeWithRemoveColumns:
             == anna_dictized
         ), self.remove_changable_columns(table_dictize(pkg, context))
 
-    @pytest.mark.usefixtures("with_request_context")
     def test_package_save(self):
         CreateTestData.create()
         context = {

--- a/ckan/tests/lib/dictization/test_model_dictize.py
+++ b/ckan/tests/lib/dictization/test_model_dictize.py
@@ -226,7 +226,7 @@ class TestGroupDictize:
         Packages returned in group are limited by context var.
         """
         group_ = factories.Group()
-        for _ in range(10):
+        for _ in range(5):
             factories.Dataset(groups=[{"name": group_["name"]}])
         group_obj = model.Session.query(model.Group).filter_by().first()
         # limit packages to 4

--- a/ckan/tests/lib/dictization/test_model_dictize.py
+++ b/ckan/tests/lib/dictization/test_model_dictize.py
@@ -20,7 +20,7 @@ from ckan.lib.dictization.model_dictize import package_dictize, group_dictize
 from ckan.tests import factories
 
 
-@pytest.mark.usefixtures("clean_db", "clean_index", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestGroupListDictize:
     def test_group_list_dictize(self):
         group = factories.Group()
@@ -148,7 +148,7 @@ class TestGroupListDictize:
         assert child_dict["groups"][0]["name"] == "parent"
 
 
-@pytest.mark.usefixtures("clean_db", "clean_index", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestGroupDictize:
     def test_group_dictize(self):
         group = factories.Group(name="test_dictize")
@@ -339,7 +339,7 @@ class TestGroupDictize:
         assert org["package_count"] == 1
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestPackageDictize:
     def remove_changable_values(self, dict_):
         dict_ = copy.deepcopy(dict_)
@@ -660,7 +660,7 @@ class TestVocabularyDictize(object):
             assert len(tag.get("packages", [])) == 0
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestActivityDictize(object):
     def test_include_data(self):
         dataset = factories.Dataset()


### PR DESCRIPTION
This is just a small PR cleaning some fixtures on the `test_dictization.py` I did while researching about our test suite and our test fixtures.

This small clean reduces the execution time of this module from ~45s to ~33s (almost 25%) so I'm going to keep digging a little bit more on this topic.