### PR TITLE
Make the landing page after password resets configurable

### DIFF
--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -493,13 +493,15 @@ class UserController(base.BaseController):
                           'or contact an administrator for help')
                     )
                     log.exception(e)
-                    return h.redirect_to(u'/')
+                    return h.redirect_to(config.get(
+                        u'ckan.user_reset_landing_page', u'/'))
             # always tell the user it succeeded, because otherwise we reveal
             # which accounts exist or not
             h.flash_success(
                 _(u'A reset link has been emailed to you '
                   '(unless the account specified does not exist)'))
-            return h.redirect_to(u'/')
+            return h.redirect_to(config.get(
+                u'ckan.user_reset_landing_page', u'/'))
         return render('user/request_reset.html')
 
     def perform_reset(self, id):
@@ -541,7 +543,8 @@ class UserController(base.BaseController):
                 mailer.create_reset_key(user_obj)
 
                 h.flash_success(_("Your password has been reset."))
-                h.redirect_to(u'home.index')
+                h.redirect_to(config.get(
+                    u'ckan.user_reset_landing_page', u'home.index'))
             except NotAuthorized:
                 h.flash_error(_('Unauthorized to edit user %s') % id)
             except NotFound as e:

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -663,14 +663,16 @@ class RequestResetView(MethodView):
                 h.flash_error(_(u'Error sending the email. Try again later '
                                 'or contact an administrator for help'))
                 log.exception(e)
-                return h.redirect_to(u'home.index')
+                return h.redirect_to(config.get(
+                    u'ckan.user_reset_landing_page', u'home.index'))
 
         # always tell the user it succeeded, because otherwise we reveal
         # which accounts exist or not
         h.flash_success(
             _(u'A reset link has been emailed to you '
               '(unless the account specified does not exist)'))
-        return h.redirect_to(u'home.index')
+        return h.redirect_to(config.get(
+            u'ckan.user_reset_landing_page', u'home.index'))
 
     def get(self):
         self._prepare()
@@ -736,7 +738,8 @@ class PerformResetView(MethodView):
             mailer.create_reset_key(context[u'user_obj'])
 
             h.flash_success(_(u'Your password has been reset.'))
-            return h.redirect_to(u'home.index')
+            return h.redirect_to(config.get(
+                u'ckan.user_reset_landing_page', u'home.index'))
         except logic.NotAuthorized:
             h.flash_error(_(u'Unauthorized to edit user %s') % id)
         except logic.NotFound:

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -1636,6 +1636,20 @@ receiving the request being is shown in the header.
 
 .. note:: This info only shows if debug is set to True.
 
+.. ckan.user_reset_landing_page:
+
+ckan.user_reset_landing_page
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Example::
+
+  ckan.user_reset_landing_page = home.index
+
+Default value: ``home.index``
+
+This controls the location that CKAN will redirect to after submitting
+a password reset request.
+
 .. end_config-front-end
 
 Resource Views Settings


### PR DESCRIPTION
Some sites may want to redirect to somewhere other than the homepage. This enables that via a new `ckan.user_reset_landing_page` config option.

### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
