### PR TITLE
[7095]POST requests to API don't work with CSRF, tests bypass CSRF protection

### DIFF
--- a/changes/6992.changes
+++ b/changes/6992.changes
@@ -1,0 +1,1 @@
+Add CKAN wrapper for CSRFProtect, re-enable the CSRF protection for the tests.

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -77,15 +77,16 @@ class CKANCSRFProtect(CSRFProtect):
     '''
     def protect(self):
 
-        if config.get_value("TESTING"):
-            # for the tests we are using the Authorization header
-            authorization_token = request.environ.get('Authorization')
-            if authorization_token:
-                return
-
         api_action = toolkit.request.view_args.get(  # type: ignore
             'logic_function', None
         )
+
+        if config.get_value("TESTING"):
+            # for the tests we are using the Authorization header
+            authorization_token = request.environ.get('Authorization')
+            if authorization_token or api_action:
+                return
+
         authorization_token = request.environ.get('HTTP_AUTHORIZATION')
         if api_action and authorization_token:
             return

--- a/ckan/tests/helpers.py
+++ b/ckan/tests/helpers.py
@@ -224,7 +224,9 @@ class CKANTestApp(object):
         if params:
             kwargs["data"] = params
 
-        extra_environ = kwargs.get("extra_environ") or {}
+        extra_environ = (
+            kwargs.get("extra_environ") or kwargs.get("environ_overrides")
+        ) or {}
         # Inject the csrf token to all POST forms that are not using
         # the Authorization header
         if not extra_environ.get("Authorization") and not kwargs.get('json'):

--- a/ckan/tests/helpers.py
+++ b/ckan/tests/helpers.py
@@ -224,7 +224,7 @@ class CKANTestApp(object):
         if params:
             kwargs["data"] = params
 
-        extra_environ = kwargs.get("extra_environ")
+        extra_environ = kwargs.get("extra_environ") or {}
         # Inject the csrf token to all POST forms that are not using
         # the Authorization header
         if not extra_environ.get("Authorization") and not kwargs.get('json'):

--- a/ckan/tests/helpers.py
+++ b/ckan/tests/helpers.py
@@ -165,7 +165,7 @@ def call_auth(auth_name: str, context, **kwargs) -> bool:
 
 def ckan_generate_csrf() -> "dict[str, Any]":
     '''
-    A Helper function to generate and inject the token into the forms, 
+    A Helper function to generate and inject the token into the forms,
     so the tests can pass the csrf validation.
     '''
     import os

--- a/ckan/tests/helpers.py
+++ b/ckan/tests/helpers.py
@@ -227,7 +227,7 @@ class CKANTestApp(object):
         extra_environ = kwargs.get("extra_environ")
         # Inject the csrf token to all POST forms that are not using
         # the Authorization header
-        if not extra_environ:
+        if not extra_environ.get("Authorization") and not kwargs.get('json'):
             csrf = ckan_generate_csrf()
             if not kwargs.get("data"):
                 kwargs["data"] = {}


### PR DESCRIPTION
Fixes #7095

Add `CKAN` wrapper for `CSRFProtect`, re-enable the `CSRF` protection for the tests.




### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [x] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
