### PR TITLE
Clean c object reference from plugins module (and group templates)

### DIFF
--- a/ckan/lib/plugins.py
+++ b/ckan/lib/plugins.py
@@ -553,18 +553,9 @@ class DefaultGroupForm(object):
 
     def setup_template_variables(self, context: Context,
                                  data_dict: dict[str, Any]) -> None:
-        ## This is messy as auths take domain object not data_dict
         context_group = context.get('group', None)
         group = context_group or getattr(g, 'group', None)
-        if group:
-            try:
-                if not context_group:
-                    context['group'] = group
-                logic.check_access('group_change_state', context)
-                g.auth_for_change_state = True
-            except logic.NotAuthorized:
-                g.auth_for_change_state = False
-        else:
+        if not group:
             # needs to be set to get template displayed when flask request
             g.group = ''
 

--- a/ckan/lib/plugins.py
+++ b/ckan/lib/plugins.py
@@ -9,7 +9,7 @@ from typing import Any, Optional, TYPE_CHECKING, TypeVar, cast
 from flask import Blueprint
 
 import ckan.logic.schema as schema
-from ckan.common import c, g
+from ckan.common import g
 from ckan import logic, model, plugins
 import ckan.authz
 from ckan.types import Context, DataDict, Schema
@@ -553,22 +553,22 @@ class DefaultGroupForm(object):
 
     def setup_template_variables(self, context: Context,
                                  data_dict: dict[str, Any]) -> None:
-        c.is_sysadmin = ckan.authz.is_sysadmin(c.user)
+        g.is_sysadmin = ckan.authz.is_sysadmin(g.user)
 
         ## This is messy as auths take domain object not data_dict
         context_group = context.get('group', None)
-        group = context_group or getattr(c, 'group', None)
+        group = context_group or getattr(g, 'group', None)
         if group:
             try:
                 if not context_group:
                     context['group'] = group
                 logic.check_access('group_change_state', context)
-                c.auth_for_change_state = True
+                g.auth_for_change_state = True
             except logic.NotAuthorized:
-                c.auth_for_change_state = False
+                g.auth_for_change_state = False
         else:
             # needs to be set to get template displayed when flask request
-            c.group = ''
+            g.group = ''
 
 
 class DefaultOrganizationForm(DefaultGroupForm):

--- a/ckan/lib/plugins.py
+++ b/ckan/lib/plugins.py
@@ -553,8 +553,6 @@ class DefaultGroupForm(object):
 
     def setup_template_variables(self, context: Context,
                                  data_dict: dict[str, Any]) -> None:
-        g.is_sysadmin = ckan.authz.is_sysadmin(g.user)
-
         ## This is messy as auths take domain object not data_dict
         context_group = context.get('group', None)
         group = context_group or getattr(g, 'group', None)

--- a/ckan/lib/plugins.py
+++ b/ckan/lib/plugins.py
@@ -553,11 +553,7 @@ class DefaultGroupForm(object):
 
     def setup_template_variables(self, context: Context,
                                  data_dict: dict[str, Any]) -> None:
-        context_group = context.get('group', None)
-        group = context_group or getattr(g, 'group', None)
-        if not group:
-            # needs to be set to get template displayed when flask request
-            g.group = ''
+        pass
 
 
 class DefaultOrganizationForm(DefaultGroupForm):

--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -21,7 +21,7 @@ import ckan.authz as authz
 import ckan.lib.navl.dictization_functions as df
 import ckan.plugins as p
 
-from ckan.common import _, c
+from ckan.common import _, g
 from ckan.types import (
     Action, ChainedAction, Model,
     ChainedAuthFunction, DataDict, ErrorDict, Context, FlattenDataDict,
@@ -258,15 +258,15 @@ def _prepopulate_context(context: Optional[Context]) -> Context:
     context.setdefault('session', model.Session)
 
     try:
-        user = c.user
+        user = g.user
     except AttributeError:
-        # c.user not set
+        # g.user not set
         user = ""
     except RuntimeError:
         # Outside of request context
         user = ""
     except TypeError:
-        # c not registered
+        # g not registered
         user = ""
 
     context.setdefault('user', user)
@@ -413,7 +413,7 @@ def get_action(action: str) -> Action:
     As the context parameter passed to an action function is commonly::
 
         context = {'model': ckan.model, 'session': ckan.model.Session,
-                   'user': pylons.c.user}
+                   'user': user}
 
     an action function returned by ``get_action()`` will automatically add
     these parameters to the context if they are not defined.  This is

--- a/ckan/templates-bs3/package/base_form_page.html
+++ b/ckan/templates-bs3/package/base_form_page.html
@@ -6,9 +6,6 @@
     <div class="module-content">
       {% block primary_content_inner %}
         {% block form %}
-          {#- passing c to a snippet is bad but is required here
-              for backwards compatibility with old templates and
-              plugins using setup_template_variables() -#}
           {{- h.snippet(form_snippet, pkg_dict=pkg_dict, **form_vars) -}}
         {% endblock %}
       {% endblock %}

--- a/ckan/templates/package/base_form_page.html
+++ b/ckan/templates/package/base_form_page.html
@@ -6,9 +6,6 @@
     <div class="module-content">
       {% block primary_content_inner %}
         {% block form %}
-          {#- passing c to a snippet is bad but is required here
-              for backwards compatibility with old templates and
-              plugins using setup_template_variables() -#}
           {{- h.snippet(form_snippet, pkg_dict=pkg_dict, **form_vars) -}}
         {% endblock %}
       {% endblock %}

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -435,7 +435,6 @@ def read(group_type: str,
         data_dict['include_users'] = False
 
         group_dict = _action(u'group_show')(context, data_dict)
-        group = context['group']
     except (NotFound, NotAuthorized):
         base.abort(404, _(u'Group not found'))
 
@@ -454,7 +453,6 @@ def read(group_type: str,
     # compatibility with templates in existing extensions
     g.q = q
     g.group_dict = group_dict
-    g.group = group
 
     extra_vars = _read(id, limit, group_type)
 
@@ -889,7 +887,6 @@ class BulkProcessView(MethodView):
         # ckan 2.9: Adding variables that were removed from c object for
         # compatibility with templates in existing extensions
         g.group_dict = group_dict
-        g.group = group
         extra_vars = _read(id, limit, group_type)
         g.packages = g.page.items
 
@@ -916,7 +913,6 @@ class BulkProcessView(MethodView):
             # be ignored and get requested on the controller anyway
             data_dict['include_datasets'] = False
             group_dict = _action(u'group_show')(context, data_dict)
-            group = context['group']
         except NotFound:
             group_label = h.humanize_entity_type(
                 u'organization' if is_organization else u'group',
@@ -936,7 +932,6 @@ class BulkProcessView(MethodView):
         # ckan 2.9: Adding variables that were removed from c object for
         # compatibility with templates in existing extensions
         g.group_dict = group_dict
-        g.group = group
 
         # use different form names so that ie7 can be detected
         form_names = set([


### PR DESCRIPTION
This PR started as updating the reference `c` -> `g` until I realize that the implementation of `setup_template_variables` is no longer needed since group templates no longer uses `g.auth_for_change_state` nor `g.group`.

I ended up cleaning this method.