### PR TITLE
[6636]Add organization_facets

### DIFF
--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -377,7 +377,11 @@ def _read(id, limit, group_type):
 
 def _update_facet_titles(facets, group_type):
     for plugin in plugins.PluginImplementations(plugins.IFacets):
-        facets = plugin.group_facets(facets, group_type, None)
+        facets = (
+            plugin.group_facets(facets, group_type, None)
+            if group_type == "group"
+            else plugin.organization_facets(facets, group_type, None)
+        )
     return facets
 
 


### PR DESCRIPTION
Fixes #6636

Adding `organization_facets` to `_update_facet_titles()` gives a possibility for extensions to hook into this function when implementing the `organization_facets` interface method.

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
