### PR TITLE
[#7076] Fix duplicate calls to index code

### DIFF
--- a/ckan/model/modification.py
+++ b/ckan/model/modification.py
@@ -47,8 +47,12 @@ class DomainObjectModificationExtension(plugins.SingletonPlugin):
                 for item in plugins.PluginImplementations(plugins.IResourceUrlChange):
                     item.notify(obj)
 
-        changed_pkgs = set(obj for obj in changed
-                           if isinstance(obj, model.Package))
+
+        changed_pkgs = set()
+        new_ids = [obj.id for obj in new]
+        for obj in changed:
+            if isinstance(obj, model.Package) and obj.id not in new_ids:
+                changed_pkgs.add(obj)
 
         for obj in new | changed | deleted:
             if not isinstance(obj, model.Package):

--- a/ckan/model/modification.py
+++ b/ckan/model/modification.py
@@ -49,9 +49,9 @@ class DomainObjectModificationExtension(plugins.SingletonPlugin):
 
 
         changed_pkgs = set()
-        new_ids = [obj.id for obj in new]
+        new_pkg_ids = [obj.id for obj in new if isinstance(obj, model.Package)]
         for obj in changed:
-            if isinstance(obj, model.Package) and obj.id not in new_ids:
+            if isinstance(obj, model.Package) and obj.id not in new_pkg_ids:
                 changed_pkgs.add(obj)
 
         for obj in new | changed | deleted:

--- a/ckan/tests/lib/search/test_index.py
+++ b/ckan/tests/lib/search/test_index.py
@@ -320,4 +320,3 @@ def test_index_only_called_once():
         assert m.call_count == 1
 
         assert helpers.call_action("package_show", id=dataset["id"])["notes"] == "hi"
-

--- a/ckan/tests/lib/search/test_index.py
+++ b/ckan/tests/lib/search/test_index.py
@@ -3,10 +3,12 @@
 import datetime
 import hashlib
 import json
+from unittest import mock
 import pytest
 import six
 from ckan.common import config
 import ckan.lib.search as search
+from ckan.tests import factories, helpers
 
 
 @pytest.mark.skipif(not search.is_available(), reason="Solr not reachable")
@@ -299,3 +301,23 @@ class TestPackageSearchIndex:
 
         # Resource types are indexed
         assert indexed_pkg["res_type"] == ["doc", "file"]
+
+
+@pytest.mark.usefixtures("clean_index")
+def test_index_only_called_once():
+
+    with mock.patch("ckan.lib.search.index.PackageSearchIndex.index_package") as m:
+
+        dataset = factories.Dataset()
+
+        assert m.call_count == 1
+
+        m.reset_mock()
+
+        dataset["notes"] = "hi"
+        helpers.call_action("package_update", **dataset)
+
+        assert m.call_count == 1
+
+        assert helpers.call_action("package_show", id=dataset["id"])["notes"] == "hi"
+


### PR DESCRIPTION
Fixes #7076

See issue for details. [`DomainObjectModificationExtension`](https://github.com/ckan/ckan/blob/9f1b5cfaff8c135b589e2ea0275f1286c2e02711/ckan/model/modification.py#L27) was sending duplicate notifications to hooks, including the one used by the indexing logic so the core indexing (and extensions using `before_dataset_index()`) was called twice.
