### PR TITLE
Mentioning `Express Loader` in DataStore Extension Document

### DIFF
--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -213,6 +213,16 @@ To install this please look at the docs here: https://github.com/ckan/datapusher
 .. note:: The DataPusher only imports the first worksheet of a spreadsheet. It also does
    not support duplicate column headers. That includes blank column headings.
 
+--------------
+Express Loader
+--------------
+
+Express Loader(or Xloader) is designed as a replacement for DataPusher because it offers ten
+times the speed and more robustness. You can loads CSV (and similar) data into CKAN's DataStore.
+XLoader pipes the CSV file directly into PostgreSQL using COPY.
+
+To install this please look at the docs here: https://github.com/ckan/ckanext-xloader
+
 .. _data_dictionary:
 
 ---------------


### PR DESCRIPTION
This PR fixes the issue: https://github.com/ckan/ckan/issues/4415

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
