### PR TITLE
Fix module bundling for 2.10 by updating MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include ckan/config/deployment.ini_tmpl
 recursive-include ckan/public *
 recursive-include ckan/config *.ini
 recursive-include ckan/config *.json
+recursive-include ckan/config *.yaml
 recursive-include ckan/config *.xml
 recursive-include ckan/i18n *
 recursive-include ckan/templates *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,27 +1,30 @@
 include ckan/config/deployment.ini_tmpl
+recursive-include ckan *.py
 recursive-include ckan/public *
+recursive-include ckan/public-bs3 *
 recursive-include ckan/config *.ini
 recursive-include ckan/config *.json
 recursive-include ckan/config *.yaml
 recursive-include ckan/config *.xml
 recursive-include ckan/i18n *
 recursive-include ckan/templates *
+recursive-include ckan/templates-bs3 *
 recursive-include ckan *.ini
 
+recursive-include ckanext *.py
 recursive-include ckanext/*/i18n *
 recursive-include ckanext/*/public *
+recursive-include ckanext/*/assets *
 recursive-include ckanext/*/templates *
 recursive-include ckanext/*/theme/public *
 recursive-include ckanext/*/theme/templates *
+recursive-include ckanext/* config_declaration.yaml
 include ckanext/datastore/set_permissions.sql
 include ckanext/datastore/allowed_functions.txt
 
 prune .git
 include CHANGELOG.txt
-include ckan/migration/migrate.cfg
 include ckan/migration/README
-recursive-include ckan/migration/versions *.sql
 include requirement-setuptools.txt
 include requirements.txt
-include requirements-py2.txt
 include dev-requirements.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ include_package_data = True
 zip_safe = False
 
 [options.packages.find]
+include = ckan, ckanext
 
 [options.extras_require]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,10 +33,8 @@ include_package_data = True
 zip_safe = False
 
 [options.packages.find]
-include = ckan, ckanext
 
 [options.extras_require]
-
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Fixes #7220

### Proposed fixes:
- Removing the setting solves the issue.
- I can't see any implications of removing the config option.
- I think it would be better to use the `exclude` option for anything that specifically requires excluding (default: all modules are auto-discovered).