### PR TITLE
Added `list-orphans` and `clear-orphans` sub-commands to the `search-…

### DIFF
--- a/changes/7044.feature
+++ b/changes/7044.feature
@@ -1,0 +1,5 @@
+Added `list-orphans` and `clear-orphans` sub-commands to the `search-index` command.
+
+`list-orphans` will list all public package IDs which exist in the solr index, but do not exist in the database.
+
+`clear-orphans` will clear the search index for all the public orphaned packages.

--- a/ckan/cli/search_index.py
+++ b/ckan/cli/search_index.py
@@ -77,6 +77,43 @@ def clear(dataset_name: str):
         clear_all()
 
 
+def list_orphans(return_list: bool=False) -> list|None:
+    import ckan.logic as logic
+    search = logic.get_action('package_search')({},{
+                'q': '*:*',
+                'fl': 'id'})
+    indexed_package_ids = {r['id'] for r in search['results']}
+
+    import ckan.model as model
+    from sqlalchemy.sql import select
+    package_ids = {r[0] for r in select([model.package_table.c['id']]).execute()}
+
+    orphaned_package_ids = []
+    for indexed_package_id in indexed_package_ids:
+        if indexed_package_id not in package_ids:
+            orphaned_package_ids.append(indexed_package_id)
+
+    if return_list:
+        return orphaned_package_ids
+    from pprint import pprint
+    pprint(orphaned_package_ids)
+
+
+@search_index.command(name=u'list-orphans', short_help=u'Lists any non-existant packages in the search index')
+def list_orphans_command():
+    return list_orphans()
+
+
+@search_index.command(name=u'clear-orphans', short_help=u'Clear any non-existant packages in the search index')
+@click.option(u'-v', u'--verbose', is_flag=True)
+def clear_orphans(verbose: bool=False):
+    from ckan.lib.search import clear
+    for orphaned_package_id in list_orphans(return_list=True):
+        if verbose:
+            print("Clearing search index for dataset %s..." % orphaned_package_id)
+        clear(orphaned_package_id)
+
+
 @search_index.command(name=u'rebuild-fast',
                       short_help=u'Reindex with multiprocessing')
 def rebuild_fast():

--- a/ckan/cli/search_index.py
+++ b/ckan/cli/search_index.py
@@ -83,7 +83,7 @@ def get_orphans() -> list[str]:
     search = None
     indexed_package_ids = []
     while search is None or len(indexed_package_ids) < search['count']:
-        search = logic.get_action('package_search')({},{
+        search = logic.get_action('package_search')({}, {
                 'q': '*:*',
                 'fl': 'id',
                 'start': len(indexed_package_ids),
@@ -101,20 +101,30 @@ def get_orphans() -> list[str]:
     return orphaned_package_ids
 
 
-@search_index.command(name=u'list-orphans', short_help=u'Lists any non-existant packages in the search index')
+@search_index.command(
+    name=u'list-orphans',
+    short_help=u'Lists any non-existant packages in the search index'
+)
 def list_orphans_command():
     orphaned_package_ids = get_orphans()
     if len(orphaned_package_ids):
         click.echo(orphaned_package_ids)
-    click.echo("Found {} orphaned package(s).".format(len(orphaned_package_ids)))
+    click.echo("Found {} orphaned package(s).".format(
+        len(orphaned_package_ids)
+    ))
 
 
-@search_index.command(name=u'clear-orphans', short_help=u'Clear any non-existant packages in the search index')
+@search_index.command(
+    name=u'clear-orphans',
+    short_help=u'Clear any non-existant packages in the search index'
+)
 @click.option(u'-v', u'--verbose', is_flag=True)
-def clear_orphans(verbose: bool=False):
+def clear_orphans(verbose: bool = False):
     for orphaned_package_id in get_orphans():
         if verbose:
-            print("Clearing search index for dataset %s..." % orphaned_package_id)
+            click.echo("Clearing search index for dataset {}...".format(
+                orphaned_package_id
+            ))
         clear(orphaned_package_id)
 
 


### PR DESCRIPTION
…index` command.

Fixes #

Adds sub-commands to `search-index` to list and clear any orphaned package indexes.

### Background info:

We ran into an issue in which there were some left-over packages in the solr index, despite that the packages were purged from the database. So we had a report of a few packages not existing but still coming up in the searches due to the solr index. We had to just run `ckan search-index clear DATASET_ID` on each one. So this sparked adding these simple cli sub-commands to deal with this issue if it happens for others.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
