### PR TITLE
Add defaults to check_ckan_version helper on 2.9

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -3003,7 +3003,7 @@ def can_update_owner_org(package_dict, user_orgs=None):
 
 
 @core_helper
-def check_ckan_version(min_version, max_version):
+def check_ckan_version(min_version=None, max_version=None):
     """Return ``True`` if the CKAN version is greater than or equal to
     ``min_version`` and less than or equal to ``max_version``,
     return ``False`` otherwise.


### PR DESCRIPTION
Defaults were lost during backporting the feature, so currently you need specify both in a template as opposed to the comment.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
