### PR TITLE
Fixed contrast of delete button in user edit page

### DIFF
--- a/ckan/public-bs3/base/css/main-rtl.css
+++ b/ckan/public-bs3/base/css/main-rtl.css
@@ -3864,8 +3864,8 @@ a.btn.disabled, fieldset[disabled] a.btn {
 
 .btn-danger, .control-custom.disabled .checkbox.btn {
   color: #fff;
-  background-color: #d9534f;
-  border-color: #d43f3a;
+  background-color: #d43f3a;
+  border-color: #c9302c;
 }
 .btn-danger:focus, .control-custom.disabled .checkbox.btn:focus, .btn-danger.focus, .control-custom.disabled .focus.checkbox.btn {
   color: #fff;

--- a/ckan/public-bs3/base/css/main.css
+++ b/ckan/public-bs3/base/css/main.css
@@ -3864,8 +3864,8 @@ a.btn.disabled, fieldset[disabled] a.btn {
 
 .btn-danger, .control-custom.disabled .checkbox.btn {
   color: #fff;
-  background-color: #d9534f;
-  border-color: #d43f3a;
+  background-color: #d43f3a;
+  border-color: #c9302c;
 }
 .btn-danger:focus, .control-custom.disabled .checkbox.btn:focus, .btn-danger.focus, .control-custom.disabled .focus.checkbox.btn {
   color: #fff;

--- a/ckan/public-bs3/base/scss/_bootstrap-variables.scss
+++ b/ckan/public-bs3/base/scss/_bootstrap-variables.scss
@@ -165,8 +165,8 @@ $btn-warning-bg:                 $brand-warning;
 $btn-warning-border:             darken($btn-warning-bg, 5%);
 
 $btn-danger-color:               #fff;
-$btn-danger-bg:                  $brand-danger;
-$btn-danger-border:              darken($btn-danger-bg, 5%);
+$btn-danger-bg:                  darken($brand-danger, 5%);
+$btn-danger-border:              darken($brand-danger, 10%);
 
 $btn-link-disabled-color:        $gray-light;
 

--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -11130,6 +11130,8 @@ h6, .h6, h5, .h5, h4, .h4, h3, .h3, h2, .h2, h1, .h1 {
 
 .btn-danger, .control-custom.disabled .checkbox.btn {
   color: #fff !important;
+  background-color: #d43f3a;
+  border-color: #d43f3a;
 }
 
 .btn-light, .btn-default {

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -11130,6 +11130,8 @@ h6, .h6, h5, .h5, h4, .h4, h3, .h3, h2, .h2, h1, .h1 {
 
 .btn-danger, .control-custom.disabled .checkbox.btn {
   color: #fff !important;
+  background-color: #d43f3a;
+  border-color: #d43f3a;
 }
 
 .btn-light, .btn-default {

--- a/ckan/public/base/scss/_custom.scss
+++ b/ckan/public/base/scss/_custom.scss
@@ -6,6 +6,8 @@ h6, .h6, h5, .h5, h4, .h4, h3, .h3, h2, .h2, h1, .h1 {
 
 .btn-danger {
     color: $white !important;
+    background-color: darken($red, 5%);
+    border-color: darken($red, 5%);
 }
 
 .btn-light, .btn-default {


### PR DESCRIPTION
Fix for Bootstrap v5 and v3

Fixes #7199

### Proposed fixes:

Fix color contrast of delete button for web accessibility

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
