### PR TITLE
Use resource_delete auth function in views.resource.DeleteView

### DIFF
--- a/changes/7131.bugfix
+++ b/changes/7131.bugfix
@@ -1,0 +1,1 @@
+Use `resource_delete` auth function in `views.resource.DeleteView`.

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -1408,7 +1408,7 @@ class TestResourceDelete(object):
             extra_environ=env
         )
         assert 403 == response.status_code
-        assert helpers.body_contains(response, "Unauthorized to delete package")
+        assert helpers.body_contains(response, "Unauthorized to delete resource")
 
     def test_sysadmins_can_delete_any_resource(self, app, sysadmin):
         owner_org = factories.Organization()

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -451,11 +451,11 @@ class DeleteView(MethodView):
             u'auth_user_obj': current_user
         })
         try:
-            check_access(u'package_delete', context, {u'id': id})
+            check_access(u'resource_delete', context, {u'id': id})
         except NotAuthorized:
             return base.abort(
                 403,
-                _(u'Unauthorized to delete package %s') % u''
+                _(u'Unauthorized to delete resource %s') % u''
             )
         return context
 

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -443,7 +443,7 @@ class EditView(MethodView):
 
 
 class DeleteView(MethodView):
-    def _prepare(self, id: str):
+    def _prepare(self, resource_id: str):
         context = cast(Context, {
             u'model': model,
             u'session': model.Session,
@@ -451,7 +451,7 @@ class DeleteView(MethodView):
             u'auth_user_obj': current_user
         })
         try:
-            check_access(u'resource_delete', context, {u'id': id})
+            check_access(u'resource_delete', context, {u'id': resource_id})
         except NotAuthorized:
             return base.abort(
                 403,
@@ -465,7 +465,7 @@ class DeleteView(MethodView):
                 u'{}_resource.edit'.format(package_type),
                 resource_id=resource_id, id=id
             )
-        context = self._prepare(id)
+        context = self._prepare(resource_id)
 
         try:
             get_action(u'resource_delete')(context, {u'id': resource_id})
@@ -487,7 +487,7 @@ class DeleteView(MethodView):
             return base.abort(404, _(u'Resource not found'))
 
     def get(self, package_type: str, id: str, resource_id: str) -> str:
-        context = self._prepare(id)
+        context = self._prepare(resource_id)
         try:
             resource_dict = get_action(u'resource_show')(
                 context, {

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -457,6 +457,8 @@ class DeleteView(MethodView):
                 403,
                 _(u'Unauthorized to delete resource %s') % u''
             )
+        except NotFound:
+            return base.abort(404, _(u'Resource not found'))
         return context
 
     def post(self, package_type: str, id: str, resource_id: str) -> Response:


### PR DESCRIPTION
Fixes #7131

### Proposed fixes:
- Use resource_delete auth function in views.resource.DeleteView

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Financed by Finland's Data Exchange Layer directory API Catalogue at https://liityntakatalogi.suomi.fi/en_GB/.
The Service is provided by the Digital and Population Data Services Agency ([https://dvv.fi/en/).](https://dvv.fi/en/)