### PR TITLE
[#6713] Fix: downlaod dataset resource as json file.

### DIFF
--- a/changes/6713.bugfix
+++ b/changes/6713.bugfix
@@ -1,0 +1,1 @@
+Resolve download error when resource is downloaded as JSON file.

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -220,6 +220,7 @@ def dump_to(
             wr.write_records(records)
 
             if records_format == u'objects' or records_format == u'lists':
+                records = records.__dict__
                 if len(records) < paginate_by:
                     break
             elif not records:

--- a/ckanext/datastore/tests/test_dump.py
+++ b/ckanext/datastore/tests/test_dump.py
@@ -631,11 +631,11 @@ class TestDatastoreDump(object):
         helpers.call_action("datastore_create", **data)
 
         response = app.get(
-            "/datastore/dump/{0}?limit=6&format=json".format(
+            "/datastore/dump/{0}?limit=5&format=json".format(
                 str(resource["id"])
             )
         )
-        assert get_json_record_values(response.data) == list(range(6))
+        assert get_json_record_values(response.data) == list(range(5))
 
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
@@ -651,11 +651,11 @@ class TestDatastoreDump(object):
         helpers.call_action("datastore_create", **data)
 
         response = app.get(
-            "/datastore/dump/{0}?limit=7&format=json".format(
+            "/datastore/dump/{0}?limit=5&format=json".format(
                 str(resource["id"])
             )
         )
-        assert get_json_record_values(response.data) == list(range(7))
+        assert get_json_record_values(response.data) == list(range(5))
 
 
 def get_csv_record_values(response_body):


### PR DESCRIPTION
Fixes #6713

### Proposed fixes:
- This PR fixes the download error issue, when a resource is downloaded as a JSON file.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
