### PR TITLE
Declaration flag for options commented by default

### DIFF
--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -294,7 +294,8 @@ groups:
           Defaults to never expiring.
 
       - key: beaker.session.cookie_domain
-        default: .example.com
+        commented: true
+        placeholder: .example.com
         description: |
           What domain the cookie should be set to. When using sub-domains,
           this should be set to the main domain the cookie should be valid for. For example,
@@ -696,7 +697,8 @@ groups:
           The amount of time before the cookie expires, as a datetime.timedelta object or integer seconds.
 
       - key: REMEMBER_COOKIE_DOMAIN
-        default: null
+        placeholder: .example.com
+        commented: true
         description: |
           If the “Remember Me” cookie should cross domains, set the domain value here
           (i.e. .example.com would allow the cookie to be used on all subdomains of example.com).
@@ -1137,7 +1139,7 @@ groups:
         editable: true
 
       - key: ckan.site_custom_css
-        description: Custom CSS directives to include on all CKAN pages. 
+        description: Custom CSS directives to include on all CKAN pages.
         editable: true
 
 

--- a/ckan/config/declaration/option.py
+++ b/ckan/config/declaration/option.py
@@ -50,6 +50,34 @@ class Flag(enum.Flag):
     modified. For example, this option is exposed via configuration form in the
     Admin UI.
 
+    commented: this option is commented by default in the config file.  Use it
+    for optional settings that may break the application when default value is
+    used. Example of such option is a cookie domain. When it's missing, the
+    current domain is used, so this value is optional. But if you try to
+    provide default value, `example.com` or any other domain, CKAN
+    authentication will not work as long as application runs on different
+    domain. While it's similar to `placeholder` attribute of the
+    :py:class:`~ckan.config.declaration.option.Option`, their goals are
+    different.
+    Option.placeholer:
+    - shows an example of expectend value
+    - is ignored when config option is **missing** from the config file
+    - shown as a default value in the config file generated from template. For
+      example, `Option<key=a, placeholder=b, commented=False>` is added to the
+      config file as `a = b`. After this, `config.get_value('a')` returns `b`,
+      because it's explicitely written in the config file.
+    Flag.commented:
+    - Marks option as commented by default
+    - Does not changes behavior of `Option.default` and `Option.placeholder`.
+    - switches option to the commented state in the config file generated from
+      template.  For example, `Option<key=a, placeholder=b, commented=True>` is
+      added to the config file as `# a = b`. After this,
+      `config.get_value('a')` returns `None`, because there is no option `a` in
+      the config file(it's commented, which makes this option non-existing)
+    If the option is missing from the config file, both `placeholder` and
+    `commented` are virtually ignored, having absolutely no impact on the value
+    of the config option.
+
     reserved_*(01-10): these flags are added for extension developers. CKAN
     doesn't treat them specially, neither includes them in groups, like
     `not_safe`/`not_iterable`. These flags are completely ignored by CKAN. If
@@ -76,6 +104,7 @@ class Flag(enum.Flag):
     internal = enum.auto()
     required = enum.auto()
     editable = enum.auto()
+    commented = enum.auto()
 
     reserved_01 = enum.auto()
     reserved_02 = enum.auto()

--- a/ckan/config/declaration/serialize.py
+++ b/ckan/config/declaration/serialize.py
@@ -99,6 +99,9 @@ def serialize_ini(
             else:
                 value = option.str_value()
 
+            if option.has_flag(Flag.commented):
+                result += "# "
+
             if isinstance(item, Pattern):
                 # Patterns are not actual config options, but rather an example
                 # of possibilities: `sqlalchemy.<option> = `. Thus they cannot

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -269,6 +269,9 @@ only for explanation and you don't need them in the real file::
           # It's recommended to enable this flag for options that are editable via AdminUI.
           editable: true
 
+          # boolean flag that marks option as commented. Such options are added
+          # as comments to the config file generated from template.
+          commented: true
 
 Dynamic config options
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Additional fix for the series of cookie-issues: #7128 #7092 #7120

@kowh-ai has already fixed the original issue in #7133. But I just realized, that now we have a default value for the cookie domain, that will be added to every new config file. This, in turn, will force every user to update this value, because the default value will be different from the real app's domain(likely). If someone won't update the cookie domain, cookies will be set for the **wrong** domain and ignored by the browser. I.e, authentication will not work at all:)

It won't take much time to update the documentation, mentioning this additional mandatory setup step. But, personally, I don't want to introduce new steps. 

We can add `default: null` to the cookie_domain declaration(which I did before, but now I see that it doesn't solve the problem completely). Beaker/flask_login uses `None` as a special value, which falls back to the current application's domain. It nice feature, but it will work only in `strict` config mode or via `config.get_value`, which validates values and resolve defaults(explanation in the following paragraph).

Empty(i.e, `default: null`) options are added to the config file as 
```ini
xxx = 
```
And, while `config.get_value` manages to get the default `None` in such case, `config.get` returns the empty string for such an option. It wouldn't be a problem if we're using config object only inside CKAN code, because we can easily convert all the `config.get` to `config.get_value`. But the thing is, `flask_login` also puts hands on our config object. And it uses the problematic `config.get`.

Using `mode = strict` would solve the problem. It validates/converts all the config options during the app's initialization so that all the further `config.get` work with correct values. But config-modes is a completely new feature and we don't want to make them mandatory just yet.

The only other option I see is to add a cookie domain as a commented option to the config file generated via `ckan config generate`. In this way, it will be set to `None` in normal mode(because it's basically a missing option) and in strict mode(because of validators/defaults/etc.)

This PR adds a new flag `commented: true` to the config option declaration. With this flag option added to the config template as a commented line.