### PR TITLE
Minor fix: update install-from-docker-compose

### DIFF
--- a/doc/maintaining/installing/install-from-docker-compose.rst
+++ b/doc/maintaining/installing/install-from-docker-compose.rst
@@ -363,7 +363,10 @@ E.g., `ckanext-spatial <https://github.com/ckan/ckanext-spatial.git>`_::
     exit
 
     # On the host
-    docker exec -it db psql -U ckan -f 20_postgis_permissions.sql
+    docker exec -it db bash
+    #Inside the db container 
+    cd docker-entrypoint-initdb.d/
+    psql -U ckan -f 20_postgis_permissions.sql
     docker exec -it ckan /usr/local/bin/ckan -c /etc/ckan/production.ini spatial initdb 
 
     sudo vim $VOL_CKAN_CONFIG/production.ini


### PR DESCRIPTION
Inside the DB container you should be sure to be in right folder before launch command, minor fixes

Fixes #

### Proposed fixes:

Modified the docs to ensure be in the actual folder, as follow:

```bash
/docker-entrypoint-initdb.d/20_postgis_permissions.sql
```

Feel free to give your opinion on this documentation update :) 


### Features:

- [ ] includes tests covering changes
- [X ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
