### PR TITLE
Add use_debugger option for cli (ckan run) to prevent upstream debug conflicts

### DIFF
--- a/changes/7278.feature
+++ b/changes/7278.feature
@@ -1,0 +1,1 @@
+Added --disable-debugger option to CKAN cli `run` command.

--- a/ckan/cli/server.py
+++ b/ckan/cli/server.py
@@ -26,6 +26,8 @@ DEFAULT_PORT = 5000
               help=u"Disable reloader")
 @click.option(u"-E", u"--passthrough-errors", is_flag=True,
               help=u"Disable error caching (useful to hook debuggers)")
+@click.option(u"-D", u"--disable-debugger", is_flag=True,
+              help=u"Disable debugger to prevent conflict with external debug tools")
 @click.option(
     u"-t", u"--threaded", is_flag=True,
     help=u"Handle each request in a separate thread"
@@ -52,7 +54,7 @@ DEFAULT_PORT = 5000
 )
 @click.pass_context
 def run(ctx: click.Context, host: str, port: str, disable_reloader: bool,
-        passthrough_errors: bool, threaded: bool, extra_files: list[str],
+        passthrough_errors: bool, disable_debugger: bool, threaded: bool, extra_files: list[str],
         processes: int, ssl_cert: Optional[str], ssl_key: Optional[str],
         prefix: Optional[str]):
     u"""Runs the Werkzeug development server"""
@@ -65,6 +67,9 @@ def run(ctx: click.Context, host: str, port: str, disable_reloader: bool,
         disable_reloader = True
         threaded = False
         processes = 1
+
+    # Flask/werkzeug debugger
+    use_debugger = not disable_debugger
 
     # Reloading
     use_reloader = not disable_reloader
@@ -117,6 +122,7 @@ def run(ctx: click.Context, host: str, port: str, disable_reloader: bool,
         port_int,
         ctx.obj.app,
         use_reloader=use_reloader,
+        use_debugger=use_debugger,
         use_evalex=True,
         threaded=threaded,
         processes=processes,

--- a/ckan/cli/server.py
+++ b/ckan/cli/server.py
@@ -26,8 +26,10 @@ DEFAULT_PORT = 5000
               help=u"Disable reloader")
 @click.option(u"-E", u"--passthrough-errors", is_flag=True,
               help=u"Disable error caching (useful to hook debuggers)")
-@click.option(u"-D", u"--disable-debugger", is_flag=True,
-              help=u"Disable debugger to prevent conflict with external debug tools")
+@click.option(
+    u"-D", u"--disable-debugger", is_flag=True,
+    help=u"Disable debugger to prevent conflict with external debug tools"
+)
 @click.option(
     u"-t", u"--threaded", is_flag=True,
     help=u"Handle each request in a separate thread"
@@ -54,9 +56,9 @@ DEFAULT_PORT = 5000
 )
 @click.pass_context
 def run(ctx: click.Context, host: str, port: str, disable_reloader: bool,
-        passthrough_errors: bool, disable_debugger: bool, threaded: bool, extra_files: list[str],
-        processes: int, ssl_cert: Optional[str], ssl_key: Optional[str],
-        prefix: Optional[str]):
+        passthrough_errors: bool, disable_debugger: bool, threaded: bool,
+        extra_files: list[str], processes: int, ssl_cert: Optional[str],
+        ssl_key: Optional[str], prefix: Optional[str]):
     u"""Runs the Werkzeug development server"""
 
     if config.get("debug"):

--- a/doc/maintaining/cli.rst
+++ b/doc/maintaining/cli.rst
@@ -503,7 +503,7 @@ Example:
  python -m pdb ckan run --passthrough-errors
 
 Use ``--disable-debugger`` for external debugging
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 CKAN uses the run_simple function from the werkzeug package, which enables
 hot reloading and debugging amongst other things. If we wish to use external

--- a/doc/maintaining/cli.rst
+++ b/doc/maintaining/cli.rst
@@ -485,6 +485,7 @@ Usage
  ckan run --port (-p)                  - Set Port
  ckan run --disable-reloader (-r)      - Use reloader
  ckan run --passthrough_errors         - Crash instead of handling fatal errors
+ ckan run --disable-debugger           - Disable the default debugger
 
 Use ``--passthrough-errors`` to enable pdb
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -500,6 +501,18 @@ simplicity.
 Example:
 
  python -m pdb ckan run --passthrough-errors
+
+Use ``--disable-debugger`` for external debugging
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+CKAN uses the run_simple function from the werkzeug package, which enables
+hot reloading and debugging amongst other things. If we wish to use external
+debugging tools such as debugpy (for remote, container-based debugging), we
+must disable the default debugger for CKAN.
+
+Example:
+
+ python -m pdb ckan run --disable-debugger
 
 
 search-index: Search index commands


### PR DESCRIPTION
Similar to PR #6512, adding another useful option to the `ckan run` CLI.

**Issue**:
- Werkzeug `run_simple` is used for the CLI `ckan run` command: https://github.com/ckan/ckan/blob/master/ckan/cli/server.py#L115
- Currently not all options are supported.
- When debugging CKAN it would be useful to have the inotify reloader running (hot reload), but remove the debugger to prevent conflict with upstream debug tools (such as debugpy or other IDE debuggers).

**Proposed solution**:
- Create a CLI flag `ckan run --disable-debugger` to pass the use_debugger param through to `run_simple`.

**References**:
- Werkzeug run_simple docs: https://werkzeug.palletsprojects.com/en/2.0.x/serving/?highlight=run_simple#werkzeug.serving.run_simple
- https://github.com/microsoft/debugpy/issues/808#issuecomment-1062502813

**Usage**:
- Add FLASK_ENV=development to your environment (**EDIT: not actually required, see comment below**).
- Run CKAN with `ckan run --disable-debugger` and your debugging tool of choice.
- Hot reloading will be provided by the inotify reloader, without conflicting with debug tool.



