### PR TITLE
Check for metadata_modified in update.py

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -320,9 +320,16 @@ def package_update(
         model.Session.rollback()
         raise ValidationError(errors)
 
-    #avoid revisioning by updating directly
+    # check for metadata_modified
+    if data_dict.get("metadata_modified"):
+        mmod = datetime.datetime.strptime(data_dict.get(
+            "metadata_modified"),  "%Y-%m-%dT%H:%M:%S.%f")
+    else:
+        mmod = datetime.datetime.utcnow()
+
+    # avoid revisioning by updating directly
     model.Session.query(model.Package).filter_by(id=pkg.id).update(
-        {"metadata_modified": datetime.datetime.utcnow()})
+        {"metadata_modified": mmod})
     model.Session.refresh(pkg)
 
     pkg = model_save.package_dict_save(data, context)


### PR DESCRIPTION
* allow passing of `metadata_modified` value to package update/patch
* if no `metadata_modified` value passed, writes `datetime.datetime.utcnow()` as before

Currently `"metadata_modified"` is always set to `datetime.datetime.utcnow()`
even when a `"metadata_modified"` value is passed in the `data_dict`.

This means updates from the API will always overwrite the value with a
timestamp from the time of the call.

In most cases this makes sense, but if a user wants to update some small
piece of information retroactively, it inaccurately represents the time
that the information in the package was last set.

See https://github.com/ckan/ckan/issues/6829 for more

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
