### PR TITLE
Config declaration improvements

### DIFF
--- a/ckan/cli/config.py
+++ b/ckan/cli/config.py
@@ -139,7 +139,7 @@ def search(
             continue
         option = decl[key]
         default = option.default
-        current = option._normalize(cfg.get(str(key), default))
+        current = option.normalize(cfg.get(str(key), default))
         if no_custom and default != current:
             continue
         if custom_only and default == current:

--- a/ckan/cli/config.py
+++ b/ckan/cli/config.py
@@ -65,8 +65,8 @@ def describe(plugins: tuple[str, ...], core: bool, enabled: bool, fmt: str):
     help="Include declarations of plugins enabled in the CKAN config file",
 )
 @click.option(
-    "-v",
-    "--verbose",
+    "-d",
+    "--include_docs",
     is_flag=True,
     help="Include documentation for options",
 )
@@ -80,14 +80,14 @@ def declaration(
     plugins: tuple[str, ...],
     core: bool,
     enabled: bool,
-    verbose: bool,
+    include_docs: bool,
     minimal: bool,
 ):
     """Print declared config options for the given plugins."""
 
     decl = _declaration(plugins, core, enabled)
     if decl:
-        click.echo(decl.into_ini(minimal, verbose))
+        click.echo(decl.into_ini(minimal, include_docs))
 
 
 @config.command()

--- a/ckan/cli/config.py
+++ b/ckan/cli/config.py
@@ -66,7 +66,7 @@ def describe(plugins: tuple[str, ...], core: bool, enabled: bool, fmt: str):
 )
 @click.option(
     "-d",
-    "--include_docs",
+    "--include-docs",
     is_flag=True,
     help="Include documentation for options",
 )

--- a/ckan/cli/generate.py
+++ b/ckan/cli/generate.py
@@ -161,7 +161,17 @@ def make_config(output_path: str, include_plugin: list[str]):
     for plugin in include_plugin:
         config_declaration.load_plugin(plugin)
 
-    variables = {"declaration": config_declaration.into_ini(False, False)}
+    variables = {
+        "app_main_section": config_declaration.into_ini(
+            minimal=False,
+            include_docs=False,
+        ),
+        "default_section": config_declaration.into_ini(
+            minimal=False,
+            include_docs=True,
+            section="DEFAULT"
+        )
+    }
     with open(template_loc, u'r') as file_in:
         template = string.Template(file_in.read())
         try:

--- a/ckan/common.py
+++ b/ckan/common.py
@@ -138,7 +138,7 @@ class CKANConfig(MutableMapping):
             return self.get(key)
 
         value = self.get(key, option.default)
-        return option._normalize(value)
+        return option.normalize(value)
 
     def subset(
             self, pattern: Key,

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -258,6 +258,8 @@ groups:
       - key: ckan.user.last_active_interval
         type: int
         default: 600
+        description: |
+          The number of seconds between requests to record the last time a user was active on the site.
       - key: cache_dir
         placeholder: "/tmp/%(ckan.site_id)s"
       - key: beaker.session.key
@@ -330,6 +332,7 @@ groups:
       - key: sqlalchemy.pool_pre_ping
         type: bool
         default: true
+
       - key: sqlalchemy.<OPTION>
         type: dynamic
         description: |
@@ -793,7 +796,10 @@ groups:
           .. note::  If you change this value, you need to rebuild the search index.
 
       - key: solr_user
+        description: User to use in HTTP Basic Authentication when connecting to Solr
       - key: solr_password
+        description: Password to use in HTTP Basic Authentication when connecting to Solr
+
       - key: ckan.search.remove_deleted_packages
         type: bool
         default: true
@@ -975,6 +981,7 @@ groups:
       - key: ckan.resource_proxy.timeout
         type: int
         default: 5
+        description: Timeout in seconds to use on Resource Proxy requests.
 
   - annotation: Front-End Settings
     options:
@@ -1120,9 +1127,11 @@ groups:
 
       - key: ckan.homepage_style
         default: "1"
+        description: Pre-configured homepage style to use. Allowed values are 1, 2 or 3.
         editable: true
 
       - key: ckan.site_custom_css
+        description: Custom CSS directives to include on all CKAN pages. 
         editable: true
 
 
@@ -1226,11 +1235,6 @@ groups:
           by CKAN core. It is currently unused and it only accepts one value: ``templates``
           (Bootstrap 3, the default value from CKAN 2.8 onwards).
 
-      - key: ckan.default.group_type
-        default: group
-      - key: ckan.default.organization_type
-        default: organization
-
   - annotation: Storage Settings
     options:
       - key: ckan.storage_path
@@ -1307,6 +1311,8 @@ groups:
 
       - key: ckan.route_after_login
         default: dashboard.datasets
+        description: |
+          Allows to customize the route that the user will get redirected to after a successful login.
 
   # TODO: move to activity extension
   - annotation: Activity Streams Settings
@@ -1380,6 +1386,7 @@ groups:
       - key: ckan.feeds.limit
         type: int
         default: 20
+        description: Number of items returned in the feeds
 
   - annotation: Internationalisation Settings
     options:

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -127,12 +127,9 @@ groups:
       - key: DEBUG_TB_PANELS
         internal: true
 
-  - annotation: General settings
+  - annotation: ~
+    section: DEFAULT
     options:
-      - key: use
-        placeholder: egg:ckan
-        validators: not_empty
-        required: true
       - key: debug
         type: bool
         example: 'true'
@@ -159,6 +156,13 @@ groups:
           .. warning:: This option should be set to ``False`` for a public site.
              With debug mode enabled, a visitor to your site could execute malicious
              commands.
+
+  - annotation: General settings
+    options:
+      - key: use
+        placeholder: egg:ckan
+        validators: not_empty
+        required: true
 
       - key: ckan.legacy_route_mappings
         default: {}

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -127,7 +127,7 @@ groups:
       - key: DEBUG_TB_PANELS
         internal: true
 
-  - annotation: ~
+  - annotation: Default settings
     section: DEFAULT
     options:
       - key: debug
@@ -982,19 +982,23 @@ groups:
         default: CKAN
         example: Open Data Scotland
         description: This sets the name of the site, as displayed in the CKAN web interface.
+        editable: true
 
       - key: ckan.site_description
         example: The easy way to get, use and share data
         description: This is for a description, or tag line for the site, as displayed in the header of the CKAN web interface.
+        editable: true
 
       - key: ckan.site_intro_text
         example: Nice introductory paragraph about CKAN or the site in general.
         description: This is for an introductory text used in the default template's index page.
+        editable: true
 
       - key: ckan.site_logo
         default: /base/images/ckan-logo.png
         example: /images/ckan_logo_fullname_long.png
         description: This sets the logo used in the title bar.
+        editable: true
 
       - key: ckan.site_about
         example: A _community-driven_ catalogue of _open data_ for the Greenfield area.
@@ -1009,6 +1013,7 @@ groups:
             option will not be translatable. For this reason, it's better to
             overload the snippet in ``home/snippets/about_text.html``. For more
             information, see :doc:`/theming/index`.
+        editable: true
 
       - key: ckan.main_css
         default: /base/css/main.css
@@ -1115,7 +1120,10 @@ groups:
 
       - key: ckan.homepage_style
         default: "1"
+        editable: true
+
       - key: ckan.site_custom_css
+        editable: true
 
 
   - annotation: Resource Views Settings

--- a/ckan/config/declaration/__init__.py
+++ b/ckan/config/declaration/__init__.py
@@ -73,7 +73,7 @@ class Declaration:
         if isinstance(pattern, str):
             pattern = Pattern.from_string(pattern)
         for k, v in self._mapping.items():
-            if v._has_flag(exclude):
+            if v.has_flag(exclude):
                 continue
             if pattern != k:
                 continue
@@ -174,19 +174,23 @@ class Declaration:
     def declare(
         self, key: Union[Key, str], default: Optional[T] = None
     ) -> Option[T]:
+        return self.declare_option(key, Option(default))
+
+    def declare_option(
+        self, key: Union[Key, str], option: Option[T]
+    ) -> Option[T]:
         if self._sealed:
             raise TypeError("Sealed declaration cannot be updated")
 
         if isinstance(key, str):
             key = Key.from_string(key)
 
-        value = Option(default)
         if key in self._mapping:
             raise ValueError(f"{key} already declared")
         self._order.append(key)
 
-        self._mapping[key] = value
-        return value
+        self._mapping[key] = option
+        return option
 
     def declare_bool(
             self, key: Key, default: Optional[bool] = False) -> Option[bool]:

--- a/ckan/config/declaration/__init__.py
+++ b/ckan/config/declaration/__init__.py
@@ -29,11 +29,12 @@ from .serialize import serializer
 if TYPE_CHECKING:
     from ckan.common import CKANConfig
 
-log = logging.getLogger(__name__)
 
 __all__ = ["Declaration", "Key"]
 
 _non_iterable = Flag.non_iterable()
+
+log = logging.getLogger(__name__)
 
 
 class Declaration:
@@ -223,10 +224,15 @@ class Declaration:
         """
         loader(self, "dict", data)
 
-    def into_ini(self, minimal: bool, include_docs: bool = False) -> str:
+    def into_ini(
+            self,
+            minimal: bool,
+            include_docs: bool = False,
+            section: str = "app:main"
+    ) -> str:
         """Serialize declaration into config template.
         """
-        return serializer(self, "ini", minimal, include_docs)
+        return serializer(self, "ini", minimal, include_docs, section)
 
     def into_schema(self) -> Dict[str, Any]:
         """Serialize declaration into validation schema.
@@ -309,7 +315,7 @@ class Declaration:
         option: Option[Any] = self.declare(key, default)
         return option
 
-    def annotate(self, annotation: str):
+    def annotate(self, text: str) -> Annotation:
         """Add section annotation.
 
         All the options added after this call(and till the next annotation)
@@ -322,4 +328,6 @@ class Declaration:
         if self._sealed:
             raise TypeError("Sealed declaration cannot be updated")
 
-        self._members.append(Annotation(annotation))
+        annotation = Annotation(text)
+        self._members.append(annotation)
+        return annotation

--- a/ckan/config/declaration/__init__.py
+++ b/ckan/config/declaration/__init__.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+"""This module contains definition of the config Declaration class.
+
+"""
 from __future__ import annotations
 
 import logging
@@ -34,15 +37,22 @@ _non_iterable = Flag.non_iterable()
 
 
 class Declaration:
+    """Container for the config declarations.
+
+    This class provides methods for all the common interactions with the config
+    declarations. So in most cases, you won't use any other member defined
+    under this module directly.
+
+    """
     __slots__ = (
-        "_mapping",
-        "_order",
+        "_options",
+        "_members",
         "_plugins",
         "_core_loaded",
         "_sealed",
     )
-    _mapping: Dict[Key, Option[Any]]
-    _order: List[Union[Key, Annotation, Any]]
+    _options: Dict[Key, Option[Any]]
+    _members: List[Union[Key, Annotation, Any]]
     _plugins: Set[str]
     _sealed: bool
     _core_loaded: bool
@@ -51,15 +61,17 @@ class Declaration:
         self._reset()
 
     def __bool__(self):
-        return bool(self._order)
+        return bool(self._members)
 
     def __contains__(self, key: Key):
-        return key in self._mapping
+        return key in self._options
 
     def __getitem__(self, key: Key) -> Option[Any]:
-        return self._mapping[key]
+        return self._options[key]
 
     def get(self, key: Union[str, Key]) -> Optional[Option[Any]]:
+        """Return the declaration of config option or `None`.
+        """
         k = Key._as_key(key)
         if k in self:
             return self[k]
@@ -70,16 +82,31 @@ class Declaration:
         pattern: Union[str, Pattern] = "*",
         exclude: Flag = _non_iterable,
     ) -> Iterator[Key]:
+        """Iterate over declared config options.
+
+        Args:
+            pattern: only iterate over options that matches the pattern
+            exclude: skip options that have given flag.
+        """
         if isinstance(pattern, str):
             pattern = Pattern.from_string(pattern)
-        for k, v in self._mapping.items():
+
+        for k, v in self._options.items():
             if v.has_flag(exclude):
                 continue
+
             if pattern != k:
                 continue
+
             yield k
 
     def setup(self):
+        """Load all the config declarations from core and enabled plugins.
+
+        This method seals the declaration object, preventing further
+        modifications.
+
+        """
         import ckan.plugins as p
 
         self._reset()
@@ -91,6 +118,16 @@ class Declaration:
         self._seal()
 
     def make_safe(self, config: "CKANConfig") -> bool:
+        """Load defaul values for missing options.
+
+        This method has effect only in strict mode, because in normal mode
+        there are no guarantees that all the default values are available and
+        valid.
+
+        Returns `True` if declaration became safe and `False` if something went
+        wrong(strict mode is not enabled).
+
+        """
         if config.get_value("config.mode") != "strict":
             return False
 
@@ -100,6 +137,17 @@ class Declaration:
         return True
 
     def normalize(self, config: "CKANConfig") -> bool:
+        """Validate and normalize all the values in the config object.
+
+        This method ensures that all the config values are in-place and
+        converts them to the expected type. This method may significantly
+        improve performance of `config.get_value`, because the latter:
+        * no longer has to check if default value required
+        * doesn't have to convert the value using validators
+
+        Works only in strict mode.
+
+        """
         import ckan.lib.navl.dictization_functions as df
 
         if config.get_value("config.mode") != "strict":
@@ -125,7 +173,11 @@ class Declaration:
 
         return True
 
-    def validate(self, config: "CKANConfig"):
+    def validate(
+            self, config: "CKANConfig"
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Return validated config dict and dictionary with validation errors.
+        """
         import ckan.lib.navl.dictization_functions as df
 
         schema = self.into_schema()
@@ -133,16 +185,24 @@ class Declaration:
         return data, errors
 
     def _reset(self):
-        self._mapping = OrderedDict()
-        self._order = []
+        """Unseal declaration and remove all the options, making it ready for
+        the new definitions.
+
+        """
+        self._options = OrderedDict()
+        self._members = []
         self._plugins = set()
         self._core_loaded = False
         self._sealed = False
 
     def _seal(self):
+        """Prevent further modifications of the declaration object.
+        """
         self._sealed = True
 
     def load_core_declaration(self):
+        """Load CKAN core declarations(no plugins are loaded).
+        """
         if self._core_loaded:
             log.debug("Declaration for core is already loaded")
             return
@@ -151,65 +211,93 @@ class Declaration:
         self._core_loaded = True
 
     def load_plugin(self, name: str):
+        """Load declarations from the enabled plugin.
+        """
         if name in self._plugins:
             log.debug("Declaration for plugin %s is already loaded", name)
             return
         loader(self, "plugin", name)
 
     def load_dict(self, data: DeclarationDict):
+        """Load declarations from dictionary.
+        """
         loader(self, "dict", data)
 
     def into_ini(self, minimal: bool, include_docs: bool = False) -> str:
+        """Serialize declaration into config template.
+        """
         return serializer(self, "ini", minimal, include_docs)
 
     def into_schema(self) -> Dict[str, Any]:
+        """Serialize declaration into validation schema.
+        """
         return serializer(self, "validation_schema")
 
     def into_docs(self) -> str:
+        """Serialize declaration into reST documentation.
+        """
         return serializer(self, "rst")
 
     def describe(self, fmt: str) -> str:
+        """Describe definition of options in the given format.
+        """
         return describer(self, fmt)
 
     def declare(
         self, key: Union[Key, str], default: Optional[T] = None
     ) -> Option[T]:
+        """Add declaration of the option with the given default value.
+        """
         return self.declare_option(key, Option(default))
 
     def declare_option(
         self, key: Union[Key, str], option: Option[T]
     ) -> Option[T]:
+        """Add the declaration using existing Option object.
+
+        Use this method for declaring options using Option subclasses.
+        """
         if self._sealed:
             raise TypeError("Sealed declaration cannot be updated")
 
         if isinstance(key, str):
             key = Key.from_string(key)
 
-        if key in self._mapping:
+        if key in self._options:
             raise ValueError(f"{key} already declared")
-        self._order.append(key)
+        self._members.append(key)
 
-        self._mapping[key] = option
+        self._options[key] = option
         return option
 
     def declare_bool(
             self, key: Key, default: Optional[bool] = False) -> Option[bool]:
+        """Declare boolean option.
+        """
         option = self.declare(key, bool(default))
         option.set_validators("boolean_validator")
         return option
 
     def declare_int(self, key: Key, default: Optional[int]) -> Option[int]:
+        """Declare numeric option.
+        """
         option = self.declare(key, default)
         option.set_validators("convert_int")
         return option
 
     def declare_list(
             self, key: Key, default: Optional[list[Any]]) -> Option[list[Any]]:
+        """Declare option that accepts space-separated list of values.
+        """
         option = self.declare(key, default)
         option.set_validators("as_list")
         return option
 
     def declare_dynamic(self, key: Key, default: Any = None) -> Option[Any]:
+        """Declare dynamic option using a Key with `<name>` segment(surrounded
+        with angles).
+
+        """
         key = Pattern(
             [
                 Wildcard(fragment[1:-1])
@@ -222,7 +310,16 @@ class Declaration:
         return option
 
     def annotate(self, annotation: str):
+        """Add section annotation.
+
+        All the options added after this call(and till the next annotation)
+        will be grouped into separate config section.
+
+        Sections only affect documentation/config template. They do not modify
+        CKAN behavior and are not reflected inside the `config` object.
+
+        """
         if self._sealed:
             raise TypeError("Sealed declaration cannot be updated")
 
-        self._order.append(Annotation(annotation))
+        self._members.append(Annotation(annotation))

--- a/ckan/config/declaration/__init__.py
+++ b/ckan/config/declaration/__init__.py
@@ -159,8 +159,8 @@ class Declaration:
     def load_dict(self, data: DeclarationDict):
         loader(self, "dict", data)
 
-    def into_ini(self, minimal: bool, verbose: bool = False) -> str:
-        return serializer(self, "ini", minimal, verbose)
+    def into_ini(self, minimal: bool, include_docs: bool = False) -> str:
+        return serializer(self, "ini", minimal, include_docs)
 
     def into_schema(self) -> Dict[str, Any]:
         return serializer(self, "validation_schema")

--- a/ckan/config/declaration/describe.py
+++ b/ckan/config/declaration/describe.py
@@ -104,11 +104,11 @@ class AbstractDescriber(metaclass=abc.ABCMeta):
         declaration: "Declaration",
         exclude: Flag,
     ):
-        for item in declaration._order:
+        for item in declaration._members:
             if isinstance(item, Annotation):
                 self.annotate(item)
             elif isinstance(item, Key):
-                option = declaration._mapping[item]
+                option = declaration._options[item]
                 if option.has_flag(exclude):
                     continue
                 self.add_option(item, option)

--- a/ckan/config/declaration/describe.py
+++ b/ckan/config/declaration/describe.py
@@ -1,4 +1,42 @@
 # -*- coding: utf-8 -*-
+"""This module defines the ways to describe the definition of config
+declaration.
+
+We expect that definition produced by describers can be loaded into exactly the
+same declaration, that was used for definition. I.e:
+
+Given:
+  config_declaration = ...
+  config_definition = describe(config_declaration)
+
+When:
+  loaded_declaration = load(config_definition)
+
+Then:
+  loaded_declaration == config_declaration
+
+For now, this rule may be violated sometimes. For example, when callables are
+used in the declaration. But in the future there should be no exceptions from
+it.
+
+New describers can be defined in the following manner:
+
+```python
+from ckan.config.declaration.describe import handler, describer
+
+@handler.register("custom-format")
+def describe_as_custom(declaration, *args, **kwargs):
+    ...
+
+## and now new `custom-format` can be used like this:
+describer(declaration, "custom-format", *args, **kwargs)
+```
+
+This mechanism allows you to re-define default describers, though it should be
+avoided unless you have an irresistible desire to hack into CKAN core.
+
+"""
+
 import abc
 from io import StringIO
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
@@ -57,6 +95,8 @@ def describe_dict(
 
 
 class AbstractDescriber(metaclass=abc.ABCMeta):
+    """Abstract class that defines the workflow for describers.
+    """
     __slots__ = ()
 
     def __call__(
@@ -88,6 +128,10 @@ class AbstractDescriber(metaclass=abc.ABCMeta):
 
 
 class BaseDictDescriber(AbstractDescriber):
+    """Describer that collects definition into a dictionary required by
+    validation schema.
+
+    """
     __slots__ = ("data", "current_listing")
 
     def __init__(self):
@@ -127,14 +171,9 @@ class BaseDictDescriber(AbstractDescriber):
         if option.placeholder:
             data["placeholder"] = option.placeholder
 
-        if option.has_flag(Flag.required):
-            data["required"] = True
-        if option.has_flag(Flag.ignored):
-            data["ignored"] = True
-        if option.has_flag(Flag.internal):
-            data["internal"] = True
-        if option.has_flag(Flag.experimental):
-            data["experimental"] = True
+        for flag in Flag:
+            if option.has_flag(flag) and flag.name:
+                data[flag.name] = True
 
         self.current_listing.append(data)
 
@@ -212,13 +251,8 @@ class PythonDescriber(AbstractDescriber):
         if validators:
             self.output.write(f".set_validators({repr(validators)})")
 
-        if option.has_flag(Flag.required):
-            self.output.write(".required()")
-        if option.has_flag(Flag.ignored):
-            self.output.write(".ignore()")
-        if option.has_flag(Flag.internal):
-            self.output.write(".internal()")
-        if option.has_flag(Flag.experimental):
-            self.output.write(".experimental()")
+        for flag in Flag:
+            if option.has_flag(flag):
+                self.output.write(f".set_flag(Flag.{flag.name})")
 
         self.output.write("\n")

--- a/ckan/config/declaration/describe.py
+++ b/ckan/config/declaration/describe.py
@@ -69,7 +69,7 @@ class AbstractDescriber(metaclass=abc.ABCMeta):
                 self.annotate(item)
             elif isinstance(item, Key):
                 option = declaration._mapping[item]
-                if option._has_flag(exclude):
+                if option.has_flag(exclude):
                     continue
                 self.add_option(item, option)
         return self.finalize()
@@ -127,13 +127,13 @@ class BaseDictDescriber(AbstractDescriber):
         if option.placeholder:
             data["placeholder"] = option.placeholder
 
-        if option._has_flag(Flag.required):
+        if option.has_flag(Flag.required):
             data["required"] = True
-        if option._has_flag(Flag.ignored):
+        if option.has_flag(Flag.ignored):
             data["ignored"] = True
-        if option._has_flag(Flag.internal):
+        if option.has_flag(Flag.internal):
             data["internal"] = True
-        if option._has_flag(Flag.experimental):
+        if option.has_flag(Flag.experimental):
             data["experimental"] = True
 
         self.current_listing.append(data)
@@ -212,13 +212,13 @@ class PythonDescriber(AbstractDescriber):
         if validators:
             self.output.write(f".set_validators({repr(validators)})")
 
-        if option._has_flag(Flag.required):
+        if option.has_flag(Flag.required):
             self.output.write(".required()")
-        if option._has_flag(Flag.ignored):
+        if option.has_flag(Flag.ignored):
             self.output.write(".ignore()")
-        if option._has_flag(Flag.internal):
+        if option.has_flag(Flag.internal):
             self.output.write(".internal()")
-        if option._has_flag(Flag.experimental):
+        if option.has_flag(Flag.experimental):
             self.output.write(".experimental()")
 
         self.output.write("\n")

--- a/ckan/config/declaration/key.py
+++ b/ckan/config/declaration/key.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
+"""This module defines utilitis for manipulations with the name of config
+option.
 
+"""
 import fnmatch
 from typing import Any, Iterable, Tuple, Union
 
@@ -143,6 +146,16 @@ class Key:
 
 
 class Pattern(Key):
+    """Key with dynamic segment, that can match everything.
+
+    Example:
+
+        >>> pattern = Key().ckan.dynamic("anything")
+        >>> assert pattern == "ckan.hello"
+        >>> assert pattern == "ckan.world"
+        >>> assert pattern == "ckan.x.y.z"
+        >>> assert pattern != "not-ckan.hello"
+    """
     __slots__ = ()
     _path: Tuple[Union[str, Wildcard], ...]
 

--- a/ckan/config/declaration/load.py
+++ b/ckan/config/declaration/load.py
@@ -65,6 +65,7 @@ class OptionV1(TypedDict, total=False):
 
 class GroupV1(TypedDict):
     annotation: str
+    section: str
     options: List[OptionV1]
 
 
@@ -112,13 +113,16 @@ def load_dict(declaration: "Declaration", definition: DeclarationDict):
 
         for group in data["groups"]:
             if group["annotation"]:
-                declaration.annotate(group["annotation"])
+                declaration.annotate(group["annotation"]).set_section(
+                    group["section"]
+                )
 
             for details in group["options"]:
                 factory = option_types[details["type"]]
                 option: Option[Any] = getattr(declaration, factory)(
                     details["key"], details.get("default")
                 )
+                option.set_section(group["section"])
                 option.append_validators(details["validators"])
 
                 extras = details.setdefault("__extras", {})

--- a/ckan/config/declaration/load.py
+++ b/ckan/config/declaration/load.py
@@ -1,4 +1,24 @@
 # -*- coding: utf-8 -*-
+"""This module defines the ways to fill config declaration with difinitions
+from different sources.
+
+New loaders can be defined in the following manner:
+
+```python
+from ckan.config.declaration.load import handler, loader
+
+@handler.register("custom-format")
+def load_from_custom(declaration, *args, **kwargs):
+    ...
+
+## and now new `custom-format` can be used like this:
+loader(declaration, "custom-format", *args, **kwargs)
+```
+
+This mechanism allows you to re-define default loaders, though it should be
+avoided unless you have an irresistible desire to hack into CKAN core.
+
+"""
 from __future__ import annotations
 
 import logging
@@ -16,6 +36,7 @@ if TYPE_CHECKING:
 
 
 log = logging.getLogger(__name__)
+
 option_types = {
     "base": "declare",
     "bool": "declare_bool",
@@ -25,6 +46,7 @@ option_types = {
 }
 
 handler: FormatHandler[Callable[..., None]] = FormatHandler()
+loader = handler.handle
 
 
 class OptionV1(TypedDict, total=False):
@@ -40,11 +62,6 @@ class OptionV1(TypedDict, total=False):
     validators: str
     type: str
 
-    disabled: bool
-    ignored: bool
-    experimental: bool
-    internal: bool
-
 
 class GroupV1(TypedDict):
     annotation: str
@@ -57,11 +74,12 @@ class DeclarationDictV1(TypedDict):
 
 
 DeclarationDict = DeclarationDictV1
-loader = handler.handle
 
 
 @handler.register("plugin")
 def load_plugin(declaration: "Declaration", name: str):
+    """Load declarations from CKAN plugin.
+    """
     from ckan.plugins import IConfigDeclaration, PluginNotFoundException
     from ckan.plugins.core import _get_service
 
@@ -80,6 +98,8 @@ def load_plugin(declaration: "Declaration", name: str):
 
 @handler.register("dict")
 def load_dict(declaration: "Declaration", definition: DeclarationDict):
+    """Load declarations from dictionary.
+    """
     from ckan.logic.schema import config_declaration_v1
     from ckan.logic import ValidationError
     from ckan.lib.navl.dictization_functions import validate
@@ -89,9 +109,11 @@ def load_dict(declaration: "Declaration", definition: DeclarationDict):
         data, errors = validate(dict(definition), config_declaration_v1())
         if errors:
             raise ValidationError(errors)
+
         for group in data["groups"]:
             if group["annotation"]:
                 declaration.annotate(group["annotation"])
+
             for details in group["options"]:
                 factory = option_types[details["type"]]
                 option: Option[Any] = getattr(declaration, factory)(
@@ -99,8 +121,9 @@ def load_dict(declaration: "Declaration", definition: DeclarationDict):
                 )
                 option.append_validators(details["validators"])
 
+                extras = details.setdefault("__extras", {})
                 for flag in Flag:
-                    if details.get(flag.name):
+                    if extras.get(flag.name):
                         option.set_flag(flag)
 
                 if details["description"]:
@@ -125,6 +148,8 @@ def load_dict(declaration: "Declaration", definition: DeclarationDict):
 
 @handler.register("core")
 def load_core(declaration: "Declaration"):
+    """Load core declarations.
+    """
     source = pathlib.Path(__file__).parent / ".." / "config_declaration.yaml"
     with source.open("r") as stream:
         data = yaml.safe_load(stream)

--- a/ckan/config/declaration/load.py
+++ b/ckan/config/declaration/load.py
@@ -29,13 +29,17 @@ handler: FormatHandler[Callable[..., None]] = FormatHandler()
 
 class OptionV1(TypedDict, total=False):
     key: str
+
     default: Any
     default_callable: str
     placeholder_callable: str
     callable_args: Dict[str, Any]
+
     description: str
+
     validators: str
     type: str
+
     disabled: bool
     ignored: bool
     experimental: bool
@@ -97,7 +101,7 @@ def load_dict(declaration: "Declaration", definition: DeclarationDict):
 
                 for flag in Flag:
                     if details.get(flag.name):
-                        option._set_flag(flag)
+                        option.set_flag(flag)
 
                 if details["description"]:
                     option.set_description(details["description"])

--- a/ckan/config/declaration/option.py
+++ b/ckan/config/declaration/option.py
@@ -128,6 +128,7 @@ class Annotation(SectionMixin, str):
     """
     pass
 
+
 class Option(SectionMixin, Generic[T]):
     """All the known details about config option.
 

--- a/ckan/config/declaration/option.py
+++ b/ckan/config/declaration/option.py
@@ -1,49 +1,142 @@
 # -*- coding: utf-8 -*-
+"""
+"""
 from __future__ import annotations
 
 import enum
-from typing import Any, Generic, Optional, TypeVar, Dict
+from typing import Any, Generic, Optional, TypeVar
+
+from typing_extensions import Self
 
 from ckan.types import Validator
-
 
 T = TypeVar("T")
 
 
-class UnsetType(Dict[str, Any]):
-    def __repr__(self):
-        return ""
-
-
 class Flag(enum.Flag):
+    """Modifiers for :py:class:`~ckan.config.declaration.option.Option`
+
+
+    ignored: this option is ignored by CKAN(not used or unconditionally
+    overriden)
+
+    experimental: this option is not stabilized and can change in
+    future. Mainly exist for extension developers, as only stable features are
+    included into public CKAN release.
+
+    internal: this option is used internally by CKAN or Flask. Such options are
+    not documented and are not supposed to be modified by users. Think about
+    them as private class attributes.
+
+    required: this option cannot be missing/empty. Add such flag to the option
+    only if CKAN application won't even start without them and there is no
+    sensible default.
+
+    editable: this option is runtime editable. Technically, every option can be
+    modified. This flag means that there is an expectation that option will be
+    modified. For example, this option is exposed via configuration form in the
+    Admin UI.
+
+    reserved_*(01-10): these flags are added for extension developers. CKAN
+    doesn't treat them specially, neither includes them in groups, like
+    `not_safe`/`not_iterable`. These flags are completely ignored by CKAN. If
+    your extension enchances the behavior of config options using some sort of
+    boolean flags - use reserved markers. Always rely on a config option that
+    controls, which reserved marker to use, in order to avoid conflicts with
+    other extensions. Example:
+
+        >>> # BAD
+        >>> marker = Flag.reserved_02
+        >>>
+        >>> # GOOD
+        >>> ### config file
+        >>> # my_extension.feature_flag = reserved_02
+        >>> key = config.get_value('my_extension.feature_flag')
+        >>> marker = Flag[key]
+
+    This allows the end user to manually solve conflicts, when multiple
+    extensions are trying to use the same reserved flag.
+
+    """
     ignored = enum.auto()
     experimental = enum.auto()
     internal = enum.auto()
     required = enum.auto()
+    editable = enum.auto()
+
+    reserved_01 = enum.auto()
+    reserved_02 = enum.auto()
+    reserved_03 = enum.auto()
+    reserved_04 = enum.auto()
+    reserved_05 = enum.auto()
+    reserved_06 = enum.auto()
+    reserved_07 = enum.auto()
+    reserved_08 = enum.auto()
+    reserved_09 = enum.auto()
+    reserved_10 = enum.auto()
 
     @classmethod
     def none(cls):
+        """Return the base flag with no modifiers enabled.
+        """
         return cls(0)
 
     @classmethod
     def non_iterable(cls):
+        """Return the union of flags that should not be iterated over.
+
+        If an option has any of these flags, it isn't listed by the majority of
+        serializers. For example, such option is not added to the documentation
+        and to the config template.
+
+        """
         return cls.ignored | cls.experimental | cls.internal
 
     @classmethod
     def not_safe(cls):
+        """Return the union of flags marking an unsafe option.
+
+        It's never safe to use an unsafe option. For example, unsafe option
+        won't have any default value, so one should never try
+        `config[unsafe_option]`. Basically, unsafe options must be treated as
+        non-existing and never be used in code.
+
+        """
         return cls.ignored | cls.internal
 
 
 class Annotation(str):
+    """Details that are not attached to any option.
+
+    Mainly serves documentation purposes. Can be used for creating section
+    separators or blocks of text with the recomendations, that are not
+    connected to any particular option and rather describle the whole section.
+
+    """
     pass
 
 
 class Option(Generic[T]):
+    """All the known details about config option.
+
+    Option-objects are created from the config declaration and describe the
+    individual config options. They contain all the known details about config
+    option, such as default values, validators and visibility flags.
+
+    Avoid direct creation of Option-objects. Use corresponding
+    :py:class:`~ckan.config.declaration.Declaration` methods instead:
+
+    - declare
+    - declare_bool
+    - declare_int
+    - declare_list
+    - declare_dynamic
+    """
     __slots__ = (
         "flags",
         "default",
         "description",
-        "_validators",
+        "validators",
         "placeholder",
         "example",
     )
@@ -53,93 +146,155 @@ class Option(Generic[T]):
     description: Optional[str]
     placeholder: Optional[str]
     example: Optional[Any]
-    _validators: str
+    validators: str
 
     def __init__(self, default: Optional[T] = None):
         self.flags = Flag.none()
         self.description = None
         self.placeholder = None
         self.example = None
-        self._validators = ""
+        self.validators = ""
         self.default = default
 
-    def __str__(self):
+    def str_value(self) -> str:
+        """Convert option's defautl value into the string.
+
+        If the option has `as_list` validator and default value is represented
+        by the Python's `list` object, result is a space-separated list of all
+        the members of the value. In other cases this method just does naive
+        string conversion.
+
+        If validators are doing complex transformations, for example string ID
+        turns into :py:class:`~ckan.model.User` object, this method won't
+        convert the user object back into ID. Instead it will just do something
+        like `str(user)` and give you `<User ...>`. So it's up to the person
+        who declares config option to add a combination of default value and
+        validators that won't throw an error after such conversion.
+
+        If more sophisticated logic cannot be avoided, consider creating a
+        subclass of :py:class:`~ckan.config.declaration.option.Option` with
+        custom `str_value` implemetation and declaring the option using
+        `declare_option` method of
+        :py:class:`~ckan.config.declaration.Declaration`.
+
+        """
         as_list = "as_list" in self.get_validators()
         if isinstance(self.default, list) and as_list:
             return " ".join(map(str, self.default))
-        return str(self.default)
+        return str(self.default) if self.has_default() else ""
 
-    def _unset_flag(self, flag: Flag):
-        self.flags &= ~flag
+    def set_flag(self, flag: Flag) -> Self:
+        """Enable specified flag.
 
-    def _set_flag(self, flag: Flag):
+        In order to disable the flag, use bit-wise inversion:
+
+            >>> option.set_flag(~Flag.required)
+        """
         self.flags |= flag
+        return self
 
-    def _has_flag(self, flag: Flag) -> bool:
+    def has_flag(self, flag: Flag) -> bool:
+        """Check if option has specified flag enabled.
+        """
         return bool(self.flags & flag)
 
     def has_default(self) -> bool:
+        """Check if option has configured default.
+        """
         return self.default is not None
 
-    def set_default(self, default: T):
+    def set_default(self, default: T) -> Self:
+        """Change the default value of option.
+
+        The default value is used whenever the option is missing from the
+        config file.
+
+        """
         self.default = default
         return self
 
-    def set_example(self, example: str):
+    def set_example(self, example: str) -> Self:
+        """Provide an example(documentation) of the valid value for option.
+        """
         self.example = example
         return self
 
-    def set_description(self, description: str):
+    def set_description(self, description: str) -> Self:
+        """Change the description of option.
+        """
         self.description = description
         return self
 
-    def set_placeholder(self, placeholder: str):
+    def set_placeholder(self, placeholder: str) -> Self:
+        """Add a placeholder for option.
+
+        Placeholder is used during generation of the config template. It's
+        similar to the default value, because it will be shown in the generated
+        configuration file as a value for option. But, unlike the default
+        value, if the option is missing from the config file, no default value
+        is used.
+
+        Placeholder can be used for different kind of secrets and URLs, when
+        you want to show the user how the value should look like.
+
+        """
         self.placeholder = placeholder
         return self
 
-    def set_validators(self, validators: str):
-        self._validators = validators
+    def set_validators(self, validators: str) -> Self:
+        """Replace validators of the option.
+
+        Use a space-separated string with the names of validators that must be
+        applied to the value.
+
+        """
+        self.validators = validators
         return self
 
-    def append_validators(self, validators: str, before: bool = False):
-        """Add extra validators before or after the current list.
+    def append_validators(self, validators: str, before: bool = False) -> Self:
+        """Add extra validators before or after the existing validators.
 
         Use it together with `Declaration.declare_*` shortcuts in order to
         define more specific common options::
 
-            declaration.declare_bool(...).append_validators(
-                "not_missing", before=True)
+            >>> # Declare a mandatory boolean option
+            >>> declaration.declare_bool(...).append_validators(
+                    "not_missing", before=True)
+
+        By default, validators are added after the existing validators. In
+        order to add a new validator before the other validators, pass
+        `before=True` argument.
 
         """
-        left = self._validators
+        left = self.validators
         right = validators
         if before:
             left, right = right, left
 
         glue = " " if left and right else ""
-        self._validators = left + glue + right
+        self.validators = left + glue + right
         return self
 
-    def get_validators(self):
-        return self._validators
+    def get_validators(self) -> str:
+        """Return the string with current validators.
+        """
+        return self.validators
 
-    def ignore(self):
-        self._set_flag(Flag.ignored)
+    def experimental(self) -> Self:
+        """Enable experimental-flag for value.
+        """
+        self.set_flag(Flag.experimental)
         return self
 
-    def experimental(self):
-        self._set_flag(Flag.experimental)
+    def required(self) -> Self:
+        """Enable required-flag for value.
+        """
+        self.set_flag(Flag.required)
         return self
 
-    def internal(self):
-        self._set_flag(Flag.internal)
-        return self
-
-    def required(self):
-        self._set_flag(Flag.required)
-        return self
-
-    def _normalize(self, value: Any):
+    def normalize(self, value: Any) -> Any:
+        """Return the value processed by option's validators.
+        """
         from ckan.lib.navl.dictization_functions import validate
 
         data, _ = validate(
@@ -148,14 +303,15 @@ class Option(Generic[T]):
 
         return data.get("value")
 
-    def _parse_validators(self):
-
+    def _parse_validators(self) -> list[Validator]:
+        """Turn the string with validators into the list of functions.
+        """
         return _validators_from_string(self.get_validators())
 
 
 # taken from ckanext-scheming
 # (https://github.com/ckan/ckanext-scheming/blob/release-2.1.0/ckanext/scheming/validation.py#L407-L426).
-# This syntax is familiar for everyone and it we can switch to the original
+# This syntax is familiar for everyone and we can switch to the original
 # when scheming become a part of core.
 def _validators_from_string(s: str) -> list[Validator]:
     """

--- a/ckan/config/declaration/option.py
+++ b/ckan/config/declaration/option.py
@@ -14,6 +14,18 @@ from ckan.types import Validator
 T = TypeVar("T")
 
 
+class SectionMixin:
+    """Mixin that allows adding objects to different sections of INI-file.
+    """
+    _section = "app:main"
+
+    def set_section(self, section: str) -> Self:
+        """Change the section of this annotation
+        """
+        self._section = section
+        return self
+
+
 class Flag(enum.Flag):
     """Modifiers for :py:class:`~ckan.config.declaration.option.Option`
 
@@ -106,7 +118,7 @@ class Flag(enum.Flag):
         return cls.ignored | cls.internal
 
 
-class Annotation(str):
+class Annotation(SectionMixin, str):
     """Details that are not attached to any option.
 
     Mainly serves documentation purposes. Can be used for creating section
@@ -116,8 +128,7 @@ class Annotation(str):
     """
     pass
 
-
-class Option(Generic[T]):
+class Option(SectionMixin, Generic[T]):
     """All the known details about config option.
 
     Option-objects are created from the config declaration and describe the

--- a/ckan/config/declaration/option.py
+++ b/ckan/config/declaration/option.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-"""
+"""This module defines Option class and its helpers.
+
 """
 from __future__ import annotations
 

--- a/ckan/config/declaration/option.py
+++ b/ckan/config/declaration/option.py
@@ -158,7 +158,7 @@ class Option(Generic[T]):
         self.default = default
 
     def str_value(self) -> str:
-        """Convert option's defautl value into the string.
+        """Convert option's default value into the string.
 
         If the option has `as_list` validator and default value is represented
         by the Python's `list` object, result is a space-separated list of all
@@ -186,10 +186,6 @@ class Option(Generic[T]):
 
     def set_flag(self, flag: Flag) -> Self:
         """Enable specified flag.
-
-        In order to disable the flag, use bit-wise inversion:
-
-            >>> option.set_flag(~Flag.required)
         """
         self.flags |= flag
         return self

--- a/ckan/config/declaration/serialize.py
+++ b/ckan/config/declaration/serialize.py
@@ -42,7 +42,7 @@ serializer = handler.handle
 
 @handler.register("ini")
 def serialize_ini(
-    declaration: "Declaration", minimal: bool, include_docs: bool
+    declaration: "Declaration", minimal: bool, include_docs: bool, section: str
 ):
     """Serialize declaration into config template.
 
@@ -62,13 +62,21 @@ def serialize_ini(
     for item in declaration._members:
 
         if isinstance(item, Annotation):
+            if item._section != section:
+                continue
+
             if minimal:
                 continue
+
             heading = f"## {item} #".ljust(80, "#")
             result += f"\n{heading}\n"
 
         elif isinstance(item, Key):
             option = declaration._options[item]
+
+            if option._section != section:
+                continue
+
             if option.has_flag(Flag.non_iterable()):
                 continue
 

--- a/ckan/config/declaration/serialize.py
+++ b/ckan/config/declaration/serialize.py
@@ -24,9 +24,9 @@ def serialize_ini(
     for item in declaration._order:
         if isinstance(item, Key):
             option = declaration._mapping[item]
-            if option._has_flag(Flag.non_iterable()):
+            if option.has_flag(Flag.non_iterable()):
                 continue
-            if minimal and not option._has_flag(Flag.required):
+            if minimal and not option.has_flag(Flag.required):
                 if item == "config.mode":
                     result += "config.mode = strict\n"
                 continue
@@ -37,9 +37,9 @@ def serialize_ini(
             if not option.has_default():
                 value = option.placeholder or ""
             elif isinstance(option.default, bool):
-                value = str(option).lower()
+                value = option.str_value().lower()
             else:
-                value = str(option)
+                value = option.str_value()
 
             if isinstance(item, Pattern):
                 result += "# "
@@ -76,7 +76,7 @@ def serialize_rst(declaration: "Declaration"):
 
         elif isinstance(item, Key):
             option = declaration._mapping[item]
-            if option._has_flag(Flag.non_iterable()):
+            if option.has_flag(Flag.non_iterable()):
                 continue
             if not option.description:
                 continue
@@ -87,7 +87,7 @@ def serialize_rst(declaration: "Declaration"):
             if option.example:
                 result += f"Example::\n\n\t{item} = {option.example}\n\n"
 
-            default = str(option) if option.has_default() else ''
+            default = option.str_value()
 
             if default != '':
                 if default.startswith(ckan_root):

--- a/ckan/config/declaration/serialize.py
+++ b/ckan/config/declaration/serialize.py
@@ -1,6 +1,27 @@
 # -*- coding: utf-8 -*-
+"""This module defines the ways to serialize the config declaration into
+different structures, such as: documentation string, config template,
+validation schema.
 
+New serializers can be defined in the following manner:
+
+```python
+from ckan.config.declaration.serialize import handler, serializer
+
+@handler.register("custom-format")
+def serialize_into_custom(declaration, *args, **kwargs):
+    ...
+
+## and now new `custom-format` can be used like this:
+serialized_declaration = serializer(declaration, "custom-format", *args, **kwargs)
+```
+
+This mechanism allows you to re-define default serializers, though it should be
+avoided unless you have an irresistible desire to hack into CKAN core.
+
+"""
 import os
+import logging
 from typing import TYPE_CHECKING, Any, Callable, Dict
 
 import ckan
@@ -12,28 +33,56 @@ from .utils import FormatHandler
 if TYPE_CHECKING:
     from . import Declaration
 
+
+log = logging.getLogger(__name__)
 handler: FormatHandler[Callable[..., Any]] = FormatHandler()
 serializer = handler.handle
 
 
 @handler.register("ini")
 def serialize_ini(
-    declaration: "Declaration", minimal: bool, verbose: bool
+    declaration: "Declaration", minimal: bool, include_docs: bool
 ):
+    """Serialize declaration into config template.
+
+    Output:
+        ## Section #######
+        ## doc string in `include_docs` mode
+        option.name = option-value
+        another.option =
+
+    Args:
+        minimal: include only required options.
+            Skip section dividers and all the options with default value
+        include_docs: include description of the option into output.
+    """
     result = ""
+
     for item in declaration._order:
-        if isinstance(item, Key):
+
+        if isinstance(item, Annotation):
+            if minimal:
+                continue
+            heading = f"## {item} #".ljust(80, "#")
+            result += f"\n{heading}\n"
+
+        elif isinstance(item, Key):
             option = declaration._mapping[item]
             if option.has_flag(Flag.non_iterable()):
                 continue
+
             if minimal and not option.has_flag(Flag.required):
+                # minimal config template relies on default values.
+                # It means, it works only in strict mode.
                 if item == "config.mode":
                     result += "config.mode = strict\n"
                 continue
-            if option.description and verbose:
+
+            if option.description and include_docs:
                 result += "\n".join(
                     "## " + line for line in option.description.splitlines()
                 ) + "\n"
+
             if not option.has_default():
                 value = option.placeholder or ""
             elif isinstance(option.default, bool):
@@ -42,47 +91,62 @@ def serialize_ini(
                 value = option.str_value()
 
             if isinstance(item, Pattern):
+                # Patterns are not actual config options, but rather an example
+                # of possibilities: `sqlalchemy.<option> = `. Thus they cannot
+                # be added to config file as real options. But still, we want
+                # to show user, that he can use patterns as well.
                 result += "# "
-            result += f"{item} = {value}\n"
 
-        elif isinstance(item, Annotation):
-            if minimal:
-                continue
-            result += "\n{}\n".format(f"## {item} #".ljust(80, "#"))
+            result += f"{item} = {value}\n"
 
     return result
 
 
 @handler.register("validation_schema")
 def serialize_validation_schema(declaration: "Declaration") -> Dict[str, Any]:
-    schema = {}
-    for key, option in declaration._mapping.items():
-        schema[str(key)] = option._parse_validators()
-
-    return schema
+    """Serialize declaration into validation schema.
+    """
+    return {
+        str(key): option._parse_validators()
+        for key, option in declaration._mapping.items()
+    }
 
 
 @handler.register("rst")
 def serialize_rst(declaration: "Declaration"):
+    """Serialize declaration into reST documentation.
+    """
     result = ""
+
+    # Config option may refer to the absolute filepath in their default
+    # values. One of such options is `ckan.resource_formats`. Just to avoid
+    # misunderstanding, we'll update these options, replacing the path till
+    # CKAN root with `/<CKAN_ROOT>` segment.
     ckan_root = os.path.dirname(
         os.path.dirname(os.path.realpath(ckan.__file__)))
 
     for item in declaration._order:
         if isinstance(item, Annotation):
-
-            result += ".. _{}:\n\n{}\n{}\n\n".format(
-                item.lower().replace(' ', '-'), item, len(item) * "-")
+            result += ".. _{anchor}:\n\n{header}\n{divider}\n\n".format(
+                anchor=item.lower().replace(' ', '-'),
+                header=item,
+                divider=len(item) * "-"
+            )
 
         elif isinstance(item, Key):
             option = declaration._mapping[item]
             if option.has_flag(Flag.non_iterable()):
                 continue
             if not option.description:
+                log.warning(
+                    "Skip %s option because it has no description",
+                    item
+                )
                 continue
 
-            result += ".. _{}:\n\n{}\n{}\n".format(
-                item, item, len(str(item)) * '^')
+            result += ".. _{anchor}:\n\n{option}\n{divider}\n".format(
+                anchor=item, option=item, divider=len(str(item)) * '^'
+            )
 
             if option.example:
                 result += f"Example::\n\n\t{item} = {option.example}\n\n"
@@ -95,8 +159,8 @@ def serialize_rst(declaration: "Declaration"):
                 default = f"``{default}``"
             else:
                 default = "none"
-            result += f"Default value: {default}\n\n"
 
+            result += f"Default value: {default}\n\n"
             result += option.description + "\n\n"
 
     return result

--- a/ckan/config/declaration/serialize.py
+++ b/ckan/config/declaration/serialize.py
@@ -13,7 +13,8 @@ def serialize_into_custom(declaration, *args, **kwargs):
     ...
 
 ## and now new `custom-format` can be used like this:
-serialized_declaration = serializer(declaration, "custom-format", *args, **kwargs)
+serialized_declaration = serializer(
+    declaration, "custom-format", *args, **kwargs)
 ```
 
 This mechanism allows you to re-define default serializers, though it should be
@@ -58,7 +59,7 @@ def serialize_ini(
     """
     result = ""
 
-    for item in declaration._order:
+    for item in declaration._members:
 
         if isinstance(item, Annotation):
             if minimal:
@@ -67,7 +68,7 @@ def serialize_ini(
             result += f"\n{heading}\n"
 
         elif isinstance(item, Key):
-            option = declaration._mapping[item]
+            option = declaration._options[item]
             if option.has_flag(Flag.non_iterable()):
                 continue
 
@@ -108,7 +109,7 @@ def serialize_validation_schema(declaration: "Declaration") -> Dict[str, Any]:
     """
     return {
         str(key): option._parse_validators()
-        for key, option in declaration._mapping.items()
+        for key, option in declaration._options.items()
     }
 
 
@@ -125,7 +126,7 @@ def serialize_rst(declaration: "Declaration"):
     ckan_root = os.path.dirname(
         os.path.dirname(os.path.realpath(ckan.__file__)))
 
-    for item in declaration._order:
+    for item in declaration._members:
         if isinstance(item, Annotation):
             result += ".. _{anchor}:\n\n{header}\n{divider}\n\n".format(
                 anchor=item.lower().replace(' ', '-'),
@@ -134,7 +135,7 @@ def serialize_rst(declaration: "Declaration"):
             )
 
         elif isinstance(item, Key):
-            option = declaration._mapping[item]
+            option = declaration._options[item]
             if option.has_flag(Flag.non_iterable()):
                 continue
             if not option.description:

--- a/ckan/config/declaration/utils.py
+++ b/ckan/config/declaration/utils.py
@@ -1,15 +1,30 @@
 # -*- coding: utf-8 -*-
 
-from typing import TYPE_CHECKING, Any, Callable, Dict, Generic, TypeVar
-
-if TYPE_CHECKING:
-    from . import Declaration
+from typing import Any, Callable, Dict, Generic, TypeVar
 
 
 T = TypeVar("T", bound=Callable[..., Any])
 
 
 class FormatHandler(Generic[T]):
+    """Registry for different implementations of serializers, loaders, etc.
+
+    Allows to collect a set of functions that can handle certain base value in
+    different ways. For example, serializers can convert config declaration
+    into config template, documentation, validation schema, etc.
+
+    Usage:
+        >>> registry = FormatHandler()
+        >>>
+        >>> # add a handler for "format-name"
+        >>> @registry.register("format-name")
+        >>> def format_handler(certain_base_value): ...
+        >>>
+        >>> # invoke a handler for `certain_base_value` in "format-name" mode
+        >>> # i.e:  serializers.handle(declaration, "ini")
+        >>> registry.handle(certain_base_value, "format-name")
+
+    """
     __slots__ = "_types"
     _types: Dict[str, T]
 
@@ -24,7 +39,7 @@ class FormatHandler(Generic[T]):
         return decorator
 
     def handle(
-        self, declaration: "Declaration", fmt: str, *args: Any, **kwargs: Any
+        self, subject: Any, fmt: str, *args: Any, **kwargs: Any
     ):
         try:
             handler = self._types[fmt]
@@ -34,4 +49,4 @@ class FormatHandler(Generic[T]):
                     fmt, list(self._types.keys())
                 )
             )
-        return handler(declaration, *args, **kwargs)
+        return handler(subject, *args, **kwargs)

--- a/ckan/config/declaration/utils.py
+++ b/ckan/config/declaration/utils.py
@@ -29,5 +29,9 @@ class FormatHandler(Generic[T]):
         try:
             handler = self._types[fmt]
         except KeyError:
-            raise TypeError(f"Cannot generate {fmt} annotation")
+            raise TypeError(
+                "Cannot handle {}. Allowed formats are: {}".format(
+                    fmt, list(self._types.keys())
+                )
+            )
         return handler(declaration, *args, **kwargs)

--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -10,8 +10,10 @@
 #
 # The %(here)s variable will be replaced with the parent directory of this file
 #
+[DEFAULT]
+$default_section
 [app:main]
-$declaration
+$app_main_section
 ## Logging configuration
 [loggers]
 keys = root, ckan, ckanext, werkzeug

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -836,7 +836,6 @@ def package_revise_schema(ignore_missing: Validator,
 def config_declaration_v1(
         ignore_missing: Validator, unicode_safe: Validator,
         not_empty: Validator, default: ValidatorFactory,
-        boolean_validator: Validator,
         dict_only: Validator, one_of: ValidatorFactory,
         ignore_empty: Validator):
     from ckan.config.declaration import Key
@@ -856,6 +855,7 @@ def config_declaration_v1(
     return cast(Schema, {
         "groups": {
             "annotation": [default(""), unicode_safe],
+            "section": [default("app:main"), unicode_safe],
             "options": {
                 "key": [not_empty, key_from_string],
                 "default": [ignore_missing],

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -859,12 +859,12 @@ def config_declaration_v1(
             "options": {
                 "key": [not_empty, key_from_string],
                 "default": [ignore_missing],
-                "example": [ignore_missing],
                 "default_callable": [ignore_empty, importable_string],
+                "placeholder": [default(""), unicode_safe],
                 "placeholder_callable": [ignore_empty, importable_string],
                 "callable_args": [ignore_empty, dict_only],
+                "example": [ignore_missing],
                 "description": [default(""), unicode_safe],
-                "placeholder": [default(""), unicode_safe],
                 "validators": [default(""), unicode_safe],
                 "type": [default("base"), one_of(list(option_types))],
             }

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -867,11 +867,6 @@ def config_declaration_v1(
                 "placeholder": [default(""), unicode_safe],
                 "validators": [default(""), unicode_safe],
                 "type": [default("base"), one_of(list(option_types))],
-
-                "ignored": [default(False), boolean_validator],
-                "experimental": [default(False), boolean_validator],
-                "internal": [default(False), boolean_validator],
-                "required": [default(False), boolean_validator],
             }
         }
     })

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -793,14 +793,18 @@ class IConfigDeclaration(Interface):
                 declaration.declare(group.enabled, "no").set_description(
                     "Enables feature"
                 )
-                declaration.declare(group.mode, "simple")
+                declaration.declare(group.mode, "simple").set_description(
+                    "Execution mode"
+                )
 
-        Produces the following config suggestion::
+        Run ``ckan config declaration my_ext --include-docs`` and get the
+        following config suggestion::
 
-            ####### MyExt config section #######
+            ## MyExt config section ######################
             # Enables feature
             ckanext.my_ext.feature.enabled = no
-            # ckanext.my_ext.feature.mode = simple
+            # Execution mode
+            ckanext.my_ext.feature.mode = simple
 
         See :ref:`declare configuration <declare-config-options>` guide for
         details.

--- a/ckan/tests/config/declaration/test_declaration.py
+++ b/ckan/tests/config/declaration/test_declaration.py
@@ -47,7 +47,7 @@ class TestDeclaration:
 
         decl.declare(key.aloha)
         decl.declare(key.hello)
-        decl.declare(key.hey).ignore()
+        decl.declare(key.hey).set_flag(Flag.ignored)
 
         pattern = key.dynamic("anything")
         assert list(decl.iter_options(pattern=pattern)) == [

--- a/ckan/tests/config/declaration/test_option.py
+++ b/ckan/tests/config/declaration/test_option.py
@@ -15,11 +15,11 @@ class TestDetails:
     def test_normalize(self):
         option = Option("123")
         option.set_validators("int_validator")
-        assert option._normalize(option.default) == 123
-        assert option._normalize("10") == 10
-        assert option._normalize(50) == 50
+        assert option.normalize(option.default) == 123
+        assert option.normalize("10") == 10
+        assert option.normalize(50) == 50
 
         option.set_default("yes").set_validators("boolean_validator")
-        assert option._normalize(option.default) is True
-        assert option._normalize("no") is False
-        assert option._normalize(False) is False
+        assert option.normalize(option.default) is True
+        assert option.normalize("no") is False
+        assert option.normalize(False) is False

--- a/ckanext/reclineview/plugin.py
+++ b/ckanext/reclineview/plugin.py
@@ -1,5 +1,8 @@
 # encoding: utf-8
 from __future__ import annotations
+import os
+
+import yaml
 
 from ckan.types import Context, Validator
 from logging import getLogger
@@ -66,6 +69,21 @@ def datastore_fields(resource: dict[str, Any],
             if f['type'] in valid_field_types]
 
 
+def _load_declaration(declaration: Any):
+    filename = os.path.join(
+        os.path.dirname(__file__),
+        "config_declaration.yaml"
+    )
+    with open(filename) as src:
+        data = yaml.safe_load(src)
+
+    try:
+        declaration.load_dict(data)
+    except ValueError:
+        # we a loading two recline plugins that are share config declaration.
+        pass
+
+
 class ReclineViewBase(p.SingletonPlugin):
     '''
     This base class for the Recline view extensions.
@@ -108,11 +126,14 @@ class ReclineViewBase(p.SingletonPlugin):
         }
 
 
-@p.toolkit.blanket.config_declarations
 class ReclineView(ReclineViewBase):
     '''
     This extension views resources using a Recline MultiView.
     '''
+    p.implements(p.IConfigDeclaration)
+
+    def declare_config_options(self, declaration: Any, key: Any):
+        _load_declaration(declaration)
 
     def info(self) -> dict[str, Any]:
         return {'name': 'recline_view',
@@ -138,11 +159,14 @@ class ReclineView(ReclineViewBase):
             return False
 
 
-@p.toolkit.blanket.config_declarations
 class ReclineGridView(ReclineViewBase):
     '''
     This extension views resources using a Recline grid.
     '''
+    p.implements(p.IConfigDeclaration)
+
+    def declare_config_options(self, declaration: Any, key: Any):
+        _load_declaration(declaration)
 
     def info(self) -> dict[str, Any]:
         return {'name': 'recline_grid_view',
@@ -154,11 +178,14 @@ class ReclineGridView(ReclineViewBase):
                 }
 
 
-@p.toolkit.blanket.config_declarations
 class ReclineGraphView(ReclineViewBase):
     '''
     This extension views resources using a Recline graph.
     '''
+    p.implements(p.IConfigDeclaration)
+
+    def declare_config_options(self, declaration: Any, key: Any):
+        _load_declaration(declaration)
 
     graph_types = [{'value': 'lines-and-points',
                     'text': 'Lines and points'},

--- a/ckanext/textview/config_declaration.yaml
+++ b/ckanext/textview/config_declaration.yaml
@@ -20,3 +20,4 @@ groups:
 
   - key: ckan.preview.jsonp_formats
     default: jsonp
+    description: Space-delimited list of JSONP based resource formats that will be rendered by the Text view plugin

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -271,7 +271,7 @@ only for explanation and you don't need them in the real file::
 
 There is a special option type, ``dynamic``. This option type is used for a set
 of options that have common name-pattern. Because ``dynamic`` type defines
-multiple options, it has no validators and serves mostly documentation
+multiple options, it has no default, validators and serves mostly documentation
 purpose. Let's use CKAN's ``sqlalchemy.*`` options as example. Every option
 whoose name follows pattern ``sqlalchemy.SOMETHING`` is passed to the
 SQLAlchemy engine created by CKAN. CKAN doesn't actually know, which options
@@ -298,13 +298,13 @@ label, the only important part here are angle brackets::
       Custom sqlalchemy config parameters used to establish the main
       database connection.
 
-That's it! Now CKAN won't report any "undeclared" ``sqlalchemy.*`` option,
-because you've just declared any possible config option with the
-``sqlalchemy.`` prefix. Use this feature sparsely, only when you really want to
-declare literally ANY value following the pattern. If you have finite set of
-possible options, consider declaring all of them, because it allows you to
-provide validators and prevents you from accidental shadowing of unrelated
-options.
+Dynamic options should not be accessed via ``config.get_value`` at the
+moment. Use ``config.get``(which is identical to ``dict.get``) instead.
+
+Use this feature sparsely, only when you really want to declare literally ANY
+value following the pattern. If you have finite set of possible options,
+consider declaring all of them, because it allows you to provide validators,
+defaults, and prevents you from accidental shadowing of unrelated options.
 
 
 Accessing config options

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -131,20 +131,20 @@ your plugin supports several config options.
           :py:attr:`~ckan.plugins.toolkit.ckan.plugins.toolkit.blanket`. Read
           the following section for additional information.
 
-Use a blanket implementation of config declaration
---------------------------------------------------
+Use a blanket implementation of the config declaration
+------------------------------------------------------
 
-The recommended way of declaring config options is using
+The recommended way of declaring config options is using the
 ``config_declarations``
 :py:attr:`~ckan.plugins.toolkit.ckan.plugins.toolkit.blanket`. It allows you to
-write less code and define config options using JSON, YAML, or TOML(if ``toml``
-package is installed inside virtual environment). And that's exactly how CKAN
+write less code and define your config options using JSON, YAML, or TOML (if the ``toml``
+package is installed inside your virtual environment). That is how CKAN
 declares config options for all its built-in plugins, like ``datastore`` or
 ``datatables_view``.
 
 Instead of implementing the
 :py:class:`~ckan.plugins.interfaces.IConfigDeclaration` interface, decorate the
-plugin with ``config_declarations`` blanket::
+plugin with the ``config_declarations`` blanket::
 
   import ckan.plugins as p
   import ckan.plugins.toolkit as tk
@@ -187,8 +187,8 @@ only for explanation and you don't need them in the real file::
           default: false
 
           # import path of the function that must be called in order to get the
-          # default value.  use it when the default value can be obtained from
-          # environment variable, database or any other external source.
+          # default value. This can be used when the default value can be obtained from
+          # an environment variable, database or any other external source.
           # IMPORTANT: use either `default` or `default_callable`, not both at the same time
           default_callable: ckanext.my_ext.utils:function_that_returns_default
 
@@ -235,12 +235,13 @@ only for explanation and you don't need them in the real file::
               est convallis tempor.  Curabitur lacinia pulvinar nibh.  Nam a
               sapien.
 
-          # the string with space-separated list of validators, applied to the value of option.
+          # a space-separated list of validators, applied to the value of option.
           validators: not_missing boolean_validator
 
           # shortcut for the most common option types. It adds validators, so you cannot use it
           # when `validators` are specified(in this case `type` is silently ignored).
-          # Valid types are: bool, int, list, dynamic
+          # Valid types are: bool, int, list, dynamic (see below for more information on dynamic
+          # options)
           type: bool
 
           # boolean flag that marks config option as experimental. Such options are hidden from
@@ -269,18 +270,19 @@ only for explanation and you don't need them in the real file::
           editable: true
 
 
+Dynamic config options
+^^^^^^^^^^^^^^^^^^^^^^
+
 There is a special option type, ``dynamic``. This option type is used for a set
 of options that have common name-pattern. Because ``dynamic`` type defines
 multiple options, it has no default, validators and serves mostly documentation
-purpose. Let's use CKAN's ``sqlalchemy.*`` options as example. Every option
-whoose name follows pattern ``sqlalchemy.SOMETHING`` is passed to the
-SQLAlchemy engine created by CKAN. CKAN doesn't actually know, which options
+purposes. Let's use CKAN's ``sqlalchemy.*`` options as example. Every option
+whose name follows the pattern ``sqlalchemy.SOMETHING`` is passed to the
+SQLAlchemy engine created by CKAN. CKAN doesn't actually know which options
 are valid and it's up to you to provide valid values. Basically, we have a set
-of options with prefix ``sqlalchemy.``. If you try to use them without
-declaration, you may observer a lot of warnings about using undeclared
-options. It doesn't hurt much, but it's really annoying. And it's a flag for
-you, that something can be improved.
-
+of options with prefix ``sqlalchemy.``. If use these options without declararing,
+it will trigger warnings about using undeclared options, which are harmless but can be
+annoying. Declaring them helps to make explicit which configuration options are actually being used.
 In order to declare such set of options, put some label surrounded with angle
 brackets instead of the dynamic part of option's name. In our case it can be
 ``sqlalchemy.<OPTION>`` or ``sqlalchemy.<anything>``.  Any word can be used as
@@ -299,12 +301,12 @@ label, the only important part here are angle brackets::
       database connection.
 
 Dynamic options should not be accessed via ``config.get_value`` at the
-moment. Use ``config.get``(which is identical to ``dict.get``) instead.
+moment. Use ``config.get`` (which is identical to ``dict.get``) instead.
 
 Use this feature sparsely, only when you really want to declare literally ANY
 value following the pattern. If you have finite set of possible options,
 consider declaring all of them, because it allows you to provide validators,
-defaults, and prevents you from accidental shadowing of unrelated options.
+defaults, and prevents you from accidental shadowing unrelated options.
 
 
 Accessing config options

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -113,14 +113,9 @@ These validators need to registered in CKAN core or in your own extension using
 the :py:class:`~ckan.plugins.interfaces.IValidators` interface.
 
 .. note:: Declared default values are also passed to validators. In addition,
-          different validators can be applied to the same option. This means that
-          validators must be idempotent and that the efault value itself must be valid for
-          the given set of validators.
-
-If this is a mandatory option (ie users need to explicitly provide a value and can't
-rely on a default value)::
-
-    option.required()
+          different validators can be applied to the same option multiple
+          times. This means that validators must be idempotent and that the
+          default value itself must be valid for the given set of validators.
 
 If you need to declare a lot of options, you can declare all of them at once loading a dict::
 
@@ -129,9 +124,188 @@ If you need to declare a lot of options, you can declare all of them at once loa
 This allows to keep the configuration declaration in a separate file to make it easier to maintain if
 your plugin supports several config options.
 
-.. note:: ``declaration.load_dict()`` takes only python dictionary as argument. If
-          you store the declaration in an external file like a JSON, YAML file, you have to parse it into a
-          Python dictionary yourself.
+.. note:: ``declaration.load_dict()`` takes only python dictionary as
+          argument. If you store the declaration in an external file like a
+          JSON, YAML file, you have to parse it into a Python dictionary
+          yourself or use corresponding
+          :py:attr:`~ckan.plugins.toolkit.ckan.plugins.toolkit.blanket`. Read
+          the following section for additional information.
+
+Use a blanket implementation of config declaration
+--------------------------------------------------
+
+The recommended way of declaring config options is using
+``config_declarations``
+:py:attr:`~ckan.plugins.toolkit.ckan.plugins.toolkit.blanket`. It allows you to
+write less code and define config options using JSON, YAML, or TOML(if ``toml``
+package is installed inside virtual environment). And that's exactly how CKAN
+declares config options for all its built-in plugins, like ``datastore`` or
+``datatables_view``.
+
+Instead of implementing the
+:py:class:`~ckan.plugins.interfaces.IConfigDeclaration` interface, decorate the
+plugin with ``config_declarations`` blanket::
+
+  import ckan.plugins as p
+  import ckan.plugins.toolkit as tk
+
+  @tk.blanket.config_declarations
+  class MyExt(p.SingletonPlugin):
+      pass
+
+Next, create a file `config_declaration.yaml` at the root directory of your
+extension: ``ckanext/my_ext/config_declaration.yaml``. You can use the `.json`
+or `.toml` extension instead of `.yaml`.
+
+Here is an example of the config declaration file. All the comments are added
+only for explanation and you don't need them in the real file::
+
+
+    # schema version of the config declaration. At the moment, the only valid value is `1`
+    version: 1
+
+    # an array of configuration blocks. Each block has an "annotation", that
+    # describes the block, and the list of options. These groups help to separate
+    # config options visually, but they have no extra meaning.
+    groups:
+
+    # short text that describes the group. It can be shown in the config file
+    # as following:
+    #   ## MyExt settings ##################
+    #   some.option = some.value
+    #   another.option = another.value
+    - annotation: MyExt settings
+
+      # an array of actual declarations
+      options:
+
+        # The only required item in the declaration is `key`. `key` defines the
+        # name of the config option
+        - key: my_ext.flag.do_something
+
+          # default value, used when the option is missing from the config file.
+          default: false
+
+          # import path of the function that must be called in order to get the
+          # default value.  use it when the default value can be obtained from
+          # environment variable, database or any other external source.
+          # IMPORTANT: use either `default` or `default_callable`, not both at the same time
+          default_callable: ckanext.my_ext.utils:function_that_returns_default
+
+          # Example of value that can be used for given option. If the config
+          # option is missing from the config file, `placeholder` IS IGNORED. It
+          # has only demonstration purpose. Good uses of `placeholder` are:
+          # examples of secrets, examples of DB connection string.
+          # IMPORTANT: do not use `default` and `placeholder` at the same
+          # time. `placeholder` should be used INSTEAD OF the `default`
+          # whenever you think it has a sense.
+          placeholder: false
+
+          # import path of the function that must be called in order to get the
+          # placeholder value.  Basically, same as `default_callable`, but it
+          # produces the value of `placeholder`.
+          # IMPORTANT: use either `placeholder` or `placeholder_callable`, not both at the same time
+          placeholder_callable: ckanext.my_ext.utils:function_that_returns_placeholder
+
+          # A dictionary with keyword-arguments that will be passed to
+          # `default_callable` or `placeholder_callable`.  As mentioned above,
+          # only one of these options may be used at the same time, so
+          # `callable_args` can be used by any of these options without a conflict.
+          callable_args:
+            arg_1: 20
+            arg_2: "hello"
+
+          # an alternative example of a valid value for option. Used only in
+          # CKAN documentation, thus has no value for extensions.
+          example: some-valid-value
+
+          # an explanation of the effect that option has. Don't hesistate to
+          # put as much details here as possible
+          description: |
+              Nullam eu ante vel est convallis dignissim.  Fusce suscipit, wisi
+              nec facilisis facilisis, est dui fermentum leo, quis tempor
+              ligula erat quis odio.  Nunc porta vulputate tellus.  Nunc rutrum
+              turpis sed pede.  Sed bibendum.  Aliquam posuere.  Nunc aliquet,
+              augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+              varius mi purus non odio.  Pellentesque condimentum, magna ut
+              suscipit hendrerit, ipsum augue ornare nulla, non luctus diam
+              neque sit amet urna.  Curabitur vulputate vestibulum lorem.
+              Fusce sagittis, libero non molestie mollis, magna orci ultrices
+              dolor, at vulputate neque nulla lacinia eros.  Sed id ligula quis
+              est convallis tempor.  Curabitur lacinia pulvinar nibh.  Nam a
+              sapien.
+
+          # the string with space-separated list of validators, applied to the value of option.
+          validators: not_missing boolean_validator
+
+          # shortcut for the most common option types. It adds validators, so you cannot use it
+          # when `validators` are specified(in this case `type` is silently ignored).
+          # Valid types are: bool, int, list, dynamic
+          type: bool
+
+          # boolean flag that marks config option as experimental. Such options are hidden from
+          # examples of configuration or any other auto-generated output. But they are declared,
+          # thus can be validated and do not produce undeclared-warning. Use it for options that
+          # are not stable and may be removed from your extension before the public release
+          experimental: true
+
+          # boolean flag that marks config option as ignored. Can be used for options that are set
+          # programmatically. This flag means that there is no sense in setting this option, because
+          # it will be overriden or won't be used at all.
+          ignored: true
+
+          # boolean flag that marks config option as hidden. Used for options that should not be set
+          # inside config file or anyhow used by others. Often this flag is used for options
+          # that are added by Flask core or its extensions.
+          internal: true
+
+          # boolean flag that marks config option as required. Doesn't have a special effect for now,
+          # but may prevent application from startup in future, so use it only on options that
+          # are essential for your plugin and that have no sensible default value.
+          required: true
+
+          # boolean flag that marks config option as editable. Doesn't have a special effect for now.
+          # It's recommended to enable this flag for options that are editable via AdminUI.
+          editable: true
+
+
+There is a special option type, ``dynamic``. This option type is used for a set
+of options that have common name-pattern. Because ``dynamic`` type defines
+multiple options, it has no validators and serves mostly documentation
+purpose. Let's use CKAN's ``sqlalchemy.*`` options as example. Every option
+whoose name follows pattern ``sqlalchemy.SOMETHING`` is passed to the
+SQLAlchemy engine created by CKAN. CKAN doesn't actually know, which options
+are valid and it's up to you to provide valid values. Basically, we have a set
+of options with prefix ``sqlalchemy.``. If you try to use them without
+declaration, you may observer a lot of warnings about using undeclared
+options. It doesn't hurt much, but it's really annoying. And it's a flag for
+you, that something can be improved.
+
+In order to declare such set of options, put some label surrounded with angle
+brackets instead of the dynamic part of option's name. In our case it can be
+``sqlalchemy.<OPTION>`` or ``sqlalchemy.<anything>``.  Any word can be used as
+label, the only important part here are angle brackets::
+
+  - key: sqlalchemy.<OPTION>
+    type: dynamic
+    description: |
+      Example::
+
+       sqlalchemy.pool_pre_ping=True
+       sqlalchemy.pool_size=10
+       sqlalchemy.max_overflow=20
+
+      Custom sqlalchemy config parameters used to establish the main
+      database connection.
+
+That's it! Now CKAN won't report any "undeclared" ``sqlalchemy.*`` option,
+because you've just declared any possible config option with the
+``sqlalchemy.`` prefix. Use this feature sparsely, only when you really want to
+declare literally ANY value following the pattern. If you have finite set of
+possible options, consider declaring all of them, because it allows you to
+provide validators and prevents you from accidental shadowing of unrelated
+options.
+
 
 Accessing config options
 ------------------------


### PR DESCRIPTION
* Add doc comments to code
* Add a detailed explanation of options that can be used in the YAML-declarations
* Move `debug` under `[DEFAULT]` section of config template(fixes #7008)