### PR TITLE
Require PostgreSQL v10 or newer

### DIFF
--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -38,7 +38,7 @@ wiki page for help):
 Package                Description
 =====================  ===============================================
 Python                 `The Python programming language, v3.6 or newer <https://www.python.org/getit/>`_
-|postgres|             `The PostgreSQL database system, v9.5 or newer <https://www.postgresql.org/docs/9.5/libpq.html>`_
+|postgres|             `The PostgreSQL database system, v10 or newer <https://www.postgresql.org/docs/10/libpq.html>`_
 libpq                  `The C programmer's interface to PostgreSQL <http://www.postgresql.org/docs/8.1/static/libpq.html>`_
 pip                    `A tool for installing and managing Python packages <https://pip.pypa.io/en/stable/>`_
 python3-venv           `The Python3 virtual environment builder (or for Python 2 use 'virtualenv' instead) <https://virtualenv.pypa.io/en/latest/>`_


### PR DESCRIPTION
Fixes #4403

### Proposed fixes:

PostgreSQL v9.x is EOL.

### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
