### PR TITLE
Close select transaction on system table query

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -73,11 +73,6 @@ def load_environment(conf: Union[Config, CKANConfig]):
 
     app_globals.reset()
 
-    # issue #3260: remove idle transaction
-    # Session that was used for getting all config params nor committed,
-    # neither removed and we have idle connection as result
-    model.Session.commit()
-
     # Build JavaScript translations. Must be done after plugins have
     # been loaded.
     build_js_translations()

--- a/ckan/lib/app_globals.py
+++ b/ckan/lib/app_globals.py
@@ -135,11 +135,7 @@ def get_globals_key(key: str) -> str:
 def reset() -> None:
     ''' set updatable values from config '''
     def get_config_value(key: str, default: str = ''):
-        # type_ignore_reason: engine theoretically uninitialized
-        if model.meta.engine.has_table('system_info'):  # type: ignore
-            value = model.get_system_info(key)
-        else:
-            value = None
+        value = model.get_system_info(key)
         config_value = config.get(key)
         # sort encodeings if needed
 

--- a/ckan/lib/app_globals.py
+++ b/ckan/lib/app_globals.py
@@ -137,7 +137,6 @@ def reset() -> None:
     def get_config_value(key: str, default: str = ''):
         value = model.get_system_info(key)
         config_value = config.get(key)
-        # sort encodeings if needed
 
         # we want to store the config the first time we get here so we can
         # reset them if needed

--- a/ckan/model/system_info.py
+++ b/ckan/model/system_info.py
@@ -10,6 +10,7 @@ For more details, check :doc:`maintaining/configuration`.
 from typing import Any, Optional
 
 from sqlalchemy import types, Column, Table
+from sqlalchemy.exc import ProgrammingError
 
 
 import ckan.model.meta as meta
@@ -48,9 +49,9 @@ meta.mapper(SystemInfo, system_info_table)
 
 def get_system_info(key: str, default: Optional[str]=None) -> Optional[str]:
     ''' get data from system_info table '''
-    from sqlalchemy.exc import ProgrammingError
     try:
         obj = meta.Session.query(SystemInfo).filter_by(key=key).first()
+        meta.Session.commit()
         if obj:
             return obj.value
     except ProgrammingError:


### PR DESCRIPTION
This is another fix for https://github.com/ckan/ckan/issues/3260

This PR moves the `model.Session.commit()` closer to the statement that open the transaction so it's clear what are we committing. 

### Proposed fixes:

 - Close the transaction right before using it.
 - Avoid checking twice for the existing of the table.

### How to replicate

PSQL status after running the server without closing the transaction:
```
ckan=# select usename, state, query from pg_stat_activity where state in ('idle','idle in transaction');
   usename    |        state        |                                                                            query                                                                             
--------------+---------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------
 ckan_default | idle in transaction | SELECT system_info.id AS system_info_id, system_info.key AS system_info_key, system_info.value AS system_info_value, system_info.state AS system_info_state +
              |                     | FROM system_info                                                                                                                                            +
              |                     | WHERE system_info.key = 'ckan.main_css'                                                                                                                     +
              |                     |  LIMIT 1
 ckan_default | idle                | COMMIT
(2 rows)

```

PSQL status after running the server closing the transaction:
```
ckan=# select usename, state, query from pg_stat_activity where state in ('idle','idle in transaction');
   usename    | state | query  
--------------+-------+--------
 ckan_default | idle  | COMMIT
 ckan_default | idle  | COMMIT
(2 rows)
```


### Extra notes:
SQLAlchemy by default (and in our config) operates in transaction mode. This means that select() queries will have an implicit `BEGIN` before executing the statement.

So, for each `select` statement we will have an `idle in transaction` connection if we don't explicitly close it. 

This is "hide" on users when using a requests since we dispose of the SQLALchemy session in our `ckan_after_request` method. However, methods like `get_system_info` that operates outside a request will leave `idle in transaction` connections if we don't close/commit/rollback it explicitly.
