### PR TITLE
Use the headers `Reply-to` value if its set in the extensions

### DIFF
--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -51,6 +51,7 @@ def _mail_recipient(
         attachments = []
 
     mail_from = config.get_value('smtp.mail_from')
+
     reply_to = config.get_value('smtp.reply_to')
 
     msg = EmailMessage()
@@ -65,13 +66,13 @@ def _mail_recipient(
             msg.replace_header(k, v)
         else:
             msg.add_header(k, v)
-
     msg['Subject'] = subject
     msg['From'] = _("%s <%s>") % (sender_name, mail_from)
     msg['To'] = u"%s <%s>" % (recipient_name, recipient_email)
     msg['Date'] = utils.formatdate(time())
     msg['X-Mailer'] = "CKAN %s" % ckan.__version__
-    if reply_to and reply_to != '':
+    # Check if extension is setting reply-to via headers or use config option
+    if reply_to and reply_to != '' and not msg['Reply-to']:
         msg['Reply-to'] = reply_to
 
     for attachment in attachments:

--- a/ckan/tests/lib/test_mailer.py
+++ b/ckan/tests/lib/test_mailer.py
@@ -269,7 +269,6 @@ class TestMailer(MailerBase):
             "subject": "Meeting",
             "body": "The meeting is cancelled.",
             "headers": {"header1": "value1"},
-            "headers": {"Reply-to": "norply@ckan.org"},
         }
         mailer.mail_recipient(**test_email)
 


### PR DESCRIPTION
There are situations when we can set the `Reply-to` in the headers when calling core `mailer`. There was no check if the header is already set so it throws an error:
`ValueError: There may be at most 1 Reply-to headers in a message`



### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
