### PR TITLE
[#6878] Fix custom dataset validation

### DIFF
--- a/ckan/lib/plugins.py
+++ b/ckan/lib/plugins.py
@@ -320,7 +320,7 @@ def plugin_validate(
     """
     if hasattr(plugin, 'validate'):
         result = plugin.validate(context, data_dict, schema, action)
-        if result is not None:
+        if result is not None and result != ({}, {}):
             return result
 
     return validate(data_dict, schema, context)

--- a/ckan/lib/plugins.py
+++ b/ckan/lib/plugins.py
@@ -320,7 +320,7 @@ def plugin_validate(
     """
     if hasattr(plugin, 'validate'):
         result = plugin.validate(context, data_dict, schema, action)
-        if result is not None and result != ({}, {}):
+        if result is not None:
             return result
 
     return validate(data_dict, schema, context)

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1268,7 +1268,7 @@ class IDatasetForm(Interface):
         return ''
 
     def validate(self, context: Context, data_dict: DataDict, schema: Schema,
-                 action: str) -> tuple[dict[str, Any], dict[str, Any]]:
+                 action: str) -> Optional[tuple[dict[str, Any], dict[str, Any]]]:
         u'''Customize validation of datasets.
 
         When this method is implemented it is used to perform all validation
@@ -1298,7 +1298,7 @@ class IDatasetForm(Interface):
           and lists-of-string-error-messages as values
         :rtype: (dictionary, dictionary)
         '''
-        return {}, {}
+        return
 
     def prepare_dataset_blueprint(self, package_type: str,
                                   blueprint: Blueprint) -> Blueprint:
@@ -1484,7 +1484,7 @@ class IGroupForm(Interface):
         '''
 
     def validate(self, context: Context, data_dict: DataDict, schema: Schema,
-                 action: str) -> tuple[dict[str, Any], dict[str, Any]]:
+                 action: str) -> Optional[tuple[dict[str, Any], dict[str, Any]]]:
         u'''Customize validation of groups.
 
         When this method is implemented it is used to perform all validation
@@ -1515,7 +1515,7 @@ class IGroupForm(Interface):
           and lists-of-string-error-messages as values
         :rtype: (dictionary, dictionary)
         '''
-        return {}, {}
+        return
 
     def prepare_group_blueprint(self, group_type: str,
                                 blueprint: Blueprint) -> Blueprint:

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1267,8 +1267,9 @@ class IDatasetForm(Interface):
         '''
         return ''
 
-    def validate(self, context: Context, data_dict: DataDict, schema: Schema,
-                 action: str) -> Optional[tuple[dict[str, Any], dict[str, Any]]]:
+    def validate(
+            self, context: Context, data_dict: DataDict, schema: Schema,
+            action: str) -> Optional[tuple[dict[str, Any], dict[str, Any]]]:
         u'''Customize validation of datasets.
 
         When this method is implemented it is used to perform all validation
@@ -1483,8 +1484,9 @@ class IGroupForm(Interface):
         Add variables to c just prior to the template being rendered.
         '''
 
-    def validate(self, context: Context, data_dict: DataDict, schema: Schema,
-                 action: str) -> Optional[tuple[dict[str, Any], dict[str, Any]]]:
+    def validate(
+            self, context: Context, data_dict: DataDict, schema: Schema,
+            action: str) -> Optional[tuple[dict[str, Any], dict[str, Any]]]:
         u'''Customize validation of groups.
 
         When this method is implemented it is used to perform all validation

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -666,6 +666,7 @@ class TestResourceCreate:
             helpers.call_action('resource_create', package_id=dataset['id'], url='http://example.com', description='hey')
             assert mock_package_show.call_args_list[0][0][0].get('for_update') is True
 
+
 @pytest.mark.usefixtures("non_clean_db")
 class TestMemberCreate(object):
     def test_group_member_creation(self):

--- a/ckanext/example_idatasetform/plugin.py
+++ b/ckanext/example_idatasetform/plugin.py
@@ -190,3 +190,15 @@ class ExampleIDatasetFormPlugin(plugins.SingletonPlugin,
     # legacy support for the deprecated method works.
     def check_data_dict(self, data_dict: dict[str, Any], schema: Any = None):
         ExampleIDatasetFormPlugin.num_times_check_data_dict_called += 1
+
+
+class ExampleIDatasetFormInheritPlugin(plugins.SingletonPlugin,
+        tk.DefaultDatasetForm):
+    """An example IDatasetForm CKAN plugin, inheriting all methods
+    from the default interface.
+    """
+    plugins.implements(plugins.IDatasetForm, inherit=True)
+
+    def package_types(self):
+
+        return ["custom_dataset"]

--- a/ckanext/example_idatasetform/tests/test_example_idatasetform.py
+++ b/ckanext/example_idatasetform/tests/test_example_idatasetform.py
@@ -526,3 +526,12 @@ class TestDatasetMultiTypes(object):
         url = url_for(type_ + '.read', id=dataset['name'])
         resp = app.get(url, status=200)
         assert resp.body == 'Hello, {}!'.format(type_)
+
+
+@pytest.mark.ckan_config("ckan.plugins", u"example_idatasetform_inherit")
+@pytest.mark.usefixtures("with_plugins")
+def test_validation_works_on_default_validate():
+
+    dataset = factories.Dataset(name="my_dataset", type="custom_dataset")
+
+    assert dataset["name"] == "my_dataset"

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,7 @@ ckan.plugins =
     recline_map = ckanext.reclineview.plugin:ReclineMapView
     example_itemplatehelpers = ckanext.example_itemplatehelpers.plugin:ExampleITemplateHelpersPlugin
     example_idatasetform = ckanext.example_idatasetform.plugin:ExampleIDatasetFormPlugin
+    example_idatasetform_inherit = ckanext.example_idatasetform.plugin:ExampleIDatasetFormInheritPlugin
     example_idatasetform_v1 = ckanext.example_idatasetform.plugin_v1:ExampleIDatasetFormPlugin
     example_idatasetform_v2 = ckanext.example_idatasetform.plugin_v2:ExampleIDatasetFormPlugin
     example_idatasetform_v3 = ckanext.example_idatasetform.plugin_v3:ExampleIDatasetFormPlugin


### PR DESCRIPTION
Fixes #6878 

The output of the default return value for `IDatasetForm.validate()` was changed during the typing work from `None` to `({}, {})` (https://github.com/ckan/ckan/commit/b2a03aa66b50fde7a68e0b2921104475117e7093), but the check performed in `plugin_validate()` to see if validation had been performed was not updated.

This meant that when validating a custom dataset on `package_create` the validation returned an empty dict instead of the data, causing SQLAlchemy to fail.

@smotornyuk I assume we need to check the `IDatasetForm.validate()` output for typing purposes so I've updated the check to account for this. Let me know if there is a better approach.