### PR TITLE
Remove log warnings about ckan.requests.timeout not being declared

### DIFF
--- a/ckan/lib/captcha.py
+++ b/ckan/lib/captcha.py
@@ -5,8 +5,6 @@ import requests
 from ckan.common import config
 from ckan.types import Request
 
-TIMEOUT = config.get_value('ckan.requests.timeout')
-
 
 def check_recaptcha(request: Request) -> None:
     '''Check a user\'s recaptcha submission is valid, and raise CaptchaError
@@ -31,7 +29,9 @@ def check_recaptcha(request: Request) -> None:
         remoteip=client_ip_address,
         response=recaptcha_response_field.encode('utf8')
     )
-    response = requests.get(recaptcha_server_name, params, timeout=TIMEOUT)
+
+    timeout = config.get_value('ckan.requests.timeout')
+    response = requests.get(recaptcha_server_name, params, timeout=timeout)
     data = response.json()
 
     try:

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -37,7 +37,6 @@ from ckan.lib.search.index import SearchIndex
 
 log = logging.getLogger(__name__)
 
-TIMEOUT = config.get_value('ckan.requests.timeout')
 
 def text_traceback() -> str:
     info = sys.exc_info()
@@ -222,9 +221,9 @@ def rebuild(package_id: Optional[str] = None,
         packages = model.Session.query(model.Package.id)
         if config.get_value('ckan.search.remove_deleted_packages'):
             packages = packages.filter(model.Package.state != 'deleted')
-        
+
         package_ids = [r[0] for r in packages.all()]
-        
+
         if only_missing:
             log.info('Indexing only missing packages...')
             package_query = query_for(model.Package)
@@ -311,6 +310,9 @@ def clear_all() -> None:
     package_index.clear()
 
 def _get_schema_from_solr(file_offset: str):
+
+    timeout = config.get_value('ckan.requests.timeout')
+
     solr_url, solr_user, solr_password = SolrSettings.get()
 
     url = solr_url.strip('/') + file_offset
@@ -318,10 +320,10 @@ def _get_schema_from_solr(file_offset: str):
     if solr_user is not None and solr_password is not None:
         response = requests.get(
             url,
-            timeout=TIMEOUT,
+            timeout=timeout,
             auth=HTTPBasicAuth(solr_user, solr_password))
     else:
-        response = requests.get(url, timeout=TIMEOUT)
+        response = requests.get(url, timeout=timeout)
 
     return response
 

--- a/ckan/model/license.py
+++ b/ckan/model/license.py
@@ -14,7 +14,6 @@ from ckan.common import _, json
 
 log = logging.getLogger(__name__)
 
-TIMEOUT = config.get_value('ckan.requests.timeout')
 
 class License():
     """Domain object for a license."""
@@ -77,12 +76,14 @@ class LicenseRegister(object):
             self._create_license_list(default_license_list)
 
     def load_licenses(self, license_url: str) -> None:
+
         try:
             if license_url.startswith('file://'):
                 with open(license_url.replace('file://', ''), 'r') as f:
                     license_data = json.load(f)
             else:
-                response = requests.get(license_url, timeout=TIMEOUT)
+                timeout = config.get_value('ckan.requests.timeout')
+                response = requests.get(license_url, timeout=timeout)
                 license_data = response.json()
         except requests.RequestException as e:
             msg = "Couldn't get the licenses file {}: {}".format(license_url, e)

--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -25,8 +25,6 @@ log = logging.getLogger(__name__)
 _get_or_bust = logic.get_or_bust
 _validate = ckan.lib.navl.dictization_functions.validate
 
-TIMEOUT = config.get_value('ckan.requests.timeout')
-
 
 def datapusher_submit(context: Context, data_dict: dict[str, Any]):
     ''' Submit a job to the datapusher. The datapusher is a service that
@@ -131,6 +129,8 @@ def datapusher_submit(context: Context, data_dict: dict[str, Any]):
     context['session'] = context['model'].meta.create_local_session()
     p.toolkit.get_action('task_status_update')(context, task)
 
+    timeout = config.get_value('ckan.requests.timeout')
+
     # This setting is checked on startup
     api_token = p.toolkit.config.get("ckan.datapusher.api_token")
     try:
@@ -139,7 +139,7 @@ def datapusher_submit(context: Context, data_dict: dict[str, Any]):
             headers={
                 'Content-Type': 'application/json'
             },
-            timeout=TIMEOUT,
+            timeout=timeout,
             data=json.dumps({
                 'api_key': api_token,
                 'job_type': 'push_to_datastore',
@@ -308,8 +308,9 @@ def datapusher_status(
     if job_id:
         url = urljoin(datapusher_url, 'job' + '/' + job_id)
         try:
+            timeout = config.get_value('ckan.requests.timeout')
             r = requests.get(url,
-                             timeout=TIMEOUT,
+                             timeout=timeout,
                              headers={'Content-Type': 'application/json',
                                       'Authorization': job_key})
             r.raise_for_status()

--- a/ckanext/resourceproxy/blueprint.py
+++ b/ckanext/resourceproxy/blueprint.py
@@ -15,7 +15,6 @@ from ckan.plugins.toolkit import (abort, get_action, c)
 
 log = getLogger(__name__)
 
-TIMEOUT = config.get_value('ckan.resource_proxy.timeout')
 
 resource_proxy = Blueprint(u'resource_proxy', __name__)
 
@@ -40,18 +39,19 @@ def proxy_resource(context: Context, data_dict: DataDict):
     if not parts.scheme or not parts.netloc:
         return abort(409, _(u'Invalid URL.'))
 
+    timeout = config.get_value('ckan.resource_proxy.timeout')
     max_file_size = config.get_value(u'ckan.resource_proxy.max_file_size')
     response = make_response()
     try:
         # first we try a HEAD request which may not be supported
         did_get = False
-        r = requests.head(url, timeout=TIMEOUT)
+        r = requests.head(url, timeout=timeout)
         # Servers can refuse HEAD requests. 405 is the appropriate
         # response, but 400 with the invalid method mentioned in the
         # text, or a 403 (forbidden) status is also possible (#2412,
         # #2530)
         if r.status_code in (400, 403, 405):
-            r = requests.get(url, timeout=TIMEOUT, stream=True)
+            r = requests.get(url, timeout=timeout, stream=True)
             did_get = True
         r.raise_for_status()
 
@@ -66,7 +66,7 @@ def proxy_resource(context: Context, data_dict: DataDict):
             )
 
         if not did_get:
-            r = requests.get(url, timeout=TIMEOUT, stream=True)
+            r = requests.get(url, timeout=timeout, stream=True)
 
         response.headers[u'content-type'] = r.headers[u'content-type']
         response.charset = r.encoding or "utf-8"


### PR DESCRIPTION
When running any `ckan` command there were these two lines coming up:

```
Option ckan.requests.timeout is not declared
Option ckan.requests.timeout is not declared
```

That's because we were trying to access this config option at import time with `get_value()`, before the config has been properly parsed. This moves the assignments to the functions, where config is properly initialized.
