### PR TITLE
fix: fixed documentation on bulk update

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -1161,7 +1161,7 @@ def bulk_update_private(context: Context, data_dict: DataDict) -> ActionResult.B
     :type datasets: list of strings
 
     :param org_id: id of the owning organization
-    :type org_id: int
+    :type org_id: string
     '''
 
     _check_access('bulk_update_private', context, data_dict)
@@ -1174,7 +1174,7 @@ def bulk_update_public(context: Context, data_dict: DataDict) -> ActionResult.Bu
     :type datasets: list of strings
 
     :param org_id: id of the owning organization
-    :type org_id: int
+    :type org_id: string
     '''
 
     _check_access('bulk_update_public', context, data_dict)
@@ -1187,7 +1187,7 @@ def bulk_update_delete(context: Context, data_dict: DataDict) -> ActionResult.Bu
     :type datasets: list of strings
 
     :param org_id: id of the owning organization
-    :type org_id: int
+    :type org_id: string
     '''
 
     _check_access('bulk_update_delete', context, data_dict)


### PR DESCRIPTION
Fixed the type of the org parameter for the bulk update methods from an
int to a string

Fixes #

### Proposed fixes:
As of right now, these three methods are documented in such a way as to describe the `org_id` parameter as an `int`, while the real code uses a `string`, all this PR does is change the documentation type from `int` to `string`
![image](https://user-images.githubusercontent.com/11317382/174857540-bb61c9ff-01a1-4a54-b5dd-efedffb8fdba.png)


### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
