### PR TITLE
Link to requirements for installation in docs

### DIFF
--- a/doc/maintaining/installing/index.rst
+++ b/doc/maintaining/installing/index.rst
@@ -12,6 +12,9 @@ There are three ways to install CKAN:
 CKAN 2.9 supports Python 3.6 or higher and Python 2.7. The next version of CKAN
 will support Python 3 only.
 
+Additional deployment tips can be found in our wiki, such as the recommended 
+`Hardware Requirements <https://github.com/ckan/ckan/wiki/Hardware-Requirements>`_.
+
 Installing from package is the quickest and easiest way to install CKAN, but it requires
 Ubuntu 18.04 64-bit or Ubuntu 20.04 64-bit. 
 


### PR DESCRIPTION
Adds a link to the hardware requirements for CKAN installation. It took me a while to find this information, yes I [searched](https://docs.ckan.org/en/latest/search.html?q=hardware&check_keywords=yes&area=default#) first. Maybe it should just directly be part of the guide. 

Note that the [wiki page](https://github.com/ckan/ckan/wiki/Hardware-Requirements) in question has not been updated since 2014 - still seems appropriate to me, but could use a quick check from the admins.

### Features:

- [x] includes updated documentation
