### PR TITLE
Fix color contrast add dataset page

### DIFF
--- a/changes/7195.misc
+++ b/changes/7195.misc
@@ -1,0 +1,1 @@
+Fix color contrast issue in add dataset page

--- a/ckan/public-bs3/base/css/main-rtl.css
+++ b/ckan/public-bs3/base/css/main-rtl.css
@@ -10126,7 +10126,6 @@ select[data-module=autocomplete] {
 }
 
 .editor .editor-info-block a {
-  color: #187794;
   text-decoration: none;
 }
 

--- a/ckan/public-bs3/base/css/main.css
+++ b/ckan/public-bs3/base/css/main.css
@@ -8198,7 +8198,6 @@ select[data-module=autocomplete] {
 }
 
 .editor .editor-info-block a {
-  color: #187794;
   text-decoration: none;
 }
 

--- a/ckan/public-bs3/base/scss/_forms.scss
+++ b/ckan/public-bs3/base/scss/_forms.scss
@@ -318,7 +318,6 @@ select[data-module="autocomplete"] {
 }
 
 .editor .editor-info-block a {
-    color: $layoutLinkColor;
     text-decoration: none;
 }
 

--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -11950,7 +11950,6 @@ select[data-module=autocomplete] {
 }
 
 .editor .editor-info-block a {
-  color: #187794;
   text-decoration: none;
 }
 

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -11950,7 +11950,6 @@ select[data-module=autocomplete] {
 }
 
 .editor .editor-info-block a {
-  color: #187794;
   text-decoration: none;
 }
 

--- a/ckan/public/base/scss/_forms.scss
+++ b/ckan/public/base/scss/_forms.scss
@@ -299,7 +299,6 @@ select[data-module="autocomplete"] {
 }
 
 .editor .editor-info-block a {
-    color: $layoutLinkColor;
     text-decoration: none;
 }
 


### PR DESCRIPTION
Fixes #7195

### Proposed fixes:

Fix color contrast in 'add dataset' page.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
