### PR TITLE
Improve CKAN_INI consistency in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get -q -y update \
 ENV CKAN_HOME /usr/lib/ckan
 ENV CKAN_VENV $CKAN_HOME/venv
 ENV CKAN_CONFIG /etc/ckan
+ENV CKAN_INI $CKAN_HOME/production.ini
 ENV CKAN_STORAGE_PATH=/var/lib/ckan
 
 # Build-time variables specified by docker-compose.yml / .env
@@ -87,4 +88,4 @@ ENTRYPOINT ["/ckan-entrypoint.sh"]
 USER ckan
 EXPOSE 5000
 
-CMD ["ckan","-c","/etc/ckan/production.ini", "run", "--host", "0.0.0.0"]
+CMD ["ckan", "run", "--host", "0.0.0.0"]

--- a/contrib/docker/ckan-entrypoint.sh
+++ b/contrib/docker/ckan-entrypoint.sh
@@ -11,8 +11,6 @@ set -e
 # URL for datapusher (required unless linked to a container called 'datapusher')
 : ${CKAN_DATAPUSHER_URL:=}
 
-CONFIG="${CKAN_CONFIG}/production.ini"
-
 abort () {
   echo "$@" >&2
   exit 1
@@ -37,8 +35,8 @@ set_environment () {
 }
 
 write_config () {
-  echo "Generating config at ${CONFIG}..."
-  ckan generate config "$CONFIG"
+  echo "Generating config at ${CKAN_INI}..."
+  ckan generate config "$CKAN_INI"
 }
 
 # Wait for PostgreSQL
@@ -69,5 +67,5 @@ if [ -z "$CKAN_DATAPUSHER_URL" ]; then
 fi
 
 set_environment
-ckan --config "$CONFIG" db init
+ckan db init
 exec "$@"


### PR DESCRIPTION
It does not make much sense to me to specify the same variable with different names in different places. Using `CKAN_INI` makes it easier to use the CLI without having to specify the configuration file path each time, which also make easier to build custom images on top of the provided `Dockerfile`.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport