### PR TITLE
[QOL-7905] ignore auth on user API when performing a password reset, #6777

### DIFF
--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -716,10 +716,12 @@ class PerformResetView(MethodView):
         except logic.NotAuthorized:
             base.abort(403, _(u'Unauthorized to reset password.'))
 
+        context[u'ignore_auth'] = True
         try:
             user_dict = logic.get_action(u'user_show')(context, {u'id': id})
         except logic.NotFound:
             base.abort(404, _(u'User not found'))
+        del context[u'ignore_auth']
         user_obj = context[u'user_obj']
         g.reset_key = request.args.get(u'key')
         if not mailer.verify_reset_link(user_obj, g.reset_key):


### PR DESCRIPTION
We verify the user via token without them logging in. This is not relevant in the default configuration, but becomes necessary if 'ckan.auth.public_user_details' is set.

Fixes #6777

### Proposed fixes:

Set the `ignore_auth` flag before retrieving user dict during a password reset.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport
