### PR TITLE
Clean isolated Session.close() code.

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -68,11 +68,6 @@ def load_environment(conf):
 
     app_globals.reset()
 
-    # issue #3260: remove idle transaction
-    # Session that was used for getting all config params nor committed,
-    # neither removed and we have idle connection as result
-    model.Session.commit()
-
     # Build JavaScript translations. Must be done after plugins have
     # been loaded.
     build_js_translations()
@@ -230,8 +225,3 @@ def update_config():
     except sqlalchemy.exc.IntegrityError:
         # Race condition, user already exists.
         pass
-
-    # Close current session and open database connections to ensure a clean
-    # clean environment even if an error occurs later on
-    model.Session.remove()
-    model.Session.bind.dispose()

--- a/ckan/tests/helpers.py
+++ b/ckan/tests/helpers.py
@@ -74,10 +74,6 @@ def reset_db():
     :returns: ``None``
 
     """
-    # Close any database connections that have been left open.
-    # This prevents CKAN from hanging waiting for some unclosed connection.
-    model.Session.close_all()
-
     model.repo.rebuild_db()
 
 


### PR DESCRIPTION
All code that opens a connection is responsible for closing it. Having isolated `just-in-case` sessions close is not recommended since it can hide errors in the logic.

This PR also cleans an isolated `model.Session.commit()` that we don't even control what's going to commit.