### PR TITLE
ckan_config test mark works with request context

### DIFF
--- a/ckan/tests/pytest_ckan/fixtures.py
+++ b/ckan/tests/pytest_ckan/fixtures.py
@@ -149,6 +149,12 @@ def make_app(ckan_config):
     Unless you need to create app instances lazily for some reason,
     use the ``app`` fixture instead.
     """
+    from ckan.lib.app_globals import _CONFIG_CACHE
+    # Reset values cached during the previous tests. Otherwise config values
+    # that were added to app_globals reset the patched versions from
+    # `ckan_config` mark.
+    _CONFIG_CACHE.clear()
+
     return test_helpers._get_test_app
 
 

--- a/ckan/tests/pytest_ckan/test_fixtures.py
+++ b/ckan/tests/pytest_ckan/test_fixtures.py
@@ -39,6 +39,12 @@ def test_with_plugins_is_able_to_run_with_stats():
     assert plugins.plugin_loaded(u"stats")
 
 
+@pytest.mark.ckan_config("ckan.site_url", "https://example.org")
+@pytest.mark.usefixtures("with_request_context")
+def test_existing_ckan_config_mark_with_test_request(ckan_config):
+    assert ckan_config["ckan.site_url"] == "https://example.org"
+
+
 class TestMethodLevelConfig(object):
     """Verify that config overrides work for individual methods.
     """

--- a/ckan/tests/test_common.py
+++ b/ckan/tests/test_common.py
@@ -109,9 +109,9 @@ def test_setting_a_key_sets_it_on_flask_config_if_app_context(monkeypatch):
 
 
 @pytest.mark.usefixtures("with_request_context")
-@pytest.mark.ckan_config(u"ckan.site_title", u"Example title")
-def test_setting_a_key_does_not_set_it_on_flask_config_if_outside_app_context():
-    assert flask.current_app.config[u"ckan.site_title"] != u"Example title"
+@pytest.mark.ckan_config("ckan.site_title", "Example title")
+def test_setting_a_key_does_set_it_on_flask_config_if_outside_app_context():
+    assert flask.current_app.config["ckan.site_title"] == "Example title"
 
 
 @pytest.mark.ckan_config(u"ckan.site_title", u"Example title")


### PR DESCRIPTION
Fixes #6841

`app_globals` module caches a set of the config options with their values when test execution started(just like it does every time web-server is launched). After that, every time the application object is created or the list of plugins is reloaded, the mentioned config options restore their original value, even if they were modified(via the `ckan_config` mark, for example)

It can be fixed by the clearing `app_globals` cache whenever a config object is required inside the test. But it creates another issue. Without the "initial" cached state, every change to the config object that is done directly(not via `ckan_config` mark or `monkeypatch` fixture), will affect all consequent tests. For example, code that tests overriding configuration via admin interface can set site title and all the other tests will reuse the updated title, not the original value defined by the configuration file.

That's why I'm creating a copy of the config object that was used before any test execution and resetting `ckan.common.config` state before each test using this snapshot.


