### PR TITLE
Fix typo in search-index command

### DIFF
--- a/doc/maintaining/cli.rst
+++ b/doc/maintaining/cli.rst
@@ -548,7 +548,7 @@ computer to reindex faster
 
 .. parsed-literal::
 
- ckan -c |ckan.ini| search-index rebuild_fast
+ ckan -c |ckan.ini| search-index rebuild-fast
 
 There is also an option to clear the whole index first and then rebuild it with all datasets:
 


### PR DESCRIPTION
Fixes #

Update typo in search-index command (rebuild-fast instead of rebuild_fast)

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
