### PR TITLE
initialize bootstrap.Popover

### DIFF
--- a/ckan/public/base/javascript/modules/dashboard.js
+++ b/ckan/public/base/javascript/modules/dashboard.js
@@ -23,10 +23,11 @@ this.ckan.module('dashboard', function ($) {
         on('click', this._onShowFolloweeDropdown);
       var title = this.button.prop('title');
 
-      this.button.popover({
+      this.button.popover = new bootstrap.Popover(document.querySelector('#followee-filter .btn'), {
           placement: 'bottom',
           html: true,
           template: '<div class="popover" role="tooltip"><div class="popover-arrow"></div><h3 class="popover-header"></h3><div class="popover-body followee-container"></div></div>',
+          customClass: 'popover-followee',
           sanitizeFn: function (content) {
             return DOMPurify.sanitize(content, { ALLOWED_TAGS: [
               "form", "div", "input", "footer", "header", "h1", "h2", "h3", "h4",
@@ -80,6 +81,7 @@ this.ckan.module('dashboard', function ($) {
      * Returns nothing.
      */
     _onSearchKeyUpTimeout: function() {
+      this.popover = this.button.popover.tip;
       var input = $('input', this.popover);
       var q = input.val().toLowerCase();
       if (q) {


### PR DESCRIPTION
Fixes #6784

### Proposed fixes:
bootstrap5 popovers no longer work as they were initialized previously in `bs3`. 
In bs5, one way of doing this is: 
`var popover = new bootstrap.Popover(document.querySelector('.example-popover'), {
  options
})`

![image](https://user-images.githubusercontent.com/72216462/161541518-06adb8b0-ba99-4a04-a892-329576ffdf29.png)
![image](https://user-images.githubusercontent.com/72216462/161541572-901b4051-e8b8-477e-b89e-db9934e1e074.png)


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
