### PR TITLE
[#6948] Avoid storing sessions on each request

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -10,7 +10,7 @@ import pkgutil
 import logging
 
 from logging.handlers import SMTPHandler
-from typing import Any, Iterable, Optional, Union, cast
+from typing import Any, Iterable, Optional, Union, cast, Dict
 
 from flask import Blueprint, send_from_directory
 from flask.ctx import _AppCtxGlobals
@@ -134,7 +134,7 @@ class BeakerSessionInterface(SessionInterface):
     def save_session(self, app: Any, session: Any, response: Any):
         session.save()
 
-    def is_null_session(self, obj: object) -> bool:
+    def is_null_session(self, obj: Dict[str, Any]) -> bool:
 
         is_null = super(BeakerSessionInterface, self).is_null_session(obj)
 

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -10,7 +10,7 @@ import pkgutil
 import logging
 
 from logging.handlers import SMTPHandler
-from typing import Any, Iterable, Optional, Union, cast
+from typing import Any, Iterable, Optional, Union, cast, Type
 
 from flask import Blueprint, send_from_directory
 from flask.ctx import _AppCtxGlobals
@@ -208,6 +208,20 @@ def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:
 
         def save_session(self, app: Any, session: Any, response: Any):
             session.save()
+
+        def is_null_session(self, obj: object) -> bool:
+
+            is_null = super(BeakerSessionInterface, self).is_null_session(obj)
+
+            if not is_null:
+                # Beaker always adds these keys on each request, so if these are
+                # the only keys present we assume it's an empty session
+                is_null = (
+                    sorted(obj.keys()) == [
+                        "_accessed_time", "_creation_time", "_domain", "_path"]
+                )
+
+            return is_null
 
     namespace = 'beaker.session.'
     session_opts = {k.replace('beaker.', ''): v

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -10,7 +10,7 @@ import pkgutil
 import logging
 
 from logging.handlers import SMTPHandler
-from typing import Any, Iterable, Optional, Union, cast, Type
+from typing import Any, Iterable, Optional, Union, cast
 
 from flask import Blueprint, send_from_directory
 from flask.ctx import _AppCtxGlobals

--- a/ckan/tests/config/test_middleware.py
+++ b/ckan/tests/config/test_middleware.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 import pytest
-import mock
+from unittest import mock
 from flask import Blueprint
 from ckan.config.middleware.flask_app import BeakerSessionInterface
 


### PR DESCRIPTION
Fixes #6948 

See https://github.com/ckan/ckan/issues/6948#issuecomment-1172152804 for details. We were storing a session on each request because Beaker always adds some default keys.

This is 2 files per request, and considering we serve assets via flask by default that mean dozens of files per request


### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

