### PR TITLE
Fix duplicated template call

### DIFF
--- a/ckan/templates-bs3/page.html
+++ b/ckan/templates-bs3/page.html
@@ -45,7 +45,7 @@
             </div>
           {% endblock %}
 
-          <div class="row wrapper{% block wrapper_class %}{% endblock %}{% if self.secondary()|trim == '' or c.action=='resource_read' %} no-nav{% endif %}">
+          <div class="row wrapper{% block wrapper_class %}{% endblock %}">
             {#
             The pre_primary block can be used to add content to before the
             rendering of the main content columns of the page.

--- a/ckan/templates/page.html
+++ b/ckan/templates/page.html
@@ -45,7 +45,7 @@
             </div>
           {% endblock %}
 
-          <div class="row wrapper{% block wrapper_class %}{% endblock %}{% if self.secondary()|trim == '' or c.action=='resource_read' %} no-nav{% endif %}">
+          <div class="row wrapper{% block wrapper_class %}{% endblock %}">
             {#
             The pre_primary block can be used to add content to before the
             rendering of the main content columns of the page.


### PR DESCRIPTION
Fixes #7152 

### Proposed fixes:

This PR directly removes the code since it has no effect under the current implementation:
 - `c.action == "resource_read"` will never evaluate to True since `resource_read` is part of the old Pylons implementation of ruotes.
 - `self.secondary()|trim == ''` will never evaluate to True in core since the secondary block itself already renders an `aside` element.
 - Extensions may override the whole `secondary` block to not render anything but in that case what's the use of having a `no-nav` class if nothing is displayed?
