### PR TITLE
Circle ci not highlighting errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,10 +77,8 @@ jobs:
 
       # Tests Backend, split across containers by segments
       - <<: *run_tests
-
       - store_test_results:
-          path: /root/junit
-
+          path: ~/junit
       - run: coveralls
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,8 @@ jobs:
       # Tests Backend, split across containers by segments
       - <<: *run_tests
       - store_test_results:
-          path: ~/junit
+          path: /root/junit
+
       - run: coveralls
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,8 @@ defaults:
   run_tests: &run_tests
     # Tests Backend, split across containers by segments
     run: |
-      mkdir -p ~/junit
-      python -m pytest -v --ckan-ini=test-core-circle-ci.ini --cov=ckan --cov=ckanext --junitxml=/root/junit/junit.xml --splits 4 --group $((CIRCLE_NODE_INDEX+1)) --splitting-algorithm least_duration
+      mkdir -p ~/junit/result
+      python -m pytest -v --ckan-ini=test-core-circle-ci.ini --cov=ckan --cov=ckanext --junitxml=/root/junit/result/junit.xml --splits 4 --group $((CIRCLE_NODE_INDEX+1)) --splitting-algorithm least_duration
 
   ckan_env: &ckan_env
     environment:
@@ -35,7 +35,7 @@ defaults:
       CKAN_POSTGRES_USER: ckan_default
       CKAN_POSTGRES_PWD: pass
       PGPASSWORD: ckan
-      PYTEST_COMMON_OPTIONS: -v --ckan-ini=test-core-circle-ci.ini --cov=ckan --cov=ckanext --junitxml=/root/junit/junit.xml --test-group-count 4  --test-group-random-seed 1
+      PYTEST_COMMON_OPTIONS: -v --ckan-ini=test-core-circle-ci.ini --cov=ckan --cov=ckanext --junitxml=/root/junit/result/junit.xml --test-group-count 4  --test-group-random-seed 1
   pg_image: &pg_image
     image: postgres:10
     environment:
@@ -77,6 +77,7 @@ jobs:
 
       # Tests Backend, split across containers by segments
       - <<: *run_tests
+
       - store_test_results:
           path: /root/junit
 

--- a/ckan/tests/test_common.py
+++ b/ckan/tests/test_common.py
@@ -183,3 +183,7 @@ def test_can_also_use_c_on_a_flask_request():
 def test_accessing_missing_key_raises_error_on_flask_request():
     with pytest.raises(AttributeError):
         getattr(ckan_g, u"user")
+
+
+def test_fail_for_ci():
+    assert False, "I'm here!"

--- a/ckan/tests/test_common.py
+++ b/ckan/tests/test_common.py
@@ -183,7 +183,3 @@ def test_can_also_use_c_on_a_flask_request():
 def test_accessing_missing_key_raises_error_on_flask_request():
     with pytest.raises(AttributeError):
         getattr(ckan_g, u"user")
-
-
-def test_fail_for_ci():
-    assert False, "I'm here!"


### PR DESCRIPTION
Fixes #6938

Put test reports inside `junit/result` instead of just `junit/`, because CircleCI requires them to be stored inside an intermediate subfolder in order to be collected.

[Overview of the failed tests](https://app.circleci.com/pipelines/github/ckan/ckan/3892/workflows/bdcd8a7c-efe5-4940-b684-9eabf80b584f/jobs/11752)