### PR TITLE
Fix package_update documentation

### DIFF
--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -253,7 +253,7 @@ def package_update(
     :param id: the name or id of the dataset to update
     :type id: string
 
-    :returns: the updated dataset (if ``'return_package_dict'`` is ``True`` in
+    :returns: the updated dataset (if ``'return_id_only'`` is ``False`` in
               the context, which is the default. Otherwise returns just the
               dataset id)
     :rtype: dictionary


### PR DESCRIPTION
### Proposed fixes:
Updates documentation as the code actually uses different parameter which is the same as in `package_create` https://github.com/ckan/ckan/blob/9da7a50af19cc032ba953bd264c36520cb58933a/ckan/logic/action/update.py#L358


### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
