### PR TITLE
Backport test fix to 2.9

### DIFF
--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -948,15 +948,15 @@ class TestUserList(object):
         users = [
             factories.User(fullname="Xander Bird", name="bird_x"),
             factories.User(fullname="Max Hankins", name="hankins_m"),
-            factories.User(fullname="", name="morgan_w"),
+            factories.User(fullname="", name="zoe_w"),
             factories.User(fullname="Kathy Tillman", name="tillman_k"),
         ]
         expected_names = [
             u['name'] for u in [
                 users[3],  # Kathy Tillman
                 users[1],  # Max Hankins
-                users[2],  # morgan_w
                 users[0],  # Xander Bird
+                users[2],  # zoe_w
             ]
         ]
 


### PR DESCRIPTION
This PR is a cherry-pick of [e16a35](https://github.com/ckan/ckan/commit/e16a35c08c3432c6d763747359a8a52f481ba5a1)

I'm backporting this fix to 2.9. This is currently "a flaky test" that depends on the locale of the database as explained in the original PR: https://github.com/ckan/ckan/pull/4635.

The goal is to keep tests on 2.9 consistent so we can run the new [CKAN Python Monitor](https://github.com/ckan/ckan-python-monitor) without them failing randomly.