### PR TITLE
Clean old drill_down_url method

### DIFF
--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -89,15 +89,6 @@ def search_url(params: Params, package_type: Optional[str] = None) -> str:
     return url_with_params(url, params)
 
 
-def drill_down_url(alternative_url: Optional[str] = None, **by: Any) -> str:
-    return h.add_url_param(
-        alternative_url=alternative_url,
-        controller=u'dataset',
-        action=u'search',
-        new_params=by
-    )
-
-
 def remove_field(package_type: Optional[str],
                  key: str,
                  value: Optional[str] = None,
@@ -242,7 +233,6 @@ def search(package_type: str) -> str:
     params_nopage = [(k, v) for k, v in request.args.items(multi=True)
                      if k != u'page']
 
-    extra_vars[u'drill_down_url'] = drill_down_url
     extra_vars[u'remove_field'] = partial(remove_field, package_type)
 
     sort_by = request.args.get(u'sort', None)

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -260,16 +260,6 @@ def _read(id: Optional[str], limit: int, group_type: str) -> dict[str, Any]:
                   for k, v in params]
         return url + u'?' + urlencode(params)
 
-    def drill_down_url(**by: Any):
-        return h.add_url_param(
-            alternative_url=None,
-            controller=group_type,
-            action=u'read',
-            extras=dict(id=g.group_dict.get(u'name')),
-            new_params=by)
-
-    extra_vars["drill_down_url"] = drill_down_url
-
     def remove_field(
             key: str, value: Optional[str] = None,
             replace: Optional[str] = None):


### PR DESCRIPTION
`drill_down_url(...)` is part of the old template logic and it is not currently used anywhere in the code.