### PR TITLE
Restore resource-icons scss file

### DIFF
--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -13958,6 +13958,212 @@ td.diff_header {
   z-index: 0;
 }
 
+.format-label {
+  text-indent: -900em;
+  background: url("../../../base/images/sprite-resource-icons.png") no-repeat 0 0;
+}
+
+.format-label {
+  width: 60px;
+  height: 65px;
+  background-position: -1720px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=html],
+.format-label[data-format*=html] {
+  width: 60px;
+  height: 65px;
+  background-position: -120px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=json],
+.format-label[data-format*=json] {
+  width: 60px;
+  height: 65px;
+  background-position: -220px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=xml],
+.format-label[data-format*=xml] {
+  width: 60px;
+  height: 65px;
+  background-position: -320px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=txt],
+.format-label[data-format*=txt] {
+  width: 60px;
+  height: 65px;
+  background-position: -420px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=doc],
+.format-label[data-format*=doc],
+.format-label[data-format=docx],
+.format-label[data-format*=docx] {
+  width: 60px;
+  height: 65px;
+  background-position: -520px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=odt],
+.format-label[data-format*=odt] {
+  width: 60px;
+  height: 65px;
+  background-position: -620px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=csv],
+.format-label[data-format*=csv] {
+  width: 60px;
+  height: 65px;
+  background-position: -720px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=xls],
+.format-label[data-format*=xls] {
+  width: 60px;
+  height: 65px;
+  background-position: -820px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=zip],
+.format-label[data-format*=zip] {
+  width: 60px;
+  height: 65px;
+  background-position: -920px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=api],
+.format-label[data-format*=api] {
+  width: 60px;
+  height: 65px;
+  background-position: -1020px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=pdf],
+.format-label[data-format*=pdf] {
+  width: 60px;
+  height: 65px;
+  background-position: -1120px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=rdf],
+.format-label[data-format*=rdf] {
+  width: 60px;
+  height: 65px;
+  background-position: -1220px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=wms],
+.format-label[data-format*=wms] {
+  width: 60px;
+  height: 65px;
+  background-position: -1320px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=png],
+.format-label[data-format*=png] {
+  width: 60px;
+  height: 65px;
+  background-position: -1420px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=jpg],
+.format-label[data-format*=jpg],
+.format-label[data-format=jpeg],
+.format-label[data-format*=jpeg] {
+  width: 60px;
+  height: 65px;
+  background-position: -1520px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=gif],
+.format-label[data-format*=gif] {
+  width: 60px;
+  height: 65px;
+  background-position: -1620px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=wfs],
+.format-label[data-format*=wfs] {
+  width: 60px;
+  height: 65px;
+  background-position: -1820px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=gml],
+.format-label[data-format*=gml] {
+  width: 60px;
+  height: 65px;
+  background-position: -1920px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=wmts],
+.format-label[data-format*=wmts] {
+  width: 60px;
+  height: 65px;
+  background-position: -2020px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=kml],
+.format-label[data-format*=kml] {
+  width: 60px;
+  height: 65px;
+  background-position: -2120px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=geo],
+.format-label[data-format*=geo] {
+  width: 60px;
+  height: 65px;
+  background-position: -2220px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
 @media (min-width: 576px) {
   .wrapper:before {
     left: initial;

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -13957,3 +13957,209 @@ td.diff_header {
 .input-group-btn:last-child > .btn {
   z-index: 0;
 }
+
+.format-label {
+  text-indent: -900em;
+  background: url("../../../base/images/sprite-resource-icons.png") no-repeat 0 0;
+}
+
+.format-label {
+  width: 60px;
+  height: 65px;
+  background-position: -1720px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=html],
+.format-label[data-format*=html] {
+  width: 60px;
+  height: 65px;
+  background-position: -120px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=json],
+.format-label[data-format*=json] {
+  width: 60px;
+  height: 65px;
+  background-position: -220px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=xml],
+.format-label[data-format*=xml] {
+  width: 60px;
+  height: 65px;
+  background-position: -320px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=txt],
+.format-label[data-format*=txt] {
+  width: 60px;
+  height: 65px;
+  background-position: -420px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=doc],
+.format-label[data-format*=doc],
+.format-label[data-format=docx],
+.format-label[data-format*=docx] {
+  width: 60px;
+  height: 65px;
+  background-position: -520px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=odt],
+.format-label[data-format*=odt] {
+  width: 60px;
+  height: 65px;
+  background-position: -620px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=csv],
+.format-label[data-format*=csv] {
+  width: 60px;
+  height: 65px;
+  background-position: -720px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=xls],
+.format-label[data-format*=xls] {
+  width: 60px;
+  height: 65px;
+  background-position: -820px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=zip],
+.format-label[data-format*=zip] {
+  width: 60px;
+  height: 65px;
+  background-position: -920px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=api],
+.format-label[data-format*=api] {
+  width: 60px;
+  height: 65px;
+  background-position: -1020px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=pdf],
+.format-label[data-format*=pdf] {
+  width: 60px;
+  height: 65px;
+  background-position: -1120px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=rdf],
+.format-label[data-format*=rdf] {
+  width: 60px;
+  height: 65px;
+  background-position: -1220px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=wms],
+.format-label[data-format*=wms] {
+  width: 60px;
+  height: 65px;
+  background-position: -1320px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=png],
+.format-label[data-format*=png] {
+  width: 60px;
+  height: 65px;
+  background-position: -1420px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=jpg],
+.format-label[data-format*=jpg],
+.format-label[data-format=jpeg],
+.format-label[data-format*=jpeg] {
+  width: 60px;
+  height: 65px;
+  background-position: -1520px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=gif],
+.format-label[data-format*=gif] {
+  width: 60px;
+  height: 65px;
+  background-position: -1620px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=wfs],
+.format-label[data-format*=wfs] {
+  width: 60px;
+  height: 65px;
+  background-position: -1820px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=gml],
+.format-label[data-format*=gml] {
+  width: 60px;
+  height: 65px;
+  background-position: -1920px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=wmts],
+.format-label[data-format*=wmts] {
+  width: 60px;
+  height: 65px;
+  background-position: -2020px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=kml],
+.format-label[data-format*=kml] {
+  width: 60px;
+  height: 65px;
+  background-position: -2120px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label[data-format=geo],
+.format-label[data-format*=geo] {
+  width: 60px;
+  height: 65px;
+  background-position: -2220px -220px;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}

--- a/ckan/public/base/scss/_ckan.scss
+++ b/ckan/public/base/scss/_ckan.scss
@@ -22,3 +22,4 @@
 @import "datapusher.scss";
 @import "alerts.scss";
 @import "input-groups.scss";
+@import "resource-icons.scss"

--- a/ckan/public/base/scss/_resource-icons.scss
+++ b/ckan/public/base/scss/_resource-icons.scss
@@ -1,0 +1,162 @@
+// RESOURCE FORMAT ICONS
+
+@use "sass:map";
+
+$icon-position: (
+ "resourceIconX": 60px,
+ "resourceIconY": 65px,
+ "resourceIconOffsetX": -20px,
+ "resourceIconOffsetY": -220px,
+);
+
+@mixin ckan-resource-icon-bg-pos($offset, $size) {
+  $w: map-get($icon-position, "#{$size}X");
+  $h: map-get($icon-position, "#{$size}Y");
+  $x: map-get($icon-position, "#{$size}OffsetX");
+  $y: map-get($icon-position, "#{$size}OffsetY");
+  width: $w;
+  height: $h;
+  background-position: ($x + -100 * $offset) $y;
+  transform: scale(0.53);
+  margin: -14px 0 0 -14px;
+}
+
+.format-label {
+    text-indent: -900em;
+    background: url("#{$imagePath}/sprite-resource-icons.png") no-repeat 0 0;
+}
+
+.format-label {
+    @include ckan-resource-icon-bg-pos(17,
+    "resourceIcon");
+}
+
+.format-label[data-format=html],
+.format-label[data-format*=html] {
+    @include ckan-resource-icon-bg-pos(1,
+    "resourceIcon");
+}
+
+.format-label[data-format=json],
+.format-label[data-format*=json] {
+    @include ckan-resource-icon-bg-pos(2,
+    "resourceIcon");
+}
+
+.format-label[data-format=xml],
+.format-label[data-format*=xml] {
+    @include ckan-resource-icon-bg-pos(3,
+    "resourceIcon");
+}
+
+.format-label[data-format=txt],
+.format-label[data-format*=txt] {
+    @include ckan-resource-icon-bg-pos(4,
+    "resourceIcon");
+}
+
+.format-label[data-format=doc],
+.format-label[data-format*=doc],
+.format-label[data-format=docx],
+.format-label[data-format*=docx] {
+    @include ckan-resource-icon-bg-pos(5,
+    "resourceIcon");
+}
+
+.format-label[data-format=odt],
+.format-label[data-format*=odt] {
+    @include ckan-resource-icon-bg-pos(6,
+    "resourceIcon");
+}
+
+.format-label[data-format=csv],
+.format-label[data-format*=csv] {
+    @include ckan-resource-icon-bg-pos(7,
+    "resourceIcon");
+}
+
+.format-label[data-format=xls],
+.format-label[data-format*=xls] {
+    @include ckan-resource-icon-bg-pos(8,
+    "resourceIcon");
+}
+
+.format-label[data-format=zip],
+.format-label[data-format*=zip] {
+    @include ckan-resource-icon-bg-pos(9,
+    "resourceIcon");
+}
+
+.format-label[data-format=api],
+.format-label[data-format*=api] {
+    @include ckan-resource-icon-bg-pos(10,
+    "resourceIcon");
+}
+
+.format-label[data-format=pdf],
+.format-label[data-format*=pdf] {
+    @include ckan-resource-icon-bg-pos(11,
+    "resourceIcon");
+}
+
+.format-label[data-format=rdf],
+.format-label[data-format*=rdf] {
+    @include ckan-resource-icon-bg-pos(12,
+    "resourceIcon");
+}
+
+.format-label[data-format=wms],
+.format-label[data-format*=wms] {
+    @include ckan-resource-icon-bg-pos(13,
+    "resourceIcon");
+}
+
+.format-label[data-format=png],
+.format-label[data-format*=png] {
+    @include ckan-resource-icon-bg-pos(14,
+    "resourceIcon");
+}
+
+.format-label[data-format=jpg],
+.format-label[data-format*=jpg],
+.format-label[data-format=jpeg],
+.format-label[data-format*=jpeg] {
+    @include ckan-resource-icon-bg-pos(15,
+    "resourceIcon");
+}
+
+.format-label[data-format=gif],
+.format-label[data-format*=gif] {
+    @include ckan-resource-icon-bg-pos(16,
+    "resourceIcon");
+}
+
+.format-label[data-format=wfs],
+.format-label[data-format*=wfs] {
+    @include ckan-resource-icon-bg-pos(18,
+    "resourceIcon");
+}
+
+.format-label[data-format=gml],
+.format-label[data-format*=gml] {
+    @include ckan-resource-icon-bg-pos(19,
+    "resourceIcon");
+}
+
+.format-label[data-format=wmts],
+.format-label[data-format*=wmts] {
+    @include ckan-resource-icon-bg-pos(20,
+    "resourceIcon");
+}
+
+.format-label[data-format=kml],
+.format-label[data-format*=kml] {
+    @include ckan-resource-icon-bg-pos(21,
+    "resourceIcon");
+}
+
+.format-label[data-format=geo],
+.format-label[data-format*=geo] {
+    @include ckan-resource-icon-bg-pos(22,
+    "resourceIcon");
+}


### PR DESCRIPTION
When cleaning old icon classes in #7205 I accidentally cleaned the Resource Format classes. This PR brings back the CSS. 

### Proposed fixes:

Added a new `_resource-icons.scss` file with all the code needed to render the icons from our `sprite-resource-icons.png` file.

#### Before
![image](https://user-images.githubusercontent.com/6672339/202519313-d71407f2-e5cd-44ed-b81a-54e0d99b2cde.png)


#### After
![image](https://user-images.githubusercontent.com/6672339/202519212-fc795451-0461-4065-8bcf-5205faf117b4.png)
