### PR TITLE
2.9 Backport of remove extra comma

### DIFF
--- a/ckan/templates/snippets/changes/maintainer.html
+++ b/ckan/templates/snippets/changes/maintainer.html
@@ -3,7 +3,7 @@
     {% if change.method == "change" %}
 
       {{ _('Set maintainer of {pkg_link} to {new_maintainer} (previously {old_maintainer})').format(
-        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),,
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
         new_maintainer = change.new_maintainer,
         old_maintainer = change.old_maintainer
         ) }}
@@ -11,7 +11,7 @@
     {% elif change.method == "add" %}
 
       {{ _('Set maintainer of {pkg_link} to {new_maintainer}').format(
-        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),,
+        pkg_link = h.nav_link(change.title, named_route='dataset.read', id=change.pkg_id),
         new_maintainer = change.new_maintainer
         ) }}
 

--- a/ckan/tests/controllers/test_api.py
+++ b/ckan/tests/controllers/test_api.py
@@ -274,6 +274,7 @@ class TestApiController(object):
             [dataset1["name"], dataset2["name"]]
         )
 
+
 def test_i18n_only_known_locales_are_accepted(app):
 
     url = url_for("api.i18n_js_translations", ver=2, lang="fr")

--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -478,7 +478,7 @@ def snippet(snippet_path, ver=API_REST_DEFAULT_VERSION):
 def i18n_js_translations(lang, ver=API_REST_DEFAULT_VERSION):
 
     if lang not in get_locales_from_config():
-        return _finish_bad_request('Unknown locale: {}'.format(lang))
+        return _finish_bad_request(u'Unknown locale: {}'.format(lang))
 
     ckan_path = os.path.join(os.path.dirname(__file__), u'..')
     source = os.path.abspath(os.path.join(ckan_path, u'public',


### PR DESCRIPTION
(cherry picked from commit fb27f2a42cd9b579e1989271f5ecf1a3f4c4e35d)

Backport of fix #6258 to ckan 2.9

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
