### PR TITLE
Fix isoformat argument for Python 2

### DIFF
--- a/ckan/cli/user.py
+++ b/ckan/cli/user.py
@@ -235,13 +235,13 @@ def list_tokens(username):
                 Strip out microseconds to force formatting as isoformat doesnt
                 have a timespec param on Python 2.
                 """
-                accessed = datetime(
+                accessed = str(datetime(
                     accessed.year,
                     accessed.month,
                     accessed.day,
                     accessed.hour,
                     accessed.minute,
-                    accessed.second).isoformat(u" ")
+                    accessed.second))
             else:
                 accessed = accessed.isoformat(u" ", u"seconds")
 


### PR DESCRIPTION
Fixes #6789

### Proposed fixes:
Remove the `u` prefix from the first argument of `isoformat`.
This is a Python 2 only patch, which should be applied to CKAN 2.9 only.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
