### PR TITLE
Fix caching logic on logged in users

### DIFF
--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -20,8 +20,7 @@ from flask import (
 import ckan.lib.helpers as h
 import ckan.plugins as p
 
-from ckan.common import request, config, session
-
+from ckan.common import request, config, session, g
 
 log = logging.getLogger(__name__)
 
@@ -116,7 +115,7 @@ def _allow_caching(cache_force: Optional[bool] = None):
     if cache_force is not None:
         allow_cache = cache_force
     # Do not allow caching of pages for logged in users/flash messages etc.
-    elif _is_valid_session_cookie_data():
+    elif ('user' in g and g.user) or _is_valid_session_cookie_data():
         allow_cache = False
     # Tests etc.
     elif 'REMOTE_USER' in request.environ:


### PR DESCRIPTION
### Proposed fixes:
`_is_valid_session_cookie_data` only checks if beaker session has something stored in it. Depending on various conditions logged in user might not have anything in there and user might get cached pages. This PR adds a check if there is a logged in user.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
