### PR TITLE
Fix activity pagination logic

### DIFF
--- a/ckanext/activity/model/activity.py
+++ b/ckanext/activity/model/activity.py
@@ -327,18 +327,12 @@ def package_activity_list(
             q, include=False, types=exclude_activity_types
         )
 
+    q = q.order_by(Activity.timestamp.desc())  # type: ignore
+
     if after:
         q = q.filter(Activity.timestamp > after)
     if before:
         q = q.filter(Activity.timestamp < before)
-
-    # revert sort queries for "only before" queries
-    revese_order = before and not after
-    if revese_order:
-        q = q.order_by(Activity.timestamp)
-    else:
-        # type_ignore_reason: incomplete SQLAlchemy types
-        q = q.order_by(Activity.timestamp.desc())  # type: ignore
 
     if offset:
         q = q.offset(offset)
@@ -347,9 +341,6 @@ def package_activity_list(
 
     results = q.all()
 
-    # revert result if required
-    if revese_order:
-        results.reverse()
     return results
 
 

--- a/ckanext/activity/tests/logic/test_pagination.py
+++ b/ckanext/activity/tests/logic/test_pagination.py
@@ -8,58 +8,59 @@ import ckan.tests.factories as factories
 import ckan.tests.helpers as helpers
 
 
+@pytest.fixture
+def activities():
+    user = factories.User()
+    org = factories.Organization()
+    dataset = factories.Dataset(owner_org=org["id"])
+
+    first = datetime.datetime.utcnow().timestamp()
+    dataset["notes"] = "First Update"
+    helpers.call_action(
+        "package_update",
+        context={"user": user["name"]},
+        **dataset,
+    )
+
+    second = datetime.datetime.utcnow().timestamp()
+    dataset["notes"] = "Second Update"
+    helpers.call_action(
+        "package_update",
+        context={"user": user["name"]},
+        **dataset,
+    )
+
+    third = datetime.datetime.utcnow().timestamp()
+    dataset["notes"] = "Third Update"
+    helpers.call_action(
+        "package_update",
+        context={"user": user["name"]},
+        **dataset,
+    )
+
+    fourth = datetime.datetime.utcnow().timestamp()
+    dataset["notes"] = "Fourth Update"
+    helpers.call_action(
+        "package_update",
+        context={"user": user["name"]},
+        **dataset,
+    )
+
+    fifth = datetime.datetime.utcnow().timestamp()
+    dataset["notes"] = "Fifth Update"
+    helpers.call_action(
+        "package_update",
+        context={"user": user["name"]},
+        **dataset,
+    )
+    return dataset, [first, second, third, fourth, fifth]
+
+
 @pytest.mark.ckan_config("ckan.plugins", "activity")
-@pytest.mark.usefixtures("clean_db", "with_plugins", "reset_index")
+@pytest.mark.usefixtures("clean_db", "with_plugins", "activities")
 class TestActivityPagination(object):
-    def test_package_activity_pagination(self):
-        """Test package activity list filters."""
-        user = factories.User()
-        org = factories.Organization()
-        dataset = factories.Dataset(owner_org=org["id"])
-
-        first = datetime.datetime.utcnow().timestamp()
-        dataset["notes"] = "First Update"
-        helpers.call_action(
-            "package_update",
-            context={"user": user["name"]},
-            **dataset,
-        )
-
-        second = datetime.datetime.utcnow().timestamp()
-        dataset["notes"] = "Second Update"
-        helpers.call_action(
-            "package_update",
-            context={"user": user["name"]},
-            **dataset,
-        )
-
-        third = datetime.datetime.utcnow().timestamp()
-        dataset["notes"] = "Third Update"
-        helpers.call_action(
-            "package_update",
-            context={"user": user["name"]},
-            **dataset,
-        )
-
-        fourth = datetime.datetime.utcnow().timestamp()
-        dataset["notes"] = "Fourth Update"
-        helpers.call_action(
-            "package_update",
-            context={"user": user["name"]},
-            **dataset,
-        )
-
-        fifth = datetime.datetime.utcnow().timestamp()
-        dataset["notes"] = "Fifth Update"
-        helpers.call_action(
-            "package_update",
-            context={"user": user["name"]},
-            **dataset,
-        )
-
-        assert first < second < third < fourth < fifth
-
-        # Default call returns list ordered by time desc. (Most recent update first)
+    def test_default_returns_ordered_by_time_desc(self, activities):
+        dataset, _ = activities
         complete_stream = helpers.call_action(
             "package_activity_list", context={}, id=dataset["id"]
         )
@@ -68,7 +69,8 @@ class TestActivityPagination(object):
             complete_stream[-1]["data"]["package"]["notes"] == "First Update"
         )
 
-        # Offset call returns list ordered by time desc. (Most recent update first)
+    def test_offset_call_returns_ordered_by_time_desc(self, activities):
+        dataset, _ = activities
         offset_stream = helpers.call_action(
             "package_activity_list",
             context={},
@@ -79,44 +81,49 @@ class TestActivityPagination(object):
         assert offset_stream[0]["data"]["package"]["notes"] == "Fifth Update"
         assert offset_stream[-1]["data"]["package"]["notes"] == "Third Update"
 
-        # Before call
+    def test_before_call_returns_ordered_by_time_desc(self, activities):
+        dataset, times = activities
         before_stream = helpers.call_action(
             "package_activity_list",
             context={},
             id=dataset["id"],
-            before=fourth,
+            before=times[3],
         )
         assert len(before_stream) == 3
         assert before_stream[0]["data"]["package"]["notes"] == "Third Update"
         assert before_stream[-1]["data"]["package"]["notes"] == "First Update"
 
-        # Before Fifth with limit 2 should get fourth and third
+    def test_before_fifth_with_limit_2_should_get_fourth_and_third(self, activities):
+        dataset, times = activities
         before_stream = helpers.call_action(
             "package_activity_list",
             context={},
             id=dataset["id"],
-            before=fifth,
+            before=times[4],
             limit=2,
         )
         assert len(before_stream) == 2
         assert before_stream[0]["data"]["package"]["notes"] == "Fourth Update"
         assert before_stream[-1]["data"]["package"]["notes"] == "Third Update"
 
-        # After call
+    def test_after_call_returns_ordered_by_time_desc(self, activities):
+        dataset, times = activities
         after_stream = helpers.call_action(
-            "package_activity_list", context={}, id=dataset["id"], after=third
+            "package_activity_list", context={}, id=dataset["id"], after=times[2]
         )
         assert len(after_stream) == 3
         assert after_stream[0]["data"]["package"]["notes"] == "Fifth Update"
         assert after_stream[1]["data"]["package"]["notes"] == "Fourth Update"
         assert after_stream[2]["data"]["package"]["notes"] == "Third Update"
-        # Before and After
+
+    def test_before_and_after_calls_returs_ordered_by_time_desc(self, activities):
+        dataset, times = activities
         before_after_stream = helpers.call_action(
             "package_activity_list",
             context={},
             id=dataset["id"],
-            after=first,
-            before=fifth,
+            after=times[0],
+            before=times[4],
         )
         assert len(before_after_stream) == 4
         assert (
@@ -128,7 +135,8 @@ class TestActivityPagination(object):
             == "First Update"
         )
 
-        # Before now should retrieve all
+    def test_before_now_should_return_all(self, activities):
+        dataset, _ = activities
         last_time = datetime.datetime.utcnow().timestamp()
         total_before_stream = helpers.call_action(
             "package_activity_list",
@@ -144,32 +152,4 @@ class TestActivityPagination(object):
         assert (
             total_before_stream[-1]["data"]["package"]["notes"]
             == "First Update"
-        )
-
-        # After middle with limit 1 should retrieve only the third update
-        limit_after_stream = helpers.call_action(
-            "package_activity_list",
-            context={},
-            id=dataset["id"],
-            after=third,
-            limit=1,
-        )
-        assert len(limit_after_stream) == 1
-        assert (
-            limit_after_stream[0]["data"]["package"]["notes"] == "Fifth Update"
-        )
-
-        # After begin with limit 1 and offset 1 should retrieve only the second update
-        after_offset_limit_stream = helpers.call_action(
-            "package_activity_list",
-            context={},
-            id=dataset["id"],
-            after=first,
-            offset=1,
-            limit=1,
-        )
-        assert len(after_offset_limit_stream) == 1
-        assert (
-            after_offset_limit_stream[0]["data"]["package"]["notes"]
-            == "Fourth Update"
         )

--- a/ckanext/activity/tests/logic/test_pagination.py
+++ b/ckanext/activity/tests/logic/test_pagination.py
@@ -153,3 +153,27 @@ class TestActivityPagination(object):
             total_before_stream[-1]["data"]["package"]["notes"]
             == "First Update"
         )
+
+    def test_after_returns_closer_elements_order_time_desc(self, activities):
+        """
+        Given [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
+        Whith after 6 and limit 2
+        Returns [8, 7]
+        """
+        dataset, time = activities
+        total_before_stream = helpers.call_action(
+            "package_activity_list",
+            context={},
+            id=dataset["id"],
+            after=time[1],
+            limit=2
+        )
+        assert len(total_before_stream) == 2
+        assert (
+            total_before_stream[0]["data"]["package"]["notes"]
+            == "Third Update"
+        )
+        assert (
+            total_before_stream[-1]["data"]["package"]["notes"]
+            == "Second Update"
+        )

--- a/ckanext/activity/tests/logic/test_pagination.py
+++ b/ckanext/activity/tests/logic/test_pagination.py
@@ -113,7 +113,7 @@ class TestActivityPagination(object):
     def test_before_4_with_limit_2_should_get_3_and_2(self, activities):
         """
         Given [4, 3, 2, 1, 0]
-        With limit 2
+        With before 4 and limit 2
         Returns [3, 2]
         """
         dataset, times = activities

--- a/ckanext/activity/tests/logic/test_pagination.py
+++ b/ckanext/activity/tests/logic/test_pagination.py
@@ -50,12 +50,12 @@ def activities():
     )
 
     activity_list = helpers.call_action(
-            "package_activity_list", context={}, id=dataset["id"]
-        )
+        "package_activity_list", context={}, id=dataset["id"]
+    )
     from_iso = datetime.datetime.fromisoformat
     activity_times = [
-        from_iso(a['timestamp']).timestamp() for a in activity_list
-        ]
+        from_iso(a["timestamp"]).timestamp() for a in activity_list
+    ]
 
     return dataset, activity_times
 
@@ -74,9 +74,7 @@ class TestActivityPagination(object):
             "package_activity_list", context={}, id=dataset["id"]
         )
         assert activity_list[0]["data"]["package"]["notes"] == "Update 4"
-        assert (
-            activity_list[-1]["data"]["package"]["notes"] == "Update 0"
-        )
+        assert activity_list[-1]["data"]["package"]["notes"] == "Update 0"
 
     def test_offset_call_returns_ordered_by_time_desc(self, activities):
         """
@@ -138,14 +136,17 @@ class TestActivityPagination(object):
         """
         dataset, times = activities
         activity_list = helpers.call_action(
-            "package_activity_list", context={}, id=dataset["id"], after=times[3]
+            "package_activity_list",
+            context={},
+            id=dataset["id"],
+            after=times[3],
         )
         assert len(activity_list) == 3
         assert activity_list[0]["data"]["package"]["notes"] == "Update 4"
         assert activity_list[1]["data"]["package"]["notes"] == "Update 3"
         assert activity_list[2]["data"]["package"]["notes"] == "Update 2"
 
-    def test_before_and_after_calls_returs_ordered_by_time_desc(self, activities):
+    def test_before_and_after_returns_ordered_by_time_desc(self, activities):
         """
         Given [4, 3, 2, 1, 0]
         With after 0 and before 4
@@ -160,14 +161,8 @@ class TestActivityPagination(object):
             before=times[0],
         )
         assert len(activity_list) == 3
-        assert (
-            activity_list[0]["data"]["package"]["notes"]
-            == "Update 3"
-        )
-        assert (
-            activity_list[-1]["data"]["package"]["notes"]
-            == "Update 1"
-        )
+        assert activity_list[0]["data"]["package"]["notes"] == "Update 3"
+        assert activity_list[-1]["data"]["package"]["notes"] == "Update 1"
 
     def test_before_now_should_return_all(self, activities):
         """
@@ -184,14 +179,8 @@ class TestActivityPagination(object):
             before=now,
         )
         assert len(activity_list) == 5
-        assert (
-            activity_list[0]["data"]["package"]["notes"]
-            == "Update 4"
-        )
-        assert (
-            activity_list[-1]["data"]["package"]["notes"]
-            == "Update 0"
-        )
+        assert activity_list[0]["data"]["package"]["notes"] == "Update 4"
+        assert activity_list[-1]["data"]["package"]["notes"] == "Update 0"
 
     def test_after_returns_closer_elements_order_time_desc(self, activities):
         """
@@ -205,14 +194,8 @@ class TestActivityPagination(object):
             context={},
             id=dataset["id"],
             after=time[4],
-            limit=2
+            limit=2,
         )
         assert len(activity_list) == 2
-        assert (
-            activity_list[0]["data"]["package"]["notes"]
-            == "Update 2"
-        )
-        assert (
-            activity_list[-1]["data"]["package"]["notes"]
-            == "Update 1"
-        )
+        assert activity_list[0]["data"]["package"]["notes"] == "Update 2"
+        assert activity_list[-1]["data"]["package"]["notes"] == "Update 1"

--- a/ckanext/activity/tests/logic/test_pagination.py
+++ b/ckanext/activity/tests/logic/test_pagination.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+
+import datetime
+
+import pytest
+
+import ckan.tests.factories as factories
+import ckan.tests.helpers as helpers
+
+
+@pytest.mark.ckan_config("ckan.plugins", "activity")
+@pytest.mark.usefixtures("clean_db", "with_plugins", "reset_index")
+class TestActivityPagination(object):
+    def test_package_activity_pagination(self):
+        """Test package activity list filters."""
+        user = factories.User()
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org=org["id"])
+
+        begin = datetime.datetime.utcnow().timestamp()
+        dataset["notes"] = "First Update"
+        helpers.call_action(
+            "package_update",
+            context={"user": user["name"]},
+            **dataset,
+        )
+
+        middle = datetime.datetime.utcnow().timestamp()
+        dataset["notes"] = "Second Update"
+        helpers.call_action(
+            "package_update",
+            context={"user": user["name"]},
+            **dataset,
+        )
+
+        end = datetime.datetime.utcnow().timestamp()
+        dataset["notes"] = "Third Update"
+        helpers.call_action(
+            "package_update",
+            context={"user": user["name"]},
+            **dataset,
+        )
+
+        assert begin < middle < end
+
+        # Default call returns list ordered by time desc. (Most recent update first)
+        complete_stream = helpers.call_action(
+            "package_activity_list", context={}, id=dataset["id"]
+        )
+        assert complete_stream[0]["data"]["package"]["notes"] == "Third Update"
+        assert (
+            complete_stream[-1]["data"]["package"]["notes"] == "First Update"
+        )
+
+        # Offset call returns list ordered by time desc. (Most recent update first)
+        offset_stream = helpers.call_action(
+            "package_activity_list",
+            context={},
+            id=dataset["id"],
+            offset=0,
+            limit=3,
+        )
+        assert offset_stream[0]["data"]["package"]["notes"] == "Third Update"
+        assert offset_stream[-1]["data"]["package"]["notes"] == "First Update"
+
+        # Before call
+        before_stream = helpers.call_action(
+            "package_activity_list",
+            context={},
+            id=dataset["id"],
+            before=middle,
+        )
+        assert len(before_stream) == 1
+        assert before_stream[0]["data"]["package"]["notes"] == "First Update"
+
+        # Before end with limit 1 should get Second Update
+        before_stream = helpers.call_action(
+            "package_activity_list",
+            context={},
+            id=dataset["id"],
+            before=end,
+            limit=1,
+        )
+        assert len(before_stream) == 1
+        assert before_stream[0]["data"]["package"]["notes"] == "Second Update"
+
+        # After call
+        after_stream = helpers.call_action(
+            "package_activity_list", context={}, id=dataset["id"], after=middle
+        )
+        assert len(after_stream) == 2
+        assert after_stream[0]["data"]["package"]["notes"] == "Third Update"
+        assert after_stream[1]["data"]["package"]["notes"] == "Second Update"
+
+        # Before and After
+        before_after_stream = helpers.call_action(
+            "package_activity_list",
+            context={},
+            id=dataset["id"],
+            after=begin,
+            before=end,
+        )
+        assert len(before_after_stream) == 2
+        assert (
+            before_after_stream[0]["data"]["package"]["notes"]
+            == "Second Update"
+        )
+        assert (
+            before_after_stream[1]["data"]["package"]["notes"]
+            == "First Update"
+        )
+
+        # Before now should retrieve all
+        last_time = datetime.datetime.utcnow().timestamp()
+        total_before_stream = helpers.call_action(
+            "package_activity_list",
+            context={},
+            id=dataset["id"],
+            before=last_time,
+        )
+        assert len(total_before_stream) == 3
+        assert (
+            total_before_stream[0]["data"]["package"]["notes"]
+            == "Third Update"
+        )
+        assert (
+            total_before_stream[1]["data"]["package"]["notes"]
+            == "Second Update"
+        )
+        assert (
+            total_before_stream[2]["data"]["package"]["notes"]
+            == "First Update"
+        )
+
+        # After middle with limit 1 should retrieve only the third update
+        limit_after_stream = helpers.call_action(
+            "package_activity_list",
+            context={},
+            id=dataset["id"],
+            after=middle,
+            limit=1,
+        )
+        assert len(limit_after_stream) == 1
+        assert (
+            limit_after_stream[0]["data"]["package"]["notes"] == "Third Update"
+        )
+
+        # After begin with limit 1 and offset 1 should retrieve only the second update
+        after_offset_limit_stream = helpers.call_action(
+            "package_activity_list",
+            context={},
+            id=dataset["id"],
+            after=middle,
+            offset=1,
+            limit=1,
+        )
+        assert len(after_offset_limit_stream) == 1
+        assert (
+            after_offset_limit_stream[0]["data"]["package"]["notes"]
+            == "Second Update"
+        )

--- a/ckanext/activity/tests/logic/test_pagination.py
+++ b/ckanext/activity/tests/logic/test_pagination.py
@@ -70,12 +70,12 @@ class TestActivityPagination(object):
         Returns [4, 3, 2, 1, 0]
         """
         dataset, _ = activities
-        complete_stream = helpers.call_action(
+        activity_list = helpers.call_action(
             "package_activity_list", context={}, id=dataset["id"]
         )
-        assert complete_stream[0]["data"]["package"]["notes"] == "Update 4"
+        assert activity_list[0]["data"]["package"]["notes"] == "Update 4"
         assert (
-            complete_stream[-1]["data"]["package"]["notes"] == "Update 0"
+            activity_list[-1]["data"]["package"]["notes"] == "Update 0"
         )
 
     def test_offset_call_returns_ordered_by_time_desc(self, activities):
@@ -85,15 +85,15 @@ class TestActivityPagination(object):
         Returns [4, 3, 2]
         """
         dataset, _ = activities
-        offset_stream = helpers.call_action(
+        activity_list = helpers.call_action(
             "package_activity_list",
             context={},
             id=dataset["id"],
             offset=0,
             limit=3,
         )
-        assert offset_stream[0]["data"]["package"]["notes"] == "Update 4"
-        assert offset_stream[-1]["data"]["package"]["notes"] == "Update 2"
+        assert activity_list[0]["data"]["package"]["notes"] == "Update 4"
+        assert activity_list[-1]["data"]["package"]["notes"] == "Update 2"
 
     def test_before_call_returns_ordered_by_time_desc(self, activities):
         """
@@ -102,15 +102,15 @@ class TestActivityPagination(object):
         Returns [3, 2, 1, 0]
         """
         dataset, times = activities
-        before_stream = helpers.call_action(
+        activity_list = helpers.call_action(
             "package_activity_list",
             context={},
             id=dataset["id"],
             before=times[0],
         )
-        assert len(before_stream) == 4
-        assert before_stream[0]["data"]["package"]["notes"] == "Update 3"
-        assert before_stream[-1]["data"]["package"]["notes"] == "Update 0"
+        assert len(activity_list) == 4
+        assert activity_list[0]["data"]["package"]["notes"] == "Update 3"
+        assert activity_list[-1]["data"]["package"]["notes"] == "Update 0"
 
     def test_before_4_with_limit_2_should_get_3_and_2(self, activities):
         """
@@ -119,16 +119,16 @@ class TestActivityPagination(object):
         Returns [3, 2]
         """
         dataset, times = activities
-        before_stream = helpers.call_action(
+        activity_list = helpers.call_action(
             "package_activity_list",
             context={},
             id=dataset["id"],
             before=times[0],
             limit=2,
         )
-        assert len(before_stream) == 2
-        assert before_stream[0]["data"]["package"]["notes"] == "Update 3"
-        assert before_stream[-1]["data"]["package"]["notes"] == "Update 2"
+        assert len(activity_list) == 2
+        assert activity_list[0]["data"]["package"]["notes"] == "Update 3"
+        assert activity_list[-1]["data"]["package"]["notes"] == "Update 2"
 
     def test_after_call_returns_ordered_by_time_desc(self, activities):
         """
@@ -137,13 +137,13 @@ class TestActivityPagination(object):
         Returns [4, 3, 2]
         """
         dataset, times = activities
-        after_stream = helpers.call_action(
+        activity_list = helpers.call_action(
             "package_activity_list", context={}, id=dataset["id"], after=times[3]
         )
-        assert len(after_stream) == 3
-        assert after_stream[0]["data"]["package"]["notes"] == "Update 4"
-        assert after_stream[1]["data"]["package"]["notes"] == "Update 3"
-        assert after_stream[2]["data"]["package"]["notes"] == "Update 2"
+        assert len(activity_list) == 3
+        assert activity_list[0]["data"]["package"]["notes"] == "Update 4"
+        assert activity_list[1]["data"]["package"]["notes"] == "Update 3"
+        assert activity_list[2]["data"]["package"]["notes"] == "Update 2"
 
     def test_before_and_after_calls_returs_ordered_by_time_desc(self, activities):
         """
@@ -152,20 +152,20 @@ class TestActivityPagination(object):
         Returns [3, 2, 1]
         """
         dataset, times = activities
-        before_after_stream = helpers.call_action(
+        activity_list = helpers.call_action(
             "package_activity_list",
             context={},
             id=dataset["id"],
             after=times[4],
             before=times[0],
         )
-        assert len(before_after_stream) == 3
+        assert len(activity_list) == 3
         assert (
-            before_after_stream[0]["data"]["package"]["notes"]
+            activity_list[0]["data"]["package"]["notes"]
             == "Update 3"
         )
         assert (
-            before_after_stream[-1]["data"]["package"]["notes"]
+            activity_list[-1]["data"]["package"]["notes"]
             == "Update 1"
         )
 
@@ -177,19 +177,19 @@ class TestActivityPagination(object):
         """
         dataset, _ = activities
         now = datetime.datetime.utcnow().timestamp()
-        total_before_stream = helpers.call_action(
+        activity_list = helpers.call_action(
             "package_activity_list",
             context={},
             id=dataset["id"],
             before=now,
         )
-        assert len(total_before_stream) == 5
+        assert len(activity_list) == 5
         assert (
-            total_before_stream[0]["data"]["package"]["notes"]
+            activity_list[0]["data"]["package"]["notes"]
             == "Update 4"
         )
         assert (
-            total_before_stream[-1]["data"]["package"]["notes"]
+            activity_list[-1]["data"]["package"]["notes"]
             == "Update 0"
         )
 
@@ -200,19 +200,19 @@ class TestActivityPagination(object):
         Returns [2, 1]
         """
         dataset, time = activities
-        total_before_stream = helpers.call_action(
+        activity_list = helpers.call_action(
             "package_activity_list",
             context={},
             id=dataset["id"],
             after=time[4],
             limit=2
         )
-        assert len(total_before_stream) == 2
+        assert len(activity_list) == 2
         assert (
-            total_before_stream[0]["data"]["package"]["notes"]
+            activity_list[0]["data"]["package"]["notes"]
             == "Update 2"
         )
         assert (
-            total_before_stream[-1]["data"]["package"]["notes"]
+            activity_list[-1]["data"]["package"]["notes"]
             == "Update 1"
         )


### PR DESCRIPTION
Fixes the pagination activity logic.

This is a small step towards #6900  

## Steps to reproduce:

#### Given a package with some activities:
```python
In [10]: [(a['timestamp'], a['data']['package']['notes']) for a in toolkit.get_action('package_activity_list')({},{'id': 'reference-for-activity-testing'})]
Out[10]: 
[('2022-06-24T15:12:41.726709', 'Update number: 8'),
 ('2022-06-24T15:04:48.494923', 'Update number: 7'),
 ('2022-06-24T15:02:36.600982', 'Update number: 6'),
 ('2022-06-24T15:01:32.760078', 'Update number: 5'),
 ('2022-06-24T14:56:21.646781', 'Update number: 4'),
 ('2022-06-24T14:52:12.638283', 'Update number: 3'),
 ('2022-06-24T14:47:29.261165', 'Update number: 2'),
 ('2022-06-24T14:46:03.045338', 'Update number: 1'),
 ('2022-06-24T14:46:02.898021', 'Update number: 1'),
 ('2022-06-24T14:45:49.367376', 'Update number: 1')]
```
#### When retrieving activities before `6` it works correctly:
```python
In [16]: before_6 = datetime.fromisoformat('2022-06-24T15:02:36.600982').timestamp()

In [17]: [(a['timestamp'], a['data']['package']['notes']) for a in toolkit.get_action('package_activity_list')({},{'id': 'reference-for-activity-testing', 'before': before_6})]
Out[17]: 
[('2022-06-24T15:01:32.760078', 'Update number: 5'),
 ('2022-06-24T14:56:21.646781', 'Update number: 4'),
 ('2022-06-24T14:52:12.638283', 'Update number: 3'),
 ('2022-06-24T14:47:29.261165', 'Update number: 2'),
 ('2022-06-24T14:46:03.045338', 'Update number: 1'),
 ('2022-06-24T14:46:02.898021', 'Update number: 1'),
 ('2022-06-24T14:45:49.367376', 'Update number: 1')]
```

#### When retrieving activities before `6` with `limit=3`; instead of getting `5,4,3`; we get the first three:
```python
In [18]: [(a['timestamp'], a['data']['package']['notes']) for a in toolkit.get_action('package_activity_list')({},{'id': 'reference-for-activity-testing', 'before': before_6, 'limit': 3})]
Out[18]: 
[('2022-06-24T14:46:03.045338', 'Update number: 1'),
 ('2022-06-24T14:46:02.898021', 'Update number: 1'),
 ('2022-06-24T14:45:49.367376', 'Update number: 1')]
```

## Additional Notes

I also added a new test file `test_pagination.py` covering most of the scenarios of `package_activity_list` parameters.