### PR TITLE
Fixes two errors when dealing with an encoded url.

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -654,7 +654,7 @@ def full_current_url():
 @core_helper
 def current_url():
     ''' Returns current url unquoted'''
-    return unquote(request.environ['CKAN_CURRENT_URL'])
+    return request.environ['CKAN_CURRENT_URL']
 
 
 @core_helper

--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -281,8 +281,6 @@ def set_ckan_current_url(environ):
 
     qs = environ.get(u'QUERY_STRING')
     if qs:
-        # sort out weird encodings
-        qs = quote(qs, u'')
         environ[u'CKAN_CURRENT_URL'] = u'%s?%s' % (path_info, qs)
     else:
         environ[u'CKAN_CURRENT_URL'] = path_info

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -16,7 +16,7 @@ import six
 from six.moves.urllib.parse import (
     urlencode, unquote, urlunparse, parse_qsl, urlparse
 )
-from six import string_types, text_type, StringIO
+from six import string_types, text_type, StringIO, PY2
 
 import ckan.plugins as p
 import ckan.plugins.toolkit as toolkit
@@ -686,6 +686,8 @@ def _insert_links(data_dict, limit, offset):
     # change the offset in the url
     parsed = list(urlparse(urlstring))
     query = parsed[4]
+    if PY2 and isinstance(query, unicode):
+        query = query.encode('utf-8')
 
     arguments = dict(parse_qsl(query))
     arguments_start = dict(arguments)

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -684,8 +684,8 @@ def _insert_links(data_dict, limit, offset):
         return  # no links required for local actions
 
     # change the offset in the url
-    parsed = list(urlparse(urlstring))
-    query = unquote(parsed[4])
+    parsed = list(urlparse.urlparse(urlstring))
+    query = parsed[4]
 
     arguments = dict(parse_qsl(query))
     arguments_start = dict(arguments)

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -684,7 +684,7 @@ def _insert_links(data_dict, limit, offset):
         return  # no links required for local actions
 
     # change the offset in the url
-    parsed = list(urlparse.urlparse(urlstring))
+    parsed = list(urlparse(urlstring))
     query = parsed[4]
 
     arguments = dict(parse_qsl(query))


### PR DESCRIPTION
The 2.9 version of #6685

* url in question /%EF%AC%81?foo=bar&bz=%AC%81
* This is a unicode character, which can't be decoded from
ascii. Jinja templates will handle this if it's unicode, or if it's
hex encoded ascii, but can't take a non-unicode string in python 2 and
put this in a template.
* The querystring was being quoted, which is incorrect, as:
  1) the special characters in the query string mean something
  2) The rest of the querystring is already quoted. This makes it
  double quoted, as seen in the datastore file
* We don't want to unquote urls before putting them in the template
anyway.
The solution here is to make sure it's unicode passed into the
function.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
