### PR TITLE
Fixes two errors when dealing with an encoded url

### DIFF
--- a/changes/7107.bugfix
+++ b/changes/7107.bugfix
@@ -1,0 +1,1 @@
+Fix urls containing unicode encoded in hex

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -655,7 +655,7 @@ def full_current_url() -> str:
 @core_helper
 def current_url() -> str:
     ''' Returns current url unquoted'''
-    return unquote(request.environ['CKAN_CURRENT_URL'])
+    return request.environ['CKAN_CURRENT_URL']
 
 
 @core_helper

--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -190,8 +190,6 @@ def set_ckan_current_url(environ: Any) -> None:
 
     qs = environ.get(u'QUERY_STRING')
     if qs:
-        # sort out weird encodings
-        qs = quote(qs, u'')
         environ[u'CKAN_CURRENT_URL'] = u'%s?%s' % (path_info, qs)
     else:
         environ[u'CKAN_CURRENT_URL'] = path_info

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -763,8 +763,8 @@ def _insert_links(data_dict: dict[str, Any], limit: int, offset: int):
         return  # no links required for local actions
 
     # change the offset in the url
-    parsed = list(urlparse(urlstring))
-    query = unquote(parsed[4])
+    parsed = list(urlparse.urlparse(urlstring))
+    query = parsed[4]
 
     arguments = dict(parse_qsl(query))
     arguments_start = dict(arguments)

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -763,7 +763,7 @@ def _insert_links(data_dict: dict[str, Any], limit: int, offset: int):
         return  # no links required for local actions
 
     # change the offset in the url
-    parsed = list(urlparse.urlparse(urlstring))
+    parsed = list(urlparse(urlstring))
     query = parsed[4]
 
     arguments = dict(parse_qsl(query))

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -21,7 +21,7 @@ from collections import OrderedDict
 
 import six
 from urllib.parse import (
-    urlencode, unquote, urlunparse, parse_qsl, urlparse
+    urlencode, urlunparse, parse_qsl, urlparse
 )
 from io import StringIO
 


### PR DESCRIPTION
The 2.10 version of #6685
Fixes #6684 

* url in question /%EF%AC%81?foo=bar&bz=%AC%81
* This is a unicode character, which can't be decoded from
ascii. Jinja templates will handle this if it's unicode, or if it's
hex encoded ascii.
* The querystring was being quoted, which is incorrect, as:
  1) the special characters in the query string mean something
  2) The rest of the querystring is already quoted. This makes it
  double quoted, as seen in the datastore file
* We don't want to unquote urls before putting them in the template
anyway.
The solution here is to make sure it's unicode passed into the
function.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport  (backport already applied)

Please [X] all the boxes above that apply
