### PR TITLE
[7104]Fix User ID does not have to be unique?

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -1010,6 +1010,7 @@ def user_create(context: Context,
     if 'password_hash' in data:
         data['_password'] = data.pop('password_hash')
 
+    data.update({'action': 'user_create'})
     user = model_save.user_dict_save(data, context)
     signals.user_created.send(user.name, user=user)
 

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -792,7 +792,6 @@ class TestUser(object):
         user = model.User.get(deleted_user["name"])
         assert user.state == "active"
 
-
     def test_user_id_uniqueness(self):
         factories.User(id='test-id')
         with pytest.raises(Exception):

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -793,6 +793,12 @@ class TestUser(object):
         assert user.state == "active"
 
 
+    def test_user_id_uniqueness(self):
+        factories.User(id='test-id')
+        with pytest.raises(Exception):
+            factories.User(id='test-id')
+
+
 @pytest.mark.usefixtures("non_clean_db")
 class TestUserImage(object):
     def test_image_url_is_shown(self, app):


### PR DESCRIPTION
Fixes #7104 

I can't think of a better solution at the moment, in this case, we don't have to be concerned about duplicate users with the same id because `primary_key=True implies null=False and unique=True.`

So I added a flag when `user_create` is triggered, which will go down to the `table_dict_save` and check if the user has an `id` and `came_from` is `'user_create'`... if so, then we want to show the `ValidationError`.

Any suggestions are welcome.


### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [x] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
