### PR TITLE
Update Beaker Parameters in config_declaration.yaml

### DIFF
--- a/changes/7133.bugfix
+++ b/changes/7133.bugfix
@@ -1,0 +1,1 @@
+Beaker session config variables need to be initialised in a newly generated ckan config file

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -288,7 +288,7 @@ groups:
           Defaults to never expiring.
 
       - key: beaker.session.cookie_domain
-        default: .please_replace.me
+        default: .example.com
         description: |
           What domain the cookie should be set to. When using sub-domains,
           this should be set to the main domain the cookie should be valid for. For example,

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -278,6 +278,7 @@ groups:
           negating the need to issue the save() method.
 
       - key: beaker.session.cookie_expires
+        type: bool
         description: |
           Determines when the cookie used to track the client-side of the session will expire.
           When set to a boolean value, it will either expire at the end of the browsers session, or never expire.
@@ -287,6 +288,7 @@ groups:
           Defaults to never expiring.
 
       - key: beaker.session.cookie_domain
+        default: .please_replace.me
         description: |
           What domain the cookie should be set to. When using sub-domains,
           this should be set to the main domain the cookie should be valid for. For example,
@@ -305,6 +307,8 @@ groups:
           browsers are instructed to not send the cookie over anything other than an SSL connection.
 
       - key: beaker.session.timeout
+        type: int
+        default: 600
         description: |
           Seconds until the session is considered invalid, after which it will be ignored and invalidated.
           This number is based on the time since the session was last accessed, not from when the session was created.


### PR DESCRIPTION
Fixes https://github.com/ckan/ckan/issues/7128 https://github.com/ckan/ckan/issues/7092 https://github.com/ckan/ckan/issues/7120

### Proposed fixes:
The `config_declaration.yaml` file contains 3 Beaker Session settings that need to be initialised in a newly generated CKAN config file (ckan.ini _or_ production.ini for a Docker install)

These are: 

`beaker.session.cookie_expires`
`beaker.session.cookie_domain`
`beaker.session.timeout`

It seems when the PR https://github.com/ckan/ckan/pull/7068 was merged it caused this error:

… `File "/usr/lib/ckan/default/lib/python3.8/site-packages/beaker/util.py", line 281, in verify_options raise Exception(error) 
Exception: Cookie expires was not a boolean, datetime, int, or timedelta instance.` ...

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
