### PR TITLE
Add healthchecks

### DIFF
--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -14,12 +14,13 @@ services:
     container_name: ckan
     build:
       context: ../../
-    links:
-      - db
-      - solr
-      - redis
     depends_on:
-      - db
+      db:
+        condition: service_healthy
+      solr:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     ports:
       - "0.0.0.0:${CKAN_PORT}:5000"
     environment:
@@ -36,6 +37,8 @@ services:
       - DS_RO_PASS=${DATASTORE_READONLY_PASSWORD}
       - POSTGRES_HOST=${POSTGRES_HOST}
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:5000"]
     # Debug with pdb (example) - Interact with `docker attach $(docker container ls -qf name=ckan)`
     #command: 'python -m pdb /usr/lib/ckan/venv/bin/ckan --config /etc/ckan/production.ini run --host 0.0.0.0 --passthrough-errors'
     #tty: true
@@ -76,8 +79,12 @@ services:
     volumes:
       - solr_data:/opt/solr/server/solr/ckan/data
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:8983/solr/"]
 
   redis:
     container_name: redis
     image: redis:6.2
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "-e", "QUIT"]


### PR DESCRIPTION
Fixes #6489

### Proposed fixes:
Add health checks is beneficial for monitoring as well as dependency management between containers.
Additional CKAN commands (like ckanext-harvest tasks) can rely on the status of the main CKAN container, waiting for it to be ready, instead of being launched at the same time (thus triggering databases issues).
I also removed the `links` section, as this does nothing, since Docker compose creates a new network by default.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport