### PR TITLE
Fix config option call

### DIFF
--- a/changes/7254.bugfix
+++ b/changes/7254.bugfix
@@ -1,0 +1,2 @@
+Fixes a bug causing `ckan.datasets_per_page` config not being used.
+`limit` parameter in group/organization view has been removed in favor of the config.

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -407,8 +407,7 @@ def _get_group_dict(id: str, group_type: str) -> dict[str, Any]:
 
 def read(group_type: str,
          is_organization: bool,
-         id: Optional[str] = None,
-         limit: int = 20) -> Union[str, Response]:
+         id: Optional[str] = None) -> Union[str, Response]:
     extra_vars = {}
     set_org(is_organization)
     context = cast(Context, {

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -425,7 +425,7 @@ def read(group_type: str,
 
     extra_vars["q"] = q
 
-    limit = config.get(u'ckan.datasets_per_page', limit)
+    limit = config.get_value('ckan.datasets_per_page')
 
     try:
         # Do not query for the group datasets when dictizing, as they will


### PR DESCRIPTION
This PR fixes the error happening in master:
```python
    def natural_number_validator(value: Any, context: Context) -> Any:
        """Ensures that the value is non-negative integer.
        """
        value = int_validator(value, context)
>       if value < 0:
E       TypeError: '<' not supported between instances of 'NoneType' and 'int'

ckan/logic/validators.py:138: TypeError
```

### Proposed fixes:


This PR fixes a call to get values from the config object. The current logic doesn't cast the value to `int` and therefore causes an error later in the validation process.

```python
ipdb> config.get_value('ckan.datasets_per_page')
20
ipdb> config.get('ckan.datasets_per_page', 10)
'20'
```

The fix is simple however this error raises two concerns:
 - Having `config.get(...)` and `config.get_value(...)` is confusing. We should document this better and edit the `CKANConfig` object to avoid this common mistake.