### PR TITLE
[6662]add strict_slashes=False

### DIFF
--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -1370,7 +1370,7 @@ def history(package_type, id):
 def register_dataset_plugin_rules(blueprint):
     blueprint.add_url_rule(u'/', view_func=search, strict_slashes=False)
     blueprint.add_url_rule(u'/new', view_func=CreateView.as_view(str(u'new')))
-    blueprint.add_url_rule(u'/<id>', view_func=read)
+    blueprint.add_url_rule(u'/<id>', view_func=read, strict_slashes=False)
     blueprint.add_url_rule(u'/resources/<id>', view_func=resources)
     blueprint.add_url_rule(
         u'/edit/<id>', view_func=EditView.as_view(str(u'edit'))

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -1308,7 +1308,7 @@ def register_group_plugin_rules(blueprint):
         u'/new',
         methods=[u'GET', u'POST'],
         view_func=CreateGroupView.as_view(str(u'new')))
-    blueprint.add_url_rule(u'/<id>', methods=[u'GET'], view_func=read)
+    blueprint.add_url_rule(u'/<id>', methods=[u'GET'], view_func=read, strict_slashes=False)
     blueprint.add_url_rule(
         u'/edit/<id>', view_func=EditGroupView.as_view(str(u'edit')))
     blueprint.add_url_rule(


### PR DESCRIPTION
Fixes #6662 

### Proposed fixes:
Added `strict_slashes=False` to prevent 404 when URL has trailing slash at the end 
e.g /organization/my-org/ and /dataset/my-dataset/ 


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
