### PR TITLE
Fix datatables download feature (2.9)

### DIFF
--- a/ckanext/datatablesview/public/datatablesview.js
+++ b/ckanext/datatablesview/public/datatablesview.js
@@ -7,6 +7,8 @@ var run_query = function(params, format) {
   f.attr("value", format);
   form.append(f);
   form.submit();
+  p.remove()
+  f.remove()
 }
 
 this.ckan.module('datatables_view', function (jQuery) {


### PR DESCRIPTION
### Affected Versions
2.9 (already fixed in 2.10 with the new `datatablesview` design)

When downloading data from the `datatablesview` plugin the hidden form is never refreshed after downloading. This causes a buggy behavior in which if the user downloads a CSV file, and then tries to download in another format, it will keep downloading CSV files.

![image](https://user-images.githubusercontent.com/6672339/196887092-67d4c87a-2a9a-4e6c-9d49-00d93983fdac.png)

### Proposed fixes

Since `datatablesview` has a major upgrade in CKAN 2.10, this patch takes the fixed applied in the `run_query` function and back ports it. It basically removes the input HTML element we are creating to set the format of the download. This causes the form to be reset to the orginal state after downloading.
https://github.com/ckan/ckan/blob/572607a8de899f1672025e25bfcd95d6c074ec6a/ckanext/datatablesview/public/datatablesview.js#L23-L34