### PR TITLE
Make heading semantic for bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,16 +7,17 @@ assignees: ''
 
 ---
 
-**CKAN version**
+## CKAN version
 
-**Describe the bug**
+## Describe the bug
 A clear and concise description of what the bug is.
 
-**Steps to reproduce**
+### Steps to reproduce
 Steps to reproduce the behavior:
 
-**Expected behavior**
+### Expected behavior
 A clear and concise description of what you expected to happen.
 
-**Additional details**
+### Additional details
 If possible, please provide the full stack trace of the error raised,  or add screenshots to help explain your problem.
+

--- a/changes/7186.misc
+++ b/changes/7186.misc
@@ -1,0 +1,1 @@
+Make heading semantic in bug report template


### PR DESCRIPTION
Fixes #7186

### Proposed fixes:

Fix bug report template to make heading tags semantic

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
