### PR TITLE
Automatically rename deprecated IPackageController methods(fix)

### DIFF
--- a/ckan/plugins/core.py
+++ b/ckan/plugins/core.py
@@ -6,6 +6,7 @@ Provides plugin services to the CKAN
 from __future__ import annotations
 
 import logging
+import warnings
 from contextlib import contextmanager
 from typing import (Any, Generic, Iterator, Optional,
                     Type, TypeVar, Union)
@@ -21,6 +22,7 @@ import ckan.plugins.interfaces as interfaces
 
 from ckan.common import config
 from ckan.types import SignalMapping
+from ckan.exceptions import CkanDeprecationWarning
 
 
 __all__ = [
@@ -141,6 +143,42 @@ class SingletonPlugin(_pca_SingletonPlugin):
     loaded. Subsequent calls to the class constructor will always return the
     same singleton instance.
     '''
+    def __init__(self, *args: Any, **kwargs: Any):
+        # Drop support by removing this __init__ function
+        super().__init__(*args, **kwargs)
+
+        if interfaces.IPackageController.implemented_by(type(self)):
+            for old_name, new_name in [
+                ["after_create", "after_dataset_create"],
+                ["after_update", "after_dataset_update"],
+                ["after_delete", "after_dataset_delete"],
+                ["after_show", "after_dataset_show"],
+                ["before_search", "before_dataset_search"],
+                ["after_search", "after_dataset_search"],
+                ["before_index", "before_dataset_index"],
+                    ["before_view", "before_dataset_view"]]:
+                if hasattr(self, old_name):
+                    warnings.warn(
+                        f"The method 'IPackageController.{old_name}' is "
+                        + f"deprecated. Please use '{new_name}' instead!",
+                        CkanDeprecationWarning)
+                    setattr(self, new_name, getattr(self, old_name))
+
+        if interfaces.IResourceController.implemented_by(type(self)):
+            for old_name, new_name in [
+                ["before_create", "before_resource_create"],
+                ["after_create", "after_resource_create"],
+                ["before_update", "before_resource_update"],
+                ["after_update", "after_resource_update"],
+                ["before_delete", "before_resource_delete"],
+                ["after_delete", "after_resource_delete"],
+                    ["before_show", "before_resource_show"]]:
+                if hasattr(self, old_name):
+                    warnings.warn(
+                        f"The method 'IResourceController.{old_name}' is "
+                        + f"deprecated. Please use '{new_name}' instead!",
+                        CkanDeprecationWarning)
+                    setattr(self, new_name, getattr(self, old_name))
 
 
 def get_plugin(plugin: str) -> Optional[SingletonPlugin]:

--- a/ckan/plugins/core.py
+++ b/ckan/plugins/core.py
@@ -158,10 +158,12 @@ class SingletonPlugin(_pca_SingletonPlugin):
                 ["before_index", "before_dataset_index"],
                     ["before_view", "before_dataset_view"]]:
                 if hasattr(self, old_name):
-                    warnings.warn(
+                    msg = (
                         f"The method 'IPackageController.{old_name}' is "
-                        + f"deprecated. Please use '{new_name}' instead!",
-                        CkanDeprecationWarning)
+                        + f"deprecated. Please use '{new_name}' instead!"
+                    )
+                    log.warning(msg)
+                    warnings.warn(msg, CkanDeprecationWarning)
                     setattr(self, new_name, getattr(self, old_name))
 
         if interfaces.IResourceController.implemented_by(type(self)):
@@ -174,10 +176,12 @@ class SingletonPlugin(_pca_SingletonPlugin):
                 ["after_delete", "after_resource_delete"],
                     ["before_show", "before_resource_show"]]:
                 if hasattr(self, old_name):
-                    warnings.warn(
+                    msg = (
                         f"The method 'IResourceController.{old_name}' is "
-                        + f"deprecated. Please use '{new_name}' instead!",
-                        CkanDeprecationWarning)
+                        + f"deprecated. Please use '{new_name}' instead!"
+                    )
+                    log.warning(msg)
+                    warnings.warn(msg, CkanDeprecationWarning)
                     setattr(self, new_name, getattr(self, old_name))
 
 

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -6,7 +6,6 @@ extend CKAN.
 '''
 from __future__ import annotations
 
-import warnings
 from typing import (Any, Callable, Iterable, Mapping, Optional, Sequence,
                     TYPE_CHECKING, Type, Union)
 
@@ -16,7 +15,6 @@ from flask.blueprints import Blueprint
 from flask.wrappers import Response
 
 from ckan.model.user import User
-from ckan.exceptions import CkanDeprecationWarning
 from ckan.types import (
     Action, AuthFunction, Context, DataDict, PFeedFactory,
     PUploader, PResourceUploader, Schema, SignalMapping, Validator)
@@ -453,23 +451,6 @@ class IPackageController(Interface):
     u'''
     Hook into the dataset view.
     '''
-    def __init__(self):
-        # Drop support by removing this __init__ function
-        for old_name, new_name in [
-            ["after_create", "after_dataset_create"],
-            ["after_update", "after_dataset_update"],
-            ["after_delete", "after_dataset_delete"],
-            ["after_show", "after_dataset_show"],
-            ["before_search", "before_dataset_search"],
-            ["after_search", "after_dataset_search"],
-            ["before_index", "before_dataset_index"],
-                ["before_view", "before_dataset_view"]]:
-            if hasattr(self, old_name):
-                warnings.warn(
-                    "The method 'IPackageController.{}' is ".format(old_name)
-                    + "deprecated. Please use '{}' instead!".format(new_name),
-                    CkanDeprecationWarning)
-                setattr(self, new_name, getattr(self, old_name))
 
     def read(self, entity: 'model.Package') -> None:
         u'''
@@ -583,22 +564,6 @@ class IResourceController(Interface):
     u'''
     Hook into the resource view.
     '''
-    def __init__(self):
-        # Drop support by removing this __init__ function
-        for old_name, new_name in [
-            ["before_create", "before_resource_create"],
-            ["after_create", "after_resource_create"],
-            ["before_update", "before_resource_update"],
-            ["after_update", "after_resource_update"],
-            ["before_delete", "before_resource_delete"],
-            ["after_delete", "after_resource_delete"],
-                ["before_show", "before_resource_show"]]:
-            if hasattr(self, old_name):
-                warnings.warn(
-                    "The method 'IResourceController.{}' is ".format(old_name)
-                    + "deprecated. Please use '{}' instead!".format(new_name),
-                    CkanDeprecationWarning)
-                setattr(self, new_name, getattr(self, old_name))
 
     def before_resource_create(
             self, context: Context, resource: dict[str, Any]) -> None:

--- a/ckan/tests/plugins/ckantestplugins.py
+++ b/ckan/tests/plugins/ckantestplugins.py
@@ -51,6 +51,7 @@ class MockPackageControllerPlugin(p.SingletonPlugin):
     p.implements(p.IPackageController)
 
     def __init__(self, *args, **kw):
+        super().__init__(*args, **kw)
         self.calls = defaultdict(int)
 
     def read(self, entity):
@@ -65,7 +66,10 @@ class MockPackageControllerPlugin(p.SingletonPlugin):
     def delete(self, entity):
         self.calls["delete"] += 1
 
-    def before_dataset_search(self, search_params):
+    # this method deliberately uses deprecated `before_search` name instead of
+    # `before_dataset_search`. Change the name after support for deprecated
+    # names is dropped.
+    def before_search(self, search_params):
         self.calls["before_dataset_search"] += 1
         return search_params
 

--- a/ckanext/example_iresourcecontroller/plugin.py
+++ b/ckanext/example_iresourcecontroller/plugin.py
@@ -10,9 +10,13 @@ class ExampleIResourceControllerPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IResourceController)
 
     def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
         self.counter = defaultdict(int)
 
-    def before_resource_create(self, context: Any, resource: Any):
+    # this method deliberately uses deprecated `before_create` name instead of
+    # `before_resource_create`. Change the name after support for deprecated
+    # names is dropped.
+    def before_create(self, context: Any, resource: Any):
         self.counter['before_resource_create'] += 1
 
     def after_resource_create(self, context: Any, resource: Any):


### PR DESCRIPTION
Last year we've deprecated `before_*` and `after_*` methods of `IPackageController` and `IResourceController` in favor of `before_dataset_*`/`before_resource_*` forms. Methods with old names are copied as the methods with new names during interface initialization.

But I noticed that this auto-copying doesn't work on master. So I had to fix it a bit. 
Instead of copying methods during corresponding *interface* initialization (which happens somewhere inside `pyutilib`), these methods are copied during the *plugin* initialization(`SingletonePlugin.__init__`) now.
And I modified a couple of tests so that they'll report if it stops working in the future.