### PR TITLE
add auth functions for 17 actions that didn't have them before

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -183,6 +183,7 @@ def member_list(context, data_dict=None):
     :raises: :class:`ckan.logic.NotFound`: if the group doesn't exist
 
     '''
+    _check_access('member_list', context, data_dict)
     model = context['model']
 
     group = model.Group.get(_get_or_bust(data_dict, 'id'))
@@ -1302,6 +1303,7 @@ def group_package_show(context, data_dict):
     :rtype: list of dictionaries
 
     '''
+    _check_access('group_package_show', context, data_dict)
 
     model = context['model']
     group_id = _get_or_bust(data_dict, 'id')
@@ -2033,6 +2035,7 @@ def resource_search(context, data_dict):
     :rtype: dict
 
     '''
+    _check_access('resource_search', context, data_dict)
     model = context['model']
 
     # Allow either the `query` or `fields` parameter to be given, but not both.
@@ -2239,6 +2242,7 @@ def tag_search(context, data_dict):
     :rtype: dictionary
 
     '''
+    _check_access('tag_search', context, data_dict)
     tags, count = _tag_search(context, data_dict)
     return {'count': count,
             'results': [_table_dictize(tag, context) for tag in tags]}
@@ -2336,6 +2340,7 @@ def term_translation_show(context, data_dict):
         (the translation of the term into the target language) and
         ``'lang_code'`` (the language code of the target language)
     '''
+    _check_access('term_translation_show', context, data_dict)
     model = context['model']
 
     trans_table = model.term_translation_table
@@ -2409,6 +2414,7 @@ def status_show(context, data_dict):
     :rtype: dictionary
 
     '''
+    _check_access('status_show', context, data_dict)
     return {
         'site_title': config.get('ckan.site_title'),
         'site_description': config.get('ckan.site_description'),
@@ -2705,6 +2711,7 @@ def user_follower_count(context, data_dict):
     :rtype: int
 
     '''
+    _check_access('user_follower_count', context, data_dict)
     return _follower_count(
         context, data_dict,
         ckan.logic.schema.default_follow_user_schema(),
@@ -2720,6 +2727,7 @@ def dataset_follower_count(context, data_dict):
     :rtype: int
 
     '''
+    _check_access('dataset_follower_count', context, data_dict)
     return _follower_count(
         context, data_dict,
         ckan.logic.schema.default_follow_dataset_schema(),
@@ -2735,6 +2743,7 @@ def group_follower_count(context, data_dict):
     :rtype: int
 
     '''
+    _check_access('group_follower_count', context, data_dict)
     return _follower_count(
         context, data_dict,
         ckan.logic.schema.default_follow_group_schema(),
@@ -2750,6 +2759,7 @@ def organization_follower_count(context, data_dict):
     :rtype: int
 
     '''
+    _check_access('organization_follower_count', context, data_dict)
     return group_follower_count(context, data_dict)
 
 
@@ -2864,6 +2874,7 @@ def am_following_user(context, data_dict):
     :rtype: bool
 
     '''
+    _check_access('am_following_user', context, data_dict)
     return _am_following(
         context, data_dict,
         ckan.logic.schema.default_follow_user_schema(),
@@ -2879,6 +2890,7 @@ def am_following_dataset(context, data_dict):
     :rtype: bool
 
     '''
+    _check_access('am_following_dataset', context, data_dict)
     return _am_following(
         context, data_dict,
         ckan.logic.schema.default_follow_dataset_schema(),
@@ -2894,6 +2906,7 @@ def am_following_group(context, data_dict):
     :rtype: bool
 
     '''
+    _check_access('am_following_group', context, data_dict)
     return _am_following(
         context, data_dict,
         ckan.logic.schema.default_follow_group_schema(),
@@ -2922,6 +2935,7 @@ def followee_count(context, data_dict):
     :rtype: int
 
     '''
+    _check_access('followee_count', context, data_dict)
     model = context['model']
     followee_users = _followee_count(context, data_dict,
                                      model.UserFollowingUser)
@@ -2947,6 +2961,7 @@ def user_followee_count(context, data_dict):
     :rtype: int
 
     '''
+    _check_access('user_followee_count', context, data_dict)
     return _followee_count(
         context, data_dict,
         context['model'].UserFollowingUser)
@@ -2961,6 +2976,7 @@ def dataset_followee_count(context, data_dict):
     :rtype: int
 
     '''
+    _check_access('dataset_followee_count', context, data_dict)
     return _followee_count(
         context, data_dict,
         context['model'].UserFollowingDataset)
@@ -2975,6 +2991,7 @@ def group_followee_count(context, data_dict):
     :rtype: int
 
     '''
+    _check_access('group_followee_count', context, data_dict)
     return _followee_count(
         context, data_dict,
         context['model'].UserFollowingGroup)

--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -471,3 +471,104 @@ def package_collaborator_list_for_user(context, data_dict):
     if user_obj and data_dict.get('id') in (user_obj.name, user_obj.id):
         return {'success': True}
     return {'success': False}
+
+
+def status_show(context, data_dict):
+    '''Show information about the site's configuration. Visible to all by default.'''
+    return {'success': True}
+
+
+def dataset_followee_count(context, data_dict):
+    '''Check if the number of datasets followed by a user are visible.
+    Visible to all by default.'''
+    return {'success': True}
+
+
+def group_followee_count(context, data_dict):
+    '''Check if the number of groups followed by a user are visible.
+    Visible to all by default.'''
+    return {'success': True}
+
+
+def user_followee_count(context, data_dict):
+    '''Check if the number of users followed by a user are visible.
+    Visible to all by default.'''
+    return {'success': True}
+
+
+def followee_count(context, data_dict):
+    '''Check if the number of objects (of any type) followed by a user are visible.
+    Visible to all by default.'''
+    return {'success': True}
+
+
+def dataset_follower_count(context, data_dict):
+    '''Check if the number of followers of a dataset are visible.
+    Visible to all by default.'''
+    return {'success': True}
+
+
+def group_follower_count(context, data_dict):
+    '''Check if the number of followers of a group are visible.
+    Visible to all by default.'''
+    return {'success': True}
+
+
+def organization_follower_count(context, data_dict):
+    '''Check if the number of followers of an organization are visible.
+    Visible to all by default.'''
+    return {'success': True}
+
+
+def user_follower_count(context, data_dict):
+    '''Check if the number of followers of a user are visible.
+    Visible to all by default.'''
+    return {'success': True}
+
+
+def am_following_dataset(context, data_dict):
+    '''Check if the information about following a dataset is visible.
+    Visible to all by default.'''
+    return {'success': True}
+
+
+def am_following_group(context, data_dict):
+    '''Check if the information about following a group is visible.
+    Visible to all by default.'''
+    return {'success': True}
+
+
+def am_following_user(context, data_dict):
+    '''Check if the information about following a user is visible.
+    Visible to all by default.'''
+    return {'success': True}
+
+
+def group_package_show(context, data_dict):
+    '''Check if the set of datasets belonging to a group is visible.
+    Visible to all by default.'''
+    return {'success': True}
+
+
+def member_list(context, data_dict):
+    '''Check if the members of a given group are visible.
+    Visible to all by default.'''
+    return {'success': True}
+
+
+def resource_search(context, data_dict):
+    '''Check if resource search is allowed.
+    Allowed for all by default.'''
+    return {'success': True}
+
+
+def tag_search(context, data_dict):
+    '''Check if tag search is allowed.
+    Allowed for all by default.'''
+    return {'success': True}
+
+
+def term_translation_show(context, data_dict):
+    '''Check if the translations for the given term(s) and language(s) are visible.
+    Visible to all by default.'''
+    return {'success': True}

--- a/ckan/tests/logic/auth/test_get.py
+++ b/ckan/tests/logic/auth/test_get.py
@@ -555,3 +555,33 @@ class TestPackageMemberList(object):
         context = self._get_context(user)
         assert helpers.call_auth(
             'package_collaborator_list', context=context, id=dataset['id'])
+
+class TestAuthFunctions(object):
+    '''Simple tests (can anonymous call it?) for a group of auth functions for actions 
+    that previously didn't have an auth function.'''
+
+    functions = [
+        "status_show",
+        "dataset_followee_count",
+        "group_followee_count",
+        "user_followee_count",
+        "followee_count",
+        "dataset_follower_count",
+        "group_follower_count",
+        "organization_follower_count",
+        "user_follower_count",
+        "am_following_dataset",
+        "am_following_group",
+        "am_following_user",
+        "group_package_show",
+        "member_list",
+        "resource_search",
+        "tag_search",
+        "term_translation_show",
+    ]
+
+    @pytest.mark.parametrize("func", functions)
+    def test_anonymous_can_call_get_method(self, func):
+        user = factories.User()
+        context = {"user": "", "model": model}
+        assert helpers.call_auth(func, context, id=user["id"])


### PR DESCRIPTION
This PR is a backport of #7042 for the `2.9` branch.

Fixes #

### Proposed fixes:

* Add auth functions for 17 GET-able API methods.
* Call the new auth functions from the corresponding action functions.

All new auth functions return `{"success": True}`. Now that they are present, they can be changed by plugin developers to fine-tune authorization. 

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
