### PR TITLE
Allow get_translated helper to fall back to base version of a language

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2575,7 +2575,15 @@ def get_translated(data_dict: dict[str, Any], field: str) -> Union[str, Any]:
     try:
         return data_dict[field + u'_translated'][language]
     except KeyError:
-        return data_dict.get(field, '')
+        pass
+    # Check the base language, en_GB->en
+    try:
+        base_language = language.split('_')[0]
+        if base_language != language:
+            return data_dict[field + u'_translated'][base_language]
+    except KeyError:
+        pass
+    return data_dict.get(field, '')
 
 
 @core_helper

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -887,6 +887,6 @@ def test_decode_view_request_filters(test_request_context):
     # Null case, falls all the way through.
     ({}, 'en', ''),
 ])
-def test_get_translated(data_dict, locale, result):
+def test_get_translated(data_dict, locale, result, monkeypatch):
     monkeypatch.setattr(flask_babel, "get_locale", lambda: locale)
     assert h.get_translated(data_dict, 'notes') == result

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -872,3 +872,21 @@ def test_decode_view_request_filters(test_request_context):
             '_id': ['1', '2', '3'],
             'Piped|Filter': ['Piped|Value']
         }
+
+
+@pytest.mark.parametrize("data_dict, locale, result", [
+    # no matching local returns base
+    ({"notes": "untranslated",
+      "notes_translated": {'en': 'en', 'en_GB': 'en_GB'}}, 'es', 'untranslated'),
+    # specific returns specfic
+    ({"notes": "untranslated",
+      "notes_translated": {'en': 'en', 'en_GB': 'en_GB'}}, 'en_GB', 'en_GB'),
+     # variant returns base
+    ({"notes": "untranslated",
+      "notes_translated": {'en': 'en'}}, 'en_GB', 'en'),
+    # Null case, falls all the way through.
+    ({}, 'en', ''),
+])
+def test_get_translated(data_dict, locale, result):
+    monkeypatch.setattr(flask_babel, "get_locale", lambda: locale)
+    assert h.get_translated(data_dict, 'notes') == result

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -881,7 +881,7 @@ def test_decode_view_request_filters(test_request_context):
     # specific returns specfic
     ({"notes": "untranslated",
       "notes_translated": {'en': 'en', 'en_GB': 'en_GB'}}, 'en_GB', 'en_GB'),
-     # variant returns base
+    # variant returns base
     ({"notes": "untranslated",
       "notes_translated": {'en': 'en'}}, 'en_GB', 'en'),
     # Null case, falls all the way through.

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -12,6 +12,7 @@ import flask_babel
 
 import pytest
 
+from ckan.config.middleware import flask_app
 import ckan.lib.helpers as h
 import ckan.exceptions
 from ckan.tests import helpers, factories
@@ -889,5 +890,5 @@ def test_decode_view_request_filters(test_request_context):
 ])
 @pytest.mark.usefixtures("with_request_context")
 def test_get_translated(data_dict, locale, result, monkeypatch):
-    monkeypatch.setattr(flask_babel, "get_locale", lambda: locale)
+    monkeypatch.setattr(flask_app, "get_locale", lambda: locale)
     assert h.get_translated(data_dict, 'notes') == result

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -887,6 +887,7 @@ def test_decode_view_request_filters(test_request_context):
     # Null case, falls all the way through.
     ({}, 'en', ''),
 ])
+@pytest.mark.usefixtures("with_request_context")
 def test_get_translated(data_dict, locale, result, monkeypatch):
     monkeypatch.setattr(flask_babel, "get_locale", lambda: locale)
     assert h.get_translated(data_dict, 'notes') == result


### PR DESCRIPTION
### Proposed fixes:

The current `get_translated` helper gets data from the `_translated.[lang]` field in the data_dict. There are language variants (for example, `en_GB`) where the dialect is a minor change, and should fall back to the `en` value if `en_GB` is not available. 

In my case, we've got interfaces that use the `en_GB` locale, but the data/schema is split between `en` and `ga` (Gaelic) languages. 

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
