### PR TITLE
Update werkzeug dependency for security patch (cve-2022-29361)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -33,5 +33,5 @@ sqlparse==0.4.2
 typing_extensions==4.3.0
 tzlocal==4.2
 webassets==2.0
-Werkzeug[watchdog]==2.0.3
+Werkzeug[watchdog]==2.1.1
 zope.interface==5.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -151,7 +151,7 @@ webassets==2.0
     # via -r requirements.in
 webencodings==0.5.1
     # via bleach
-werkzeug[watchdog]==2.0.3
+werkzeug[watchdog]==2.1.1
     # via
     #   -r requirements.in
     #   flask


### PR DESCRIPTION
Issue:
- Security vulnerability in Werkzeug package <2.1.1
- https://avd.aquasec.com/nvd/cve-2022-29361

Solution:
- Upgraded Werkzeug from 2.0.3 --> 2.1.1

As noted here: https://github.com/ckan/ckan/security/policy, security patches are not included in the changelog, so I haven't created an issue or added to the `changes` directory for the towncrier test to pass. Let me know if I should create another commit to rectify this.
