### PR TITLE
Clean _internal_test_request_context

### DIFF
--- a/changes/7250.removal
+++ b/changes/7250.removal
@@ -1,0 +1,6 @@
+Removes internal push of test request context when calling `url_for`.
+
+CKAN will no longer silently push a test request_context when calling for `url_for`, from now on
+it will need to be explicitly created if it is needed. If a URL is needed in test just write
+exactly the URL you're trying to test in the request instead of generating it. (Or call for
+url_for inside a test_request_context)

--- a/changes/7251.removal
+++ b/changes/7251.removal
@@ -1,4 +1,4 @@
-Removes internal push of test request context when calling `url_for`.
+Removes _internal_test_request_context.
 
 CKAN will no longer silently push a test request_context when calling for `url_for`, from now on
 it will need to be explicitly created if it is needed. If a URL is needed in test just write

--- a/ckan/config/middleware/__init__.py
+++ b/ckan/config/middleware/__init__.py
@@ -3,9 +3,7 @@
 """WSGI app initialization"""
 
 import logging
-from typing import Optional, Union
-
-from flask.ctx import RequestContext
+from typing import Union
 
 from ckan.config.environment import load_environment
 from ckan.config.middleware.flask_app import make_flask_stack
@@ -13,10 +11,6 @@ from ckan.common import CKANConfig
 from ckan.types import CKANApp, Config
 
 log = logging.getLogger(__name__)
-
-# This is a test Flask request context to be used internally.
-# Do not use it!
-_internal_test_request_context: Optional[RequestContext] = None
 
 
 def make_app(conf: Union[Config, CKANConfig]) -> CKANApp:
@@ -27,10 +21,5 @@ def make_app(conf: Union[Config, CKANConfig]) -> CKANApp:
     load_environment(conf)
 
     flask_app = make_flask_stack(conf)
-
-    # Set this internal test request context with the configured environment so
-    # it can be used when calling url_for from tests
-    global _internal_test_request_context
-    _internal_test_request_context = flask_app._wsgi_app.test_request_context()
 
     return flask_app

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -32,7 +32,6 @@ from ckan.common import asbool, config, current_user
 from flask import flash
 from flask import get_flashed_messages as _flask_get_flashed_messages
 from flask import redirect as _flask_redirect
-from flask import _request_ctx_stack
 from flask import url_for as _flask_default_url_for
 from werkzeug.routing import BuildError as FlaskRouteBuildError
 from ckan.lib import i18n
@@ -299,28 +298,6 @@ def get_site_protocol_and_host() -> Union[tuple[str, str], tuple[None, None]]:
     return (None, None)
 
 
-def _get_auto_flask_context():
-    '''
-    Provides a Flask test request context if we are outside the context
-    of a web request (tests or CLI)
-    '''
-
-    from ckan.config.middleware import _internal_test_request_context
-
-    # This is a normal web request, there is a request context present
-    if _request_ctx_stack.top:
-        return None
-
-    # We are outside a web request. A test web application was created
-    # (and with it a test request context with the relevant configuration)
-    if _internal_test_request_context:
-        return _internal_test_request_context
-
-    from ckan.tests.pytest_ckan.ckan_setup import _tests_test_request_context
-    if _tests_test_request_context:
-        return _tests_test_request_context
-
-
 @core_helper
 def url_for(*args: Any, **kw: Any) -> str:
     '''Return the URL for an endpoint given some parameters.
@@ -373,22 +350,10 @@ def url_for(*args: Any, **kw: Any) -> str:
         if not ver:
             raise Exception('API URLs must specify the version (eg ver=3)')
 
-    _auto_flask_context = _get_auto_flask_context()
-    try:
-        if _auto_flask_context:
-            _auto_flask_context.push()
-
-        # First try to build the URL with the Flask router
-        # Temporary mapping for pylons to flask route names
-        if len(args):
-            args = (map_pylons_to_flask_route_name(args[0]),)
-        my_url = _url_for_flask(*args, **kw)
-
-    except FlaskRouteBuildError:
-        raise
-    finally:
-        if _auto_flask_context:
-            _auto_flask_context.pop()
+    # Temporary mapping for pylons to flask route names
+    if len(args):
+        args = (map_pylons_to_flask_route_name(args[0]),)
+    my_url = _url_for_flask(*args, **kw)
 
     # Add back internal params
     kw['__ckan_no_root'] = no_root
@@ -565,11 +530,6 @@ def _local_url(url_to_amend: str, **kw: Any):
     if locale and locale not in allowed_locales:
         locale = None
 
-    _auto_flask_context = _get_auto_flask_context()
-
-    if _auto_flask_context:
-        _auto_flask_context.push()
-
     if locale:
         if locale == 'default':
             default_locale = True
@@ -593,9 +553,6 @@ def _local_url(url_to_amend: str, **kw: Any):
         root = urlunparse(
             (protocol, host, path,
                 parts.params, parts.query, parts.fragment))
-
-    if _auto_flask_context:
-        _auto_flask_context.pop()
 
     # ckan.root_path is defined when we have none standard language
     # position in the url

--- a/ckan/tests/config/test_middleware.py
+++ b/ckan/tests/config/test_middleware.py
@@ -78,7 +78,7 @@ def test_no_beaker_secret_crashes(make_app):
 
 @pytest.mark.ckan_config(u"ckan.plugins", u"test_blueprint_plugin")
 @pytest.mark.usefixtures(u"with_plugins")
-def test_all_plugin_blueprints_are_registered(app):
+def test_all_plugin_blueprints_are_registered(app, with_request_context):
     url = url_for("bp1.plugin_view_endpoint")
     assert url == "/simple_url"
     res = app.get(url, status=200)

--- a/ckan/tests/config/test_sessions.py
+++ b/ckan/tests/config/test_sessions.py
@@ -44,16 +44,12 @@ class FlashMessagePlugin(p.SingletonPlugin):
     def add_flash_success_message(self):
         """Add flash message, then redirect to render it."""
         h.flash_success(u"This is a success message")
-        return h.redirect_to(
-            h.url_for("test_flash_plugin.flash_message_view")
-        )
+        return h.redirect_to("/flask_view_flash_message")
 
     def add_flash_success_message_with_html(self):
         """Add flash message, then redirect to render it."""
         h.flash_success(u"<h1> This is a success message with HTML</h1>", allow_html=True)
-        return h.redirect_to(
-            h.url_for("test_flash_plugin.flash_message_view")
-        )
+        return h.redirect_to("/flask_view_flash_message")
 
     def get_blueprint(self):
         """Return Flask Blueprint object."""

--- a/ckan/tests/controllers/test_admin.py
+++ b/ckan/tests/controllers/test_admin.py
@@ -8,7 +8,6 @@ import ckan.model as model
 import ckan.tests.factories as factories
 import ckan.tests.helpers as helpers
 from ckan.common import config
-from ckan.lib.helpers import url_for
 from ckan.model.system_info import get_system_info
 
 
@@ -35,13 +34,13 @@ def mock_current_user(current_user):
 
 def _reset_config(app, sysadmin_env):
     """Reset config via action"""
-    app.post(url=url_for("admin.reset_config"), extra_environ=sysadmin_env)
+    app.post("/ckan-admin/reset_config", extra_environ=sysadmin_env)
 
 
-@pytest.mark.usefixtures("clean_db", "with_request_context")
+@pytest.mark.usefixtures("clean_db")
 def test_index(app, user_env, sysadmin_env):
 
-    url = url_for("admin.index")
+    url = "/ckan-admin"
     # Anonymous User
     response = app.get(url, status=403)
 
@@ -63,7 +62,7 @@ class TestConfig(object):
         index_response = app.get("/")
         assert "Welcome - CKAN" in index_response
 
-        url = url_for(u"admin.config")
+        url = "/ckan-admin/config"
 
         # change site title
         form = {"ckan.site_title": "Test Site Title", "save": ""}
@@ -85,7 +84,7 @@ class TestConfig(object):
         index_response = app.get("/")
         assert "main.css" in index_response or "main.min.css" in index_response
 
-        url = url_for(u"admin.config")
+        url = "/ckan-admin/config"
 
         # set new style css
         form = {"ckan.theme": "css/main-rtl", "save": ""}
@@ -103,7 +102,7 @@ class TestConfig(object):
         index_response = app.get("/")
         assert "Special Tagline" not in index_response
 
-        url = url_for(u"admin.config")
+        url = "/ckan-admin/config"
 
         # set new tagline css
         form = {"ckan.site_description": "Special Tagline", "save": ""}
@@ -113,7 +112,7 @@ class TestConfig(object):
         new_index_response = app.get("/")
         assert "Special Tagline" not in new_index_response
 
-        url = url_for(u"admin.config")
+        url = "/ckan-admin/config"
         # remove logo
         form = {"ckan.site_logo": "", "save": ""}
         app.post(url, data=form)
@@ -135,7 +134,7 @@ class TestConfig(object):
         assert "My special about text" not in about_response
 
         # set new about
-        url = url_for(u"admin.config")
+        url = "/ckan-admin/config"
         form = {"ckan.site_about": "My special about text", "save": ""}
         app.post(url, extra_environ=sysadmin_env, data=form)
 
@@ -156,7 +155,7 @@ class TestConfig(object):
         assert "My special intro text" not in intro_response
 
         # set new intro
-        url = url_for(u"admin.config")
+        url = "/ckan-admin/config"
         form = {"ckan.site_intro_text": "My special intro text", "save": ""}
         app.post(url, extra_environ=sysadmin_env, data=form)
 
@@ -177,7 +176,7 @@ class TestConfig(object):
         assert len(style_tag) == 0
 
         # set new tagline css
-        url = url_for(u"admin.config")
+        url = "/ckan-admin/config"
         form = {
             "ckan.site_custom_css": "body {background-color:red}",
             "save": "",
@@ -204,7 +203,7 @@ class TestConfig(object):
         assert "<!-- Snippet home/layout1.html start -->" in index_response
 
         # set new style css
-        url = url_for(u"admin.config")
+        url = "/ckan-admin/config"
         form = {"ckan.homepage_style": "2", "save": ""}
         app.post(url, extra_environ=sysadmin_env, data=form)
 
@@ -230,19 +229,19 @@ class TestTrashView(object):
 
     def test_trash_view_anon_user(self, app):
         """An anon user shouldn't be able to access trash view."""
-        trash_url = url_for("admin.trash")
+        trash_url = "/ckan-admin/trash"
         trash_response = app.get(trash_url)
         assert trash_response.status_code == 403
 
     def test_trash_view_normal_user(self, app, user_env):
         """A normal logged in user shouldn't be able to access trash view."""
-        trash_url = url_for("admin.trash")
+        trash_url = "/ckan-admin/trash"
         trash_response = app.get(trash_url, extra_environ=user_env, status=403)
         assert trash_response.status_code == 403
 
     def test_trash_view_sysadmin(self, app, sysadmin_env):
         """A sysadmin should be able to access trash view."""
-        trash_url = url_for("admin.trash")
+        trash_url = "/ckan-admin/trash"
         trash_response = app.get(trash_url, extra_environ=sysadmin_env, status=200)
         # On the purge page
         assert "purge-all" in trash_response
@@ -252,7 +251,7 @@ class TestTrashView(object):
         datasets."""
         factories.Dataset()
 
-        trash_url = url_for("admin.trash")
+        trash_url = "/ckan-admin/trash"
         trash_response = app.get(trash_url, extra_environ=sysadmin_env, status=200)
 
         response_html = BeautifulSoup(trash_response.body)
@@ -265,7 +264,7 @@ class TestTrashView(object):
         groups."""
         factories.Group()
 
-        trash_url = url_for("admin.trash")
+        trash_url = "/ckan-admin/trash"
         trash_response = app.get(trash_url, extra_environ=sysadmin_env, status=200)
 
         response_html = BeautifulSoup(trash_response.body)
@@ -278,7 +277,7 @@ class TestTrashView(object):
         organizations."""
         factories.Organization()
 
-        trash_url = url_for("admin.trash")
+        trash_url = "/ckan-admin/trash"
         trash_response = app.get(trash_url, extra_environ=sysadmin_env, status=200)
 
         response_html = BeautifulSoup(trash_response.body)
@@ -294,7 +293,7 @@ class TestTrashView(object):
         factories.Dataset(state="deleted")
         factories.Dataset()
 
-        trash_url = url_for("admin.trash")
+        trash_url = "/ckan-admin/trash"
         response = app.get(trash_url, extra_environ=sysadmin_env, status=200)
 
         response_html = BeautifulSoup(response.body)
@@ -311,7 +310,7 @@ class TestTrashView(object):
         factories.Dataset(state="deleted")
         factories.Dataset()
 
-        trash_url = url_for("admin.trash")
+        trash_url = "/ckan-admin/trash"
 
         response = app.get(trash_url, extra_environ=sysadmin_env, status=200)
 
@@ -327,7 +326,7 @@ class TestTrashView(object):
         factories.Group(state="deleted")
         factories.Group()
 
-        trash_url = url_for("admin.trash")
+        trash_url = "/ckan-admin/trash"
         response = app.get(trash_url, extra_environ=sysadmin_env, status=200)
 
         response_html = BeautifulSoup(response.body)
@@ -342,7 +341,7 @@ class TestTrashView(object):
         factories.Organization(state="deleted")
         factories.Organization()
 
-        trash_url = url_for("admin.trash")
+        trash_url = "/ckan-admin/trash"
         response = app.get(trash_url, extra_environ=sysadmin_env, status=200)
 
         response_html = BeautifulSoup(response.body)
@@ -358,7 +357,7 @@ class TestTrashView(object):
         factories.Organization(state="deleted")
         factories.Organization()
 
-        trash_url = url_for("admin.trash")
+        trash_url = "/ckan-admin/trash"
         response = app.get(trash_url, extra_environ=sysadmin_env, status=200)
 
         response_html = BeautifulSoup(response.body)
@@ -382,7 +381,7 @@ class TestTrashView(object):
         pkgs_before_purge = model.Session.query(model.Package).count()
         assert pkgs_before_purge == 1
 
-        trash_url = url_for("admin.trash")
+        trash_url = "/ckan-admin/trash"
         response = app.post(trash_url, data={"action": "package"}, status=200)
         # check for flash success msg
         assert "datasets have been purged" in response.body
@@ -404,7 +403,7 @@ class TestTrashView(object):
         pkgs_before_purge = model.Session.query(model.Package).count()
         assert pkgs_before_purge == 3
 
-        trash_url = url_for("admin.trash")
+        trash_url = "/ckan-admin/trash"
         response = app.post(trash_url, data={"action": "package"}, status=200)
         # check for flash success msg
         assert "datasets have been purged" in response.body
@@ -427,7 +426,7 @@ class TestTrashView(object):
         pkgs_before_purge = model.Session.query(model.Package).count()
         assert pkgs_before_purge == 3
 
-        trash_url = url_for("admin.trash")
+        trash_url = "/ckan-admin/trash"
         response = app.post(trash_url, data={"action": "package"}, status=200)
         # check for flash success msg
         assert "datasets have been purged" in response.body
@@ -448,7 +447,7 @@ class TestTrashView(object):
         grps_before_purge = model.Session.query(model.Group).count()
         assert grps_before_purge == 3
 
-        trash_url = url_for("admin.trash")
+        trash_url = "/ckan-admin/trash"
         response = app.post(trash_url, data={"action": "group"}, status=200)
         # check for flash success msg
         assert "groups have been purged" in response
@@ -470,7 +469,7 @@ class TestTrashView(object):
             is_organization=True).count()
         assert orgs_before_purge == 3
 
-        trash_url = url_for("admin.trash")
+        trash_url = "/ckan-admin/trash"
         response = app.post(trash_url, data={"action": "organization"}, status=200)
         # check for flash success msg
         assert "organizations have been purged" in response
@@ -496,7 +495,7 @@ class TestTrashView(object):
         orgs_and_grps_before_purge = model.Session.query(model.Group).count()
         assert pkgs_before_purge + orgs_and_grps_before_purge == 5
 
-        trash_url = url_for("admin.trash")
+        trash_url = "/ckan-admin/trash"
         response = app.post(trash_url, data={"action": "all"}, status=200)
         # check for flash success msg
         assert "Massive purge complete" in response
@@ -523,7 +522,7 @@ class TestTrashView(object):
         pkgs_before_purge = model.Session.query(model.Package).count()
         orgs_and_grps_before_purge = model.Session.query(model.Group).count()
         assert pkgs_before_purge + orgs_and_grps_before_purge == 5
-        trash_url = url_for("admin.trash")
+        trash_url = "/ckan-admin/trash"
         response = app.post(trash_url, data={"action": "all"}, status=200)
         # check for flash success msg
         assert "Massive purge complete" in response
@@ -545,7 +544,7 @@ class TestTrashView(object):
             is_organization=True).count()
         assert orgs_before_purge == 2
 
-        trash_url = url_for("admin.trash", name="purge-organization")
+        trash_url = "/ckan-admin/trash?name=purge-organization"
         response = app.post(trash_url, data={"cancel": ""}, status=200)
         # flash success msg should be absent
         assert "Organizations have been purged" not in response
@@ -558,7 +557,7 @@ class TestTrashView(object):
     def test_trash_no_button_with_no_deleted_datasets(self, app, sysadmin_env):
         """Getting the trash view with no 'deleted' datasets should not
         contain the purge button."""
-        trash_url = url_for("admin.trash")
+        trash_url = "/ckan-admin/trash"
         trash_response = app.get(trash_url, extra_environ=sysadmin_env, status=200)
         assert "form-purge-package" not in trash_response
 
@@ -567,7 +566,7 @@ class TestTrashView(object):
         contain the purge button."""
         factories.Dataset(state="deleted")
 
-        trash_url = url_for("admin.trash")
+        trash_url = "/ckan-admin/trash"
         trash_response = app.get(trash_url, extra_environ=sysadmin_env, status=200)
         assert "form-purge-package" in trash_response
 
@@ -575,7 +574,7 @@ class TestTrashView(object):
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 class TestAdminConfigUpdate(object):
     def _update_config_option(self, app, sysadmin_env):
-        url = url_for(u"admin.config")
+        url = "/ckan-admin/config"
         form = {"ckan.site_title": "My Updated Site Title", "save": ""}
         return app.post(url, extra_environ=sysadmin_env, data=form)
 

--- a/ckan/tests/controllers/test_home.py
+++ b/ckan/tests/controllers/test_home.py
@@ -9,7 +9,7 @@ from ckan.tests import factories
 
 class TestHome(object):
     def test_home_renders(self, app):
-        response = app.get(url_for("home.index"))
+        response = app.get("/")
         assert "Welcome to CKAN" in response.body
 
     def test_template_head_end(self, app):
@@ -18,13 +18,13 @@ class TestHome(object):
             '<link rel="stylesheet" '
             'href="TEST_TEMPLATE_HEAD_END.css" type="text/css">'
         )
-        response = app.get(url_for("home.index"))
+        response = app.get("/")
         assert test_link in response.body
 
     def test_template_footer_end(self, app):
         # test-core.ini sets ckan.template_footer_end to this:
         test_html = "<strong>TEST TEMPLATE_FOOTER_END TEST</strong>"
-        response = app.get(url_for("home.index"))
+        response = app.get("/")
         assert test_html in response.body
 
     @pytest.mark.usefixtures("non_clean_db")
@@ -40,10 +40,10 @@ class TestHome(object):
         user_token = factories.APIToken(user=user.id)
         env = {"Authorization": user_token["token"]}
 
-        response = app.get(url=url_for("home.index"), extra_environ=env)
+        response = app.get(url="/", extra_environ=env)
 
         assert "update your profile" in response.body
-        assert str(url_for("user.edit")) in response.body
+        assert "/user/edit/" in response.body
         assert " and add your email address." in response.body
 
     @pytest.mark.usefixtures("non_clean_db")
@@ -52,14 +52,14 @@ class TestHome(object):
         user_token = factories.APIToken(user=user["name"])
 
         env = {"Authorization": user_token["token"]}
-        response = app.get(url=url_for("home.index"), extra_environ=env)
+        response = app.get(url="/", extra_environ=env)
 
         assert "add your email address" not in response
 
     @pytest.mark.ckan_config(
         "ckan.legacy_route_mappings", '{"my_home_route": "home.index"}'
     )
-    def test_map_pylons_to_flask_route(self, app):
+    def test_map_pylons_to_flask_route(self, app, with_request_context):
         response = app.get(url_for("my_home_route"))
         assert "Welcome to CKAN" in response.body
 
@@ -69,7 +69,7 @@ class TestHome(object):
     @pytest.mark.ckan_config(
         "ckan.legacy_route_mappings", {"my_home_route": "home.index"}
     )
-    def test_map_pylons_to_flask_route_using_dict(self, app):
+    def test_map_pylons_to_flask_route_using_dict(self, app, with_request_context):
         response = app.get(url_for("my_home_route"))
         assert "Welcome to CKAN" in response.body
 
@@ -81,7 +81,7 @@ class TestHome(object):
 class TestI18nURLs(object):
     def test_right_urls_are_rendered_on_language_selector(self, app):
 
-        response = app.get(url_for("home.index"))
+        response = app.get("/")
         html = BeautifulSoup(response.body)
 
         select = html.find(id="field-lang-select")
@@ -98,7 +98,7 @@ class TestI18nURLs(object):
     def test_default_english_option_is_selected_on_language_selector(
         self, app
     ):
-        response = app.get(url_for("home.index"))
+        response = app.get("/")
         html = BeautifulSoup(response.body)
 
         select = html.find(id="field-lang-select")

--- a/ckan/tests/controllers/test_resource.py
+++ b/ckan/tests/controllers/test_resource.py
@@ -3,7 +3,7 @@
 import csv
 import datetime
 import pytest
-import ckan.lib.helpers as h
+
 import ckan.plugins as plugins
 import ckan.tests.factories as factories
 from ckan.tests.helpers import call_action
@@ -18,9 +18,7 @@ class TestPluggablePreviews:
         plugin = plugins.get_plugin("test_resource_view")
         plugin.calls.clear()
 
-        url = h.url_for(
-            "resource.read", id=res["package_id"], resource_id=res["id"]
-        )
+        url = f"/dataset/{res['package_id']}/resource/{res['id']}"
         result = app.get(url)
         assert "There are no views created" in result
 
@@ -45,11 +43,7 @@ class TestPluggablePreviews:
         assert len(views) == 1
         assert views[0]["view_type"] == "test_resource_view"
 
-        view_url = h.url_for(
-            "resource.view",
-            id=res["package_id"], resource_id=res["id"], view_id=views[0]["id"]
-        )
-
+        view_url = f"/dataset/{res['package_id']}/resource/{res['id']}/view/{views[0]['id']}"
         result = app.get(view_url)
 
         assert plugin.calls["setup_template_variables"] == 1
@@ -189,7 +183,7 @@ class TestTracking(object):
         package = factories.Dataset()
         resource = factories.Resource(package_id=package["id"])
 
-        url = h.url_for("dataset.read", id=package["name"])
+        url = f"/dataset/{package['name']}"
         track(url)
 
         update_tracking_summary()
@@ -227,9 +221,7 @@ class TestTracking(object):
     def test_resource_with_one_preview(self, track):
         package = factories.Dataset()
         resource = factories.Resource(package_id=package["id"])
-        url = h.url_for(
-            "resource.read", id=package["name"], resource_id=resource["id"]
-        )
+        url = f"/dataset/{package['name']}/resource/{resource['id']}"
         track(url)
 
         update_tracking_summary()
@@ -347,7 +339,7 @@ class TestTracking(object):
     def test_package_with_many_views(self, track):
         package = factories.Dataset()
         resource = factories.Resource(package_id=package["id"])
-        url = h.url_for("dataset.read", id=package["name"])
+        url = f"/dataset/{package['name']}"
 
         # View the package three times from different IPs.
         track(url, ip="111.222.333.44")
@@ -461,7 +453,7 @@ class TestTracking(object):
         """
         package = factories.Dataset()
         factories.Resource(package_id=package["id"])
-        url = h.url_for("dataset.read", id=package["name"])
+        url = f"/dataset/{package['name']}"
 
         # Visit the dataset three times from the same IP.
         track(url)
@@ -516,14 +508,14 @@ class TestTracking(object):
         d2 = factories.Dataset()
         d3 = factories.Dataset()
 
-        url = h.url_for("dataset.read", id=d1["name"])
+        url = f"/dataset/{d1['name']}"
         track(url)
 
-        url = h.url_for("dataset.read", id=d2["name"])
+        url = f"/dataset/{d2['name']}"
         track(url, ip="111.11.111.111")
         track(url, ip="222.22.222.222")
 
-        url = h.url_for("dataset.read", id=d3["name"])
+        url = f"/dataset/{d3['name']}"
         track(url, ip="111.11.111.111")
         track(url, ip="222.22.222.222")
         track(url, ip="333.33.333.333")
@@ -546,14 +538,14 @@ class TestTracking(object):
         factories.Dataset(name="the_player_of_games")
         factories.Dataset(name="use_of_weapons")
 
-        url = h.url_for("dataset.read", id="consider_phlebas")
+        url = "/dataset/consider_phlebas"
         track(url)
 
-        url = h.url_for("dataset.read", id="the_player_of_games")
+        url = "/dataset/the_player_of_games"
         track(url, ip="111.11.111.111")
         track(url, ip="222.22.222.222")
 
-        url = h.url_for("dataset.read", id="use_of_weapons")
+        url = "/dataset/use_of_weapons"
         track(url, ip="111.11.111.111")
         track(url, ip="222.22.222.222")
         track(url, ip="333.33.333.333")
@@ -583,13 +575,13 @@ class TestTracking(object):
         package_2 = factories.Dataset(user=admin, name="another_package")
 
         # View the package_1 three times from different IPs.
-        url = h.url_for("dataset.read", id=package_1["name"])
+        url = f"/dataset/{package_1['name']}"
         track(url, ip="111.222.333.44")
         track(url, ip="111.222.333.55")
         track(url, ip="111.222.333.66")
 
         # View the package_2 twice from different IPs.
-        url = h.url_for("dataset.read", id=package_2["name"])
+        url = f"/dataset/{package_2['name']}"
         track(url, ip="111.222.333.44")
         track(url, ip="111.222.333.55")
 

--- a/ckan/tests/controllers/test_util.py
+++ b/ckan/tests/controllers/test_util.py
@@ -2,13 +2,11 @@
 
 import pytest
 
-from ckan.lib.helpers import url_for as url_for
-
 
 class TestUtil(object):
     def test_redirect_ok(self, app):
         response = app.get(
-            url=url_for("util.internal_redirect"),
+            url="/util/redirect",
             query_string={"url": "/dataset"},
             status=302,
             follow_redirects=False,
@@ -19,7 +17,7 @@ class TestUtil(object):
 
     def test_redirect_external(self, app):
         app.get(
-            url=url_for("util.internal_redirect"),
+            url="/util/redirect",
             query_string={"url": "http://nastysite.com"},
             status=403,
         )
@@ -27,7 +25,7 @@ class TestUtil(object):
     @pytest.mark.parametrize("params", [{}, {"url": ""}])
     def test_redirect_no_params(self, params, app):
         app.get(
-            url=url_for("util.internal_redirect"),
+            url="/util/redirect",
             query_string=params,
             status=400,
         )

--- a/ckan/tests/lib/dictization/test_model_dictize.py
+++ b/ckan/tests/lib/dictization/test_model_dictize.py
@@ -479,14 +479,16 @@ class TestPackageDictize:
         }
         self.assert_equals_expected(expected_dict, result["resources"][0])
 
-    def test_package_dictize_resource_upload_and_striped(self):
+    def test_package_dictize_resource_upload_and_striped(self, app):
         dataset = factories.Dataset()
-        resource = factories.Resource(
-            package=dataset["id"],
-            name="test_pkg_dictize",
-            url_type="upload",
-            url="some_filename.csv",
-        )
+        with app.flask_app.test_request_context():
+            # when calling with url, factory depends on a request context due to url_for call
+            resource = factories.Resource(
+                package=dataset["id"],
+                name="test_pkg_dictize",
+                url_type="upload",
+                url="some_filename.csv",
+            )
 
         context = {"model": model, "session": model.Session}
 
@@ -495,14 +497,16 @@ class TestPackageDictize:
         expected_dict = {u"url": u"some_filename.csv", u"url_type": u"upload"}
         assert expected_dict["url"] == result.url
 
-    def test_package_dictize_resource_upload_with_url_and_striped(self):
+    def test_package_dictize_resource_upload_with_url_and_striped(self, app):
         dataset = factories.Dataset()
-        resource = factories.Resource(
-            package=dataset["id"],
-            name="test_pkg_dictize",
-            url_type="upload",
-            url="http://some_filename.csv",
-        )
+        with app.flask_app.test_request_context():
+            # when calling with url, factory depends on a request context due to url_for call
+            resource = factories.Resource(
+                package=dataset["id"],
+                name="test_pkg_dictize",
+                url_type="upload",
+                url="http://some_filename.csv",
+            )
 
         context = {"model": model, "session": model.Session}
 

--- a/ckan/tests/lib/test_base.py
+++ b/ckan/tests/lib/test_base.py
@@ -4,7 +4,6 @@ import six
 import pytest
 
 import ckan.tests.factories as factories
-import ckan.lib.helpers as h
 
 
 @pytest.mark.ckan_config("debug", True)
@@ -22,11 +21,7 @@ def test_comment_absent_if_debug_false(app):
 def test_apitoken_missing(app):
     request_headers = {}
     data_dict = {"type": "dataset", "name": "a-name"}
-    url = h.url_for(
-            "api.action",
-            logic_function="package_create",
-            ver=3,
-        )
+    url = "/api/3/action/package_create"
     app.post(url, json=data_dict, headers=request_headers, status=403)
 
 
@@ -56,11 +51,7 @@ def test_apitoken_contains_unicode(app):
     # nicely if unicode is supplied
     request_headers = {"Authorization": "\xc2\xb7"}
     data_dict = {"type": "dataset", "name": "a-name"}
-    url = h.url_for(
-            "api.action",
-            logic_function="package_create",
-            ver=3,
-        )
+    url = "/api/3/action/package_create"
     app.post(url, json=data_dict, headers=request_headers, status=403)
 
 
@@ -477,14 +468,11 @@ def test_cache_control_when_cache_is_not_set_in_config(app):
 
 @pytest.mark.ckan_config('ckan.cache_enabled', 'true')
 def test_cache_control_while_logged_in(app):
-    from ckan.lib.helpers import url_for
     user = factories.User(password="correct123")
     identity = {"login": user["name"], "password": "correct123"}
     request_headers = {}
 
-    response = app.post(
-        url_for("user.login"), data=identity, headers=request_headers
-    )
+    response = app.post("/user/login", data=identity, headers=request_headers)
     response_headers = dict(response.headers)
 
     assert 'Cache-Control' in response_headers

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -85,7 +85,8 @@ class TestHelpersUrlForStatic(BaseUrlFor):
         "//assets.ckan.org/ckan.jpg",
     ],
 )
-def test_url_for_static_or_external(url):
+def test_url_for_static_or_external(url, with_request_context):
+
     generated = h.url_for_static_or_external(url)
     assert generated == url
     assert isinstance(generated, str)
@@ -388,7 +389,7 @@ class TestHelpersRenderMarkdown(object):
             ),
         ],
     )
-    def test_render_markdown(self, data, output, allow_html):
+    def test_render_markdown(self, data, output, allow_html, with_request_context):
         assert h.render_markdown(data, allow_html=allow_html) == output
 
     def test_internal_tag_with_no_closing_quote_does_not_match(self):
@@ -397,19 +398,19 @@ class TestHelpersRenderMarkdown(object):
         out = h.render_markdown(data)
         assert "<a href" not in out
 
-    def test_tag_names_match_simple_punctuation(self):
+    def test_tag_names_match_simple_punctuation(self, with_request_context):
         """Asserts punctuation and capital letters are matched in the tag name"""
         data = 'tag:"Test- _." foobar'
         output = '<p><a href="/dataset/?tags=Test-+_.">tag:&quot;Test- _.&quot;</a> foobar</p>'
         assert h.render_markdown(data) == output
 
-    def test_tag_names_do_not_match_commas(self):
+    def test_tag_names_do_not_match_commas(self, with_request_context):
         """Asserts commas don't get matched as part of a tag name"""
         data = "tag:Test,tag foobar"
         output = '<p><a href="/dataset/?tags=Test">tag:Test</a>,tag foobar</p>'
         assert h.render_markdown(data) == output
 
-    def test_tag_names_dont_match_non_space_whitespace(self):
+    def test_tag_names_dont_match_non_space_whitespace(self, with_request_context):
         """Asserts that the only piece of whitespace matched in a tagname is a space"""
         whitespace_characters = "\t\n\r\f\v"
         for ch in whitespace_characters:

--- a/ckan/tests/lib/test_signals.py
+++ b/ckan/tests/lib/test_signals.py
@@ -8,20 +8,19 @@ import ckan.model as model
 
 from ckan.lib import mailer, signals
 from ckan.tests import factories
-from ckan.lib.helpers import url_for
 
 
-@pytest.mark.ckan_config(u"ckan.plugins", u"example_idatasetform_v6")
+@pytest.mark.ckan_config("ckan.plugins", "example_idatasetform_v6")
 def test_register_blueprint(make_app):
     receiver = mock.Mock()
     with signals.register_blueprint.connected_to(receiver):
         make_app()
     assert receiver.call_count == 2
     (type_,), _ = receiver.call_args_list[0]
-    assert type_ == u"dataset"
+    assert type_ == "dataset"
 
     (type_,), _ = receiver.call_args_list[1]
-    assert type_ == u"resource"
+    assert type_ == "resource"
 
 
 def test_request_signals(app):
@@ -29,18 +28,18 @@ def test_request_signals(app):
     finish_receiver = mock.Mock()
     with signals.request_started.connected_to(start_receiver):
         with signals.request_finished.connected_to(finish_receiver):
-            app.get(u"/")
+            app.get("/")
     assert start_receiver.call_count == 1
     assert finish_receiver.call_count == 1
 
     with signals.request_started.connected_to(start_receiver):
         with signals.request_finished.connected_to(finish_receiver):
-            app.get(u"/about")
+            app.get("/about")
     assert start_receiver.call_count == 2
     assert finish_receiver.call_count == 2
 
 
-@pytest.mark.usefixtures(u"non_clean_db", u"with_request_context")
+@pytest.mark.usefixtures("non_clean_db")
 class TestUserSignals:
     def test_user_created(self):
         created = mock.Mock()
@@ -52,54 +51,48 @@ class TestUserSignals:
         user = factories.User()
         request_reset = mock.Mock()
         monkeypatch.setattr(
-            mailer, u"send_reset_link", mailer.create_reset_key
+            mailer, "send_reset_link", mailer.create_reset_key
         )
         with signals.request_password_reset.connected_to(request_reset):
-            app.post(
-                url_for(u"user.request_reset"), data={u"user": user[u"name"]}
-            )
+            app.post("/user/reset", data={"user": user["name"]})
             assert request_reset.call_count == 1
 
         perform_reset = mock.Mock()
         user_obj = model.User.get(user['id'])
         with signals.perform_password_reset.connected_to(perform_reset):
             app.post(
-                url_for(
-                    u"user.perform_reset",
-                    id=user[u"id"],
-                    key=user_obj.reset_key
-                ),
+                f"/user/reset/{user['id']}?key={user_obj.reset_key}",
                 data={
-                    u'password1': u'password123',
-                    u'password2': u'password123',
+                    'password1': 'password123',
+                    'password2': 'password123',
                 }
             )
             assert perform_reset.call_count == 1
 
     def test_login(self, app):
-        user = factories.User(email='user@ckan.org', password=u"correct123")
-        url = url_for(u"user.login")
+        user = factories.User(email='user@ckan.org', password="correct123")
+        url = "/user/login"
         success = mock.Mock()
         fail = mock.Mock()
         invalid = factories.User.stub().name
         with signals_user_logged_in.connected_to(success):
             with signals.failed_login.connected_to(fail):
-                data = {u"login": invalid, u"password": u"invalid"}
+                data = {"login": invalid, "password": "invalid"}
                 app.post(url, data=data)
                 assert success.call_count == 0
                 assert fail.call_count == 1
 
-                data = {u"login": user[u"name"], u"password": u"invalid"}
+                data = {"login": user["name"], "password": "invalid"}
                 app.post(url, data=data)
                 assert success.call_count == 0
                 assert fail.call_count == 2
 
-                data = {u"login": invalid, u"password": u"correct123"}
+                data = {"login": invalid, "password": "correct123"}
                 app.post(url, data=data)
                 assert success.call_count == 0
                 assert fail.call_count == 3
 
-                data = {u"login": user[u"name"], u"password": u"correct123"}
+                data = {"login": user["name"], "password": "correct123"}
                 app.post(url, data=data)
                 assert success.call_count == 1
                 assert fail.call_count == 3

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -1448,7 +1448,8 @@ class TestUserUpdate(object):
         user_obj = model.User.get(user["id"])
         assert user_obj.password != "pretend-this-is-a-valid-hash"
 
-    def test_user_update_image_url(self):
+    def test_user_update_image_url(self, app, with_request_context):
+
         user = factories.User(image_url="user_image.jpg")
         context = {"user": user["name"]}
 
@@ -1465,7 +1466,7 @@ class TestUserUpdate(object):
 
 @pytest.mark.usefixtures("non_clean_db")
 class TestGroupUpdate(object):
-    def test_group_update_image_url_field(self):
+    def test_group_update_image_url_field(self, app, with_request_context):
         user = factories.User()
         context = {"user": user["name"]}
         group = factories.Group(

--- a/ckan/tests/model/test_user.py
+++ b/ckan/tests/model/test_user.py
@@ -233,7 +233,6 @@ class TestUser:
 
     def test_user_last_active(self, app):
         import datetime
-        from ckan.lib.helpers import url_for
         from freezegun import freeze_time
 
         frozen_time = datetime.datetime.utcnow()
@@ -245,16 +244,16 @@ class TestUser:
         with freeze_time(frozen_time):
             user = model.User.get(data["id"])
             assert user.last_active is None
-            app.get(url_for("dataset.search"), extra_environ=env)
+            app.get("/dataset/", extra_environ=env)
             assert isinstance(user.last_active, datetime.datetime)
             assert user.last_active == datetime.datetime.utcnow()
 
         with freeze_time(frozen_time + datetime.timedelta(seconds=540)):
             user = model.User.get(data["id"])
-            app.get(url_for("user.read", id=user.id), extra_environ=env)
+            app.get(f"/user/{user.id}", extra_environ=env)
             assert user.last_active != datetime.datetime.utcnow()
 
         with freeze_time(frozen_time + datetime.timedelta(seconds=660)):
             user = model.User.get(data["id"])
-            app.get(url_for("dataset.read", id=dataset["id"]), extra_environ=env)
+            app.get(f"/dataset/{dataset['id']}", extra_environ=env)
             assert user.last_active == datetime.datetime.utcnow()

--- a/ckan/tests/pytest_ckan/fixtures.py
+++ b/ckan/tests/pytest_ckan/fixtures.py
@@ -369,7 +369,9 @@ class FakeFileStorage(FlaskFileStorage):
 
 
 @pytest.fixture
-def create_with_upload(clean_db, ckan_config, monkeypatch, tmpdir):
+def create_with_upload(
+    clean_db, ckan_config, monkeypatch, tmpdir, with_request_context
+        ):
     """Shortcut for creating resource/user/org with upload.
 
     Requires content and name for newly created object. By default is

--- a/ckanext/activity/tests/logic/test_functional.py
+++ b/ckanext/activity/tests/logic/test_functional.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-import ckan.plugins.toolkit as tk
 import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
 
@@ -27,13 +26,13 @@ class TestPagination():
             )
 
         # Test initial pagination buttons are rendered correctly
-        url = tk.url_for("dataset.activity", id=dataset["id"])
+        url = f"/dataset/activity/{dataset['id']}"
         response = app.get(url)
 
         assert '<a href="None" class="btn disabled">Newer activities</a>' in response.body
         assert f'<a href="/dataset/activity/{dataset["id"]}?before=' in response.body
 
-        url = tk.url_for("activity.organization_activity", id=org["id"])
+        url = f"/organization/activity/{org['id']}"
         response = app.get(url)
 
         assert '<a href="None" class="btn disabled">Newer activities</a>' in response.body

--- a/ckanext/activity/tests/test_views.py
+++ b/ckanext/activity/tests/test_views.py
@@ -28,7 +28,7 @@ class TestOrganization(object):
         user = factories.User()
         org = factories.Organization(user=user)
 
-        url = url_for("activity.organization_activity", id=org["id"])
+        url = f"/organization/activity/{org['id']}"
         response = app.get(url)
         assert user["fullname"] in response
         assert "created the organization" in response
@@ -37,7 +37,7 @@ class TestOrganization(object):
         user = factories.User()
         org = factories.Organization(user=user)
 
-        url = url_for("activity.organization_activity", id=org["id"])
+        url = f"/organization/activity/{org['id']}"
         response = app.get(url)
         assert (
             '<a href="/user/{}">{}'.format(user["name"], user["fullname"])
@@ -58,7 +58,7 @@ class TestOrganization(object):
             "organization_update", context={"user": user["name"]}, **org
         )
 
-        url = url_for("activity.organization_activity", id=org["id"])
+        url = f"/organization/activity/{org['id']}"
         response = app.get(url)
         assert (
             '<a href="/user/{}">{}'.format(user["name"], user["fullname"])
@@ -79,7 +79,7 @@ class TestOrganization(object):
             "organization_delete", context={"user": user["name"]}, **org
         )
 
-        url = url_for("activity.organization_activity", id=org["id"])
+        url = f"/organization/activity/{org['id']}"
         env = {"REMOTE_USER": user["name"]}
         app.get(url, extra_environ=env, status=404)
         # organization_delete causes the Member to state=deleted and then the
@@ -97,7 +97,7 @@ class TestOrganization(object):
             "organization_update", context={"user": user["name"]}, **org
         )
 
-        url = url_for("activity.organization_activity", id=org["id"])
+        url = f"/organization/activity/{org['id']}"
         env = {"REMOTE_USER": user["name"]}
         response = app.get(url, extra_environ=env)
         assert (
@@ -116,7 +116,7 @@ class TestOrganization(object):
         _clear_activities()
         dataset = factories.Dataset(owner_org=org["id"], user=user)
 
-        url = url_for("activity.organization_activity", id=org["id"])
+        url = f"/organization/activity/{org['id']}"
         response = app.get(url)
         page = BeautifulSoup(response.body)
         href = page.select_one(".dataset")
@@ -138,7 +138,7 @@ class TestOrganization(object):
             "package_update", context={"user": user["name"]}, **dataset
         )
 
-        url = url_for("activity.organization_activity", id=org["id"])
+        url = f"/organization/activity/{org['id']}"
         response = app.get(url)
         page = BeautifulSoup(response.body)
         href = page.select_one(".dataset")
@@ -159,7 +159,7 @@ class TestOrganization(object):
             "package_delete", context={"user": user["name"]}, **dataset
         )
 
-        url = url_for("activity.organization_activity", id=org["id"])
+        url = f"/organization/activity/{org['id']}"
         response = app.get(url)
         page = BeautifulSoup(response.body)
         href = page.select_one(".dataset")
@@ -180,7 +180,7 @@ class TestUser:
 
         user = factories.User()
 
-        url = url_for("activity.user_activity", id=user["id"])
+        url = f"/user/activity/{user['id']}"
         response = app.get(url)
         assert user["fullname"] in response
         assert "signed up" in response
@@ -189,7 +189,7 @@ class TestUser:
 
         user = factories.User()
 
-        url = url_for("activity.user_activity", id=user["id"])
+        url = f"/user/activity/{user['id']}"
         response = app.get(url)
         assert (
             '<a href="/user/{}">{}'.format(user["name"], user["fullname"])
@@ -206,7 +206,7 @@ class TestUser:
             "user_update", context={"user": user["name"]}, **user
         )
 
-        url = url_for("activity.user_activity", id=user["id"])
+        url = f"/user/activity/{user['id']}"
         response = app.get(url)
         assert (
             '<a href="/user/{}">{}'.format(user["name"], user["fullname"])
@@ -220,7 +220,7 @@ class TestUser:
         _clear_activities()
         dataset = factories.Dataset(user=user)
 
-        url = url_for("activity.user_activity", id=user["id"])
+        url = f"/user/activity/{user['id']}"
         response = app.get(url)
         page = BeautifulSoup(response.body)
         href = page.select_one(".dataset")
@@ -242,7 +242,7 @@ class TestUser:
             "package_update", context={"user": user["name"]}, **dataset
         )
 
-        url = url_for("activity.user_activity", id=user["id"])
+        url = f"/user/activity/{user['id']}"
         response = app.get(url)
         page = BeautifulSoup(response.body)
         href = page.select_one(".dataset")
@@ -264,7 +264,7 @@ class TestUser:
             "package_delete", context={"user": user["name"]}, **dataset
         )
 
-        url = url_for("activity.user_activity", id=user["id"])
+        url = f"/user/activity/{user['id']}"
         env = {"REMOTE_USER": user["name"]}
         response = app.get(url, extra_environ=env)
         page = BeautifulSoup(response.body)
@@ -282,7 +282,7 @@ class TestUser:
         user = factories.User()
         group = factories.Group(user=user)
 
-        url = url_for("activity.user_activity", id=user["id"])
+        url = f"/user/activity/{user['id']}"
         response = app.get(url)
         page = BeautifulSoup(response.body)
         href = page.select_one(".group")
@@ -305,7 +305,7 @@ class TestUser:
             "group_update", context={"user": user["name"]}, **group
         )
 
-        url = url_for("activity.user_activity", id=user["id"])
+        url = f"/user/activity/{user['id']}"
         response = app.get(url)
         page = BeautifulSoup(response.body)
         href = page.select_one(".group")
@@ -326,7 +326,7 @@ class TestUser:
             "group_delete", context={"user": user["name"]}, **group
         )
 
-        url = url_for("activity.user_activity", id=user["id"])
+        url = f"/user/activity/{user['id']}"
         response = app.get(url)
         page = BeautifulSoup(response.body)
         href = page.select_one(".group")
@@ -348,7 +348,7 @@ class TestUser:
             "group_update", context={"user": user["name"]}, **group
         )
 
-        url = url_for("activity.group_activity", id=group["id"])
+        url = f"/group/activity/{group['id']}"
         env = {"REMOTE_USER": user["name"]}
         response = app.get(url, extra_environ=env)
         assert (
@@ -370,7 +370,7 @@ class TestPackage:
         user = factories.User()
         dataset = factories.Dataset(user=user)
 
-        url = url_for("activity.package_activity", id=dataset["id"])
+        url = f"/dataset/activity/{dataset['id']}"
         response = app.get(url)
         assert user["fullname"] in response
         assert "created the dataset" in response
@@ -380,7 +380,7 @@ class TestPackage:
         user = factories.User()
         dataset = factories.Dataset(user=user)
 
-        url = url_for("activity.package_activity", id=dataset["id"])
+        url = f"/dataset/activity/{dataset['id']}"
         response = app.get(url)
         page = BeautifulSoup(response.body)
         href = page.select_one(".dataset")
@@ -403,7 +403,7 @@ class TestPackage:
             "package_update", context={"user": user["name"]}, **dataset
         )
 
-        url = url_for("activity.package_activity", id=dataset["id"])
+        url = f"/dataset/activity/{dataset['id']}"
         response = app.get(url)
         page = BeautifulSoup(response.body)
         href = page.select_one(".dataset")
@@ -425,7 +425,7 @@ class TestPackage:
             "package_update", context={"user": user["name"]}, **dataset
         )
 
-        url = url_for("activity.package_activity", id=dataset["id"])
+        url = f"/dataset/activity/{dataset['id']}"
         response = app.get(url)
         page = BeautifulSoup(response.body)
         href = page.select_one(".dataset")
@@ -452,7 +452,7 @@ class TestPackage:
             "package_update", context={"user": user["name"]}, **dataset
         )
 
-        url = url_for("activity.package_activity", id=dataset["id"])
+        url = f"/dataset/activity/{dataset['id']}"
         response = app.get(url)
         page = BeautifulSoup(response.body)
         href = page.select_one(".dataset")
@@ -479,7 +479,7 @@ class TestPackage:
             "package_update", context={"user": user["name"]}, **dataset
         )
 
-        url = url_for("activity.package_activity", id=dataset["id"])
+        url = f"/dataset/activity/{dataset['id']}"
         response = app.get(url)
         page = BeautifulSoup(response.body)
         href = page.select_one(".dataset")
@@ -508,7 +508,7 @@ class TestPackage:
             package_id=dataset["id"],
         )
 
-        url = url_for("activity.package_activity", id=dataset["id"])
+        url = f"/dataset/activity/{dataset['id']}"
         response = app.get(url)
         page = BeautifulSoup(response.body)
         href = page.select_one(".dataset")
@@ -541,7 +541,7 @@ class TestPackage:
             package_id=dataset["id"],
         )
 
-        url = url_for("activity.package_activity", id=dataset["id"])
+        url = f"/dataset/activity/{dataset['id']}"
         response = app.get(url)
         page = BeautifulSoup(response.body)
         href = page.select_one(".dataset")
@@ -568,7 +568,7 @@ class TestPackage:
             "package_delete", context={"user": user["name"]}, **dataset
         )
 
-        url = url_for("activity.organization_activity", id=org["id"])
+        url = f"/organization/activity/{org['id']}"
         response = app.get(url)
         page = BeautifulSoup(response.body)
         href = page.select_one(".dataset")
@@ -587,7 +587,7 @@ class TestPackage:
         env = {"REMOTE_USER": user["name"]}
         dataset = factories.Dataset(user=user)
 
-        url = url_for("activity.package_activity", id=dataset["id"])
+        url = f"/dataset/activity/{dataset['id']}"
         response = app.get(url, extra_environ=env)
         assert "View this version" in response
 
@@ -596,7 +596,7 @@ class TestPackage:
         user = factories.User()
         dataset = factories.Dataset(user=user)
 
-        url = url_for("activity.package_activity", id=dataset["id"])
+        url = f"/dataset/activity/{dataset['id']}"
         response = app.get(url)
         assert "View this version" not in response
 
@@ -608,7 +608,7 @@ class TestPackage:
         dataset["title"] = "Changed"
         helpers.call_action("package_update", **dataset)
 
-        url = url_for("activity.package_activity", id=dataset["id"])
+        url = f"/dataset/activity/{dataset['id']}"
         response = app.get(url, extra_environ=env)
         assert "Changes" in response
 
@@ -617,7 +617,7 @@ class TestPackage:
         dataset["title"] = "Changed"
         helpers.call_action("package_update", **dataset)
 
-        url = url_for("activity.package_activity", id=dataset["id"])
+        url = f"/dataset/activity/{dataset['id']}"
         response = app.get(url)
         assert "Changes" not in response
 
@@ -658,7 +658,7 @@ class TestPackage:
         }
         helpers.call_action("activity_create", **activity_dict)
 
-        url = url_for("activity.package_activity", id=dataset["id"])
+        url = f"/dataset/activity/{dataset['id']}"
         response = app.get(url)
         assert (
             '<a href="/user/{}">{}'.format(user["name"], user["fullname"])
@@ -678,21 +678,18 @@ class TestPackage:
         sysadmin = factories.Sysadmin()
         env = {"REMOTE_USER": sysadmin["name"]}
         response = app.get(
-            url_for(
-                "activity.package_history",
-                id=dataset["id"],
-                activity_id=activity.id,
-            ),
+            f"/dataset/{dataset['id']}/history/{activity.id}",
             status=302,
             extra_environ=env,
             follow_redirects=False,
         )
-        expected_path = url_for(
-            "activity.package_history",
-            id=dataset["name"],
-            _external=True,
-            activity_id=activity.id,
-        )
+        with app.flask_app.test_request_context():
+            expected_path = url_for(
+                "activity.package_history",
+                id=dataset["name"],
+                _external=True,
+                activity_id=activity.id,
+            )
         assert response.headers["location"] == expected_path
 
     def test_read_dataset_as_it_used_to_be(self, app):
@@ -708,11 +705,7 @@ class TestPackage:
         sysadmin = factories.Sysadmin()
         env = {"REMOTE_USER": sysadmin["name"]}
         response = app.get(
-            url_for(
-                "activity.package_history",
-                id=dataset["name"],
-                activity_id=activity.id,
-            ),
+            f"/dataset/{dataset['name']}/history/{activity.id}",
             extra_environ=env,
         )
         assert helpers.body_contains(response, "Original title")
@@ -756,11 +749,7 @@ class TestPackage:
         sysadmin = factories.Sysadmin()
         env = {"REMOTE_USER": sysadmin["name"]}
         app.get(
-            url_for(
-                "activity.package_history",
-                id=dataset["name"],
-                activity_id=activity.id,
-            ),
+            f"/dataset/{dataset['name']}/history/{activity.id}",
             extra_environ=env,
             status=404,
         )
@@ -775,10 +764,7 @@ class TestPackage:
             dataset["id"], limit=1, offset=0
         )[0]
         env = {"REMOTE_USER": user["name"]}
-        response = app.get(
-            url_for("activity.package_changes", id=activity.id),
-            extra_environ=env,
-        )
+        response = app.get(f"/dataset/changes/{activity.id}", extra_environ=env)
         assert helpers.body_contains(response, "First")
         assert helpers.body_contains(response, "Second")
 
@@ -788,7 +774,7 @@ class TestPackage:
         user = factories.User()
         dataset = factories.Dataset(user=user)
 
-        url = url_for("activity.package_activity", id=dataset["id"])
+        url = f"/dataset/activity/{dataset['id']}"
         response = app.get(url, query_string={"before": "XXX"}, status=400)
         assert "Invalid parameters" in response.body
 
@@ -805,7 +791,7 @@ class TestPackage:
         dataset["title"] = "Fourth title"
         helpers.call_action("package_update", **dataset)
 
-        url = url_for("activity.package_activity", id=dataset["id"])
+        url = f"/dataset/activity/{dataset['id']}"
         response = app.get(url)
         activities = helpers.call_action(
             "package_activity_list", id=dataset["id"]
@@ -852,7 +838,7 @@ class TestPackage:
         last_act_page_1_time = datetime.fromisoformat(
             activities[2]["timestamp"]
         )
-        url = url_for("activity.package_activity", id=dataset["id"])
+        url = f"/dataset/activity/{dataset['id']}"
         response = app.get(
             url, query_string={"before": last_act_page_1_time.timestamp()}
         )
@@ -886,7 +872,7 @@ class TestPackage:
         )
         before_time = datetime.fromisoformat(activities[2]["timestamp"])
 
-        url = url_for("activity.package_activity", id=dataset["id"])
+        url = f"/dataset/activity/{dataset['id']}"
         # url for page 2
         response = app.get(
             url, query_string={"before": before_time.timestamp()}
@@ -912,7 +898,7 @@ class TestGroup:
         user = factories.User()
         group = factories.Group(user=user)
 
-        url = url_for("activity.group_activity", id=group["id"])
+        url = f"/group/activity/{group['id']}"
         response = app.get(url)
         assert user["fullname"] in response
         assert "created the group" in response
@@ -921,7 +907,7 @@ class TestGroup:
         user = factories.User()
         group = factories.Group(user=user)
 
-        url = url_for("activity.group_activity", id=group["id"])
+        url = f"/group/activity/{group['id']}"
         response = app.get(url)
         assert (
             '<a href="/user/{}">{}'.format(user["name"], user["fullname"])
@@ -942,7 +928,7 @@ class TestGroup:
             "group_update", context={"user": user["name"]}, **group
         )
 
-        url = url_for("activity.group_activity", id=group["id"])
+        url = f"/group/activity/{group['id']}"
         response = app.get(url)
         assert (
             '<a href="/user/{}">{}'.format(user["name"], user["fullname"])
@@ -962,7 +948,7 @@ class TestGroup:
             "group_delete", context={"user": user["name"]}, **group
         )
 
-        url = url_for("activity.group_activity", id=group["id"])
+        url = f"/group/activity/{group['id']}"
         env = {"REMOTE_USER": user["name"]}
         app.get(url, extra_environ=env, status=404)
         # group_delete causes the Member to state=deleted and then the user
@@ -980,7 +966,7 @@ class TestGroup:
             "group_update", context={"user": user["name"]}, **group
         )
 
-        url = url_for("activity.group_activity", id=group["id"])
+        url = f"/group/activity/{group['id']}"
         env = {"REMOTE_USER": user["name"]}
         response = app.get(url, extra_environ=env)
         assert (
@@ -999,7 +985,7 @@ class TestGroup:
         _clear_activities()
         dataset = factories.Dataset(groups=[{"id": group["id"]}], user=user)
 
-        url = url_for("activity.group_activity", id=group["id"])
+        url = f"/group/activity/{group['id']}"
         response = app.get(url)
         page = BeautifulSoup(response.body)
         href = page.select_one(".dataset")
@@ -1022,7 +1008,7 @@ class TestGroup:
             "package_update", context={"user": user["name"]}, **dataset
         )
 
-        url = url_for("activity.group_activity", id=group["id"])
+        url = f"/group/activity/{group['id']}"
         response = app.get(url)
         page = BeautifulSoup(response.body)
         href = page.select_one(".dataset")
@@ -1043,7 +1029,7 @@ class TestGroup:
             "package_delete", context={"user": user["name"]}, **dataset
         )
 
-        url = url_for("activity.group_activity", id=group["id"])
+        url = f"/group/activity/{group['id']}"
         response = app.get(url)
         page = BeautifulSoup(response.body)
         href = page.select_one(".dataset")

--- a/ckanext/audioview/tests/test_view.py
+++ b/ckanext/audioview/tests/test_view.py
@@ -1,7 +1,6 @@
 # encoding: utf-8
 import pytest
 
-from ckan.lib.helpers import url_for
 from ckan.tests import factories
 
 
@@ -20,9 +19,7 @@ def test_view_shown_on_resource_page_with_audio_url(app):
         view_type='audio_view',
         audio_url='http://example.wav')
 
-    url = url_for('{}_resource.read'.format(dataset['type']),
-                  id=dataset['name'], resource_id=resource['id'])
-
+    url = f"/dataset/{dataset['name']}/resource/{resource['id']}"
     response = app.get(url)
 
     assert resource_view['audio_url'] in response

--- a/ckanext/datapusher/tests/test_interfaces.py
+++ b/ckanext/datapusher/tests/test_interfaces.py
@@ -36,7 +36,7 @@ class TestInterace(object):
 
     @responses.activate
     @pytest.mark.parametrize("resource__url_type", ["datastore"])
-    def test_send_datapusher_creates_task(self, test_request_context, resource):
+    def test_send_datapusher_creates_task(self, with_request_context, resource):
         sysadmin = factories.Sysadmin()
 
         responses.add(
@@ -47,10 +47,10 @@ class TestInterace(object):
         )
 
         context = {"ignore_auth": True, "user": sysadmin["name"]}
-        with test_request_context():
-            result = p.toolkit.get_action("datapusher_submit")(
-                context, {"resource_id": resource["id"]}
-            )
+
+        result = p.toolkit.get_action("datapusher_submit")(
+            context, {"resource_id": resource["id"]}
+        )
         assert not result
 
         context.pop("task_status", None)

--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -428,7 +428,9 @@ class TestDatastoreCreate(object):
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
     @pytest.mark.usefixtures("with_plugins")
     def test_create_duplicate_alias_name(self, app):
-        resource = factories.Resource(url_type = 'datastore')
+        with app.flask_app.test_request_context():
+            # datastore before_resource_show depends on url_for
+            resource = factories.Resource(url_type = 'datastore')
         data = {"resource_id": resource['id'], "aliases": u"myalias"}
         auth = {"Authorization": self.sysadmin_token}
         res = app.post(
@@ -441,7 +443,8 @@ class TestDatastoreCreate(object):
         assert res_dict["success"] is True
 
         # try to create another table with the same alias
-        resource_2 = factories.Resource(url_type = 'datastore')
+        with app.flask_app.test_request_context():
+            resource_2 = factories.Resource(url_type = 'datastore')
         data = {"resource_id": resource_2['id'], "aliases": u"myalias"}
         auth = {"Authorization": self.sysadmin_token}
         res = app.post(
@@ -1195,7 +1198,9 @@ class TestDatastoreCreate(object):
     @pytest.mark.usefixtures("with_plugins")
     def test_datastore_create_with_invalid_data_value(self, app):
         """datastore_create() should return an error for invalid data."""
-        resource = factories.Resource(url_type="datastore")
+        with app.flask_app.test_request_context():
+            # datastore before_resource_show depends on url_for
+            resource = factories.Resource(url_type="datastore")
         data_dict = {
             "resource_id": resource["id"],
             "fields": [{"id": "value", "type": "numeric"}],

--- a/ckanext/datastore/tests/test_info.py
+++ b/ckanext/datastore/tests/test_info.py
@@ -4,7 +4,6 @@ import pytest
 import six
 import ckan.tests.factories as factories
 import ckan.tests.helpers as helpers
-from ckan.lib import helpers as template_helpers
 
 
 @pytest.mark.ckan_config("ckan.plugins", "datastore")
@@ -65,13 +64,7 @@ def test_api_info(app):
 
     # the 'API info' is seen on the resource_read page, a snippet loaded by
     # javascript via data_api_button.html
-    url = template_helpers.url_for(
-        "api.snippet",
-        ver=1,
-        snippet_path="api_info.html",
-        resource_id=resource["id"],
-    )
-
+    url = f"/api/1/util/snippet/api_info.html?resource_id={resource['id']}"
     page = app.get(url, status=200)
 
     # check we built all the urls ok

--- a/ckanext/example_iapitoken/tests/test_plugin.py
+++ b/ckanext/example_iapitoken/tests/test_plugin.py
@@ -7,7 +7,6 @@ import six
 import ckan.model as model
 import ckan.tests.factories as factories
 import ckan.tests.helpers as helpers
-import ckan.plugins.toolkit as tk
 
 
 @pytest.mark.ckan_config(u"ckan.plugins", u"example_iapitoken")
@@ -51,7 +50,7 @@ class TestIApiTokenPlugin(object):
         assert obj.last_access is None
 
         app.get(
-            tk.h.url_for(u"api.action", logic_function=u"user_show", ver=3),
+            "/api/3/action/user_show",
             params={u"id": user[u"id"]},
             headers={u"authorization": six.ensure_str(data[u"token"])},
         )
@@ -61,7 +60,7 @@ class TestIApiTokenPlugin(object):
         assert obj.last_access is not None
 
         app.get(
-            tk.h.url_for(u"api.action", logic_function=u"user_show", ver=3),
+            "/api/3/action/user_show",
             params={u"id": user[u"id"]},
             headers={u"authorization": six.ensure_str(data[u"token"])},
         )

--- a/ckanext/example_iauthenticator/tests/test_example_iauthenticator.py
+++ b/ckanext/example_iauthenticator/tests/test_example_iauthenticator.py
@@ -7,32 +7,28 @@ import ckan.plugins as p
 toolkit = p.toolkit
 
 
-@pytest.mark.ckan_config(u'ckan.plugins', u'example_iauthenticator')
-@pytest.mark.usefixtures(u'with_plugins')
+@pytest.mark.ckan_config('ckan.plugins', 'example_iauthenticator')
+@pytest.mark.usefixtures('with_plugins')
 class TestExampleIAuthenticator(object):
 
     def test_identify_sets_cookie(self, app):
-
-        resp = app.get(toolkit.url_for(u'home.index'))
-
-        assert u'example_iauthenticator=hi' in resp.headers[u'Set-Cookie']
+        resp = app.get("/")
+        assert 'example_iauthenticator=hi' in resp.headers['Set-Cookie']
 
     def test_login_redirects(self, app):
 
-        resp = app.get(
-            toolkit.url_for(u'user.login'),
-            follow_redirects=False
-        )
+        resp = app.get("/user/login", follow_redirects=False)
 
         assert resp.status_code == 302
-        assert resp.headers[u'Location'] == toolkit.url_for(u'example_iauthenticator.custom_login', _external=True)
+        with app.flask_app.test_request_context():
+            expected = toolkit.url_for('example_iauthenticator.custom_login', _external=True)
+        assert resp.headers[u'Location'] == expected
 
     def test_logout_redirects(self, app):
 
-        resp = app.get(
-            toolkit.url_for(u'user.logout'),
-            follow_redirects=False
-        )
+        resp = app.get("/user/_logout", follow_redirects=False)
 
         assert resp.status_code == 302
-        assert resp.headers[u'Location'] == toolkit.url_for(u'example_iauthenticator.custom_logout', _external=True)
+        with app.flask_app.test_request_context():
+            expected = toolkit.url_for('example_iauthenticator.custom_logout', _external=True)
+        assert resp.headers['Location'] == expected

--- a/ckanext/example_itranslation/tests/test_plugin.py
+++ b/ckanext/example_itranslation/tests/test_plugin.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from ckan import plugins
 from ckan.tests import helpers
 
 
@@ -11,38 +10,32 @@ from ckan.tests import helpers
 class TestExampleITranslationPlugin(object):
 
     def test_translated_string_in_extensions_templates(self, app):
-        response = app.get(
-            url=plugins.toolkit.url_for(u"home.index", locale="fr"),
-        )
+        response = app.get('/fr/')
         assert helpers.body_contains(response, "This is a itranslated string")
         assert not helpers.body_contains(response, "This is an untranslated string")
 
         # double check the untranslated strings
-        response = app.get(url=plugins.toolkit.url_for(u"home.index"),)
+        response = app.get("/")
         assert helpers.body_contains(response, "This is an untranslated string")
         assert not helpers.body_contains(response, "This is a itranslated string")
 
     def test_translated_string_in_core_templates(self, app):
-        response = app.get(
-            url=plugins.toolkit.url_for(u"home.index", locale="fr"),
-        )
+        response = app.get("/fr/")
         assert helpers.body_contains(response, "Overwritten string in ckan.mo")
         assert not helpers.body_contains(response, "Connexion")
 
         # double check the untranslated strings
-        response = app.get(url=plugins.toolkit.url_for(u"home.index"),)
+        response = app.get("/")
         assert helpers.body_contains(response, "Log in")
         assert not helpers.body_contains(response, "Overwritten string in ckan.mo")
 
         # check that we have only overwritten 'fr'
-        response = app.get(
-            url=plugins.toolkit.url_for(u"home.index", locale="de"),
-        )
+        response = app.get("/de/")
         assert helpers.body_contains(response, "Einloggen")
         assert not helpers.body_contains(response, "Overwritten string in ckan.mo")
 
     @pytest.mark.ckan_config("ckan.auth.create_user_via_web", True)
     def test_english_translation_replaces_default_english_string(self, app):
-        response = app.get(url=plugins.toolkit.url_for(u"home.index"),)
+        response = app.get("/")
         assert helpers.body_contains(response, "Replaced")
         assert not helpers.body_contains(response, "Register")

--- a/ckanext/expire_api_token/tests/test_plugin.py
+++ b/ckanext/expire_api_token/tests/test_plugin.py
@@ -10,7 +10,6 @@ import ckan.model as model
 import ckan.lib.api_token as api_token
 import ckan.tests.factories as factories
 import ckan.tests.helpers as helpers
-from ckan.lib.helpers import url_for
 
 
 @pytest.mark.ckan_config(u"ckan.plugins", u"expire_api_token")
@@ -32,7 +31,7 @@ class TestExpireApiTokenPlugin(object):
         decoded = api_token.decode(data["token"])
         id = decoded["jti"]
         assert model.ApiToken.get(id)
-        url = url_for("api.action", logic_function=u"api_token_list", ver=3, user=user["id"])
+        url = f"/api/3/action/api_token_list?user={user['id']}"
         app.get(
             url, headers={u"authorization": six.ensure_str(data[u"token"])},
         )

--- a/ckanext/imageview/tests/test_view.py
+++ b/ckanext/imageview/tests/test_view.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 import pytest
-from ckan.lib.helpers import url_for
+
 from ckan.tests import factories
 import ckan.tests.helpers as helpers
 
@@ -20,9 +20,7 @@ def test_view_shown_on_resource_page_with_image_url(app):
         resource_id=resource['id'],
         image_url='http://some.image.png')
 
-    url = url_for('{}_resource.read'.format(dataset['type']),
-                  id=dataset['name'], resource_id=resource['id'])
-
+    url = f"/dataset/{dataset['name']}/resource/{resource['id']}"
     response = app.get(url)
 
     assert helpers.body_contains(response, resource_view['image_url'])

--- a/ckanext/multilingual/tests/test_multilingual_plugin.py
+++ b/ckanext/multilingual/tests/test_multilingual_plugin.py
@@ -4,7 +4,6 @@ import pytest
 
 import ckan.plugins
 import ckanext.multilingual.plugin as mulilingual_plugin
-import ckan.lib.helpers as h
 import ckan.lib.create_test_data
 import ckan.model as model
 from ckan.tests.helpers import body_contains, call_action
@@ -62,7 +61,7 @@ class TestDatasetTermTranslation:
         # It is testsysadmin who created the dataset, so testsysadmin whom
         # we'd expect to see the datasets for.
         for user_name in ("testsysadmin",):
-            offset = str(h.url_for("user.read", id=user_name))
+            offset = f"/user/{user_name}"
             for (lang_code, translations) in (
                 ("de", _create_test_data.german_translations),
                 ("fr", _create_test_data.french_translations),

--- a/ckanext/reclineview/tests/test_view.py
+++ b/ckanext/reclineview/tests/test_view.py
@@ -4,14 +4,13 @@ import pytest
 
 import ckan.model as model
 import ckan.plugins as p
-import ckan.lib.helpers as h
 import ckanext.reclineview.plugin as plugin
 import ckan.lib.create_test_data as create_test_data
 
 from ckan.tests import helpers, factories
 
 
-@pytest.mark.usefixtures("with_plugins", "with_request_context")
+@pytest.mark.usefixtures("with_plugins")
 class BaseTestReclineViewBase(object):
 
     @pytest.fixture(autouse=True)
@@ -29,8 +28,7 @@ class BaseTestReclineViewBase(object):
         assert not self.p.can_view(data_dict)
 
     def test_title_description_iframe_shown(self, app):
-        url = h.url_for('{}_resource.read'.format(self.package.type),
-                        id=self.package.name, resource_id=self.resource_id)
+        url = f"/dataset/{self.package.name}/resource/{self.resource_id}"
         result = app.get(url)
         assert self.resource_view['title'] in result
         assert self.resource_view['description'] in result
@@ -80,13 +78,12 @@ class TestReclineViewDatastoreOnly(object):
             'fields': [{'id': 'a'}, {'id': 'b'}],
             'records': [{'a': 1, 'b': 'xyz'}, {'a': 2, 'b': 'zzz'}]
         }
-        result = helpers.call_action('datastore_create', **data)
+        with app.flask_app.test_request_context():
+            result = helpers.call_action('datastore_create', **data)
 
         resource_id = result['resource_id']
 
-        url = h.url_for('{}_resource.read'.format(dataset['type']),
-                        id=dataset['id'], resource_id=resource_id)
-
+        url = f"/dataset/{dataset['id']}/resource/{resource_id}"
         result = app.get(url)
 
         assert 'data-module="data-viewer"' in result.body

--- a/ckanext/textview/tests/test_view.py
+++ b/ckanext/textview/tests/test_view.py
@@ -5,7 +5,6 @@ from ckan.common import config
 
 from urllib.parse import urljoin
 
-import ckan.lib.helpers as h
 import ckanext.textview.plugin as plugin
 from ckan.tests import factories
 
@@ -41,28 +40,26 @@ class TestTextView(object):
 
         assert not p.can_view(data_dict)
 
-    @pytest.mark.usefixtures("non_clean_db", "with_request_context")
+    @pytest.mark.usefixtures("non_clean_db")
     def test_title_description_iframe_shown(self, app, create_with_upload):
         package = factories.Dataset()
         resource = create_with_upload("hello world", "file.txt", package_id=package["id"])
         resource_view = factories.ResourceView(view_type="text_view", resource_id=resource["id"])
 
-        url = h.url_for('{}_resource.read'.format(package["type"]),
-                        id=package["name"], resource_id=resource["id"])
+        url = f"/dataset/{package['name']}/resource/{resource['id']}"
         result = app.get(url)
         assert resource_view['title'] in result
         assert resource_view['description'] in result
         assert 'data-module="data-viewer"' in result.body
 
-    @pytest.mark.usefixtures("non_clean_db", "with_request_context")
+    @pytest.mark.usefixtures("non_clean_db")
     def test_js_included(self, app, create_with_upload):
         package = factories.Dataset()
         resource = create_with_upload("hello world", "file.txt", package_id=package["id"])
         resource_view = factories.ResourceView(view_type="text_view", resource_id=resource["id"])
 
-        url = h.url_for(package["type"] + '_resource.view',
-                        id=package["name"], resource_id=resource["id"],
-                        view_id=resource_view['id'])
+        url = f"/dataset/{package['name']}/resource/{resource['id']}/view/{resource_view['id']}"
+
         result = app.get(url)
         assert (('text_view.js' in result.body) or  # Source file
                 ('textview.js' in result.body))     # Compiled file

--- a/ckanext/videoview/tests/test_view.py
+++ b/ckanext/videoview/tests/test_view.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from ckan.lib.helpers import url_for
 from ckan.tests import factories
 
 
@@ -21,9 +20,7 @@ def test_view_shown_on_resource_page_with_video_url(app):
         view_type='video_view',
         video_url='https://example/video.mp4')
 
-    url = url_for('{}_resource.read'.format(dataset['type']),
-                  id=dataset['name'], resource_id=resource['id'])
-
+    url = f"/dataset/{dataset['name']}/resource/{resource['id']}"
     response = app.get(url)
 
     assert resource_view['video_url'] in response

--- a/ckanext/webpageview/tests/test_view.py
+++ b/ckanext/webpageview/tests/test_view.py
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 import pytest
-from ckan.lib.helpers import url_for
 
 from ckan.tests import factories
 
@@ -25,10 +24,7 @@ class TestWebPageView(object):
             page_url="http://some.other.website.html",
         )
 
-        url = url_for(
-            "resource.read", id=dataset["name"], resource_id=resource["id"]
-        )
-
+        url = f"/dataset/{dataset['name']}/resource/{resource['id']}"
         response = app.get(url)
 
         assert resource_view["page_url"] in response

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/ckanext/{{cookiecutter.project_shortname}}/tests/test_plugin.py
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/ckanext/{{cookiecutter.project_shortname}}/tests/test_plugin.py
@@ -32,7 +32,7 @@ For functional tests that involve requests to the application, you can use the
 
     def test_some_endpoint(app):
 
-        url = toolkit.url_for('myblueprint.some_endpoint')
+        url = '/dataset/'
 
         response = app.get(url)
 

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/ckanext/{{cookiecutter.project_shortname}}/tests/test_views.py
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/ckanext/{{cookiecutter.project_shortname}}/tests/test_views.py
@@ -11,6 +11,6 @@ import ckan.plugins.toolkit as tk
 @pytest.mark.ckan_config("ckan.plugins", "{{cookiecutter.project_shortname}}")
 @pytest.mark.usefixtures("with_plugins")
 def test_{{cookiecutter.project_shortname}}_blueprint(app, reset_db):
-    resp = app.get(tk.h.url_for("{{cookiecutter.project_shortname}}.page"))
+    resp = app.get("/{{cookiecutter.project_shortname}}/page")
     assert resp.status_code == 200
     assert resp.body == "Hello, {{cookiecutter.project_shortname}}!"


### PR DESCRIPTION
This PR cleans the `_internal_test_request_context` global variable and replaces the calls to `url_for` in tests except when it is explicitly needed.

This is a follow up of #7246 

### Proposed fixes:

Since the migration to Flask was completed, our `_internal_test_request_context` only existed to provide the capability of using `url_for` inside tests without calling for a request context. However this is not consider a good practice.

As pointed out [in this SO comment](https://stackoverflow.com/a/46646961) by one of Flask's developer: 

> url_for is typically for generating URLs within the app, unit tests are external. Typically, you just write exactly the URL you're trying to test in the request instead of generating it.

### Explicit is better than implicit

Silently pushing test requests context can make Unit Tests pass when the code will not work in the real scenario. It also hides errors in implementation like calling view functions in our models:

https://github.com/ckan/ckan/blob/e75c90c2ffacd23f111acea59d1246af6b8d996e/ckan/lib/dictization/model_dictize.py#L131-L138

Currently calling `model_dictize.py` outside a request context in a test pass but it will fail in a real scenario since it will not have a silently pushed context.

**Proliferating our tests with `url_for` forces us to push request context where it shouldn't exist.**

### Spamming of `with_request_context`

I have also noticed that we are currently spamming request context in tests without a clear understanding of where or why it is needed. This is a clear consequence of having `url_for` calls so down in the architecture layer.

Example: We are calling an action (not view) but we require a Request Context.
```python
    class TestGroupUpdate(object):
    def test_group_update_image_url_field(self, app, with_request_context):
        user = factories.User()
        context = {"user": user["name"]}
        group = factories.Group(
            type="group",
            user=user,
            image_url="group_image.jpg",
        )

        group = helpers.call_action(
            "group_update",
            context=context,
            id=group["id"],
            name=group["name"],
            type=group["type"],
            image_url="new_image_url.jpg",
        )

        assert group["image_url"] == "new_image_url.jpg"

```

In the previous code, it is not clear at all why do we need a Request Context or what part of the code uses it. Could you guess? (Both factories.Group() and `group_update` are needed of a request context)

While this PR does not address this issue it is a good opportunity to point this out.

### TODO

- `test_confirm_cancel_delete` is failing with: `The CSRF token is missing.`