### PR TITLE
Clean resource search action

### DIFF
--- a/changes/6687.removal
+++ b/changes/6687.removal
@@ -1,0 +1,1 @@
+Remove deprecated `fields` parameter in `resource_search` method.

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1949,7 +1949,7 @@ def package_search(context, data_dict):
 @logic.validate(logic.schema.default_resource_search_schema)
 def resource_search(context, data_dict):
     '''
-    Searches for resources satisfying a given search criteria.
+    Searches for resources in public Datasets satisfying the search criteria.
 
     It returns a dictionary with 2 fields: ``count`` and ``results``.  The
     ``count`` field contains the total number of Resources found without the

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1957,7 +1957,7 @@ def resource_search(context, data_dict):
     list of dictized Resource objects.
 
     The 'query' parameter is a required field.  It is a string of the form
-    ``{field}:{term}`` or a list of strings, each of the same form.  Within
+    ``{field}:{term}`` or a list of strings, each of the same form. Within
     each string, ``{field}`` is a field or extra field on the Resource domain
     object.
 
@@ -1995,9 +1995,6 @@ def resource_search(context, data_dict):
     Currently only ordering one field is available, and in ascending order
     only.
 
-    The ``fields`` parameter is deprecated as it is not compatible with calling
-    this action with a GET request to the action API.
-
     The context may contain a flag, `search_query`, which if True will make
     this action behave as if being used by the internal search api.  ie - the
     results will not be dictized, and SearchErrors are thrown for bad search
@@ -2005,8 +2002,6 @@ def resource_search(context, data_dict):
 
     :param query: The search criteria.  See above for description.
     :type query: string or list of strings of the form ``{field}:{term1}``
-    :param fields: Deprecated
-    :type fields: dict of fields to search terms.
     :param order_by: A field on the Resource model that orders the results.
     :type order_by: string
     :param offset: Apply an offset to the query.


### PR DESCRIPTION
The `fields` parameter in `resource_search` has been deprecated 10 years ago. This PR cleans the old code.
