### PR TITLE
Use API Tokens in Datapusher

### DIFF
--- a/changes/7139.migration
+++ b/changes/7139.migration
@@ -1,0 +1,1 @@
+Users of the Xloader or DataPusher need to provide a valid API Token in their configurations using the ``ckanext.xloader.api_token`` or ``ckan.datapusher.api_token`` keys respectively.

--- a/ckan/tests/cli/test_config.py
+++ b/ckan/tests/cli/test_config.py
@@ -89,6 +89,11 @@ class TestDescribe(object):
                             "description": mock.ANY,
                         },
                         {
+                            "key": "ckan.datapusher.api_token",
+                            "description": mock.ANY,
+                        },
+
+                        {
                             "key": "ckan.datapusher.callback_url_base",
                             "description": mock.ANY,
                             "placeholder": "%(ckan.site_url)s",

--- a/ckanext/datapusher/config_declaration.yaml
+++ b/ckanext/datapusher/config_declaration.yaml
@@ -28,6 +28,11 @@ groups:
       running on port 8800. If you want to manually install the DataPusher, follow
       the installation `instructions <http://docs.ckan.org/projects/datapusher>`_.
 
+  - key: ckan.datapusher.api_token
+    description: >-
+      Starting from CKAN 2.10, DataPusher requires a valid API token to operate (see :ref:`api authentication`), and
+      will fail to start if this option is not set.
+
   - key: ckan.datapusher.callback_url_base
     example: http://ckan:5000/
     placeholder: '%(ckan.site_url)s'

--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -131,9 +131,8 @@ def datapusher_submit(context: Context, data_dict: dict[str, Any]):
     context['session'] = context['model'].meta.create_local_session()
     p.toolkit.get_action('task_status_update')(context, task)
 
-    site_user = p.toolkit.get_action(
-        'get_site_user')({'ignore_auth': True}, {})
-
+    # This setting is checked on startup
+    api_token = p.toolkit.config.get("ckan.datapusher.api_token")
     try:
         r = requests.post(
             urljoin(datapusher_url, 'job'),
@@ -142,7 +141,7 @@ def datapusher_submit(context: Context, data_dict: dict[str, Any]):
             },
             timeout=TIMEOUT,
             data=json.dumps({
-                'api_key': site_user['apikey'],
+                'api_key': api_token,
                 'job_type': 'push_to_datastore',
                 'result_url': callback_url,
                 'metadata': {

--- a/ckanext/datapusher/plugin.py
+++ b/ckanext/datapusher/plugin.py
@@ -42,8 +42,9 @@ class DatapusherPlugin(p.SingletonPlugin):
         self.config = config
 
         for config_option in (
-            u'ckan.site_url',
-            u'ckan.datapusher.url',
+            "ckan.site_url",
+            "ckan.datapusher.url",
+            "ckan.datapusher.api_token",
         ):
             if not config.get_value(config_option):
                 raise Exception(

--- a/ckanext/datapusher/tests/__init__.py
+++ b/ckanext/datapusher/tests/__init__.py
@@ -1,0 +1,6 @@
+# encoding: utf-8
+from ckan.tests import factories
+
+
+def get_api_token() -> str:
+    return factories.SysadminWithToken()["sysadmin"]

--- a/ckanext/datapusher/tests/test.py
+++ b/ckanext/datapusher/tests/test.py
@@ -13,9 +13,11 @@ from ckan.tests import factories
 from ckan.tests.helpers import call_action
 from ckan.common import config
 from ckanext.datastore.tests.helpers import set_url_type
+from ckanext.datapusher.tests import get_api_token
 
 
 @pytest.mark.ckan_config("ckan.plugins", "datastore datapusher")
+@pytest.mark.ckan_config("ckan.datapusher.api_token", get_api_token())
 @pytest.mark.usefixtures("with_plugins", "non_clean_db")
 class TestDatastoreNew:
     def test_create_ckan_resource_in_package(self, app, api_token):
@@ -63,6 +65,7 @@ class TestDatastoreNew:
 
 
 @pytest.mark.ckan_config("ckan.plugins", "datastore datapusher")
+@pytest.mark.ckan_config("ckan.datapusher.api_token", get_api_token())
 @pytest.mark.usefixtures("with_plugins")
 class TestDatastoreCreate(object):
     sysadmin_user = None

--- a/ckanext/datapusher/tests/test_action.py
+++ b/ckanext/datapusher/tests/test_action.py
@@ -7,6 +7,7 @@ import pytest
 from ckan.logic import _actions
 
 from ckan.tests import helpers, factories
+from ckanext.datapusher.tests import get_api_token
 
 
 def _pending_task(resource_id):
@@ -23,6 +24,7 @@ def _pending_task(resource_id):
 
 
 @pytest.mark.ckan_config("ckan.plugins", "datapusher datastore")
+@pytest.mark.ckan_config("ckan.datapusher.api_token", get_api_token())
 @pytest.mark.usefixtures("non_clean_db", "with_plugins")
 class TestSubmit:
     def test_submit(self, monkeypatch):

--- a/ckanext/datapusher/tests/test_default_views.py
+++ b/ckanext/datapusher/tests/test_default_views.py
@@ -5,12 +5,14 @@ import datetime
 import pytest
 
 from ckan.tests import helpers, factories
+from ckanext.datapusher.tests import get_api_token
 
 
 @pytest.mark.ckan_config("ckan.views.default_views", "recline_grid_view")
 @pytest.mark.ckan_config(
     "ckan.plugins", "datapusher datastore recline_grid_view"
 )
+@pytest.mark.ckan_config("ckan.datapusher.api_token", get_api_token())
 @pytest.mark.usefixtures("non_clean_db", "with_plugins")
 def test_datapusher_creates_default_views_on_complete():
 
@@ -59,6 +61,7 @@ def test_datapusher_creates_default_views_on_complete():
 @pytest.mark.ckan_config(
     "ckan.plugins", "datapusher datastore recline_grid_view"
 )
+@pytest.mark.ckan_config("ckan.datapusher.api_token", get_api_token())
 @pytest.mark.usefixtures("non_clean_db", "with_plugins")
 def test_datapusher_does_not_create_default_views_on_pending():
 

--- a/ckanext/datapusher/tests/test_interfaces.py
+++ b/ckanext/datapusher/tests/test_interfaces.py
@@ -8,6 +8,8 @@ import responses
 
 import ckan.plugins as p
 import ckanext.datapusher.interfaces as interfaces
+from ckanext.datapusher.tests import get_api_token
+
 from ckan.tests import helpers, factories
 
 
@@ -28,6 +30,7 @@ class FakeDataPusherPlugin(p.SingletonPlugin):
 @pytest.mark.ckan_config(
     "ckan.plugins", "datastore datapusher test_datapusher_plugin"
 )
+@pytest.mark.ckan_config("ckan.datapusher.api_token", get_api_token())
 @pytest.mark.usefixtures("non_clean_db", "with_plugins")
 class TestInterace(object):
 

--- a/ckanext/datapusher/tests/test_views.py
+++ b/ckanext/datapusher/tests/test_views.py
@@ -6,10 +6,12 @@ import pytest
 import ckan.tests.factories as factories
 import ckan.model as model
 from ckan.logic import _actions
+from ckanext.datapusher.tests import get_api_token
 
 
 @mock.patch("flask_login.utils._get_user")
 @pytest.mark.ckan_config(u"ckan.plugins", u"datapusher datastore")
+@pytest.mark.ckan_config("ckan.datapusher.api_token", get_api_token())
 @pytest.mark.usefixtures(u"non_clean_db", u"with_plugins", u"with_request_context")
 def test_resource_data(current_user, app, monkeypatch):
     user = factories.User()

--- a/ckanext/datastore/tests/test_dictionary.py
+++ b/ckanext/datastore/tests/test_dictionary.py
@@ -4,8 +4,11 @@ import pytest
 import ckan.tests.factories as factories
 import ckan.tests.helpers as helpers
 
+from ckanext.datapusher.tests import get_api_token
+
 
 @pytest.mark.ckan_config(u"ckan.plugins", u"datastore datapusher")
+@pytest.mark.ckan_config("ckan.datapusher.api_token", get_api_token())
 @pytest.mark.usefixtures(u"clean_datastore", u"with_plugins", u"with_request_context")
 def test_read(app):
     user = factories.User()


### PR DESCRIPTION
The DataPusher extension relied on an API key being sent to the DataPusher service (the site user one). From CKAN 2.10 onward this no longer works, so we need to use API tokens instead. This follows the pattern already used in [ckanext-xloader](https://github.com/ckan/ckanext-xloader/pull/164), where a  new config option is added so users can explicitly define a token in their configuration.

In the future we might want to automate this partially using something like service accounts, but this seems like an easy first step