### PR TITLE
Use codespell to find typos in ckan/tests

### DIFF
--- a/ckan/tests/cli/test_cli.py
+++ b/ckan/tests/cli/test_cli.py
@@ -97,7 +97,7 @@ def test_ckan_config_loader_parse_two_files():
     filename = os.path.join(extension_tpl_dir, u'test-extension.ini.tpl')
     conf = CKANConfigLoader(filename).get_config()
 
-    # Debug should not be overriden by lower-level config test-core.ini.tpl
+    # Debug should not be overridden by lower-level config test-core.ini.tpl
     assert conf[u'debug'] == u'true'
     # __file__ should never be override if parsing two files
     assert conf[u'__file__'] == filename
@@ -157,7 +157,7 @@ def test_recursive_loading():
 
 
 def test_variables_in_chained_files():
-    """Variables are available accross all files in chain.
+    """Variables are available across all files in chain.
 
     When variables got redefined latest version is used, just as in python's
     class-inheritance. The only exception is the `here` variable, which

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -429,7 +429,7 @@ class TestUser(object):
         user_pass = "TestPassword1"
         user = factories.User(password=user_pass)
 
-        # Have to do an actual login as this test relys on repoze cookie handling.
+        # Have to do an actual login as this test relies on repoze cookie handling.
         # get the form
         response = app.post(
             "/login_generic?came_from=/user/logged_in",
@@ -455,7 +455,7 @@ class TestUser(object):
         user_pass = "TestPassword1"
         user = factories.User(password=user_pass)
 
-        # Have to do an actual login as this test relys on repoze cookie handling.
+        # Have to do an actual login as this test relies on repoze cookie handling.
         # get the form
         response = app.post(
             "/login_generic?came_from=/user/logged_in",
@@ -481,7 +481,7 @@ class TestUser(object):
         user_pass = "TestPassword1"
         user = factories.User(password=user_pass)
 
-        # Have to do an actual login as this test relys on repoze cookie handling.
+        # Have to do an actual login as this test relies on repoze cookie handling.
         # get the form
         response = app.post(
             "/login_generic?came_from=/user/logged_in",

--- a/ckan/tests/factories.py
+++ b/ckan/tests/factories.py
@@ -3,7 +3,7 @@
 """This is a collection of factory classes for building CKAN users, datasets,
 etc.
 
-Factories can be either used directly or via corresponging pytes fixtures to
+Factories can be either used directly or via corresponding pytes fixtures to
 create any objects that are needed for the tests. These factories are written
 using ``factory_boy``:
 
@@ -113,7 +113,7 @@ fake = Faker()
 def _get_action_user_name(kwargs: dict[str, Any]) -> Optional[str]:
     """Return the name of the user in kwargs, defaulting to the site user
 
-    It can be overriden by explictly setting {'user': None} in the keyword
+    It can be overridden by explicitly setting {'user': None} in the keyword
     arguments. In that case, this method will return None.
     """
 
@@ -148,7 +148,7 @@ class CKANOptions(factory.alchemy.SQLAlchemyOptions):
 
     :param action: name of the CKAN API action used for entity creation
     :param primary_key: name of the entity's property that can be used for
-        retriving entity object from database
+        retrieving entity object from database
 
     """
 
@@ -199,7 +199,7 @@ class CKANFactory(factory.alchemy.SQLAlchemyModelFactory):
 
     @classmethod
     def model(cls, **kwargs):
-        """Create entity via API and retrive result directly from the DB."""
+        """Create entity via API and retrieve result directly from the DB."""
         result = cls(**kwargs)
         return cls._meta.sqlalchemy_session.query(cls._meta.model).get(
             result[cls._meta.primary_key]

--- a/ckan/tests/factories.py
+++ b/ckan/tests/factories.py
@@ -3,7 +3,7 @@
 """This is a collection of factory classes for building CKAN users, datasets,
 etc.
 
-Factories can be either used directly or via corresponding pytes fixtures to
+Factories can be either used directly or via corresponding pytest fixtures to
 create any objects that are needed for the tests. These factories are written
 using ``factory_boy``:
 

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -586,9 +586,9 @@ class TestResourceCreate:
             "resource_create",
             package_id=dataset["id"],
             somekey="somevalue",  # this is how to do resource extras
-            extras={u"someotherkey": u"alt234"},  # this isnt
+            extras={u"someotherkey": u"alt234"},  # this isn't
             subobject={u"hello": u"there"},  # JSON objects supported
-            sublist=[1, 2, 3],  # JSON lists suppoted
+            sublist=[1, 2, 3],  # JSON lists supported
             format=u"plain text",
             url=u"http://datahub.io/download/",
         )
@@ -920,7 +920,7 @@ class TestDatasetCreate(object):
                     "alt_url": u"alt123",
                     "description": u"Full text.",
                     "somekey": "somevalue",  # this is how to do resource extras
-                    "extras": {u"someotherkey": u"alt234"},  # this isnt
+                    "extras": {u"someotherkey": u"alt234"},  # this isn't
                     "format": u"plain text",
                     "hash": u"abc123",
                     "position": 0,

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -1270,7 +1270,7 @@ class TestCurrentPackageList(object):
 
     def test_current_package_list_private_datasets_anonoymous_user(self):
         """
-        Test current_package_list_with_resources with an anoymous user and
+        Test current_package_list_with_resources with an anonymous user and
         a private dataset
         """
         user = factories.User()

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -556,7 +556,7 @@ class TestDatasetUpdate(object):
                     "alt_url": "alt123",
                     "description": "Full text.",
                     "somekey": "somevalue",  # this is how to do resource extras
-                    "extras": {"someotherkey": "alt234"},  # this isnt
+                    "extras": {"someotherkey": "alt234"},  # this isn't
                     "format": "plain text",
                     "hash": "abc123",
                     "position": 0,
@@ -848,7 +848,7 @@ class TestResourceViewUpdate(object):
             resource_id=resource_id, title="View 2"
         )
 
-        # Reorder Views back just by specifiying a single view to go first
+        # Reorder Views back just by specifying a single view to go first
 
         result = helpers.call_action(
             "resource_view_reorder",
@@ -1278,7 +1278,7 @@ class TestResourceUpdate(object):
             "resource_update",
             id=dataset["resources"][0]["id"],
             somekey="somevalue",  # this is how to do resource extras
-            extras={"someotherkey": "alt234"},  # this isnt
+            extras={"someotherkey": "alt234"},  # this isn't
             format="plain text",
             url="http://datahub.io/download/",
         )

--- a/ckan/tests/plugins/test_blanket.py
+++ b/ckan/tests/plugins/test_blanket.py
@@ -151,7 +151,7 @@ class TestBlanketImplementation(object):
         assert self._config_declarations_registered(ckan_config)
 
     def test_blanket_must_be_used(self, app, cli, ckan_config):
-        """There is no accidential use of blanket implementation if module not
+        """There is no accidental use of blanket implementation if module not
         loades.
 
         """

--- a/ckan/tests/pytest_ckan/ckan_setup.py
+++ b/ckan/tests/pytest_ckan/ckan_setup.py
@@ -55,7 +55,7 @@ def pytest_runtest_setup(item):
 
     `ckan_config` mark itself does nothing(as any mark). All actual
     config changes performed inside `ckan_config` fixture. So let's
-    implicitely use `ckan_config` fixture inside any test that patches
+    implicitly use `ckan_config` fixture inside any test that patches
     config object. This will save us from adding
     `@mark.usefixtures("ckan_config")` every time.
 

--- a/ckan/tests/pytest_ckan/fixtures.py
+++ b/ckan/tests/pytest_ckan/fixtures.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """This is a collection of pytest fixtures for use in tests.
 
-All fixtures bellow available anywhere under the root of CKAN
+All fixtures below available anywhere under the root of CKAN
 repository. Any external CKAN extension should be able to include them
 by adding next lines under root `conftest.py`
 
@@ -23,7 +23,7 @@ There are three type of fixtures available in CKAN:
   test). But presence of these fixtures in test usually signals that
   is's a good time to refactor this test.
 
-Deeper expanation can be found in `official documentation
+Deeper explanation can be found in `official documentation
 <https://docs.pytest.org/en/latest/fixture.html>`_
 
 """
@@ -379,7 +379,7 @@ def create_with_upload(clean_db, ckan_config, monkeypatch, tmpdir):
     argument. Default value: `upload`.
 
     In addition, accepts named argument `context` which will be passed
-    to `ckan.tests.helpers.call_action` and arbitary number of
+    to `ckan.tests.helpers.call_action` and arbitrary number of
     additional named arguments, that will be used as resource
     properties.
 


### PR DESCRIPTION
Fixes #

### Proposed fixes:

https://pypi.org/project/codespell
`codespell --ignore-words-list=dum,nwe,reall,russion --skip="*_stop.txt,*.js,*.json,*.map,*.po" ./ckan/tests`

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
