### PR TITLE
Fix edit draft dataset form

### DIFF
--- a/ckan/templates/package/snippets/package_basic_fields.html
+++ b/ckan/templates/package/snippets/package_basic_fields.html
@@ -116,7 +116,7 @@
 
   {% if data.id and h.check_access('package_delete', {'id': data.id}) and data.state != 'active' %}
   <div class="form-group control-medium">
-    <label for="field-state" class="form-label>{{ _('State') }}</label>
+    <label for="field-state" class="form-label">{{ _('State') }}</label>
     <div class="controls">
       <select class="form-control" id="field-state" name="state">
         <option value="active" {% if data.get('state', 'none') == 'active' %} selected="selected" {% endif %}>{{ _('Active') }}</option>


### PR DESCRIPTION
Fixes enclosing double quotes on class attribute.

### Proposed fixes:
The `class` attribute was missing the closing `"` causing the form to be incorrectly rendered when editing a **draft** dataset.

![image](https://user-images.githubusercontent.com/6672339/200164862-61038f42-bdb8-4349-a2e4-0644b534850c.png)
