### PR TITLE
[6116]Fix activity stream notification email does not include root_path

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -12,6 +12,7 @@ import datetime
 import logging
 import re
 import os
+from xml.dom import ValidationErr
 import pytz
 import tzlocal
 import pprint
@@ -3013,3 +3014,10 @@ def can_update_owner_org(
         return True
 
     return False
+
+
+@core_helper
+def generate_url_to_root_path():
+    site_url = config.get_value('ckan.site_url')
+    root_path = config.get_value('ckan.root_path')
+    return site_url + root_path if root_path else site_url

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -12,7 +12,6 @@ import datetime
 import logging
 import re
 import os
-from xml.dom import ValidationErr
 import pytz
 import tzlocal
 import pprint

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -3013,10 +3013,3 @@ def can_update_owner_org(
         return True
 
     return False
-
-
-@core_helper
-def generate_url_to_root_path() -> str:
-    site_url = config.get_value('ckan.site_url')
-    root_path = config.get_value('ckan.root_path')
-    return site_url + root_path if root_path else site_url

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -3016,7 +3016,7 @@ def can_update_owner_org(
 
 
 @core_helper
-def generate_url_to_root_path():
+def generate_url_to_root_path() -> str:
     site_url = config.get_value('ckan.site_url')
     root_path = config.get_value('ckan.root_path')
     return site_url + root_path if root_path else site_url

--- a/ckan/templates-bs3/activity_streams/activity_stream_email_notifications.text
+++ b/ckan/templates-bs3/activity_streams/activity_stream_email_notifications.text
@@ -1,7 +1,7 @@
 {% set num = activities|length %}{{ ungettext("You have {num} new activity on your {site_title} dashboard", "You have {num} new activities on your {site_title} dashboard", num).format(site_title=g.site_title, num=num) }} {{ _('To view your dashboard, click on this link:') }}
 
-{{ g.site_url + '/dashboard' }}
+{{ h.url_for('dashboard.index', _external=True) }}
 
 {{ _('You can turn off these email notifications in your {site_title} preferences. To change your preferences, click on this link:').format(site_title=g.site_title) }}
 
-{{ g.site_url + '/user/edit' }}
+{{ h.url_for('user.edit', _external=True) }}

--- a/ckan/templates/activity_streams/activity_stream_email_notifications.text
+++ b/ckan/templates/activity_streams/activity_stream_email_notifications.text
@@ -1,7 +1,7 @@
 {% set num = activities|length %}{{ ungettext("You have {num} new activity on your {site_title} dashboard", "You have {num} new activities on your {site_title} dashboard", num).format(site_title=g.site_title, num=num) }} {{ _('To view your dashboard, click on this link:') }}
 
-{{ g.site_url + '/dashboard' }}
+{{ h.generate_url_to_root_path() + '/dashboard' }}
 
 {{ _('You can turn off these email notifications in your {site_title} preferences. To change your preferences, click on this link:').format(site_title=g.site_title) }}
 
-{{ g.site_url + '/user/edit' }}
+{{ h.generate_url_to_root_path() + '/user/edit' }}

--- a/ckan/templates/activity_streams/activity_stream_email_notifications.text
+++ b/ckan/templates/activity_streams/activity_stream_email_notifications.text
@@ -1,7 +1,7 @@
 {% set num = activities|length %}{{ ungettext("You have {num} new activity on your {site_title} dashboard", "You have {num} new activities on your {site_title} dashboard", num).format(site_title=g.site_title, num=num) }} {{ _('To view your dashboard, click on this link:') }}
 
-{{ h.generate_url_to_root_path() + '/dashboard' }}
+{{ h.url_for('dashboard.index', _external=True) }}
 
 {{ _('You can turn off these email notifications in your {site_title} preferences. To change your preferences, click on this link:').format(site_title=g.site_title) }}
 
-{{ h.generate_url_to_root_path() + '/user/edit' }}
+{{ h.url_for('user.edit', _external=True) }}


### PR DESCRIPTION
Fixes #6116 

### Proposed fixes:
Add helper function to generate url to `root_path`

![image](https://user-images.githubusercontent.com/72216462/157522927-db82f4ab-1507-49ed-b64f-f1ba847a0ac1.png)


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
