### PR TITLE
Prevent non-sysadmin users to change their own state

### DIFF
--- a/changes/6956.misc
+++ b/changes/6956.misc
@@ -1,0 +1,1 @@
+Non-sysadmin users are no longer able to change their own state

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -434,7 +434,7 @@ def default_user_schema(
         'reset_key': [ignore],
         'activity_streams_email_notifications': [ignore_missing,
                                                  boolean_validator],
-        'state': [ignore_missing],
+        'state': [ignore_missing, ignore_not_sysadmin],
         'image_url': [ignore_missing, unicode_safe],
         'image_display_url': [ignore_missing, unicode_safe],
         'plugin_extras': [ignore_missing, json_object, ignore_not_sysadmin],

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -355,6 +355,29 @@ class TestUpdate(object):
             "http://a.html",
         ]
 
+    def test_normal_user_can_not_change_their_state(self):
+
+        user = factories.User(state='pending')
+
+        user['state'] = 'active'
+
+        updated_user = helpers.call_action("user_update", **user)
+
+        updated_user['state'] == 'pending'
+
+    def test_sysadmin_user_can_change_a_user_state(self):
+
+        user = factories.User(state='pending')
+        sysadmin = factories.Sysadmin()
+
+        user['state'] = 'active'
+
+        context = {'user': sysadmin['name']}
+
+        updated_user = helpers.call_action("user_update", context=context, **user)
+
+        updated_user['state'] == 'active'
+
     def test_update_dataset_cant_change_type(self):
         user = factories.User()
         dataset = factories.Dataset(

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -720,10 +720,10 @@ class PerformResetView(MethodView):
             updated_user = logic.get_action("user_update")(context, user_dict)
             # Users can not change their own state, so we need another edit
             if (updated_user["state"] == model.State.PENDING):
-                patch_context = {
+                patch_context = cast(Context, {
                     'user': logic.get_action("get_site_user")(
                         {"ignore_auth": True}, {})["name"]
-                }
+                })
                 logic.get_action("user_patch")(
                     patch_context,
                     {"id": user_dict['id'], "state": model.State.ACTIVE}

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -717,8 +717,17 @@ class PerformResetView(MethodView):
             if (username is not None and username != u''):
                 user_dict[u'name'] = username
             user_dict[u'reset_key'] = g.reset_key
-            user_dict[u'state'] = model.State.ACTIVE
-            logic.get_action(u'user_update')(context, user_dict)
+            updated_user = logic.get_action("user_update")(context, user_dict)
+            # Users can not change their own state, so we need another edit
+            if (updated_user["state"] == model.State.PENDING):
+                patch_context = {
+                    'user': logic.get_action("get_site_user")(
+                        {"ignore_auth": True}, {})["name"]
+                }
+                logic.get_action("user_patch")(
+                    patch_context,
+                    {"id": user_dict['id'], "state": model.State.ACTIVE}
+                )
             mailer.create_reset_key(context[u'user_obj'])
             signals.perform_password_reset.send(
                 username, user=context[u'user_obj'])


### PR DESCRIPTION
Only sysadmins can update a user state

### Features:

- [x] includes tests covering changes
- [x] includes bugfix for possible backport
