### PR TITLE
[7028]Lock down cookie based authentication on API endpoints [PART ONE]

### DIFF
--- a/ckan/public-bs3/base/javascript/client.js
+++ b/ckan/public-bs3/base/javascript/client.js
@@ -51,6 +51,10 @@
       if (type == 'POST') {
         options.type = 'POST';
         options.data = JSON.stringify(data);
+        var csrf_token = $('meta[name=_csrf_token]').attr('content');
+        options.headers = {
+          'X-CSRFToken': csrf_token
+        }
       } else {
         options.type = 'GET';
         options.url += data;

--- a/ckan/public-bs3/base/javascript/modules/confirm-action.js
+++ b/ckan/public-bs3/base/javascript/modules/confirm-action.js
@@ -100,6 +100,13 @@ this.ckan.module('confirm-action', function (jQuery) {
         var form = this.el.closest('form');
       }
 
+      // get the csrf value
+      var csrf_value = $('meta[name=_csrf_token]').attr('content')
+      // set the hidden input
+      var hidden_csrf_input = $('<input name="_csrf_token" type="hidden" value="'+csrf_value+'">')
+      // insert the hidden input at the beginning of the form
+      hidden_csrf_input.prependTo(form)
+
       form.appendTo('body').submit();
     },
 

--- a/ckan/public/base/javascript/client.js
+++ b/ckan/public/base/javascript/client.js
@@ -51,7 +51,7 @@
       if (type == 'POST') {
         options.type = 'POST';
         options.data = JSON.stringify(data);
-        csrfInput()
+        addCsrfHeader()
       } else {
         options.type = 'GET';
         options.url += data;

--- a/ckan/public/base/javascript/client.js
+++ b/ckan/public/base/javascript/client.js
@@ -51,6 +51,7 @@
       if (type == 'POST') {
         options.type = 'POST';
         options.data = JSON.stringify(data);
+        csrfInput()
       } else {
         options.type = 'GET';
         options.url += data;

--- a/ckan/public/base/javascript/client.js
+++ b/ckan/public/base/javascript/client.js
@@ -51,7 +51,10 @@
       if (type == 'POST') {
         options.type = 'POST';
         options.data = JSON.stringify(data);
-        addCsrfHeader()
+        var csrf_token = $('meta[name=_csrf_token]').attr('content');
+        options.headers = {
+          'X-CSRFToken': csrf_token
+        }
       } else {
         options.type = 'GET';
         options.url += data;

--- a/ckan/public/base/javascript/module.js
+++ b/ckan/public/base/javascript/module.js
@@ -201,7 +201,7 @@ this.ckan = this.ckan || {};
 
   /* Adds the X-CSRFToken header
     */
-  csrfInput = function() {
+  addCsrfHeader = function() {
     var csrftoken = $('meta[name=_csrf_token]').attr('content')
     $.ajaxSetup({
       beforeSend: function(xhr, settings) {

--- a/ckan/public/base/javascript/module.js
+++ b/ckan/public/base/javascript/module.js
@@ -199,6 +199,19 @@ this.ckan = this.ckan || {};
     }
   });
 
+  /* Adds the X-CSRFToken header
+    */
+  csrfInput = function() {
+    var csrftoken = $('meta[name=_csrf_token]').attr('content')
+    $.ajaxSetup({
+      beforeSend: function(xhr, settings) {
+        if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type) && !this.crossDomain) {
+          xhr.setRequestHeader("X-CSRFToken", csrftoken)
+        }
+      }
+    })
+  };
+
   /* Add a new module to the registry.
    *
    * This expects an object of methods/properties to be provided. These will

--- a/ckan/public/base/javascript/module.js
+++ b/ckan/public/base/javascript/module.js
@@ -199,19 +199,6 @@ this.ckan = this.ckan || {};
     }
   });
 
-  /* Adds the X-CSRFToken header
-    */
-  addCsrfHeader = function() {
-    var csrftoken = $('meta[name=_csrf_token]').attr('content')
-    $.ajaxSetup({
-      beforeSend: function(xhr, settings) {
-        if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type) && !this.crossDomain) {
-          xhr.setRequestHeader("X-CSRFToken", csrftoken)
-        }
-      }
-    })
-  };
-
   /* Add a new module to the registry.
    *
    * This expects an object of methods/properties to be provided. These will

--- a/ckan/public/base/javascript/modules/confirm-action.js
+++ b/ckan/public/base/javascript/modules/confirm-action.js
@@ -100,6 +100,13 @@ this.ckan.module('confirm-action', function (jQuery) {
         var form = this.el.closest('form');
       }
 
+      // get the csrf value
+      var csrf_value = $('meta[name=_csrf_token]').attr('content')
+      // set the hidden input
+      var hidden_csrf_input = $('<input name="_csrf_token" type="hidden" value="'+csrf_value+'">')
+      // insert the hidden input at the beginning of the form
+      hidden_csrf_input.prependTo(form)
+
       form.appendTo('body').submit();
     },
 

--- a/ckan/public/base/javascript/modules/follow.js
+++ b/ckan/public/base/javascript/modules/follow.js
@@ -30,19 +30,6 @@ this.ckan.module('follow', function($) {
 			this.el.on('click', this._onClick);
 		},
 
-		/* Adds the X-CSRFToken header
-		*/
-		addCsrfTokenHeader: function() {
-			var csrftoken = $('meta[name=_csrf_token]').attr('content')
-			$.ajaxSetup({
-				beforeSend: function(xhr, settings) {
-					if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type) && !this.crossDomain) {
-						xhr.setRequestHeader("X-CSRFToken", csrftoken)
-					}
-				}
-			})
-		},
-
 		/* Handles the clicking of the follow button
 		 *
 		 * event - An event object.
@@ -51,7 +38,6 @@ this.ckan.module('follow', function($) {
 		 */
 		_onClick: function(event) {
 			var options = this.options;
-			this.addCsrfTokenHeader()
 			if (
 				options.action
 				&& options.type

--- a/ckan/templates-bs3/base.html
+++ b/ckan/templates-bs3/base.html
@@ -24,7 +24,7 @@
     #}
     {%- block meta -%}
       <meta charset="utf-8" />
-      {{ h.csrf_input() }}
+      <meta name="{{ g.csrf_field_name }}" content="{{ csrf_token() }}" />
       {% block meta_generator %}<meta name="generator" content="ckan {{ h.ckan_version() }}" />{% endblock %}
       {% block meta_viewport %}<meta name="viewport" content="width=device-width, initial-scale=1.0">{% endblock %}
     {%- endblock -%}

--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -235,7 +235,7 @@ def action(logic_function: str, ver: int = API_DEFAULT_VERSION) -> Response:
         u'auth_user_obj': current_user
     })
     model.Session()._context = context
- 
+
     return_dict: dict[str, Any] = {
         u'help': url_for(u'api.action',
                          logic_function=u'help_show',

--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -15,7 +15,6 @@ from werkzeug.datastructures import MultiDict
 
 import ckan.model as model
 from ckan.common import json, _, g, request, current_user
-from ckan.config.middleware.flask_app import csrf
 from ckan.lib.helpers import url_for
 from ckan.lib.base import render
 from ckan.lib.i18n import get_locales_from_config
@@ -208,8 +207,6 @@ def _get_request_data(try_url_params: bool = False):
 
 # View functions
 
-# exempt the CKAN API actions from csrf-validation.
-@csrf.exempt
 def action(logic_function: str, ver: int = API_DEFAULT_VERSION) -> Response:
     u'''Main endpoint for the action API (v3)
 
@@ -238,7 +235,7 @@ def action(logic_function: str, ver: int = API_DEFAULT_VERSION) -> Response:
         u'auth_user_obj': current_user
     })
     model.Session()._context = context
-
+ 
     return_dict: dict[str, Any] = {
         u'help': url_for(u'api.action',
                          logic_function=u'help_show',


### PR DESCRIPTION
Fixes #7028 

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [x] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
