### PR TITLE
Clean group extra revisions before purging a group

### DIFF
--- a/changes/7317.bugfix
+++ b/changes/7317.bugfix
@@ -1,0 +1,1 @@
+Ensure that we remove group extra revision while we purge a group.

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -524,6 +524,9 @@ def _group_or_org_purge(
             m.purge()
         model.repo.commit_and_remove()
 
+    # Purge group_extra_revisions
+    group.clean_extra_revisions()
+
     group = model.Group.get(id)
     assert group
     group.purge()

--- a/ckan/model/group.py
+++ b/ckan/model/group.py
@@ -414,7 +414,7 @@ class Group(core.StatefulObjectMixin,
         ''' Ensure clean extra revisions before purging a group. '''
 
         clean_extra_revision_query = (
-            "DELETE FROM group_extra_revision "
+            "DELETE FROM public.group_extra_revision "
             "WHERE group_id = :group_id"
         )
         meta.Session.query(
@@ -424,6 +424,7 @@ class Group(core.StatefulObjectMixin,
         ).params(
             group_id=self.id
         )
+        meta.Session.commit()
 
     def __repr__(self):
         return '<Group %s>' % self.name

--- a/ckan/model/group.py
+++ b/ckan/model/group.py
@@ -410,8 +410,24 @@ class Group(core.StatefulObjectMixin,
                             table_name='package')
             meta.Session.add(member)
 
+    def clean_extra_revisions(self) -> None:
+        ''' Ensure clean extra revisions before purging a group. '''
+
+        clean_extra_revision_query = (
+            "DELETE FROM group_extra_revision "
+            "WHERE group_id = :group_id"
+        )
+        meta.Session.query(
+            Group
+        ).from_statement(
+            text(clean_extra_revision_query)
+        ).params(
+            group_id=self.id
+        )
+
     def __repr__(self):
         return '<Group %s>' % self.name
+
 
 meta.mapper(Group, group_table)
 


### PR DESCRIPTION
Fixes https://github.com/okfn/ckanext-unhcr/issues/728

### Proposed fixes:

It's not clear to me if Group extra revisions continues working in CKAN.
It's also not clear if they are some kind of cascade deletion policy running.
In case this don't work anymore but I have old records for revision, a severe error could happen.
This PR ensures that we remove group extra revision while we purge a group.

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
