### PR TITLE
[#6649] gettext not for metadata fields

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2748,8 +2748,7 @@ def get_translated(data_dict, field):
     try:
         return data_dict[field + u'_translated'][language]
     except KeyError:
-        val = data_dict.get(field, '')
-        return _(val) if val and isinstance(val, str) else val
+        return data_dict.get(field, '')
 
 
 @core_helper


### PR DESCRIPTION
Fixes #6649

### Proposed fixes:

Don't call gettext from `get_translated` helper. This helper is for pulling translations from fields like `title_translated`, `notes_translated`: custom metadata fields that contain different language versions of core metadata fields. It doesn't make sense to fall back to gettext for normal `title`, `notes` fields when a translation is not found. 

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport