### PR TITLE
remove `rank` from datastore_search()

### DIFF
--- a/changes/6961.misc
+++ b/changes/6961.misc
@@ -1,0 +1,1 @@
+ The "rank" field is no longer returned in datastore_search results unless explicitly defined in the fields parameter

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1901,7 +1901,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
         elif fields and fts_q:
             field_ids = datastore_helpers.get_list(fields)
             all_field_ids = list(fields_types.keys())
-            all_field_ids.remove('rank')
+            all_field_ids.remove("rank")
             field_intersect = [x for x in field_ids
                                if x not in all_field_ids]
             field_ids = all_field_ids + field_intersect

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1901,7 +1901,8 @@ class DatastorePostgresqlBackend(DatastoreBackend):
         elif fields and fts_q:
             field_ids = datastore_helpers.get_list(fields)
             all_field_ids = list(fields_types.keys())
-            all_field_ids.remove("rank")
+            if "rank" not in fields:
+                all_field_ids.remove("rank")
             field_intersect = [x for x in field_ids
                                if x not in all_field_ids]
             field_ids = all_field_ids + field_intersect

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1901,6 +1901,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
         elif fields and fts_q:
             field_ids = datastore_helpers.get_list(fields)
             all_field_ids = list(fields_types.keys())
+            all_field_ids.remove('rank')
             field_intersect = [x for x in field_ids
                                if x not in all_field_ids]
             field_ids = all_field_ids + field_intersect

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -2089,10 +2089,8 @@ class TestDatastoreSearchRecordsFormat(object):
         }
         result = helpers.call_action("datastore_search", **search_data)
         ranks_from = [r["rank from"] for r in result["records"]]
-        ranks = [r["rank"] for r in result["records"]]
         assert len(result["records"]) == 2
         assert len(set(ranks_from)) == 1
-        assert len(set(ranks)) == 2
 
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")


### PR DESCRIPTION
Fixes #6172 

### Proposed fixes:
- Remove the hidden `rank` field from response, when `full_text` and `fields` parameters are passed in the same API call.



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
