### PR TITLE
Add side_effect_free to Activity actions

### DIFF
--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -478,8 +478,8 @@ def get_action(action: str) -> Action:
             '.' + action_module_name, 'ckan.logic.action')
         for k, v in authz.get_local_functions(module):
             _actions[k] = v
-            # Whitelist all actions defined in logic/action/get.py as
-            # being side-effect free.
+            # Allow all actions defined in logic/action/get.py to
+            # be side-effect free.
             if action_module_name == 'get' and \
                not hasattr(v, 'side_effect_free'):
                 v.side_effect_free = True

--- a/ckanext/activity/logic/action.py
+++ b/ckanext/activity/logic/action.py
@@ -65,6 +65,7 @@ def dashboard_mark_activities_old(
         model.repo.commit()
 
 
+@tk.side_effect_free
 def activity_create(
     context: Context, data_dict: DataDict
 ) -> Optional[dict[str, Any]]:
@@ -117,6 +118,7 @@ def activity_create(
 
 
 @validate(schema.default_activity_list_schema)
+@tk.side_effect_free
 def user_activity_list(
     context: Context, data_dict: DataDict
 ) -> list[dict[str, Any]]:
@@ -173,6 +175,7 @@ def user_activity_list(
 
 
 @validate(schema.default_activity_list_schema)
+@tk.side_effect_free
 def package_activity_list(
     context: Context, data_dict: DataDict
 ) -> list[dict[str, Any]]:
@@ -258,6 +261,7 @@ def package_activity_list(
 
 
 @validate(schema.default_activity_list_schema)
+@tk.side_effect_free
 def group_activity_list(
     context: Context, data_dict: DataDict
 ) -> list[dict[str, Any]]:
@@ -319,6 +323,7 @@ def group_activity_list(
 
 
 @validate(schema.default_activity_list_schema)
+@tk.side_effect_free
 def organization_activity_list(
     context: Context, data_dict: DataDict
 ) -> list[dict[str, Any]]:
@@ -377,6 +382,7 @@ def organization_activity_list(
 
 
 @validate(schema.default_dashboard_activity_list_schema)
+@tk.side_effect_free
 def recently_changed_packages_activity_list(
     context: Context, data_dict: DataDict
 ) -> list[dict[str, Any]]:
@@ -407,6 +413,7 @@ def recently_changed_packages_activity_list(
 
 
 @validate(schema.default_dashboard_activity_list_schema)
+@tk.side_effect_free
 def dashboard_activity_list(
     context: Context, data_dict: DataDict
 ) -> list[dict[str, Any]]:
@@ -468,6 +475,7 @@ def dashboard_activity_list(
     return activity_dicts
 
 
+@tk.side_effect_free
 def dashboard_new_activities_count(
     context: Context, data_dict: DataDict
 ) -> ActionResult.DashboardNewActivitiesCount:
@@ -488,6 +496,7 @@ def dashboard_new_activities_count(
     return len([activity for activity in activities if activity["is_new"]])
 
 
+@tk.side_effect_free
 def activity_show(context: Context, data_dict: DataDict) -> dict[str, Any]:
     """Show details of an item of 'activity' (part of the activity stream).
 
@@ -510,6 +519,7 @@ def activity_show(context: Context, data_dict: DataDict) -> dict[str, Any]:
     return activity
 
 
+@tk.side_effect_free
 def activity_data_show(
     context: Context, data_dict: DataDict
 ) -> dict[str, Any]:
@@ -552,6 +562,7 @@ def activity_data_show(
     return activity_data
 
 
+@tk.side_effect_free
 def activity_diff(context: Context, data_dict: DataDict) -> dict[str, Any]:
     """Returns a diff of the activity, compared to the previous version of the
     object


### PR DESCRIPTION
### Proposed fixes:

All core actions are automatically set with `side_effect_free` when calling `get_action(...)`.

https://github.com/ckan/ckan/blob/e923b61a256c423cac90a76faac3b69f3967aa4f/ckan/logic/__init__.py#L476-L485

To keep the same behavior of the activity API we need to manually set them in the extension. I have also updated the language of the comment.