### PR TITLE
Refactor _internal_test_request_context into fixture

### DIFF
--- a/changes/7246.removal
+++ b/changes/7246.removal
@@ -1,3 +1,3 @@
 `_internal_test_request_context` variable (and its logic) has been removed. Tests depending
-on a request context (calling `url_for`, etc) should explicitly une `with_request_context` or `app`
+on a request context (calling `url_for`, etc) should explicitly use `with_request_context` or `app`
 fixtures.

--- a/changes/7246.removal
+++ b/changes/7246.removal
@@ -1,0 +1,3 @@
+`_internal_test_request_context` variable (and its logic) has been removed. Tests depending
+on a request context (calling `url_for`, etc) should explicitly une `with_request_context` or `app`
+fixtures.

--- a/ckan/config/middleware/__init__.py
+++ b/ckan/config/middleware/__init__.py
@@ -3,9 +3,8 @@
 """WSGI app initialization"""
 
 import logging
-from typing import Optional, Union
 
-from flask.ctx import RequestContext
+from typing import Union
 
 from ckan.config.environment import load_environment
 from ckan.config.middleware.flask_app import make_flask_stack
@@ -13,10 +12,6 @@ from ckan.common import CKANConfig
 from ckan.types import CKANApp, Config
 
 log = logging.getLogger(__name__)
-
-# This is a test Flask request context to be used internally.
-# Do not use it!
-_internal_test_request_context: Optional[RequestContext] = None
 
 
 def make_app(conf: Union[Config, CKANConfig]) -> CKANApp:
@@ -27,10 +22,5 @@ def make_app(conf: Union[Config, CKANConfig]) -> CKANApp:
     load_environment(conf)
 
     flask_app = make_flask_stack(conf)
-
-    # Set this internal test request context with the configured environment so
-    # it can be used when calling url_for from tests
-    global _internal_test_request_context
-    _internal_test_request_context = flask_app._wsgi_app.test_request_context()
 
     return flask_app

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -32,7 +32,6 @@ from ckan.common import asbool, config, current_user
 from flask import flash
 from flask import get_flashed_messages as _flask_get_flashed_messages
 from flask import redirect as _flask_redirect
-from flask import _request_ctx_stack
 from flask import url_for as _flask_default_url_for
 from werkzeug.routing import BuildError as FlaskRouteBuildError
 from ckan.lib import i18n

--- a/ckan/tests/lib/dictization/test_model_dictize.py
+++ b/ckan/tests/lib/dictization/test_model_dictize.py
@@ -479,7 +479,8 @@ class TestPackageDictize:
         }
         self.assert_equals_expected(expected_dict, result["resources"][0])
 
-    def test_package_dictize_resource_upload_and_striped(self):
+    def test_package_dictize_resource_upload_and_striped(self, with_request_context):
+        # model_dictize depends on url_for so we need to add with_request_context fixture
         dataset = factories.Dataset()
         resource = factories.Resource(
             package=dataset["id"],
@@ -495,7 +496,8 @@ class TestPackageDictize:
         expected_dict = {u"url": u"some_filename.csv", u"url_type": u"upload"}
         assert expected_dict["url"] == result.url
 
-    def test_package_dictize_resource_upload_with_url_and_striped(self):
+    def test_package_dictize_resource_upload_with_url_and_striped(self, with_request_context):
+        # model_dictize depends on url_for so we need to add with_request_context fixture
         dataset = factories.Dataset()
         resource = factories.Resource(
             package=dataset["id"],

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -22,12 +22,9 @@ CkanUrlException = ckan.exceptions.CkanUrlException
 
 class BaseUrlFor(object):
     @pytest.fixture(autouse=True)
-    def request_context(self, monkeypatch, ckan_config, app):
+    def app(self, monkeypatch, ckan_config, app):
         monkeypatch.setitem(ckan_config, "ckan.site_url", "http://example.com")
-        self.request_context = app.flask_app.test_request_context()
-        self.request_context.push()
-        yield
-        self.request_context.pop()
+        yield app
 
 
 class TestHelpersUrlForStatic(BaseUrlFor):
@@ -74,21 +71,20 @@ class TestHelpersUrlForStatic(BaseUrlFor):
         generated_url = h.url_for_static("/my-asset/file.txt", qualified=True)
         assert generated_url == url
 
-
-@pytest.mark.parametrize(
-    "url",
-    [
-        "/assets/ckan.jpg",
-        "http://assets.ckan.org/ckan.jpg",
-        u"/ckan.jpg",
-        "/ckan.jpg",
-        "//assets.ckan.org/ckan.jpg",
-    ],
-)
-def test_url_for_static_or_external(url):
-    generated = h.url_for_static_or_external(url)
-    assert generated == url
-    assert isinstance(generated, str)
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "/assets/ckan.jpg",
+            "http://assets.ckan.org/ckan.jpg",
+            "/ckan.jpg",
+            "/ckan.jpg",
+            "//assets.ckan.org/ckan.jpg",
+        ],
+    )
+    def test_url_for_static_or_external(self, url):
+        generated = h.url_for_static_or_external(url)
+        assert generated == url
+        assert isinstance(generated, str)
 
 
 class TestHelpersUrlFor(BaseUrlFor):
@@ -257,7 +253,7 @@ class TestHelpersUrlForFlaskandPylons(BaseUrlFor):
             assert generated_url == url
 
 
-class TestHelpersRenderMarkdown(object):
+class TestHelpersRenderMarkdown(BaseUrlFor):
     @pytest.mark.parametrize(
         "data,output,allow_html",
         [

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -1448,10 +1448,11 @@ class TestUserUpdate(object):
         user_obj = model.User.get(user["id"])
         assert user_obj.password != "pretend-this-is-a-valid-hash"
 
-    def test_user_update_image_url(self):
+    def test_user_update_image_url(self, with_request_context):
         user = factories.User(image_url="user_image.jpg")
         context = {"user": user["name"]}
 
+        # model_dictize depends on url_for so we need to add with_request_context fixture
         user = helpers.call_action(
             "user_update",
             context=context,
@@ -1465,7 +1466,7 @@ class TestUserUpdate(object):
 
 @pytest.mark.usefixtures("non_clean_db")
 class TestGroupUpdate(object):
-    def test_group_update_image_url_field(self):
+    def test_group_update_image_url_field(self, with_request_context):
         user = factories.User()
         context = {"user": user["name"]}
         group = factories.Group(
@@ -1474,6 +1475,7 @@ class TestGroupUpdate(object):
             image_url="group_image.jpg",
         )
 
+        # model_dictize depends on url_for so we need to add with_request_context fixture
         group = helpers.call_action(
             "group_update",
             context=context,


### PR DESCRIPTION
### Proposed fixes:

This PR refactors the global `_internal_test_request_context` variable into a fixture that pushes a request context whenever we are using the `app` fixture

### Notes:

This solution is based in https://github.com/pytest-dev/pytest-flask fixtures. Note that using `url_for` in tests is not considered a good practice, however we have adopted it widely.

Also, some internal methods in `model_dictize.py` depends on calling `h.url_for(...)` making them dependent on a Request Context even when they are a low level function.