### PR TITLE
Make actions' data_dict param optional again

### DIFF
--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -502,8 +502,8 @@ def get_action(action: str) -> Action:
     # wrap the functions
     for action_name, _action in _actions.items():
         def make_wrapped(_action: Action, action_name: str):
-            def wrapped(context: Optional[Context],
-                        data_dict: DataDict, **kw: Any):
+            def wrapped(context: Optional[Context] = None,
+                        data_dict: Optional[DataDict] = None, **kw: Any):
                 if kw:
                     log.critical('%s was passed extra keywords %r'
                                  % (_action.__name__, kw))

--- a/ckan/tests/logic/test_logic.py
+++ b/ckan/tests/logic/test_logic.py
@@ -61,3 +61,8 @@ def test_user_inside_context_of_check_access(is_authorized: mock.Mock):
     logic.check_access("site_read", {"user": "test"})
     context = is_authorized.call_args[0][1]
     assert context["user"] == "test"
+
+
+def test_get_action_optional_params():
+
+    assert "ckan_version" in logic.get_action("status_show")()


### PR DESCRIPTION
Because of how the wrapped functions returned by `get_action()` params are defined, you must pass a data_dict value when calling them, otherwise you get an error:

    E       TypeError: wrapped() missing 1 required positional argument:
'data_dict'

But not all actions require a `data_dict`, eg `status_show`, `package_list`, etc

This was not an issue on the HTTP API endpoint because the blueprint always passes a value for `data_dict`, even if it's None, but calling actions directly from Python will fail:

    toolkit.get_action("package_list")({"ignore_auth": True})

    toolkit.get_action("package_list")()

@smotornyuk let me know if the type hints make sense