### PR TITLE
config.get -> config.get_value / extra config declarations [2.10 backport]

### DIFF
--- a/changes/7257.feature
+++ b/changes/7257.feature
@@ -1,2 +1,22 @@
-`toolkit.asbool` now converts any iterable other than `list` and `tuple` into a `list`: `list(value)`.
-Before, such values were just wrapped into a list, i.e: `[value]`
+`toolkit.aslist` now converts any iterable other than ``list`` and `tuple` into a ``list``: ``list(value)``.
+Before, such values were just wrapped into a list, i.e: ``[value]``.
+
+.. list-table:: Short overview of changes
+   :widths: 40 30 30
+   :header-rows: 1
+
+   * - Expresion
+     - Before
+     - After
+   * - ``aslist([1,2])``
+     - ``[1, 2]``
+     - ``[1, 2]``
+   * - ``aslist({1,2})``
+     - ``[{1, 2}]``
+     - ``[1, 2]``
+   * - ``aslist({1: "one", 2: "two"})``
+     - ``[{1: "one", 2: "two"}]``
+     - ``[1, 2]``
+   * - ``aslist(range(1,3))``
+     - ``[range(1, 3)]``
+     - ``[1, 2]``

--- a/changes/7257.feature
+++ b/changes/7257.feature
@@ -1,0 +1,2 @@
+`toolkit.asbool` now converts any iterable other than `list` and `tuple` into a `list`: `list(value)`.
+Before, such values were just wrapped into a list, i.e: `[value]`

--- a/ckan/common.py
+++ b/ckan/common.py
@@ -10,10 +10,10 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import MutableMapping
+from collections.abc import MutableMapping, Iterable
 
 from typing import (
-    Any, Iterable, Optional, TYPE_CHECKING,
+    Any, Optional, TYPE_CHECKING,
     TypeVar, cast, overload, Container, Union)
 from typing_extensions import Literal
 
@@ -261,6 +261,8 @@ def aslist(obj: Any, sep: Optional[str] = None, strip: bool = True) -> Any:
         return lst
     elif isinstance(obj, (list, tuple)):
         return cast(Any, obj)
+    elif isinstance(obj, Iterable):
+        return list(obj)
     elif obj is None:
         return []
     else:

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -1258,15 +1258,44 @@ groups:
 
       - key: ckan.default.package_type
         default: dataset
-        description: Default type of dataset that used in UI links(eg. **New Dataset**)
+        description: |
+          Default type of dataset that will be used in the UI links (eg. "New Dataset").
+
+          Use this option to change the dataset type that is used site-wide. Only existing dataset
+          types can be used as a value for this option. Upon setting a custom value, the following
+          happens:
+
+          * all new datasets have their ``type`` field set to the custom value(if no explicit value provided)
+          * all labels(e.g. "Create a Dataset", "My datasets", "Search datasets..") are adapted to the custom value
+          * all default links(e.g. ``/dataset/new``, ``/dataset/<name>/resource``) are adapted to the custom value
+
+          If labels require additional changes, register a chained helpers for :py:func:`~ckan.lib.helpers.humanize_entity_type`.
+          For example, setting a dataset type ``camel_photo`` as default, will turn the "Datasets" link in the header into
+          "Camel-photos". If "Camel Photos" is expected, the code below can be used::
+
+              @p.toolkit.chained_helper
+              def humanize_entity_type(next_helper: Callable[..., Any],
+                                       entity_type: str, object_type: str, purpose: str):
+                  if purpose == "main nav":
+                      return "Camel Photos"
+
+                  return next_helper(entity_type, object_type, purpose)
+
+          See :py:func:`~ckan.lib.helpers.humanize_entity_type` for additional details.
 
       - key: ckan.default.group_type
         default: group
-        description: Default type of group that used in UI links(eg. **New Group** button, **Groups** link in header)
+        description: |
+          Default type of group that used in UI links(eg. "New Group" button, "Groups" link in header)
+
+          Same as :ref:`ckan.default.package_type`, but for groups.
 
       - key: ckan.default.organization_type
         default: organization
-        description: Default type of group that used in UI links(eg. **New Organization** button, **Organizations** link in header)
+        description: |
+          Default type of group that used in UI links(eg. "New Organization" button, "Organizations" link in header)
+
+          Same as :ref:`ckan.default.package_type`, but for organizations.
 
       - key: ckan.admin_tabs
         default: {}

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -7,8 +7,6 @@ groups:
         internal: true
       - key: here
         internal: true
-      - key: ckan.admin_tabs
-        internal: true
       - key: plugin_template_paths
         ignored: true
       - key: plugin_public_paths
@@ -637,38 +635,46 @@ groups:
       - key: WTF_CSRF_ENABLED
         type: bool
         default: True
-        description: Set to False to disable all CSRF protection. Default is True.
+        description: Set to False to disable all CSRF protection.
 
       - key: WTF_CSRF_CHECK_DEFAULT
         type: bool
         default: True
         description: |
           When using the CSRF protection extension,
-          this controls whether every view is protected by default. Default is True.
+          this controls whether every view is protected by default.
 
       - key: WTF_CSRF_SECRET_KEY
         description: Random data for generating secure tokens.
         placeholder_callable: secrets:token_urlsafe
 
       - key: WTF_CSRF_METHODS
-        default: {'POST', 'PUT', 'PATCH', 'DELETE'}
-        description: HTTP methods to protect from CSRF. Default is {'POST', 'PUT', 'PATCH', 'DELETE'}.
+        type: list
+        default:
+          - POST
+          - PUT
+          - PATCH
+          - DELETE
+
+        description: HTTP methods to protect from CSRF.
 
       - key: WTF_CSRF_FIELD_NAME
         default: csrf_token
-        description: Name of the form field and session key that holds the CSRF token. Default is csrf_token.
+        description: Name of the form field and session key that holds the CSRF token.
 
       - key: WTF_CSRF_HEADERS
-        default: ['X-CSRFToken', 'X-CSRF-Token']
+        type: list
+        default:
+          - X-CSRFToken
+          - X-CSRF-Token
         description: |
           HTTP headers to search for CSRF token when it is not provided in the form.
-          Default is ['X-CSRFToken', 'X-CSRF-Token'].
 
       - key: WTF_CSRF_TIME_LIMIT
         default: 3600
         description: |
           Max age in seconds for CSRF tokens.
-          Default is 3600. If set to None, the CSRF token is valid for the life of the session.
+          If set to None, the CSRF token is valid for the life of the session.
 
       - key: WTF_CSRF_SSL_STRICT
         type: bool
@@ -682,7 +688,15 @@ groups:
         default: True
         description: |
           Set to False to disable Flask-Babel I18N support.
-          Also set to False if you want to use WTForms’s built-in messages directly, see more info here. Default is True.
+          Also set to False if you want to use WTForms’s built-in messages directly, see more info here.
+
+      - key: ckan.csrf_protection.ignore_extensions
+        type: bool
+        default: true
+        description: |
+          Exempt plugins blueprints from CSRF protection.
+
+          .. warning:: This feature will be deprecated in future versions.
 
   - annotation: Flask-Login Remember me cookie settings
     options:
@@ -1142,7 +1156,6 @@ groups:
         description: Custom CSS directives to include on all CKAN pages.
         editable: true
 
-
   - annotation: Resource Views Settings
     options:
       - key: ckan.views.default_views
@@ -1237,16 +1250,29 @@ groups:
 
       - key: ckan.base_templates_folder
         default: templates
-        example: templates
+        example: templates-bs3
         description: |
           This config option is used to configure the base folder for templates used
           by CKAN core. It is currently unused and it only accepts one value: ``templates``
           (Bootstrap 3, the default value from CKAN 2.8 onwards).
 
+      - key: ckan.default.package_type
+        default: dataset
+        description: Default type of dataset that used in UI links(eg. **New Dataset**)
+
       - key: ckan.default.group_type
         default: group
+        description: Default type of group that used in UI links(eg. **New Group** button, **Groups** link in header)
+
       - key: ckan.default.organization_type
         default: organization
+        description: Default type of group that used in UI links(eg. **New Organization** button, **Organizations** link in header)
+
+      - key: ckan.admin_tabs
+        default: {}
+        example: '{"home.about": {"icon": "hammer", "label": "Hammer!"}}'
+        validators: convert_to_json_if_string dict_only
+        description: Extra navigation items for Sysadmin Settings.
 
   - annotation: Storage Settings
     options:

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -178,7 +178,7 @@ def update_config() -> None:
 
     # Templates and CSS loading from configuration
     valid_base_templates_folder_names = ['templates', 'templates-bs3']
-    templates = config.get('ckan.base_templates_folder', 'templates')
+    templates = config.get_value('ckan.base_templates_folder')
     config['ckan.base_templates_folder'] = templates
 
     if templates not in valid_base_templates_folder_names:

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -268,7 +268,7 @@ def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:
     # Set up each IBlueprint extension as a Flask Blueprint
     _register_plugins_blueprints(app)
 
-    if asbool(config.get("ckan.csrf_protection.ignore_extensions", True)):
+    if config.get_value("ckan.csrf_protection.ignore_extensions"):
         log.warn(csrf_warn_extensions)
         _exempt_plugins_blueprints_from_csrf(csrf)
 

--- a/ckan/lib/captcha.py
+++ b/ckan/lib/captcha.py
@@ -5,8 +5,6 @@ import requests
 from ckan.common import config
 from ckan.types import Request
 
-TIMEOUT = config.get_value('ckan.requests.timeout')
-
 
 def check_recaptcha(request: Request) -> None:
     '''Check a user\'s recaptcha submission is valid, and raise CaptchaError
@@ -31,7 +29,9 @@ def check_recaptcha(request: Request) -> None:
         remoteip=client_ip_address,
         response=recaptcha_response_field.encode('utf8')
     )
-    response = requests.get(recaptcha_server_name, params, timeout=TIMEOUT)
+    response = requests.get(
+        recaptcha_server_name, params,
+        timeout=config.get_value('ckan.requests.timeout'))
     data = response.json()
 
     try:

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -375,7 +375,7 @@ def group_dictize(group: model.Group, context: Context,
                 if is_group_member:
                     q['include_private'] = True
                 else:
-                    if config.get('ckan.auth.allow_dataset_collaborators'):
+                    if config.get_value('ckan.auth.allow_dataset_collaborators'):
                         q['include_private'] = True
 
             if not just_the_count:

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1016,7 +1016,8 @@ def humanize_entity_type(entity_type: str, object_type: str,
       >>> humanize_entity_type('group', 'custom_group', 'not real purpuse')
       'Custom Group'
 
-    Possible purposes(depends on `entity_type` and change over time):
+    Possible purposes(depends on `entity_type` and change over time)::
+
         `add link`: "Add [object]" button on search pages
         `breadcrumb`: "Home / [object]s / New" section in breadcrums
         `content tab`: "[object]s | Groups | Activity" tab on details page

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -924,7 +924,7 @@ def build_extra_admin_nav() -> Markup:
     :rtype: HTML literal
 
     '''
-    admin_tabs_dict = config.get('ckan.admin_tabs', {})
+    admin_tabs_dict = config.get_value('ckan.admin_tabs')
     output: Markup = literal('')
     if admin_tabs_dict:
         for k, v in admin_tabs_dict.items():
@@ -978,7 +978,7 @@ def default_group_type(type_: str) -> str:
 def default_package_type() -> str:
     """Get default package type for using site-wide.
     """
-    return str(config.get('ckan.default.package_type', "dataset"))
+    return config.get_value('ckan.default.package_type')
 
 
 def _humanize_activity(object_type: str, activity_type: str) -> str:

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -37,7 +37,6 @@ from ckan.lib.search.index import SearchIndex
 
 log = logging.getLogger(__name__)
 
-TIMEOUT = config.get_value('ckan.requests.timeout')
 
 def text_traceback() -> str:
     info = sys.exc_info()
@@ -222,9 +221,9 @@ def rebuild(package_id: Optional[str] = None,
         packages = model.Session.query(model.Package.id)
         if config.get_value('ckan.search.remove_deleted_packages'):
             packages = packages.filter(model.Package.state != 'deleted')
-        
+
         package_ids = [r[0] for r in packages.all()]
-        
+
         if only_missing:
             log.info('Indexing only missing packages...')
             package_query = query_for(model.Package)
@@ -315,13 +314,15 @@ def _get_schema_from_solr(file_offset: str):
 
     url = solr_url.strip('/') + file_offset
 
+    timeout = config.get_value('ckan.requests.timeout')
     if solr_user is not None and solr_password is not None:
         response = requests.get(
             url,
-            timeout=TIMEOUT,
+            timeout=timeout,
             auth=HTTPBasicAuth(solr_user, solr_password))
     else:
-        response = requests.get(url, timeout=TIMEOUT)
+        response = requests.get(
+            url, timeout=timeout)
 
     return response
 

--- a/ckan/model/license.py
+++ b/ckan/model/license.py
@@ -14,7 +14,6 @@ from ckan.common import _, json
 
 log = logging.getLogger(__name__)
 
-TIMEOUT = config.get_value('ckan.requests.timeout')
 
 class License():
     """Domain object for a license."""
@@ -82,7 +81,9 @@ class LicenseRegister(object):
                 with open(license_url.replace('file://', ''), 'r') as f:
                     license_data = json.load(f)
             else:
-                response = requests.get(license_url, timeout=TIMEOUT)
+                response = requests.get(
+                    license_url,
+                    timeout=config.get_value('ckan.requests.timeout'))
                 license_data = response.json()
         except requests.RequestException as e:
             msg = "Couldn't get the licenses file {}: {}".format(license_url, e)

--- a/ckan/model/user.py
+++ b/ckan/model/user.py
@@ -23,7 +23,7 @@ from ckan.model import meta
 from ckan.model import core
 from ckan.model import types as _types
 from ckan.model import domain_object
-from ckan.common import config, asint, session
+from ckan.common import config, session
 from ckan.types import Query
 
 if TYPE_CHECKING:
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 
 def last_active_check():
-    last_active = asint(config.get('ckan.user.last_active_interval', 600))
+    last_active = config.get_value('ckan.user.last_active_interval')
     calc_time = datetime.datetime.utcnow() - datetime.timedelta(seconds=last_active)
 
     return calc_time

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -198,7 +198,7 @@ def add_ckan_admin_tab(
     Update 'ckan.admin_tabs' dict the passed config dict.
     """
     # get the admin_tabs dict from the config, or an empty dict.
-    admin_tabs_dict = config_.get(config_var, {})
+    admin_tabs_dict = config_.get_value(config_var)
     # update the admin_tabs dict with the new values
     admin_tabs_dict.update({route_name: {"label": tab_label, "icon": icon}})
     # update the config with the updated admin_tabs dict

--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -25,8 +25,6 @@ log = logging.getLogger(__name__)
 _get_or_bust = logic.get_or_bust
 _validate = ckan.lib.navl.dictization_functions.validate
 
-TIMEOUT = config.get_value('ckan.requests.timeout')
-
 
 def datapusher_submit(context: Context, data_dict: dict[str, Any]):
     ''' Submit a job to the datapusher. The datapusher is a service that
@@ -132,14 +130,14 @@ def datapusher_submit(context: Context, data_dict: dict[str, Any]):
     p.toolkit.get_action('task_status_update')(context, task)
 
     # This setting is checked on startup
-    api_token = p.toolkit.config.get("ckan.datapusher.api_token")
+    api_token = p.toolkit.config.get_value("ckan.datapusher.api_token")
     try:
         r = requests.post(
             urljoin(datapusher_url, 'job'),
             headers={
                 'Content-Type': 'application/json'
             },
-            timeout=TIMEOUT,
+            timeout=config.get_value('ckan.requests.timeout'),
             data=json.dumps({
                 'api_key': api_token,
                 'job_type': 'push_to_datastore',
@@ -309,7 +307,7 @@ def datapusher_status(
         url = urljoin(datapusher_url, 'job' + '/' + job_id)
         try:
             r = requests.get(url,
-                             timeout=TIMEOUT,
+                             timeout=config.get_value('ckan.requests.timeout'),
                              headers={'Content-Type': 'application/json',
                                       'Authorization': job_key})
             r.raise_for_status()

--- a/ckanext/example_iconfigurer/tests/test_iconfigurer_toolkit.py
+++ b/ckanext/example_iconfigurer/tests/test_iconfigurer_toolkit.py
@@ -3,6 +3,7 @@
 import ckan.plugins.toolkit as toolkit
 from ckan.common import CKANConfig
 
+
 class TestIConfigurerToolkitAddCkanAdminTab(object):
 
     """

--- a/ckanext/example_iconfigurer/tests/test_iconfigurer_toolkit.py
+++ b/ckanext/example_iconfigurer/tests/test_iconfigurer_toolkit.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 import ckan.plugins.toolkit as toolkit
-
+from ckan.common import CKANConfig
 
 class TestIConfigurerToolkitAddCkanAdminTab(object):
 
@@ -11,7 +11,7 @@ class TestIConfigurerToolkitAddCkanAdminTab(object):
 
     def test_add_ckan_admin_tab_updates_config_dict(self):
         """Config dict updated by toolkit.add_ckan_admin_tabs method."""
-        config = {}
+        config = CKANConfig()
 
         toolkit.add_ckan_admin_tab(config, "my_route_name", "my_label")
 
@@ -26,7 +26,7 @@ class TestIConfigurerToolkitAddCkanAdminTab(object):
         Calling add_ckan_admin_tab twice with same values returns expected
         config.
         """
-        config = {}
+        config = CKANConfig()
 
         toolkit.add_ckan_admin_tab(config, "my_route_name", "my_label")
         toolkit.add_ckan_admin_tab(config, "my_route_name", "my_label")
@@ -44,7 +44,7 @@ class TestIConfigurerToolkitAddCkanAdminTab(object):
         Calling add_ckan_admin_tab twice with a different value returns
         expected config.
         """
-        config = {}
+        config = CKANConfig()
 
         toolkit.add_ckan_admin_tab(config, "my_route_name", "my_label")
         toolkit.add_ckan_admin_tab(
@@ -66,7 +66,7 @@ class TestIConfigurerToolkitAddCkanAdminTab(object):
         """
         Add two different route/label pairs to ckan.admin_tabs.
         """
-        config = {}
+        config = CKANConfig()
 
         toolkit.add_ckan_admin_tab(config, "my_route_name", "my_label")
         toolkit.add_ckan_admin_tab(
@@ -89,14 +89,14 @@ class TestIConfigurerToolkitAddCkanAdminTab(object):
         """
         Config already has a ckan.admin_tabs option.
         """
-        config = {
+        config = CKANConfig(**{
             "ckan.admin_tabs": {
                 "my_existing_route": {
                     "label": "my_existing_label",
                     "icon": None,
                 }
             }
-        }
+        })
 
         toolkit.add_ckan_admin_tab(config, "my_route_name", "my_label")
         toolkit.add_ckan_admin_tab(
@@ -123,7 +123,7 @@ class TestIConfigurerToolkitAddCkanAdminTab(object):
         """
         Config already has existing other option.
         """
-        config = {"ckan.my_option": "This is my option"}
+        config = CKANConfig(**{"ckan.my_option": "This is my option"})
 
         toolkit.add_ckan_admin_tab(config, "my_route_name", "my_label")
         toolkit.add_ckan_admin_tab(


### PR DESCRIPTION
Backport of #7257
❗ Check description of original PR before reviewing this one

* Change a couple of `config.get` to `config.get_value` 
* Add a few missing config declarations
* do not access the `config` object on the module level because it evaluates only once when the module is imported. All future changes to the config object are ignored.