### PR TITLE
Show resource tag on dataset homepage

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -10,6 +10,7 @@ import re
 import datetime
 from socket import error as socket_error
 from typing import Any, Union, cast
+from ckan.lib.helpers import resource_formats
 
 import six
 
@@ -303,7 +304,16 @@ def resource_create(context: Context,
     if 'size' not in data_dict:
         if hasattr(upload, 'filesize'):
             data_dict['size'] = upload.filesize
-
+   
+    if 'format' not in data_dict:
+        # Get resource formats from ckan/config/resource_formats.json file.
+        RESOURCE_FORMATS = resource_formats() 
+        file_format = data_dict['url'].split('.')[-1]
+        if file_format in RESOURCE_FORMATS:
+            data_dict['format'] = file_format
+        else:
+            data_dict['format'] = ''
+            
     pkg_dict['resources'].append(data_dict)
 
     try:


### PR DESCRIPTION
Fixes #6706 

### Proposed fixes:
- Show the tag of a resource on dataset homepage when a resource is uploaded with a custom resource id by `resource_create` API call.
> Note: This PR fixes the first part of the issue #6706 
>> - If a resource id is given in the call to resource_create, the resource file (in this case a json file) is uploaded and can be clicked on to view, but no red "JSON" tag appears against the dataset.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
