### PR TITLE
Update release policy documentation

### DIFF
--- a/doc/_supported_versions.rst
+++ b/doc/_supported_versions.rst
@@ -1,0 +1,6 @@
+.. note::
+    The currently supported CKAN version is |latest_release_version_format| 
+
+    Security and performance fixes are also provided for |previous_release_version_format|.
+
+    Read more about :ref:`officially supported versions <supported_versions>`

--- a/doc/_supported_versions.rst
+++ b/doc/_supported_versions.rst
@@ -1,3 +1,6 @@
+
+.. include:: /_substitutions.rst
+
 .. note::
     The currently supported CKAN version is |latest_release_version_format| 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -124,7 +124,7 @@ release = ckan.__version__
 version_re = None
 point_releases_ = None
 
-SUPPORTED_CKAN_VERSIONS = 3
+SUPPORTED_CKAN_VERSIONS = 2
 
 
 def get_release_tags():
@@ -249,6 +249,23 @@ def get_current_release_version():
     return version
 
 
+def get_previous_release_version() -> str:
+    """Returns the version number of the previous release
+
+    eg if the latest release is 2.9.5, it returns 2.8.10
+
+    """
+    current_version = parse_version(get_current_release_version())
+
+    previous_tag_prefix = f"ckan-{current_version[0]}.{int(current_version[1]) - 1}"
+
+    previous_version_tags = [
+        r for r in get_release_tags() if r.startswith(previous_tag_prefix)
+    ]
+    previous_release_version = previous_version_tags[-1][len("ckan-"):]
+    return previous_release_version
+
+
 def get_latest_package_name(distro, py_version=None):
     '''Return the filename of the Ubuntu package for the latest stable release.
 
@@ -351,6 +368,7 @@ def write_substitutions_file(**kwargs):
 
 current_release_tag_value = get_current_release_tag()
 current_release_version = get_current_release_version()
+previous_release_version = get_previous_release_version()
 current_minor_version = current_release_version[:current_release_version.find(".", 3)]
 latest_release_tag_value = get_latest_release_tag()
 latest_release_version = get_latest_release_version()
@@ -362,6 +380,7 @@ is_latest_version = version == latest_release_version
 write_substitutions_file(
     current_release_tag=current_release_tag_value,
     current_release_version=current_release_version,
+    previous_release_version=previous_release_version,
     current_minor_version=current_minor_version,
     latest_release_tag=latest_release_tag_value,
     latest_release_version=latest_release_version,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -369,9 +369,11 @@ def write_substitutions_file(**kwargs):
 current_release_tag_value = get_current_release_tag()
 current_release_version = get_current_release_version()
 previous_release_version = get_previous_release_version()
+previous_release_version_format = f"**CKAN {previous_release_version}**"
 current_minor_version = current_release_version[:current_release_version.find(".", 3)]
 latest_release_tag_value = get_latest_release_tag()
 latest_release_version = get_latest_release_version()
+latest_release_version_format = f"**CKAN {latest_release_version}**"
 latest_minor_version = latest_release_version[:latest_release_version.find(".", 3)]
 is_master = "a" in release.split(".")[-1]
 is_supported = get_status_of_this_version() == 'supported'
@@ -381,9 +383,11 @@ write_substitutions_file(
     current_release_tag=current_release_tag_value,
     current_release_version=current_release_version,
     previous_release_version=previous_release_version,
+    previous_release_version_format=previous_release_version_format,
     current_minor_version=current_minor_version,
     latest_release_tag=latest_release_tag_value,
     latest_release_version=latest_release_version,
+    latest_release_version_format=latest_release_version_format,
     latest_package_name_bionic=get_latest_package_name('bionic'),
     latest_package_name_focal_py2=get_latest_package_name('focal', py_version=2),
     latest_package_name_focal_py3=get_latest_package_name('focal', py_version=3),

--- a/doc/maintaining/index.rst
+++ b/doc/maintaining/index.rst
@@ -8,6 +8,7 @@ installing, upgrading and configuring CKAN and its features and extensions.
 .. toctree::
    :maxdepth: 1
 
+   releases
    installing/index
    upgrading/index
    getting-started

--- a/doc/maintaining/installing/index.rst
+++ b/doc/maintaining/installing/index.rst
@@ -1,6 +1,11 @@
+
+.. include:: /_substitutions.rst
+
 ---------------
 Installing CKAN
 ---------------
+
+.. include:: /_supported_versions.rst
 
 Before you can use CKAN on your own computer, you need to install it.
 There are three ways to install CKAN:

--- a/doc/maintaining/installing/index.rst
+++ b/doc/maintaining/installing/index.rst
@@ -1,6 +1,3 @@
-
-.. include:: /_substitutions.rst
-
 ---------------
 Installing CKAN
 ---------------

--- a/doc/maintaining/releases.rst
+++ b/doc/maintaining/releases.rst
@@ -1,0 +1,103 @@
+.. include:: /_substitutions.rst
+
+.. _releases:
+
+=============
+CKAN releases
+=============
+
+This document describes the different types of CKAN releases, and explains which
+releases are officially supported at any given time.
+
+.. note::
+    The currently supported CKAN version is CKAN |latest_release_version| 
+
+    Security and performance fixes are also provided for CKAN |previous_release_version|.
+
+    Read more about :ref:`officially supported versions <supported_versions>`
+
+
+-------------
+Release types
+-------------
+
+CKAN follows a predictable release cycle so that users can depend on stable
+releases of CKAN, and can plan their upgrades to new releases.
+
+Each release has a version number of the form ``M.m`` (eg. 2.1) or ``M.m.p``
+(eg. 1.8.2), where ``M`` is the **major version**, ``m`` is the **minor
+version** and ``p`` is the **patch version** number. There are three types of
+release:
+
+Major Releases
+ Major releases, such as CKAN 1.0 and CKAN 2.0, increment the major version
+ number.  These releases contain major changes in the CKAN code base, with
+ significant refactorings and breaking changes, for instance in the API or the
+ templates.  These releases are very infrequent.
+
+Minor Releases
+ Minor releases, such as CKAN 2.9 and CKAN 2.10, increment the minor version
+ number. These releases are not as disruptive as major releases, but the will
+ *may* include some backwards-incompatible changes. The
+ :doc:`/changelog` will document any breaking changes. We aim to release a minor
+ version of CKAN roughly twice a year.
+
+Patch Releases
+  Patch releases, such as CKAN 2.9.5 or CKAN 2.10.1, increment the patch version
+  number. These releases do not break backwards-compatibility, they include
+  only bug fixes for security and performance issues.
+  Patch releases do not contain:
+
+  - Database schema changes or migrations (unless addressing security issues)
+  - Solr schema changes
+  - Function interface changes
+  - Plugin interface changes
+  - New dependencies (unless addressing security issues)
+  - Big refactorings or new features in critical parts of the code
+
+.. note::
+
+
+   Outdated patch releases will no longer be supported after a newer patch
+   release has been released. For example once CKAN 2.9.2 has been released,
+   CKAN 2.9.1 will no longer be supported.
+
+Releases are announced on the
+`ckan-announce mailing list <https://groups.google.com/a/ckan.org/g/ckan-announce>`_,
+a low-volume list that CKAN instance maintainers can subscribe to in order to
+be up to date with upcoming releases.
+
+
+.. _supported_versions:
+
+------------------
+Supported versions
+------------------
+
+At any one time, the CKAN Tech Team will support the latest patch release of the last
+released minor version plus the last patch release of the previous minor version.
+
+The previous minor version will only receive security and bug fixes. If a patch does not clearly
+fit in these categories, it is up to the maintainers to decide if it can be backported to a previous version.
+
+The latest patch releases are the only ones officially supported. Users should always run the
+latest patch release for the minor release they are on, as they contain important bug fixes and security updates.
+Running CKAN in an unsupported version puts your site and data at risk.
+
+Because patch releases don't include backwards incompatible changes, the
+upgrade process (as described in :doc:`upgrading/upgrade-package-to-patch-release`)
+should be straightforward.
+
+Extension maintainers can decide at their discretion to support older CKAN versions.
+
+
+.. seealso::
+
+   :doc:`/changelog`
+     The changelog lists all CKAN releases and the main changes introduced in
+     each release.
+
+   :doc:`/contributing/release-process`
+     Documentation of the process that the CKAN developers follow to do a
+     CKAN release.
+

--- a/doc/maintaining/releases.rst
+++ b/doc/maintaining/releases.rst
@@ -9,13 +9,7 @@ CKAN releases
 This document describes the different types of CKAN releases, and explains which
 releases are officially supported at any given time.
 
-.. note::
-    The currently supported CKAN version is CKAN |latest_release_version| 
-
-    Security and performance fixes are also provided for CKAN |previous_release_version|.
-
-    Read more about :ref:`officially supported versions <supported_versions>`
-
+.. include:: /_supported_versions.rst
 
 -------------
 Release types

--- a/doc/maintaining/releases.rst
+++ b/doc/maintaining/releases.rst
@@ -1,4 +1,3 @@
-.. include:: /_substitutions.rst
 
 .. _releases:
 

--- a/doc/maintaining/upgrading/index.rst
+++ b/doc/maintaining/upgrading/index.rst
@@ -1,11 +1,19 @@
+.. include:: /_substitutions.rst
+
+.. _upgrading:
+
 ==============
 Upgrading CKAN
 ==============
 
-This document describes the different types of CKAN release, and explains
-how to upgrade a site to a newer version of CKAN.
+This document explains how to upgrade a site to a newer version of CKAN. It will
+walk you through the steps to upgrade your CKAN site to a newer version of CKAN.
 
 .. seealso::
+
+   :doc:`/maintaining/releases`
+     Information about the different CKAN releases and the officially supported
+     versions.
 
    :doc:`/changelog`
      The changelog lists all CKAN releases and the main changes introduced in
@@ -14,73 +22,6 @@ how to upgrade a site to a newer version of CKAN.
    :doc:`/contributing/release-process`
      Documentation of the process that the CKAN developers follow to do a
      CKAN release.
-
-
-.. _releases:
-
--------------
-CKAN releases
--------------
-
-CKAN follows a predictable release cycle so that users can depend on stable
-releases of CKAN, and can plan their upgrades to new releases.
-
-Each release has a version number of the form ``M.m`` (eg. 2.1) or ``M.m.p``
-(eg. 1.8.2), where ``M`` is the **major version**, ``m`` is the **minor
-version** and ``p`` is the **patch version** number. There are three types of
-release:
-
-Major Releases
- Major releases, such as CKAN 1.0 and CKAN 2.0, increment the major version
- number.  These releases contain major changes in the CKAN code base, with
- significant refactorings and breaking changes, for instance in the API or the
- templates.  These releases are very infrequent.
-
-Minor Releases
- Minor releases, such as CKAN 1.8 and CKAN 2.1, increment the minor version
- number. These releases are not as disruptive as major releases, but
- backwards-incompatible changes *may* be introduced in minor releases. The
- :doc:`/changelog` will document any breaking changes. We aim to release a minor
- version of CKAN roughly every three months.
-
-Patch Releases
-  Patch releases, such as CKAN 1.8.1 or CKAN 2.0.1, increment the patch version
-  number. These releases do not break backwards-compatibility, they include
-  only bug fixes and security fixes, ensured to be non-breaking.
-  Patch releases do not contain:
-
-  - Database schema changes or migrations
-  - Function interface changes
-  - Plugin interface changes
-  - New dependencies (unless absolutely necessary)
-  - Big refactorings or new features in critical parts of the code
-
-.. note::
-
-   Users should always run the latest patch release for the minor release they
-   are on, as patch releases contain important bug fixes and security updates.
-   Because patch releases don't include backwards incompatible changes, the
-   upgrade process (as described in :doc:`upgrade-package-to-patch-release`)
-   should be straightforward.
-
-   Outdated patch releases will no longer be supported after a newer patch
-   release has been released. For example once CKAN 2.0.2 has been released,
-   CKAN 2.0.1 will no longer be supported.
-
-Releases are announced on the
-`ckan-announce mailing list <https://groups.google.com/a/ckan.org/g/ckan-announce>`_,
-a low-volume list that CKAN instance maintainers can subscribe to in order to
-be up to date with upcoming releases.
-
-
-.. _upgrading:
-
---------------
-Upgrading CKAN
---------------
-
-This section will walk you through the steps to upgrade your CKAN site to a
-newer version of CKAN.
 
 .. note::
 

--- a/doc/maintaining/upgrading/index.rst
+++ b/doc/maintaining/upgrading/index.rst
@@ -9,50 +9,22 @@ Upgrading CKAN
 This document explains how to upgrade a site to a newer version of CKAN. It will
 walk you through the steps to upgrade your CKAN site to a newer version of CKAN.
 
-.. seealso::
-
-   :doc:`/maintaining/releases`
-     Information about the different CKAN releases and the officially supported
-     versions.
-
-   :doc:`/changelog`
-     The changelog lists all CKAN releases and the main changes introduced in
-     each release.
-
-   :doc:`/contributing/release-process`
-     Documentation of the process that the CKAN developers follow to do a
-     CKAN release.
-
 .. include:: /_supported_versions.rst
 
-.. note::
+1. Prepare the upgrade
+======================
 
-    Before upgrading your version of CKAN you should check that any custom
-    templates or extensions you're using work with the new version of CKAN.
-    For example, you could install the new version of CKAN in a new virtual
-    environment and use that to test your templates and extensions.
+*  Before upgrading your version of CKAN you should check that any custom
+   templates or extensions you're using work with the new version of CKAN.
+   For example, you could install the new version of CKAN in a new virtual
+   environment and use that to test your templates and extensions.
 
-.. note::
+* You should also read the :doc:`/changelog` to see if there are any extra
+  notes to be aware of when upgrading to the new version.
 
-    You should also read the :doc:`/changelog` to see if there are any extra
-    notes to be aware of when upgrading to the new version.
-
-
-1. Backup your database
-=======================
-
-You should always backup your CKAN database before upgrading CKAN. If something
-goes wrong with the CKAN upgrade you can use the backup to restore the database
-to its pre-upgrade state.
-
-#. Activate your virtualenv and switch to the ckan source directory, e.g.:
-
-   .. parsed-literal::
-
-    |activate|
-    cd |virtualenv|/src/ckan
-
-#. :ref:`Backup your CKAN database <db dumping and loading>`
+.. warning:: You should always **backup your CKAN database** before upgrading CKAN. If something
+   goes wrong with the CKAN upgrade you can use the backup to restore the database
+   to its pre-upgrade state. See :ref:`Backup your CKAN database <db dumping and loading>`
 
 
 2. Upgrade CKAN
@@ -72,3 +44,18 @@ appropriate one of these documents:
     upgrade-source
     upgrade-postgres
     upgrade-to-python3
+
+
+.. seealso::
+
+   :doc:`/maintaining/releases`
+     Information about the different CKAN releases and the officially supported
+     versions.
+
+   :doc:`/changelog`
+     The changelog lists all CKAN releases and the main changes introduced in
+     each release.
+
+   :doc:`/contributing/release-process`
+     Documentation of the process that the CKAN developers follow to do a
+     CKAN release.

--- a/doc/maintaining/upgrading/index.rst
+++ b/doc/maintaining/upgrading/index.rst
@@ -23,6 +23,8 @@ walk you through the steps to upgrade your CKAN site to a newer version of CKAN.
      Documentation of the process that the CKAN developers follow to do a
      CKAN release.
 
+.. include:: /_supported_versions.rst
+
 .. note::
 
     Before upgrading your version of CKAN you should check that any custom

--- a/doc/maintaining/upgrading/index.rst
+++ b/doc/maintaining/upgrading/index.rst
@@ -1,4 +1,3 @@
-.. include:: /_substitutions.rst
 
 .. _upgrading:
 


### PR DESCRIPTION
I made some changes to the documentation to hopefully make clear what versions are supported and which aren't and reflect recent changes in number of old versions supported.

On this PR:

* Move release information to its own dedicated page.
* Highlight the actual latest patch release on the top of the releases page (and potentially the install / upgrade pages). I think it's important that we are clear in that "we support 2.9.5" instead of "we support 2.9"
* Limit supported versions to just current minor plus a previous one.(so currently 2.9 and 2.8)
* **Update**: Added the supported versions box to the install and upgrade pages as well

Here's how the changes look in RTD: http://docs.ckan.org/en/update-release-docs/maintaining/releases.html
(**note**: Looks like RTD is struggling today so I added screenshots of the most relevant parts below.)

Apart from the documentation changes, I'll like to write a blog post explaining the policy and describing specifically what happens to each version. I'll share the draft before publishing but here are my proposed points:

* Going forward we will support only one previous minor version (so 2.9 and 2.8 now, 2.10 and 2.9 once 2.10 is out)
* Use the latest patch release!
* We no longer support 2.7
* For 2.8 we can decide, either we stick to the policy and stop supporting it when 2.10 is out (realistically end of summer / fall) or we extend 2.8 support a bit until the end of the year (1, maybe 2 more patch releases)
* Python 2.7 support for CKAN 2.9 dropped at the end of the year (TODO discuss)

----

![Screenshot 2022-07-26 at 12-22-33 CKAN releases — CKAN 2 10 0a0 documentation](https://user-images.githubusercontent.com/200230/180984060-fb10788b-a56a-405f-b678-1f0fe50e6c62.png)


![Screenshot 2022-07-21 at 13-29-37 CKAN releases — CKAN 2 10 0a0 documentation](https://user-images.githubusercontent.com/200230/180206582-74a601c9-e2af-4161-aa15-63926a15ec27.png)


