### PR TITLE
Read ckan.datasets_per_page on group read handler

### DIFF
--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -425,6 +425,8 @@ def read(group_type: str,
 
     extra_vars["q"] = q
 
+    limit = config.get(u'ckan.datasets_per_page', limit)
+
     try:
         # Do not query for the group datasets when dictizing, as they will
         # be ignored and get requested on the controller anyway


### PR DESCRIPTION
Fixes #7111

### Proposed fixes:
Read ckan.datasets_per_page on group read handler to update the limit

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
