### PR TITLE
Fix failing test after updating Werkzeug to 2.1.1

### DIFF
--- a/ckan/tests/controllers/test_home.py
+++ b/ckan/tests/controllers/test_home.py
@@ -135,7 +135,7 @@ class TestI18nURLs(object):
             assert response.status_code == 308
             assert (
                 response.headers['Location'] ==
-                f'/{new_locale}'
+                f'http://test.ckan.net/{new_locale}'
             )
 
             response = app.get(f'/{legacy_locale}/dataset?some=param', follow_redirects=False)
@@ -143,5 +143,5 @@ class TestI18nURLs(object):
             assert response.status_code == 308
             assert (
                 response.headers['Location'] ==
-                f'/{new_locale}/dataset?some=param'
+                f'http://test.ckan.net/{new_locale}/dataset?some=param'
             )

--- a/ckan/tests/controllers/test_home.py
+++ b/ckan/tests/controllers/test_home.py
@@ -135,7 +135,7 @@ class TestI18nURLs(object):
             assert response.status_code == 308
             assert (
                 response.headers['Location'] ==
-                f'http://test.ckan.net/{new_locale}'
+                f'/{new_locale}'
             )
 
             response = app.get(f'/{legacy_locale}/dataset?some=param', follow_redirects=False)
@@ -143,5 +143,5 @@ class TestI18nURLs(object):
             assert response.status_code == 308
             assert (
                 response.headers['Location'] ==
-                f'http://test.ckan.net/{new_locale}/dataset?some=param'
+                f'/{new_locale}/dataset?some=param'
             )

--- a/ckan/views/home.py
+++ b/ckan/views/home.py
@@ -96,13 +96,14 @@ def about() -> str:
 
 
 def redirect_locale(target_locale: str, path: Optional[str] = None) -> Any:
-
     target = f'/{target_locale}/{path}' if path else f'/{target_locale}'
 
     if request.args:
         target += f'?{urlencode(request.args)}'
 
-    return redirect(target, code=308)
+    url = h.url_for(target, _external=True)
+
+    return redirect(url, code=308)
 
 
 util_rules: List[Tuple[str, Any]] = [


### PR DESCRIPTION
When updating Werkzeug to 2.1.1 a test started failing.

This is because in this new version, Werkzeug does not autocorrect the `Location` header by default:

https://github.com/pallets/werkzeug/blob/3115aa6a6276939f5fd6efa46282e0256ff21f1a/src/werkzeug/wrappers/response.py#L145-L153
```python
    #: If a redirect ``Location`` header is a relative URL, make it an
    #: absolute URL, including scheme and domain.
    #:
    #: .. versionchanged:: 2.1
    #:     This is disabled by default, so responses will send relative
    #:     redirects.
    #:
    #: .. versionadded:: 0.8
    autocorrect_location_header = False
```

### Proposed fixed

Since we are redirecting to a relative path, the expected value of the Location header should be a relative path.

https://github.com/ckan/ckan/blob/0aa468c0421088bc9f3bb65e8333c3471de697c2/ckan/views/home.py#L98-L105