### PR TITLE
Fix py3.8

### DIFF
--- a/ckan/config/declaration/load.py
+++ b/ckan/config/declaration/load.py
@@ -3,7 +3,10 @@
 import logging
 import pathlib
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Union
-from typing_extensions import TypedDict
+try:  # Python 3.8+
+    from typing import TypedDict
+except ImportError:  # Python <3.8
+    from typing_extensions import TypedDict
 import yaml
 
 from .key import Key


### PR DESCRIPTION
Fixes #6691

### Proposed fixes:
Use built-in `typing` provided with Python 3.5+ even for `TypedDict` (Python 3.8+). This fixes compatibility with newer versions of Python.
We need to use try/except, as CKAN master targets Python 3.7+.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
