### PR TITLE
Rename configuration option route_after_login

### DIFF
--- a/changes/7084.misc
+++ b/changes/7084.misc
@@ -1,0 +1,1 @@
+Configuration option ckan.route_after_login changed to ckan.auth.route_after_login

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -1330,7 +1330,7 @@ groups:
           This controls the page where users will be sent after requesting a password reset.
           This is ordinarily the home page, but specific sites may prefer somewhere else.
 
-      - key: ckan.route_after_login
+      - key: ckan.auth.route_after_login
         default: dashboard.datasets
         description: |
           Allows to customize the route that the user will get redirected to after a successful login.

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -136,8 +136,13 @@ def index():
 
 
 def me() -> Response:
+    redirect_route = config.get_value(u'ckan.route_after_login')
+    if redirect_route:
+        log.warning('"ckan.route_after_login" is deprecated.  '
+                    'Use the "ckan.auth.route_after_login" instead')
+        return h.redirect_to(redirect_route)
     return h.redirect_to(
-        config.get_value(u'ckan.route_after_login'))
+        config.get_value(u'ckan.auth.route_after_login'))
 
 
 def read(id: str) -> Union[Response, str]:


### PR DESCRIPTION
Fixes #7084

### Proposed fixes:

Rename configuration option 'ckan.route_after_login' to 'ckan.auth.route_after_login'


### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
