### PR TITLE
Finish updating from control-label to form-label

### DIFF
--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -11888,10 +11888,6 @@ textarea {
   width: 100%;
 }
 
-.control-large .control-label {
-  font-size: 1.09375rem;
-}
-
 .control-required {
   color: #c6898b;
 }
@@ -12475,10 +12471,6 @@ select[data-module=autocomplete] {
   margin-top: 5px;
   margin-left: 2px;
   font-weight: bold;
-}
-
-.add-member-form .control-label {
-  display: block;
 }
 
 .add-member-or-wrap {
@@ -13805,6 +13797,7 @@ td.diff_header {
     border-width: 0;
     box-shadow: 0;
     border-radius: 0;
+    display: -webkit-box;
     display: -webkit-flex;
     display: flex;
     -webkit-box-orient: vertical;

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -11888,10 +11888,6 @@ textarea {
   width: 100%;
 }
 
-.control-large .control-label {
-  font-size: 1.09375rem;
-}
-
 .control-required {
   color: #c6898b;
 }
@@ -12475,10 +12471,6 @@ select[data-module=autocomplete] {
   margin-top: 5px;
   margin-left: 2px;
   font-weight: bold;
-}
-
-.add-member-form .control-label {
-  display: block;
 }
 
 .add-member-or-wrap {
@@ -13805,6 +13797,7 @@ td.diff_header {
     border-width: 0;
     box-shadow: 0;
     border-radius: 0;
+    display: -webkit-box;
     display: -webkit-flex;
     display: flex;
     -webkit-box-orient: vertical;
@@ -13823,6 +13816,7 @@ td.diff_header {
     -webkit-order: 2;
     order: 2;
   }
+
   .js .main .secondary .filters {
     display: none;
     position: fixed;

--- a/ckan/public/base/scss/_forms.scss
+++ b/ckan/public/base/scss/_forms.scss
@@ -95,12 +95,6 @@ textarea {
     width: 100%;
 }
 
-.control-large {
-    .control-label {
-        font-size: $btn-font-size-lg;
-    }
-}
-
 .control-required {
     color: $errorBorder;
 }
@@ -148,15 +142,6 @@ textarea {
     }
 }
 
-// Override the default form widths.
-// .form-horizontal .control-label {
-//     width: 120px;
-// }
-// @media (min-width: $screen-sm-min) {
-//     .form-horizontal .controls {
-//         margin-left: 130px;
-//     }
-// }
 .form-group .info-block {
     position: relative;
     display: block;
@@ -712,10 +697,6 @@ select[data-module="autocomplete"] {
       margin-left: 2px;
       font-weight: bold;
     }
-}
-
-.add-member-form .control-label {
-  display: block;
 }
 
 .add-member-or-wrap{

--- a/ckan/templates/group/member_new.html
+++ b/ckan/templates/group/member_new.html
@@ -16,7 +16,7 @@
       <div class="col-md-5">
         <div class="form-group control-medium">
           {% if not user %}
-            <label class="control-label" for="username">
+            <label class="form-label" for="username">
               {{ _('Existing User') }}
             </label>
             <p>
@@ -44,7 +44,7 @@
       </div>
       <div class="col-md-5">
         <div class="form-group control-medium">
-          <label class="control-label" for="email">
+          <label class="form-label" for="email">
             {{ _('New User') }}
           </label>
           <p>

--- a/ckan/templates/organization/member_new.html
+++ b/ckan/templates/organization/member_new.html
@@ -18,7 +18,7 @@
       <div class="col-md-5">
         <div class="form-group control-medium">
           {% if not user %}
-            <label class="control-label" for="username">
+            <label class="form-label" for="username">
               {{ _('Existing User') }}
             </label>
             <p>
@@ -46,7 +46,7 @@
       </div>
       <div class="col-md-5">
         <div class="form-group control-medium">
-          <label class="control-label" for="email">
+          <label class="form-label" for="email">
             {{ _('New User') }}
           </label>
           <p>

--- a/ckan/templates/package/collaborators/collaborator_new.html
+++ b/ckan/templates/package/collaborators/collaborator_new.html
@@ -16,7 +16,7 @@
       <div class="col-md-5">
         <div class="form-group control-medium">
           {% if not user %}
-            <label class="control-label" for="username">
+            <label class="form-label" for="username">
               {{ _('Existing User') }}
             </label>
             <p>

--- a/ckan/templates/package/snippets/resource_upload_field.html
+++ b/ckan/templates/package/snippets/resource_upload_field.html
@@ -35,7 +35,7 @@ placeholder - placeholder text for url field
   <input type="radio" id="resource-url-none" name="url_type" value="" {{
     'checked' if not data.url and not data.url_type else '' }}>
   <div class="select-type">
-    <label id="resource-menu-label" class="control-label"
+    <label id="resource-menu-label" class="form-label"
       >{{ menu_label or _('Data') }}</label>
     <div role="group" aria-labelledby="resource-menu-label">
       {% block url_type_select %}
@@ -72,7 +72,7 @@ placeholder - placeholder text for url field
                   document.getElementById('field-clear-upload').checked = true;
                   document.getElementById('field-resource-upload').focus();
                 ">{{ _('Clear Upload') }}</button>
-              <label class="control-label">{{ upload_label or _('File') }}</label>
+              <label class="form-label">{{ upload_label or _('File') }}</label>
               <div class="controls">
                 {% set existing_name = data.get('url', '').split('/')[-1].split('?')[0].split('#')[0] %}
                 <input value="{{ existing_name }}" class="form-control" readonly>

--- a/ckanext/datatablesview/templates/datatables/datatables_form.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_form.html
@@ -26,7 +26,7 @@
 {% endcall %}
 
 <div class="control-group">
-  <label class="control-label">{{ _('Show Columns') }}</label>
+  <label class="form-label">{{ _('Show Columns') }}</label>
   <div class="controls">
     <table class="table table-striped table-bordered">
       <thead>
@@ -44,7 +44,7 @@
             value="_id" checked/>_id</label>
           </td>
           <td></td>
-        </tr>      
+        </tr>
       {% for f in h.datastore_dictionary(resource.id) %}
         <tr>
           <td>

--- a/ckanext/example_idatasetform/templates/package/snippets/package_metadata_fields.html
+++ b/ckanext/example_idatasetform/templates/package/snippets/package_metadata_fields.html
@@ -8,7 +8,7 @@
 {% block package_metadata_fields %}
 
   <div class="control-group">
-    <label class="control-label" for="field-country_code">{{ _("Country Code") }}</label>
+    <label class="form-label" for="field-country_code">{{ _("Country Code") }}</label>
     <div class="controls">
       <select id="field-country_code" name="country_code" data-module="autocomplete">
         {% for country_code in h.country_codes()  %}


### PR DESCRIPTION
When migrating to Bootstrap 5 we changed our custom `control-label` class for the native `form-label`. This PR finishes the migration and cleans the attribute from our less files.

### Proposed fixes:
Use Bootstrap native `form-label` class in all forms as we do in our `input_block` template.

https://github.com/ckan/ckan/blob/4a438423a4f5752509e812ddb1ec349adf456781/ckan/templates/macros/form/input_block.html#L23-L32