### PR TITLE
Allow using `%(here)s` in `use`(config chain)

### DIFF
--- a/ckan/tests/cli/data/test-here-invalid-master.ini
+++ b/ckan/tests/cli/data/test-here-invalid-master.ini
@@ -1,0 +1,4 @@
+[app:main]
+use = config:%(here)s/test-here-invalid-slave.ini
+
+master = true

--- a/ckan/tests/cli/data/test-here-master.ini
+++ b/ckan/tests/cli/data/test-here-master.ini
@@ -1,0 +1,4 @@
+[app:main]
+use = config:%(here)s/test-here-slave.ini
+
+master = true

--- a/ckan/tests/cli/data/test-here-slave.ini
+++ b/ckan/tests/cli/data/test-here-slave.ini
@@ -1,0 +1,4 @@
+[app:main]
+use = egg:ckan
+
+slave = true

--- a/ckan/tests/cli/test_cli.py
+++ b/ckan/tests/cli/test_cli.py
@@ -186,3 +186,24 @@ def test_invalid_use_option():
         os.path.dirname(__file__), u'data', u'test-invalid-use.ini')
     with pytest.raises(CkanConfigurationException):
         CKANConfigLoader(filename).get_config()
+
+
+def test_error_if_refers_not_real_file():
+    """Report unexisting config file
+    """
+    filename = os.path.join(
+        os.path.dirname(__file__), u'data', u'test-here-invalid-master.ini')
+
+    with pytest.raises(CkanConfigurationException, match="Config file .+ does not exist"):
+        CKANConfigLoader(filename).get_config()
+
+
+def test_here_in_use():
+    """Verify that `%(here)s` reference inside `use` directive is resolved.
+    """
+    filename = os.path.join(
+        os.path.dirname(__file__), u'data', u'test-here-master.ini')
+
+    conf = CKANConfigLoader(filename).get_config()
+    assert conf["master"]
+    assert conf["slave"]


### PR DESCRIPTION
Config chains(including config file via `use` option) do not interpolate `%(here)s` references in the `use` option when the config chain is resolved.
I.e, if you have the following line in the `/etc/ckan/default/ckan.ini`:
```ini
use = config:%(here)s/default.ini
``` 
Instead of loading `/etc/ckan/default/default.ini`, CKAN will use a literal value and try loading `/etc/ckan/default/%(here)s/default.ini`. 

It happens because CKAN resolves the whole config chain first, and only then loads config files and interpolates variables. So we have to replace `%(here)s` inside `use` manually. It's the only config option that is used in this way before the configuration is loaded, so other options do not require such a special treatment.

PS In 2.9 config chains were resolved in a different way, evaluating variables instantly, so this fix does not require backporting