### PR TITLE
Clean old search_url_params

### DIFF
--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -258,9 +258,6 @@ def search(package_type: str) -> str:
 
     pager_url = partial(_pager_url, params_nopage, package_type)
 
-    search_url_params = urlencode(_encode_params(params_nopage))
-    extra_vars[u'search_url_params'] = search_url_params
-
     details = _get_search_details()
     extra_vars[u'fields'] = details[u'fields']
     extra_vars[u'fields_grouped'] = details[u'fields_grouped']


### PR DESCRIPTION
Currently we are passing the `search_url_params` variable as a template variable but we are not using it anywhere in the code.