### PR TITLE
restore original plugin template directory order

### DIFF
--- a/changes/7085.bugfix
+++ b/changes/7085.bugfix
@@ -1,0 +1,1 @@
+restore original plugin template directory order after update_config order change

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -11,6 +11,8 @@ groups:
         internal: true
       - key: plugin_template_paths
         ignored: true
+      - key: plugin_public_paths
+        ignored: true
       - key: computed_template_paths
         ignored: true
       - key: clear_logo_upload

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -9,6 +9,8 @@ groups:
         internal: true
       - key: ckan.admin_tabs
         internal: true
+      - key: plugin_template_paths
+        ignored: true
       - key: computed_template_paths
         ignored: true
       - key: clear_logo_upload

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -115,9 +115,6 @@ def update_config() -> None:
 
     webassets_init()
 
-    # clear generated values before reloading config:
-    config.pop('plugin_template_paths', None)
-    config.pop('plugin_public_paths', None)
     for plugin in reversed(list(p.PluginImplementations(p.IConfigurer))):
         # must do update in place as this does not work:
         # config = plugin.update_config(config)
@@ -194,11 +191,11 @@ def update_config() -> None:
     template_paths = [jinja2_templates_path]
 
     extra_template_paths = config.get_value('extra_template_paths')
+    if 'plugin_template_paths' in config:
+        template_paths = config['plugin_template_paths'] + template_paths
     if extra_template_paths:
         # must be first for them to override defaults
         template_paths = extra_template_paths.split(',') + template_paths
-    if 'plugin_template_paths' in config:
-        template_paths.extend(config['plugin_template_paths'])
     config['computed_template_paths'] = template_paths
 
     # Enable pessimistic disconnect handling (added in SQLAlchemy 1.2)

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -194,6 +194,8 @@ def update_config() -> None:
     if extra_template_paths:
         # must be first for them to override defaults
         template_paths = extra_template_paths.split(',') + template_paths
+    if 'plugin_template_paths' in config:
+        template_paths.extend(config['plugin_template_paths'])
     config['computed_template_paths'] = template_paths
 
     # Enable pessimistic disconnect handling (added in SQLAlchemy 1.2)

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -115,6 +115,9 @@ def update_config() -> None:
 
     webassets_init()
 
+    # clear generated values before reloading config:
+    config.pop('plugin_template_paths', None)
+    config.pop('plugin_public_paths', None)
     for plugin in reversed(list(p.PluginImplementations(p.IConfigurer))):
         # must do update in place as this does not work:
         # config = plugin.update_config(config)

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -145,7 +145,9 @@ def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:
     public_folder = config.get_value(u'ckan.base_public_folder')
     app.static_folder = config.get_value(
         'extra_public_paths'
-    ).split(',') + [os.path.join(root, public_folder)] + storage_folder
+    ).split(',') + config.get('plugin_public_paths', []) + [
+        os.path.join(root, public_folder)
+    ] + storage_folder
 
     app.jinja_options = jinja_extensions.get_jinja_env_options()
     app.jinja_env.policies['ext.i18n.trimmed'] = True

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -123,7 +123,7 @@ def add_template_directory(config_: CKANConfig, relative_path: str):
     The path is relative to the file calling this function.
 
     """
-    _add_served_directory(config_, relative_path, "extra_template_paths")
+    _add_served_directory(config_, relative_path, "plugin_template_paths")
 
 
 def add_public_directory(config_: CKANConfig, relative_path: str):
@@ -139,7 +139,7 @@ def add_public_directory(config_: CKANConfig, relative_path: str):
     from ckan.lib.helpers import _local_url
     from ckan.lib.webassets_tools import add_public_path
 
-    path = _add_served_directory(config_, relative_path, "extra_public_paths")
+    path = _add_served_directory(config_, relative_path, "plugin_public_paths")
     url = _local_url("/", locale="default")
     add_public_path(path, url)
 
@@ -150,18 +150,18 @@ def _add_served_directory(
     import inspect
     import os
 
-    assert config_var in ("extra_template_paths", "extra_public_paths")
+    assert config_var in ("plugin_template_paths", "plugin_public_paths")
     # we want the filename that of the function caller but they will
     # have used one of the available helper functions
     filename = inspect.stack()[2].filename
 
     this_dir = os.path.dirname(filename)
     absolute_path = os.path.join(this_dir, relative_path)
-    if absolute_path not in config_.get_value(config_var).split(","):
+    if absolute_path not in config_.get(config_var, []):
         if config_.get_value(config_var):
-            config_[config_var] = absolute_path + "," + config_[config_var]
+            config_[config_var] = [absolute_path] + config_[config_var]
         else:
-            config_[config_var] = absolute_path
+            config_[config_var] = [absolute_path]
     return absolute_path
 
 

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -159,7 +159,7 @@ def _add_served_directory(
     absolute_path = os.path.join(this_dir, relative_path)
     if absolute_path not in config_.get_value(config_var).split(","):
         if config_.get_value(config_var):
-            config_[config_var] += "," + absolute_path
+            config_[config_var] = absolute_path + "," + config_[config_var]
         else:
             config_[config_var] = absolute_path
     return absolute_path

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -158,7 +158,7 @@ def _add_served_directory(
     this_dir = os.path.dirname(filename)
     absolute_path = os.path.join(this_dir, relative_path)
     if absolute_path not in config_.get(config_var, []):
-        if config_.get_value(config_var):
+        if config_var in config_:
             config_[config_var] = [absolute_path] + config_[config_var]
         else:
             config_[config_var] = [absolute_path]

--- a/ckan/tests/helpers.py
+++ b/ckan/tests/helpers.py
@@ -598,6 +598,7 @@ class FakeSMTP(smtplib.SMTP):
 
     def __init__(self):
         self._msgs = []
+        self.esmtp_features = ['starttls']
 
     def __call__(self, *args):
         return self


### PR DESCRIPTION
Fixes #7085

### Proposed fixes:

restore original plugin template directory order after update_config order change #7033

also cleans up some code that used string concatenation for adding to a list of paths and clearly separates "extra_{template,public}_paths" settings from an ini file from template/public paths added by plugins at startup.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport