### PR TITLE
[5888] return string as error response

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -506,7 +506,7 @@ def package_revise(context: Context, data_dict: DataDict) -> ActionResult.Packag
             dfunc.update_merge_dict(orig, data['update'])
         except dfunc.DataError as de:
             model.Session.rollback()
-            raise ValidationError({'message': [{'update': [de.error]}]})
+            raise ValidationError({'message': {'update':"{}".format(de.error)}})
 
     # update __extend keys before __#__* so that files may be
     # attached to newly added resources in the same call
@@ -517,7 +517,7 @@ def package_revise(context: Context, data_dict: DataDict) -> ActionResult.Packag
             dfunc.update_merge_string_key(orig, k, v)
         except dfunc.DataError as de:
             model.Session.rollback()
-            raise ValidationError({'message': [{k: [de.error]}]})
+            raise ValidationError({'message': "{}: {}".format(k, de.error)})
 
     _check_access('package_revise', context, {"update": orig})
 


### PR DESCRIPTION
Fixes #5888

### Proposed fixes:
Return string as a error response for `package_revise` instead of a list.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
