### PR TITLE
Add option to run development server in non-root path

### DIFF
--- a/ckan/cli/server.py
+++ b/ckan/cli/server.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 import click
 from werkzeug.serving import run_simple
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
 
 from ckan.common import config
 from . import error_shout
@@ -45,10 +46,15 @@ DEFAULT_PORT = 5000
     u"-K", u"--ssl-key", default=None,
     help=u"Key file to use to enable SSL. Passing 'adhoc' will "
     " automatically generate a new one (on each server reload).")
+@click.option(
+    u"-P", u"--prefix", default="",
+    help=u"Run ckan in prefix path."
+)
 @click.pass_context
 def run(ctx: click.Context, host: str, port: str, disable_reloader: bool,
         passthrough_errors: bool, threaded: bool, extra_files: list[str],
-        processes: int, ssl_cert: Optional[str], ssl_key: Optional[str]):
+        processes: int, ssl_cert: Optional[str], ssl_key: Optional[str],
+        prefix: Optional[str]):
     u"""Runs the Werkzeug development server"""
 
     if config.get_value("debug"):
@@ -86,6 +92,14 @@ def run(ctx: click.Context, host: str, port: str, disable_reloader: bool,
     else:
         ssl_context = None
 
+    if prefix:
+        if not prefix.startswith(u'/'):
+            error_shout(u"Prefix must start with /, example /data.")
+            raise click.Abort()
+        ctx.obj.app = DispatcherMiddleware(ctx.obj.app, {
+            prefix: ctx.obj.app
+        })
+
     host = host or config.get_value('ckan.devserver.host')
     port = port or config.get_value('ckan.devserver.port')
     try:
@@ -94,8 +108,9 @@ def run(ctx: click.Context, host: str, port: str, disable_reloader: bool,
         error_shout(u"Server port must be an integer, not {}".format(port))
         raise click.Abort()
 
-    log.info(u"Running CKAN on {scheme}://{host}:{port}".format(
-        scheme='https' if ssl_context else 'http', host=host, port=port_int))
+    log.info(u"Running CKAN on {scheme}://{host}:{port}{prefix}".format(
+        scheme='https' if ssl_context else 'http', host=host, port=port_int,
+        prefix=prefix))
 
     run_simple(
         host,


### PR DESCRIPTION
### Proposed fixes:
Werkzeug does not have an option to run applications in subpath, this would be useful while developing extensions for instances which are hosted in one with `root_path` set to something else like `/data/{{LANG}})`. This adds option to CLI to prefix all the routes with given prefix. 


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
