### PR TITLE
Add option to output token value without extra messages

### DIFF
--- a/changes/7217.misc
+++ b/changes/7217.misc
@@ -1,0 +1,1 @@
+Add ``--quiet`` option to ``ckan user token add`` command to mak easier to integrate with automated scripts

--- a/ckan/cli/user.py
+++ b/ckan/cli/user.py
@@ -162,8 +162,15 @@ def token():
     default=u"{}",
     help=u"Valid JSON object with additional fields for api_token_create",
 )
+@click.option(
+    "--quiet",
+    "-q",
+    is_flag=True,
+    help="Output just the token itself (useful in automated scripts)",
+)
 def add_token(
-        username: str, token_name: str, extras: list[str], json_str: str):
+        username: str, token_name: str, extras: list[str], json_str: str,
+        quiet: bool):
     """Create a new API Token for the given user.
 
     Arbitrary fields can be passed in the form `key=value` or using
@@ -197,8 +204,9 @@ def add_token(
     except logic.NotFound as e:
         error_shout(e)
         raise click.Abort()
-    click.secho(u"API Token created:", fg=u"green")
-    click.echo(u"\t", nl=False)
+    if not quiet:
+        click.secho(u"API Token created:", fg=u"green")
+        click.echo(u"\t", nl=False)
     click.echo(token[u"token"])
 
 


### PR DESCRIPTION
When running `ckan user token add` you get this output by default:

```
API Token created:
        eyJ0eXAiOiJKV1QiL...
```

This is user-friendly, but is not great for integrating in automated scripts as you need to clean up the output a bit, eg:

```
export CKAN_API_TOKEN=$(ckan user token add ckan_user my_token | tail -n 1 | tr -d '\t')
```

### Proposed fixes:

The changes suggested add a `--quiet` / `-q` flag that make the command just output the token directly so you can do:

```
export CKAN_API_TOKEN=$(ckan user token add ckan_user my_token -q)
```


### Features:


- [x] includes bugfix for possible backport


