### PR TITLE
Fix failing type checks

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import email.utils
 import datetime
 import logging
-import numbers
 import re
 import os
 import pytz
@@ -2373,7 +2372,8 @@ def format_resource_items(
     reg_ex_float = r'^-?\d{1,}\.\d{1,}$'
     for key, value in items:
         if (key in blacklist
-                or (not isinstance(value, numbers.Number) and not value)):
+                or (not isinstance(value, (int, float))
+                    and not value)):
             # Ignore blocked keys and values that evaluate to
             # `bool(value) == False` (e.g. `""`, `[]` or `{}`),
             # with the exception of numbers such as `False`, `0`,`0.0`.
@@ -2397,8 +2397,8 @@ def format_resource_items(
                 value = formatters.localised_number(int(value))
         elif isinstance(value, bool):
             value = str(value)
-        elif isinstance(value, numbers.Number):
-            value = formatters.localised_number(value)
+        elif isinstance(value, (int, float)):
+            value = formatters.localised_number(float(value))
         key = key.replace('_', ' ')
         output.append((key, value))
     return sorted(output, key=lambda x: x[0])


### PR DESCRIPTION
### Proposed fixes:
Abstract class Number cannot be converted to int, float or complex in type checks, this should not have a functional difference but the failing check should pass.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
