### PR TITLE
Update after_dataset_search docstring

### DIFF
--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -546,7 +546,7 @@ class IPackageController(Interface):
         parameters, and should return a modified (or not) object with the
         same structure::
 
-            {'count': '', 'results': '', 'facets': ''}
+            {'count': '', 'results': '', 'search_facets': ''}
 
         Note that count and facets may need to be adjusted if the extension
         changed the results for some reason.


### PR DESCRIPTION
`facets` parameter has been deprecated in favor of `search_facets`: http://docs.ckan.org/en/latest/api/index.html#ckan.logic.action.get.package_search

This PR just update the docstring of the method.
