### PR TITLE
6833 auth function for status show

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -2433,6 +2433,7 @@ def status_show(context: Context, data_dict: DataDict) -> ActionResult.StatusSho
     :rtype: dictionary
 
     '''
+    _check_access('status_show', context, data_dict)
     extensions = config.get_value('ckan.plugins')
 
     return {

--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -487,3 +487,8 @@ def package_collaborator_list_for_user(context: Context,
     if user_obj and data_dict.get('id') in (user_obj.name, user_obj.id):
         return {'success': True}
     return {'success': False}
+
+
+def status_show(context, data_dict):
+    '''Show information about the site's configuration. Visible to all by default.'''
+    return {'success': True}

--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -489,6 +489,6 @@ def package_collaborator_list_for_user(context: Context,
     return {'success': False}
 
 
-def status_show(context, data_dict):
+def status_show(context: Context, data_dict: DataDict) -> AuthResult:
     '''Show information about the site's configuration. Visible to all by default.'''
     return {'success': True}

--- a/ckan/tests/logic/auth/test_get.py
+++ b/ckan/tests/logic/auth/test_get.py
@@ -621,3 +621,11 @@ class TestFollowee:
         sysadmin = factories.Sysadmin()
         context = {"user": sysadmin["name"], "model": model}
         assert helpers.call_auth(func, context=context)
+
+
+@pytest.mark.usefixtures("non_clean_db")
+class TestStatusShow:
+    
+    def test_status_show_is_visible_to_anonymous(self):
+        context = {"user": "", "model": model}
+        assert helpers.call_auth("status_show", context)

--- a/ckan/tests/logic/auth/test_get.py
+++ b/ckan/tests/logic/auth/test_get.py
@@ -625,7 +625,7 @@ class TestFollowee:
 
 @pytest.mark.usefixtures("non_clean_db")
 class TestStatusShow:
-    
+
     def test_status_show_is_visible_to_anonymous(self):
         context = {"user": "", "model": model}
         assert helpers.call_auth("status_show", context)

--- a/ckan/tests/test_coding_standards.py
+++ b/ckan/tests/test_coding_standards.py
@@ -326,7 +326,6 @@ class TestActionAuth(object):
         "get: recently_changed_packages_activity_list",
         "get: resource_search",
         "get: roles_show",
-        "get: status_show",
         "get: tag_search",
         "get: term_translation_show",
         "get: user_followee_count",


### PR DESCRIPTION
Fixes #6833 

### Proposed fixes:

- add an auth function for `status_show`
- call new auth function from `status_show` action function

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
