### PR TITLE
Update documentation on creating new extension

### DIFF
--- a/doc/theming/templates.rst
+++ b/doc/theming/templates.rst
@@ -23,13 +23,13 @@ static files, so before getting started on our CKAN theme we'll have to create
 an extension and plugin. For a detailed explanation of the steps below, see
 :doc:`/extensions/tutorial`.
 
-1. Use the ``ckan create`` command to create an empty extension:
+1. Use the ``ckan generate extension`` command to create an empty extension:
 
    .. parsed-literal::
 
       |activate|
       cd |virtualenv|/src
-      ckan -c |ckan.ini| create -t ckanext |extension_dir|
+      ckan -c |ckan.ini| generate extension -o |extension_dir|
 
 2. Create the file |plugin.py| with the following contents:
 


### PR DESCRIPTION
Fixes Updating documentation on creating extension

The `ckan create` command seems to be deprecated in current version of `ckan` and being replaced by `ckan generate extantion` command.

This PR updates to documentation page on creating extension to use `ckan generate extension` instead of the `ckan create` command.

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
