### PR TITLE
Make the pytest options consistent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ defaults:
     # Tests Backend, split across containers by segments
     run: |
       mkdir -p ~/junit/result
-      python -m pytest -v --ckan-ini=test-core-circle-ci.ini --cov=ckan --cov=ckanext --junitxml=/root/junit/result/junit.xml --splits 4 --group $((CIRCLE_NODE_INDEX+1)) --splitting-algorithm least_duration
+      python -m pytest ${PYTEST_COMMON_OPTIONS} --splits 4 --group $((CIRCLE_NODE_INDEX+1)) --splitting-algorithm least_duration
 
   ckan_env: &ckan_env
     environment:
@@ -36,7 +36,7 @@ defaults:
       CKAN_POSTGRES_USER: ckan_default
       CKAN_POSTGRES_PWD: pass
       PGPASSWORD: ckan
-      PYTEST_COMMON_OPTIONS: -v --ckan-ini=test-core-circle-ci.ini --cov=ckan --cov=ckanext --junitxml=/root/junit/result/junit.xml --test-group-count 4  --test-group-random-seed 1
+      PYTEST_COMMON_OPTIONS: -v --ckan-ini=test-core-circle-ci.ini --cov=ckan --cov=ckanext --junitxml=~/junit/result/junit.xml
   pg_image: &pg_image
     image: postgres:10
     environment:


### PR DESCRIPTION
### Proposed fixes:

* use `~/junit` rather than `/root/junit` to match the `mkdir -p`
* actually use the common options in the pytest call
* put the split options in the runtime call
* Remove obsolete option in the `PYTEST_COMMON_OPTIONS`

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
