### PR TITLE
Upgrade dev-requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,25 +1,25 @@
 # These are packages that are required by ckan developers - for running ckan in debug mode, running ckan tests, building the docs and to pip-compile the requirements.in file.
 
-beautifulsoup4==4.9.3
+beautifulsoup4==4.10.0
 cookiecutter==1.7.3
 coveralls   #Let Unpinned - Requires latest coveralls
-docutils==0.16
-Faker==9.3.1
-factory-boy==3.2.0
-flask-debugtoolbar==0.11.0
-freezegun==1.1.0
-ipdb==0.13.7
-pip-tools==5.1.2
-Pillow==8.4.0
-responses==0.13.3
-sphinx-rtd-theme==0.4.3
+docutils==0.17.1
+Faker==13.3.4
+factory-boy==3.2.1
+flask-debugtoolbar==0.13.1
+freezegun==1.2.1
+ipdb==0.13.9
+pip-tools==6.5.1
+Pillow==9.0.1
+responses==0.20.0
+sphinx-rtd-theme==1.0.0
 sqlalchemy-stubs==0.4
-sphinx==4.4.0
-towncrier==21.3.0
+sphinx==4.5.0
+towncrier==21.9.0
 
-pytest==6.2.2
-pytest-cov==2.11.1
+pytest==7.1.1
+pytest-cov==3.0.0
 pytest-factoryboy==2.1.0
 pytest-freezegun==0.4.2
-pytest-rerunfailures==9.1.1
-pytest-split==0.3.3
+pytest-rerunfailures==10.2
+pytest-split==0.7.0


### PR DESCRIPTION
Updated dev-requirements to the latest version, except for:

docutils (0.17.1 instead of 0.18.1) because sphinx-rtd-theme requires docutils<0.18
