### PR TITLE
Add entity type to package get_index

### DIFF
--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -298,7 +298,7 @@ class PackageSearchQuery(SearchQuery):
             'rows': 1,
             'q': 'name:"%s" OR id:"%s"' % (reference, reference),
             'wt': 'json',
-            'fq': 'site_id:"%s"' % config.get_value('ckan.site_id')}
+            'fq': 'site_id:"%s" ' % config.get_value('ckan.site_id') + '+entity_type:package'}
 
         try:
             if query['q'].startswith('{!'):


### PR DESCRIPTION
### Proposed fixes:

While working with ckanext-sitesearch, I noticed that our solr assumes that there is only single document with single id which works fine when there are only packages indexed into solr. With ckanext-sitesearch there can be multiple documents with same ids but with different entity types and I couldn't find a way to configure it from the extension. This adds `entity_type:package` when fetching the document with id.  


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
