### PR TITLE
Don't lose the user!

### DIFF
--- a/changes/7112.misc
+++ b/changes/7112.misc
@@ -1,0 +1,2 @@
+Creates a `fresh_context` function to allow cleaning the `context` dict preserving most importan values (`user`, `model`, etc)
+

--- a/ckan/common.py
+++ b/ckan/common.py
@@ -13,7 +13,7 @@ import logging
 from collections.abc import MutableMapping
 
 from typing import (
-    Any, Iterable, Optional, TYPE_CHECKING,
+    Any, Iterable, List, Optional, TYPE_CHECKING,
     TypeVar, cast, overload, Container, Union)
 from typing_extensions import Literal
 
@@ -29,7 +29,7 @@ from flask_babel import (gettext as flask_ugettext,
 import simplejson as json  # type: ignore # noqa: re-export
 import ckan.lib.maintain as maintain
 from ckan.config.declaration import Declaration, Key
-from ckan.types import Model
+from ckan.types import Model, Context
 
 
 if TYPE_CHECKING:
@@ -265,6 +265,28 @@ def aslist(obj: Any, sep: Optional[str] = None, strip: bool = True) -> Any:
         return []
     else:
         return [obj]
+
+
+def clean_context(
+    context: Context,
+    fields: Optional[List[str]] = None
+) -> Context:
+    """ Copy just the minimum fields into a new context
+        for cases in which we reuse the context and
+        we want a clean version with minimum fields """
+    new_context = {}
+    if fields is None:
+        fields = [
+            'model', 'session', 'user', 'auth_user_obj',
+            'ignore_auth'
+        ]
+
+    for field in fields:
+        if field in context:
+            new_context[field] = context[field]
+
+    new_context = cast(Context, new_context)
+    return new_context
 
 
 local = Local()

--- a/ckan/common.py
+++ b/ckan/common.py
@@ -269,22 +269,15 @@ def aslist(obj: Any, sep: Optional[str] = None, strip: bool = True) -> Any:
 
 def clean_context(
     context: Context,
-    fields: Optional[List[str]] = None
 ) -> Context:
     """ Copy just the minimum fields into a new context
         for cases in which we reuse the context and
         we want a clean version with minimum fields """
-    new_context = {}
-    if fields is None:
-        fields = [
-            'model', 'session', 'user', 'auth_user_obj',
-            'ignore_auth'
-        ]
-
-    for field in fields:
-        if field in context:
-            new_context[field] = context[field]
-
+    new_context = {
+        k:context[k] for k in (
+            'model', 'session', 'user', 'auth_user_obj', 'ignore_auth'
+        ) if k in context
+    }
     new_context = cast(Context, new_context)
     return new_context
 

--- a/ckan/common.py
+++ b/ckan/common.py
@@ -13,7 +13,7 @@ import logging
 from collections.abc import MutableMapping
 
 from typing import (
-    Any, Iterable, List, Optional, TYPE_CHECKING,
+    Any, Iterable, Optional, TYPE_CHECKING,
     TypeVar, cast, overload, Container, Union)
 from typing_extensions import Literal
 
@@ -29,7 +29,7 @@ from flask_babel import (gettext as flask_ugettext,
 import simplejson as json  # type: ignore # noqa: re-export
 import ckan.lib.maintain as maintain
 from ckan.config.declaration import Declaration, Key
-from ckan.types import Model, Context
+from ckan.types import Model
 
 
 if TYPE_CHECKING:
@@ -265,21 +265,6 @@ def aslist(obj: Any, sep: Optional[str] = None, strip: bool = True) -> Any:
         return []
     else:
         return [obj]
-
-
-def clean_context(
-    context: Context,
-) -> Context:
-    """ Copy just the minimum fields into a new context
-        for cases in which we reuse the context and
-        we want a clean version with minimum fields """
-    new_context = {
-        k:context[k] for k in (
-            'model', 'session', 'user', 'auth_user_obj', 'ignore_auth'
-        ) if k in context
-    }
-    new_context = cast(Context, new_context)
-    return new_context
 
 
 local = Local()

--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -864,3 +864,18 @@ def guard_against_duplicated_email(email: str):
                 )
             )
         raise
+
+
+def fresh_context(
+    context: Context,
+) -> Context:
+    """ Copy just the minimum fields into a new context
+        for cases in which we reuse the context and
+        we want a clean version with minimum fields """
+    new_context = {
+        k: context[k] for k in (
+            'model', 'session', 'user', 'auth_user_obj', 'ignore_auth'
+        ) if k in context
+    }
+    new_context = cast(Context, new_context)
+    return new_context

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1254,8 +1254,9 @@ def _group_or_org_show(
         schema = group_plugin.db_to_form_schema()
 
     if include_followers:
+        context['session'] = model.Session
         group_dict['num_followers'] = logic.get_action('group_follower_count')(
-            {'model': model, 'session': model.Session},
+            context,
             {'id': group_dict['id']})
     else:
         group_dict['num_followers'] = 0

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -34,7 +34,7 @@ import ckan.lib.plugins as lib_plugins
 import ckan.lib.datapreview as datapreview
 import ckan.authz as authz
 
-from ckan.common import _, clean_context
+from ckan.common import _
 from ckan.types import ActionResult, Context, DataDict, Query, Schema
 
 log = logging.getLogger('ckan.logic')
@@ -1254,7 +1254,7 @@ def _group_or_org_show(
         schema = group_plugin.db_to_form_schema()
 
     if include_followers:
-        context = clean_context(context)
+        context = plugins.toolkit.fresh_context(context)
         group_dict['num_followers'] = logic.get_action('group_follower_count')(
             context,
             {'id': group_dict['id']})

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -34,7 +34,7 @@ import ckan.lib.plugins as lib_plugins
 import ckan.lib.datapreview as datapreview
 import ckan.authz as authz
 
-from ckan.common import _
+from ckan.common import _, clean_context
 from ckan.types import ActionResult, Context, DataDict, Query, Schema
 
 log = logging.getLogger('ckan.logic')
@@ -1254,7 +1254,7 @@ def _group_or_org_show(
         schema = group_plugin.db_to_form_schema()
 
     if include_followers:
-        context['session'] = model.Session
+        context = clean_context(context)
         group_dict['num_followers'] = logic.get_action('group_follower_count')(
             context,
             {'id': group_dict['id']})

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -31,6 +31,7 @@ from ckan.logic import (  # noqa: re-export
     auth_sysadmins_check,
     auth_allow_anonymous_access,
     auth_disallow_anonymous_access,
+    fresh_context,
 )
 
 import ckan.plugins.blanket as blanket
@@ -99,7 +100,8 @@ __all__ = [
     "mail_recipient", "mail_user",
     "render_snippet", "add_template_directory", "add_public_directory",
     "add_resource", "add_ckan_admin_tab",
-    "check_ckan_version", "requires_ckan_version", "get_endpoint"
+    "check_ckan_version", "requires_ckan_version", "get_endpoint",
+    "fresh_context",
 ]
 
 get_converter = get_validator

--- a/ckan/tests/logic/test_logic.py
+++ b/ckan/tests/logic/test_logic.py
@@ -2,7 +2,9 @@
 
 from unittest import mock
 import pytest
+from typing import cast
 from ckan import logic, model
+from ckan.types import Context
 import ckan.tests.factories as factories
 
 
@@ -66,3 +68,25 @@ def test_user_inside_context_of_check_access(is_authorized: mock.Mock):
 def test_get_action_optional_params():
 
     assert "ckan_version" in logic.get_action("status_show")()
+
+
+def test_fresh_context():
+    """ Test the fresh_context function.
+        It should return a new context object only with
+        'model', 'session', 'user', 'auth_user_obj', 'ignore_auth'
+        values (if they exists)."""
+
+    dirty_context = {
+        "user": "test",
+        "ignore_auth": True,
+        "to_be_cleaned": "test",
+    }
+    dirty_Context = cast(Context, dirty_context)
+    cleaned_context = logic.fresh_context(dirty_Context)
+
+    assert "to_be_cleaned" not in cleaned_context
+    assert cleaned_context["user"] == "test"
+    assert cleaned_context["ignore_auth"] is True
+    assert "model" not in cleaned_context
+    assert "session" not in cleaned_context
+    assert "auth_user_obj" not in cleaned_context


### PR DESCRIPTION
Fixes problems in extensions that requires always a user 
The `group_follower_count` and other actions now have an auth function and this is a problem.
With this change we preserve context['user'] for places is which this is required.

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply