### PR TITLE
Fix error message for missing blanket config declaration

### DIFF
--- a/ckan/plugins/blanket.py
+++ b/ckan/plugins/blanket.py
@@ -234,7 +234,6 @@ def _declaration_file_extractor(plugin: p.SingletonPlugin):
         log.error(
             "Unable to import config_declaration for "
             "blanket implementation of %s",
-            "config_declaration",
             plugin.__name__,
         )
         raise FileNotFoundError("config_declaration.EXT")


### PR DESCRIPTION
When the `config_declaration` blanket is used, it reports a missing config declaration source. But the format string in the report message is a bit wrong, so it causes an exception instead.