### PR TITLE
[CKAN-2.9.5]Fix errno2 

### DIFF
--- a/ckan/lib/i18n.py
+++ b/ckan/lib/i18n.py
@@ -76,7 +76,7 @@ _JS_TRANSLATIONS_DIR = os.path.join(_CKAN_DIR, u'public', u'base', u'i18n')
 
 def get_ckan_i18n_dir():
     path = config.get(
-        u'ckan.i18n_directory', os.path.join(_CKAN_DIR, u'i18n'))
+        u'ckan.i18n_directory') or os.path.join(_CKAN_DIR, u'i18n')
     if os.path.isdir(os.path.join(path, u'i18n')):
         path = os.path.join(path, u'i18n')
 


### PR DESCRIPTION
#### CKAN version
2.9.5

### Describe the bug
When running `ckan run` command, I m getting this error:

![image](https://user-images.githubusercontent.com/72216462/152645054-52cfcfd5-746d-4ede-886c-f39ea8a8dffe.png)

Seems like `config.get()` is ignoring the default value that we are giving and returns empty strings.

### Proposed fixes:
I added `or operator` same as on `master`



- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
