### PR TITLE
Fix for Extra Resource metadata field

### DIFF
--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -374,7 +374,7 @@ class EditView(MethodView):
         try:
             if resource_id:
                 data[u'id'] = resource_id
-                get_action(u'resource_update')(context, data)
+                get_action(u'resource_patch')(context, data)
             else:
                 get_action(u'resource_create')(context, data)
         except ValidationError as e:


### PR DESCRIPTION
Fixes #6998 

### Proposed fixes: 
This PR fixes the loss of extra resource metadata fields when updated via UI



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
