### PR TITLE
Fix 404 when selecting the same date in the changes view

### DIFF
--- a/changes/7191.bugfix
+++ b/changes/7191.bugfix
@@ -1,0 +1,1 @@
+Fix 404 error when selecting the same date in the changes view

--- a/ckanext/activity/views.py
+++ b/ckanext/activity/views.py
@@ -447,7 +447,7 @@ def package_changes_multiple() -> Union[Response, str]:  # noqa
     # TODO: do something better here - go back to the previous page,
     # display a warning that the user can't look at a sequence where
     # the newest item is older than the oldest one, etc
-    if time_diff.total_seconds() < 0:
+    if time_diff.total_seconds() <= 0:
         return package_changes(tk.h.get_request_param("current_new_id"))
 
     done = False


### PR DESCRIPTION
In the `/dataset/<id>/changes_multiple` page, if the user selects the same date in both select controls a 404 is returned. The case when the second date was more recent than the first one is already handled (selecting the most recent version), we just need to account for the case when both dates are the same.


https://user-images.githubusercontent.com/200230/200816966-83fc7fbe-00d4-4d8f-9501-197fc782a6b6.mp4

This could probably be handled better with more clever select controls that update with the relevant options but this is a good first patch