### PR TITLE
Fix SASS warnings

### DIFF
--- a/ckan/public-bs3/base/scss/_forms.scss
+++ b/ckan/public-bs3/base/scss/_forms.scss
@@ -783,7 +783,7 @@ select[data-module="autocomplete"] {
         margin-right: 0;
         margin-top: 2px;
         top: $grid-gutter-width;
-        right: $grid-gutter-width / 6;
+        right: math.div($grid-gutter-width, 6);
         padding: 0 12px;
         border-radius: 100px;
         .icon-remove {

--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -12144,7 +12144,7 @@ select[data-module=autocomplete] {
   margin-right: 0;
   margin-top: 2px;
   top: 1.5rem;
-  right: div(1.5rem, 6);
+  right: 0.25rem;
   padding: 0 12px;
   border-radius: 100px;
 }

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -12144,7 +12144,7 @@ select[data-module=autocomplete] {
   margin-right: 0;
   margin-top: 2px;
   top: 1.5rem;
-  right: div(1.5rem, 6);
+  right: 0.25rem;
   padding: 0 12px;
   border-radius: 100px;
 }

--- a/ckan/public/base/scss/_forms.scss
+++ b/ckan/public/base/scss/_forms.scss
@@ -770,7 +770,7 @@ select[data-module="autocomplete"] {
         margin-right: 0;
         margin-top: 2px;
         top: $grid-gutter-width;
-        right: $grid-gutter-width / 6;
+        right: math.div($grid-gutter-width, 6);
         padding: 0 12px;
         border-radius: 100px;
         .icon-remove {


### PR DESCRIPTION
Change SASS syntax to avoid this warning when running `ckan sass`:

```

DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($grid-gutter-width, 6)

More info and automated migrator: https://sass-lang.com/d/slash-div

    ╷
773 │         right: $grid-gutter-width / 6;
    │                ^^^^^^^^^^^^^^^^^^^^^^
    ╵
    ckan/public/base/scss/_forms.scss 773:16  https://github.com/import
    ckan/public/base/scss/_ckan.scss 8:9      https://github.com/import
    ckan/public/base/scss/main-rtl.scss 2:9   root stylesheet
```
