### PR TITLE
Fix Bootstrap 3 webassets files

### DIFF
--- a/ckan/public-bs3/base/javascript/webassets.yml
+++ b/ckan/public-bs3/base/javascript/webassets.yml
@@ -46,7 +46,6 @@ ckan:
     - modules/resource-reorder.js
     - modules/resource-view-reorder.js
     - modules/follow.js
-    - modules/activity-stream.js
     - modules/resource-view-embed.js
     - modules/resource-view-filters-form.js
     - modules/resource-view-filters.js

--- a/ckan/public-bs3/base/vendor/webassets.yml
+++ b/ckan/public-bs3/base/vendor/webassets.yml
@@ -33,8 +33,6 @@ vendor:
     - jed.js
     - moment-with-locales.js
     - select2/select2.js
-    - popperjs.js
-    - purify.js
 
 bootstrap:
   filters: rjsmin
@@ -44,7 +42,7 @@ bootstrap:
       - vendor/fontawesome
       - vendor/jquery
   contents:
-    - bootstrap/js/bootstrap.js
+    - bootstrap/javascripts/bootstrap.js
 
 fileupload:
   filters: rjsmin


### PR DESCRIPTION
Currently on master, switching to use Bootstrap 3 is no longer working due to bundle errors like:

```
webassets.exceptions.BundleError: 'popperjs.js' not found in load path:
```

### Proposed fixes:
- `modules/activity-stream.js` is no longer valid since activities is a new extension.
- There's an error in `bootstrap.js` path
- I think`popper.js` and `purify.js` are no valid and a result of a bad merge when updating Fontawesome: d7498da2db8a057de5591f73956e9572a9d76552

