### PR TITLE
Remove deprecated CKAN_DB config

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -120,16 +120,6 @@ def update_config():
         # config = plugin.update_config(config)
         plugin.update_config(config)
 
-    # Set whitelisted env vars on config object
-    # This is set up before globals are initialized
-
-    ckan_db = os.environ.get('CKAN_DB', None)
-    if ckan_db:
-        msg = 'Setting CKAN_DB as an env var is deprecated and will be' \
-            ' removed in a future release. Use CKAN_SQLALCHEMY_URL instead.'
-        log.warn(msg)
-        config['sqlalchemy.url'] = ckan_db
-
     for option in CONFIG_FROM_ENV_VARS:
         from_env = os.environ.get(CONFIG_FROM_ENV_VARS[option], None)
         if from_env:

--- a/ckan/tests/config/test_environment.py
+++ b/ckan/tests/config/test_environment.py
@@ -14,7 +14,6 @@ ENV_VAR_LIST = [
     (u"CKAN_DATASTORE_READ_URL", u"http://mynewdbreadurl/"),
     (u"CKAN_SOLR_URL", u"http://mynewsolrurl/solr"),
     (u"CKAN_SITE_ID", u"my-site"),
-    (u"CKAN_DB", u"postgresql://mydeprectatesqlurl/"),
     (u"CKAN_SMTP_SERVER", u"mail.example.com"),
     (u"CKAN_SMTP_STARTTLS", u"True"),
     (u"CKAN_SMTP_USER", u"my_user"),
@@ -60,16 +59,6 @@ def test_update_config_env_vars(ckan_config):
     assert ckan_config[u"smtp.password"] == u"password"
     assert ckan_config[u"smtp.mail_from"] == u"server@example.com"
     assert ckan_config[u"ckan.max_resource_size"] == u"50"
-
-
-@pytest.mark.usefixtures("reset_env")
-def test_update_config_db_url_precedence(ckan_config):
-    """CKAN_SQLALCHEMY_URL in the env takes precedence over CKAN_DB"""
-    os.environ.setdefault("CKAN_DB", "postgresql://mydeprectatesqlurl/")
-    os.environ.setdefault("CKAN_SQLALCHEMY_URL", "postgresql://mynewsqlurl/")
-    p.load()
-
-    assert ckan_config["sqlalchemy.url"] == "postgresql://mynewsqlurl/"
 
 
 @pytest.mark.ckan_config("ckan.site_url", "")


### PR DESCRIPTION
`CKAN_DB` config has been deprecated and it's no longer needed in the code base.