### PR TITLE
Replace c reference to g object in Core Extensions

### DIFF
--- a/ckanext/datapusher/views.py
+++ b/ckanext/datapusher/views.py
@@ -42,8 +42,8 @@ class ResourceDataView(MethodView):
                                           })
 
             # backward compatibility with old templates
-            toolkit.c.pkg_dict = pkg_dict
-            toolkit.c.resource = resource
+            toolkit.g.pkg_dict = pkg_dict
+            toolkit.g.resource = resource
 
         except (logic.NotFound, logic.NotAuthorized):
             base.abort(404, _(u'Resource not found'))

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -14,7 +14,7 @@ from ckan.logic import (
 )
 from ckan.plugins.toolkit import (
     ObjectNotFound, NotAuthorized, get_action, get_validator, _, request,
-    abort, render, c, h
+    abort, render, g, h
 )
 from ckan.types import Schema, ValidatorFactory
 from ckanext.datastore.logic.schema import (
@@ -123,8 +123,8 @@ class DictionaryView(MethodView):
         data_dict = self._prepare(id, resource_id)
 
         # global variables for backward compatibility
-        c.pkg_dict = data_dict[u'pkg_dict']
-        c.resource = data_dict[u'resource']
+        g.pkg_dict = data_dict[u'pkg_dict']
+        g.resource = data_dict[u'resource']
 
         return render(u'datastore/dictionary.html', data_dict)
 

--- a/ckanext/multilingual/plugin.py
+++ b/ckanext/multilingual/plugin.py
@@ -10,7 +10,7 @@ import ckan.model
 
 import ckan.plugins as plugins
 
-from ckan.common import request, config, c
+from ckan.common import request, config, g
 from ckan.logic import get_action
 
 
@@ -341,7 +341,7 @@ class MultilingualDataset(plugins.SingletonPlugin):
         desired_lang_code = request.environ['CKAN_LANG']
         fallback_lang_code = config.get_value('ckan.locale_default')
         try:
-            fields = c.fields
+            fields = g.fields
         except AttributeError:
             return translate_data_dict(dataset_dict)
         terms = [value for _param, value in fields]
@@ -349,7 +349,7 @@ class MultilingualDataset(plugins.SingletonPlugin):
                 cast(Context, {'model': ckan.model}),
                 {'terms': terms,
                  'lang_codes': (desired_lang_code, fallback_lang_code)})
-        c.translated_fields = {}
+        g.translated_fields = {}
         for param, value in fields:
             matching_translations = [translation for translation in
                     translations if translation['term'] == value and
@@ -361,7 +361,7 @@ class MultilingualDataset(plugins.SingletonPlugin):
             if matching_translations:
                 assert len(matching_translations) == 1
                 translation = matching_translations[0]['term_translation']
-                c.translated_fields[(param, value)] = translation
+                g.translated_fields[(param, value)] = translation
 
         # Now translate the fields of the dataset itself.
         return translate_data_dict(dataset_dict)


### PR DESCRIPTION
This PR replaces `c` to `g` since the `c` object is part of the old Pylons architecture.