### PR TITLE
Small documentation fixes

### DIFF
--- a/ckan/cli/__init__.py
+++ b/ckan/cli/__init__.py
@@ -106,6 +106,8 @@ class CKANConfigLoader(object):
 
 
 def error_shout(exception: Any) -> None:
+    """Report CLI error with a styled message.
+    """
     click.secho(str(exception), fg=u'red', err=True)
 
 

--- a/ckan/common.py
+++ b/ckan/common.py
@@ -178,6 +178,14 @@ def _get_session():
 
 
 def asbool(obj: Any) -> bool:
+    """Convert a string (e.g. 1, true, True) into a boolean.
+
+    Example::
+
+        assert asbool("yes") is True
+
+    """
+
     if isinstance(obj, str):
         obj = obj.strip().lower()
         if obj in truthy:
@@ -190,6 +198,13 @@ def asbool(obj: Any) -> bool:
 
 
 def asint(obj: Any) -> int:
+    """Convert a string into an int.
+
+    Example::
+
+        assert asint("111") == 111
+
+    """
     try:
         return int(obj)
     except (TypeError, ValueError):
@@ -222,6 +237,14 @@ def aslist(obj: Literal[None],
 
 
 def aslist(obj: Any, sep: Optional[str] = None, strip: bool = True) -> Any:
+    """Convert a space-separated string into a list.
+
+    Example::
+
+        assert aslist("a b c") == ["a", "b", "c"]
+
+    """
+
     if isinstance(obj, str):
         lst = obj.split(sep)
         if strip:

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -1,8 +1,9 @@
 # encoding: utf-8
 
-"""The base Controller API
+"""The base functionality for web-views.
 
-Provides the BaseController class for subclassing.
+Provides functions for rendering templates, aborting the request, etc.
+
 """
 from __future__ import annotations
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -96,6 +96,8 @@ LEGACY_ROUTE_NAMES = {
 
 
 class HelperAttributeDict(Dict[str, Callable[..., Any]]):
+    """Collection of CKAN native and extension-provided helpers.
+    """
     def __missing__(self, key: str) -> NoReturn:
         raise ckan.exceptions.HelperError(
             'Helper \'{key}\' has not been defined.'.format(

--- a/ckan/lib/plugins.py
+++ b/ckan/lib/plugins.py
@@ -533,21 +533,25 @@ class DefaultGroupForm(object):
         '''Check if the return data is correct, mostly for checking out
         if spammers are submitting only part of the form
 
-        # Resources might not exist yet (eg. Add Dataset)
-        surplus_keys_schema = ['__extras', '__junk', 'state', 'groups',
-                               'extras_validation', 'save', 'return_to',
-                               'resources']
+        .. code-block:: python
 
-        schema_keys = form_to_db_package_schema().keys()
-        keys_in_schema = set(schema_keys) - set(surplus_keys_schema)
+            # Resources might not exist yet (eg. Add Dataset)
+            surplus_keys_schema = ['__extras', '__junk', 'state', 'groups',
+                'extras_validation', 'save', 'return_to',
+                'resources'
+            ]
 
-        missing_keys = keys_in_schema - set(data_dict.keys())
+            schema_keys = form_to_db_package_schema().keys()
+            keys_in_schema = set(schema_keys) - set(surplus_keys_schema)
 
-        if missing_keys:
-            #print data_dict
-            #print missing_keys
-            log.info('incorrect form fields posted')
-            raise DataError(data_dict)
+            missing_keys = keys_in_schema - set(data_dict.keys())
+
+            if missing_keys:
+                #print data_dict
+                #print missing_keys
+                log.info('incorrect form fields posted')
+                raise DataError(data_dict)
+
         '''
         pass
 

--- a/ckan/lib/signals.py
+++ b/ckan/lib/signals.py
@@ -1,4 +1,10 @@
 # -*- coding: utf-8 -*-
+"""Contains ``ckan`` and ``ckanext`` namespaces for signals as well as a bunch
+of predefined core-level signals.
+
+Check :doc:`signals` for extra detais.
+
+"""
 
 from typing import Any
 import flask.signals

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -365,22 +365,5 @@ attributes for getting things like the request headers, query-string variables,
 request body variables, cookies, the request URL, etc.
 
 """,
-    "asbool": """Convert a string (e.g. 1,
-true, True) from the config file into a boolean.
-
-For example: ``if toolkit.asbool("yes"):``
-
-""",
-    "asint": """Convert a string from the config
-file into an int.
-
-For example: ``bar = toolkit.asint("111")``
-
-""",
-    "aslist": """Convert a space-separated
-string from the config file into a list.
-
-For example: `bar = toolkit.aslist(config.get('ckan.foo.bar', []))`
-
-""",
+    "ckan": "``ckan`` package itself."
 }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,6 +18,8 @@ import re
 import os
 import subprocess
 
+from packaging.version import parse as version_parse
+
 import ckan
 
 # If your extensions (or modules documented by autodoc) are in another directory,
@@ -133,8 +135,7 @@ def get_release_tags():
 
     # git tag -l prints out the tags in the right order anyway, but don't rely
     # on that, sort them again here for good measure.
-    release_tags_.sort()
-
+    release_tags_.sort(key=version_parse)
     return release_tags_
 
 
@@ -261,7 +262,8 @@ def get_latest_package_name(distro, py_version=None):
     # We don't create a new package file name for a patch release like 2.1.1,
     # instead we just update the existing 2.1 package. So package names only
     # have the X.Y part of the version number in them, not X.Y.Z.
-    latest_minor_version = get_latest_release_version()[:3]
+    version = get_latest_release_version()
+    latest_minor_version = version[:version.find(".", 3)]
 
     if py_version:
         name = 'python-ckan_{version}-py{py_version}-{distro}_amd64.deb'.format(
@@ -349,10 +351,10 @@ def write_substitutions_file(**kwargs):
 
 current_release_tag_value = get_current_release_tag()
 current_release_version = get_current_release_version()
-current_minor_version = current_release_version[:3]
+current_minor_version = current_release_version[:current_release_version.find(".", 3)]
 latest_release_tag_value = get_latest_release_tag()
 latest_release_version = get_latest_release_version()
-latest_minor_version = latest_release_version[:3]
+latest_minor_version = latest_release_version[:latest_release_version.find(".", 3)]
 is_master = release.endswith('a')
 is_supported = get_status_of_this_version() == 'supported'
 is_latest_version = version == latest_release_version

--- a/doc/extensions/validators.rst
+++ b/doc/extensions/validators.rst
@@ -8,4 +8,3 @@ Validator functions reference
 .. automodule:: ckan.logic.converters
    :members:
    :undoc-members:
-


### PR DESCRIPTION
* Add [missing docstrings inside toolkit](http://docs.ckan.org/en/latest/extensions/plugins-toolkit.html#ckan.plugins.toolkit.ckan.plugins.toolkit.h)
* [Fix the order of versions](https://github.com/ckan/ckan/compare/2.10-version-in-docs?expand=1#diff-e170e9a7d787c21095c6c11bb25f0f1ff0294a42a46d45ba6fb5ed794e457624L136). Previously versions were sorted alphabetically and `2.10.0` was reported as "no longer supported", because it's smaller that `2.8.0`:)
* Some tiny changes in the documentation
* [Correct reference to the current minor version](https://github.com/ckan/ckan/compare/2.10-version-in-docs?expand=1#diff-e170e9a7d787c21095c6c11bb25f0f1ff0294a42a46d45ba6fb5ed794e457624L264). At the moment documentation takes first three characters of the full version(`2.9.5` -> `2.9`) in order to produce a reference to debian package/latest documentation/etc. But in case of `2.10` it will not work: `"2.10.0"[:3]` -> `2.1`