### PR TITLE
[#7028] CSRF and API calls, tests

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -327,7 +327,7 @@ def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:
         This callback function is called whenever a user could not be
         authenticated via the session cookie, so we fall back to the API token.
         """
-        g.login_via_request = True
+        g.login_via_auth_header = True
 
         user = _get_user_for_apitoken()
 
@@ -414,8 +414,8 @@ def ckan_before_request() -> Optional[Response]:
     response = identify_user()
 
     # Disable CSRF protection if user was logged in via the Authorization
-    # header from the request
-    if g.get("login_via_request"):
+    # header
+    if g.get("login_via_auth_header"):
         csrf.exempt(f"ckan.views.{request.endpoint}")
 
     # Set the csrf_field_name so we can use it in our templates

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -418,8 +418,9 @@ def ckan_before_request() -> Optional[Response]:
     if g.get("login_via_auth_header"):
         # Get the actual view function, as it might not match the endpoint,
         # eg "organization.edit" -> "group.edit", or custom dataset types
-        view = current_app.view_functions.get(request.endpoint)
-        dest = f"{view.__module__}.{view.__name__}"
+        endpoint = request.endpoint or ""
+        view = current_app.view_functions.get(endpoint)
+        dest = f"{view.__module__}.{view.__name__}"     # type: ignore
         csrf.exempt(dest)
 
     # Set the csrf_field_name so we can use it in our templates

--- a/ckan/tests/controllers/test_api.py
+++ b/ckan/tests/controllers/test_api.py
@@ -380,3 +380,38 @@ def test_cookie_based_auth_disabled(app):
     res = app.get(url, environ_overrides=env)
 
     assert res.status_code == 200
+
+
+@pytest.mark.usefixtures("clean_db")
+def test_header_based_auth_default(app):
+
+    sysadmin = factories.SysadminWithToken()
+    org = factories.Organization()
+    dataset = factories.Dataset(private=True, owner_org=org["id"])
+
+    url = url_for("api.action", ver=3, logic_function="package_show", id=dataset["id"])
+
+    env = {"Authorization": sysadmin["token"]}
+
+    res = app.get(url, environ_overrides=env)
+
+    assert res.status_code == 200
+
+@pytest.mark.usefixtures("clean_db")
+def test_header_based_auth_default_post(app):
+
+    sysadmin = factories.SysadminWithToken()
+    org = factories.Organization()
+    dataset = factories.Dataset(private=True, owner_org=org["id"])
+
+    url = url_for("api.action", ver=3, logic_function="package_patch")
+
+    env = {"Authorization": sysadmin["token"]}
+
+    data = {
+        "id": dataset["id"],
+        "notes": "updated",
+    }
+    res = app.post(url, environ_overrides=env, data=data)
+
+    assert res.status_code == 200

--- a/ckan/tests/controllers/test_api.py
+++ b/ckan/tests/controllers/test_api.py
@@ -397,6 +397,7 @@ def test_header_based_auth_default(app):
 
     assert res.status_code == 200
 
+
 @pytest.mark.usefixtures("clean_db")
 def test_header_based_auth_default_post(app):
 

--- a/ckan/tests/controllers/test_organization.py
+++ b/ckan/tests/controllers/test_organization.py
@@ -135,7 +135,7 @@ class TestOrganizationEdit(object):
     def test_all_fields_saved(self, app, user):
         env = {"Authorization": user["token"]}
         group = factories.Organization(user=user)
-        app.post(
+        xx = app.post(
             url=url_for(
                 "organization.edit", id=group["id"]
             ),

--- a/ckan/tests/controllers/test_organization.py
+++ b/ckan/tests/controllers/test_organization.py
@@ -135,7 +135,7 @@ class TestOrganizationEdit(object):
     def test_all_fields_saved(self, app, user):
         env = {"Authorization": user["token"]}
         group = factories.Organization(user=user)
-        xx = app.post(
+        app.post(
             url=url_for(
                 "organization.edit", id=group["id"]
             ),

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -249,7 +249,8 @@ class TestPackageNew(object):
                 "save": "",
                 "_ckan_phase": 1
             },
-        follow_redirects=False)
+            follow_redirects=False
+        )
 
         location = _get_location(response)
         response = app.post(location, data={

--- a/ckan/tests/helpers.py
+++ b/ckan/tests/helpers.py
@@ -268,8 +268,6 @@ def _get_test_app():
 
     """
     config["testing"] = True
-    # exempt the CKAN TESTS from csrf-validation.
-    config["WTF_CSRF_METHODS"] = []
     app = ckan.config.middleware.make_app(config)
     app = CKANTestApp(app)
 


### PR DESCRIPTION
Fixes #7095 

* Disable CSRF protection if the user was authenticated via `Authorization` header
* Re-enable CSRF protection in tests, still WIP