### PR TITLE
ci: add minimum GitHub token permissions for workflow

### DIFF
--- a/.github/workflows/towncrier.yml
+++ b/.github/workflows/towncrier.yml
@@ -1,6 +1,9 @@
 name: Changelog entries
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   towncrier:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using https://github.com/step-security/secure-workflows.

The GitHub Actions workflow has a GITHUB_TOKEN with write access to multiple scopes.
Here is an example of the permissions in one of the workflow runs:
https://github.com/ckan/ckan/runs/8250906501?check_suite_focus=true#step:1:19

After this change, the scopes will be reduced to the minimum needed for the following workflow:

- towncrier.yml

The following workflows already have the least privileged token permission set:

- codeql-analysis.yml
- cypress.yml
- flake8.yml
- pyright.yml

### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced.
- GitHub recommends defining minimum GITHUB_TOKEN permissions.
  https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>
