### PR TITLE
Fixes incorrectly encoded url current url

### DIFF
--- a/ckan/config/middleware/__init__.py
+++ b/ckan/config/middleware/__init__.py
@@ -151,8 +151,6 @@ class AskAppDispatcherMiddleware(object):
             qs = environ.get('QUERY_STRING')
 
             if qs:
-                # sort out weird encodings
-                qs = urllib.quote(qs, '')
                 environ['CKAN_CURRENT_URL'] = '%s?%s' % (path_info, qs)
             else:
                 environ['CKAN_CURRENT_URL'] = path_info

--- a/ckan/controllers/template.py
+++ b/ckan/controllers/template.py
@@ -29,6 +29,10 @@ class TemplateController(base.BaseController):
         By default this controller aborts the request with a 404 (Not
         Found)
         """
+        try:
+            url = unicode(url.encode('utf-8'))
+        except UnicodeDecodeError, UnicodeEncodeError:
+            return base.abort(404)
         if url.endswith(u'.txt'):
             response.headers[b'Content-Type'] = b'text/plain; charset=utf-8'
         # Default content-type is text/html

--- a/ckan/controllers/template.py
+++ b/ckan/controllers/template.py
@@ -30,7 +30,7 @@ class TemplateController(base.BaseController):
         Found)
         """
         try:
-            url = unicode(url.encode('utf-8'))
+            url = unicode(url.encode(u'utf-8'))
         except UnicodeDecodeError, UnicodeEncodeError:
             return base.abort(404)
         if url.endswith(u'.txt'):

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -601,7 +601,7 @@ def full_current_url():
 @core_helper
 def current_url():
     ''' Returns current url unquoted'''
-    return urllib.unquote(request.environ['CKAN_CURRENT_URL'])
+    return request.environ['CKAN_CURRENT_URL']
 
 
 @core_helper

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -656,7 +656,7 @@ def _insert_links(data_dict, limit, offset):
 
     # change the offset in the url
     parsed = list(urlparse.urlparse(urlstring))
-    query = urllib2.unquote(parsed[4])
+    query = parsed[4]
 
     arguments = dict(urlparse.parse_qsl(query))
     arguments_start = dict(arguments)


### PR DESCRIPTION
Fixes #6684

### Proposed fixes:

* url in question /%EF%AC%81?foo=bar&bz=%AC%81
* This is a unicode character, which can't be decoded from
ascii. Jinja templates will handle this if it's unicode, or if it's
hex encoded ascii, but can't take a non-unicode string in python 2 and
put this in a template.
* The querystring was being quoted, which is incorrect, as:
  1) the special characters in the query string mean something
  2) The rest of the querystring is already quoted. This makes it
  double quoted, as seen in the datastore file
* We don't want to unquote urls before putting them in the template
anyway.
* There was s further error passing this unicode path to the template
resolution, where in posix path, it fails:
```
File '/usr/lib/ckan/default/lib/python2.7/posixpath.py', line 73 in join
  path += '/' + b
UnicodeDecodeError: 'ascii' codec can't decode byte 0xef in position 1: ordinal not in range(128)
```
The solution here is to make sure it's unicode passed into the
function.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
