### PR TITLE
[6951]: sysadmin UI updates when config shema is changed

### DIFF
--- a/ckan/templates/admin/config.html
+++ b/ckan/templates/admin/config.html
@@ -4,31 +4,56 @@
 
 {% import 'macros/form.html' as form %}
 
+{% set site_title = data['ckan.site_title']%} 
+{% set ckan_theme = data['ckan.theme'] %}
+{% set site_tag_line = data['ckan.site_description'] %}
+{% set site_about = data['ckan.site_about'] %}
+{% set site_intro_text = data['ckan.site_intro_text'] %}
+{% set site_custom_css =  data['ckan.site_custom_css']%}
+{% set field_url = 'ckan.site_logo' %}
+{% set is_upload = data[field_url] and not data[field_url].startswith('http') %}
+{% set is_url = data[field_url] and data[field_url].startswith('http') %}
+{% set homepage_style = data['ckan.homepage_style'] %}
+
 {% block primary_content_inner %}
 
   {{ form.errors(error_summary) }}
 
   <form method='post' action="" id="admin-config-form" enctype="multipart/form-data">
     {% block admin_form %}
+    {{ h.csrf_input() }}
+    
+      {% if site_title or site_title == '' %}
+      {{ form.input('ckan.site_title', id='field-ckan-site-title', label=_('Site Title'), value=site_title, error=error, classes=['control-medium']) }}
+      {% endif %}  
 
-      {{ form.input('ckan.site_title', id='field-ckan-site-title', label=_('Site Title'), value=data['ckan.site_title'], error=error, classes=['control-medium']) }}
+      {% if ckan_theme %}
+      {{ form.input('ckan.theme', id='field-ckan-main-css', label=_('Custom Stylesheet'), value=ckan_theme, error=error, classes=['control-medium']) }}
+      {% endif %}
 
-      {{ form.select('ckan.main_css', id='field-ckan-main-css', label=_('Style'), options=styles, selected=data['ckan.main_css'], error=error) }}
+      {% if site_tag_line or site_tag_line == '' %}
+      {{ form.input('ckan.site_description', id='field-ckan-site-description', label=_('Site Tag Line'), value=site_tag_line, error=error, classes=['control-medium']) }}
+      {% endif %}
 
-      {{ form.input('ckan.site_description', id='field-ckan-site-description', label=_('Site Tag Line'), value=data['ckan.site_description'], error=error, classes=['control-medium']) }}
-
-      {% set field_url = 'ckan.site_logo' %}
-      {% set is_upload = data[field_url] and not data[field_url].startswith('http') %}
-      {% set is_url = data[field_url] and data[field_url].startswith('http') %}
+      {% if is_upload or is_url or is_upload == '' or is_url == '' %}
       {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_url, is_upload=is_upload, upload_label = _('Site logo'), url_label=_('Site logo'),  field_url=field_url, field_upload='logo_upload', field_clear='clear_logo_upload' )}}
+      {% endif %}
 
-      {{ form.markdown('ckan.site_about', id='field-ckan-site-about', label=_('About'), value=data['ckan.site_about'], error=error, placeholder=_('About page text')) }}
+      {% if site_about or site_about == '' %}
+      {{ form.markdown('ckan.site_about', id='field-ckan-site-about', label=_('About'), value=site_about, error=error, placeholder=_('About page text')) }}
+      {% endif %}
 
-      {{ form.markdown('ckan.site_intro_text', id='field-ckan-site-intro-text', label=_('Intro Text'), value=data['ckan.site_intro_text'], error=error, placeholder=_('Text on home page')) }}
+      {% if site_intro_text or site_intro_text == '' %}
+      {{ form.markdown('ckan.site_intro_text', id='field-ckan-site-intro-text', label=_('Intro Text'), value=site_intro_text, error=error, placeholder=_('Text on home page')) }}
+      {% endif %}
 
-      {{ form.textarea('ckan.site_custom_css', id='field-ckan-site-custom-css', label=_('Custom CSS'), value=data['ckan.site_custom_css'], error=error, placeholder=_('Customisable css inserted into the page header')) }}
+      {% if site_custom_css or site_custom_css == '' %}
+      {{ form.textarea('ckan.site_custom_css', id='field-ckan-site-custom-css', label=_('Custom CSS'), value=site_custom_css, error=error, placeholder=_('Customisable css inserted into the page header')) }}
+      {% endif %}
 
-      {{ form.select('ckan.homepage_style', id='field-homepage-style', label=_('Homepage'), options=homepages, selected=data['ckan.homepage_style'], error=error) }}
+      {% if homepage_style or homepage_style =='' %}
+      {{ form.select('ckan.homepage_style', id='field-homepage-style', label=_('Homepage'), options=homepages, selected=homepage_style , error=error) }}
+      {% endif %}
 
       {% endblock %}
       <div class="form-actions">
@@ -49,24 +74,57 @@
         {% set about_url = h.url_for(controller='home', action='about') %}
         {% set home_url = h.url_for(controller='home', action='index') %}
         {% set docs_url = "http://docs.ckan.org/en/{0}/theming".format(g.ckan_doc_version) %}
+        {% if site_title or site_title == '' %} 
         {% trans %}
-          <p><strong>Site Title:</strong> This is the title of this CKAN instance
-            It appears in various places throughout CKAN.</p>
-          <p><strong>Style:</strong> Choose from a list of simple variations of
-            the main colour scheme to get a very quick custom theme working.</p>
-          <p><strong>Site Tag Logo:</strong> This is the logo that appears in the
-            header of all the CKAN instance templates.</p>
-          <p><strong>About:</strong> This text will appear on this CKAN instances
-            <a href="{{ about_url }}">about page</a>.</p>
-          <p><strong>Intro Text:</strong> This text will appear on this CKAN instances
-            <a href="{{ home_url }}">home page</a> as a welcome to visitors.</p>
-          <p><strong>Custom CSS:</strong> This is a block of CSS that appears in
-            <code>&lt;head&gt;</code> tag of every page. If you wish to customize
-            the templates more fully we recommend
-            <a href="{{ docs_url }}" target="_blank">reading the documentation</a>.</p>
-          <p><strong>Homepage:</strong> This is for choosing a predefined layout for
-            the modules that appear on your homepage.</p>
-      {% endtrans %}
+        <p><strong>Site Title:</strong> This is the title of this CKAN instance
+          It appears in various places throughout CKAN.</p>
+        {% endtrans %}
+        {% endif %}
+
+        {% if ckan_theme %} 
+        {% trans %}
+        <p><strong>Style:</strong> Choose from a list of simple variations of
+          the main colour scheme to get a very quick custom theme working.</p>
+        {% endtrans %}
+        {% endif %}
+
+        {% if is_upload or is_url or is_upload == '' or is_url == ''%}
+        {% trans %}
+        <p><strong>Site Tag Logo:</strong> This is the logo that appears in the
+          header of all the CKAN instance templates.</p>
+        {% endtrans %}
+        {% endif %}
+
+        {% if site_about or site_about == '' %}
+        {% trans %}
+        <p><strong>About:</strong> This text will appear on this CKAN instances
+          <a href="{{ about_url }}">about page</a>.</p>
+        {% endtrans %}
+        {% endif %}
+
+        {% if site_intro_text or site_intro_text == '' %}
+        {% trans %}
+        <p><strong>Intro Text:</strong> This text will appear on this CKAN instances
+          <a href="{{ home_url }}">home page</a> as a welcome to visitors.</p>
+        {% endtrans %}
+        {% endif %}
+
+        {% if site_custom_css or site_custom_css == ''%}
+        {% trans %}
+        <p><strong>Custom CSS:</strong> This is a block of CSS that appears in
+          <code>&lt;head&gt;</code> tag of every page. If you wish to customize
+          the templates more fully we recommend
+          <a href="{{ docs_url }}" target="_blank">reading the documentation</a>.</p>
+        {% endtrans %}
+        {% endif %}
+
+        {% if homepage_style or homepage_style =='' %}
+        {% trans %}
+        <p><strong>Homepage:</strong> This is for choosing a predefined layout for
+          the modules that appear on your homepage.</p>
+        {% endtrans %}
+        {% endif %}
+      
     {% endblock %}
     </div>
   </div>


### PR DESCRIPTION
Fixes #6951 

### Proposed fixes:

- This PR fixes the config UI render issue, when config schema is updated via the extension. 
- Only the components which are specified in the schema are rendered  with their helping text in `admin/config.html` form.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
