### PR TITLE
[#6957] Fix disclaimer for latest docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -355,7 +355,7 @@ current_minor_version = current_release_version[:current_release_version.find(".
 latest_release_tag_value = get_latest_release_tag()
 latest_release_version = get_latest_release_version()
 latest_minor_version = latest_release_version[:latest_release_version.find(".", 3)]
-is_master = release.endswith('a')
+is_master = "a" in release.split(".")[-1]
 is_supported = get_status_of_this_version() == 'supported'
 is_latest_version = version == latest_release_version
 


### PR DESCRIPTION
Fixes #6957

We changed the version number from `2.10.0a` to `2.10.0a0` to follow [Python's guidance](https://peps.python.org/pep-0440/#pre-releases) and that broke the logic that checked if we were building the docs on the master branch