### PR TITLE
Separate requirements install instruction

### DIFF
--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -26,8 +26,8 @@ work on CKAN.
 1. Install the required packages
 --------------------------------
 
-If you're using a Debian-based operating system (such as Ubuntu) install the required
-packages with this command::
+If you're using a Debian-based operating system (such as Ubuntu) install the
+required packages with this command::
 
     sudo apt-get install python3-dev libpq-dev python3-pip python3-venv git-core redis-server
 

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -24,10 +24,26 @@ work on CKAN.
 1. Install the required packages
 --------------------------------
 
-If you're using a Debian-based operating system (such as Ubuntu) install the
-required packages with this command::
+CKAN is a Python application that requires three main services: PostgreSQL, Solr and Redis.
 
-    sudo apt-get install python3-dev postgresql libpq-dev python3-pip python3-venv git-core solr-tomcat openjdk-8-jdk redis-server
+Python required packages::
+
+    sudo apt-get install python3-dev libpq-dev python3-pip python3-venv git-core
+
+The 3 main services (PostgreSQL, Solr and Redis) can be installed locally or dockerized. If
+you want to run them locally you will need to install the following dependencies.
+
+PostgreSQL requirements::
+
+    sudo apt-get install postgresql
+
+Solr requirements::
+
+    sudo apt-get install solr-tomcat openjdk-8-jdk
+
+Redis requirements::
+
+    sudo apt-get install redis-server
 
 If you're not using a Debian-based operating system, find the best way to
 install the following packages on your operating system (see
@@ -211,16 +227,17 @@ site_url
 
 .. _postgres-init:
 
-----------------------
-6. Link to ``who.ini``
-----------------------
+---------------
+6. Setup Redis
+---------------
 
-``who.ini`` (the Repoze.who configuration file) needs to be accessible in the
-same directory as your CKAN config file, so create a symlink to it:
+If you installed it locally on the first step, make sure you have a Redis
+instance running in the `6379` port.
 
-.. parsed-literal::
+If you have Docker installed, you can setup a default Redis instance by
+running::
 
-    ln -s |virtualenv|/src/ckan/who.ini |config_dir|/who.ini
+    docker run --name ckan-redis -p 6379:6379 -d redis
 
 -------------------------
 7. Create database tables

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -4,6 +4,8 @@
 Installing CKAN from source
 ===========================
 
+CKAN is a Python application that requires three main services: PostgreSQL, Solr and Redis.
+
 This section describes how to install CKAN from source. Although
 :doc:`install-from-package` is simpler, it requires Ubuntu 18.04 64-bit or
 Ubuntu 16.04 64-bit. Installing CKAN from source works with other
@@ -24,26 +26,10 @@ work on CKAN.
 1. Install the required packages
 --------------------------------
 
-CKAN is a Python application that requires three main services: PostgreSQL, Solr and Redis.
+If you're using a Debian-based operating system (such as Ubuntu) install the required
+packages with this command::
 
-Python required packages::
-
-    sudo apt-get install python3-dev libpq-dev python3-pip python3-venv git-core
-
-The 3 main services (PostgreSQL, Solr and Redis) can be installed locally or dockerized. If
-you want to run them locally you will need to install the following dependencies.
-
-PostgreSQL requirements::
-
-    sudo apt-get install postgresql
-
-Solr requirements::
-
-    sudo apt-get install solr-tomcat openjdk-8-jdk
-
-Redis requirements::
-
-    sudo apt-get install redis-server
+    sudo apt-get install python3-dev libpq-dev python3-pip python3-venv git-core redis-server
 
 If you're not using a Debian-based operating system, find the best way to
 install the following packages on your operating system (see

--- a/doc/maintaining/installing/postgres.rst
+++ b/doc/maintaining/installing/postgres.rst
@@ -1,11 +1,16 @@
 :orphan:
 
+Install PostgreSQL required packages::
+
+    sudo apt-get install postgreqsl
+
+
 .. note::
 
-    If you are facing a problem in case postgresql is not running, 
-    execute the command ``sudo service postgresql start`` 
-    
-    
+    If you are facing a problem in case postgresql is not running,
+    execute the command ``sudo service postgresql start``
+
+
 Check that |postgres| was installed correctly by listing the existing databases::
 
     sudo -u postgres psql -l

--- a/doc/maintaining/installing/solr.rst
+++ b/doc/maintaining/installing/solr.rst
@@ -32,6 +32,10 @@ You can now jump to the `Next steps <#next-steps-with-solr>`_ section.
 Installing Solr manually
 ========================
 
+#. Install the OS dependencies if you haven't done it before::
+
+      sudo apt-get install solr-tomcat openjdk-8-jdk
+
 #. Download the latest supported version from the `Solr downloads page <https://solr.apache.org/downloads.html>`_. CKAN supports Solr version 8.x.
 
 #. Extract the downloaded file to your desired location (adjust the Solr version number to the one you are using)::

--- a/doc/maintaining/installing/solr.rst
+++ b/doc/maintaining/installing/solr.rst
@@ -32,7 +32,7 @@ You can now jump to the `Next steps <#next-steps-with-solr>`_ section.
 Installing Solr manually
 ========================
 
-#. Install the OS dependencies if you haven't done it before::
+#. Install the OS dependencies::
 
       sudo apt-get install solr-tomcat openjdk-8-jdk
 


### PR DESCRIPTION
A common issue for some installs are the requirements for Solr which are not mandatory if the user will run it using Docker.

This PR proposes a small change into the introduction of the instructions to install it from source to:

 - Explicitly name all the service required (I think it provide a good general view of the upcoming install process)
 - Separate each requirement in a different command so specifically link it to the service.
 - Cleans the old `who.ini` file section since it's no longer needed in CKAN 2.10.