### PR TITLE
Clean dataset-form CSS class from HTML templates

### DIFF
--- a/changes/7164.removal
+++ b/changes/7164.removal
@@ -1,0 +1,1 @@
+Removes dataset-form and dataset-resource-form classes from our HTML templates since they do not exist in our CSS files.

--- a/ckan/templates-bs3/group/member_new.html
+++ b/ckan/templates-bs3/group/member_new.html
@@ -10,7 +10,7 @@
     {% block page_heading %}{{ _('Edit Member') if user else _('Add Member') }}{% endblock %}
   </h1>
   {% block form %}
-  <form class="dataset-form add-member-form" method='post' id="add-member-form">
+  <form class="add-member-form" method='post' id="add-member-form">
     {{ h.csrf_input() }}
     <div class="row">
       <div class="col-md-5">

--- a/ckan/templates-bs3/group/snippets/group_form.html
+++ b/ckan/templates-bs3/group/snippets/group_form.html
@@ -1,7 +1,7 @@
 {% import 'macros/form.html' as form %}
 
 
-<form id="group-edit" class="dataset-form" method="post" data-module="basic-form" enctype="multipart/form-data">
+<form id="group-edit" method="post" data-module="basic-form" enctype="multipart/form-data">
   {{ h.csrf_input() }}
   {% block error_summary %}
     {{ form.errors(error_summary) }}

--- a/ckan/templates-bs3/organization/member_new.html
+++ b/ckan/templates-bs3/organization/member_new.html
@@ -12,7 +12,7 @@
     {% block page_heading %}{{ _('Edit Member') if user else _('Add Member') }}{% endblock %}
   </h1>
   {% block form %}
-  <form class="dataset-form add-member-form" method='post'>
+  <form class="add-member-form" method='post'>
     {{ h.csrf_input() }}
     <div class="row">
       <div class="col-md-5">

--- a/ckan/templates-bs3/organization/snippets/organization_form.html
+++ b/ckan/templates-bs3/organization/snippets/organization_form.html
@@ -1,7 +1,7 @@
 {% import 'macros/form.html' as form %}
 
 
-<form id='organization-edit-form' class="dataset-form" method="post" data-module="basic-form" enctype="multipart/form-data">
+<form id='organization-edit-form' method="post" data-module="basic-form" enctype="multipart/form-data">
   {{ h.csrf_input() }}
   {% block error_summary %}
     {{ form.errors(error_summary) }}

--- a/ckan/templates-bs3/package/collaborators/collaborator_new.html
+++ b/ckan/templates-bs3/package/collaborators/collaborator_new.html
@@ -11,7 +11,7 @@
   </h1>
   {% block form %}
   {{ h.csrf_input() }}
-  <form class="dataset-form add-member-form" method='post'>
+  <form class="add-member-form" method='post'>
     <div class="row">
       <div class="col-md-5">
         <div class="form-group control-medium">

--- a/ckan/templates-bs3/package/edit_view.html
+++ b/ckan/templates-bs3/package/edit_view.html
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block form %}
-  <form class="dataset-resource-form" method="post" data-module="basic-form resource-form">
+  <form method="post" data-module="basic-form resource-form">
     {{ h.csrf_input() }}
     {% include 'package/snippets/view_form.html' %}
     <div class="form-actions">

--- a/ckan/templates-bs3/package/edit_view.html
+++ b/ckan/templates-bs3/package/edit_view.html
@@ -13,8 +13,8 @@
 {% endblock %}
 
 {% block form %}
-  <form class="dataset-form dataset-resource-form" method="post" data-module="basic-form resource-form">
-    {{ h.csrf_input() }}	  
+  <form class="dataset-resource-form" method="post" data-module="basic-form resource-form">
+    {{ h.csrf_input() }}
     {% include 'package/snippets/view_form.html' %}
     <div class="form-actions">
       <button class="btn btn-danger pull-left" name="delete" value="Delete"> {{ _('Delete') }} </button>

--- a/ckan/templates-bs3/package/new_view.html
+++ b/ckan/templates-bs3/package/new_view.html
@@ -22,7 +22,7 @@
     </p>
   {% endif %}
 
-  <form class="dataset-resource-form" method="post" data-module="basic-form resource-form">
+  <form method="post" data-module="basic-form resource-form">
     {{ h.csrf_input() }}
     {% include 'package/snippets/view_form.html' %}
     <div class="form-actions">

--- a/ckan/templates-bs3/package/new_view.html
+++ b/ckan/templates-bs3/package/new_view.html
@@ -22,8 +22,8 @@
     </p>
   {% endif %}
 
-  <form class="dataset-form dataset-resource-form" method="post" data-module="basic-form resource-form">
-    {{ h.csrf_input() }}	  
+  <form class="dataset-resource-form" method="post" data-module="basic-form resource-form">
+    {{ h.csrf_input() }}
     {% include 'package/snippets/view_form.html' %}
     <div class="form-actions">
         <button class="btn btn-default {% if not h.resource_view_display_preview(data) %}hide{%endif%}" name="preview" value="True" type="submit">{{ _('Preview') }}</button>

--- a/ckan/templates-bs3/package/snippets/package_form.html
+++ b/ckan/templates-bs3/package/snippets/package_form.html
@@ -3,8 +3,8 @@
 
 {# This provides a full page that renders a form for adding a dataset. It can
 then itself be extended to add/remove blocks of functionality. #}
-<form id="dataset-edit" class="dataset-form" method="post" action="{{ action }}" data-module="basic-form" novalidate>
-  {{ h.csrf_input() }}	
+<form id="dataset-edit" method="post" action="{{ action }}" data-module="basic-form" novalidate>
+  {{ h.csrf_input() }}
   {% block stages %}
     {{ h.snippet('package/snippets/stages.html', stages=stage, dataset_type=dataset_type) }}
   {% endblock %}

--- a/ckan/templates-bs3/package/snippets/resource_form.html
+++ b/ckan/templates-bs3/package/snippets/resource_form.html
@@ -5,7 +5,7 @@
 {% set action = form_action or h.url_for(dataset_type ~ '_resource.new', id=pkg_name) %}
 
 
-<form id="resource-edit" class="dataset-resource-form" method="post" action="{{ action }}" data-module="basic-form resource-form" enctype="multipart/form-data">
+<form id="resource-edit" method="post" action="{{ action }}" data-module="basic-form resource-form" enctype="multipart/form-data">
 
   {{ h.csrf_input() }}
   {% block stages %}

--- a/ckan/templates-bs3/package/snippets/resource_form.html
+++ b/ckan/templates-bs3/package/snippets/resource_form.html
@@ -5,9 +5,9 @@
 {% set action = form_action or h.url_for(dataset_type ~ '_resource.new', id=pkg_name) %}
 
 
-<form id="resource-edit" class="dataset-form dataset-resource-form" method="post" action="{{ action }}" data-module="basic-form resource-form" enctype="multipart/form-data">
+<form id="resource-edit" class="dataset-resource-form" method="post" action="{{ action }}" data-module="basic-form resource-form" enctype="multipart/form-data">
 
-  {{ h.csrf_input() }}	
+  {{ h.csrf_input() }}
   {% block stages %}
     {# An empty stages variable will not show the stages #}
     {% if stage %}

--- a/ckan/templates-bs3/user/edit_user_form.html
+++ b/ckan/templates-bs3/user/edit_user_form.html
@@ -1,7 +1,7 @@
 {% import 'macros/form.html' as form %}
 
 {% block form %}
-  <form id="user-edit-form" class="dataset-form" method="post" action="{{ action }}" enctype="multipart/form-data">
+  <form id="user-edit-form" method="post" action="{{ action }}" enctype="multipart/form-data">
     {{ h.csrf_input() }}
     {% block form_errors %}{{ form.errors(error_summary) }}{% endblock %}
 

--- a/ckan/templates/group/member_new.html
+++ b/ckan/templates/group/member_new.html
@@ -10,7 +10,7 @@
     {% block page_heading %}{{ _('Edit Member') if user else _('Add Member') }}{% endblock %}
   </h1>
   {% block form %}
-  <form class="dataset-form add-member-form" method='post' id="add-member-form">
+  <form class="add-member-form" method='post' id="add-member-form">
     {{ h.csrf_input() }}
     <div class="row">
       <div class="col-md-5">

--- a/ckan/templates/group/snippets/group_form.html
+++ b/ckan/templates/group/snippets/group_form.html
@@ -1,8 +1,8 @@
 {% import 'macros/form.html' as form %}
 
 
-<form id="group-edit" class="dataset-form" method="post" data-module="basic-form" enctype="multipart/form-data">
-  {{ h.csrf_input() }} 
+<form id="group-edit" method="post" data-module="basic-form" enctype="multipart/form-data">
+  {{ h.csrf_input() }}
   {% block error_summary %}
     {{ form.errors(error_summary) }}
   {% endblock %}

--- a/ckan/templates/organization/snippets/organization_form.html
+++ b/ckan/templates/organization/snippets/organization_form.html
@@ -1,8 +1,8 @@
 {% import 'macros/form.html' as form %}
 
 
-<form id='organization-edit-form' class="dataset-form" method="post" data-module="basic-form" enctype="multipart/form-data">
-  {{ h.csrf_input() }} 
+<form id='organization-edit-form' method="post" data-module="basic-form" enctype="multipart/form-data">
+  {{ h.csrf_input() }}
   {% block error_summary %}
     {{ form.errors(error_summary) }}
   {% endblock %}

--- a/ckan/templates/package/collaborators/collaborator_new.html
+++ b/ckan/templates/package/collaborators/collaborator_new.html
@@ -10,7 +10,7 @@
     {% block page_heading %}{{ _('Edit Collaborator') if user else _('Add Collaborator') }}{% endblock %}
   </h1>
   {% block form %}
-  <form class="dataset-form add-member-form" method='post'>
+  <form class="add-member-form" method='post'>
     {{ h.csrf_input() }}
     <div class="row">
       <div class="col-md-5">

--- a/ckan/templates/package/edit_view.html
+++ b/ckan/templates/package/edit_view.html
@@ -13,8 +13,8 @@
 {% endblock %}
 
 {% block form %}
-  <form class="dataset-form dataset-resource-form" method="post" data-module="basic-form resource-form">
-    {{ h.csrf_input() }} 
+  <form class="dataset-resource-form" method="post" data-module="basic-form resource-form">
+    {{ h.csrf_input() }}
     {% include 'package/snippets/view_form.html' %}
     <div class="form-actions">
       <button class="btn btn-danger pull-left" name="delete" value="Delete"> {{ _('Delete') }} </button>

--- a/ckan/templates/package/edit_view.html
+++ b/ckan/templates/package/edit_view.html
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block form %}
-  <form class="dataset-resource-form" method="post" data-module="basic-form resource-form">
+  <form method="post" data-module="basic-form resource-form">
     {{ h.csrf_input() }}
     {% include 'package/snippets/view_form.html' %}
     <div class="form-actions">

--- a/ckan/templates/package/new_view.html
+++ b/ckan/templates/package/new_view.html
@@ -22,8 +22,8 @@
     </p>
   {% endif %}
 
-  <form class="dataset-form dataset-resource-form" method="post" data-module="basic-form resource-form">
-    {{ h.csrf_input() }} 
+  <form class="dataset-resource-form" method="post" data-module="basic-form resource-form">
+    {{ h.csrf_input() }}
     {% include 'package/snippets/view_form.html' %}
     <div class="form-actions">
         <button class="btn btn-default {% if not h.resource_view_display_preview(data) %}hide{%endif%}" name="preview" value="True" type="submit">{{ _('Preview') }}</button>

--- a/ckan/templates/package/new_view.html
+++ b/ckan/templates/package/new_view.html
@@ -22,7 +22,7 @@
     </p>
   {% endif %}
 
-  <form class="dataset-resource-form" method="post" data-module="basic-form resource-form">
+  <form method="post" data-module="basic-form resource-form">
     {{ h.csrf_input() }}
     {% include 'package/snippets/view_form.html' %}
     <div class="form-actions">

--- a/ckan/templates/package/snippets/package_form.html
+++ b/ckan/templates/package/snippets/package_form.html
@@ -3,7 +3,7 @@
 
 {# This provides a full page that renders a form for adding a dataset. It can
 then itself be extended to add/remove blocks of functionality. #}
-<form id="dataset-edit" class="dataset-form" method="post" action="{{ action }}" data-module="basic-form" novalidate>
+<form id="dataset-edit" method="post" action="{{ action }}" data-module="basic-form" novalidate>
   {{ h.csrf_input() }}
   {% block stages %}
     {{ h.snippet('package/snippets/stages.html', stages=stage, dataset_type=dataset_type) }}

--- a/ckan/templates/package/snippets/resource_form.html
+++ b/ckan/templates/package/snippets/resource_form.html
@@ -5,8 +5,8 @@
 {% set action = form_action or h.url_for(dataset_type ~ '_resource.new', id=pkg_name) %}
 
 
-<form id="resource-edit" class="dataset-form dataset-resource-form" method="post" action="{{ action }}" data-module="basic-form resource-form" enctype="multipart/form-data">
-  {{ h.csrf_input() }} 
+<form id="resource-edit" class="dataset-resource-form" method="post" action="{{ action }}" data-module="basic-form resource-form" enctype="multipart/form-data">
+  {{ h.csrf_input() }}
   {% block stages %}
     {# An empty stages variable will not show the stages #}
     {% if stage %}

--- a/ckan/templates/package/snippets/resource_form.html
+++ b/ckan/templates/package/snippets/resource_form.html
@@ -5,7 +5,7 @@
 {% set action = form_action or h.url_for(dataset_type ~ '_resource.new', id=pkg_name) %}
 
 
-<form id="resource-edit" class="dataset-resource-form" method="post" action="{{ action }}" data-module="basic-form resource-form" enctype="multipart/form-data">
+<form id="resource-edit" method="post" action="{{ action }}" data-module="basic-form resource-form" enctype="multipart/form-data">
   {{ h.csrf_input() }}
   {% block stages %}
     {# An empty stages variable will not show the stages #}

--- a/ckan/templates/user/edit_user_form.html
+++ b/ckan/templates/user/edit_user_form.html
@@ -1,7 +1,7 @@
 {% import 'macros/form.html' as form %}
 
 {% block form %}
-  <form id="user-edit-form" class="dataset-form" method="post" action="{{ action }}" enctype="multipart/form-data">
+  <form id="user-edit-form" method="post" action="{{ action }}" enctype="multipart/form-data">
     {{ h.csrf_input() }}
     {% block form_errors %}{{ form.errors(error_summary) }}{% endblock %}
 


### PR DESCRIPTION
### Proposed fixes:

I'm removing both `dataset-form` and `dataset-resource-form` classes from HTML files since they don't exist in our CSS files.