### PR TITLE
Add details about JWT secrets to docs [backport v2.9]

### DIFF
--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -965,8 +965,10 @@ Default value: same as ``beaker.session.secret`` config option with ``string:`` 
 
 A key suitable for the chosen algorithm(``api_token.jwt.algorithm``):
 
-* for asymmetric algorithms: path to private key with ``file:`` prefix. I.e ``file:/path/private/key``
-* for symmetric algorithms: plain string, sufficiently long for security with ``string:`` prefix. I.e ``string:123abc``
+* for asymmetric algorithms(RS256): path to private key with ``file:`` prefix. I.e ``file:/path/private/key``
+* for symmetric algorithms(HS256): plain string, sufficiently long for security with ``string:`` prefix. I.e ``string:123abc...``
+
+.. note:: For symmetric algorithms this value must be identical to :ref:`api_token.jwt.decode.secret`. The algorithm used is controlled by the :ref:`api_token.jwt.algorithm` option.
 
 Value must have prefix, which defines its type. Supported prefixes are:
 
@@ -986,8 +988,10 @@ Default value: same as ``beaker.session.secret`` config option with ``string:`` 
 
 A key suitable for the chosen algorithm(``api_token.jwt.algorithm``):
 
-* for asymmetric algorithms: path to public key with ``file:`` prefix. I.e ``file:/path/public/key.pub``
-* for symmetric algorithms: plain string, sufficiently long for security with ``string:`` prefix. I.e ``string:123abc``
+* for asymmetric algorithms(RS256): path to public key with ``file:`` prefix. I.e ``file:/path/public/key.pub``
+* for symmetric algorithms(HS256): plain string, sufficiently long for security with ``string:`` prefix. I.e ``string:123abc...``
+
+.. note:: For symmetric algorithms this value must be identical to :ref:`api_token.jwt.encode.secret`. The algorithm used is defined by the :ref:`api_token.jwt.algorithm` option.
 
 Value must have prefix, which defines it's type. Supported prefixes are:
 
@@ -1006,6 +1010,14 @@ Example::
 Default value: ``HS256``
 
 Algorithm to sign the token with, e.g. "ES256", "RS256"
+
+Depending on the algorithm, additional restrictions may apply to
+:ref:`api_token.jwt.decode.secret` and :ref:`api_token.jwt.encode.secret`. For
+example, RS256 implies that :ref:`api_token.jwt.encode.secret` contains RSA
+private key and :ref:`api_token.jwt.decode.secret` contains public key. Whereas
+HS256(default value) requires both :ref:`api_token.jwt.decode.secret` and
+:ref:`api_token.jwt.encode.secret` to have exactly the same value.
+
 
 Search Settings
 ---------------


### PR DESCRIPTION
Backport or https://github.com/ckan/ckan/pull/7329

Describe a bit more api_token config options. For example, mention the fact, that encode.secret and decode.secret must be identical in the default setup