### PR TITLE
Fix resource file size not updating with resource_patch

### DIFF
--- a/changes/7075.bugfix
+++ b/changes/7075.bugfix
@@ -1,0 +1,1 @@
+Fix resource file size not updating with resource_patch

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -302,7 +302,7 @@ def package_update(
             if hasattr(upload, 'mimetype'):
                 resource['mimetype'] = upload.mimetype
 
-        if 'size' not in resource and 'url_type' in resource:
+        if 'url_type' in resource:
             if hasattr(upload, 'filesize'):
                 resource['size'] = upload.filesize
 


### PR DESCRIPTION
Fixes #7075

### Proposed fixes:
- Remove `size` check as it retains previous file size when patching a resource

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Financed by Finland's Data Exchange Layer directory API Catalogue at https://liityntakatalogi.suomi.fi/en_GB/.
The Service is provided by the Digital and Population Data Services Agency ([https://dvv.fi/en/).](https://dvv.fi/en/)
