### PR TITLE
Clean package_tag_all

### DIFF
--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -140,7 +140,7 @@ def package_tag_list_save(tag_dicts: Optional[list[dict[str, Any]]],
 
     tag_package_tag = dict((package_tag.tag, package_tag)
                             for package_tag in
-                            package.package_tag_all)
+                            package.package_tags)
 
     tag_package_tag_inactive = {
         tag: pt for tag,pt in tag_package_tag.items()
@@ -174,7 +174,7 @@ def package_tag_list_save(tag_dicts: Optional[list[dict[str, Any]]],
         package_tag = tag_package_tag[tag]
         package_tag.state = state
 
-    package.package_tag_all[:] = tag_package_tag.values()
+    package.package_tags[:] = tag_package_tag.values()
 
 def package_membership_list_save(
         group_dicts: Optional[list[dict[str, Any]]],

--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -110,7 +110,6 @@ class Package(core.StatefulObjectMixin,
     state: str
 
     package_tags: list["PackageTag"]
-    package_tag_all: list["PackageTag"]
 
     resources_all: list["Resource"]
     _extras: dict[str, Any]  # list['PackageExtra']
@@ -562,10 +561,6 @@ meta.mapper(Package, package_table, properties={
         ),
     })
 
-meta.mapper(tag.PackageTag, tag.package_tag_table, properties={
-    'pkg':orm.relation(Package, backref='package_tag_all',
-        cascade='none',
-        )
-    })
+meta.mapper(tag.PackageTag, tag.package_tag_table)
 
 meta.mapper(PackageMember, package_member_table)

--- a/ckan/tests/model/test_tags.py
+++ b/ckan/tests/model/test_tags.py
@@ -14,7 +14,7 @@ class TestTags(object):
         # method 1
         tag1 = model.Tag(name=factories.Tag.stub().name)
         package_tag1 = model.PackageTag(package=pkg, tag=tag1)
-        pkg.package_tag_all[:] = [package_tag1]
+        pkg.package_tags[:] = [package_tag1]
 
         # method 2
         tag2 = model.Tag(name=factories.Tag.stub().name)


### PR DESCRIPTION
When migrating to SQLAlchemy 1.4 I have a warning of conflicting relationships related to PackageTag. 

> /home/pdelboca/Repos/ckan/.venv/lib/python3.8/site-packages/sqlalchemy/orm/relationships.py:3435: SAWarning: relationship 'Package.package_tag_all' will copy column package.id to column package_tag.package_id, which conflicts with relationship(s): 'PackageTag.package' (copies package.id to package_tag.package_id), 'Package.package_tags' (copies package.id to package_tag.package_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   The 'overlaps' parameter may be used to remove this warning.

This PR is an attempt to clean it since `Package.package_tag_all` seems to be identical to `Package.package_tags`:

