### PR TITLE
[#6948] Avoid storing sessions on each request (2.9 version)

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -106,9 +106,17 @@ class BeakerSessionInterface(SessionInterface):
         if not is_null:
             # Beaker always adds these keys on each request, so if these are
             # the only keys present we assume it's an empty session
+
             is_null = (
-                sorted(obj.keys()) == [
-                    u"_accessed_time", u"_creation_time", u"_domain", u"_path"]
+                (
+                    # Beaker 0.11 (py3)
+                    sorted(obj.keys()) == [
+                        u"_accessed_time", u"_creation_time", u"_domain", u"_path"]
+                ) or (
+                    # Beaker 0.10 (py2)
+                    sorted(obj.keys()) == [
+                        u"_accessed_time", u"_creation_time"]
+                )
             )
 
         return is_null

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -106,7 +106,9 @@ class BeakerSessionInterface(SessionInterface):
         if not is_null:
             # Beaker always adds these keys on each request, so if these are
             # the only keys present we assume it's an empty session
-            is_null = sorted(obj.keys()) == ["_accessed_time", "_creation_time"]
+            is_null = (
+                sorted(obj.keys()) == ["_accessed_time", "_creation_time"]
+            )
 
         return is_null
 

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -107,7 +107,8 @@ class BeakerSessionInterface(SessionInterface):
             # Beaker always adds these keys on each request, so if these are
             # the only keys present we assume it's an empty session
             is_null = (
-                sorted(obj.keys()) == [u"_accessed_time", u"_creation_time"]
+                sorted(obj.keys()) == [
+                    u"_accessed_time", u"_creation_time", u"_domain", u"_path"]
             )
 
         return is_null

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -111,7 +111,8 @@ class BeakerSessionInterface(SessionInterface):
                 (
                     # Beaker 0.11 (py3)
                     sorted(obj.keys()) == [
-                        u"_accessed_time", u"_creation_time", u"_domain", u"_path"]
+                        u"_accessed_time", u"_creation_time",
+                        u"_domain", u"_path"]
                 ) or (
                     # Beaker 0.10 (py2)
                     sorted(obj.keys()) == [

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -107,7 +107,7 @@ class BeakerSessionInterface(SessionInterface):
             # Beaker always adds these keys on each request, so if these are
             # the only keys present we assume it's an empty session
             is_null = (
-                sorted(obj.keys()) == ["_accessed_time", "_creation_time"]
+                sorted(obj.keys()) == [u"_accessed_time", u"_creation_time"]
             )
 
         return is_null

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -110,7 +110,8 @@ class BeakerSessionInterface(SessionInterface):
             is_null = (
                 sorted(obj.keys()) in [
                     # Beaker 0.11 (py3)
-                    [u"_accessed_time", u"_creation_time", u"_domain", u"_path"],
+                    [u"_accessed_time", u"_creation_time", u"_domain",
+                        u"_path"],
                     # Beaker 0.10 (py2)
                     [u"_accessed_time", u"_creation_time"]
                 ]

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -108,16 +108,12 @@ class BeakerSessionInterface(SessionInterface):
             # the only keys present we assume it's an empty session
 
             is_null = (
-                (
+                sorted(obj.keys()) in [
                     # Beaker 0.11 (py3)
-                    sorted(obj.keys()) == [
-                        u"_accessed_time", u"_creation_time",
-                        u"_domain", u"_path"]
-                ) or (
+                    [u"_accessed_time", u"_creation_time", u"_domain", u"_path"],
                     # Beaker 0.10 (py2)
-                    sorted(obj.keys()) == [
-                        u"_accessed_time", u"_creation_time"]
-                )
+                    [u"_accessed_time", u"_creation_time"]
+                ]
             )
 
         return is_null

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -174,6 +174,17 @@ def make_flask_stack(conf):
         def save_session(self, app, session, response):
             session.save()
 
+        def is_null_session(self, obj):
+
+            is_null = super(BeakerSessionInterface, self).is_null_session(obj)
+
+            if not is_null:
+                # Beaker always adds these keys on each request, so if these are
+                # the only keys present we assume it's an empty session
+                is_null = sorted(obj.keys()) == ["_accessed_time", "_creation_time"]
+
+            return is_null
+
     namespace = 'beaker.session.'
     session_opts = {k.replace('beaker.', ''): v
                     for k, v in six.iteritems(config)

--- a/ckan/tests/config/test_middleware.py
+++ b/ckan/tests/config/test_middleware.py
@@ -13,7 +13,7 @@ import ckan.plugins as p
 import ckan.tests.factories as factories
 from ckan.common import config, _
 from ckan.config.middleware import AskAppDispatcherMiddleware
-from ckan.config.middleware.flask_app import CKANFlask
+from ckan.config.middleware.flask_app import CKANFlask, BeakerSessionInterface
 if six.PY2:
     from ckan.config.middleware.pylons_app import CKANPylonsApp
 else:
@@ -393,3 +393,20 @@ def test_ask_around_flask_core_route_post(app):
         (True, u"flask_app", u"core"),
         (False, u"pylons_app"),
     ]
+
+
+def test_no_session_stored_by_default(app, monkeypatch, test_request_context):
+
+    save_session_mock = mock.Mock()
+
+    class CustomBeakerSessionInterface(BeakerSessionInterface):
+
+        save_session = save_session_mock
+
+    monkeypatch.setattr(
+        app.flask_app, 'session_interface', CustomBeakerSessionInterface())
+
+    with test_request_context():
+        app.get("/")
+
+    save_session_mock.assert_not_called()

--- a/ckan/tests/config/test_middleware.py
+++ b/ckan/tests/config/test_middleware.py
@@ -404,9 +404,9 @@ def test_no_session_stored_by_default(app, monkeypatch, test_request_context):
         save_session = save_session_mock
 
     monkeypatch.setattr(
-        app.flask_app, 'session_interface', CustomBeakerSessionInterface())
+        app.flask_app, u"session_interface", CustomBeakerSessionInterface())
 
     with test_request_context():
-        app.get("/")
+        app.get(u"/")
 
     save_session_mock.assert_not_called()


### PR DESCRIPTION
See https://github.com/ckan/ckan/issues/6948#issuecomment-1172152804 for details. We were storing a session on each requests because Beaker always adds a couple of keys





### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

