### PR TITLE
Document majority of validators

### DIFF
--- a/ckan/lib/navl/validators.py
+++ b/ckan/lib/navl/validators.py
@@ -18,7 +18,17 @@ Invalid = df.Invalid
 
 def keep_extras(key: FlattenKey, data: FlattenDataDict,
                 errors: FlattenErrorDict, context: Context) -> None:
+    """Convert dictionary into simple fields.
 
+    .. code-block::
+
+        data, errors = tk.navl_validate(
+            {"input": {"hello": 1, "world": 2}},
+            {"input": [keep_extras]}
+        )
+        assert data == {"hello": 1, "world": 2}
+
+    """
     extras = data.pop(key, {})
     for extras_key, value in extras.items():
         data[key[:-1] + (extras_key,)] = value
@@ -26,7 +36,8 @@ def keep_extras(key: FlattenKey, data: FlattenDataDict,
 
 def not_missing(key: FlattenKey, data: FlattenDataDict,
                 errors: FlattenErrorDict, context: Context) -> None:
-
+    """Ensure value is not missing from the input, but may be empty.
+    """
     value = data.get(key)
     if value is missing:
         errors[key].append(_('Missing value'))
@@ -35,13 +46,25 @@ def not_missing(key: FlattenKey, data: FlattenDataDict,
 
 def not_empty(key: FlattenKey, data: FlattenDataDict,
               errors: FlattenErrorDict, context: Context) -> None:
-
+    """Ensure value is available in the input and is not empty.
+    """
     value = data.get(key)
     if not value or value is missing:
         errors[key].append(_('Missing value'))
         raise StopOnError
 
 def if_empty_same_as(other_key: str) -> Callable[..., Any]:
+    """Copy value from other field when current field is missing or empty.
+
+    .. code-block::
+
+        data, errors = tk.navl_validate(
+            {"hello": 1},
+            {"hello": [], "world": [if_empty_same_as("hello")]}
+        )
+        assert data == {"hello": 1, "world": 1}
+
+    """
     def callable(key: FlattenKey, data: FlattenDataDict,
                  errors: FlattenErrorDict, context: Context):
         value = data.get(key)
@@ -52,7 +75,17 @@ def if_empty_same_as(other_key: str) -> Callable[..., Any]:
 
 
 def both_not_empty(other_key: str) -> Validator:
+    """Ensure that either current, or other field has value.
 
+    .. code-block::
+
+        data, errors = tk.navl_validate(
+            {"hello": 1},
+            {"hello": [], "world": [both_not_empty("hello")]}
+        )
+        assert errors == {"world": [error_message]}
+
+    """
     def callable(key: FlattenKey, data: FlattenDataDict,
                  errors: FlattenErrorDict, context: Context):
         value = data.get(key)
@@ -67,6 +100,8 @@ def both_not_empty(other_key: str) -> Validator:
 
 def empty(key: FlattenKey, data: FlattenDataDict,
           errors: FlattenErrorDict, context: Context) -> None:
+    """Ensure that value is not present in the input.
+    """
 
     value = data.pop(key, None)
 
@@ -81,13 +116,23 @@ def empty(key: FlattenKey, data: FlattenDataDict,
 
 def ignore(key: FlattenKey, data: FlattenDataDict,
            errors: FlattenErrorDict, context: Context) -> NoReturn:
-
+    """Remove the value from the input and skip the rest of validators.
+    """
     data.pop(key, None)
     raise StopOnError
 
 def default(default_value: Any) -> Validator:
-    '''When key is missing or value is an empty string or None, replace it with
-    a default value'''
+    """Convert missing or empty value to the default one.
+
+    .. code-block::
+
+        data, errors = tk.navl_validate(
+            {},
+            {"hello": [default("not empty")]}
+        )
+        assert data == {"hello": "not empty"}
+
+    """
 
     def callable(key: FlattenKey, data: FlattenDataDict,
                  errors: FlattenErrorDict, context: Context):
@@ -136,7 +181,8 @@ def ignore_missing(key: FlattenKey, data: FlattenDataDict,
 
 def ignore_empty(key: FlattenKey, data: FlattenDataDict,
                  errors: FlattenErrorDict, context: Context) -> None:
-
+    """Skip the rest of validators if the value is empty or missing.
+    """
     value = data.get(key)
 
     if value is missing or not value:
@@ -144,7 +190,8 @@ def ignore_empty(key: FlattenKey, data: FlattenDataDict,
         raise StopOnError
 
 def convert_int(value: Any) -> int:
-
+    """Ensure that the value is a valid integer.
+    """
     try:
         return int(value)
     except ValueError:

--- a/ckan/logic/converters.py
+++ b/ckan/logic/converters.py
@@ -15,6 +15,8 @@ from ckan.types import (
 def convert_to_extras(key: FlattenKey, data: FlattenDataDict,
                       errors: FlattenErrorDict, context: Context) -> Any:
 
+    """Convert given field into an extra field.
+    """
     # Get the current extras index
     current_indexes = [k[1] for k in data.keys()
                        if len(k) > 1 and k[0] == 'extras']
@@ -27,7 +29,8 @@ def convert_to_extras(key: FlattenKey, data: FlattenDataDict,
 
 def convert_from_extras(key: FlattenKey, data: FlattenDataDict,
                         errors: FlattenErrorDict, context: Context) -> Any:
-
+    """Restore field using object's extras.
+    """
     def remove_from_extras(data: FlattenDataDict, key: FlattenKey):
         to_remove = []
         for data_key, _data_value in data.items():
@@ -48,6 +51,8 @@ def convert_from_extras(key: FlattenKey, data: FlattenDataDict,
     remove_from_extras(data, data_key[1])
 
 def extras_unicode_convert(extras: FlattenDataDict, context: Context):
+    """Convert every value of the dictionary into string.
+    """
     for extra in extras:
         extras[extra] = str(extras[extra])
     return extras
@@ -55,6 +60,8 @@ def extras_unicode_convert(extras: FlattenDataDict, context: Context):
 
 def free_tags_only(key: FlattenKey, data: FlattenDataDict,
                    errors: FlattenErrorDict, context: Context) -> Any:
+    """Ensure that none of the tags belong to a vocabulary.
+    """
     tag_number = key[1]
     if not data.get(('tags', tag_number, 'vocabulary_id')):
         return
@@ -63,6 +70,8 @@ def free_tags_only(key: FlattenKey, data: FlattenDataDict,
             del data[k]
 
 def convert_to_tags(vocab: Any) -> DataValidator:
+    """Convert list of tag names into a list of tag dictionaries
+    """
     def func(key: FlattenKey, data: FlattenDataDict,
              errors: FlattenErrorDict, context: Context):
         new_tags = data.get(key)
@@ -188,6 +197,8 @@ def convert_group_name_or_id_to_id(group_name_or_id: Any,
 
 
 def convert_to_json_if_string(value: Any, context: Context) -> Any:
+    """Parse string value as a JSON object.
+    """
     if isinstance(value, str):
         try:
             return json.loads(value)
@@ -198,10 +209,14 @@ def convert_to_json_if_string(value: Any, context: Context) -> Any:
 
 
 def as_list(value: Any):
+    """Convert whitespace separated string into a list of strings.
+    """
     return aslist(value)
 
 
 def convert_to_list_if_string(value: Any) -> Any:
+    """Transform string into one-item list
+    """
     if isinstance(value, str):
         return [value]
     else:
@@ -233,6 +248,8 @@ def json_list_or_string(value: Any) -> Any:
 
 
 def remove_whitespace(value: Any, context: Context) -> Any:
+    """Trim whitespaces from the value.
+    """
     if isinstance(value, str):
         return value.strip()
     return value

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -40,7 +40,7 @@ def owner_org_validator(key: FlattenKey, data: FlattenDataDict,
 
     Depending on the settings and user's permissions, this validator checks
     whether organization is optional and ensures that specified organization
-    can be set as an owher of dataset.
+    can be set as an owner of dataset.
 
     """
     value = data.get(key)

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -36,6 +36,13 @@ missing = df.missing
 
 def owner_org_validator(key: FlattenKey, data: FlattenDataDict,
                         errors: FlattenErrorDict, context: Context) -> Any:
+    """Validate organization for the dataset.
+
+    Depending on the settings and user's permissions, this validator checks
+    whether organization is optional and ensures that specified organization
+    can be set as an owher of dataset.
+
+    """
     value = data.get(key)
 
     if value is missing or value is None:
@@ -85,6 +92,8 @@ def owner_org_validator(key: FlattenKey, data: FlattenDataDict,
 
 
 def package_id_not_changed(value: Any, context: Context) -> Any:
+    """Ensures that package's ID is not changed during the update.
+    """
 
     package = context.get('package')
     if package and value != package.id:
@@ -123,12 +132,16 @@ def int_validator(value: Any, context: Context) -> Any:
     raise Invalid(_('Invalid integer'))
 
 def natural_number_validator(value: Any, context: Context) -> Any:
+    """Ensures that the value is non-negative integer.
+    """
     value = int_validator(value, context)
     if value < 0:
         raise Invalid(_('Must be a natural number'))
     return value
 
 def is_positive_integer(value: Any, context: Context) -> Any:
+    """Ensures that the value is an integer that is greater than zero.
+    """
     value = int_validator(value, context)
     if value < 1:
         raise Invalid(_('Must be a positive integer'))
@@ -151,6 +164,8 @@ def boolean_validator(value: Any, context: Context) -> Any:
     return False
 
 def isodate(value: Any, context: Context) -> Any:
+    """Convert the value into ``datetime.datetime`` object.
+    """
     if isinstance(value, datetime.datetime):
         return value
     if value == '':
@@ -162,7 +177,8 @@ def isodate(value: Any, context: Context) -> Any:
     return date
 
 def package_id_exists(value: str, context: Context) -> Any:
-
+    """Ensures that the value is an existing package's ID or name.
+    """
     model = context['model']
     session = context['session']
 
@@ -172,6 +188,8 @@ def package_id_exists(value: str, context: Context) -> Any:
     return value
 
 def package_id_does_not_exist(value: str, context: Context) -> Any:
+    """Ensures that the value is not used as a package's ID or name.
+    """
 
     model = context['model']
     session = context['session']
@@ -182,6 +200,8 @@ def package_id_does_not_exist(value: str, context: Context) -> Any:
     return value
 
 def package_name_exists(value: str, context: Context) -> Any:
+    """Ensures that the value is an existing package's name.
+    """
 
     model = context['model']
     session = context['session']
@@ -217,6 +237,9 @@ def package_id_or_name_exists(
 
 
 def resource_id_exists(value: Any, context: Context) -> Any:
+    """Ensures that the value is not used as a resource's ID or name.
+    """
+
     model = context['model']
     session = context['session']
     if not session.query(model.Resource).get(value):
@@ -372,6 +395,8 @@ def name_validator(value: Any, context: Context) -> Any:
 
 def package_name_validator(key: FlattenKey, data: FlattenDataDict,
                            errors: FlattenErrorDict, context: Context) -> Any:
+    """Ensures that value can be used as a package's name
+    """
     model = context['model']
     session = context['session']
     package = context.get('package')
@@ -401,6 +426,8 @@ def package_name_validator(key: FlattenKey, data: FlattenDataDict,
         )
 
 def package_version_validator(value: Any, context: Context) -> Any:
+    """Ensures that value can be used as a package's version
+    """
 
     if len(value) > PACKAGE_VERSION_MAX_LENGTH:
         raise Invalid(_('Version must be a maximum of %i characters long') % \
@@ -410,6 +437,8 @@ def package_version_validator(value: Any, context: Context) -> Any:
 
 def duplicate_extras_key(key: FlattenKey, data: FlattenDataDict,
                          errors: FlattenErrorDict, context: Context) -> Any:
+    """Ensures that there are no duplicated extras.
+    """
 
     unflattened = df.unflatten(data)
     extras = unflattened.get('extras', [])
@@ -428,6 +457,9 @@ def duplicate_extras_key(key: FlattenKey, data: FlattenDataDict,
 
 def group_name_validator(key: FlattenKey, data: FlattenDataDict,
                          errors: FlattenErrorDict, context: Context) -> Any:
+    """Ensures that value can be used as a group's name
+    """
+
     model = context['model']
     session = context['session']
     group = context.get('group')
@@ -444,7 +476,8 @@ def group_name_validator(key: FlattenKey, data: FlattenDataDict,
         errors[key].append(_('Group name already exists in database'))
 
 def tag_length_validator(value: Any, context: Context) -> Any:
-
+    """Ensures that tag length is in the acceptable range.
+    """
     if len(value) < MIN_TAG_LENGTH:
         raise Invalid(
             _('Tag "%s" length is less than minimum %s') % (value, MIN_TAG_LENGTH)
@@ -456,7 +489,8 @@ def tag_length_validator(value: Any, context: Context) -> Any:
     return value
 
 def tag_name_validator(value: Any, context: Context) -> Any:
-
+    """Ensures that tag does not contain wrong characters
+    """
     tagname_match = re.compile(r'[\w \-.]*$', re.UNICODE)
     if not tagname_match.match(value):
         raise Invalid(_('Tag "%s" can only contain alphanumeric '
@@ -465,7 +499,8 @@ def tag_name_validator(value: Any, context: Context) -> Any:
     return value
 
 def tag_not_uppercase(value: Any, context: Context) -> Any:
-
+    """Ensures that tag is lower-cased.
+    """
     tagname_uppercase = re.compile('[A-Z]')
     if tagname_uppercase.search(value):
         raise Invalid(_('Tag "%s" must not be uppercase' % (value)))
@@ -606,7 +641,8 @@ def user_name_validator(key: FlattenKey, data: FlattenDataDict,
 def user_both_passwords_entered(key: FlattenKey, data: FlattenDataDict,
                                 errors: FlattenErrorDict,
                                 context: Context) -> Any:
-
+    """Ensures that both password and password confirmation is not empty
+    """
     password1 = data.get(('password1',),None)
     password2 = data.get(('password2',),None)
 
@@ -618,6 +654,8 @@ def user_both_passwords_entered(key: FlattenKey, data: FlattenDataDict,
 def user_password_validator(key: FlattenKey, data: FlattenDataDict,
                             errors: FlattenErrorDict,
                             context: Context) -> Any:
+    """Ensures that password is safe enough.
+    """
     value = data[key]
 
     if isinstance(value, Missing):
@@ -633,7 +671,8 @@ def user_password_validator(key: FlattenKey, data: FlattenDataDict,
 
 def user_passwords_match(key: FlattenKey, data: FlattenDataDict,
                          errors: FlattenErrorDict, context: Context) -> Any:
-
+    """Ensures that password and password confirmation match.
+    """
     password1 = data.get(('password1',),None)
     password2 = data.get(('password2',),None)
 
@@ -660,12 +699,16 @@ def user_password_not_empty(key: FlattenKey, data: FlattenDataDict,
             errors[key].append(_('Missing value'))
 
 def user_about_validator(value: Any,context: Context) -> Any:
+    """Ensures that user's ``about`` field does not contains links.
+    """
     if 'http://' in value or 'https://' in value:
         raise Invalid(_('Edit not allowed as it looks like spam. Please avoid links in your description.'))
 
     return value
 
 def vocabulary_name_validator(name: str, context: Context) -> Any:
+    """Ensures that the value can be used as a tag vocabulary name.
+    """
     model = context['model']
     session = context['session']
 
@@ -682,6 +725,8 @@ def vocabulary_name_validator(name: str, context: Context) -> Any:
     return name
 
 def vocabulary_id_not_changed(value: Any, context: Context) -> Any:
+    """Ensures that vocabulary ID is not changed during the update.
+    """
     vocabulary = context.get('vocabulary')
     if vocabulary and value != vocabulary.id:
         raise Invalid(_('Cannot change value of key from %s to %s. '
@@ -689,6 +734,8 @@ def vocabulary_id_not_changed(value: Any, context: Context) -> Any:
     return value
 
 def vocabulary_id_exists(value: Any, context: Context) -> Any:
+    """Ensures that value contains existing vocabulary's ID or name.
+    """
     model = context['model']
     session = context['session']
     result = session.query(model.Vocabulary).get(value)
@@ -697,6 +744,8 @@ def vocabulary_id_exists(value: Any, context: Context) -> Any:
     return value
 
 def tag_in_vocabulary_validator(value: Any, context: Context) -> Any:
+    """Ensures that the tag belongs to the vocabulary.
+    """
     model = context['model']
     session = context['session']
     vocabulary = context.get('vocabulary')
@@ -712,6 +761,8 @@ def tag_in_vocabulary_validator(value: Any, context: Context) -> Any:
 
 def tag_not_in_vocabulary(key: FlattenKey, tag_dict: FlattenDataDict,
                           errors: FlattenErrorDict, context: Context) -> Any:
+    """Ensures that the tag does not belong to the vocabulary.
+    """
     tag_name = tag_dict[('name',)]
     if not tag_name:
         raise Invalid(_('No tag name'))
@@ -755,6 +806,8 @@ def url_validator(key: FlattenKey, data: FlattenDataDict,
 
 
 def user_name_exists(user_name: str, context: Context) -> Any:
+    """Ensures that user's name exists.
+    """
     model = context['model']
     session = context['session']
     result = session.query(model.User).filter_by(name=user_name).first()
@@ -764,6 +817,8 @@ def user_name_exists(user_name: str, context: Context) -> Any:
 
 
 def role_exists(role: str, context: Context) -> Any:
+    """Ensures that value is an existing CKAN Role name.
+    """
     if role not in authz.ROLE_PERMISSIONS:
         raise Invalid(_('role does not exist.'))
     return role
@@ -801,6 +856,8 @@ def datasets_with_no_organization_cannot_be_private(key: FlattenKey,
 
 def list_of_strings(key: FlattenKey, data: FlattenDataDict,
                     errors: FlattenErrorDict, context: Context) -> Any:
+    """Ensures that value is a list of strings.
+    """
     value = data.get(key)
     if not isinstance(value, list):
         raise Invalid(_('Not a list'))
@@ -811,6 +868,8 @@ def list_of_strings(key: FlattenKey, data: FlattenDataDict,
 
 def if_empty_guess_format(key: FlattenKey, data: FlattenDataDict,
                           errors: FlattenErrorDict, context: Context) -> Any:
+    """Make an attempt to guess resource's format using URL.
+    """
     value = data[key]
     resource_id = data.get(key[:-1] + ('id',))
 
@@ -831,6 +890,8 @@ def if_empty_guess_format(key: FlattenKey, data: FlattenDataDict,
             data[key] = mimetype
 
 def clean_format(format: str):
+    """Normalize resource's format.
+    """
     return h.unified_resource_format(format)
 
 
@@ -893,7 +954,8 @@ def filter_fields_and_values_exist_and_are_valid(key: FlattenKey,
 def extra_key_not_in_root_schema(key: FlattenKey, data: FlattenDataDict,
                                  errors: FlattenErrorDict,
                                  context: Context) -> Any:
-
+    """Ensures that extras are not duplicating base fields
+    """
     for schema_key in context.get('schema_keys', []):
         if schema_key == data[key]:
             raise Invalid(_('There is a schema field with the same name'))
@@ -972,6 +1034,8 @@ def collect_prefix_validate(prefix: str, *validator_names: str) -> Validator:
 
 
 def dict_only(value: Any) -> dict[Any, Any]:
+    """Ensures that the value is a dictionary
+    """
     if not isinstance(value, dict):
         raise Invalid(_('Must be a dict'))
     return value
@@ -1022,6 +1086,8 @@ def json_object(value: Any) -> Any:
 
 
 def extras_valid_json(extras: Any, context: Context) -> Any:
+    """Ensures that every item in the value dictionary is JSON-serializable.
+    """
     for extra, value in extras.items():
         try:
             json.dumps(value)

--- a/ckan/tests/controllers/test_group.py
+++ b/ckan/tests/controllers/test_group.py
@@ -700,7 +700,7 @@ class TestGroupSearch(object):
         assert 'No groups found for "No Results Here"' in search_response
 
 
-@pytest.mark.usefixtures("clean_db", "clean_index", "with_request_context")
+@pytest.mark.usefixtures("clean_db", "clean_index")
 class TestGroupInnerSearch(object):
     """Test searching within an group."""
 

--- a/ckan/tests/controllers/test_organization.py
+++ b/ckan/tests/controllers/test_organization.py
@@ -401,7 +401,7 @@ class TestOrganizationSearch(object):
         )
 
 
-@pytest.mark.usefixtures("clean_db", "clean_index", "with_request_context")
+@pytest.mark.usefixtures("clean_db", "clean_index")
 class TestOrganizationInnerSearch(object):
     """Test searching within an organization."""
 
@@ -453,7 +453,7 @@ class TestOrganizationInnerSearch(object):
             org_url,
             query_string={"q": "One"}
         )
-        assert "1 dataset found for &#34;One&#34;" in search_response
+        assert "1 dataset found" in search_response
 
         search_response_html = BeautifulSoup(search_response.body)
 

--- a/doc/extensions/validators.rst
+++ b/doc/extensions/validators.rst
@@ -3,12 +3,11 @@ Validator functions reference
 
 Validators in CKAN are user-defined functions that serves two purposes:
 
-* ensure that input satisfies requirements
-* convert the input into expected form
+* Ensuring that the input satisfies certain requirements
+* Converting the input to an expected form
 
-Validators can be defined as a function that accepts one, two or four
-arguments. But these implementation details must not bother you, as one must
-never call validators directly. Instead,
+Validators can be defined as a function that accepts one, two or four arguments. But this is an implementation detail 
+and validators should not be called directly. Instead, the
 :py:func:`ckan.plugins.toolkit.navl_validate` function must be used whenever
 input requires validation.
 
@@ -23,10 +22,10 @@ input requires validation.
    )
 
 
-And in order to make it more flexible, don't import validator
-functions. Instead, register them via
-:py:class:`~ckan.plugins.interfaces.IValidators` interface and get using
-:py:func:`ckan.plugins.tookit.get_validator` function.
+And in order to be more flexible and allow overrides, don't import validator
+functions directly. Instead, register them via the
+:py:class:`~ckan.plugins.interfaces.IValidators` interface and use the
+:py:func:`ckan.plugins.tookit.get_validator` function:
 
 .. code-block::
 
@@ -51,20 +50,21 @@ functions. Instead, register them via
 
 
 As you should have already noticed, ``navl_validate`` requires two
-parameters. In addition it accepts third optional parameter. That's their
+parameters and additionally accepts an optional one. That's their
 purpose:
 
-1. Data that requires validation. Must be represented by `dict` object.
-2. Validation schema. It's a mapping of field names to the lists of validators
-   for these fields.
+1. Data that requires validation. Must be a `dict` object, with keys being the names of the fields.
+2. The validation schema. It's a mapping of field names to the lists of validators
+   for that particular field.
 3. Optional context. Contains any extra details that can change validation
-   workflow in special cases. For the simpliticy sake, we are not going to use
-   context in this section.
+   workflow in special cases. For the simplicity sake, we are not going to use
+   context in this section, and in general is best not to rely on context variables 
+   inside validators.
 
 
-Let's imagine the input, that contains two fields ``first`` and ``second``. The
-``first`` must be an integer and must be provided, while ``second`` is an
-optional string. If we have following four validators:
+Let's imagine an input that contains two fields ``first`` and ``second``. The
+``first`` field must be an integer and must be provided, while the ``second`` field 
+is an optional string. If we have following four validators:
 
 * ``is_integer``
 * ``is_string``
@@ -81,7 +81,7 @@ we can validate data in the following way::
 
   data, errors = tk.navl_validate(input, schema)
 
-If input is valid, ``data`` contains validated input and ``errors`` is an empty
+If the input is valid, ``data`` contains validated input and ``errors`` is an empty
 dictionary. Otherwise, ``errors`` contains all the validation errors for the
 provided input.
 

--- a/doc/extensions/validators.rst
+++ b/doc/extensions/validators.rst
@@ -1,6 +1,98 @@
 Validator functions reference
 =============================
 
+Validators in CKAN are user-defined functions that serves two purposes:
+
+* ensure that input satisfies requirements
+* convert the input into expected form
+
+Validators can be defined as a function that accepts one, two or four
+arguments. But these implementation details must not bother you, as one must
+never call validators directly. Instead,
+:py:func:`ckan.plugins.toolkit.navl_validate` function must be used whenever
+input requires validation.
+
+.. code-block::
+
+   import ckan.plugins.toolkit as tk
+   from ckanext.my_ext.validators import is_valid
+
+   data, errors = tk.navl_validate(
+       {"input": "value"},
+       {"input": [is_valid]},
+   )
+
+
+And in order to make it more flexible, don't import validator
+functions. Instead, register them via
+:py:class:`~ckan.plugins.interfaces.IValidators` interface and get using
+:py:func:`ckan.plugins.tookit.get_validator` function.
+
+.. code-block::
+
+   import ckan.plugins as p
+   import ckan.plugins.toolkit as tk
+
+   def is_valid(value):
+       return value
+
+   class MyPlugin(p.SingletonPlugin)
+       p.implements(p.IValidators)
+
+       def get_validators(self):
+           return {"is_valid": is_valid}
+
+   ...
+   # somewhere in code
+   data, errors = tk.navl_validate(
+       {"input": "value"},
+       {"input": [tk.get_validator("is_valid")]},
+   )
+
+
+As you should have already noticed, ``navl_validate`` requires two
+parameters. In addition it accepts third optional parameter. That's their
+purpose:
+
+1. Data that requires validation. Must be represented by `dict` object.
+2. Validation schema. It's a mapping of field names to the lists of validators
+   for these fields.
+3. Optional context. Contains any extra details that can change validation
+   workflow in special cases. For the simpliticy sake, we are not going to use
+   context in this section.
+
+
+Let's imagine the input, that contains two fields ``first`` and ``second``. The
+``first`` must be an integer and must be provided, while ``second`` is an
+optional string. If we have following four validators:
+
+* ``is_integer``
+* ``is_string``
+* ``is_required``
+* ``is_optional``
+
+we can validate data in the following way::
+
+  input = {"first": "123"}
+  schema = {
+      "first": [is_required, is_integer],
+      "second": [is_optional, is_string],
+  }
+
+  data, errors = tk.navl_validate(input, schema)
+
+If input is valid, ``data`` contains validated input and ``errors`` is an empty
+dictionary. Otherwise, ``errors`` contains all the validation errors for the
+provided input.
+
+
+Built-in validators
+~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ckan.lib.navl.validators
+   :members:
+   :undoc-members:
+
 .. automodule:: ckan.logic.validators
    :members:
    :undoc-members:
@@ -8,4 +100,3 @@ Validator functions reference
 .. automodule:: ckan.logic.converters
    :members:
    :undoc-members:
-


### PR DESCRIPTION
* Provide minimal documentation for the majority of validators. Some of them are still undocumented because they are quite special.
* Add a few lines of explanation of how to validate data.
* List `ckan.lib.navl.validators` (`default`, `not_missing`, etc.) among all the validators. Previously, this module was missed from the autodoc-generator.