### PR TITLE
Fix to display site description when logo defined

### DIFF
--- a/ckan/templates/header.html
+++ b/ckan/templates/header.html
@@ -75,6 +75,11 @@
         <img src="{{ h.url_for_static_or_external(g.site_logo) }}" alt="{{ g.site_title }}"
           title="{{ g.site_title }}" />
       </a>
+        {% if g.site_description %}
+       <div>
+      {{ g.site_description }}
+       </div>
+       {% endif %}
       {% else %}
       <h1>
         <a href="{{ h.url_for('home.index') }}">{{ g.site_title }}</a>


### PR DESCRIPTION
Fixes #6111 

### Proposed fixes:
This fix will allow to use ckan site description even when site logo is defined



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
