### PR TITLE
Fix default values for REMEMBER_COOKIE_* options

### DIFF
--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -679,12 +679,13 @@ groups:
         description: The name of the cookie to store the “remember me” information in.
 
       - key: REMEMBER_COOKIE_DURATION
-        default: 365 days (1 non-leap Gregorian year)
+        default: 31_536_000
+        type: int
         description: |
           The amount of time before the cookie expires, as a datetime.timedelta object or integer seconds.
 
       - key: REMEMBER_COOKIE_DOMAIN
-        default: None
+        default: null
         description: |
           If the “Remember Me” cookie should cross domains, set the domain value here
           (i.e. .example.com would allow the cookie to be used on all subdomains of example.com).


### PR DESCRIPTION
Modern browsers won't allow the addition of a cookie for single-word domains(like `localhost`, `com`, `xxx`). There must be at least one `.` in the domain name.
The declared default value of `REMEMBER_COOKIE_DOMAIN` is set to `None`, which is interpreted by YAML parser as a string. As result, flask-login tries to set a remember-cookie for the `None` domain, which is not allowed, as mentioned above.

### Proposed fixes:

Change declaration of `REMEMBER_COOKIE_DOMAIN` to `default: null`, which is parsed to python's `None` and work as expected.
In addition, change the declaration `REMEMBER_COOKIE_DURATION`. flask-login expects it to be an integer, not the `365 days` string.

@amercader, this change fixes the problem in the master. There is a similar issue for v2.9.5 - #7065 - but I just realized that it's probably unrelated because there is no `flask-login` in v2.9.5. And, there were no incorrect config declarations that actually caused the problem. 