### PR TITLE
Attach the actual config object to Click context

### DIFF
--- a/ckan/cli/cli.py
+++ b/ckan/cli/cli.py
@@ -53,8 +53,12 @@ class CtxObject(object):
     def __init__(self, conf: Optional[str] = None):
         # Don't import `load_config` by itself, rather call it using
         # module so that it can be patched during tests
-        self.config = ckan_cli.load_config(conf)
-        self.app = make_app(self.config)
+        raw_config = ckan_cli.load_config(conf)
+        self.app = make_app(raw_config)
+
+        # Attach the actual CKAN config object to the context
+        from ckan.common import config
+        self.config = config
 
 
 class ExtendableGroup(click.Group):


### PR DESCRIPTION
The current version was attaching the raw values from the ini file, without any of the processing done in `load_environment()` (config declaration modifications, changes by plugins etc). We now attach the actual CKAN config object once it has been initialized.

The symptom for that was using the new `ckan shell` command:
```
****** Welcome to the CKAN shell ******

This session has some variables pre-populated:
  - app (CKAN Application object)
  - config (CKAN config dictionary)
  - model (CKAN model module to access the Database)
  - toolkit (CKAN toolkit module)

```

The `config` var was not showing the expected values (values overridden by ckanext-envvars) and didn't include the new methods (eg `get_value()`)