### PR TITLE
Upload image macro update

### DIFF
--- a/ckan/templates/macros/form/image_upload.html
+++ b/ckan/templates/macros/form/image_upload.html
@@ -10,50 +10,39 @@ Example
 
 #}
 {% macro image_upload(data, errors, field_url='image_url', field_upload='image_upload', field_clear='clear_upload',
-                    is_url=false, is_upload=false, is_upload_enabled=false, placeholder=false,
-                    url_label='', upload_label='', field_name='image_url')  %}
-{% set placeholder = placeholder if placeholder else _('http://example.com/my-image.jpg') %}
-{% set url_label = url_label or _('Image URL')  %}
-{% set upload_label = upload_label or _('Image')  %}
-{% set previous_upload = data['previous_upload'] %}
+                      is_url=false, is_upload=false, is_upload_enabled=false, classes=['control-full'], attrs={'class': 'form-control'}, placeholder=false,
+                      url_label='', upload_label='', field_name='image_url')  %}
+  {% set extra_html = caller() if caller %}
+  {% set placeholder = placeholder if placeholder else _('http://example.com/my-image.jpg') %}
+  {% set url_label = url_label or _('Image URL')  %}
+  {% set upload_label = upload_label or _('Image')  %}
+  {% set previous_upload = data['previous_upload'] %}
 
-{% if field_url == 'url' and field_upload == 'upload' %}
-    {# backwards compatibility for old resource forms that still call the `forms.image_upload()` macro, eg ckanext-scheming #}
-    {% snippet 'package/snippets/resource_upload_field.html',
-    data=data,
-    errors=errors,
-    is_url=is_url,
-    is_upload=is_upload,
-    is_upload_enabled=is_upload_enabled,
-    url_label=url_label,
-    upload_label=upload_label,
-    placeholder=placeholder %}
-{% else %}
-    {% if is_upload_enabled %}
-    <div class="image-upload"
-            data-module="image-upload"
-            data-module-is_url="{{ 'true' if is_url else 'false' }}"
-            data-module-is_upload="{{ 'true' if is_upload else 'false' }}"
-            data-module-field_url="{{ field_url }}"
-            data-module-field_upload="{{ field_upload }}"
-            data-module-field_clear="{{ field_clear }}"
-            data-module-upload_label="{{ upload_label }}"
-            data-module-field_name="{{ field_name }}"
-            data-module-previous_upload="{{ 'true' if previous_upload else 'false' }}">
-    {% endif %}
+  {% if is_upload_enabled %}
+
+  <div class="image-upload" {{ attributes(attrs) }}
+       data-module="image-upload"
+       data-module-is_url="{{ 'true' if is_url else 'false' }}"
+       data-module-is_upload="{{ 'true' if is_upload else 'false' }}"
+       data-module-field_url="{{ field_url }}"
+       data-module-field_upload="{{ field_upload }}"
+       data-module-field_clear="{{ field_clear }}"
+       data-module-upload_label="{{ upload_label }}"
+       data-module-field_name="{{ field_name }}"
+       data-module-previous_upload="{{ 'true' if previous_upload else 'false' }}">
+  {% endif %}
 
 
-    {{ input(field_url, label=url_label, id='field-image-url', type='url', placeholder=placeholder, value=data.get(field_url), error=errors.get(field_url), classes=['control-full']) }}
+   {{ input(field_url, label=url_label, id='field-image-url', type='url', placeholder=placeholder, value=data.get(field_url), error=errors.get(field_url), classes=classes, attrs=attrs) }}
 
 
     {% if is_upload_enabled %}
-    {{ input(field_upload, label=upload_label, id='field-image-upload', type='file', placeholder='', value='', error='', classes=['control-full']) }}
+    {{ input(field_upload, label=upload_label, id='field-image-upload', type='file', placeholder='', value='', error='', classes=classes, attrs=attrs) }}
     {% if is_upload %}
-        {{ checkbox(field_clear, label=_('Clear Upload'), id='field-clear-upload', value='true', error='', classes=['control-full']) }}
+    {{ checkbox(field_clear, label=_('Clear Upload'), id='field-clear-upload', value='true', error='', classes=classes, attrs=attrs) }}
     {% endif %}
     {% endif %}
 
     {% if is_upload_enabled %}</div>{% endif %}
-{% endif %}
-
-{% endmacro %}
+   {{ extra_html }}
+  {% endmacro %}


### PR DESCRIPTION
Make image_upload macro callable. 
This will help to fix the [scheming](https://github.com/ckan/ckanext-scheming/blob/master/ckanext/scheming/templates/scheming/form_snippets/upload.html#L18) form snippet
Add attrs and classes params to allow design changes


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
