### PR TITLE
[#6793] allow _id for datastore_upsert

### DIFF
--- a/changes/6793.feature
+++ b/changes/6793.feature
@@ -1,0 +1,1 @@
+allow _id for datastore_upsert unique key

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1169,7 +1169,7 @@ def upsert_data(context: Context, data_dict: dict[str, Any]):
                     'table': [u'unique key must be passed for update/upsert']
                 })
 
-            else:
+            elif '_id' not in record:
                 # all key columns have to be defined
                 missing_fields = [field for field in unique_keys
                                   if field not in record]

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1212,7 +1212,6 @@ def upsert_data(context: Context, data_dict: dict[str, Any]):
 
             used_values = [record[field] for field in used_field_names]
 
-
             if method == _UPDATE:
                 sql_string = u'''
                     UPDATE {res_id}

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -219,14 +219,14 @@ def datastore_upsert(context: Context, data_dict: dict[str, Any]):
 
     *upsert*
         Update if record with same key already exists, otherwise insert.
-        Requires unique key.
+        Requires unique key or _id field.
     *insert*
         Insert only. This method is faster that upsert, but will fail if any
         inserted record matches an existing one. Does *not* require a unique
         key.
     *update*
         Update only. An exception will occur if the key that should be updated
-        does not exist. Requires unique key.
+        does not exist. Requires unique key or _id field.
 
 
     :param resource_id: resource id that the data is going to be stored under.

--- a/ckanext/datastore/tests/test_upsert.py
+++ b/ckanext/datastore/tests/test_upsert.py
@@ -552,6 +552,66 @@ class TestDatastoreUpsert(object):
         last_analyze = when_was_last_analyze(resource["id"])
         assert last_analyze is not None
 
+    @pytest.mark.ckan_config("ckan.plugins", "datastore")
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    def test_no_pk_update(self):
+        resource = factories.Resource()
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "fields": [
+                {"id": "book", "type": "text"},
+            ],
+            "records": [{"book": u"El Niño"}],
+        }
+        helpers.call_action("datastore_create", **data)
+
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "method": "upsert",
+            "records": [
+                {"_id": "1", "book": u"The boy"}
+            ],
+        }
+        helpers.call_action("datastore_upsert", **data)
+
+        search_result = _search(resource["id"])
+        assert search_result["total"] == 1
+        assert search_result["records"][0]["book"] == "The boy"
+
+    @pytest.mark.ckan_config("ckan.plugins", "datastore")
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    def test_id_instead_of_pk_update(self):
+        resource = factories.Resource()
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "primary_key": "id",
+            "fields": [
+                {"id": "pk", "type": "text"},
+                {"id": "book", "type": "text"},
+                {"id": "author", "type": "text"},
+            ],
+            "records": [{"pk": "1000", "book": u"El Niño", "author": "Torres"}],
+        }
+        helpers.call_action("datastore_create", **data)
+
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "method": "upsert",
+            "records": [
+                {"_id": "1", "book": u"The boy", "author": u"F Torres"}
+            ],
+        }
+        helpers.call_action("datastore_upsert", **data)
+
+        search_result = _search(resource["id"])
+        assert search_result["total"] == 1
+        assert search_result["records"][0]["pk"] == "1000"
+        assert search_result["records"][0]["book"] == "The boy"
+        assert search_result["records"][0]["author"] == "F Torres"
 
 @pytest.mark.usefixtures("with_request_context")
 class TestDatastoreInsert(object):
@@ -829,3 +889,64 @@ class TestDatastoreUpdate(object):
         with pytest.raises(ValidationError) as context:
             helpers.call_action("datastore_upsert", **data)
         assert u'fields "dummy" do not exist' in str(context.value)
+
+    @pytest.mark.ckan_config("ckan.plugins", "datastore")
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    def test_no_pk_update(self):
+        resource = factories.Resource()
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "fields": [
+                {"id": "book", "type": "text"},
+            ],
+            "records": [{"book": u"El Niño"}],
+        }
+        helpers.call_action("datastore_create", **data)
+
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "method": "update",
+            "records": [
+                {"_id": "1", "book": u"The boy"}
+            ],
+        }
+        helpers.call_action("datastore_upsert", **data)
+
+        search_result = _search(resource["id"])
+        assert search_result["total"] == 1
+        assert search_result["records"][0]["book"] == "The boy"
+
+    @pytest.mark.ckan_config("ckan.plugins", "datastore")
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    def test_id_instead_of_pk_update(self):
+        resource = factories.Resource()
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "primary_key": "id",
+            "fields": [
+                {"id": "pk", "type": "text"},
+                {"id": "book", "type": "text"},
+                {"id": "author", "type": "text"},
+            ],
+            "records": [{"pk": "1000", "book": u"El Niño", "author": "Torres"}],
+        }
+        helpers.call_action("datastore_create", **data)
+
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "method": "update",
+            "records": [
+                {"_id": "1", "book": u"The boy", "author": u"F Torres"}
+            ],
+        }
+        helpers.call_action("datastore_upsert", **data)
+
+        search_result = _search(resource["id"])
+        assert search_result["total"] == 1
+        assert search_result["records"][0]["pk"] == "1000"
+        assert search_result["records"][0]["book"] == "The boy"
+        assert search_result["records"][0]["author"] == "F Torres"

--- a/ckanext/datastore/tests/test_upsert.py
+++ b/ckanext/datastore/tests/test_upsert.py
@@ -587,7 +587,7 @@ class TestDatastoreUpsert(object):
         data = {
             "resource_id": resource["id"],
             "force": True,
-            "primary_key": "id",
+            "primary_key": "pk",
             "fields": [
                 {"id": "pk", "type": "text"},
                 {"id": "book", "type": "text"},
@@ -612,6 +612,7 @@ class TestDatastoreUpsert(object):
         assert search_result["records"][0]["pk"] == "1000"
         assert search_result["records"][0]["book"] == "The boy"
         assert search_result["records"][0]["author"] == "F Torres"
+
 
 @pytest.mark.usefixtures("with_request_context")
 class TestDatastoreInsert(object):

--- a/ckanext/datastore/tests/test_upsert.py
+++ b/ckanext/datastore/tests/test_upsert.py
@@ -926,7 +926,7 @@ class TestDatastoreUpdate(object):
         data = {
             "resource_id": resource["id"],
             "force": True,
-            "primary_key": "id",
+            "primary_key": "pk",
             "fields": [
                 {"id": "pk", "type": "text"},
                 {"id": "book", "type": "text"},


### PR DESCRIPTION
Fixes #6793 

### Proposed fixes:
modify `datastore_upsert` "update" and "upsert" methods to accept `_id` in addition to user-defined primary key fields


### Features:

- [x] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [X] includes API changes
- [X] includes bugfix for possible backport