### PR TITLE
[#5857] Extract translations from emails

### DIFF
--- a/ckan/templates-bs3/emails/invite_user.txt
+++ b/ckan/templates-bs3/emails/invite_user.txt
@@ -1,3 +1,4 @@
+{% trans %}
 Dear {{ user_name }},
 
 You have been invited to {{ site_title }}.
@@ -15,3 +16,4 @@ Have a nice day.
 
 --
 Message sent by {{ site_title }} ({{ site_url }})
+{% endtrans %}

--- a/ckan/templates-bs3/emails/invite_user_subject.txt
+++ b/ckan/templates-bs3/emails/invite_user_subject.txt
@@ -1,1 +1,3 @@
+{% trans %}
 Invite for {{ site_title }}
+{% endtrans %}

--- a/ckan/templates-bs3/emails/reset_password.txt
+++ b/ckan/templates-bs3/emails/reset_password.txt
@@ -1,3 +1,4 @@
+{% trans %}
 Dear {{ user_name }},
 
 You have requested your password on {{ site_title }} to be reset.
@@ -10,3 +11,4 @@ Have a nice day.
 
 --
 Message sent by {{ site_title }} ({{ site_url }})
+{% endtrans %}

--- a/ckan/templates-bs3/emails/reset_password_subject.txt
+++ b/ckan/templates-bs3/emails/reset_password_subject.txt
@@ -1,1 +1,3 @@
+{% trans %}
 Reset your password - {{ site_title }}
+{% endtrans %}

--- a/ckan/templates/emails/invite_user.txt
+++ b/ckan/templates/emails/invite_user.txt
@@ -1,3 +1,4 @@
+{% trans %}
 Dear {{ user_name }},
 
 You have been invited to {{ site_title }}.
@@ -15,3 +16,4 @@ Have a nice day.
 
 --
 Message sent by {{ site_title }} ({{ site_url }})
+{% endtrans %}

--- a/ckan/templates/emails/invite_user_subject.txt
+++ b/ckan/templates/emails/invite_user_subject.txt
@@ -1,1 +1,3 @@
+{% trans %}
 Invite for {{ site_title }}
+{% endtrans %}

--- a/ckan/templates/emails/reset_password.txt
+++ b/ckan/templates/emails/reset_password.txt
@@ -1,3 +1,4 @@
+{% trans %}
 Dear {{ user_name }},
 
 You have requested your password on {{ site_title }} to be reset.
@@ -10,3 +11,4 @@ Have a nice day.
 
 --
 Message sent by {{ site_title }} ({{ site_url }})
+{% endtrans %}

--- a/ckan/templates/emails/reset_password_subject.txt
+++ b/ckan/templates/emails/reset_password_subject.txt
@@ -1,1 +1,3 @@
+{% trans %}
 Reset your password - {{ site_title }}
+{% endtrans %}


### PR DESCRIPTION
Fixes #5857

Add `trans` tag to email templates in order to process them while extracting messages for translation.