### PR TITLE
Fix for numeric return of data through datastore_search_sql

### DIFF
--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -824,6 +824,8 @@ def convert(data: Any, type_name: str) -> Any:
     if type_name == 'nested':
         return json.loads(data[0])
     # array type
+    if type_name == 'numeric':
+        return data
     if type_name.startswith('_'):
         sub_type = type_name[1:]
         return [convert(item, sub_type) for item in data]


### PR DESCRIPTION
Fixes #5753

### Proposed fixes:
This fix handles correct return of numeric data as numeric data instead of by default string return.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
