### PR TITLE
Fix tag list css class

### DIFF
--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -4448,7 +4448,7 @@ textarea.form-control-lg {
   color: #fff;
 }
 
-.card, .tag-list {
+.card {
   position: relative;
   display: flex;
   flex-direction: column;
@@ -4459,31 +4459,30 @@ textarea.form-control-lg {
   border: 1px solid rgba(0, 0, 0, 0.125);
   border-radius: 0.25rem;
 }
-.card > hr, .tag-list > hr {
+.card > hr {
   margin-right: 0;
   margin-left: 0;
 }
-.card > .list-group, .tag-list > .list-group {
+.card > .list-group {
   border-top: inherit;
   border-bottom: inherit;
 }
-.card > .list-group:first-child, .tag-list > .list-group:first-child {
+.card > .list-group:first-child {
   border-top-width: 0;
   border-top-left-radius: calc(0.25rem - 1px);
   border-top-right-radius: calc(0.25rem - 1px);
 }
-.card > .list-group:last-child, .tag-list > .list-group:last-child {
+.card > .list-group:last-child {
   border-bottom-width: 0;
   border-bottom-right-radius: calc(0.25rem - 1px);
   border-bottom-left-radius: calc(0.25rem - 1px);
 }
-.card > .card-header + .list-group, .tag-list > .card-header + .list-group,
-.card > .list-group + .card-footer,
-.tag-list > .list-group + .card-footer {
+.card > .card-header + .list-group,
+.card > .list-group + .card-footer {
   border-top: 0;
 }
 
-.card-body, .tag-list {
+.card-body {
   flex: 1 1 auto;
   padding: 1rem 1rem;
 }
@@ -4567,7 +4566,7 @@ textarea.form-control-lg {
   border-bottom-left-radius: calc(0.25rem - 1px);
 }
 
-.card-group > .card, .card-group > .tag-list {
+.card-group > .card {
   margin-bottom: 0.75rem;
 }
 @media (min-width: 576px) {
@@ -4575,40 +4574,36 @@ textarea.form-control-lg {
     display: flex;
     flex-flow: row wrap;
   }
-  .card-group > .card, .card-group > .tag-list {
+  .card-group > .card {
     flex: 1 0 0%;
     margin-bottom: 0;
   }
-  .card-group > .card + .card, .card-group > .tag-list + .card, .card-group > .card + .tag-list, .card-group > .tag-list + .tag-list {
+  .card-group > .card + .card {
     margin-left: 0;
     border-left: 0;
   }
-  .card-group > .card:not(:last-child), .card-group > .tag-list:not(:last-child) {
+  .card-group > .card:not(:last-child) {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
   }
-  .card-group > .card:not(:last-child) .card-img-top, .card-group > .tag-list:not(:last-child) .card-img-top,
-.card-group > .card:not(:last-child) .card-header,
-.card-group > .tag-list:not(:last-child) .card-header {
+  .card-group > .card:not(:last-child) .card-img-top,
+.card-group > .card:not(:last-child) .card-header {
     border-top-right-radius: 0;
   }
-  .card-group > .card:not(:last-child) .card-img-bottom, .card-group > .tag-list:not(:last-child) .card-img-bottom,
-.card-group > .card:not(:last-child) .card-footer,
-.card-group > .tag-list:not(:last-child) .card-footer {
+  .card-group > .card:not(:last-child) .card-img-bottom,
+.card-group > .card:not(:last-child) .card-footer {
     border-bottom-right-radius: 0;
   }
-  .card-group > .card:not(:first-child), .card-group > .tag-list:not(:first-child) {
+  .card-group > .card:not(:first-child) {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-  .card-group > .card:not(:first-child) .card-img-top, .card-group > .tag-list:not(:first-child) .card-img-top,
-.card-group > .card:not(:first-child) .card-header,
-.card-group > .tag-list:not(:first-child) .card-header {
+  .card-group > .card:not(:first-child) .card-img-top,
+.card-group > .card:not(:first-child) .card-header {
     border-top-left-radius: 0;
   }
-  .card-group > .card:not(:first-child) .card-img-bottom, .card-group > .tag-list:not(:first-child) .card-img-bottom,
-.card-group > .card:not(:first-child) .card-footer,
-.card-group > .tag-list:not(:first-child) .card-footer {
+  .card-group > .card:not(:first-child) .card-img-bottom,
+.card-group > .card:not(:first-child) .card-footer {
     border-bottom-left-radius: 0;
   }
 }
@@ -12649,16 +12644,14 @@ select[data-module=autocomplete] {
 }
 
 .tag-list {
-  margin: 0;
-  list-style: none;
   padding: 10px 10px 5px 10px;
   background-color: #f8f9fa;
-  margin-bottom: 1rem;
+  border: 1px solid #ddd;
+  border-radius: 0.25rem;
 }
 
 .tag-list li {
   display: inline-block;
-  margin-right: 5px;
 }
 
 .tag-list li:last-child {
@@ -14016,33 +14009,33 @@ td.diff_header {
   margin-top: 1rem;
   color: #444;
 }
-.homepage .module-stats .card, .homepage .module-stats .tag-list {
+.homepage .module-stats .card {
   padding: 1.5rem 1.75rem;
 }
-.homepage .module-stats .card ul, .homepage .module-stats .tag-list ul {
+.homepage .module-stats .card ul {
   margin: 0;
   list-style: none;
   padding: 0;
 }
-.homepage .module-stats .card ul::after, .homepage .module-stats .tag-list ul::after {
+.homepage .module-stats .card ul::after {
   display: block;
   clear: both;
   content: "";
 }
-.homepage .module-stats .card ul li, .homepage .module-stats .tag-list ul li {
+.homepage .module-stats .card ul li {
   float: left;
   width: 25%;
   font-weight: 300;
 }
-.homepage .module-stats .card ul li a, .homepage .module-stats .tag-list ul li a {
+.homepage .module-stats .card ul li a {
   display: block;
 }
-.homepage .module-stats .card ul li a b, .homepage .module-stats .tag-list ul li a b {
+.homepage .module-stats .card ul li a b {
   display: block;
   font-size: 0.875rem;
   line-height: 1.5;
 }
-.homepage .module-stats .card ul li a:hover, .homepage .module-stats .tag-list ul li a:hover {
+.homepage .module-stats .card ul li a:hover {
   text-decoration: none;
 }
 .homepage .module-feeds {
@@ -14061,7 +14054,7 @@ td.diff_header {
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;
   }
-  .homepage .module-feeds .card, .homepage .module-feeds .tag-list {
+  .homepage .module-feeds .card {
     margin-top: 1rem;
     margin-bottom: 1rem;
   }

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -4448,7 +4448,7 @@ textarea.form-control-lg {
   color: #fff;
 }
 
-.card, .tag-list {
+.card {
   position: relative;
   display: flex;
   flex-direction: column;
@@ -4459,31 +4459,30 @@ textarea.form-control-lg {
   border: 1px solid rgba(0, 0, 0, 0.125);
   border-radius: 0.25rem;
 }
-.card > hr, .tag-list > hr {
+.card > hr {
   margin-right: 0;
   margin-left: 0;
 }
-.card > .list-group, .tag-list > .list-group {
+.card > .list-group {
   border-top: inherit;
   border-bottom: inherit;
 }
-.card > .list-group:first-child, .tag-list > .list-group:first-child {
+.card > .list-group:first-child {
   border-top-width: 0;
   border-top-left-radius: calc(0.25rem - 1px);
   border-top-right-radius: calc(0.25rem - 1px);
 }
-.card > .list-group:last-child, .tag-list > .list-group:last-child {
+.card > .list-group:last-child {
   border-bottom-width: 0;
   border-bottom-right-radius: calc(0.25rem - 1px);
   border-bottom-left-radius: calc(0.25rem - 1px);
 }
-.card > .card-header + .list-group, .tag-list > .card-header + .list-group,
-.card > .list-group + .card-footer,
-.tag-list > .list-group + .card-footer {
+.card > .card-header + .list-group,
+.card > .list-group + .card-footer {
   border-top: 0;
 }
 
-.card-body, .tag-list {
+.card-body {
   flex: 1 1 auto;
   padding: 1rem 1rem;
 }
@@ -4567,7 +4566,7 @@ textarea.form-control-lg {
   border-bottom-left-radius: calc(0.25rem - 1px);
 }
 
-.card-group > .card, .card-group > .tag-list {
+.card-group > .card {
   margin-bottom: 0.75rem;
 }
 @media (min-width: 576px) {
@@ -4575,40 +4574,36 @@ textarea.form-control-lg {
     display: flex;
     flex-flow: row wrap;
   }
-  .card-group > .card, .card-group > .tag-list {
+  .card-group > .card {
     flex: 1 0 0%;
     margin-bottom: 0;
   }
-  .card-group > .card + .card, .card-group > .tag-list + .card, .card-group > .card + .tag-list, .card-group > .tag-list + .tag-list {
+  .card-group > .card + .card {
     margin-left: 0;
     border-left: 0;
   }
-  .card-group > .card:not(:last-child), .card-group > .tag-list:not(:last-child) {
+  .card-group > .card:not(:last-child) {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
   }
-  .card-group > .card:not(:last-child) .card-img-top, .card-group > .tag-list:not(:last-child) .card-img-top,
-.card-group > .card:not(:last-child) .card-header,
-.card-group > .tag-list:not(:last-child) .card-header {
+  .card-group > .card:not(:last-child) .card-img-top,
+.card-group > .card:not(:last-child) .card-header {
     border-top-right-radius: 0;
   }
-  .card-group > .card:not(:last-child) .card-img-bottom, .card-group > .tag-list:not(:last-child) .card-img-bottom,
-.card-group > .card:not(:last-child) .card-footer,
-.card-group > .tag-list:not(:last-child) .card-footer {
+  .card-group > .card:not(:last-child) .card-img-bottom,
+.card-group > .card:not(:last-child) .card-footer {
     border-bottom-right-radius: 0;
   }
-  .card-group > .card:not(:first-child), .card-group > .tag-list:not(:first-child) {
+  .card-group > .card:not(:first-child) {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-  .card-group > .card:not(:first-child) .card-img-top, .card-group > .tag-list:not(:first-child) .card-img-top,
-.card-group > .card:not(:first-child) .card-header,
-.card-group > .tag-list:not(:first-child) .card-header {
+  .card-group > .card:not(:first-child) .card-img-top,
+.card-group > .card:not(:first-child) .card-header {
     border-top-left-radius: 0;
   }
-  .card-group > .card:not(:first-child) .card-img-bottom, .card-group > .tag-list:not(:first-child) .card-img-bottom,
-.card-group > .card:not(:first-child) .card-footer,
-.card-group > .tag-list:not(:first-child) .card-footer {
+  .card-group > .card:not(:first-child) .card-img-bottom,
+.card-group > .card:not(:first-child) .card-footer {
     border-bottom-left-radius: 0;
   }
 }
@@ -12649,16 +12644,14 @@ select[data-module=autocomplete] {
 }
 
 .tag-list {
-  margin: 0;
-  list-style: none;
   padding: 10px 10px 5px 10px;
   background-color: #f8f9fa;
-  margin-bottom: 1rem;
+  border: 1px solid #ddd;
+  border-radius: 0.25rem;
 }
 
 .tag-list li {
   display: inline-block;
-  margin-right: 5px;
 }
 
 .tag-list li:last-child {
@@ -14016,33 +14009,33 @@ td.diff_header {
   margin-top: 1rem;
   color: #444;
 }
-.homepage .module-stats .card, .homepage .module-stats .tag-list {
+.homepage .module-stats .card {
   padding: 1.5rem 1.75rem;
 }
-.homepage .module-stats .card ul, .homepage .module-stats .tag-list ul {
+.homepage .module-stats .card ul {
   margin: 0;
   list-style: none;
   padding: 0;
 }
-.homepage .module-stats .card ul::after, .homepage .module-stats .tag-list ul::after {
+.homepage .module-stats .card ul::after {
   display: block;
   clear: both;
   content: "";
 }
-.homepage .module-stats .card ul li, .homepage .module-stats .tag-list ul li {
+.homepage .module-stats .card ul li {
   float: left;
   width: 25%;
   font-weight: 300;
 }
-.homepage .module-stats .card ul li a, .homepage .module-stats .tag-list ul li a {
+.homepage .module-stats .card ul li a {
   display: block;
 }
-.homepage .module-stats .card ul li a b, .homepage .module-stats .tag-list ul li a b {
+.homepage .module-stats .card ul li a b {
   display: block;
   font-size: 0.875rem;
   line-height: 1.5;
 }
-.homepage .module-stats .card ul li a:hover, .homepage .module-stats .tag-list ul li a:hover {
+.homepage .module-stats .card ul li a:hover {
   text-decoration: none;
 }
 .homepage .module-feeds {
@@ -14061,7 +14054,7 @@ td.diff_header {
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;
   }
-  .homepage .module-feeds .card, .homepage .module-feeds .tag-list {
+  .homepage .module-feeds .card {
     margin-top: 1rem;
     margin-bottom: 1rem;
   }

--- a/ckan/public/base/scss/_dataset.scss
+++ b/ckan/public/base/scss/_dataset.scss
@@ -155,17 +155,14 @@
 // Dataset Forms
 // Tag List
 .tag-list {
-    @include list-unstyled;
     padding: 10px 10px 5px 10px;
-    @extend .card;
-    @extend .card-body;
     background-color: $gray-100;
-    margin-bottom: $paragraph-margin-bottom;
+    border: 1px solid $genericBorderColor;
+    border-radius: 0.25rem;
 }
 
 .tag-list li {
     display: inline-block;
-    margin-right: 5px;
 }
 
 .tag-list li:last-child {
@@ -232,7 +229,7 @@
     background-color: #0b4498;
 }
 
-.badge-default[href]:hover, 
+.badge-default[href]:hover,
 .badge-default[href]:focus {
     background-color: #5e5e5e;
     color: $white;

--- a/ckan/templates/snippets/tag_list.html
+++ b/ckan/templates/snippets/tag_list.html
@@ -5,7 +5,7 @@
 
   Example:
 
-    {% snippet 'snippets/tag_list.html', tags=tags, _class='tag-list well' %}
+    {% snippet 'snippets/tag_list.html', tags=tags, _class='tag-list' %}
 
 #}
 {% set _class = _class or 'tag-list' %}


### PR DESCRIPTION
This PR fixes the CSS class of `tag-list` to properly render it in Bootstrap 5.

- By no extending `card` we simplify a lot our CSS structure
- Removed `well` from template example since it's an old BS3 class

### Before
![image](https://user-images.githubusercontent.com/6672339/201065337-fae7f2b6-f24f-44cb-bda7-0c6f69e709e6.png)


### After
![image](https://user-images.githubusercontent.com/6672339/201065173-db8c791a-6455-41f3-b6c0-3d8cbf729f33.png)
