### PR TITLE
datastore_search: new include_primary_key parameter to report primary…

### DIFF
--- a/changes/7034.feature
+++ b/changes/7034.feature
@@ -1,0 +1,1 @@
+datastore_search: new include_primary_key parameter to report primary keys (default false)

--- a/ckanext/datastore/logic/schema.py
+++ b/ckanext/datastore/logic/schema.py
@@ -193,7 +193,8 @@ def datastore_search_schema() -> Schema:
             one_of([u'objects', u'lists', u'csv', u'tsv'])],
         '__junk': [empty],
         '__before': [rename('id', 'resource_id')],
-        'full_text': [ignore_missing, unicode_safe]
+        'full_text': [ignore_missing, unicode_safe],
+        'include_primary_key': [ignore_missing, default(False), boolean_validator],
     }
     return schema
 


### PR DESCRIPTION
Fixes #7034 

### Proposed fixes:
Add a new optional `include_primary_key` parameter to `datastore_search` that will return the primary key(s) for the table when set to True (defaults to False)


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport