### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,8 +14,15 @@ on:
   schedule:
     - cron: '0 3 * * 2'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/autobuild to send a status report
     name: Analyze
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -4,6 +4,9 @@ env:
   NODE_VERSION: '16'
   PYTHON_VERSION: '3.7'
 
+permissions:
+  contents: read
+
 jobs:
   cypress:
     runs-on: ubuntu-latest

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,6 +1,9 @@
 name: Lint
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -4,6 +4,9 @@ env:
   NODE_VERSION: '16'
   PYTHON_VERSION: '3.7'
 
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
