### PR TITLE
Update setuptools requirement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,6 @@ jobs:
       - <<: *install_deps
       - run: |
           # Python Dependencies
-          pip install -r requirement-setuptools.txt
           pip install -r requirements.txt
           pip install -r dev-requirements.txt
           python setup.py develop

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -49,7 +49,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install python deps
-        run: pip install -r requirement-setuptools.txt -r requirements.txt -r dev-requirements.txt -e.
+        run: pip install -r requirements.txt -r dev-requirements.txt -e.
 
       - name: Init environment
         run: |

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install python deps
-        run: pip install -r requirement-setuptools.txt -r requirements.txt -r dev-requirements.txt -e.
+        run: pip install -r requirements.txt -r dev-requirements.txt -e.
       - name: Install node deps
         run: npm ci
       - name: Check types

--- a/.github/workflows/towncrier.yml
+++ b/.github/workflows/towncrier.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: '3.7'
           cache: 'pip'
       - name: Install python deps
-        run: pip install -r requirement-setuptools.txt -r requirements.txt -r dev-requirements.txt -e.
+        run: pip install -r requirements.txt -r dev-requirements.txt -e.
 
       - name: Check that changelog is updated
         run: towncrier check >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,6 @@ ENV PATH=${CKAN_VENV}/bin:${PATH}
 # Setup CKAN
 ADD . $CKAN_VENV/src/ckan/
 RUN ckan-pip3 install -U pip && \
-    ckan-pip3 install --upgrade --no-cache-dir -r $CKAN_VENV/src/ckan/requirement-setuptools.txt && \
     ckan-pip3 install --upgrade --no-cache-dir -r $CKAN_VENV/src/ckan/requirements.txt && \
     ckan-pip3 install -e $CKAN_VENV/src/ckan/ && \
     ln -s $CKAN_VENV/src/ckan/ckan/config/who.ini $CKAN_CONFIG/who.ini && \

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -25,6 +25,5 @@ include ckanext/datastore/allowed_functions.txt
 prune .git
 include CHANGELOG.txt
 include ckan/migration/README
-include requirement-setuptools.txt
 include requirements.txt
 include dev-requirements.txt

--- a/changes/7271.removal
+++ b/changes/7271.removal
@@ -1,0 +1,1 @@
+Removes requirement-setuptools.txt since we're compatible with all recent versions of setuptools.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -296,16 +296,6 @@ def get_latest_package_name(distro, py_version=None):
     return name
 
 
-def get_min_setuptools_version():
-    '''
-    Get the minimum setuptools version as defined in requirement-setuptools.txt
-    '''
-    filename = os.path.join(os.path.dirname(__file__), '..',
-                            'requirement-setuptools.txt')
-    with open(filename) as f:
-        return f.read().split('==')[1].strip()
-
-
 def config_defaults_from_declaration():
     from ckan.config.declaration import Declaration
     decl = Declaration()
@@ -396,7 +386,6 @@ write_substitutions_file(
     latest_package_name_bionic=get_latest_package_name('bionic'),
     latest_package_name_focal_py2=get_latest_package_name('focal', py_version=2),
     latest_package_name_focal_py3=get_latest_package_name('focal', py_version=3),
-    min_setuptools_version=get_min_setuptools_version(),
     **config_defaults_from_declaration()
 )
 

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -99,11 +99,10 @@ a. Create a Python `virtual environment <https://virtualenv.pypa.io/en/latest/>`
        |activate|
 
 
-b. Install the recommended ``setuptools`` version and up-to-date pip:
+b. Install an up-to-date pip:
 
    .. parsed-literal::
 
-       pip install setuptools==\ |min_setuptools_version|
        pip install --upgrade pip
 
 c. Install the CKAN source code into your virtualenv.

--- a/requirement-setuptools.txt
+++ b/requirement-setuptools.txt
@@ -1,1 +1,0 @@
-setuptools>=44.1.0

--- a/requirement-setuptools.txt
+++ b/requirement-setuptools.txt
@@ -1,1 +1,1 @@
-setuptools==44.1.0
+setuptools>=44.1.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,5 +2,4 @@
 
 -r requirements.txt
 -r dev-requirements.txt
--r requirement-setuptools.txt
 -e .

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ if os.environ.get("USER", "") == "vagrant":
 extras_require = {}
 _extras_groups = [
     ("requirements", "requirements.txt"),
-    ("setuptools", "requirement-setuptools.txt"),
     ("dev", "dev-requirements.txt"),
 ]
 


### PR DESCRIPTION
### Proposed fixes:
Unpin the old version of setuptools

The previous pin was likely for zope-interface < 5.0 or rdflib-jsonld, which was required for python 3.6 compatibility.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
