### PR TITLE
change test usernames so they don't conflict

### DIFF
--- a/ckan/tests/controllers/test_group.py
+++ b/ckan/tests/controllers/test_group.py
@@ -367,13 +367,13 @@ class TestGroupMembership(object):
         user_obj = model.User.get(user["name"])
         # mock current_user
         current_user.return_value = user_obj
-        factories.User(fullname="My Fullname", name="my-user")
+        factories.User(fullname="My Fullname", name="my-new-user")
         group = self._create_group(user["name"])
 
         url = url_for("group.member_new", id=group["name"])
         add_response = app.post(
             url,
-            data={"save": "", "username": "my-user", "role": "member"},
+            data={"save": "", "username": "my-new-user", "role": "member"},
         )
 
         assert "2 members" in add_response.body
@@ -434,7 +434,6 @@ class TestGroupMembership(object):
         assert role_option and role_option.get('value') == 'admin'
         assert page.select_one('#username').get('value') == member['name']
 
-    @pytest.mark.usefixtures("clean_db")
     @mock.patch("flask_login.utils._get_user")
     def test_admin_add(self, current_user, app):
         """Admin can be added via add member page"""
@@ -442,13 +441,13 @@ class TestGroupMembership(object):
         user_obj = model.User.get(owner["name"])
         # mock current_user
         current_user.return_value = user_obj
-        factories.User(fullname="My Fullname", name="my-user")
+        factories.User(fullname="My Fullname", name="my-admin-user")
         group = self._create_group(owner["name"])
 
         url = url_for("group.member_new", id=group["name"])
         add_response = app.post(
             url,
-            data={"save": "", "username": "my-user", "role": "admin"},
+            data={"save": "", "username": "my-admin-user", "role": "admin"},
         )
 
         assert "2 members" in add_response

--- a/ckan/tests/controllers/test_group.py
+++ b/ckan/tests/controllers/test_group.py
@@ -434,6 +434,7 @@ class TestGroupMembership(object):
         assert role_option and role_option.get('value') == 'admin'
         assert page.select_one('#username').get('value') == member['name']
 
+    @pytest.mark.usefixtures("clean_db")
     @mock.patch("flask_login.utils._get_user")
     def test_admin_add(self, current_user, app):
         """Admin can be added via add member page"""


### PR DESCRIPTION
Fixes #7036

### Proposed fixes:

Use distinct usernames in different group membership tests, so we don't get validation errors and don't need to reset the whole db before each test.
