### PR TITLE
Replace deprecated Session.close_all()

### DIFF
--- a/ckan/tests/helpers.py
+++ b/ckan/tests/helpers.py
@@ -76,7 +76,7 @@ def reset_db():
     """
     # Close any database connections that have been left open.
     # This prevents CKAN from hanging waiting for some unclosed connection.
-    model.Session.close_all()
+    model.Session.close_all_sessions()
 
     model.repo.rebuild_db()
 


### PR DESCRIPTION
`Session.close_all()` has been deprecated: https://docs.sqlalchemy.org/en/13/orm/session_api.html#sqlalchemy.orm.session.sessionmaker.close_all

```
SADeprecationWarning: The Session.close_all() method is deprecated and will be removed in a future release.  Please refer to session.close_all_sessions().
```