### PR TITLE
Fix server error in tag autocomplete when vocabulary does not exist

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -2203,7 +2203,7 @@ def _tag_search(
         # Filter by vocabulary.
         vocab = model.Vocabulary.get(_get_or_bust(data_dict, 'vocabulary_id'))
         if not vocab:
-            raise NotFound
+            return [], 0
         q = q.filter(model.Tag.vocabulary_id == vocab.id)
     else:
         # If no vocabulary_name in data dict then show free tags only.


### PR DESCRIPTION
### Proposed fixes:
NotFound is not caught anywhere where `_tag_search` is called and therefore calling autocomplete API results in internal server error, for example https://demo.ckan.org/api/2/util/tag/autocomplete?incomplete=sometag&vocabulary_id=some_vocabulary


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
