### PR TITLE
[#2628] Fix followee count

### DIFF
--- a/changes/2628.feature
+++ b/changes/2628.feature
@@ -1,0 +1,1 @@
+Add `organization_followee_count` to the get api

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -2,7 +2,6 @@
 
 '''API functions for searching for and getting data from CKAN.'''
 from __future__ import annotations
-from multiprocessing.spawn import is_forking
 
 import uuid
 import logging
@@ -13,7 +12,7 @@ from typing import (Container, Optional,
 
 from ckan.common import config, asbool
 import sqlalchemy
-from sqlalchemy import false, text
+from sqlalchemy import text
 
 
 import ckan
@@ -21,7 +20,6 @@ import ckan.lib.dictization
 import ckan.logic as logic
 import ckan.logic.action
 import ckan.logic.schema
-import ckan.logic.validators as validators
 import ckan.lib.dictization.model_dictize as model_dictize
 import ckan.lib.jobs as jobs
 import ckan.lib.navl.dictization_functions
@@ -2820,7 +2818,7 @@ def group_followee_count(
 
 def organization_followee_count(
         context: Context,
-        data_dict: DataDict) -> ActionResult.GroupFolloweeCount:
+        data_dict: DataDict) -> ActionResult.OrganizationFolloweeCount:
     '''Return the number of organizations that are followed by the given user.
 
     :param id: the id of the user

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -2726,7 +2726,7 @@ def am_following_group(context: Context,
 def _followee_count(
         context: Context, data_dict: DataDict,
         FollowerClass: Type['ModelFollowingModel[Any ,Any]'],
-        is_org: Optional[bool] = False
+        is_org: bool = False
         ) -> int:
     if not context.get('skip_validation'):
         schema = context.get('schema',
@@ -2735,7 +2735,7 @@ def _followee_count(
         if errors:
             raise ValidationError(errors)
     
-    followees = _group_or_org_followee_list(context, data_dict, is_org = is_org)
+    followees = _group_or_org_followee_list(context, data_dict, is_org)
 
     return len(followees)
 

--- a/ckan/model/follower.py
+++ b/ckan/model/follower.py
@@ -63,11 +63,6 @@ class ModelFollowingModel(domain_object.DomainObject,
         return cls.get(follower_id, object_id) is not None
 
     @classmethod
-    def followee_count(cls, follower_id: str) -> int:
-        '''Return the number of objects followed by the follower.'''
-        return cls._get_followees(follower_id).count()
-
-    @classmethod
     def followee_list(cls, follower_id: Optional[str]) -> list[Self]:
         '''Return a list of objects followed by the follower.'''
         query = cls._get_followees(follower_id)
@@ -106,7 +101,8 @@ class ModelFollowingModel(domain_object.DomainObject,
 
     @classmethod
     def _get(
-            cls, follower_id: Optional[str] = None,
+            cls, 
+            follower_id: Optional[str] = None,
             object_id: Optional[str] = None
     ) -> Query[tuple[Self, Follower, Followed]]:
         follower_alias = sqlalchemy.orm.aliased(cls._follower_class())

--- a/ckan/model/follower.py
+++ b/ckan/model/follower.py
@@ -63,6 +63,11 @@ class ModelFollowingModel(domain_object.DomainObject,
         return cls.get(follower_id, object_id) is not None
 
     @classmethod
+    def followee_count(cls, follower_id: str) -> int:
+        '''Return the number of objects followed by the follower.'''
+        return cls._get_followees(follower_id).count()
+
+    @classmethod
     def followee_list(cls, follower_id: Optional[str]) -> list[Self]:
         '''Return a list of objects followed by the follower.'''
         query = cls._get_followees(follower_id)

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -2,7 +2,6 @@
 
 import datetime
 import re
-from ckan.logic.action.get import organization_followee_count
 
 import pytest
 
@@ -2901,7 +2900,8 @@ class TestFollow(object):
 
         assert group_followee_count == 2
         assert organization_followee_count == 1
-        
+
+
 class TestStatusShow(object):
     @pytest.mark.ckan_config("ckan.plugins", "stats")
     @pytest.mark.usefixtures("clean_db", "with_plugins")

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -2,6 +2,7 @@
 
 import datetime
 import re
+from ckan.logic.action.get import organization_followee_count
 
 import pytest
 
@@ -2876,8 +2877,29 @@ class TestFollow(object):
 
         assert len(followee_list) == 1
         assert followee_list[0]["display_name"] == "Environment"
+    
+    def test_followee_count_for_org_or_group(self):
+        group = factories.Group(title="Finance")
+        org = factories.Organization(title="Acme")
 
+        user = factories.User()
 
+        context = {"user": user["name"]}
+
+        helpers.call_action("follow_group", context, id=group["id"])
+        helpers.call_action("follow_group", context, id=org["id"])
+
+        group_followee_count = helpers.call_action(
+            "group_followee_count", context, id=user["name"]
+        )
+
+        organization_followee_count = helpers.call_action(
+            "organization_followee_count", context, id=user["name"]
+        )
+
+        assert group_followee_count == 1
+        assert organization_followee_count == 1
+        
 class TestStatusShow(object):
     @pytest.mark.ckan_config("ckan.plugins", "stats")
     @pytest.mark.usefixtures("clean_db", "with_plugins")

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -2876,7 +2876,7 @@ class TestFollow(object):
 
         assert len(followee_list) == 1
         assert followee_list[0]["display_name"] == "Environment"
-    
+
     def test_followee_count_for_org_or_group(self):
         group = factories.Group(title="Finance")
         group2 = factories.Group(title="Environment")

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -2880,6 +2880,7 @@ class TestFollow(object):
     
     def test_followee_count_for_org_or_group(self):
         group = factories.Group(title="Finance")
+        group2 = factories.Group(title="Environment")
         org = factories.Organization(title="Acme")
 
         user = factories.User()
@@ -2887,6 +2888,7 @@ class TestFollow(object):
         context = {"user": user["name"]}
 
         helpers.call_action("follow_group", context, id=group["id"])
+        helpers.call_action("follow_group", context, id=group2["id"])
         helpers.call_action("follow_group", context, id=org["id"])
 
         group_followee_count = helpers.call_action(
@@ -2897,7 +2899,7 @@ class TestFollow(object):
             "organization_followee_count", context, id=user["name"]
         )
 
-        assert group_followee_count == 1
+        assert group_followee_count == 2
         assert organization_followee_count == 1
         
 class TestStatusShow(object):

--- a/ckan/tests/test_coding_standards.py
+++ b/ckan/tests/test_coding_standards.py
@@ -319,6 +319,7 @@ class TestActionAuth(object):
         "get: dataset_follower_count",
         "get: followee_count",
         "get: group_followee_count",
+        "get: organization_followee_count",
         "get: group_follower_count",
         "get: group_package_show",
         "get: member_list",

--- a/ckan/types/logic/action_result.py
+++ b/ckan/types/logic/action_result.py
@@ -64,6 +64,7 @@ FolloweeCount = int
 UserFolloweeCount = int
 DatasetFolloweeCount = int
 GroupFolloweeCount = int
+OrganizationFolloweeCount = int
 FolloweeList = List[AnyDict]
 UserFolloweeList = List[AnyDict]
 DatasetFolloweeList = List[AnyDict]


### PR DESCRIPTION
Fixes #2628

Rework of #3458

Made separate API action for `organization_followee_count` because the `group_followee_count` returns the sum of orgs and groups

- [x] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [x] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
