### PR TITLE
[6727]Fix error 500 when providing template-bs3 in the config

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2695,6 +2695,9 @@ def resource_formats() -> dict[str, list[str]]:
     global _RESOURCE_FORMATS
     if not _RESOURCE_FORMATS:
         format_file_path = config.get_value('ckan.resource_formats')
+        if not format_file_path:
+            format_file_path = resource_formats_default_file()
+
         with open(format_file_path, encoding='utf-8') as format_file:
             try:
                 file_resource_formats = json.loads(format_file.read())

--- a/ckan/templates-bs3/error_document_template.html
+++ b/ckan/templates-bs3/error_document_template.html
@@ -18,7 +18,7 @@
 
 {% block flash %}
   {# eat the flash messages caused by the 404 #}
-  {% set flash_messages = h.flash.pop_messages() %}
+  {% set flash_messages = h.get_flashed_messages() %}
 {% endblock %}
 
 {% block secondary %}{% endblock %}

--- a/ckan/templates-bs3/page.html
+++ b/ckan/templates-bs3/page.html
@@ -23,8 +23,8 @@
           {% block flash %}
             <div class="flash-messages">
               {% block flash_inner %}
-                {% for message in h.flash.pop_messages() | list %}
-                  <div class="alert fade in {{ message.category }}">
+              {% for category, message in h.get_flashed_messages(with_categories=true) %}
+                  <div class="alert fade in {{ category }}">
                     {{ h.literal(message) }}
                   </div>
                 {% endfor %}


### PR DESCRIPTION
Fixes #6727 

### Proposed fixes:

This `PR` fixes two errors:

* The first error occurs because `CKAN Master` could not find `flask.pop_message()` it was removed in #6239.
* Another error occurs when trying to add a resource to a dataset and I think it has to do with the previous merge of #6607
<img width="1009" alt="image" src="https://user-images.githubusercontent.com/72216462/156184585-f22e935a-9d5f-47af-8f55-85d19826825e.png">




### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
