### PR TITLE
Added the `csrf_input.html` in templates-bs3/snippets

### DIFF
--- a/changes/7127.misc
+++ b/changes/7127.misc
@@ -1,0 +1,1 @@
+Added the csrf_input.html in templates-bs3/snippets

--- a/ckan/templates-bs3/snippets/csrf_input.html
+++ b/ckan/templates-bs3/snippets/csrf_input.html
@@ -1,0 +1,2 @@
+{# Adds a csrf_token to the forms as a hidden input. #}
+<input type="hidden" name="{{ g.csrf_field_name }}" value="{{ csrf_token() }}"/>


### PR DESCRIPTION
Fixes #7124 

### Proposed fixes:
`csrf_input.html` is added in templates-bs3/snippets.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
