### PR TITLE
[7102]Hyperlink with the UK Open Government License does not work

### DIFF
--- a/ckan/model/license.py
+++ b/ckan/model/license.py
@@ -303,7 +303,7 @@ class LicenseOpenGovernment(DefaultLicense):
     id = "uk-ogl"
     od_conformance = 'approved'
     # CS: bad_spelling ignore
-    url = "http://reference.data.gov.uk/id/open-government-licence"
+    url = "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
 
     @property
     def title(self):


### PR DESCRIPTION
Fixes #7102 

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
