### PR TITLE
current_app is defined in common but never accessed

### DIFF
--- a/ckan/common.py
+++ b/ckan/common.py
@@ -34,7 +34,6 @@ if TYPE_CHECKING:
     MutableMapping = MutableMapping[str, Any]
 
 log = logging.getLogger(__name__)
-current_app = flask.current_app
 
 
 @maintain.deprecated('All web requests are served by Flask', since="2.10.0")


### PR DESCRIPTION
By reviewing how CKAN App is created and our init workflow I noticed that `current_app` in common module is never accessed.