### PR TITLE
Fix formatting of fake-data command

### DIFF
--- a/ckan/cli/generate.py
+++ b/ckan/cli/generate.py
@@ -240,16 +240,18 @@ def fake_data(ctx: click.Context, category: Optional[str],
 
     For instance:
 
-         ckan generate fake-data dataset
-         ckan generate fake-data dataset  --title="My test dataset"
-
-         ckan generate fake-data dataset \
-                 --factory-class=ckanext.myext.tests.factories.MyCustomDataset
+    \b
+        ckan generate fake-data dataset
+        ckan generate fake-data dataset  --title="My test dataset"
+        ckan generate fake-data dataset \\
+            -f ckanext.myext.tests.factories.MyCustomDataset
 
     All the validation rules still apply. For example, if you have
     `ckan.auth.create_unowned_dataset` config option set to `False`,
     `--owner_org` must be supplied:
 
+    \b
+        # use jq to obtain ID of the new organization
         owner_org=$(ckan generate fake-data organization | jq .id -r)
         ckan generate fake-data dataset  --owner_org=$owner_org
 


### PR DESCRIPTION
Help message from `ckan generate fake-data` does not preserve newlines and indents.
Before:
![image](https://user-images.githubusercontent.com/11091199/164981194-d091e5ea-ee1b-418f-b31f-692188712a10.png)

After:
![image](https://user-images.githubusercontent.com/11091199/164981202-093634e2-02d3-47c8-86d9-a48ac585894a.png)
