### PR TITLE
wrap field label in a block for datatablesview

### DIFF
--- a/ckanext/datatablesview/templates/datatables/datatables_form.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_form.html
@@ -56,7 +56,11 @@
             {{ 'checked' if 'show_fields' not in data else
               'checked' if f.id in data.show_fields else '' }}
             />{{ f.id }}</label></td>
-          <td>{{ f.get('info', {}).label }}</td>
+          <td>
+            {%- block dict_field_label scoped -%}
+              {{ f.get('info', {}).label }}
+            {%- endblock -%}
+          </td>
         </tr>
       {% endfor %}
     </table>


### PR DESCRIPTION
Fixes #

### Proposed fixes:

- Wrap field label in a block for the datatables form to allow override by other extensions. An example for a usecase is a multilingual website that wants to render language specific field labels


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
