### PR TITLE
[#7031] prepare_dataset_blueprint: support dataset type

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -531,7 +531,7 @@ def _register_core_blueprints(app: CKANApp):
     u'''Register all blueprints defined in the `views` folder
     '''
     def is_blueprint(mm: Any):
-        return isinstance(mm, Blueprint)
+        return isinstance(mm, Blueprint) and getattr(mm, 'auto_register', True)
 
     path = os.path.join(os.path.dirname(__file__), '..', '..', 'views')
 

--- a/ckan/lib/plugins.py
+++ b/ckan/lib/plugins.py
@@ -135,16 +135,16 @@ def register_package_blueprints(app: 'CKANFlask') -> None:
     from ckan.views.dataset import dataset, register_dataset_plugin_rules
     from ckan.views.resource import resource, register_dataset_plugin_rules as dataset_resource_rules
 
+    registered_dataset = False
+
     # Create the mappings and register the fallback behaviour if one is found.
     for plugin in plugins.PluginImplementations(plugins.IDatasetForm):
         for package_type in plugin.package_types():
 
-            if package_type == u'dataset':
-                # The default routes are registered with the core
-                # 'dataset' blueprint
-                continue
+            if package_type == 'dataset':
+                registered_dataset = True
 
-            elif package_type in app.blueprints:
+            if package_type in app.blueprints:
                 raise ValueError(
                     'A blueprint for has already been associated for the '
                     'package type {}'.format(package_type))
@@ -180,6 +180,11 @@ def register_package_blueprints(app: 'CKANFlask') -> None:
             log.debug(
                 'Registered blueprints for custom dataset type \'{}\''.format(
                     package_type))
+
+    if not registered_dataset:
+        # core dataset blueprint not overridden
+        app.register_blueprint(dataset)
+        app.register_blueprint(resource)
 
 
 def set_default_package_plugin() -> None:

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -1244,3 +1244,4 @@ def register_dataset_plugin_rules(blueprint: Blueprint):
 
 
 register_dataset_plugin_rules(dataset)
+dataset.auto_register = False

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -812,3 +812,4 @@ def register_dataset_plugin_rules(blueprint: Blueprint) -> None:
 
 register_dataset_plugin_rules(resource)
 register_dataset_plugin_rules(prefixed_resource)
+resource.auto_register = False


### PR DESCRIPTION
Fixes #7031

### Proposed fixes:
Delay registering dataset and resource blueprints until after plugins have had a chance to override them

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport