### PR TITLE
package_update performance backport version

### DIFF
--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -59,8 +59,12 @@ def package_resource_list_save(res_dicts, package, context):
     if res_dicts is None and allow_partial_update:
         return
 
+    session = context['session']
+    model = context['model']
     resource_list = package.resources_all
-    old_list = package.resources_all[:]
+    old_list = session.query(model.Resource) \
+        .filter(model.Resource.package_id == package.id) \
+        .filter(model.Resource.state != 'deleted')[:]
 
     obj_list = []
     for res_dict in res_dicts or []:


### PR DESCRIPTION
Fixes (in 2.9) #7119

### Proposed fixes:

This targets only the source of the slowness (iterating over all the deleted resources in python and resubmitting them with state='deleted' to postgres) and maintains the ever-growing list of deleted resources in the db

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport