### PR TITLE
Revert #6954 (checking for a null session)

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -10,7 +10,7 @@ import pkgutil
 import logging
 
 from logging.handlers import SMTPHandler
-from typing import Any, Iterable, Optional, Union, cast, Dict
+from typing import Any, Iterable, Optional, Union, cast
 
 from flask import Blueprint, send_from_directory
 from flask.ctx import _AppCtxGlobals
@@ -122,20 +122,6 @@ class BeakerSessionInterface(SessionInterface):
 
     def save_session(self, app: Any, session: Any, response: Any):
         session.save()
-
-    def is_null_session(self, obj: Dict[str, Any]) -> bool:
-
-        is_null = super(BeakerSessionInterface, self).is_null_session(obj)
-
-        if not is_null:
-            # Beaker always adds these keys on each request, so if these are
-            # the only keys present we assume it's an empty session
-            is_null = (
-                sorted(obj.keys()) == [
-                    "_accessed_time", "_creation_time", "_domain", "_path"]
-            )
-
-        return is_null
 
 
 def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:

--- a/ckan/tests/config/test_middleware.py
+++ b/ckan/tests/config/test_middleware.py
@@ -76,20 +76,3 @@ def test_no_beaker_secret_crashes(make_app):
     # RuntimeError instead (thrown on `make_flask_stack`)
     with pytest.raises(RuntimeError):
         make_app()
-
-
-def test_no_session_stored_by_default(app, monkeypatch, test_request_context):
-
-    save_session_mock = mock.Mock()
-
-    class CustomBeakerSessionInterface(BeakerSessionInterface):
-
-        save_session = save_session_mock
-
-    monkeypatch.setattr(
-        app.flask_app, 'session_interface', CustomBeakerSessionInterface())
-
-    with test_request_context():
-        app.get("/")
-
-    save_session_mock.assert_not_called()

--- a/ckan/tests/config/test_middleware.py
+++ b/ckan/tests/config/test_middleware.py
@@ -1,9 +1,7 @@
 # encoding: utf-8
 
 import pytest
-from unittest import mock
 from flask import Blueprint
-from ckan.config.middleware.flask_app import BeakerSessionInterface
 
 import ckan.plugins as p
 from ckan.common import config, _


### PR DESCRIPTION
In #6954 we added a custom check at the end of each request to decide whether a session was null or not at then end of a request, to avoid storing unneeded session files (Beaker always adds some keys to the session regardless of whethere something is actually stored in it by the app). With the CSRF protection implemented (#6863), the CSRF Flask plugin always add a `_csrf_token` to the session so we do actually need to store it.

The original issue described in #6954 was problematic because it meant that session files were created on each different request, regardless of the user. However, this does not happen in CKAN 2.10, probably because of better user session management by Flask login, so we get the expected result: session files are stored per user (or rather visitor or browser session, as they are also stored on anonymous requests)

So to sum up, with the CSRF protection turned on (the default), we'll get a session file (or db/redis record depending on your backend) per browser session which I think that's reasonable.
In CKAN 2.9 we still need the patch because otherwise session files are created for each request.
