### PR TITLE
Fix social icons

### DIFF
--- a/ckan/templates-bs3/snippets/social.html
+++ b/ckan/templates-bs3/snippets/social.html
@@ -6,8 +6,8 @@
     {% endblock %}
     {% block social_nav %}
       <ul class="nav nav-simple">
-        <li class="nav-item"><a href="https://twitter.com/share?url={{ current_url }}" target="_blank"><i class="fa fa-twitter-square"></i> Twitter</a></li>
-        <li class="nav-item"><a href="https://www.facebook.com/sharer.php?u={{ current_url }}" target="_blank"><i class="fa fa-facebook-square"></i> Facebook</a></li>
+        <li class="nav-item"><a href="https://twitter.com/share?url={{ current_url }}" target="_blank"><i class="fa-brands fa-twitter-square"></i> Twitter</a></li>
+        <li class="nav-item"><a href="https://www.facebook.com/sharer.php?u={{ current_url }}" target="_blank"><i class="fa-brands fa-facebook-square"></i> Facebook</a></li>
       </ul>
     {% endblock %}
   </section>

--- a/ckan/templates/snippets/social.html
+++ b/ckan/templates/snippets/social.html
@@ -6,8 +6,8 @@
     {% endblock %}
     {% block social_nav %}
       <ul class="nav nav-simple">
-        <li class="nav-item"><a href="https://twitter.com/share?url={{ current_url }}" target="_blank"><i class="fa fa-twitter-square"></i> Twitter</a></li>
-        <li class="nav-item"><a href="https://www.facebook.com/sharer.php?u={{ current_url }}" target="_blank"><i class="fa fa-facebook-square"></i> Facebook</a></li>
+        <li class="nav-item"><a href="https://twitter.com/share?url={{ current_url }}" target="_blank"><i class="fa-brands fa-twitter-square"></i> Twitter</a></li>
+        <li class="nav-item"><a href="https://www.facebook.com/sharer.php?u={{ current_url }}" target="_blank"><i class="fa-brands fa-facebook-square"></i> Facebook</a></li>
       </ul>
     {% endblock %}
   </section>


### PR DESCRIPTION
This PR updates the social icons to Font Awesome 6 syntax.

## Before
![image](https://user-images.githubusercontent.com/6672339/201469838-55ef3e76-24ef-4828-825c-a9894b3ba7af.png)


## After
![image](https://user-images.githubusercontent.com/6672339/201469805-239d6379-fd2a-47e9-bc6a-43d779af8742.png)
