### PR TITLE
config.get -> config.get_value / extra config declarations

### DIFF
--- a/changes/7257.feature
+++ b/changes/7257.feature
@@ -1,2 +1,2 @@
-`toolkit.asbool` now converts any iterable other than `list` and `tuple` into a `list`: `list(value)`.
+`toolkit.aslist` now converts any iterable other than `list` and `tuple` into a `list`: `list(value)`.
 Before, such values were just wrapped into a list, i.e: `[value]`

--- a/changes/7257.feature
+++ b/changes/7257.feature
@@ -1,2 +1,22 @@
-`toolkit.aslist` now converts any iterable other than `list` and `tuple` into a `list`: `list(value)`.
-Before, such values were just wrapped into a list, i.e: `[value]`
+`toolkit.aslist` now converts any iterable other than ``list`` and `tuple` into a ``list``: ``list(value)``.
+Before, such values were just wrapped into a list, i.e: ``[value]``.
+
+.. list-table:: Short overview of changes
+   :widths: 40 30 30
+   :header-rows: 1
+
+   * - Expresion
+     - Before
+     - After
+   * - ``aslist([1,2])``
+     - ``[1, 2]``
+     - ``[1, 2]``
+   * - ``aslist({1,2})``
+     - ``[{1, 2}]``
+     - ``[1, 2]``
+   * - ``aslist({1: "one", 2: "two"})``
+     - ``[{1: "one", 2: "two"}]``
+     - ``[1, 2]``
+   * - ``aslist(range(1,3))``
+     - ``[range(1, 3)]``
+     - ``[1, 2]``

--- a/changes/7257.feature
+++ b/changes/7257.feature
@@ -1,0 +1,2 @@
+`toolkit.asbool` now converts any iterable other than `list` and `tuple` into a `list`: `list(value)`.
+Before, such values were just wrapped into a list, i.e: `[value]`

--- a/ckan/common.py
+++ b/ckan/common.py
@@ -10,10 +10,10 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import MutableMapping
+from collections.abc import MutableMapping, Iterable
 
 from typing import (
-    Any, Iterable, Optional, TYPE_CHECKING,
+    Any, Optional, TYPE_CHECKING,
     TypeVar, cast, overload, Container, Union)
 from typing_extensions import Literal
 
@@ -261,6 +261,8 @@ def aslist(obj: Any, sep: Optional[str] = None, strip: bool = True) -> Any:
         return lst
     elif isinstance(obj, (list, tuple)):
         return cast(Any, obj)
+    elif isinstance(obj, Iterable):
+        return list(obj)
     elif obj is None:
         return []
     else:

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -7,8 +7,6 @@ groups:
         internal: true
       - key: here
         internal: true
-      - key: ckan.admin_tabs
-        internal: true
       - key: plugin_template_paths
         ignored: true
       - key: plugin_public_paths
@@ -641,38 +639,46 @@ groups:
       - key: WTF_CSRF_ENABLED
         type: bool
         default: True
-        description: Set to False to disable all CSRF protection. Default is True.
+        description: Set to False to disable all CSRF protection.
 
       - key: WTF_CSRF_CHECK_DEFAULT
         type: bool
         default: True
         description: |
           When using the CSRF protection extension,
-          this controls whether every view is protected by default. Default is True.
+          this controls whether every view is protected by default.
 
       - key: WTF_CSRF_SECRET_KEY
         description: Random data for generating secure tokens.
         placeholder_callable: secrets:token_urlsafe
 
       - key: WTF_CSRF_METHODS
-        default: {'POST', 'PUT', 'PATCH', 'DELETE'}
-        description: HTTP methods to protect from CSRF. Default is {'POST', 'PUT', 'PATCH', 'DELETE'}.
+        type: list
+        default:
+          - POST
+          - PUT
+          - PATCH
+          - DELETE
+
+        description: HTTP methods to protect from CSRF.
 
       - key: WTF_CSRF_FIELD_NAME
         default: csrf_token
-        description: Name of the form field and session key that holds the CSRF token. Default is csrf_token.
+        description: Name of the form field and session key that holds the CSRF token.
 
       - key: WTF_CSRF_HEADERS
-        default: ['X-CSRFToken', 'X-CSRF-Token']
+        type: list
+        default:
+          - X-CSRFToken
+          - X-CSRF-Token
         description: |
           HTTP headers to search for CSRF token when it is not provided in the form.
-          Default is ['X-CSRFToken', 'X-CSRF-Token'].
 
       - key: WTF_CSRF_TIME_LIMIT
         default: 3600
         description: |
           Max age in seconds for CSRF tokens.
-          Default is 3600. If set to None, the CSRF token is valid for the life of the session.
+          If set to None, the CSRF token is valid for the life of the session.
 
       - key: WTF_CSRF_SSL_STRICT
         type: bool
@@ -686,7 +692,15 @@ groups:
         default: True
         description: |
           Set to False to disable Flask-Babel I18N support.
-          Also set to False if you want to use WTForms’s built-in messages directly, see more info here. Default is True.
+          Also set to False if you want to use WTForms’s built-in messages directly, see more info here.
+
+      - key: ckan.csrf_protection.ignore_extensions
+        type: bool
+        default: true
+        description: |
+          Exempt plugins blueprints from CSRF protection.
+
+          .. warning:: This feature will be deprecated in future versions.
 
   - annotation: Flask-Login Remember me cookie settings
     options:
@@ -1146,7 +1160,6 @@ groups:
         description: Custom CSS directives to include on all CKAN pages.
         editable: true
 
-
   - annotation: Resource Views Settings
     options:
       - key: ckan.views.default_views
@@ -1241,16 +1254,29 @@ groups:
 
       - key: ckan.base_templates_folder
         default: templates
-        example: templates
+        example: templates-bs3
         description: |
           This config option is used to configure the base folder for templates used
           by CKAN core. It is currently unused and it only accepts one value: ``templates``
           (Bootstrap 3, the default value from CKAN 2.8 onwards).
 
+      - key: ckan.default.package_type
+        default: dataset
+        description: Default type of dataset that used in UI links(eg. **New Dataset**)
+
       - key: ckan.default.group_type
         default: group
+        description: Default type of group that used in UI links(eg. **New Group** button, **Groups** link in header)
+
       - key: ckan.default.organization_type
         default: organization
+        description: Default type of group that used in UI links(eg. **New Organization** button, **Organizations** link in header)
+
+      - key: ckan.admin_tabs
+        default: {}
+        example: '{"home.about": {"icon": "hammer", "label": "Hammer!"}}'
+        validators: convert_to_json_if_string dict_only
+        description: Extra navigation items for Sysadmin Settings.
 
   - annotation: Storage Settings
     options:

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -1262,7 +1262,7 @@ groups:
 
       - key: ckan.default.package_type
         default: dataset
-        description: Default type of dataset that used in UI links(eg. **New Dataset**)
+        description: Default type of dataset that will be used in the UI links (eg. "New Dataset")
 
       - key: ckan.default.group_type
         default: group

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -1262,15 +1262,44 @@ groups:
 
       - key: ckan.default.package_type
         default: dataset
-        description: Default type of dataset that will be used in the UI links (eg. "New Dataset")
+        description: |
+          Default type of dataset that will be used in the UI links (eg. "New Dataset").
+
+          Use this option to change the dataset type that is used site-wide. Only existing dataset
+          types can be used as a value for this option. Upon setting a custom value, the following
+          happens:
+
+          * all new datasets have their ``type`` field set to the custom value(if no explicit value provided)
+          * all labels(e.g. "Create a Dataset", "My datasets", "Search datasets..") are adapted to the custom value
+          * all default links(e.g. ``/dataset/new``, ``/dataset/<name>/resource``) are adapted to the custom value
+
+          If labels require additional changes, register a chained helpers for :py:func:`~ckan.lib.helpers.humanize_entity_type`.
+          For example, setting a dataset type ``camel_photo`` as default, will turn the "Datasets" link in the header into
+          "Camel-photos". If "Camel Photos" is expected, the code below can be used::
+
+              @p.toolkit.chained_helper
+              def humanize_entity_type(next_helper: Callable[..., Any],
+                                       entity_type: str, object_type: str, purpose: str):
+                  if purpose == "main nav":
+                      return "Camel Photos"
+
+                  return next_helper(entity_type, object_type, purpose)
+
+          See :py:func:`~ckan.lib.helpers.humanize_entity_type` for additional details.
 
       - key: ckan.default.group_type
         default: group
-        description: Default type of group that used in UI links(eg. **New Group** button, **Groups** link in header)
+        description: |
+          Default type of group that used in UI links(eg. "New Group" button, "Groups" link in header)
+
+          Same as :ref:`ckan.default.package_type`, but for groups.
 
       - key: ckan.default.organization_type
         default: organization
-        description: Default type of group that used in UI links(eg. **New Organization** button, **Organizations** link in header)
+        description: |
+          Default type of group that used in UI links(eg. "New Organization" button, "Organizations" link in header)
+
+          Same as :ref:`ckan.default.package_type`, but for organizations.
 
       - key: ckan.admin_tabs
         default: {}

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -178,7 +178,7 @@ def update_config() -> None:
 
     # Templates and CSS loading from configuration
     valid_base_templates_folder_names = ['templates', 'templates-bs3']
-    templates = config.get('ckan.base_templates_folder', 'templates')
+    templates = config.get_value('ckan.base_templates_folder')
     config['ckan.base_templates_folder'] = templates
 
     if templates not in valid_base_templates_folder_names:

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -268,7 +268,7 @@ def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:
     # Set up each IBlueprint extension as a Flask Blueprint
     _register_plugins_blueprints(app)
 
-    if asbool(config.get("ckan.csrf_protection.ignore_extensions", True)):
+    if config.get_value("ckan.csrf_protection.ignore_extensions"):
         log.warn(csrf_warn_extensions)
         _exempt_plugins_blueprints_from_csrf(csrf)
 

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -375,7 +375,7 @@ def group_dictize(group: model.Group, context: Context,
                 if is_group_member:
                     q['include_private'] = True
                 else:
-                    if config.get('ckan.auth.allow_dataset_collaborators'):
+                    if config.get_value('ckan.auth.allow_dataset_collaborators'):
                         q['include_private'] = True
 
             if not just_the_count:

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1016,7 +1016,8 @@ def humanize_entity_type(entity_type: str, object_type: str,
       >>> humanize_entity_type('group', 'custom_group', 'not real purpuse')
       'Custom Group'
 
-    Possible purposes(depends on `entity_type` and change over time):
+    Possible purposes(depends on `entity_type` and change over time)::
+
         `add link`: "Add [object]" button on search pages
         `breadcrumb`: "Home / [object]s / New" section in breadcrums
         `content tab`: "[object]s | Groups | Activity" tab on details page

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -924,7 +924,7 @@ def build_extra_admin_nav() -> Markup:
     :rtype: HTML literal
 
     '''
-    admin_tabs_dict = config.get('ckan.admin_tabs', {})
+    admin_tabs_dict = config.get_value('ckan.admin_tabs')
     output: Markup = literal('')
     if admin_tabs_dict:
         for k, v in admin_tabs_dict.items():
@@ -978,7 +978,7 @@ def default_group_type(type_: str) -> str:
 def default_package_type() -> str:
     """Get default package type for using site-wide.
     """
-    return str(config.get('ckan.default.package_type', "dataset"))
+    return config.get_value('ckan.default.package_type')
 
 
 def _humanize_activity(object_type: str, activity_type: str) -> str:

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -317,6 +317,7 @@ def _get_schema_from_solr(file_offset: str):
 
     url = solr_url.strip('/') + file_offset
 
+    timeout = config.get_value('ckan.requests.timeout')
     if solr_user is not None and solr_password is not None:
         response = requests.get(
             url,

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -317,7 +317,6 @@ def _get_schema_from_solr(file_offset: str):
 
     url = solr_url.strip('/') + file_offset
 
-    timeout = config.get_value('ckan.requests.timeout')
     if solr_user is not None and solr_password is not None:
         response = requests.get(
             url,

--- a/ckan/model/user.py
+++ b/ckan/model/user.py
@@ -23,7 +23,7 @@ from ckan.model import meta
 from ckan.model import core
 from ckan.model import types as _types
 from ckan.model import domain_object
-from ckan.common import config, asint, session
+from ckan.common import config, session
 from ckan.types import Query
 
 if TYPE_CHECKING:
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 
 def last_active_check():
-    last_active = asint(config.get('ckan.user.last_active_interval', 600))
+    last_active = config.get_value('ckan.user.last_active_interval')
     calc_time = datetime.datetime.utcnow() - datetime.timedelta(seconds=last_active)
 
     return calc_time

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -198,7 +198,7 @@ def add_ckan_admin_tab(
     Update 'ckan.admin_tabs' dict the passed config dict.
     """
     # get the admin_tabs dict from the config, or an empty dict.
-    admin_tabs_dict = config_.get(config_var, {})
+    admin_tabs_dict = config_.get_value(config_var)
     # update the admin_tabs dict with the new values
     admin_tabs_dict.update({route_name: {"label": tab_label, "icon": icon}})
     # update the config with the updated admin_tabs dict

--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -132,7 +132,7 @@ def datapusher_submit(context: Context, data_dict: dict[str, Any]):
     timeout = config.get_value('ckan.requests.timeout')
 
     # This setting is checked on startup
-    api_token = p.toolkit.config.get("ckan.datapusher.api_token")
+    api_token = p.toolkit.config.get_value("ckan.datapusher.api_token")
     try:
         r = requests.post(
             urljoin(datapusher_url, 'job'),

--- a/ckanext/example_iconfigurer/tests/test_iconfigurer_toolkit.py
+++ b/ckanext/example_iconfigurer/tests/test_iconfigurer_toolkit.py
@@ -3,6 +3,7 @@
 import ckan.plugins.toolkit as toolkit
 from ckan.common import CKANConfig
 
+
 class TestIConfigurerToolkitAddCkanAdminTab(object):
 
     """

--- a/ckanext/example_iconfigurer/tests/test_iconfigurer_toolkit.py
+++ b/ckanext/example_iconfigurer/tests/test_iconfigurer_toolkit.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 import ckan.plugins.toolkit as toolkit
-
+from ckan.common import CKANConfig
 
 class TestIConfigurerToolkitAddCkanAdminTab(object):
 
@@ -11,7 +11,7 @@ class TestIConfigurerToolkitAddCkanAdminTab(object):
 
     def test_add_ckan_admin_tab_updates_config_dict(self):
         """Config dict updated by toolkit.add_ckan_admin_tabs method."""
-        config = {}
+        config = CKANConfig()
 
         toolkit.add_ckan_admin_tab(config, "my_route_name", "my_label")
 
@@ -26,7 +26,7 @@ class TestIConfigurerToolkitAddCkanAdminTab(object):
         Calling add_ckan_admin_tab twice with same values returns expected
         config.
         """
-        config = {}
+        config = CKANConfig()
 
         toolkit.add_ckan_admin_tab(config, "my_route_name", "my_label")
         toolkit.add_ckan_admin_tab(config, "my_route_name", "my_label")
@@ -44,7 +44,7 @@ class TestIConfigurerToolkitAddCkanAdminTab(object):
         Calling add_ckan_admin_tab twice with a different value returns
         expected config.
         """
-        config = {}
+        config = CKANConfig()
 
         toolkit.add_ckan_admin_tab(config, "my_route_name", "my_label")
         toolkit.add_ckan_admin_tab(
@@ -66,7 +66,7 @@ class TestIConfigurerToolkitAddCkanAdminTab(object):
         """
         Add two different route/label pairs to ckan.admin_tabs.
         """
-        config = {}
+        config = CKANConfig()
 
         toolkit.add_ckan_admin_tab(config, "my_route_name", "my_label")
         toolkit.add_ckan_admin_tab(
@@ -89,14 +89,14 @@ class TestIConfigurerToolkitAddCkanAdminTab(object):
         """
         Config already has a ckan.admin_tabs option.
         """
-        config = {
+        config = CKANConfig(**{
             "ckan.admin_tabs": {
                 "my_existing_route": {
                     "label": "my_existing_label",
                     "icon": None,
                 }
             }
-        }
+        })
 
         toolkit.add_ckan_admin_tab(config, "my_route_name", "my_label")
         toolkit.add_ckan_admin_tab(
@@ -123,7 +123,7 @@ class TestIConfigurerToolkitAddCkanAdminTab(object):
         """
         Config already has existing other option.
         """
-        config = {"ckan.my_option": "This is my option"}
+        config = CKANConfig(**{"ckan.my_option": "This is my option"})
 
         toolkit.add_ckan_admin_tab(config, "my_route_name", "my_label")
         toolkit.add_ckan_admin_tab(


### PR DESCRIPTION
❗  contains a breaking change

* Change a couple of `config.get` to `config.get_value` 
* Add a few missing config declarations

### Breaking change

Before, `toolkit.aslist` wrapped any value other than str/list/tuple into a list. I.e `aslist({1,2}) -> [{1,2}]`. Now iterables will be converted to the list, i.e `aslist({1,2}) -> list({1,2}) -> [1,2]`. Non-iterables behave in the same way: `aslist(1) -> [1]` 

Not sure if such a change is acceptable. But documentation of this method has no mention of types other than `str`, so there were no guarantees, right? :)
In this particular case, we need this change because of the `WTF_CSRF_METHODS` config options. It's declared as a list, but internally flask-wtf converts it into the set. *If* validators are applied to this converted value again(it generally happens only in tests, but it's a possible case for the real world as well and I even mentioned in in [the docs](https://docs.ckan.org/en/latest/maintaining/configuration.html#declaring-config-options) - check first note about idempotence of validators), we'll get `aslist({"POST", "PUT"}) -> [{"POST", "PUT"}]`. And then we'll get a type error when `flask-wtf` try to convert this value into a set once again.

*We can* create a separate validator or even declaration type(i.e, allow using something like `type: set` in the declaration file), but:
* It's really a rare case. Even though I would choose it, there is a second reason:
* We are releasing a new CKAN version. It's the best time to introduce breaking changes. And this particular change makes code more intuitive, isn't it?

ℹ️ Tests are fixed in #7254 
