### PR TITLE
Added `organization_show` action call into loop of orgs for the retur…

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -743,7 +743,12 @@ def organization_list_for_user(context: Context,
     context['with_capacity'] = True
     orgs_list = model_dictize.group_list_dictize(orgs_and_capacities, context,
         with_package_counts=asbool(data_dict.get('include_dataset_count')))
-    return orgs_list
+    return_list = []
+    for org in orgs_list:
+        return_list.append(logic.get_action('organization_show')(
+                                context,
+                                {'id': org['id']}))
+    return return_list
 
 
 def license_list(context: Context, data_dict: DataDict) -> ActionResult.LicenseList:
@@ -2746,7 +2751,7 @@ def _followee_count(
         data_dict, errors = _validate(data_dict, schema, context)
         if errors:
             raise ValidationError(errors)
-    
+
     followees = _group_or_org_followee_list(context, data_dict, is_org)
 
     return len(followees)


### PR DESCRIPTION
…n of `organization_list_for_user` action.

Fixes #

`organization_list_for_user` action does not return processed org schemas.

### Proposed fixes:

Implement reusable code to process org/group schemas (such as shown in `_group_or_org_show`)?

Basically we do not wish to have the `organization_list_for_user` action do DB executions on the group table, and then loop through the orgs to just redo very similar DB executions on the same table.

Doing this on the dictization level does not really allow for schema integration. Nor would it easily be able to implement the `IOrganizationController.read` and `IGroupController.read`.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
