### PR TITLE
Set absolute URL for using by who-friend behind SSL proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,8 @@ RUN ckan-pip3 install -U pip && \
     ckan-pip3 install --upgrade --no-cache-dir -r $CKAN_VENV/src/ckan/requirement-setuptools.txt && \
     ckan-pip3 install --upgrade --no-cache-dir -r $CKAN_VENV/src/ckan/requirements.txt && \
     ckan-pip3 install -e $CKAN_VENV/src/ckan/ && \
+    sed -i "s|post_login_url = /user/logged_in|post_login_url = ${CKAN_SITE_URL}/user/logged_in|" $CKAN_VENV/src/ckan/ckan/config/who.ini && \
+    sed -i "s|post_logout_url = /user/logged_out|post_logout_url = ${CKAN_SITE_URL}/user/logged_out|" $CKAN_VENV/src/ckan/ckan/config/who.ini && \
     ln -s $CKAN_VENV/src/ckan/ckan/config/who.ini $CKAN_CONFIG/who.ini && \
     cp -v $CKAN_VENV/src/ckan/contrib/docker/ckan-entrypoint.sh /ckan-entrypoint.sh && \
     chmod +x /ckan-entrypoint.sh && \


### PR DESCRIPTION
Fixes #4129

### Proposed fixes:
If anyone build docker container behind SSL proxy such as AWS ALB, redirect to HTTP insted of HTTPS regardless of `ckan.site_url` after login.

who-friendly use an exception in WebOb to redirect to `post_login_url`.
But [_HTTPMove exception](https://github.com/Pylons/webob/blob/master/src/webob/exc.py#L591) does not support `X-Forwarded-Proto` header.

`req.path_url` has HTTP protocol because already terminated SSL in AWS ALB or reverse proxy.
Therefore, joined URL has HTTP protocol but that URL is not valid to connect with SSL.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
