### PR TITLE
Improve error when downloading resource

### DIFF
--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -176,8 +176,10 @@ def download(package_type: str,
     try:
         rsc = get_action(u'resource_show')(context, {u'id': resource_id})
         get_action(u'package_show')(context, {u'id': id})
-    except (NotFound, NotAuthorized):
+    except NotFound:
         return base.abort(404, _(u'Resource not found'))
+    except NotAuthorized:
+        return base.abort(401, _(u'Not authorized to download resource'))
 
     if rsc.get(u'url_type') == u'upload':
         upload = uploader.get_resource_uploader(rsc)

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -179,7 +179,7 @@ def download(package_type: str,
     except NotFound:
         return base.abort(404, _(u'Resource not found'))
     except NotAuthorized:
-        return base.abort(401, _(u'Not authorized to download resource'))
+        return base.abort(403, _(u'Not authorized to download resource'))
 
     if rsc.get(u'url_type') == u'upload':
         upload = uploader.get_resource_uploader(rsc)


### PR DESCRIPTION
This PR handles `NotAuthorized` exception separately when trying to download a resource.

Currently, the error message will be `Not Found 404` even when the resource exist but the user doesn't have access to it.