### PR TITLE
Fix non_clean_db fixture for pytest-ckan

### DIFF
--- a/ckan/tests/pytest_ckan/fixtures.py
+++ b/ckan/tests/pytest_ckan/fixtures.py
@@ -334,14 +334,14 @@ def with_extended_cli(ckan_config, monkeypatch):
 
 
 @pytest.fixture(scope="session")
-def _reset_db_once(reset_db):
+def reset_db_once(reset_db):
     """Internal fixture that cleans DB only the first time it's used.
     """
     reset_db()
 
 
 @pytest.fixture
-def non_clean_db(_reset_db_once):
+def non_clean_db(reset_db_once):
     """Guarantees that DB is initialized.
 
     This fixture either initializes DB if it hasn't been done yet or does


### PR DESCRIPTION
Background:
`pytest-ckan` uses `from ckan.tests.fixtures import *` instruction, which imports everything, except `_*` module members.

Problem:
`non_clean_db` fixture, that increases speed of test execution, relies on "private" fixture `_reset_db_once`. Because this private fixture has a name in the form `_*`, it's ignored by `pytest-ckan`. This means, that `non_clean_db` cannot be used by extensions, because it relies on the non-existing internal fixture.

Solution:
rename `_reset_db_once` to `reset_db_once`(without underscore). We already have a similar fixture `reset_db`, so it doesn't violate the coding style.

PS no changelog record required, as `non_clean_db` wasn't included in public release 