### PR TITLE
[7227] Autofocus the `upload` button when page is rendered

### DIFF
--- a/changes/7227.misc
+++ b/changes/7227.misc
@@ -1,0 +1,1 @@
+Autofocus the upload button for keyboard accessibility.

--- a/ckan/templates/package/snippets/resource_upload_field.html
+++ b/ckan/templates/package/snippets/resource_upload_field.html
@@ -45,7 +45,7 @@ placeholder - placeholder text for url field
             onclick="
               document.getElementById('resource-url-upload').checked = true;
               document.getElementById('field-resource-upload').click();
-            "><i class="fa fa-cloud-upload"></i>{{ _("Upload") }}</button>
+            "autofocus="true"><i class="fa fa-cloud-upload"></i>{{ _("Upload") }}</button>
         {% endif %}
         <button type="button" class="btn btn-default" id="resource-link-button"
           title="{{ _('Link to a URL on the internet (you can also link to an API)') }}"


### PR DESCRIPTION
Fixes #7227 

### Proposed fixes:
- upload button is auto focused when the web page loads 
- When `enter` is clicked user file system opens up.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
