### PR TITLE
Patch config options for test running in CKAN 2.9

### DIFF
--- a/ckan/tests/cli/test_clean.py
+++ b/ckan/tests/cli/test_clean.py
@@ -7,6 +7,8 @@ from ckan.tests.helpers import call_action
 
 @pytest.mark.usefixtures("clean_db")
 class TestUserClean:
+    @pytest.mark.ckan_config("ckan.upload.user.mimetypes", "image/png")
+    @pytest.mark.ckan_config("ckan.upload.user.types", "images")
     def test_output_if_there_are_not_invalid_users(self, cli):
         result = cli.invoke(ckan, ["clean", "users"])
         assert "No users were found with invalid images." in result.output


### PR DESCRIPTION
CKAN 2.9 does not have default values for both `ckan.upload.user.mimetypes` and `ckan.upload.user.types` options so test is failing with: 

```
 =================================== FAILURES ===================================
___________ TestUserClean.test_output_if_there_are_not_invalid_users ___________

self = <ckan.tests.cli.test_clean.TestUserClean object at 0x7f24f9388410>
cli = <ckan.tests.helpers.CKANCliRunner object at 0x7f24fd088990>

    def test_output_if_there_are_not_invalid_users(self, cli):
        result = cli.invoke(ckan, ["clean", "users"])
>       assert "No users were found with invalid images." in result.output
E       AssertionError: assert 'No users were found with invalid images.' in 'No mimetypes have been configured for user uploads.\n'
E        +  where 'No mimetypes have been configured for user uploads.\n' = <Result okay>.output

ckan/tests/cli/test_clean.py:12: AssertionError
======= 1 failed, 2769 passed, 36 skipped, 2 xfailed in 1553.77 seconds ========
```
From ckan-python-monitor: https://github.com/ckan/ckan-python-monitor/actions/runs/3879357318/jobs/6616459456