### PR TITLE
package_update performance purge resources approach

### DIFF
--- a/changes/7119.bugfix
+++ b/changes/7119.bugfix
@@ -1,0 +1,1 @@
+remove old deleted resources on package_update so that performance is consistent over time (no longer degrading)

--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -69,9 +69,14 @@ def package_resource_list_save(
     session = context['session']
     model = context['model']
     resource_list = package.resources_all
+    # existing resources not marked as deleted - when removed these
+    # need to be kept in the db marked as deleted so that extensions like
+    # datastore have a chance to remove tables created for those resources
     old_list = session.query(model.Resource) \
         .filter(model.Resource.package_id == package.id) \
         .filter(model.Resource.state != 'deleted')[:]
+    # resources previously deleted can be removed permanently as part
+    # of this update
     deleted_list = session.query(model.Resource) \
         .filter(model.Resource.package_id == package.id) \
         .filter(model.Resource.state == 'deleted')[:]

--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -72,6 +72,9 @@ def package_resource_list_save(
     old_list = session.query(model.Resource) \
         .filter(model.Resource.package_id == package.id) \
         .filter(model.Resource.state != 'deleted')[:]
+    deleted_list = session.query(model.Resource) \
+        .filter(model.Resource.package_id == package.id) \
+        .filter(model.Resource.state == 'deleted')[:]
 
     obj_list = []
     for res_dict in res_dicts or []:
@@ -91,9 +94,13 @@ def package_resource_list_save(
     # according to their ordering in the obj_list.
     resource_list[:] = obj_list
 
-    # Permanently remove any left-over resources
-    for resource in set(old_list) - set(obj_list):
+    # Permanently remove old deleted resources
+    for resource in set(deleted_list) - set(obj_list):
         resource.purge()
+    # Mark any left-over resources as deleted
+    for resource in set(old_list) - set(obj_list):
+        resource.state = 'deleted'
+        resource_list.append(resource)
 
 
 def package_extras_save(

--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -66,8 +66,12 @@ def package_resource_list_save(
     if res_dicts is None and allow_partial_update:
         return
 
+    session = context['session']
+    model = context['model']
     resource_list = package.resources_all
-    old_list = package.resources_all[:]
+    old_list = session.query(model.Resource) \
+        .filter(model.Resource.package_id == package.id) \
+        .filter(model.Resource.state != 'deleted')[:]
 
     obj_list = []
     for res_dict in res_dicts or []:

--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -87,10 +87,9 @@ def package_resource_list_save(
     # according to their ordering in the obj_list.
     resource_list[:] = obj_list
 
-    # Mark any left-over resources as deleted
+    # Permanently remove any left-over resources
     for resource in set(old_list) - set(obj_list):
-        resource.state = 'deleted'
-        resource_list.append(resource)
+        resource.purge()
 
 
 def package_extras_save(


### PR DESCRIPTION
Fixes #7119 

### Proposed fixes:

This solves the issue by purging resources that are removed in a package_update. This seems like a better solution because I can't think of any value in keeping these deleted resources in the db

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport