### PR TITLE
Added `ckan.record_private_activity` check for private package activi…

### DIFF
--- a/changes/7018.feature
+++ b/changes/7018.feature
@@ -1,0 +1,1 @@
+Added `ckan.record_private_activity` config to allow for private package activity streams

--- a/ckanext/activity/subscriptions.py
+++ b/ckanext/activity/subscriptions.py
@@ -93,7 +93,7 @@ def package_changed(sender: str, **kwargs: Any):
     pkg = context["model"].Package.get(id_)
     assert pkg
 
-    if pkg.private:
+    if pkg.private and not tk.config.get('ckan.record_private_activity', False):
         return
 
     user_obj = context["model"].User.get(context["user"])


### PR DESCRIPTION
…ty stream item creations.

Fixes #

Add config check to allow users to record package activity streams for private packages. Still does not create activity stream items by default.

### Proposed fixes:

This feature could be patched back into version 2.9, into the `logic.actions.(update | create | delete)`

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
