### PR TITLE
Allow context['user'] to be the users id

### DIFF
--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -328,7 +328,7 @@ def check_access(action: str,
     if not context.get('ignore_auth'):
         if not context.get('__auth_user_obj_checked'):
             if context["user"] and not context["auth_user_obj"]:
-                context['auth_user_obj'] = model.User.by_name(context['user'])
+                context['auth_user_obj'] = model.User.get(context['user'])
             context['__auth_user_obj_checked'] = True
     try:
         logic_authorization = authz.is_authorized(action, context, data_dict)


### PR DESCRIPTION
Is the `name` of the user mandatory for the context?
Can we use the `id`?

**This is just a question PR**

### Proposed fixes:
Allow to use the user id in context and not only the name

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
