### PR TITLE
Consolidate session config options declarations, add beaker prefix

### DIFF
--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -254,6 +254,7 @@ groups:
         placeholder: "/tmp/%(ckan.site_id)s"
       - key: beaker.session.key
         default: ckan
+        description: Name of the cookie key used to save the session under.
       - key: beaker.session.secret
         validators: not_empty
         required: true
@@ -263,18 +264,16 @@ groups:
         description: |
           This is the secret token that the beaker library uses to hash the
           cookie sent to the client. `ckan generate config` generates a unique
-          value for this each time it generates a config file.
-
-  - annotation: Beaker session settings
-    options:
-      - key: auto
+          value for this each time it generates a config file. When used in a
+          cluster environment, the value must be the same on every machine.
+      - key: beaker.session.auto
         type: bool
         default: False
         description: |
           When set to True, the session will save itself anytime it is accessed during a request,
           negating the need to issue the save() method.
 
-      - key: cookie_expires
+      - key: beaker.session.cookie_expires
         description: |
           Determines when the cookie used to track the client-side of the session will expire.
           When set to a boolean value, it will either expire at the end of the browsers session, or never expire.
@@ -283,35 +282,25 @@ groups:
           I.e. a value of 300 will result in the cookie being set to expire in 300 seconds.
           Defaults to never expiring.
 
-      - key: cookie_domain
+      - key: beaker.session.cookie_domain
         description: |
           What domain the cookie should be set to. When using sub-domains,
           this should be set to the main domain the cookie should be valid for. For example,
           if a cookie should be valid under www.nowhere.com and files.nowhere.com then it should be set to .nowhere.com.
           Defaults to the current domain in its entirety.
 
-      - key: key
-        required: True
-        description: Name of the cookie key used to save the session under.
-
-      - key: save_accessed_time
+      - key: beaker.session.save_accessed_time
         type: bool
         default: True
         description: Whether beaker should save the session's access time (true) or only modification time (false).
 
-      - key: secret
-        required: True
-        description: |
-          Used with the HMAC to ensure session integrity. This value should ideally be a randomly generated string.
-          When using in a cluster environment, the secret must be the same on every machine.
-
-      - key: secure
+      - key: beaker.session.secure
         type: bool
         description: |
           Whether or not the session cookie should be marked as secure. When marked as secure,
           browsers are instructed to not send the cookie over anything other than an SSL connection.
 
-      - key: timeout
+      - key: beaker.session.timeout
         description: |
           Seconds until the session is considered invalid, after which it will be ignored and invalidated.
           This number is based on the time since the session was last accessed, not from when the session was created.


### PR DESCRIPTION
This was an oversight of #6964, some improvements on the session config options documentation:

* Consolidate "Session" and "Beaker session" sections
* Add the `beaker.session.` prefix to the config keys
