### PR TITLE
Clean old c attribute from helpers.py

### DIFF
--- a/changes/6765.removal
+++ b/changes/6765.removal
@@ -1,0 +1,2 @@
+`unselected_facet_items` helper has been removed. You can use
+`get_facet_items_dict` with exclude_active=True instead.

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1168,7 +1168,7 @@ def unselected_facet_items(
 
     '''
     return get_facet_items_dict(
-        facet, c.search_facets, limit=limit, exclude_active=True)
+        facet, g.search_facets, limit=limit, exclude_active=True)
 
 
 @core_helper
@@ -1774,11 +1774,11 @@ def dump_json(obj: Any, **kw: Any) -> str:
 
 @core_helper
 def auto_log_message() -> str:
-    if (c.action == 'new'):
+    if (g.action == 'new'):
         return _('Created new dataset.')
-    elif (c.action == 'editresources'):
+    elif (g.action == 'editresources'):
         return _('Edited resources.')
-    elif (c.action == 'edit'):
+    elif (g.action == 'edit'):
         return _('Edited settings.')
     return ''
 
@@ -1831,10 +1831,10 @@ def follow_button(obj_type: str, obj_id: str) -> str:
     obj_type = obj_type.lower()
     assert obj_type in _follow_objects
     # If the user is logged in show the follow/unfollow button
-    if c.user:
+    if g.user:
         context = cast(
             Context,
-            {'model': model, 'session': model.Session, 'user': c.user})
+            {'model': model, 'session': model.Session, 'user': g.user})
         action = 'am_following_%s' % obj_type
         following = logic.get_action(action)(context, {'id': obj_id})
         return snippet('snippets/follow_button.html',
@@ -1861,7 +1861,7 @@ def follow_count(obj_type: str, obj_id: str) -> int:
     assert obj_type in _follow_objects
     action = '%s_follower_count' % obj_type
     context = cast(
-        Context, {'model': model, 'session': model.Session, 'user': c.user}
+        Context, {'model': model, 'session': model.Session, 'user': g.user}
     )
     return logic.get_action(action)(context, {'id': obj_id})
 
@@ -2020,7 +2020,7 @@ def organizations_available(permission: str = 'manage_group',
     '''Return a list of organizations that the current user has the specified
     permission for.
     '''
-    context: Context = {'user': c.user}
+    context: Context = {'user': g.user}
     data_dict = {
         'permission': permission,
         'include_dataset_count': include_dataset_count}
@@ -2037,16 +2037,16 @@ def roles_translated() -> dict[str, str]:
 def user_in_org_or_group(group_id: str) -> bool:
     ''' Check if user is in a group or organization '''
     # we need a user
-    if not c.userobj:
+    if not g.userobj:
         return False
     # sysadmins can do anything
-    if c.userobj.sysadmin:
+    if g.userobj.sysadmin:
         return True
     query = model.Session.query(model.Member) \
         .filter(model.Member.state == 'active') \
         .filter(model.Member.table_name == 'user') \
         .filter(model.Member.group_id == group_id) \
-        .filter(model.Member.table_id == c.userobj.id)
+        .filter(model.Member.table_id == g.userobj.id)
     return len(query.all()) != 0
 
 
@@ -2071,7 +2071,7 @@ def dashboard_activity_stream(user_id: str,
 
     '''
     context = cast(
-        Context, {'model': model, 'session': model.Session, 'user': c.user})
+        Context, {'model': model, 'session': model.Session, 'user': g.user})
 
     if filter_type:
         action_functions = {
@@ -2095,7 +2095,7 @@ def recently_changed_packages_activity_stream(
     else:
         data_dict = {}
     context = cast(
-        Context, {'model': model, 'session': model.Session, 'user': c.user}
+        Context, {'model': model, 'session': model.Session, 'user': g.user}
     )
     return logic.get_action('recently_changed_packages_activity_list')(
         context, data_dict)
@@ -2473,7 +2473,7 @@ def new_activities() -> Optional[int]:
     details.
 
     '''
-    if not c.userobj:
+    if not g.userobj:
         return None
     action = logic.get_action('dashboard_new_activities_count')
     return action({}, {})
@@ -2874,7 +2874,7 @@ def can_update_owner_org(
     collaborators_can_change_owner_org = authz.check_config_permission(
         'allow_collaborators_to_change_owner_org')
 
-    user = model.User.get(c.user)
+    user = model.User.get(g.user)
 
     if (user
             and authz.check_config_permission('allow_dataset_collaborators')

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1071,20 +1071,16 @@ def get_facet_items_dict(
     match each facet item).
 
     Reads the complete list of facet items for the given facet from
-    c.search_facets, and filters out the facet items that the user has already
+    search_facets, and filters out the facet items that the user has already
     selected.
 
     Arguments:
     facet -- the name of the facet to filter.
-    search_facets -- dict with search facets(c.search_facets in Pylons)
+    search_facets -- dict with search facets
     limit -- the max. number of facet items to return.
     exclude_active -- only return unselected facets.
 
     '''
-    if search_facets is None:
-        search_facets = getattr(
-            c, u'search_facets', None)
-
     if not search_facets \
        or not isinstance(search_facets, dict) \
        or not search_facets.get(facet, {}).get('items'):
@@ -1121,12 +1117,12 @@ def has_more_facets(facet: str,
     limit.
 
     Reads the complete list of facet items for the given facet from
-    c.search_facets, and filters out the facet items that the user has already
+    search_facets, and filters out the facet items that the user has already
     selected.
 
     Arguments:
     facet -- the name of the facet to filter.
-    search_facets -- dict with search facets(c.search_facets in Pylons)
+    search_facets -- dict with search facets
     limit -- the max. number of facet items.
     exclude_active -- only return unselected facets.
 
@@ -1145,30 +1141,6 @@ def has_more_facets(facet: str,
     if limit is not None and len(facets) > limit:
         return True
     return False
-
-
-@core_helper
-def unselected_facet_items(
-        facet: str, limit: int = 10) -> list[dict[str, Any]]:
-    '''Return the list of unselected facet items for the given facet, sorted
-    by count.
-
-    Returns the list of unselected facet contraints or facet items (e.g. tag
-    names like "russian" or "tolstoy") for the given search facet (e.g.
-    "tags"), sorted by facet item count (i.e. the number of search results that
-    match each facet item).
-
-    Reads the complete list of facet items for the given facet from
-    c.search_facets, and filters out the facet items that the user has already
-    selected.
-
-    Arguments:
-    facet -- the name of the facet to filter.
-    limit -- the max. number of facet items to return.
-
-    '''
-    return get_facet_items_dict(
-        facet, g.search_facets, limit=limit, exclude_active=True)
 
 
 @core_helper

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -56,7 +56,7 @@ import ckan
 
 
 from ckan.lib.pagination import Page  # type: ignore # noqa: re-export
-from ckan.common import _, ungettext, c, g, request, json
+from ckan.common import _, ungettext, g, request, json
 
 from ckan.lib.webassets_tools import include_asset, render_assets
 from markupsafe import Markup, escape
@@ -1098,9 +1098,9 @@ def get_facet_items_dict(
     sort_facets: Callable[[Any], tuple[int, str]] = lambda it: (
         -it['count'], it['display_name'].lower())
     facets.sort(key=sort_facets)
-    if hasattr(c, 'search_facets_limits'):
-        if c.search_facets_limits and limit is None:
-            limit = c.search_facets_limits.get(facet)
+    if hasattr(g, 'search_facets_limits'):
+        if g.search_facets_limits and limit is None:
+            limit = g.search_facets_limits.get(facet)
     # zero treated as infinite for hysterical raisins
     if limit is not None and limit > 0:
         return facets[:limit]
@@ -1136,8 +1136,8 @@ def has_more_facets(facet: str,
             facets.append(dict(active=False, **facet_item))
         elif not exclude_active:
             facets.append(dict(active=True, **facet_item))
-    if getattr(c, 'search_facets_limits', None) and limit is None:
-        limit = c.search_facets_limits.get(facet)
+    if getattr(g, 'search_facets_limits', None) and limit is None:
+        limit = g.search_facets_limits.get(facet)
     if limit is not None and len(facets) > limit:
         return True
     return False

--- a/ckan/templates-bs3/group/read.html
+++ b/ckan/templates-bs3/group/read.html
@@ -34,7 +34,7 @@
   <div class="filters">
     <div>
       {% for facet in facet_titles %}
-        {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, extras={'id':group_dict.id}) }}
+        {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, extras={'id':group_dict.id}, search_facets=search_facets) }}
       {% endfor %}
     </div>
     <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span class="text">close</span></a>

--- a/ckan/templates-bs3/home/snippets/search.html
+++ b/ckan/templates-bs3/home/snippets/search.html
@@ -1,4 +1,4 @@
-{% set tags = h.get_facet_items_dict('tags', c.search_facets, limit=3) %}
+{% set tags = h.get_facet_items_dict('tags', search_facets, limit=3) %}
 {% set placeholder = _('E.g. environment') %}
 {% set dataset_type = h.default_package_type() %}
 

--- a/ckan/templates-bs3/organization/read.html
+++ b/ckan/templates-bs3/organization/read.html
@@ -39,7 +39,7 @@
   <div class="filters">
     <div>
       {% for facet in facet_titles %}
-        {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, extras={'id':group_dict.id}) }}
+        {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, extras={'id':group_dict.id}, search_facets=search_facets) }}
       {% endfor %}
     </div>
     <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span class="text">close</span></a>

--- a/ckan/templates-bs3/snippets/facet_list.html
+++ b/ckan/templates-bs3/snippets/facet_list.html
@@ -37,12 +37,12 @@ Boolean for when a facet list should appear in the the right column of the
 page and not the left column.
 
 search_facets
-Dictionary with search facets(or `c.search_facets` if not provided)
+Dictionary with search facets
 
 #}
 {% block facet_list %}
     {% set hide_empty = hide_empty or false %}
-    {% with items = items or h.get_facet_items_dict(name, search_facets or c.search_facets) %}
+    {% with items = items or h.get_facet_items_dict(name, search_facets) %}
 	{% if items or not hide_empty %}
 	    {% if within_tertiary %}
 		{% set nav_class = 'nav nav-pills nav-stacked' %}
@@ -58,7 +58,7 @@ Dictionary with search facets(or `c.search_facets` if not provided)
 			</h2>
 		    {% endblock %}
 		    {% block facet_list_items %}
-			{% with items = items or h.get_facet_items_dict(name, search_facets or c.search_facets) %}
+			{% with items = items or h.get_facet_items_dict(name, search_facets) %}
 			    {% if items %}
 				<nav aria-label="{{ title }}">
 				    <ul class="{{ nav_class or 'list-unstyled nav nav-simple nav-facet' }}">
@@ -80,7 +80,7 @@ Dictionary with search facets(or `c.search_facets` if not provided)
 
 				<p class="module-footer">
 				    {% if h.get_param_int('_%s_limit' % name) %}
-					{% if h.has_more_facets(name, search_facets or c.search_facets) %}
+					{% if h.has_more_facets(name, search_facets) %}
 					    <a href="{{ h.remove_url_param('_%s_limit' % name, replace=0, extras=extras, alternative_url=alternative_url) }}" class="read-more">{{ _('Show More {facet_type}').format(facet_type=title) }}</a>
 					{% endif %}
 				    {% else %}

--- a/ckan/templates/group/read.html
+++ b/ckan/templates/group/read.html
@@ -34,7 +34,7 @@
   <div class="filters">
     <div>
       {% for facet in facet_titles %}
-        {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, extras={'id':group_dict.id}) }}
+        {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, extras={'id':group_dict.id}, search_facets=search_facets) }}
       {% endfor %}
     </div>
     <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span class="text">close</span></a>

--- a/ckan/templates/home/snippets/search.html
+++ b/ckan/templates/home/snippets/search.html
@@ -1,4 +1,4 @@
-{% set tags = h.get_facet_items_dict('tags', c.search_facets, limit=3) %}
+{% set tags = h.get_facet_items_dict('tags', search_facets, limit=3) %}
 {% set placeholder = _('E.g. environment') %}
 {% set dataset_type = h.default_package_type() %}
 

--- a/ckan/templates/organization/bulk_process.html
+++ b/ckan/templates/organization/bulk_process.html
@@ -108,6 +108,6 @@
 {% block secondary_content %}
     {{  super() }}
     {% for facet in c.facet_titles %}
-    {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id':group_dict.id}) }}
+    {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id':group_dict.id}, search_facets=search_facets) }}
   {% endfor %}
 {% endblock %}

--- a/ckan/templates/organization/read.html
+++ b/ckan/templates/organization/read.html
@@ -39,7 +39,7 @@
   <div class="filters">
     <div>
       {% for facet in facet_titles %}
-        {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, extras={'id':group_dict.id}) }}
+        {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, extras={'id':group_dict.id}, search_facets=search_facets) }}
       {% endfor %}
     </div>
     <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span class="text">close</span></a>

--- a/ckan/templates/snippets/facet_list.html
+++ b/ckan/templates/snippets/facet_list.html
@@ -37,12 +37,12 @@ Boolean for when a facet list should appear in the the right column of the
 page and not the left column.
 
 search_facets
-Dictionary with search facets(or `c.search_facets` if not provided)
+Dictionary with search facets
 
 #}
 {% block facet_list %}
     {% set hide_empty = hide_empty or false %}
-    {% with items = items or h.get_facet_items_dict(name, search_facets or c.search_facets) %}
+    {% with items = items or h.get_facet_items_dict(name, search_facets) %}
 	{% if items or not hide_empty %}
 	    {% if within_tertiary %}
 		{% set nav_class = 'nav nav-pills nav-stacked' %}
@@ -58,7 +58,7 @@ Dictionary with search facets(or `c.search_facets` if not provided)
 			</h2>
 		    {% endblock %}
 		    {% block facet_list_items %}
-			{% with items = items or h.get_facet_items_dict(name, search_facets or c.search_facets) %}
+			{% with items = items or h.get_facet_items_dict(name, search_facets) %}
 			    {% if items %}
 				<nav aria-label="{{ title }}">
 				    <ul class="{{ nav_class or 'list-unstyled nav nav-simple nav-facet' }}">
@@ -80,7 +80,7 @@ Dictionary with search facets(or `c.search_facets` if not provided)
 
 				<p class="module-footer">
 				    {% if h.get_param_int('_%s_limit' % name) %}
-					{% if h.has_more_facets(name, search_facets or c.search_facets) %}
+					{% if h.has_more_facets(name, search_facets) %}
 					    <a href="{{ h.remove_url_param('_%s_limit' % name, replace=0, extras=extras, alternative_url=alternative_url) }}" class="read-more">{{ _('Show More {facet_type}').format(facet_type=title) }}</a>
 					{% endif %}
 				    {% else %}

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -355,10 +355,10 @@ def _read(id: Optional[str], limit: int, group_type: str) -> dict[str, Any]:
         # compatibility with templates in existing extensions
         g.group_dict['package_count'] = query['count']
 
-        extra_vars["search_facets"] = g.search_facets = query['search_facets']
+        extra_vars["search_facets"] = query['search_facets']
         extra_vars["search_facets_limits"] = g.search_facets_limits = {}
         default_limit: int = config.get_value(u'search.facets.default')
-        for facet in g.search_facets.keys():
+        for facet in extra_vars["search_facets"].keys():
             limit = int(request.args.get(u'_%s_limit' % facet, default_limit))
             g.search_facets_limits[facet] = limit
         extra_vars["page"].items = query['results']

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -891,15 +891,9 @@ class BulkProcessView(MethodView):
         g.group_dict = group_dict
         g.group = group
         extra_vars = _read(id, limit, group_type)
-        g.packages = g.page.items
-
-        extra_vars: dict[str, Any] = {
-            u"group_dict": group_dict,
-            u"group": group,
-            u"page": g.page,
-            u"packages": g.page.items,
-            u'group_type': group_type
-        }
+        extra_vars['packages'] = g.page.items
+        extra_vars['group_dict'] = group_dict
+        extra_vars['group'] = group
 
         return base.render(
             _get_group_template(u'bulk_process_template', group_type),

--- a/ckan/views/home.py
+++ b/ckan/views/home.py
@@ -49,7 +49,6 @@ def index() -> str:
             u'sort': u'view_recent desc',
             u'fq': u'capacity:"public"'}
         query = logic.get_action(u'package_search')(context, data_dict)
-        g.search_facets = query['search_facets']
         g.package_count = query['count']
         g.datasets = query['results']
 


### PR DESCRIPTION
The `c` object is a legacy attribute that adds noise and complexity to our code base. While working with Pylons, the `c` object was used a lot to store variables needed when rendering templates. Currently we have the `extra_vars` dict so some of the changes is to explicitly pass the variable to the snippets and do not rely on it being magically stored in the `c` object.

This PR cleans its usage in the `helpers.py` module.

## Changes
- There are some direct replacements `c` -> `g` since currently we proxy the value
- Add some explicit `search_facets` parameters to remove the dependency on `c.search_facets` 


