### PR TITLE
Fix typo in search-index command

### DIFF
--- a/doc/maintaining/cli.rst
+++ b/doc/maintaining/cli.rst
@@ -564,7 +564,7 @@ computer to reindex faster
 
 .. parsed-literal::
 
- ckan -c |ckan.ini| search-index rebuild_fast
+ ckan -c |ckan.ini| search-index rebuild-fast
 
 There are other search related commands, mostly useful for debugging purposes
 


### PR DESCRIPTION
Fixes #
Update typo in search-index command (rebuild-fast instead of rebuild_fast)

### Proposed fixes:
Typo in search-index command


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
