### PR TITLE
Remove dataset count from group view defaults

### DIFF
--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -429,6 +429,7 @@ def read(group_type: str,
         # Do not query for the group datasets when dictizing, as they will
         # be ignored and get requested on the controller anyway
         data_dict['include_datasets'] = False
+        data_dict['include_dataset_count'] = False
 
         # Do not query group members as they aren't used in the view
         data_dict['include_users'] = False


### PR DESCRIPTION
While fixing ckanext-hierarchy, I was puzzled why there is multiple package_search calls while calling group views. 

`group_dictize` calls package_search if `packages_field` is not none, `group_show` only sets it to None if no packages or count is requested:

https://github.com/ckan/ckan/blob/07669305decebaec827142cb26ecbd739473d2ab/ckan/logic/action/get.py#L1197-L1202

### Proposed fixes:

Removes dataset count from group view as it is later fetched with package_search itself.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
