### PR TITLE
package update performance fix with resource purge (backport)

### DIFF
--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -59,8 +59,12 @@ def package_resource_list_save(res_dicts, package, context):
     if res_dicts is None and allow_partial_update:
         return
 
+    session = context['session']
+    model = context['model']
     resource_list = package.resources_all
-    old_list = package.resources_all[:]
+    old_list = session.query(model.Resource) \
+        .filter(model.Resource.package_id == package.id) \
+        .filter(model.Resource.state != 'deleted')[:]
 
     obj_list = []
     for res_dict in res_dicts or []:

--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -65,6 +65,9 @@ def package_resource_list_save(res_dicts, package, context):
     old_list = session.query(model.Resource) \
         .filter(model.Resource.package_id == package.id) \
         .filter(model.Resource.state != 'deleted')[:]
+    deleted_list = session.query(model.Resource) \
+        .filter(model.Resource.package_id == package.id) \
+        .filter(model.Resource.state == 'deleted')[:]
 
     obj_list = []
     for res_dict in res_dicts or []:
@@ -84,6 +87,9 @@ def package_resource_list_save(res_dicts, package, context):
     # according to their ordering in the obj_list.
     resource_list[:] = obj_list
 
+    # Permanently remove old deleted resources
+    for resource in set(deleted_list) - set(obj_list):
+        resource.purge()
     # Mark any left-over resources as deleted
     for resource in set(old_list) - set(obj_list):
         resource.state = 'deleted'


### PR DESCRIPTION
Fixes #7119

### Proposed fixes:
same as #7122 

Original approach of #7121 triggers errors after updating a dataset 3 times because some resource rows no longer have a value for required FK package_id.

As discussed on last dev call @smotornyuk might have a less invasive approach than this one for backporting. If an alternate approach isn't chosen I think this is an important enough issue to consider the same change proposed for master in #7122
