### PR TITLE
[4986]user_invite

### DIFF
--- a/changes/6897.changes
+++ b/changes/6897.changes
@@ -1,0 +1,3 @@
+Removed the password creation logic for user, when inviting a user.
+Added new schema `create_user_for_user_invite` that disables the password 
+field on user creation.

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -1076,14 +1076,10 @@ def user_invite(context: Context,
         'role': data['role']
     }
 
-    if group.is_organization:
-        _get_action('organization_member_create')(context, member_dict)
-        group_dict = _get_action('organization_show')(context,
-                                                      {'id': data['group_id']})
-    else:
-        _get_action('group_member_create')(context, member_dict)
-        group_dict = _get_action('group_show')(context,
-                                               {'id': data['group_id']})
+    _get_action(f'{group.type}_member_create')(context, member_dict)
+    group_dict = _get_action(f'{group.type}_show')(context,
+                                                    {'id': data['group_id']})
+    breakpoint()
     try:
         mailer.send_invite(user, group_dict, data['role'])
     except (socket_error, mailer.MailerException) as error:

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -1077,8 +1077,9 @@ def user_invite(context: Context,
     }
 
     _get_action(f'{group.type}_member_create')(context, member_dict)
-    group_dict = _get_action(f'{group.type}_show')(context,
-                                                    {'id': data['group_id']})
+    group_dict = _get_action(f'{group.type}_show')(
+        context, {'id': data['group_id']})
+
     try:
         mailer.send_invite(user, group_dict, data['role'])
     except (socket_error, mailer.MailerException) as error:

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -1079,7 +1079,7 @@ def user_invite(context: Context,
     _get_action(f'{group.type}_member_create')(context, member_dict)
     group_dict = _get_action(f'{group.type}_show')(context,
                                                     {'id': data['group_id']})
-    breakpoint()
+
     try:
         mailer.send_invite(user, group_dict, data['role'])
     except (socket_error, mailer.MailerException) as error:

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -1063,7 +1063,7 @@ def user_invite(context: Context,
     # send the proper schema when creating a user from here
     # so the password field would be ignored.
     invite_schema = ckan.logic.schema.create_user_for_user_invite_schema()
-    
+
     data['state'] = model.State.PENDING
     user_dict = _get_action('user_create')(
         cast(Context, dict(context, schema=invite_schema)),

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -1079,7 +1079,6 @@ def user_invite(context: Context,
     _get_action(f'{group.type}_member_create')(context, member_dict)
     group_dict = _get_action(f'{group.type}_show')(context,
                                                     {'id': data['group_id']})
-
     try:
         mailer.send_invite(user, group_dict, data['role'])
     except (socket_error, mailer.MailerException) as error:

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -34,7 +34,7 @@ import ckan.authz as authz
 import ckan.model
 
 from ckan.common import _
-from ckan.types import Context, DataDict, ErrorDict, Schema, FlattenErrorDict
+from ckan.types import Context, DataDict, ErrorDict, Schema
 
 # FIXME this looks nasty and should be shared better
 from ckan.logic.action.update import _update_package_relationship
@@ -1044,7 +1044,6 @@ def user_invite(context: Context,
     :returns: the newly created user
     :rtype: dictionary
     '''
-    import string
     _check_access('user_invite', context, data_dict)
 
     schema = context.get('schema',
@@ -1059,24 +1058,16 @@ def user_invite(context: Context,
         raise NotFound()
 
     name = _get_random_username_from_email(data['email'])
-    # Choose a password. However it will not be used - the invitee will not be
-    # told it - they will need to reset it
-    while True:
-        password = ''.join(random.SystemRandom().choice(
-            string.ascii_lowercase + string.ascii_uppercase + string.digits)
-            for _ in range(12))
-        # Occasionally it won't meet the constraints, so check
-        validation_errors: FlattenErrorDict = {}
-        ckan.logic.validators.user_password_validator(
-            ('password', ), {('password', ): password},
-            validation_errors, context)
-        if not validation_errors:
-            break
 
     data['name'] = name
-    data['password'] = password
+    # send the proper schema when creating a user from here
+    # so the password field would be ignored.
+    context['schema'] = ckan.logic.schema.create_user_for_user_invite_schema()
     data['state'] = model.State.PENDING
     user_dict = _get_action('user_create')(context, data)
+    # we already created the user so we don't need the schema anymore
+    # as we are calling for other actions bellow
+    context.pop('schema')
     user = model.User.get(user_dict['id'])
     assert user
     member_dict = {

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -442,6 +442,13 @@ def default_user_schema(
 
 
 @validator_args
+def create_user_for_user_invite_schema(ignore_missing: Validator):
+    schema = default_user_schema()
+    schema['password'] = [ignore_missing]
+    return schema
+
+
+@validator_args
 def user_new_form_schema(
         unicode_safe: Validator, user_both_passwords_entered: Validator,
         user_password_validator: Validator, user_passwords_match: Validator):

--- a/ckan/tests/controllers/test_organization.py
+++ b/ckan/tests/controllers/test_organization.py
@@ -5,6 +5,8 @@ import six
 from bs4 import BeautifulSoup
 
 import ckan.authz as authz
+import ckan.logic.schema as schema
+import ckan.model as model
 from ckan.lib.helpers import url_for
 from ckan.tests import factories, helpers
 
@@ -575,3 +577,18 @@ class TestOrganizationMembership(object):
                 },
                 status=403,
             )
+
+    def test_create_user_for_user_invite(self):
+        context = {"schema": schema.create_user_for_user_invite_schema()}
+
+        user_form = {
+            "email": "user@ckan.org",
+            "name": "user", 
+            "state": "pending"
+        }
+        user_dict = helpers.call_action("user_create", context, **user_form)
+        user_obj = model.User.get(user_dict["id"])
+
+        assert user_obj.password is None
+        assert user_obj.state == 'pending'
+        assert user_obj.last_active is None

--- a/ckan/tests/controllers/test_organization.py
+++ b/ckan/tests/controllers/test_organization.py
@@ -583,7 +583,7 @@ class TestOrganizationMembership(object):
 
         user_form = {
             "email": "user@ckan.org",
-            "name": "user", 
+            "name": "user",
             "state": "pending"
         }
         user_dict = helpers.call_action("user_create", context, **user_form)

--- a/ckan/tests/controllers/test_organization.py
+++ b/ckan/tests/controllers/test_organization.py
@@ -578,15 +578,18 @@ class TestOrganizationMembership(object):
                 status=403,
             )
 
-    def test_create_user_for_user_invite(self):
-        context = {"schema": schema.create_user_for_user_invite_schema()}
+    def test_create_user_for_user_invite(self, mail_server):
+        group = factories.Group()
+        sysadmin = factories.Sysadmin()
+        context = {"user": sysadmin["name"]}
 
         user_form = {
             "email": "user@ckan.org",
-            "name": "user",
-            "state": "pending"
+            "group_id": group["id"],
+            "role": "member"
         }
-        user_dict = helpers.call_action("user_create", context, **user_form)
+
+        user_dict = helpers.call_action("user_invite", context, **user_form)
         user_obj = model.User.get(user_dict["id"])
 
         assert user_obj.password is None

--- a/ckan/tests/controllers/test_organization.py
+++ b/ckan/tests/controllers/test_organization.py
@@ -5,7 +5,6 @@ import six
 from bs4 import BeautifulSoup
 
 import ckan.authz as authz
-import ckan.logic.schema as schema
 import ckan.model as model
 from ckan.lib.helpers import url_for
 from ckan.tests import factories, helpers


### PR DESCRIPTION
Fixes #4986 

### Proposed fixes:
Hey @wardi, at first I tried with your proposal number 2, what confuses me is that we need to send that flag `password_disabled ` into the password validators in order to turn them off, this way if you have your own custom validator you will have to implement this logic on your own validator too.

I come up with this solution that from my point of view seems cleaner ( maybe I m wrong I don't see the bigger pic as you :) ) we are disabling the password field in the schema so the extensions developers would not care what implementation they have in their custom validators.

Please, let me know your opinion on this.

Thanks


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
