### PR TITLE
Update datastore api example

### DIFF
--- a/ckanext/datastore/templates/ajax_snippets/api_info.html
+++ b/ckanext/datastore/templates/ajax_snippets/api_info.html
@@ -119,10 +119,10 @@ Example
               <div id="collapse-python" class="accordion-collapse collapse" aria-labelledby="collapse-python" data-bs-parent="#accordion2">
                 <div class="accordion-body">
                   <pre>
-        import urllib
+        import urllib.request
         url = '{{ h.url_for('api.action', qualified=True, ver=3, logic_function='datastore_search', resource_id=resource_id, limit=5) + '&q=title:jones' }}'  {# not urlencoding the ":" because its clearer #}
-        fileobj = urllib.urlopen(url)
-        print fileobj.read()
+        fileobj = urllib.request.urlopen(url)
+        print(fileobj.read())
         </pre>
                 </div>
               </div>


### PR DESCRIPTION
### Proposed fixes:

The datastore Data API button currently shows a Python 2 example. This is no longer relevant, so it's a good idea to replace it with a Python 3 example.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
