### PR TITLE
add resource as param to after_resource_delete

### DIFF
--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -684,7 +684,7 @@ class IResourceController(Interface):
         pass
 
     def after_resource_delete(
-            self, context: Context,
+            self, context: Context, resource: dict[str, Any],
             resources: list[dict[str, Any]]) -> None:
         u'''
         Extensions will receive this after a resource is deleted.
@@ -692,6 +692,9 @@ class IResourceController(Interface):
         :param context: The context object of the current request, this
             includes for example access to the ``model`` and the ``user``.
         :type context: dictionary
+        :param resource: An object representing the resource that is 
+            deleted. This is a dictionary with one key: ``id`` which
+            holds the id ``string`` of the resource that is deleted.
         :param resources: A list of objects representing the remaining
             resources after a resource has been removed.
         :type resource: list


### PR DESCRIPTION
Fixes #

### Proposed fixes:

Provide the `resource_id` of deleted resource to extensions that need to perform chained actions, such as remove validation report of a deleted resource

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
