### PR TITLE
Clean non necessary fixture calls in action tests

### DIFF
--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -19,7 +19,7 @@ from ckan.lib.navl.dictization_functions import DataError
 from freezegun import freeze_time
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestUserInvite(object):
     @mock.patch("ckan.lib.mailer.send_invite")
     def test_invited_user_is_created_as_pending(self, _):
@@ -575,7 +575,6 @@ class TestResourceCreate:
         size = int(result.pop("size"))
         assert size == 500
 
-    @pytest.mark.usefixtures("with_request_context")
     def test_extras(self):
         user = factories.User()
         dataset = factories.Dataset(user=user)
@@ -653,7 +652,7 @@ class TestResourceCreate:
         assert created_resource["name"] == "created by collaborator"
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestMemberCreate(object):
     def test_group_member_creation(self):
         user = factories.User()
@@ -738,7 +737,7 @@ class TestMemberCreate(object):
             )
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestDatasetCreate(object):
     def test_private_package(self):
         org = factories.Organization()
@@ -970,7 +969,7 @@ class TestDatasetCreate(object):
         assert isinstance(dataset, str)
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestGroupCreate(object):
     def test_create_group(self):
         user = factories.User()
@@ -1029,7 +1028,7 @@ class TestGroupCreate(object):
             assert created[k] == shown[k], k
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestOrganizationCreate(object):
     def test_create_organization(self):
         user = factories.User()
@@ -1106,7 +1105,7 @@ class TestOrganizationCreate(object):
         assert org["type"] == custom_org_type
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestUserCreate(object):
     def test_user_create_with_password_hash(self):
         sysadmin = factories.Sysadmin()
@@ -1182,7 +1181,7 @@ def _clear_activities():
     model.Session.flush()
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestFollowCommon(object):
     def test_validation(self):
         user = factories.User()
@@ -1220,7 +1219,7 @@ class TestFollowCommon(object):
                     helpers.call_action(action, context, id=object_id)
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestFollowDataset(object):
     def test_auth(self):
         user = factories.User()
@@ -1286,7 +1285,7 @@ class TestFollowDataset(object):
         )
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestFollowGroup(object):
     def test_auth(self):
         user = factories.User()
@@ -1335,7 +1334,7 @@ class TestFollowGroup(object):
         )
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestFollowOrganization(object):
     def test_auth(self):
         user = factories.User()
@@ -1384,7 +1383,7 @@ class TestFollowOrganization(object):
         )
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestFollowUser(object):
     def test_auth(self):
         user = factories.User()

--- a/ckan/tests/logic/action/test_delete.py
+++ b/ckan/tests/logic/action/test_delete.py
@@ -13,7 +13,7 @@ import ckan.tests.factories as factories
 import ckan.tests.helpers as helpers
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestDelete:
     def test_resource_delete(self):
         user = factories.User()
@@ -73,7 +73,7 @@ class TestDeleteResource(object):
 
 
 @pytest.mark.ckan_config("ckan.plugins", "image_view")
-@pytest.mark.usefixtures("clean_db", "with_plugins", "with_request_context")
+@pytest.mark.usefixtures("clean_db", "with_plugins")
 class TestDeleteResourceViews(object):
     def test_resource_view_delete(self):
         resource_view = factories.ResourceView()
@@ -188,7 +188,7 @@ class TestDeleteTags(object):
         assert pkg["tags"] == []
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestGroupPurge(object):
     def test_a_non_sysadmin_cant_purge_group(self):
         user = factories.User()
@@ -282,7 +282,7 @@ class TestGroupPurge(object):
             helpers.call_action("group_purge", id="123")
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestOrganizationPurge(object):
     def test_a_non_sysadmin_cant_purge_org(self):
         user = factories.User()
@@ -379,7 +379,7 @@ class TestOrganizationPurge(object):
             helpers.call_action("organization_purge", id="123")
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestDatasetPurge(object):
     def test_a_non_sysadmin_cant_purge_dataset(self):
         user = factories.User()
@@ -505,7 +505,7 @@ class TestDatasetPurge(object):
             helpers.call_action("dataset_purge", id="123")
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestUserDelete(object):
     def test_user_delete(self):
         user = factories.User()

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -645,15 +645,15 @@ class TestGroupShow(object):
                 dataset["id"] for dataset in group["packages"]
             ], "group_show() should never show private datasets"
 
-    @pytest.mark.ckan_config("ckan.search.rows_max", "5")
+    @pytest.mark.ckan_config("ckan.search.rows_max", "2")
     def test_package_limit_configured(self):
         group = factories.Group()
-        for _ in range(7):
+        for _ in range(3):
             factories.Dataset(groups=[{"id": group["id"]}])
         id = group["id"]
 
         results = helpers.call_action("group_show", id=id, include_datasets=1)
-        assert len(results["packages"]) == 5  # i.e. ckan.search.rows_max
+        assert len(results["packages"]) == 2  # i.e. ckan.search.rows_max
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -838,17 +838,17 @@ class TestOrganizationShow(object):
         assert org_dict["packages"][0]["name"] == "dataset_1"
         assert org_dict["package_count"] == 1
 
-    @pytest.mark.ckan_config("ckan.search.rows_max", "5")
+    @pytest.mark.ckan_config("ckan.search.rows_max", "2")
     def test_package_limit_configured(self):
         org = factories.Organization()
-        for _ in range(7):
+        for _ in range(3):
             factories.Dataset(owner_org=org["id"])
         id = org["id"]
 
         results = helpers.call_action(
             "organization_show", id=id, include_datasets=1
         )
-        assert len(results["packages"]) == 5  # i.e. ckan.search.rows_max
+        assert len(results["packages"]) == 2  # i.e. ckan.search.rows_max
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -1439,11 +1439,11 @@ class TestPackageSearch(object):
         results = logic.get_action("package_search")({}, {})
         assert len(results["results"]) == 10  # i.e. 'rows' default value
 
-    @pytest.mark.ckan_config("ckan.search.rows_max", "12")
+    @pytest.mark.ckan_config("ckan.search.rows_max", "3")
     def test_rows_returned_limited(self):
-        self._create_bulk_datasets("rows_limited", 14)
+        self._create_bulk_datasets("rows_limited", 5)
         results = logic.get_action("package_search")({}, {"rows": "15"})
-        assert len(results["results"]) == 12  # i.e. ckan.search.rows_max
+        assert len(results["results"]) == 3  # i.e. ckan.search.rows_max
 
     def test_facets(self):
         org = factories.Organization(name="test-org-facet", title="Test Org")
@@ -4569,17 +4569,17 @@ class TestDashboardNewActivities(object):
             == 0
         )
 
-    @pytest.mark.ckan_config("ckan.activity_list_limit", "15")
+    @pytest.mark.ckan_config("ckan.activity_list_limit", "5")
     def test_maximum_number_of_new_activities(self):
-        """Test that the new activities count does not go higher than 15, even
-        if there are more than 15 new activities from the user's followers."""
+        """Test that the new activities count does not go higher than 5, even
+        if there are more than 5 new activities from the user's followers."""
         user = factories.User()
         another_user = factories.Sysadmin()
         dataset = factories.Dataset()
         helpers.call_action(
             "follow_dataset", context={"user": user["name"]}, **dataset
         )
-        for n in range(0, 20):
+        for n in range(0, 7):
             dataset["notes"] = "Updated {n} times".format(n=n)
             helpers.call_action(
                 "package_update",
@@ -4590,7 +4590,7 @@ class TestDashboardNewActivities(object):
             helpers.call_action(
                 "dashboard_new_activities_count", context={"user": user["id"]}
             )
-            == 15
+            == 5
         )
 
 

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -15,7 +15,7 @@ from ckan import __version__
 from ckan.lib.search.common import SearchError
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestPackageShow(object):
     def test_package_show(self):
         # simple dataset, simple checks
@@ -207,7 +207,7 @@ class TestPackageShow(object):
         assert "new_field" not in dataset2
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestGroupList(object):
     def test_group_list(self):
 
@@ -475,7 +475,7 @@ class TestGroupList(object):
             helpers.call_action("group_list", offset="-2")
 
 
-@pytest.mark.usefixtures("clean_db", "clean_index", "with_request_context")
+@pytest.mark.usefixtures("clean_db", "clean_index")
 class TestGroupShow(object):
     def test_group_show(self):
         group = factories.Group(user=factories.User())
@@ -656,7 +656,7 @@ class TestGroupShow(object):
         assert len(results["packages"]) == 5  # i.e. ckan.search.rows_max
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestOrganizationList(object):
     def test_organization_list(self):
 
@@ -767,7 +767,7 @@ class TestOrganizationList(object):
         assert len(results) == 5  # i.e. configured limit
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestOrganizationShow(object):
     def test_organization_show(self):
         org = factories.Organization()
@@ -851,7 +851,7 @@ class TestOrganizationShow(object):
         assert len(results["packages"]) == 5  # i.e. ckan.search.rows_max
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestUserList(object):
     def test_user_list_default_values(self):
         # we need to set fullname because user_list by default sorts by
@@ -1029,7 +1029,7 @@ class TestUserList(object):
             helpers.call_action("user_list", order_by="edits")
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestUserShow(object):
     def test_user_show_default_values(self):
 
@@ -1224,7 +1224,7 @@ class TestUserShow(object):
         assert "reset_key" not in got_user
 
 
-@pytest.mark.usefixtures("clean_db", "clean_index", "with_request_context")
+@pytest.mark.usefixtures("clean_db", "clean_index")
 class TestCurrentPackageList(object):
     def test_current_package_list(self):
         """
@@ -1299,7 +1299,7 @@ class TestCurrentPackageList(object):
         assert len(current_package_list) == 2
 
 
-@pytest.mark.usefixtures("clean_db", "clean_index", "with_request_context")
+@pytest.mark.usefixtures("clean_db", "clean_index")
 class TestPackageAutocomplete(object):
     def test_package_autocomplete_match_name(self):
         pkg = factories.Dataset(name="warandpeace")
@@ -1372,7 +1372,7 @@ class TestPackageAutocomplete(object):
         assert len(package_list) == 2
 
 
-@pytest.mark.usefixtures("clean_db", "clean_index", "with_request_context")
+@pytest.mark.usefixtures("clean_db", "clean_index")
 class TestPackageSearch(object):
     def test_search(self):
         factories.Dataset(title="Rivers")
@@ -1959,7 +1959,7 @@ class TestPackageSearch(object):
 
 
 @pytest.mark.ckan_config("ckan.plugins", "example_idatasetform")
-@pytest.mark.usefixtures("clean_db", "with_plugins", "with_request_context")
+@pytest.mark.usefixtures("clean_db", "with_plugins")
 class TestPackageAutocompleteWithDatasetForm(object):
     def test_custom_schema_returned(self):
         dataset1 = factories.Dataset(custom_text="foo")
@@ -1986,7 +1986,7 @@ class TestPackageAutocompleteWithDatasetForm(object):
         assert query["results"][0]["extras"][0]["value"] == "foo"
 
 
-@pytest.mark.usefixtures("clean_db", "clean_index", "with_request_context")
+@pytest.mark.usefixtures("clean_db", "clean_index")
 class TestUserAutocomplete(object):
     def test_autocomplete(self):
         factories.Sysadmin(name="autocompletesysadmin")
@@ -2010,7 +2010,7 @@ class TestUserAutocomplete(object):
         assert len(result) == 1
 
 
-@pytest.mark.usefixtures("clean_db", "clean_index", "with_request_context")
+@pytest.mark.usefixtures("clean_db", "clean_index")
 class TestFormatAutocomplete:
     def test_missing_param(self):
         with pytest.raises(logic.ValidationError):
@@ -2024,7 +2024,7 @@ class TestFormatAutocomplete:
         assert result == ["csv"]
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestBadLimitQueryParameters(object):
     """test class for #1258 non-int query parameters cause 500 errors
 
@@ -2060,7 +2060,7 @@ class TestBadLimitQueryParameters(object):
             helpers.call_action("package_search", **kwargs)
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestOrganizationListForUser(object):
     """Functional tests for the organization_list_for_user() action function."""
 
@@ -2706,7 +2706,7 @@ class TestTagList(object):
             helpers.call_action("tag_list", vocabulary_id="does-not-exist")
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestMembersList(object):
     def test_dataset_delete_marks_membership_of_group_as_deleted(self):
         sysadmin = factories.Sysadmin()
@@ -2829,7 +2829,7 @@ class TestMembersList(object):
         assert len(org_members) == 0
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestFollow(object):
     def test_followee_list(self):
 
@@ -2877,9 +2877,7 @@ class TestFollow(object):
 
 class TestStatusShow(object):
     @pytest.mark.ckan_config("ckan.plugins", "stats")
-    @pytest.mark.usefixtures(
-        "clean_db", "with_plugins", "with_request_context"
-    )
+    @pytest.mark.usefixtures("clean_db", "with_plugins")
     def test_status_show(self):
 
         status = helpers.call_action("status_show")
@@ -2949,7 +2947,7 @@ def _seconds_since_timestamp(timestamp, format_):
     return (now - dt).total_seconds()
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestActivityShow(object):
     def test_simple_without_data(self):
         dataset = factories.Dataset()
@@ -3009,7 +3007,7 @@ def _clear_activities():
     model.Session.flush()
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestPackageActivityList(object):
     def test_create_dataset(self):
         user = factories.User()
@@ -3403,7 +3401,7 @@ class TestPackageActivityList(object):
         ]
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestUserActivityList(object):
     def test_create_user(self):
         user = factories.User()
@@ -3606,7 +3604,7 @@ class TestUserActivityList(object):
         assert len(results) == 7  # i.e. ckan.activity_list_limit_max
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestGroupActivityList(object):
     def test_create_group(self):
         user = factories.User()
@@ -3847,7 +3845,7 @@ class TestGroupActivityList(object):
         ]
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestOrganizationActivityList(object):
     def test_create_organization(self):
         user = factories.User()
@@ -4088,7 +4086,7 @@ class TestOrganizationActivityList(object):
         ]
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestRecentlyChangedPackagesActivityList(object):
     def test_create_dataset(self):
         user = factories.User()
@@ -4231,7 +4229,7 @@ class TestRecentlyChangedPackagesActivityList(object):
         assert len(results) == 7  # i.e. ckan.activity_list_limit_max
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestDashboardActivityList(object):
     def test_create_user(self):
         user = factories.User()
@@ -4340,7 +4338,7 @@ class TestDashboardActivityList(object):
         assert len(results) == 7  # i.e. ckan.activity_list_limit_max
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestDashboardNewActivities(object):
     def test_users_own_activities(self):
         # a user's own activities are not shown as "new"
@@ -4885,7 +4883,7 @@ class TestCollaboratorsSearch(object):
         assert results["results"][1]["id"] == dataset2["id"]
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestResourceSearch(object):
     def test_required_fields(self):
         with pytest.raises(logic.ValidationError):

--- a/ckan/tests/logic/action/test_patch.py
+++ b/ckan/tests/logic/action/test_patch.py
@@ -5,7 +5,7 @@ import pytest
 from ckan.tests import helpers, factories
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestPatch(object):
     def test_package_patch_updating_single_field(self):
         user = factories.User()

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -26,7 +26,7 @@ def datetime_from_string(s):
     return datetime.datetime.strptime(s, "%Y-%m-%dT%H:%M:%S.%f")
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestUpdate(object):
     def teardown(self):
         # Since some of the test methods below use the mock module to patch
@@ -435,7 +435,7 @@ class TestUpdate(object):
         )
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestDatasetUpdate(object):
     def test_missing_id(self):
         user = factories.User()
@@ -757,7 +757,7 @@ class TestSendEmailNotifications(object):
 
 @pytest.mark.ckan_config("ckan.views.default_views", "")
 @pytest.mark.ckan_config("ckan.plugins", "image_view")
-@pytest.mark.usefixtures("clean_db", "with_plugins", "with_request_context")
+@pytest.mark.usefixtures("clean_db", "with_plugins")
 class TestResourceViewUpdate(object):
     def test_resource_view_update(self):
         resource_view = factories.ResourceView()
@@ -877,7 +877,7 @@ class TestResourceViewUpdate(object):
 
 
 @pytest.mark.ckan_config("ckan.plugins", "image_view recline_view")
-@pytest.mark.usefixtures("clean_db", "with_plugins", "with_request_context")
+@pytest.mark.usefixtures("clean_db", "with_plugins")
 class TestResourceUpdate(object):
     def test_url_only(self):
         dataset = factories.Dataset()
@@ -1509,7 +1509,7 @@ class TestResourceUpdate(object):
             assert resource["metadata_modified"] == "2020-02-25T12:00:00"
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestConfigOptionUpdate(object):
 
     # NOTE: the opposite is tested in
@@ -1530,7 +1530,7 @@ class TestConfigOptionUpdate(object):
         assert getattr(app_globals.app_globals, globals_key) == value
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestUserUpdate(object):
     def test_user_update_with_password_hash(self):
         sysadmin = factories.Sysadmin()
@@ -1578,7 +1578,7 @@ class TestUserUpdate(object):
         assert user["image_url"] == "new_image_url.jpg"
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestGroupUpdate(object):
     def test_group_update_image_url_field(self):
         user = factories.User()
@@ -1621,7 +1621,7 @@ class TestGroupUpdate(object):
         )
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestPackageOwnerOrgUpdate(object):
     def test_package_owner_org_added(self):
         """A package without an owner_org can have one added."""
@@ -1674,7 +1674,7 @@ class TestPackageOwnerOrgUpdate(object):
         assert dataset_obj.owner_org is None
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestBulkOperations(object):
     def test_bulk_make_private(self):
 
@@ -1778,7 +1778,7 @@ class TestBulkOperations(object):
         assert activities[0]["activity_type"] == "deleted package"
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestDashboardMarkActivitiesOld(object):
     def test_mark_as_old_some_activities_by_a_followed_user(self):
         # do some activity that will show up on user's dashboard
@@ -1838,7 +1838,7 @@ class TestDashboardMarkActivitiesOld(object):
         ]
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 @pytest.mark.ckan_config("ckan.auth.allow_dataset_collaborators", True)
 class TestCollaboratorsUpdate(object):
     @pytest.mark.ckan_config("ckan.auth.allow_admin_collaborators", True)
@@ -1972,7 +1972,7 @@ class TestCollaboratorsUpdate(object):
         assert updated_dataset["owner_org"] == org2["id"]
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestDatasetRevise(object):
     def test_revise_description(self):
         factories.Dataset(name="xyz", notes="old notes")

--- a/ckan/tests/logic/auth/test_create.py
+++ b/ckan/tests/logic/auth/test_create.py
@@ -44,7 +44,7 @@ def test_cud_overrides_acd():
         helpers.call_auth("package_create", context)
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestUserCreate:
     def test_sysadmin_can_create_via_api(self):
         sysadmin = factories.Sysadmin()
@@ -72,7 +72,7 @@ class TestUserCreate:
         assert helpers.call_auth("user_create", context)
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestRealUsersAuth(object):
     def test_no_org_user_can_create(self):
         user = factories.User()

--- a/ckan/tests/logic/auth/test_delete.py
+++ b/ckan/tests/logic/auth/test_delete.py
@@ -13,7 +13,7 @@ from ckan import authz, model
 logic = helpers.logic
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestDeleteAuth:
     def test_auth_deleted_users_are_always_unauthorized(self):
         def always_success(x, y):
@@ -135,7 +135,7 @@ def test_anon_cant_clear():
         helpers.call_auth("resource_view_clear", context=context, **params)
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 def test_normal_user_cant_clear():
     user = factories.User()
 
@@ -145,7 +145,7 @@ def test_normal_user_cant_clear():
         helpers.call_auth("resource_view_clear", context=context)
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 def test_sysadmin_user_can_clear():
     user = factories.User(sysadmin=True)
 

--- a/ckan/tests/logic/auth/test_get.py
+++ b/ckan/tests/logic/auth/test_get.py
@@ -31,7 +31,7 @@ def test_user_list_email_parameter():
         helpers.call_auth("user_list", email="a@example.com", context=context)
 
 
-@pytest.mark.usefixtures(u"clean_db", "with_request_context")
+@pytest.mark.usefixtures(u"clean_db")
 class TestGetAuth(object):
 
     @pytest.mark.ckan_config(u"ckan.auth.public_user_details", u"false")

--- a/ckan/tests/logic/auth/test_init.py
+++ b/ckan/tests/logic/auth/test_init.py
@@ -90,7 +90,7 @@ def test_get_group_object_id_none():
     _get_object_id_none("group")
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestInit(object):
     def test_get_package_object_with_id(self):
 

--- a/ckan/tests/logic/auth/test_update.py
+++ b/ckan/tests/logic/auth/test_update.py
@@ -12,7 +12,6 @@ import ckan.tests.factories as factories
 import ckan.tests.helpers as helpers
 
 
-@pytest.mark.usefixtures("with_request_context")
 def test_user_update_visitor_cannot_update_user():
     """Visitors should not be able to update users' accounts."""
 
@@ -41,7 +40,6 @@ def test_user_update_visitor_cannot_update_user():
 # START-AFTER
 
 
-@pytest.mark.usefixtures("with_request_context")
 def test_user_update_user_cannot_update_another_user():
     """Users should not be able to update other users' accounts."""
 
@@ -78,7 +76,6 @@ def test_user_update_user_cannot_update_another_user():
 # END-BEFORE
 
 
-@pytest.mark.usefixtures("with_request_context")
 def test_user_update_user_can_update_her():
     """Users should be authorized to update their own accounts."""
 
@@ -130,7 +127,7 @@ def test_user_update_with_no_user_in_context():
 
 
 @pytest.mark.ckan_config("ckan.plugins", "image_view")
-@pytest.mark.usefixtures("clean_db", "with_plugins", "with_request_context")
+@pytest.mark.usefixtures("clean_db", "with_plugins")
 class TestUpdateWithView(object):
     def test_anon_can_not_update(self):
 
@@ -206,7 +203,7 @@ class TestUpdateWithView(object):
             )
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 class TestUpdate(object):
     def test_config_option_update_anon_user(self):
         """An anon user is not authorized to use config_option_update

--- a/ckan/tests/logic/test_logic.py
+++ b/ckan/tests/logic/test_logic.py
@@ -24,6 +24,7 @@ def test_check_access_auth_user_obj_is_not_set():
         assert context["__auth_user_obj_checked"]
         assert context["auth_user_obj"] is None
 
+
 @pytest.mark.usefixtures("clean_db")
 def test_check_access_auth_user_obj_is_set():
     user = factories.User()
@@ -34,6 +35,7 @@ def test_check_access_auth_user_obj_is_set():
     assert result
     assert context["__auth_user_obj_checked"]
     assert context["auth_user_obj"].name == user["name"]
+
 
 @pytest.mark.usefixtures("clean_db")
 def test_check_access_auth_user_obj_is_not_set_when_ignoring_auth():

--- a/ckan/tests/logic/test_logic.py
+++ b/ckan/tests/logic/test_logic.py
@@ -25,7 +25,6 @@ def test_check_access_auth_user_obj_is_not_set():
         assert context["auth_user_obj"] is None
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
 def test_check_access_auth_user_obj_is_set():
     user = factories.User()
     context = {"user": user["name"]}
@@ -37,7 +36,6 @@ def test_check_access_auth_user_obj_is_set():
     assert context["auth_user_obj"].name == user["name"]
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
 def test_check_access_auth_user_obj_is_not_set_when_ignoring_auth():
     user = factories.User()
     context = {"user": user["name"], "ignore_auth": True}

--- a/ckan/tests/logic/test_logic.py
+++ b/ckan/tests/logic/test_logic.py
@@ -24,7 +24,7 @@ def test_check_access_auth_user_obj_is_not_set():
         assert context["__auth_user_obj_checked"]
         assert context["auth_user_obj"] is None
 
-
+@pytest.mark.usefixtures("clean_db")
 def test_check_access_auth_user_obj_is_set():
     user = factories.User()
     context = {"user": user["name"]}
@@ -35,7 +35,7 @@ def test_check_access_auth_user_obj_is_set():
     assert context["__auth_user_obj_checked"]
     assert context["auth_user_obj"].name == user["name"]
 
-
+@pytest.mark.usefixtures("clean_db")
 def test_check_access_auth_user_obj_is_not_set_when_ignoring_auth():
     user = factories.User()
     context = {"user": user["name"], "ignore_auth": True}

--- a/ckan/tests/logic/test_validators.py
+++ b/ckan/tests/logic/test_validators.py
@@ -769,7 +769,7 @@ def test_user_id_or_name_exists_empty():
         validators.user_id_or_name_exists("", _make_context())
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 def test_user_id_or_name_exists():
     user = factories.User(name="username")
     v = validators.user_id_or_name_exists(user["id"], _make_context())
@@ -783,7 +783,7 @@ def test_group_id_or_name_exists_empty():
         validators.user_id_or_name_exists("", _make_context())
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 def test_group_id_or_name_exists(group):
     v = validators.group_id_or_name_exists(group["id"], _make_context())
     assert v == group["id"]

--- a/ckan/tests/model/test_package.py
+++ b/ckan/tests/model/test_package.py
@@ -6,7 +6,7 @@ from ckan import model
 from ckan.tests import factories
 
 
-@pytest.mark.usefixtures(u"clean_db", u"with_request_context")
+@pytest.mark.usefixtures(u"clean_db")
 class TestPackage(object):
     def test_create(self):
         # Demonstrate creating a package.

--- a/ckan/tests/test_factories.py
+++ b/ckan/tests/test_factories.py
@@ -17,7 +17,7 @@ import ckan.tests.factories as factories
         factories.MockUser,
     ],
 )
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 def test_id_uniqueness(entity):
     first, second = entity(), entity()
     assert first[u"id"] != second[u"id"]


### PR DESCRIPTION
The fixture `with_request_context` should be use only if the test needs access to the session or the request. They are not necessary while testing the action layer since it doesn't access those objects (except specific cases that need some refactoring).

`with_request_context` internally calls flask `create_app` method, so it adds a lot of overhead and it should be use when really needed. Just by removing this fixture I reduced the execution time of the action tests locally from ~9 to ~5 minutes.

From:
```
===== 621 passed, 1 skipped in 515.43s (0:08:35) =====
```

To:
```
===== 621 passed, 1 skipped in 290.00s (0:04:49) =====
```

It also reduces our CircleCI run from ~13m to ~10m.