### PR TITLE
Fix user reset password

### DIFF
--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -885,6 +885,7 @@ class TestUser(object):
 
         assert "Error sending the email" in response
 
+
     def test_sysadmin_not_authorized(self, app):
         user = factories.User()
         env = {"REMOTE_USER": user["name"].encode("ascii")}
@@ -1037,6 +1038,21 @@ class TestUser(object):
 
         userobj = model.User.get(userobj.id)
         assert userobj.is_deleted(), userobj
+
+    @pytest.mark.ckan_config(u"ckan.auth.public_user_details", u"false")
+    def test_request_reset_public_user_details(self, app):
+        user = factories.User()
+        user_obj = helpers.model.User.by_name(user["name"])
+        create_reset_key(user_obj)
+        key = user_obj.reset_key
+        offset = url_for(
+            controller="user",
+            action="perform_reset",
+            id=user_obj.id,
+            key=key,
+        )
+        response = app.get(offset)
+        assert "Reset Your Password" in response
 
 
 @pytest.mark.usefixtures("clean_db", "with_request_context")

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -693,10 +693,18 @@ class PerformResetView(MethodView):
         except logic.NotAuthorized:
             base.abort(403, _(u'Unauthorized to reset password.'))
 
+        # Ignore auth for the user_show action only.
+        # user_show will fail for anon users if
+        # `ckan.auth.public_user_details` is False
+        context[u'ignore_auth'] = True
         try:
             user_dict = logic.get_action(u'user_show')(context, {u'id': id})
         except logic.NotFound:
             base.abort(404, _(u'User not found'))
+
+        # remove ignore auth for any future use of this context.
+        del(context[u'ignore_auth'])
+
         user_obj = context[u'user_obj']
         g.reset_key = request.params.get(u'key')
         if not mailer.verify_reset_link(user_obj, g.reset_key):


### PR DESCRIPTION
Fix issue where if ckan.auth.public_user_details is false, a user can't reset their password

Fixes #7624

### Proposed fixes:

Ignores auth when getting the user via user_show.

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
