### PR TITLE
[#7222] Use parsed config values in Flask config

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -163,7 +163,13 @@ def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:
     # Update Flask config with the CKAN values. We use the common config
     # object as values might have been modified on `load_environment`
     if config:
-        app.config.update(config)
+        if config.get_value("config.mode") == "strict":
+            # Config values have been already parsed and validated
+            app.config.update(config)
+        else:
+            # Parse all values to ensure Flask gets the validated values
+            for key in config.keys():
+                app.config[key] = config.get_value(key)
     else:
         app.config.update(conf)
 

--- a/ckan/tests/config/test_middleware.py
+++ b/ckan/tests/config/test_middleware.py
@@ -93,3 +93,18 @@ def test_all_plugin_blueprints_are_registered(app):
     assert url == "/another_simple_url"
     res = app.get(url, status=200)
     assert "Hello World, this is another view served from an extension" in res.body
+
+
+@pytest.mark.ckan_config("REMEMBER_COOKIE_DURATION", "12345")
+def test_flask_config_values_are_parsed(app):
+    assert (
+        app.flask_app.config["REMEMBER_COOKIE_DURATION"] == 12345
+    )
+
+
+@pytest.mark.ckan_config("config.mode", "strict")
+@pytest.mark.ckan_config("REMEMBER_COOKIE_DURATION", "12345")
+def test_flask_config_values_are_parsed_in_strict_mode(app):
+    assert (
+        app.flask_app.config["REMEMBER_COOKIE_DURATION"] == 12345
+    )


### PR DESCRIPTION
Fixes #7222 

Ensure that we apply the validators to config values before assigning them to the Flask config object.
In strict mode this has been done before in `load_environment` but in default mode we need to call `get_value()` on all keys to make sure they are parsed.
