### PR TITLE
Added a `search-index` subcommand `list-unindexed`

### DIFF
--- a/changes/7175.feature
+++ b/changes/7175.feature
@@ -1,0 +1,3 @@
+Added `list-unindexed` sub-commands to the `search-index` command.
+
+Accepts `-p` or `--include_private` flag to list all unindexed packages. Otherwise, it will only list unindexed public packages.

--- a/changes/7175.feature
+++ b/changes/7175.feature
@@ -1,3 +1,1 @@
-Added `list-unindexed` sub-commands to the `search-index` command.
-
-Accepts `-p` or `--include_private` flag to list all unindexed packages. Otherwise, it will only list unindexed public packages.
+Added `list-unindexed` sub-commands to the `search-index` command, which lists all ununindexed packages.

--- a/ckan/cli/search_index.py
+++ b/ckan/cli/search_index.py
@@ -147,10 +147,8 @@ def list_unindexed(include_private: bool = False):
 
     package_ids = {r[0] for r in model.Session.query(model.Package.id).filter(
         (lambda: model.Package.private
-                    if include_private
-                    else model.Package.private==False
-        )()
-    )}
+            if include_private
+            else model.Package.private == False)())}
 
     unindexed_package_ids = []
 


### PR DESCRIPTION
Adds a subcommand to `ckan search-index` called `list-unindexed` which lists unindexed packages that are in the database.

Includes a command option `-p` `--include-private` to also query private packages along with public ones (in the case that users need to index both public and private packages). Default is to only report on public packages, i.e. `--include-private=False`

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
- [X] None of the above

Please [X] all the boxes above that apply
