### PR TITLE
Deprecate Recline views

### DIFF
--- a/changes/7078.removal
+++ b/changes/7078.removal
@@ -1,0 +1,1 @@
+The Recline-based view plugins (`recline_view`, `recline_grid_view`, `recline_graph_view` and `recline_map_view`) are deprecated and will be removed in future versions. Check :ref:`data-viewer` for alternatives.

--- a/ckan/cli/views.py
+++ b/ckan/cli/views.py
@@ -40,10 +40,10 @@ def views():
 def create(ctx: click.Context, types: list[str], dataset: list[str],
            no_default_filters: bool, search: str, yes: bool):
     """Create views on relevant resources. You can optionally provide
-    specific view types (eg `recline_view`, `image_view`). If no types
+    specific view types (eg `datatables_view`, `image_view`). If no types
     are provided, the default ones will be used. These are generally
     the ones defined in the `ckan.views.default_views` config option.
-    Note that on either case, plugins must be loaded (ie added to
+    Note that in either case, plugins must be loaded (ie added to
     `ckan.plugins`), otherwise the command will stop.
 
     """

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -928,7 +928,7 @@ groups:
         required: true
         type: list
         placeholder: activity
-        example: disqus datapreview googleanalytics follower
+        example: activity scheming_datasets datatables_view datastore xloader
         description: |
           Specify which CKAN plugins are to be enabled.
 
@@ -1116,8 +1116,8 @@ groups:
         type: list
         default:
           - image_view
-          - recline_view
-        example: image_view webpage_view recline_grid_view
+          - datatables_view
+        example: image_view webpage_view datatables_view
         description: |
           Defines the resource views that should be created by default when creating or
           updating a dataset. From this list only the views that are relevant to a particular
@@ -1128,8 +1128,8 @@ groups:
 
 
           .. note:: You must have the relevant view plugins loaded on the ``ckan.plugins`` setting to be able to create the default views, eg::
-                        ckan.plugins = image_view webpage_view recline_grid_view datatables_view ...
-                        ckan.views.default_views = image_view webpage_view recline_grid_view
+                        ckan.plugins = image_view webpage_view geo_view datatables_view ...
+                        ckan.views.default_views = image_view webpage_view datatables_view
 
   - annotation: Theming Settings
     options:

--- a/ckan/lib/datapreview.py
+++ b/ckan/lib/datapreview.py
@@ -20,7 +20,7 @@ from ckan.types import Context
 log = logging.getLogger(__name__)
 
 
-DEFAULT_RESOURCE_VIEW_TYPES = ['image_view', 'recline_view']
+DEFAULT_RESOURCE_VIEW_TYPES = ['image_view', 'datatables_view']
 
 
 def res_format(resource: dict[str, Any]) -> Optional[str]:

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -232,7 +232,7 @@ class IResourceView(Interface):
         The available keys are:
 
         :param name: name of the view type. This should match the name of the
-            actual plugin (eg ``image_view`` or ``recline_view``).
+            actual plugin (eg ``image_view`` or ``datatables_view``).
         :param title: title of the view type. Will be displayed on the
             frontend. This should be translatable (ie wrapped with
             ``toolkit._('Title')``).

--- a/ckan/templates/package/resource_read.html
+++ b/ckan/templates/package/resource_read.html
@@ -130,7 +130,7 @@
                     <p class="text-muted">
                       <i class="fa fa-info-circle"></i>
                       {{ _("Not seeing the views you were expecting?")}}
-                      <a href="javascript:void(0);" data-toggle="collapse" data-target="#data-view-info">
+                      <a href="javascript:void(0);" data-bs-toggle="collapse" data-bs-target="#data-view-info">
                         {{ _('Click here for more information.') }}</a>
                     </p>
                     <div id="data-view-info" class="collapse">

--- a/ckan/templates/package/snippets/resource_view.html
+++ b/ckan/templates/package/snippets/resource_view.html
@@ -31,7 +31,7 @@
           <p class="text-danger">
             <i class="fa fa-info-circle"></i>
             {{ _('This resource view is not available at the moment.') }}
-            <a href="#" data-toggle="collapse" data-target="#data-view-error">
+            <a href="#" data-bs-toggle="collapse" data-bs-target="#data-view-error">
               {{ _('Click here for more information.') }}
             </a>
           </p>

--- a/ckan/tests/lib/test_datapreview.py
+++ b/ckan/tests/lib/test_datapreview.py
@@ -56,7 +56,7 @@ class MockDatastoreBasedResourceView(p.SingletonPlugin):
 
 
 @pytest.mark.ckan_config(
-    "ckan.plugins", "image_view recline_view webpage_view test_datastore_view"
+    "ckan.plugins", "image_view datatables_view webpage_view test_datastore_view"
 )
 @pytest.mark.usefixtures("with_plugins")
 class TestDatapreviewWithWebpageView(object):
@@ -66,7 +66,15 @@ class TestDatapreviewWithWebpageView(object):
 
         assert sorted(
             [view_plugin.info()["name"] for view_plugin in default_views]
-        ) == sorted(datapreview.DEFAULT_RESOURCE_VIEW_TYPES)
+        ) == ["image_view"]
+
+    def test_no_config_with_datastore_plugins(self):
+
+        default_views = datapreview.get_default_view_plugins(get_datastore_views=True)
+
+        assert sorted(
+            [view_plugin.info()["name"] for view_plugin in default_views]
+        ) == ["datatables_view"]
 
     @pytest.mark.ckan_config("ckan.views.default_views", "")
     def test_empty_config(self):

--- a/ckan/tests/logic/action/test_delete.py
+++ b/ckan/tests/logic/action/test_delete.py
@@ -117,7 +117,7 @@ class TestDeleteResourceViews(object):
             helpers.call_action("resource_view_delete", context={}, **params)
 
 
-@pytest.mark.ckan_config("ckan.plugins", "image_view recline_view")
+@pytest.mark.ckan_config("ckan.plugins", "image_view datatables_view")
 @pytest.mark.ckan_config("ckan.views.default_views", "")
 @pytest.mark.usefixtures("non_clean_db", "with_plugins")
 class TestClearResourceViews(object):
@@ -127,8 +127,8 @@ class TestClearResourceViews(object):
         factories.ResourceView(view_type="image_view")
         factories.ResourceView(view_type="image_view")
 
-        factories.ResourceView(view_type="recline_view")
-        factories.ResourceView(view_type="recline_view")
+        factories.ResourceView(view_type="datatables_view")
+        factories.ResourceView(view_type="datatables_view")
 
         count = model.Session.query(model.ResourceView).count()
 
@@ -147,8 +147,8 @@ class TestClearResourceViews(object):
         factories.ResourceView(view_type="image_view")
         factories.ResourceView(view_type="image_view")
 
-        factories.ResourceView(view_type="recline_view")
-        factories.ResourceView(view_type="recline_view")
+        factories.ResourceView(view_type="datatables_view")
+        factories.ResourceView(view_type="datatables_view")
 
         count = model.Session.query(model.ResourceView).count()
 
@@ -162,7 +162,7 @@ class TestClearResourceViews(object):
 
         assert len(view_types) == 2
         for view_type in view_types:
-            assert view_type[0] == "recline_view"
+            assert view_type[0] == "datatables_view"
 
 
 class TestDeleteTags(object):

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -739,7 +739,7 @@ class TestResourceViewUpdate(object):
         assert result == resource_view
 
 
-@pytest.mark.ckan_config("ckan.plugins", "image_view recline_view")
+@pytest.mark.ckan_config("ckan.plugins", "image_view text_view resource_proxy")
 @pytest.mark.usefixtures("non_clean_db", "with_plugins")
 class TestResourceUpdate(object):
     def test_url_only(self):
@@ -1158,7 +1158,7 @@ class TestResourceUpdate(object):
         assert "someotherkey" not in resource
 
     @pytest.mark.ckan_config(
-        "ckan.views.default_views", "image_view recline_view"
+        "ckan.views.default_views", "image_view text_view"
     )
     def test_resource_format_update(self):
         dataset = factories.Dataset()
@@ -1175,11 +1175,11 @@ class TestResourceUpdate(object):
 
         # Update resource with format
         resource = helpers.call_action(
-            "resource_update", id=resource["id"], format="CSV"
+            "resource_update", id=resource["id"], format="TXT"
         )
 
         # Format changed
-        assert resource["format"] == "CSV"
+        assert resource["format"] == "TXT"
 
         res_views = helpers.call_action(
             "resource_view_list", id=resource["id"]
@@ -1189,7 +1189,7 @@ class TestResourceUpdate(object):
         assert len(res_views) == 1
 
         second_resource = factories.Resource(
-            package=dataset, url="http://localhost", name="Test2", format="CSV"
+            package=dataset, url="http://localhost", name="Test2", format="TXT"
         )
 
         res_views = helpers.call_action(
@@ -1236,11 +1236,11 @@ class TestResourceUpdate(object):
         assert len(res_views) == 0
 
         third_resource = helpers.call_action(
-            "resource_update", id=third_resource["id"], format="CSV"
+            "resource_update", id=third_resource["id"], format="TXT"
         )
 
         # Format changed
-        assert third_resource["format"] == "CSV"
+        assert third_resource["format"] == "TXT"
 
         res_views = helpers.call_action(
             "resource_view_list", id=third_resource["id"]

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -581,7 +581,7 @@ def view(package_type: str,
 
     Depending on the type, different views are loaded. This could be an
     img tag where the image is loaded directly or an iframe that embeds a
-    webpage or a recline preview.
+    webpage or another preview.
     """
     context = cast(Context, {
         u'model': model,

--- a/ckanext/reclineview/plugin.py
+++ b/ckanext/reclineview/plugin.py
@@ -83,7 +83,10 @@ class ReclineViewBase(p.SingletonPlugin):
         toolkit.add_template_directory(config, 'theme/templates')
         toolkit.add_resource('theme/public', 'ckanext-reclineview')
 
-        log.warning("The Recline-based views are deprecated and will be removed in future versions")
+        log.warning(
+            "The Recline-based views are deprecated and"
+            "will be removed in future versions"
+        )
 
     def can_view(self, data_dict: dict[str, Any]):
         resource = data_dict['resource']

--- a/ckanext/reclineview/plugin.py
+++ b/ckanext/reclineview/plugin.py
@@ -83,6 +83,8 @@ class ReclineViewBase(p.SingletonPlugin):
         toolkit.add_template_directory(config, 'theme/templates')
         toolkit.add_resource('theme/public', 'ckanext-reclineview')
 
+        log.warning("The Recline-based views are deprecated and will be removed in future versions")
+
     def can_view(self, data_dict: dict[str, Any]):
         resource = data_dict['resource']
         return (resource.get('datastore_active') or

--- a/ckanext/reclineview/plugin.py
+++ b/ckanext/reclineview/plugin.py
@@ -66,7 +66,6 @@ def datastore_fields(resource: dict[str, Any],
             if f['type'] in valid_field_types]
 
 
-@p.toolkit.blanket.config_declarations
 class ReclineViewBase(p.SingletonPlugin):
     '''
     This base class for the Recline view extensions.
@@ -104,6 +103,7 @@ class ReclineViewBase(p.SingletonPlugin):
         }
 
 
+@p.toolkit.blanket.config_declarations
 class ReclineView(ReclineViewBase):
     '''
     This extension views resources using a Recline MultiView.
@@ -133,6 +133,7 @@ class ReclineView(ReclineViewBase):
             return False
 
 
+@p.toolkit.blanket.config_declarations
 class ReclineGridView(ReclineViewBase):
     '''
     This extension views resources using a Recline grid.
@@ -148,6 +149,7 @@ class ReclineGridView(ReclineViewBase):
                 }
 
 
+@p.toolkit.blanket.config_declarations
 class ReclineGraphView(ReclineViewBase):
     '''
     This extension views resources using a Recline graph.

--- a/doc/contributing/frontend/index.rst
+++ b/doc/contributing/frontend/index.rst
@@ -124,7 +124,8 @@ main.scss:
     This contains *all* the styles for the website including
     dependancies and local styles. The only files that are excluded here
     are those that are conditionally loaded such as IE only CSS and large
-    external apps (like recline) that only appear on a single page.
+    external apps (like some preview plugins) that only appear on a single
+    page.
 ckan.scss:
     This includes all the local ckan stylesheets.
 

--- a/doc/extensions/tutorial.rst
+++ b/doc/extensions/tutorial.rst
@@ -187,7 +187,7 @@ you gave to your plugin class in the :ref:`left-hand-side of the assignment in
 the setup.py file <setup.py>` (``example_iauthfunctions`` in this example) is
 the name you'll use for your plugin in CKAN's config file::
 
-    ckan.plugins = stats text_view recline_view example_iauthfunctions
+    ckan.plugins = stats text_view datatables_view example_iauthfunctions
 
 You should now be able to start CKAN in the development web server and have it
 start up without any problems:

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -236,7 +236,7 @@ file settings, for reference.
 
         [app:main]
         # This setting will work.
-        ckan.plugins = stats text_view recline_view
+        ckan.plugins = stats text_view datatables_view
 
    If the same option is set more than once in your config file, exeption will
    be raised and CKAN application will not start

--- a/doc/maintaining/data-viewer.rst
+++ b/doc/maintaining/data-viewer.rst
@@ -54,7 +54,7 @@ The *New view* dropdown will show the available view types for this particular
 resource. If the list is empty, you may need to add the relevant view plugins
 to the :ref:`ckan.plugins` setting on your configuration file, eg::
 
-    ckan.plugins = ... image_view recline_view pdf_view
+    ckan.plugins = ... image_view datatables_view pdf_view
 
 Defining views to appear by default
 -----------------------------------
@@ -70,7 +70,7 @@ a suitable one, a view will be created.
 This is configured with the :ref:`ckan.views.default_views` setting. In it you
 define the view plugins that you want to be created as default::
 
-    ckan.views.default_views = recline_view pdf_view geojson_view
+    ckan.views.default_views = datatables_view pdf_view geojson_view
 
 This configuration does not mean that each new resource will get all of these
 views by default, but that for instance if the uploaded file is a PDF file,
@@ -123,93 +123,6 @@ It's also optimized for embedding datasets and saved searches on external
 sites - with a backlink to the portal and automatic resizing.
 
 This plugin requires data to be in the DataStore.
-
-
-.. _data-explorer:
-
-Data Explorer
-+++++++++++++
-
-.. image:: /images/recline_view.png
-
-View plugin: ``recline_view``
-
-Adds a rich widget, based on the Recline_ Javascript library. It  allows
-querying, filtering, graphing and mapping data. The Data Explorer is optimized
-for displaying structured data hosted on the :doc:`datastore`.
-
-The Data Explorer can also display certain formats of tabular data (CSV and
-Excel files) without its contents being uploaded to the DataStore. This is
-done via the DataProxy_, an external service that will parse the contents of
-the file and return a response that the view widget understands. However, as
-the resource must be downloaded by the DataProxy service and parsed before it
-is viewed, this option is slower and less reliable than viewing data that is
-in the DataStore. It also does not properly support different encodings, proper
-field type detection, etc so users are strongly encouraged to host data on the
-DataStore instead.
-
-.. note:: Support for the DataProxy will be dropped on future CKAN releases
-
-The three main panes of the Data Explorer are also available as separate views.
-
-DataStore Grid
-++++++++++++++
-
-
-.. image:: /images/recline_grid_view.png
-
-View plugin: ``recline_grid_view``
-
-Displays a filterable, sortable, table view of structured data.
-
-This plugin requires data to be in the DataStore.
-
-DataStore Graph
-+++++++++++++++
-
-.. image:: /images/recline_graph_view.png
-
-View plugin: ``recline_graph_view``
-
-Allows to create graphs from data stored on the DataStore. You can choose the
-graph type (such as lines, bars, columns, etc) and restrict the displayed data,
-by filtering by a certain field value or defining an offset and the number of
-rows.
-
-This plugin requires data to be in the DataStore.
-
-DataStore Map
-+++++++++++++
-
-.. image:: /images/recline_map_view.png
-
-View plugin: ``recline_map_view``
-
-Shows data stored on the DataStore in an interactive map. It supports plotting
-markers from a pair of latitude / longitude fields or from a field containing
-a GeoJSON_ representation of the geometries. The configuration also allows to
-cluster markers if there is a high density of them and to zoom automatically
-to the rendered features.
-
-This plugin requires data to be in the DataStore.
-
-There is partial support to change the map tiles to a different service, such
-as Mapbox. Look below for an example to add to your configuration file::
-
-    #Mapbox example:
-    ckanext.spatial.common_map.type = mapbox
-    ckanext.spatial.common_map.mapbox.map_id = <id>
-    ckanext.spatial.common_map.mapbox.access_token = <token>
-    ckanext.spatial.common_map.attribution=© <a target=_blank href='https://www.mapbox.com/map-feedback/'>Mapbox</a> © <a target=_blank href='http://www.openstreetmap.org/copyright'>OpenStreetMap</a>
-    ckanext.spatial.common_map.subdomains = <subdomains>
-
-    #Custom example:
-    ckanext.spatial.common_map.type = custom
-    ckanext.spatial.common_map.custom.url = <url>
-    ckanext.spatial.common_map.custom.tms = <tms>
-    ckanext.spatial.common_map.attribution = <copyright link>
-    ckanext.spatial.common_map.subdomains = <subdomains>
-
 
 
 
@@ -293,16 +206,18 @@ alternative URL on the edit view form.
     .. warning:: Do not activate this plugin unless you trust the URL sources.
         It is not recommended to enable this view type on instances where all users
         can create datasets.
-
+        
 Other view plugins
-++++++++++++++++++
+------------------
 
-There are many more view plugins developed by the CKAN team and others which
+There are many more view plugins developed by the CKAN community, which
 are hosted on separate repositories. Some examples include:
 
+* `React Data explorer`_: A modern replacement for Recline, maintained by Datopian.
+* `Ckanext Visualize`_: An extension to easily create user visualization from data in the DataStore, maintained by Keitaro.
 * `Dashboard`_: Allows to combine multiple views into a single dashboard.
 * `PDF viewer`_: Allows to render PDF files on the resource page.
-* `GeoJSON map`_: Renders GeoJSON_ files on an interactive map.
+* `Geo viewer`_: Renders various spatial formats like GeoJSON_, WMS or shapefiles in an interactive map.
 * `Choropleth map`_: Displays data on the DataStore on a choropleth map.
 * `Basic charts`_: Provides alternative graph types and renderings.
 
@@ -314,7 +229,110 @@ the :py:class:`~ckan.plugins.interfaces.IResourceView` interface.
 
 .. todo:: Link to a proper tutorial for writing custom views
 
+Deprecated view plugins
+-----------------------
 
+.. _data-explorer:
+
+Data Explorer
++++++++++++++
+
+.. warning:: This Recline-based view plugin is deprecated and will be removed in future
+    versions
+
+
+.. image:: /images/recline_view.png
+
+View plugin: ``recline_view``
+
+Adds a rich widget, based on the Recline_ Javascript library. It  allows
+querying, filtering, graphing and mapping data. The Data Explorer is optimized
+for displaying structured data hosted on the :doc:`datastore`.
+
+The Data Explorer can also display certain formats of tabular data (CSV and
+Excel files) without its contents being uploaded to the DataStore. This is
+done via the DataProxy_, an external service that will parse the contents of
+the file and return a response that the view widget understands. However, as
+the resource must be downloaded by the DataProxy service and parsed before it
+is viewed, this option is slower and less reliable than viewing data that is
+in the DataStore. It also does not properly support different encodings, proper
+field type detection, etc so users are strongly encouraged to host data on the
+DataStore instead.
+
+.. note:: Support for the DataProxy will be dropped on future CKAN releases
+
+The three main panes of the Data Explorer are also available as separate views.
+
+DataStore Grid
+++++++++++++++
+
+.. warning:: This Recline-based view plugin is deprecated and will be removed in future
+    versions
+
+.. image:: /images/recline_grid_view.png
+
+View plugin: ``recline_grid_view``
+
+Displays a filterable, sortable, table view of structured data.
+
+This plugin requires data to be in the DataStore.
+
+DataStore Graph
++++++++++++++++
+
+.. warning:: This Recline-based view plugin is deprecated and will be removed in future
+    versions
+
+.. image:: /images/recline_graph_view.png
+
+View plugin: ``recline_graph_view``
+
+Allows to create graphs from data stored on the DataStore. You can choose the
+graph type (such as lines, bars, columns, etc) and restrict the displayed data,
+by filtering by a certain field value or defining an offset and the number of
+rows.
+
+This plugin requires data to be in the DataStore.
+
+DataStore Map
++++++++++++++
+
+.. warning:: This Recline-based view plugin is deprecated and will be removed in future
+    versions
+
+.. image:: /images/recline_map_view.png
+
+View plugin: ``recline_map_view``
+
+Shows data stored on the DataStore in an interactive map. It supports plotting
+markers from a pair of latitude / longitude fields or from a field containing
+a GeoJSON_ representation of the geometries. The configuration also allows to
+cluster markers if there is a high density of them and to zoom automatically
+to the rendered features.
+
+This plugin requires data to be in the DataStore.
+
+There is partial support to change the map tiles to a different service, such
+as Mapbox. Look below for an example to add to your configuration file::
+
+    #Mapbox example:
+    ckanext.spatial.common_map.type = mapbox
+    ckanext.spatial.common_map.mapbox.map_id = <id>
+    ckanext.spatial.common_map.mapbox.access_token = <token>
+    ckanext.spatial.common_map.attribution=© <a target=_blank href='https://www.mapbox.com/map-feedback/'>Mapbox</a> © <a target=_blank href='http://www.openstreetmap.org/copyright'>OpenStreetMap</a>
+    ckanext.spatial.common_map.subdomains = <subdomains>
+
+    #Custom example:
+    ckanext.spatial.common_map.type = custom
+    ckanext.spatial.common_map.custom.url = <url>
+    ckanext.spatial.common_map.custom.tms = <tms>
+    ckanext.spatial.common_map.attribution = <copyright link>
+    ckanext.spatial.common_map.subdomains = <subdomains>
+
+
+
+.. _React Data explorer: https://github.com/datopian/data-explorer
+.. _Ckanext visualize: https://github.com/keitaroinc/ckanext-visualize
 .. _Recline: https://github.com/okfn/recline/
 .. _DataTables: https://datatables.net/
 .. _DataProxy: https://github.com/okfn/dataproxy
@@ -323,7 +341,7 @@ the :py:class:`~ckan.plugins.interfaces.IResourceView` interface.
 .. _Basic charts: https://github.com/ckan/ckanext-basiccharts
 .. _Choropleth map: https://github.com/ckan/ckanext-mapviews
 .. _PDF viewer: https://github.com/ckan/ckanext-pdfview
-.. _GeoJSON map: https://github.com/ckan/ckanext-spatial
+.. _Geo viewer: https://github.com/ckan/ckanext-geoview
 
 
 .. _resource-proxy:
@@ -378,7 +396,7 @@ resources fields.
 Before each run, you will be prompted with the number of datasets affected and
 asked if you want to continue (unless you pass the ``-y`` option)::
 
-    You are about to check 3336 datasets for the following view plugins: ['image_view', 'recline_view', 'text_view']
+    You are about to check 3336 datasets for the following view plugins: ['image_view', 'datatables_view', 'text_view']
      Do you want to continue? [Y/n]
 
 .. note:: On large CKAN instances the migration process can take a significant
@@ -394,7 +412,7 @@ If no view types are provided, the default ones are used
 
 Specific view types can be also provided::
 
-    ckan -c |ckan.ini| views create image_view recline_view pdf_view
+    ckan -c |ckan.ini| views create image_view datatables_view pdf_view
 
 For certain view types (the ones with plugins included in the main CKAN core),
 default filters are applied to the search to only get relevant resources. For

--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -282,8 +282,8 @@ database and the API as thin as possible to allow you to use the features you wo
 expect from a powerful database management system.
 
 A DataStore resource can not be created on its own. It is always required to have an
-associated CKAN resource. If data is stored in the DataStore, it will automatically be
-previewed by the :ref:`recline preview extension <data-explorer>`.
+associated CKAN resource. If data is stored in the DataStore, it can automatically be
+previewed by a :ref:`preview extension <data-explorer>`.
 
 
 Making a Data API request

--- a/doc/theming/templates.rst
+++ b/doc/theming/templates.rst
@@ -47,7 +47,7 @@ an extension and plugin. For a detailed explanation of the steps below, see
 5. Add the plugin to the ``ckan.plugins`` setting in your |ckan.ini|
    file::
 
-    ckan.plugins = stats text_view recline_view example_theme
+    ckan.plugins = stats text_view datatables_view example_theme
 
 6. Start CKAN in the development web server:
 


### PR DESCRIPTION
It has served CKAN very well but in 2.10 is time to start saying goodbye to the venerable Recline-based views. Recline hasn't been maintained in many years, and it doesn't even have its [own repository now](https://github.com/datopian/portal.js#what-happened-to-recline). 

The DataTables view is a much more solid replacement for tabular data, and for the functionality that will be lost (generate (crappy) graphs or maps from tabular data) there are more modern alternatives maintained elsewhere (eg from [Keitaro](https://github.com/keitaroinc/ckanext-visualize) or [Datopian](https://github.com/datopian/ckanext-dataexplorer-react)). The other thing that Recline offered that has no immediate replacement is the ability to preview tabular data *not* present in the DataStore via the DataProxy service but this has always proven very unreliable and the source of confusion for users, so again I think it's worth deprecating it.

This PR does a bit of cleanup and it mainly includes:
* Remove recline views from config defaults, tests and examples in docs
* Adds a warning deprecation notice when loading a recline plugin
* Adds `datatables_view` as a default view to be created (if loaded). I didn't add it as default to `ckan.plugins` as without the `datastore` one (and `xloader`) it won't work, but happy to discuss
* Refreshes the data viewer documentation, marking the recline views as deprecated and mentioning community alternatives like the ones mentioned before.

It doesn't remove the actual plugins, which we can do later on.
