### PR TITLE
Modified the default `sort_key` callable for `group_list_dictize` to …

### DIFF
--- a/changes/7039.bugfix
+++ b/changes/7039.bugfix
@@ -1,0 +1,1 @@
+Changed default sort key for group and user lists from ASCII Alphebitized to new `strxfrm` helper, resulting in human-readable alphebitization.

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -532,7 +532,7 @@ def tag_dictize(tag: model.Tag, context: Context,
 def user_list_dictize(
         obj_list: Union[list[model.User], list[tuple[model.User, str]]],
         context: Context,
-        sort_key: Callable[[Any], Any] = lambda x:x['name'],
+        sort_key: Callable[[Any], Any] = lambda x: x['name'].lower(),
         reverse: bool=False) -> list[dict[str, Any]]:
 
     result_list = []

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -43,7 +43,7 @@ def group_list_dictize(
         obj_list: Union[Iterable[model.Group],
                         Iterable[tuple[model.Group, str]]],
         context: Context,
-        sort_key: Callable[..., Any]=lambda x: x['display_name'].lower(), reverse: bool=False,
+        sort_key: Callable[..., Any]=lambda x: h.strxfrm(x['display_name']), reverse: bool=False,
         with_package_counts: bool=True,
         include_groups: bool=False,
         include_tags: bool=False,
@@ -532,7 +532,7 @@ def tag_dictize(tag: model.Tag, context: Context,
 def user_list_dictize(
         obj_list: Union[list[model.User], list[tuple[model.User, str]]],
         context: Context,
-        sort_key: Callable[[Any], Any] = lambda x: x['name'].lower(),
+        sort_key: Callable[[Any], Any] = lambda x: h.strxfrm(x['name']),
         reverse: bool=False) -> list[dict[str, Any]]:
 
     result_list = []

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -43,7 +43,7 @@ def group_list_dictize(
         obj_list: Union[Iterable[model.Group],
                         Iterable[tuple[model.Group, str]]],
         context: Context,
-        sort_key: Callable[..., Any]=lambda x: x['display_name'], reverse: bool=False,
+        sort_key: Callable[..., Any]=lambda x: x['display_name'].lower(), reverse: bool=False,
         with_package_counts: bool=True,
         include_groups: bool=False,
         include_tags: bool=False,

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -18,6 +18,7 @@ import pprint
 import copy
 import uuid
 import functools
+import unicodedata
 
 from collections import defaultdict
 from typing import (
@@ -662,6 +663,15 @@ def current_url() -> str:
 def lang() -> Optional[str]:
     ''' Return the language code for the current locale eg `en` '''
     return request.environ.get('CKAN_LANG')
+
+
+@core_helper
+def strxfrm(s: str) -> str:
+    '''
+    Transform a string to one that can be used in locale-aware comparisons.
+    Override this helper if you have different text sorting needs.
+    '''
+    return unicodedata.normalize('NFD', s).lower()
 
 
 @core_helper


### PR DESCRIPTION
…not be ASCIIbetical, matching the sorting coming from the db queries elsewhere.

Fixes #

Used `lower()` call in the `sort_key` default callable in `group_list_dictize`. Python sort/sorted is ASCIIbetical, whereas the db queries are purely alphabetical. This change makes sure that the `group_list_dictize` sorting matches the db query sorting.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
