### PR TITLE
Use http://localhost:5000 as default for ckan.site_url

### DIFF
--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -359,7 +359,7 @@ groups:
       - key: ckan.site_url
         validators: not_empty
         required: true
-        placeholder: http://127.0.0.1:5000
+        placeholder: http://localhost:5000
         example: http://scotdata.ckan.net
         description: |
           Set this to the URL of your CKAN site. Many CKAN features that need an absolute URL to your


### PR DESCRIPTION
Instead of http://127.0.0.1:5000, for consistency with docs and `ckan.devserver.host`
