### PR TITLE
Revisit the config.get / config.get_value

### DIFF
--- a/changes/6467.feature
+++ b/changes/6467.feature
@@ -1,1 +1,58 @@
-:ref:`declare-config-options`: declare configuration options to ensure validation and default values
+:ref:`declare-config-options`: declare configuration options to ensure validation and default values.
+
+All the native config options from CKAN are validated and converted to the
+expected type during application startup. That's how change the behavior::
+
+    debug = config.get("debug")
+
+    # CKAN <= v2.9
+    assert type(debug) is str
+    assert debug == "false" # or any value that is specified in the config file
+
+    # CKAN >= v2.10
+    assert type(debug) is bool
+    assert debug is False # or ``True``
+
+If you are using ``aslist``, ``asbool``, ``asint`` convertes from
+``ckan.plugins.toolkit``, nothing will change, because they are idempotent::
+
+    # produces the same result in v2.9 and v2.10
+    assesrt tk.asbool(config.get("debug")) is False
+    assesrt tk.asint(config.get("devserver.port")) == 5000
+    assesrt tk.aslist(config.get("ckan.plugins")) == ["stats"]
+
+If you are using custom logic, the code requires a review. For example, the
+following will produce an ``AttributeError``, because ``ckan.plugins`` is
+converted into a list during application's startup::
+
+    # AttributeError
+    plugins = config.get("ckan.plugins").split()
+
+Depending on desired backward compatibility, one of the following expressions
+can be used instead::
+
+    # if both v2.9 and v2.10 are supported
+    plugins = tk.aslist(config.get("ckan.plugins"))
+
+    # if only v2.10 is supported
+    plugins = config.get("ckan.plugins")
+
+The second major change affects default values. Starting from CKAN v2.10,
+majority of the config options has a declared default value. It means that
+whenever you invoke ``config.get`` method, the **declared default** value is
+returned instead of ``None``. Example::
+
+    # CKAN v2.9
+    assert config.get("search.facets.limit") is None
+
+    # CKAN v2.10
+    assert config.get("search.facets.limit") == 10
+
+The second argument to ``config.get`` is used only when you are trying to get
+the value of the missing **undeclared** option::
+
+    assert config.get("not.declared.and.missing.from.config", 1) == 1
+
+
+The above is the same for any extension that **declares** its config options
+using ``IConfigDeclaration`` interface or ``config_declarations`` blanket.

--- a/changes/6467.feature
+++ b/changes/6467.feature
@@ -1,7 +1,7 @@
 :ref:`declare-config-options`: declare configuration options to ensure validation and default values.
 
-All the native config options from CKAN are validated and converted to the
-expected type during application startup. That's how change the behavior::
+All the CKAN configuration options are validated and converted to the
+expected type during the application startup. That's how the behavior has changed::
 
     debug = config.get("debug")
 
@@ -13,22 +13,21 @@ expected type during application startup. That's how change the behavior::
     assert type(debug) is bool
     assert debug is False # or ``True``
 
-If you are using ``aslist``, ``asbool``, ``asint`` convertes from
-``ckan.plugins.toolkit``, nothing will change, because they are idempotent::
+The ``aslist``, ``asbool``, ``asint`` converters from ``ckan.plugins.toolkit`` will keep the current behaviour::
 
     # produces the same result in v2.9 and v2.10
-    assesrt tk.asbool(config.get("debug")) is False
-    assesrt tk.asint(config.get("devserver.port")) == 5000
-    assesrt tk.aslist(config.get("ckan.plugins")) == ["stats"]
+    assert tk.asbool(config.get("debug")) is False
+    assert tk.asint(config.get("ckan.devserver.port")) == 5000
+    assert tk.aslist(config.get("ckan.plugins")) == ["stats"]
 
 If you are using custom logic, the code requires a review. For example, the
-following will produce an ``AttributeError``, because ``ckan.plugins`` is
-converted into a list during application's startup::
+following code will produce an ``AttributeError`` exception, because ``ckan.plugins`` is
+converted into a list during the application's startup::
 
     # AttributeError
     plugins = config.get("ckan.plugins").split()
 
-Depending on desired backward compatibility, one of the following expressions
+Depending on the desired backward compatibility, one of the following expressions
 can be used instead::
 
     # if both v2.9 and v2.10 are supported
@@ -37,9 +36,9 @@ can be used instead::
     # if only v2.10 is supported
     plugins = config.get("ckan.plugins")
 
-The second major change affects default values. Starting from CKAN v2.10,
-majority of the config options has a declared default value. It means that
-whenever you invoke ``config.get`` method, the **declared default** value is
+The second major change affects default values for configuration options. Starting from CKAN 2.10,
+the majority of the config options have a declared default value. It means that
+whenever you invoke ``config.get`` method, the *declared default* value is
 returned instead of ``None``. Example::
 
     # CKAN v2.9
@@ -48,11 +47,10 @@ returned instead of ``None``. Example::
     # CKAN v2.10
     assert config.get("search.facets.limit") == 10
 
-The second argument to ``config.get`` is used only when you are trying to get
-the value of the missing **undeclared** option::
+The second argument to ``config.get`` should be only used to get
+the value of a missing *undeclared* option::
 
     assert config.get("not.declared.and.missing.from.config", 1) == 1
 
-
-The above is the same for any extension that **declares** its config options
+The above is the same for any extension that *declares* its config options
 using ``IConfigDeclaration`` interface or ``config_declarations`` blanket.

--- a/ckan/authz.py
+++ b/ckan/authz.py
@@ -540,7 +540,7 @@ def check_config_permission(permission: str) -> Union[list[str], bool]:
 
     config_key = 'ckan.auth.' + key
 
-    value = config.get_value(config_key)
+    value = config.get(config_key)
 
     return value
 

--- a/ckan/cli/clean.py
+++ b/ckan/cli/clean.py
@@ -56,7 +56,7 @@ def users(force: bool):
       ckan clean users --force
 
     """
-    mimetypes = config.get_value("ckan.upload.user.mimetypes")
+    mimetypes = config.get("ckan.upload.user.mimetypes")
     if not mimetypes:
         click.echo("No mimetypes have been configured for user uploads.")
         return

--- a/ckan/cli/config.py
+++ b/ckan/cli/config.py
@@ -13,16 +13,10 @@ from . import error_shout
 
 
 @click.group(
-    short_help="Search, validate and describe config options on strict mode"
+    short_help="Search, validate and describe config options."
 )
 def config():
-    mode = cfg.get_value("config.mode")
-    if mode != "strict":
-        error_shout(
-            "`config.mode = strict` is required to use the declarative"
-            " config features"
-        )
-        raise click.Abort()
+    pass
 
 
 @config.command()
@@ -229,7 +223,7 @@ def _declaration(
     additional = ()
     if include_enabled:
         additional = (
-            p for p in cfg.get_value("ckan.plugins") if p not in plugins
+            p for p in cfg.get("ckan.plugins") if p not in plugins
         )
 
     for name in itertools.chain(additional, plugins):

--- a/ckan/cli/db.py
+++ b/ckan/cli/db.py
@@ -98,7 +98,7 @@ def _get_pending_plugins() -> dict[str, int]:
     plugins = [(plugin, state)
                for plugin, state
                in ((plugin, current_revision(plugin))
-                   for plugin in config.get_value('ckan.plugins'))
+                   for plugin in config.get('ckan.plugins'))
                if state and not state.endswith('(head)')]
     pending = {}
     for plugin, current in plugins:

--- a/ckan/cli/sass.py
+++ b/ckan/cli/sass.py
@@ -21,7 +21,7 @@ from ckan.common import config
 def sass(debug: bool):
     command = ('npm', 'run', 'build')
 
-    public = config.get_value('ckan.base_public_folder')
+    public = config.get('ckan.base_public_folder')
 
     root = os.path.join(os.path.dirname(__file__), '..', public, 'base')
     root = os.path.abspath(root)

--- a/ckan/cli/search_index.py
+++ b/ckan/cli/search_index.py
@@ -135,7 +135,7 @@ def clear_orphans(verbose: bool = False):
 )
 def list_unindexed():
     packages = model.Session.query(model.Package.id)
-    if config.get_value('ckan.search.remove_deleted_packages'):
+    if config.get('ckan.search.remove_deleted_packages'):
         packages = packages.filter(model.Package.state != 'deleted')
 
     package_ids = [r[0] for r in packages.all()]

--- a/ckan/cli/server.py
+++ b/ckan/cli/server.py
@@ -57,7 +57,7 @@ def run(ctx: click.Context, host: str, port: str, disable_reloader: bool,
         prefix: Optional[str]):
     u"""Runs the Werkzeug development server"""
 
-    if config.get_value("debug"):
+    if config.get("debug"):
         warnings.filterwarnings("default", category=CkanDeprecationWarning)
 
     # passthrough_errors overrides conflicting options
@@ -68,21 +68,21 @@ def run(ctx: click.Context, host: str, port: str, disable_reloader: bool,
 
     # Reloading
     use_reloader = not disable_reloader
-    config_extra_files = config.get_value(u"ckan.devserver.watch_patterns")
+    config_extra_files = config.get(u"ckan.devserver.watch_patterns")
     extra_files = list(extra_files) + [
         config[u"__file__"]
     ] + config_extra_files
 
     # Threads and processes
-    threaded = threaded or config.get_value(u"ckan.devserver.threaded")
-    processes = processes or config.get_value(u"ckan.devserver.multiprocess")
+    threaded = threaded or config.get(u"ckan.devserver.threaded")
+    processes = processes or config.get(u"ckan.devserver.multiprocess")
     if threaded and processes > 1:
         error_shout(u"Cannot have a multithreaded and multi process server")
         raise click.Abort()
 
     # SSL
-    cert_file = ssl_cert or config.get_value('ckan.devserver.ssl_cert')
-    key_file = ssl_key or config.get_value('ckan.devserver.ssl_key')
+    cert_file = ssl_cert or config.get('ckan.devserver.ssl_cert')
+    key_file = ssl_key or config.get('ckan.devserver.ssl_key')
 
     if cert_file and key_file:
         if cert_file == key_file == 'adhoc':
@@ -100,8 +100,8 @@ def run(ctx: click.Context, host: str, port: str, disable_reloader: bool,
             prefix: ctx.obj.app
         })
 
-    host = host or config.get_value('ckan.devserver.host')
-    port = port or config.get_value('ckan.devserver.port')
+    host = host or config.get('ckan.devserver.host')
+    port = port or config.get('ckan.devserver.port')
     try:
         port_int = int(port)
     except ValueError:

--- a/ckan/cli/translation.py
+++ b/ckan/cli/translation.py
@@ -137,7 +137,7 @@ def sync_po_file_msgids(entries_to_change: dict[str, Any], path: str):
 
 
 def get_i18n_path() -> str:
-    return config.get_value(
+    return config.get(
         u'ckan.i18n_directory') or os.path.join(ckan_path, u'i18n')
 
 

--- a/ckan/cli/views.py
+++ b/ckan/cli/views.py
@@ -295,13 +295,13 @@ def _add_default_filters(search_data_dict: dict[str, Any],
     """
 
     from ckanext.textview.plugin import get_formats as get_text_formats
-    datapusher_formats = config.get_value("ckan.datapusher.formats")
+    datapusher_formats = config.get("ckan.datapusher.formats")
 
     filter_formats = []
 
     for view_type in view_types:
         if view_type == u"image_view":
-            formats = config.get_value(
+            formats = config.get(
                 "ckan.preview.image_formats").split()
             for _format in formats:
                 filter_formats.extend([_format, _format.upper()])

--- a/ckan/common.py
+++ b/ckan/common.py
@@ -14,7 +14,7 @@ from collections.abc import MutableMapping, Iterable
 
 from typing import (
     Any, Optional, TYPE_CHECKING,
-    TypeVar, cast, overload, Container, Union)
+    TypeVar, cast, overload, Union)
 from typing_extensions import Literal
 
 import flask
@@ -28,7 +28,7 @@ from flask_babel import (gettext as flask_ugettext,
 
 import simplejson as json  # type: ignore # noqa: re-export
 import ckan.lib.maintain as maintain
-from ckan.config.declaration import Declaration, Key
+from ckan.config.declaration import Declaration
 from ckan.types import Model
 
 

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -177,23 +177,18 @@ groups:
         default: default
         example: strict
         description: |
-          Controls the parsing and validation of ``config`` object. In ``default`` mode there is no validation
-          applied to the provided configuration values and they are not guaranteed to be present. This is the
-          current default behaviour and was the only one available in CKAN<=2.9.
+          Controls the behavior of application when invalid values detected in
+          the ``config`` object.
 
-          Enabling `strict` mode does the following:
+          In the ``default`` mode any invalid value left unprocessed(i.e.,
+          remains ``str``). In addition, every invalid option is reported using
+          a log record with a ``WARNING`` level.
 
-          * For all the :ref:`declared config options <declare-config-options>`, if they
-            are not provided the config file, the ddefault value from the declaration will be
-            used in the ``config`` object.
-
-          * All the :ref:`declared config options <declare-config-options>` will be
-            normalized using validators specified in the declaration.
-
-          * None of CKAN CLI commands will be executed and the CKAN application itself will
-            not start unless **all** config options are valid according to the validators defined
-            in the declaration. For every invalid config option, an error will be printed to the
-            output stream.
+          In the ``strict`` mode none of CKAN CLI commands will be executed and
+          the CKAN application itself will not start unless **all** config
+          options are valid according to the validators defined in the
+          declaration. For every invalid config option, an error will be
+          printed to the output stream.
 
   - annotation: Development settings
     options:

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -180,14 +180,13 @@ groups:
           Controls the behavior of application when invalid values detected in
           the ``config`` object.
 
-          In the ``default`` mode any invalid value left unprocessed(i.e.,
-          remains ``str``). In addition, every invalid option is reported using
+          In the ``default`` mode any invalid value is left unprocessed (i.e.,
+          it remains a ``str``). In addition, every invalid option is reported using
           a log record with a ``WARNING`` level.
 
-          In the ``strict`` mode none of CKAN CLI commands will be executed and
-          the CKAN application itself will not start unless **all** config
+          In the ``strict`` mode, CKAN will not start unless **all** config
           options are valid according to the validators defined in the
-          declaration. For every invalid config option, an error will be
+          configuration declaration. For every invalid config option, an error will be
           printed to the output stream.
 
   - annotation: Development settings

--- a/ckan/config/declaration/__init__.py
+++ b/ckan/config/declaration/__init__.py
@@ -118,41 +118,23 @@ class Declaration:
             plugin.declare_config_options(self, Key())
         self._seal()
 
-    def make_safe(self, config: "CKANConfig") -> bool:
+    def make_safe(self, config: "CKANConfig"):
         """Load defaul values for missing options.
-
-        This method has effect only in strict mode, because in normal mode
-        there are no guarantees that all the default values are available and
-        valid.
-
-        Returns `True` if declaration became safe and `False` if something went
-        wrong(strict mode is not enabled).
-
         """
-        if config.get_value("config.mode") != "strict":
-            return False
 
         for key in self.iter_options(exclude=Flag.not_safe()):
             if key not in config and not isinstance(key, Pattern):
                 config[str(key)] = self[key].default
-        return True
 
-    def normalize(self, config: "CKANConfig") -> bool:
+    def normalize(self, config: "CKANConfig"):
         """Validate and normalize all the values in the config object.
 
         This method ensures that all the config values are in-place and
-        converts them to the expected type. This method may significantly
-        improve performance of `config.get_value`, because the latter:
-        * no longer has to check if default value required
-        * doesn't have to convert the value using validators
-
-        Works only in strict mode.
+        converts them to the expected type. If config option doesn't pass
+        validation value is left unprocessed, as a string.
 
         """
         import ckan.lib.navl.dictization_functions as df
-
-        if config.get_value("config.mode") != "strict":
-            return False
 
         data, errors = self.validate(config)
 
@@ -160,10 +142,11 @@ class Declaration:
             if v is df.missing:
                 continue
 
-            assert k not in errors, f"Invalid value for {k}: {v}"
-
             if k not in cast(Container[str], self):
                 # it either __extra or __junk
+                continue
+
+            if k in errors:
                 continue
 
             if config.get(k) == v:
@@ -171,8 +154,6 @@ class Declaration:
 
             log.debug(f"Normalized {k} config option: {v}")
             config[k] = v
-
-        return True
 
     def validate(
             self, config: "CKANConfig"

--- a/ckan/config/declaration/option.py
+++ b/ckan/config/declaration/option.py
@@ -64,7 +64,7 @@ class Flag(enum.Flag):
     - is ignored when config option is **missing** from the config file
     - shown as a default value in the config file generated from template. For
       example, `Option<key=a, placeholder=b, commented=False>` is added to the
-      config file as `a = b`. After this, `config.get_value('a')` returns `b`,
+      config file as `a = b`. After this, `config.get('a')` returns `b`,
       because it's explicitely written in the config file.
     Flag.commented:
     - Marks option as commented by default
@@ -72,7 +72,7 @@ class Flag(enum.Flag):
     - switches option to the commented state in the config file generated from
       template.  For example, `Option<key=a, placeholder=b, commented=True>` is
       added to the config file as `# a = b`. After this,
-      `config.get_value('a')` returns `None`, because there is no option `a` in
+      `config.get('a')` returns `None`, because there is no option `a` in
       the config file(it's commented, which makes this option non-existing)
     If the option is missing from the config file, both `placeholder` and
     `commented` are virtually ignored, having absolutely no impact on the value
@@ -92,7 +92,7 @@ class Flag(enum.Flag):
         >>> # GOOD
         >>> ### config file
         >>> # my_extension.feature_flag = reserved_02
-        >>> key = config.get_value('my_extension.feature_flag')
+        >>> key = config.get('my_extension.feature_flag')
         >>> marker = Flag[key]
 
     This allows the end user to manually solve conflicts, when multiple

--- a/ckan/config/declaration/serialize.py
+++ b/ckan/config/declaration/serialize.py
@@ -82,9 +82,6 @@ def serialize_ini(
 
             if minimal and not option.has_flag(Flag.required):
                 # minimal config template relies on default values.
-                # It means, it works only in strict mode.
-                if item == "config.mode":
-                    result += "config.mode = strict\n"
                 continue
 
             if option.description and include_docs:

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -126,18 +126,27 @@ def update_config() -> None:
         if from_env:
             config[option] = from_env
 
-    if config.get_value("config.mode") == "strict":
-        _, errors = config_declaration.validate(config)
-        if errors:
+    _, errors = config_declaration.validate(config)
+    if errors:
+        if config.get("config.mode") == "strict":
             msg = "\n".join(
                 "{}: {}".format(key, "; ".join(issues))
                 for key, issues in errors.items()
             )
+
             raise CkanConfigurationException(msg)
+        else:
+            for key, issues in errors.items():
+                log.warning(
+                    "Invalid value for %s(%s): %s",
+                    key,
+                    config.get(key),
+                    "; ".join(issues)
+                )
 
     root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-    site_url = config.get_value('ckan.site_url')
+    site_url = config.get('ckan.site_url')
     if not site_url:
         raise RuntimeError(
             'ckan.site_url is not configured and it must have a value.'
@@ -149,7 +158,7 @@ def update_config() -> None:
     # Remove backslash from site_url if present
     config['ckan.site_url'] = site_url.rstrip('/')
 
-    display_timezone = config.get_value('ckan.display_timezone')
+    display_timezone = config.get('ckan.display_timezone')
     if (display_timezone and
             display_timezone != 'server' and
             display_timezone not in pytz.all_timezones):
@@ -161,9 +170,9 @@ def update_config() -> None:
     # from ckan.lib.search import SolrSettings, check_solr_schema_version
 
     # lib.search is imported here as we need the config enabled and parsed
-    search.SolrSettings.init(config.get_value('solr_url'),
-                             config.get_value('solr_user'),
-                             config.get_value('solr_password'))
+    search.SolrSettings.init(config.get('solr_url'),
+                             config.get('solr_user'),
+                             config.get('solr_password'))
     search.check_solr_schema_version()
 
     lib_plugins.reset_package_plugins()
@@ -178,7 +187,7 @@ def update_config() -> None:
 
     # Templates and CSS loading from configuration
     valid_base_templates_folder_names = ['templates', 'templates-bs3']
-    templates = config.get_value('ckan.base_templates_folder')
+    templates = config.get('ckan.base_templates_folder')
     config['ckan.base_templates_folder'] = templates
 
     if templates not in valid_base_templates_folder_names:
@@ -191,7 +200,7 @@ def update_config() -> None:
     log.info('Loading templates from %s' % jinja2_templates_path)
     template_paths = [jinja2_templates_path]
 
-    extra_template_paths = config.get_value('extra_template_paths')
+    extra_template_paths = config.get('extra_template_paths')
     if 'plugin_template_paths' in config:
         template_paths = config['plugin_template_paths'] + template_paths
     if extra_template_paths:

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -133,7 +133,7 @@ def update_config() -> None:
                 "{}: {}".format(key, "; ".join(issues))
                 for key, issues in errors.items()
             )
-msg = "Invalid configuration values provided:\n" + msg
+            msg = "Invalid configuration values provided:\n" + msg
             raise CkanConfigurationException(msg)
         else:
             for key, issues in errors.items():

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -133,12 +133,12 @@ def update_config() -> None:
                 "{}: {}".format(key, "; ".join(issues))
                 for key, issues in errors.items()
             )
-
+msg = "Invalid configuration values provided:\n" + msg
             raise CkanConfigurationException(msg)
         else:
             for key, issues in errors.items():
                 log.warning(
-                    "Invalid value for %s(%s): %s",
+                    "Invalid value for %s (%s): %s",
                     key,
                     config.get(key),
                     "; ".join(issues)

--- a/ckan/config/middleware/common_middleware.py
+++ b/ckan/config/middleware/common_middleware.py
@@ -35,7 +35,7 @@ class TrackingMiddleware(object):
 
     def __init__(self, app: CKANApp, config: CKANConfig):
         self.app = app
-        self.engine = sa.create_engine(config.get_value('sqlalchemy.url'))
+        self.engine = sa.create_engine(config.get('sqlalchemy.url'))
 
     def __call__(self, environ: Any, start_response: Any) -> Any:
         path = environ['PATH_INFO']
@@ -81,7 +81,7 @@ class HostHeaderMiddleware(object):
         if path_info in ['/login_generic', '/user/login',
                          '/user/logout', '/user/logged_in',
                          '/user/logged_out']:
-            site_url = config.get_value('ckan.site_url')
+            site_url = config.get('ckan.site_url')
             parts = urlparse(site_url)
             environ['HTTP_HOST'] = str(parts.netloc)
         return self.app(environ, start_response)

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -144,8 +144,8 @@ def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:
         storage_folder = [os.path.join(storage, 'storage')]
 
     # Static files folders (core and extensions)
-    public_folder = config.get_value(u'ckan.base_public_folder')
-    app.static_folder = config.get_value(
+    public_folder = config.get(u'ckan.base_public_folder')
+    app.static_folder = config.get(
         'extra_public_paths'
     ).split(',') + config.get('plugin_public_paths', []) + [
         os.path.join(root, public_folder)
@@ -163,16 +163,7 @@ def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:
     # Update Flask config with the CKAN values. We use the common config
     # object as values might have been modified on `load_environment`
     if config:
-        if config.get_value("config.mode") == "strict":
-            # Config values have been already parsed and validated
-            app.config.update(config)
-        else:
-            # Parse all values to ensure Flask gets the validated values
-            for key in config.keys():
-                if config.is_declared(key):
-                    app.config[key] = config.get_value(key)
-                else:
-                    app.config[key] = config.get(key)
+        app.config.update(config)
     else:
         app.config.update(conf)
 
@@ -180,12 +171,12 @@ def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:
 
     # Secret key needed for flask-debug-toolbar and sessions
     if not app.config.get('SECRET_KEY'):
-        app.config['SECRET_KEY'] = config.get_value('beaker.session.secret')
+        app.config['SECRET_KEY'] = config.get('beaker.session.secret')
     if not app.config.get('SECRET_KEY'):
         raise RuntimeError(u'You must provide a value for the secret key'
                            ' with the SECRET_KEY config option')
 
-    root_path = config.get_value('ckan.root_path')
+    root_path = config.get('ckan.root_path')
     if debug:
         from flask_debugtoolbar import DebugToolbarExtension
         app.config['DEBUG_TB_INTERCEPT_REDIRECTS'] = False
@@ -277,7 +268,7 @@ def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:
     # Set up each IBlueprint extension as a Flask Blueprint
     _register_plugins_blueprints(app)
 
-    if config.get_value("ckan.csrf_protection.ignore_extensions"):
+    if config.get("ckan.csrf_protection.ignore_extensions"):
         log.warn(csrf_warn_extensions)
         _exempt_plugins_blueprints_from_csrf(csrf)
 
@@ -302,7 +293,7 @@ def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:
     # make anonymous_user an instance of CKAN custom class
     login_manager.anonymous_user = model.AnonymousUser
     # The name of the view to redirect to when the user needs to log in.
-    login_manager.login_view = config.get_value("ckan.auth.login_view")
+    login_manager.login_view = config.get("ckan.auth.login_view")
 
     @login_manager.user_loader
     def load_user(user_id: str) -> Optional["model.User"]:  # type: ignore
@@ -317,7 +308,7 @@ def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:
         endpoint = request.endpoint or ""
         is_api = endpoint.split(".")[0] == "api"
         if (
-            not config.get_value("ckan.auth.enable_cookie_auth_in_api")
+            not config.get("ckan.auth.enable_cookie_auth_in_api")
                 and is_api):
             return
 
@@ -346,7 +337,7 @@ def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:
 
     app = I18nMiddleware(app)
 
-    if config.get_value('ckan.tracking_enabled'):
+    if config.get('ckan.tracking_enabled'):
         app = TrackingMiddleware(app, config)
 
     # Add a reference to the actual Flask app so it's easier to access
@@ -364,7 +355,7 @@ def get_locale() -> str:
     '''
     return request.environ.get(
         u'CKAN_LANG',
-        config.get_value(u'ckan.locale_default'))
+        config.get(u'ckan.locale_default'))
 
 
 def set_remote_user_as_current_user_for_tests():
@@ -408,7 +399,7 @@ def ckan_before_request() -> Optional[Response]:
     # This is needed for the TESTS of the CKAN extensions only!
     # we should remove it as soon as the maintainers of the
     # CKAN extensions change their tests according to the new changes.
-    if config.get_value("testing"):
+    if config.get("testing"):
         set_remote_user_as_current_user_for_tests()
 
     # Identify the user from the flask-login cookie or the API header
@@ -426,7 +417,7 @@ def ckan_before_request() -> Optional[Response]:
         csrf.exempt(dest)
 
     # Set the csrf_field_name so we can use it in our templates
-    g.csrf_field_name = config.get_value("WTF_CSRF_FIELD_NAME")
+    g.csrf_field_name = config.get("WTF_CSRF_FIELD_NAME")
 
     # Provide g.controller and g.action for backward compatibility
     # with extensions
@@ -611,7 +602,7 @@ def _register_error_handler(app: CKANApp):
     def error_handler(e: Exception) -> Union[
         tuple[str, Optional[int]], Optional[Response]
     ]:
-        debug = config.get_value('debug')
+        debug = config.get('debug')
         if isinstance(e, HTTPException):
             if debug:
                 log.debug(e, exc_info=sys.exc_info)  # type: ignore
@@ -638,7 +629,7 @@ def _register_error_handler(app: CKANApp):
         app.register_error_handler(code, error_handler)
     if not app.debug and not app.testing:
         app.register_error_handler(Exception, error_handler)
-        if config.get_value('email_to'):
+        if config.get('email_to'):
             _setup_error_mail_handler(app)
 
 
@@ -652,20 +643,20 @@ def _setup_error_mail_handler(app: CKANApp):
             log_record.headers = request.headers
             return True
 
-    smtp_server = config.get_value('smtp.server')
+    smtp_server = config.get('smtp.server')
     mailhost = cast("tuple[str, int]", tuple(smtp_server.split(':'))) \
         if ':' in smtp_server else smtp_server
     credentials = None
-    if config.get_value('smtp.user'):
+    if config.get('smtp.user'):
         credentials = (
-            config.get_value('smtp.user'),
-            config.get_value('smtp.password')
+            config.get('smtp.user'),
+            config.get('smtp.password')
         )
-    secure = () if config.get_value('smtp.starttls') else None
+    secure = () if config.get('smtp.starttls') else None
     mail_handler = SMTPHandler(
         mailhost=mailhost,
-        fromaddr=config.get_value('error_email_from'),
-        toaddrs=[config.get_value('email_to')],
+        fromaddr=config.get('error_email_from'),
+        toaddrs=[config.get('email_to')],
         subject='Application Error',
         credentials=credentials,
         secure=secure
@@ -687,7 +678,7 @@ Headers:            %(headers)s
 
 
 def _setup_webassets(app: CKANApp):
-    app.use_x_sendfile = config.get_value('ckan.webassets.use_x_sendfile')
+    app.use_x_sendfile = config.get('ckan.webassets.use_x_sendfile')
 
     webassets_folder = get_webassets_path()
 

--- a/ckan/lib/api_token.py
+++ b/ckan/lib/api_token.py
@@ -29,14 +29,14 @@ def _get_plugins() -> Iterable[plugins.IApiToken]:
 
 
 def _get_algorithm() -> str:
-    return config.get_value(_config_algorithm)
+    return config.get(_config_algorithm)
 
 
 def _get_secret(encode: bool) -> str:
     config_key = _config_encode_secret if encode else _config_decode_secret
-    secret: str = config.get_value(config_key)
+    secret: str = config.get(config_key)
     if not secret:
-        secret = u"string:" + config.get_value(_config_secret_fallback)
+        secret = u"string:" + config.get(_config_secret_fallback)
     type_, value = secret.split(u":", 1)
     if type_ == u"file":
         with open(value, u"r") as key_file:

--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -70,7 +70,7 @@ def render_snippet(*template_names: str, **kw: Any) -> str:
     for template_name in template_names:
         try:
             output = render(template_name, extra_vars=kw)
-            if config.get_value('debug'):
+            if config.get('debug'):
                 output = (
                     '\n<!-- Snippet %s start -->\n%s\n<!-- Snippet %s end -->'
                     '\n' % (template_name, output, template_name))
@@ -127,7 +127,7 @@ def _allow_caching(cache_force: Optional[bool] = None):
     elif request.args.get('__no_cache__'):
         allow_cache = False
     # Don't cache if caching is not enabled in config
-    elif not config.get_value('ckan.cache_enabled'):
+    elif not config.get('ckan.cache_enabled'):
         allow_cache = False
 
     if not allow_cache:

--- a/ckan/lib/captcha.py
+++ b/ckan/lib/captcha.py
@@ -9,7 +9,7 @@ from ckan.types import Request
 def check_recaptcha(request: Request) -> None:
     '''Check a user\'s recaptcha submission is valid, and raise CaptchaError
     on failure.'''
-    recaptcha_private_key = config.get_value('ckan.recaptcha.privatekey')
+    recaptcha_private_key = config.get('ckan.recaptcha.privatekey')
     if not recaptcha_private_key:
         # Recaptcha not enabled
         return
@@ -30,7 +30,7 @@ def check_recaptcha(request: Request) -> None:
         response=recaptcha_response_field.encode('utf8')
     )
 
-    timeout = config.get_value('ckan.requests.timeout')
+    timeout = config.get('ckan.requests.timeout')
     response = requests.get(recaptcha_server_name, params, timeout=timeout)
     data = response.json()
 

--- a/ckan/lib/datapreview.py
+++ b/ckan/lib/datapreview.py
@@ -56,7 +56,7 @@ def compare_domains(urls: Iterable[str]) -> bool:
 
 def on_same_domain(data_dict: dict[str, Any]) -> bool:
     # compare CKAN domain and resource URL
-    ckan_url = config.get_value('ckan.site_url')
+    ckan_url = config.get('ckan.site_url')
     resource_url = data_dict['resource']['url']
 
     return compare_domains([ckan_url, resource_url])
@@ -124,7 +124,7 @@ def get_default_view_plugins(
 
     Returns a list of IResourceView plugins
     '''
-    default_view_types = config.get_value('ckan.views.default_views')
+    default_view_types = config.get('ckan.views.default_views')
 
     default_view_plugins = []
     for view_type in default_view_types:

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -375,7 +375,7 @@ def group_dictize(group: model.Group, context: Context,
                 if is_group_member:
                     q['include_private'] = True
                 else:
-                    if config.get_value('ckan.auth.allow_dataset_collaborators'):
+                    if config.get('ckan.auth.allow_dataset_collaborators'):
                         q['include_private'] = True
 
             if not just_the_count:

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -292,7 +292,7 @@ def get_site_protocol_and_host() -> Union[tuple[str, str], tuple[None, None]]:
     If the setting is missing, `(None, None)` is returned instead.
 
     '''
-    site_url = config.get_value('ckan.site_url')
+    site_url = config.get('ckan.site_url')
     if site_url is not None:
         parsed_url = urlparse(site_url)
         return (parsed_url.scheme, parsed_url.netloc)
@@ -547,7 +547,7 @@ def is_url(*args: Any, **kw: Any) -> bool:
     except ValueError:
         return False
 
-    valid_schemes = config.get_value('ckan.valid_url_schemes')
+    valid_schemes = config.get('ckan.valid_url_schemes')
 
     return url.scheme in (valid_schemes)
 
@@ -599,7 +599,7 @@ def _local_url(url_to_amend: str, **kw: Any):
 
     # ckan.root_path is defined when we have none standard language
     # position in the url
-    root_path = config.get_value('ckan.root_path')
+    root_path = config.get('ckan.root_path')
     if root_path:
         # FIXME this can be written better once the merge
         # into the ecportal core is done - Toby
@@ -695,12 +695,12 @@ def lang_native_name(lang_: Optional[str] = None) -> Optional[str]:
 
 @core_helper
 def is_rtl_language() -> bool:
-    return lang() in config.get_value('ckan.i18n.rtl_languages')
+    return lang() in config.get('ckan.i18n.rtl_languages')
 
 
 @core_helper
 def get_rtl_theme() -> str:
-    return config.get_value('ckan.i18n.rtl_theme')
+    return config.get('ckan.i18n.rtl_theme')
 
 
 @core_helper
@@ -901,7 +901,7 @@ def build_nav(menu_item: str, title: str, **kw: Any) -> Markup:
 def map_pylons_to_flask_route_name(menu_item: str):
     '''returns flask routes for old fashioned route names'''
     # Pylons to Flask legacy route names mappings
-    mappings = config.get_value('ckan.legacy_route_mappings')
+    mappings = config.get('ckan.legacy_route_mappings')
     if mappings:
         if isinstance(mappings, str):
             LEGACY_ROUTE_NAMES.update(json.loads(mappings))
@@ -924,7 +924,7 @@ def build_extra_admin_nav() -> Markup:
     :rtype: HTML literal
 
     '''
-    admin_tabs_dict = config.get_value('ckan.admin_tabs')
+    admin_tabs_dict = config.get('ckan.admin_tabs')
     output: Markup = literal('')
     if admin_tabs_dict:
         for k, v in admin_tabs_dict.items():
@@ -971,14 +971,14 @@ def _make_menu_item(menu_item: str, title: str, **kw: Any) -> Markup:
 def default_group_type(type_: str) -> str:
     """Get default group/organization type for using site-wide.
     """
-    return config.get_value(f'ckan.default.{type_}_type')
+    return config.get(f'ckan.default.{type_}_type')
 
 
 @core_helper
 def default_package_type() -> str:
     """Get default package type for using site-wide.
     """
-    return config.get_value('ckan.default.package_type')
+    return config.get('ckan.default.package_type')
 
 
 def _humanize_activity(object_type: str, activity_type: str) -> str:
@@ -1217,7 +1217,7 @@ def sorted_extras(package_extras: list[dict[str, Any]],
 
     # If exclude is not supplied use values defined in the config
     if not exclude:
-        exclude = config.get_value('package_hide_extras')
+        exclude = config.get('package_hide_extras')
     output = []
     for extra in sorted(package_extras, key=lambda x: x['key']):
         if extra.get('state') == 'deleted':
@@ -1384,7 +1384,7 @@ def gravatar(email_hash: str,
              size: int = 100,
              default: Optional[str] = None) -> Markup:
     if default is None:
-        default = config.get_value('ckan.gravatar_default')
+        default = config.get('ckan.gravatar_default')
     assert default is not None
 
     if default not in _VALID_GRAVATAR_DEFAULTS:
@@ -1443,7 +1443,7 @@ def user_image(user_id: str, size: int = 100) -> Union[Markup, str]:
     except logic.NotFound:
         return ''
 
-    gravatar_default = config.get_value('ckan.gravatar_default')
+    gravatar_default = config.get('ckan.gravatar_default')
 
     if user_dict['image_display_url']:
         return literal('''<img src="{url}"
@@ -1498,7 +1498,7 @@ def get_display_timezone() -> datetime.tzinfo:
     configuration file or UTC if not specified.
     :rtype: timezone
     '''
-    timezone_name = config.get_value('ckan.display_timezone')
+    timezone_name = config.get('ckan.display_timezone')
 
     if timezone_name == 'server':
         return tzlocal.get_localzone()
@@ -2416,7 +2416,7 @@ def get_featured_organizations(count: int = 1) -> list[dict[str, Any]]:
     '''Returns a list of favourite organization in the form
     of organization_list action function
     '''
-    config_orgs = config.get_value('ckan.featured_orgs')
+    config_orgs = config.get('ckan.featured_orgs')
     orgs = featured_group_org(get_action='organization_show',
                               list_action='organization_list',
                               count=count,
@@ -2429,7 +2429,7 @@ def get_featured_groups(count: int = 1) -> list[dict[str, Any]]:
     '''Returns a list of favourite group the form
     of organization_list action function
     '''
-    config_groups = config.get_value('ckan.featured_groups')
+    config_groups = config.get('ckan.featured_groups')
     groups = featured_group_org(get_action='group_show',
                                 list_action='group_list',
                                 count=count,
@@ -2509,7 +2509,7 @@ def resource_formats() -> dict[str, list[str]]:
     '''
     global _RESOURCE_FORMATS
     if not _RESOURCE_FORMATS:
-        format_file_path = config.get_value('ckan.resource_formats')
+        format_file_path = config.get('ckan.resource_formats')
         if not format_file_path:
             format_file_path = resource_formats_default_file()
 
@@ -2606,7 +2606,7 @@ def get_translated(data_dict: dict[str, Any], field: str) -> Union[str, Any]:
 @core_helper
 def facets() -> list[str]:
     u'''Returns a list of the current facet names'''
-    return config.get_value(u'search.facets')
+    return config.get(u'search.facets')
 
 
 @core_helper

--- a/ckan/lib/i18n.py
+++ b/ckan/lib/i18n.py
@@ -70,7 +70,7 @@ _JS_TRANSLATIONS_DIR = os.path.join(_CKAN_DIR, u'public', u'base', u'i18n')
 
 
 def get_ckan_i18n_dir() -> str:
-    path = config.get_value(u'ckan.i18n_directory') or os.path.join(
+    path = config.get(u'ckan.i18n_directory') or os.path.join(
         _CKAN_DIR, u'i18n')
     if os.path.isdir(os.path.join(path, u'i18n')):
         path = os.path.join(path, u'i18n')
@@ -81,10 +81,10 @@ def get_ckan_i18n_dir() -> str:
 def get_locales_from_config() -> set[str]:
     ''' despite the name of this function it gets the locales defined by
     the config AND also the locals available subject to the config. '''
-    locales_offered = config.get_value('ckan.locales_offered')
-    filtered_out = config.get_value('ckan.locales_filtered_out')
-    locale_default = [config.get_value('ckan.locale_default')]
-    locale_order = config.get_value('ckan.locale_order')
+    locales_offered = config.get('ckan.locales_offered')
+    filtered_out = config.get('ckan.locales_filtered_out')
+    locale_default = [config.get('ckan.locale_default')]
+    locale_order = config.get('ckan.locale_order')
 
     known_locales = get_locales()
     all_locales = (set(known_locales) |
@@ -100,10 +100,10 @@ def _get_locales() -> list[str]:
     assert not config.get('lang'), \
         ('"lang" config option not supported - please use ckan.locale_default '
          'instead.')
-    locales_offered = config.get_value('ckan.locales_offered')
-    filtered_out = config.get_value('ckan.locales_filtered_out')
-    locale_default = config.get_value('ckan.locale_default')
-    locale_order = config.get_value('ckan.locale_order')
+    locales_offered = config.get('ckan.locales_offered')
+    filtered_out = config.get('ckan.locales_filtered_out')
+    locale_default = config.get('ckan.locale_default')
+    locale_order = config.get('ckan.locale_order')
 
     locales = ['en']
     i18n_path = get_ckan_i18n_dir()
@@ -171,7 +171,7 @@ def non_translated_locals() -> list[str]:
     no translations. returns a list like ['en', 'de', ...] '''
     global _non_translated_locals
     if not _non_translated_locals:
-        locales = config.get_value('ckan.locale_order')
+        locales = config.get('ckan.locale_order')
         _non_translated_locals = [x for x in locales if x not in get_locales()]
     return _non_translated_locals
 
@@ -226,7 +226,7 @@ def get_identifier_from_locale_class(locale: Locale) -> str:
 def handle_request(request: Request, tmpl_context: Any) -> str:
     ''' Set the language for the request '''
     lang = request.environ.get('CKAN_LANG') or \
-        config.get_value('ckan.locale_default')
+        config.get('ckan.locale_default')
     if lang != 'en':
         set_lang(lang)
 
@@ -244,7 +244,7 @@ def get_lang() -> str:
 def set_lang(language_code: str) -> None:
     ''' Wrapper to pylons call '''
     if language_code in non_translated_locals():
-        language_code = config.get_value('ckan.locale_default')
+        language_code = config.get('ckan.locale_default')
 
 
 def _get_js_translation_entries(filename: str) -> set[str]:

--- a/ckan/lib/jobs.py
+++ b/ckan/lib/jobs.py
@@ -161,7 +161,7 @@ def enqueue(fn: Callable[..., Any],
         kwargs = {}
     if rq_kwargs is None:
         rq_kwargs = {}
-    timeout = config.get_value(u'ckan.jobs.timeout')
+    timeout = config.get(u'ckan.jobs.timeout')
     rq_kwargs[u'timeout'] = rq_kwargs.get(u'timeout', timeout)
 
     job = get_queue(queue).enqueue_call(

--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -47,9 +47,9 @@ def _mail_recipient(
     if not attachments:
         attachments = []
 
-    mail_from = config.get_value('smtp.mail_from')
+    mail_from = config.get('smtp.mail_from')
 
-    reply_to = config.get_value('smtp.reply_to')
+    reply_to = config.get('smtp.reply_to')
 
     msg = EmailMessage()
 
@@ -67,7 +67,7 @@ def _mail_recipient(
     msg['From'] = _("%s <%s>") % (sender_name, mail_from)
     msg['To'] = u"%s <%s>" % (recipient_name, recipient_email)
     msg['Date'] = utils.formatdate(time())
-    if not config.get_value('ckan.hide_version'):
+    if not config.get('ckan.hide_version'):
         msg['X-Mailer'] = "CKAN %s" % ckan.__version__
     # Check if extension is setting reply-to via headers or use config option
     if reply_to and reply_to != '' and not msg['Reply-to']:
@@ -91,10 +91,10 @@ def _mail_recipient(
             _file.read(), filename=name, maintype=main_type, subtype=sub_type)
 
     # Send the email using Python's smtplib.
-    smtp_server = config.get_value('smtp.server')
-    smtp_starttls = config.get_value('smtp.starttls')
-    smtp_user = config.get_value('smtp.user')
-    smtp_password = config.get_value('smtp.password')
+    smtp_server = config.get('smtp.server')
+    smtp_starttls = config.get('smtp.starttls')
+    smtp_user = config.get('smtp.user')
+    smtp_password = config.get('smtp.password')
 
     try:
         smtp_connection = smtplib.SMTP(smtp_server)
@@ -178,8 +178,8 @@ def mail_recipient(recipient_name: str,
             ]
     :type: list
     '''
-    site_title = config.get_value('ckan.site_title')
-    site_url = config.get_value('ckan.site_url')
+    site_title = config.get('ckan.site_title')
+    site_url = config.get('ckan.site_url')
     return _mail_recipient(
         recipient_name, recipient_email,
         site_title, site_url, subject, body,
@@ -213,8 +213,8 @@ def mail_user(recipient: model.User,
 def get_reset_link_body(user: model.User) -> str:
     extra_vars = {
         'reset_link': get_reset_link(user),
-        'site_title': config.get_value('ckan.site_title'),
-        'site_url': config.get_value('ckan.site_url'),
+        'site_title': config.get('ckan.site_title'),
+        'site_url': config.get('ckan.site_url'),
         'user_name': user.name,
     }
     # NOTE: This template is translated
@@ -226,8 +226,8 @@ def get_invite_body(user: model.User,
                     role: Optional[str] = None) -> str:
     extra_vars = {
         'reset_link': get_reset_link(user),
-        'site_title': config.get_value('ckan.site_title'),
-        'site_url': config.get_value('ckan.site_url'),
+        'site_title': config.get('ckan.site_title'),
+        'site_url': config.get('ckan.site_url'),
         'user_name': user.name,
     }
 
@@ -254,7 +254,7 @@ def send_reset_link(user: model.User) -> None:
     create_reset_key(user)
     body = get_reset_link_body(user)
     extra_vars = {
-        'site_title': config.get_value('ckan.site_title')
+        'site_title': config.get('ckan.site_title')
     }
     subject = render('emails/reset_password_subject.txt', extra_vars)
 
@@ -271,7 +271,7 @@ def send_invite(
     create_reset_key(user)
     body = get_invite_body(user, group_dict, role)
     extra_vars = {
-        'site_title': config.get_value('ckan.site_title')
+        'site_title': config.get('ckan.site_title')
     }
     subject = render('emails/invite_user_subject.txt', extra_vars)
 

--- a/ckan/lib/redis.py
+++ b/ckan/lib/redis.py
@@ -35,7 +35,7 @@ def connect_to_redis() -> Redis:  # type: ignore
     '''
     global _connection_pool
     if _connection_pool is None:
-        url = config.get_value('ckan.redis.url')
+        url = config.get('ckan.redis.url')
         log.debug(u'Using Redis at {}'.format(url))
         _connection_pool = ConnectionPool.from_url(url)
     return Redis(connection_pool=_connection_pool)

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -219,7 +219,7 @@ def rebuild(package_id: Optional[str] = None,
             package_index.update_dict(pkg_dict, True)
     else:
         packages = model.Session.query(model.Package.id)
-        if config.get_value('ckan.search.remove_deleted_packages'):
+        if config.get('ckan.search.remove_deleted_packages'):
             packages = packages.filter(model.Package.state != 'deleted')
 
         package_ids = [r[0] for r in packages.all()]
@@ -311,7 +311,7 @@ def clear_all() -> None:
 
 def _get_schema_from_solr(file_offset: str):
 
-    timeout = config.get_value('ckan.requests.timeout')
+    timeout = config.get('ckan.requests.timeout')
 
     solr_url, solr_user, solr_password = SolrSettings.get()
 

--- a/ckan/lib/search/common.py
+++ b/ckan/lib/search/common.py
@@ -87,7 +87,7 @@ def make_connection(decode_dates: bool = True) -> Solr:
                                        quote_plus(solr_password),
                                        solr_url)
 
-    timeout = config.get_value('solr_timeout')
+    timeout = config.get('solr_timeout')
 
     if decode_dates:
         decoder = simplejson.JSONDecoder(object_hook=solr_datetime_decoder)

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -49,7 +49,7 @@ def escape_xml_illegal_chars(val: str, replacement: str='') -> str:
 
 def clear_index() -> None:
     conn = make_connection()
-    query = "+site_id:\"%s\"" % (config.get_value('ckan.site_id'))
+    query = "+site_id:\"%s\"" % (config.get('ckan.site_id'))
     try:
         conn.delete(q=query)
         conn.commit()
@@ -135,7 +135,7 @@ class PackageSearchIndex(SearchIndex):
         if title:
             pkg_dict['title_string'] = title
 
-        if config.get_value('ckan.search.remove_deleted_packages'):
+        if config.get('ckan.search.remove_deleted_packages'):
             # delete the package if there is no state, or the state is `deleted`
             if pkg_dict.get('state') in [None, 'deleted']:
                 return self.delete_package(pkg_dict)
@@ -269,7 +269,7 @@ class PackageSearchIndex(SearchIndex):
         pkg_dict['metadata_modified'] += 'Z'
 
         # mark this CKAN instance as data source:
-        pkg_dict['site_id'] = config.get_value('ckan.site_id')
+        pkg_dict['site_id'] = config.get('ckan.site_id')
 
         # Strip a selection of the fields.
         # These fields are possible candidates for sorting search results on,
@@ -284,7 +284,7 @@ class PackageSearchIndex(SearchIndex):
 
         # add a unique index_id to avoid conflicts
         import hashlib
-        pkg_dict['index_id'] = hashlib.md5(six.b('%s%s' % (pkg_dict['id'],config.get_value('ckan.site_id')))).hexdigest()
+        pkg_dict['index_id'] = hashlib.md5(six.b('%s%s' % (pkg_dict['id'],config.get('ckan.site_id')))).hexdigest()
 
         for item in PluginImplementations(IPackageController):
             pkg_dict = item.before_dataset_index(pkg_dict)
@@ -303,7 +303,7 @@ class PackageSearchIndex(SearchIndex):
         try:
             conn = make_connection()
             commit = not defer_commit
-            if not config.get_value('ckan.search.solr_commit'):
+            if not config.get('ckan.search.solr_commit'):
                 commit = False
             conn.add(docs=[pkg_dict], commit=commit)
         except pysolr.SolrError as e:
@@ -332,9 +332,9 @@ class PackageSearchIndex(SearchIndex):
     def delete_package(self, pkg_dict: dict[str, Any]) -> None:
         conn = make_connection()
         query = "+%s:%s AND +(id:\"%s\" OR name:\"%s\") AND +site_id:\"%s\"" % \
-                (TYPE_FIELD, PACKAGE_TYPE, pkg_dict.get('id'), pkg_dict.get('id'), config.get_value('ckan.site_id'))
+                (TYPE_FIELD, PACKAGE_TYPE, pkg_dict.get('id'), pkg_dict.get('id'), config.get('ckan.site_id'))
         try:
-            commit = config.get_value('ckan.search.solr_commit')
+            commit = config.get('ckan.search.solr_commit')
             conn.delete(q=query, commit=commit)
         except Exception as e:
             log.exception(e)

--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -286,7 +286,7 @@ class PackageSearchQuery(SearchQuery):
         Return a list of the IDs of all indexed packages.
         """
         query = "*:*"
-        fq = "+site_id:\"%s\" " % config.get_value('ckan.site_id')
+        fq = "+site_id:\"%s\" " % config.get('ckan.site_id')
         fq += "+state:active "
 
         conn = make_connection()
@@ -298,7 +298,7 @@ class PackageSearchQuery(SearchQuery):
             'rows': 1,
             'q': 'name:"%s" OR id:"%s"' % (reference, reference),
             'wt': 'json',
-            'fq': 'site_id:"%s" ' % config.get_value('ckan.site_id') + '+entity_type:package'}
+            'fq': 'site_id:"%s" ' % config.get('ckan.site_id') + '+entity_type:package'}
 
         try:
             if query['q'].startswith('{!'):
@@ -367,7 +367,7 @@ class PackageSearchQuery(SearchQuery):
         fq.extend(query.get('fq_list', []))
 
         # show only results from this CKAN instance
-        fq.append('+site_id:%s' % solr_literal(config.get_value('ckan.site_id')))
+        fq.append('+site_id:%s' % solr_literal(config.get('ckan.site_id')))
 
         # filter for package status
         if not '+state:' in query.get('fq', ''):
@@ -381,7 +381,7 @@ class PackageSearchQuery(SearchQuery):
 
         # faceting
         query['facet'] = query.get('facet', 'true')
-        query['facet.limit'] = query.get('facet.limit', config.get_value('search.facets.limit'))
+        query['facet.limit'] = query.get('facet.limit', config.get('search.facets.limit'))
         query['facet.mincount'] = query.get('facet.mincount', 1)
 
         # return the package ID and search scores

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -80,7 +80,7 @@ def get_resource_uploader(data_dict: dict[str, Any]) -> PResourceUploader:
 
 def get_storage_path() -> str:
     '''Function to get the storage path from config file.'''
-    storage_path = config.get_value('ckan.storage_path')
+    storage_path = config.get('ckan.storage_path')
     if not storage_path:
         log.critical('''Please specify a ckan.storage_path in your config
                         for your uploads''')
@@ -89,11 +89,11 @@ def get_storage_path() -> str:
 
 
 def get_max_image_size() -> int:
-    return config.get_value('ckan.max_image_size')
+    return config.get('ckan.max_image_size')
 
 
 def get_max_resource_size() -> int:
-    return config.get_value('ckan.max_resource_size')
+    return config.get('ckan.max_resource_size')
 
 
 class Upload(object):
@@ -205,9 +205,9 @@ class Upload(object):
         if not self.filename or not self.upload_file:
             return
 
-        mimetypes = config.get_value(
+        mimetypes = config.get(
             f"ckan.upload.{self.object_type}.mimetypes")
-        types = config.get_value(f"ckan.upload.{self.object_type}.types")
+        types = config.get(f"ckan.upload.{self.object_type}.types")
         if not mimetypes and not types:
             return
 
@@ -230,7 +230,7 @@ class ResourceUpload(object):
 
     def __init__(self, resource: dict[str, Any]) -> None:
         path = get_storage_path()
-        config_mimetype_guess = config.get_value('ckan.mimetype_guess')
+        config_mimetype_guess = config.get('ckan.mimetype_guess')
 
         if not path:
             self.storage_path = None

--- a/ckan/lib/webassets_tools.py
+++ b/ckan/lib/webassets_tools.py
@@ -51,7 +51,7 @@ def webassets_init() -> None:
 
     static_path = get_webassets_path()
 
-    public = config.get_value(u'ckan.base_public_folder')
+    public = config.get(u'ckan.base_public_folder')
 
     public_folder = os.path.abspath(os.path.join(
         os.path.dirname(__file__), u'..', public))
@@ -60,7 +60,7 @@ def webassets_init() -> None:
 
     env = Environment()
     env.directory = static_path
-    env.debug = config.get_value(u'debug')
+    env.debug = config.get(u'debug')
     env.url = u'/webassets/'
 
     add_public_path(base_path, u'/base/')
@@ -149,10 +149,10 @@ def render_assets(type_: str) -> Markup:
 
 
 def get_webassets_path() -> str:
-    webassets_path = config.get_value(u'ckan.webassets.path')
+    webassets_path = config.get(u'ckan.webassets.path')
 
     if not webassets_path:
-        storage_path = config.get_value(
+        storage_path = config.get(
             u'ckan.storage_path'
         ) or tempfile.gettempdir()
 

--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -167,7 +167,7 @@ def checks_and_delete_if_csrf_token_in_forms(parsed: dict[str, Any]):
     from ckan.common import config
 
     # WTF_CSRF_FIELD_NAME is added by flask_wtf
-    csrf_token = config.get_value("WTF_CSRF_FIELD_NAME")
+    csrf_token = config.get("WTF_CSRF_FIELD_NAME")
     if csrf_token in parsed:
         parsed.pop(csrf_token)
     return parsed

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -337,7 +337,7 @@ def _group_or_org_list(
             data_dict, ckan.logic.schema.default_pagination_schema(), context)
         if errors:
             raise ValidationError(errors)
-    sort = data_dict.get('sort') or config.get_value('ckan.default_group_sort')
+    sort = data_dict.get('sort') or config.get('ckan.default_group_sort')
     q = data_dict.get('q', '').strip()
 
     all_fields = asbool(data_dict.get('all_fields', None))
@@ -345,13 +345,13 @@ def _group_or_org_list(
     if all_fields:
         # all_fields is really computationally expensive, so need a tight limit
         try:
-            max_limit = config.get_value(
+            max_limit = config.get(
                 'ckan.group_and_organization_list_all_fields_max')
         except ValueError:
             max_limit = 25
     else:
         try:
-            max_limit = config.get_value('ckan.group_and_organization_list_max')
+            max_limit = config.get('ckan.group_and_organization_list_max')
         except ValueError:
             max_limit = 1000
 
@@ -869,7 +869,7 @@ def user_list(
         query = model.Session.query(model.User.name)
 
     if not asbool(data_dict.get('include_site_user', False)):
-        site_id = config.get_value('ckan.site_id')
+        site_id = config.get('ckan.site_id')
         query = query.filter(model.User.name != site_id)
 
     if q:
@@ -1203,7 +1203,7 @@ def _group_or_org_show(
 
     try:
         include_tags = asbool(data_dict.get('include_tags', True))
-        if config.get_value('ckan.auth.public_user_details'):
+        if config.get('ckan.auth.public_user_details'):
             include_users = asbool(data_dict.get('include_users', True))
         else:
             include_users = asbool(data_dict.get('include_users', False))
@@ -1890,7 +1890,7 @@ def package_search(context: Context, data_dict: DataDict) -> ActionResult.Packag
     abort = data_dict.get('abort_search', False)
 
     if data_dict.get('sort') in (None, 'rank'):
-        data_dict['sort'] = config.get_value('ckan.search.default_package_sort')
+        data_dict['sort'] = config.get('ckan.search.default_package_sort')
 
     results: list[dict[str, Any]] = []
     facets: dict[str, Any] = {}
@@ -2430,7 +2430,7 @@ def get_site_user(context: Context, data_dict: DataDict) -> ActionResult.GetSite
     '''
     _check_access('get_site_user', context, data_dict)
     model = context['model']
-    site_id = config.get_value('ckan.site_id')
+    site_id = config.get('ckan.site_id')
     user = model.User.get(site_id)
     if not user:
         apikey = str(uuid.uuid4())
@@ -2455,17 +2455,17 @@ def status_show(context: Context, data_dict: DataDict) -> ActionResult.StatusSho
 
     '''
     _check_access('status_show', context, data_dict)
-    extensions = config.get_value('ckan.plugins')
+    extensions = config.get('ckan.plugins')
 
     site_info = {
-        'site_title': config.get_value('ckan.site_title'),
-        'site_description': config.get_value('ckan.site_description'),
-        'site_url': config.get_value('ckan.site_url'),
-        'error_emails_to': config.get_value('email_to'),
-        'locale_default': config.get_value('ckan.locale_default'),
+        'site_title': config.get('ckan.site_title'),
+        'site_description': config.get('ckan.site_description'),
+        'site_url': config.get('ckan.site_url'),
+        'error_emails_to': config.get('email_to'),
+        'locale_default': config.get('ckan.locale_default'),
         'extensions': extensions,
     }
-    if not config.get_value('ckan.hide_version') or authz.is_sysadmin(context['user']):
+    if not config.get('ckan.hide_version') or authz.is_sysadmin(context['user']):
         site_info['ckan_version'] = ckan.__version__
     return site_info
 
@@ -2762,7 +2762,7 @@ def _followee_count(
         data_dict, errors = _validate(data_dict, schema, context)
         if errors:
             raise ValidationError(errors)
-    
+
     followees = _group_or_org_followee_list(context, data_dict, is_org)
 
     return len(followees)

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -662,7 +662,7 @@ def _group_or_org_update(
         raise NotFound('Group was not found.')
     context["group"] = group
 
-    data_dict_type = data_dict.get('type') 
+    data_dict_type = data_dict.get('type')
     if data_dict_type is None:
         data_dict['type'] = group.type
     else:
@@ -1146,7 +1146,7 @@ def _bulk_update_dataset(
             'q': q,
             'fl': 'data_dict',
             'wt': 'json',
-            'fq': 'site_id:"%s"' % config.get_value('ckan.site_id'),
+            'fq': 'site_id:"%s"' % config.get('ckan.site_id'),
             'rows': BATCH_SIZE
         }
 

--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -86,7 +86,7 @@ def user_list(context: Context, data_dict: DataDict) -> AuthResult:
     if data_dict.get('email'):
         # only sysadmins can specify the 'email' parameter
         return {'success': False}
-    if not config.get_value('ckan.auth.public_user_details'):
+    if not config.get('ckan.auth.public_user_details'):
         return restrict_anon(context)
     else:
         return {'success': True}
@@ -171,7 +171,7 @@ def group_show(context: Context, data_dict: DataDict) -> AuthResult:
     user = context.get('user')
     group = get_group_object(context, data_dict)
     if group.state == 'active':
-        if config.get_value('ckan.auth.public_user_details') or \
+        if config.get('ckan.auth.public_user_details') or \
             (not asbool(data_dict.get('include_users', False)) and
                 (data_dict.get('object_type', None) != 'user')):
             return {'success': True}
@@ -200,7 +200,7 @@ def tag_show(context: Context, data_dict: DataDict) -> AuthResult:
 def user_show(context: Context, data_dict: DataDict) -> AuthResult:
     # By default, user details can be read by anyone, but some properties like
     # the API key are stripped at the action level if not not logged in.
-    if not config.get_value('ckan.auth.public_user_details'):
+    if not config.get('ckan.auth.public_user_details'):
         return restrict_anon(context)
     else:
         return {'success': True}
@@ -468,4 +468,3 @@ def term_translation_show(context: Context, data_dict: DataDict) -> AuthResult:
     '''Check if the translations for the given term(s) and language(s) are visible.
     Visible to all by default.'''
     return {'success': True}
-

--- a/ckan/model/__init__.py
+++ b/ckan/model/__init__.py
@@ -276,7 +276,7 @@ class Repository():
         self.reset_alembic_output()
         alembic_config = AlembicConfig(self._alembic_ini)
         alembic_config.set_main_option(
-            "sqlalchemy.url", config.get_value("sqlalchemy.url")
+            "sqlalchemy.url", config.get("sqlalchemy.url")
         )
         try:
             sqlalchemy_migrate_version = self.metadata.bind.execute(

--- a/ckan/model/api_token.py
+++ b/ckan/model/api_token.py
@@ -18,7 +18,7 @@ __all__ = [u"ApiToken", u"api_token_table"]
 
 
 def _make_token() -> str:
-    nbytes = config.get_value(u"api_token.nbytes")
+    nbytes = config.get(u"api_token.nbytes")
     return token_urlsafe(nbytes)
 
 

--- a/ckan/model/license.py
+++ b/ckan/model/license.py
@@ -52,7 +52,7 @@ class LicenseRegister(object):
     licenses: list[License]
 
     def __init__(self):
-        group_url = config.get_value('licenses_group_url')
+        group_url = config.get('licenses_group_url')
         if group_url:
             self.load_licenses(group_url)
         else:
@@ -82,7 +82,7 @@ class LicenseRegister(object):
                 with open(license_url.replace('file://', ''), 'r') as f:
                     license_data = json.load(f)
             else:
-                timeout = config.get_value('ckan.requests.timeout')
+                timeout = config.get('ckan.requests.timeout')
                 response = requests.get(license_url, timeout=timeout)
                 license_data = response.json()
         except requests.RequestException as e:

--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -264,7 +264,7 @@ class Package(core.StatefulObjectMixin,
         _dict['extras'] = {key: value for key, value in self.extras.items()}
         _dict['resources'] = [res.as_dict(core_columns_only=False) \
                               for res in self.resources]
-        site_url = config.get_value('ckan.site_url')
+        site_url = config.get('ckan.site_url')
         if site_url:
             _dict['ckan_url'] = '%s/dataset/%s' % (site_url, self.name)
         _dict['relationships'] = [rel.as_dict(self, ref_package_by=ref_package_by) for rel in self.get_relationships()]

--- a/ckan/model/resource.py
+++ b/ckan/model/resource.py
@@ -152,7 +152,7 @@ class Resource(core.StatefulObjectMixin,
     @classmethod
     def get_extra_columns(cls) -> list[str]:
         if cls.extra_columns is None:
-            cls.extra_columns = config.get_value("ckan.extra_resource_fields")
+            cls.extra_columns = config.get("ckan.extra_resource_fields")
             for field in cls.extra_columns:
                 setattr(cls, field, DictProxy(field, 'extras'))
         assert cls.extra_columns is not None

--- a/ckan/model/user.py
+++ b/ckan/model/user.py
@@ -31,14 +31,14 @@ if TYPE_CHECKING:
 
 
 def last_active_check():
-    last_active = config.get_value('ckan.user.last_active_interval')
+    last_active = config.get('ckan.user.last_active_interval')
     calc_time = datetime.datetime.utcnow() - datetime.timedelta(seconds=last_active)
 
     return calc_time
 
 
 def set_api_key() -> Optional[str]:
-    if config.get_value('ckan.auth.create_default_api_keys'):
+    if config.get('ckan.auth.create_default_api_keys'):
         return _types.make_uuid()
     return None
 

--- a/ckan/plugins/core.py
+++ b/ckan/plugins/core.py
@@ -97,7 +97,7 @@ class PluginImplementations(ExtensionPoint, Generic[TInterface]):
 
         plugin_lookup = {pf.name: pf for pf in iterator}
 
-        plugins = config.get_value("ckan.plugins")
+        plugins = config.get("ckan.plugins")
         if plugins is None:
             plugins = []
         elif isinstance(plugins, str):
@@ -219,7 +219,7 @@ def load_all() -> None:
     # Clear any loaded plugins
     unload_all()
 
-    plugins = config.get_value('ckan.plugins') + find_system_plugins()
+    plugins = config.get('ckan.plugins') + find_system_plugins()
 
     load(*plugins)
 

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -198,7 +198,7 @@ def add_ckan_admin_tab(
     Update 'ckan.admin_tabs' dict the passed config dict.
     """
     # get the admin_tabs dict from the config, or an empty dict.
-    admin_tabs_dict = config_.get_value(config_var)
+    admin_tabs_dict = config_.get(config_var)
     # update the admin_tabs dict with the new values
     admin_tabs_dict.update({route_name: {"label": tab_label, "icon": icon}})
     # update the config with the updated admin_tabs dict
@@ -302,7 +302,7 @@ docstring_overrides = {
 
 It stores the configuration values defined in the :ref:`config_file`, eg::
 
-    title = toolkit.config.get_value("ckan.site_title")
+    title = toolkit.config.get("ckan.site_title")
 
 """,
     "_": """Translates a string to the current locale.

--- a/ckan/tests/cli/test_config.py
+++ b/ckan/tests/cli/test_config.py
@@ -11,7 +11,7 @@ from ckan.cli.cli import ckan
 @pytest.fixture
 def command(cli):
     def invoke(*args):
-        return cli.invoke(ckan, ("config",) + args, catch_exceptions=False)
+        return cli.invoke(ckan, ("config",) + args)
 
     return invoke
 

--- a/ckan/tests/config/declaration/test_declaration.py
+++ b/ckan/tests/config/declaration/test_declaration.py
@@ -142,7 +142,6 @@ class TestDeclaration:
         decl.make_safe(cfg)
         assert cfg == CKANConfig({"a": 20})
 
-
     def test_normalize_convert_types(self):
         decl = Declaration()
         decl.declare_int(Key().a, "10")

--- a/ckan/tests/config/declaration/test_declaration.py
+++ b/ckan/tests/config/declaration/test_declaration.py
@@ -75,24 +75,9 @@ class TestDeclaration:
         # core declarations loaded
         assert Key().ckan.site_url in decl
 
-        # no safe-mode by default
-        missing = set(decl.iter_options()) - set(ckan_config)
-        assert Key().api_token.jwt.algorithm in missing
+        # normalization changed types
+        assert isinstance(ckan_config["debug"], bool)
 
-        # no normalization by default
-        assert isinstance(ckan_config["debug"], str)
-
-    @pytest.mark.ckan_config("config.mode", "strict")
-    def test_safe_setup(self, ckan_config):
-        delimiter = Key().ckan.template_title_delimiter
-        decl = Declaration()
-
-        assert delimiter not in ckan_config
-        decl.setup()
-        decl.make_safe(ckan_config)
-        assert delimiter in ckan_config
-
-    @pytest.mark.ckan_config("config.mode", "strict")
     @pytest.mark.ckan_config("ckan.jobs.timeout", "zero")
     def test_strict_setup(self, ckan_config):
         decl = Declaration()
@@ -100,7 +85,6 @@ class TestDeclaration:
         _, errors = decl.validate(ckan_config)
         assert "ckan.jobs.timeout" in errors
 
-    @pytest.mark.ckan_config("config.mode", "strict")
     def test_normalized_setup(self, ckan_config):
         decl = Declaration()
         decl.setup()
@@ -142,47 +126,36 @@ class TestDeclaration:
 
         assert k in decl
 
-    def test_make_safe_no_effect(self):
+    def test_make_safe_uses_defaults(self):
         decl = Declaration()
         decl.declare(Key().a, 10)
 
         cfg = CKANConfig()
-        assert not decl.make_safe(cfg)
-        assert cfg == CKANConfig()
-
-    def test_make_safe_in_safe_mode(self):
-        decl = Declaration()
-        decl.declare(Key().a, 10)
-
-        cfg = CKANConfig({"config.mode": "strict"})
-        assert decl.make_safe(cfg)
-        assert cfg == CKANConfig({"config.mode": "strict", "a": 10})
+        decl.make_safe(cfg)
+        assert cfg == CKANConfig({"a": 10})
 
     def test_make_safe_no_overrides(self):
         decl = Declaration()
         decl.declare(Key().a, 10)
 
-        cfg = CKANConfig({"config.mode": "strict", "a": 20})
-        assert decl.make_safe(cfg)
-        assert cfg == CKANConfig({"config.mode": "strict", "a": 20})
+        cfg = CKANConfig({"a": 20})
+        decl.make_safe(cfg)
+        assert cfg == CKANConfig({"a": 20})
 
-    def test_normalize_no_effect(self):
+
+    def test_normalize_convert_types(self):
         decl = Declaration()
         decl.declare_int(Key().a, "10")
 
         cfg = CKANConfig()
-        assert not decl.normalize(cfg)
+        decl.normalize(cfg)
+        # in non-safe mode default value has no effect
         assert cfg == CKANConfig()
 
-    def test_normalize_in_normalized_mode(self):
-        decl = Declaration()
-        decl.declare_int(Key().a, "10")
+        decl.make_safe(cfg)
+        decl.normalize(cfg)
+        assert cfg == CKANConfig({"a": 10})
 
-        cfg = CKANConfig({"config.mode": "strict"})
-        assert decl.normalize(cfg)
-        # in non-safe mode default value has no effect
-        assert cfg == CKANConfig({"config.mode": "strict"})
-
-        cfg = CKANConfig({"config.mode": "strict", "a": "10"})
-        assert decl.normalize(cfg)
-        assert cfg == CKANConfig({"config.mode": "strict", "a": 10})
+        cfg = CKANConfig({"a": "20"})
+        decl.normalize(cfg)
+        assert cfg == CKANConfig({"a": 20})

--- a/ckan/tests/config/test_middleware.py
+++ b/ckan/tests/config/test_middleware.py
@@ -100,11 +100,3 @@ def test_flask_config_values_are_parsed(app):
     assert (
         app.flask_app.config["REMEMBER_COOKIE_DURATION"] == 12345
     )
-
-
-@pytest.mark.ckan_config("config.mode", "strict")
-@pytest.mark.ckan_config("REMEMBER_COOKIE_DURATION", "12345")
-def test_flask_config_values_are_parsed_in_strict_mode(app):
-    assert (
-        app.flask_app.config["REMEMBER_COOKIE_DURATION"] == 12345
-    )

--- a/ckan/tests/lib/test_datapreview.py
+++ b/ckan/tests/lib/test_datapreview.py
@@ -194,7 +194,7 @@ class TestDatapreview(object):
         )
 
         # Change default views config setting
-        config["ckan.views.default_views"] = "image_view"
+        config["ckan.views.default_views"] = ["image_view"]
 
         context = {"user": helpers.call_action("get_site_user")["name"]}
         created_views = datapreview.add_views_to_dataset_resources(
@@ -231,7 +231,7 @@ class TestDatapreview(object):
         )
 
         # Change default views config setting
-        config["ckan.views.default_views"] = "image_view"
+        config["ckan.views.default_views"] = ["image_view"]
 
         context = {"user": helpers.call_action("get_site_user")["name"]}
         created_views = datapreview.add_views_to_resource(

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -785,7 +785,7 @@ def test_gravatar():
 def test_gravatar_config_set_default(ckan_config):
     """Test when default gravatar is None, it is pulled from the config file"""
     email = "zephod@gmail.com"
-    default = ckan_config.get_value("ckan.gravatar_default")
+    default = ckan_config.get("ckan.gravatar_default")
     expected = (
         '<img src="//gravatar.com/avatar/7856421db6a63efa5b248909c472fbd2?s=200&amp;d=%s"'
         % default

--- a/ckan/tests/lib/test_mailer.py
+++ b/ckan/tests/lib/test_mailer.py
@@ -201,8 +201,8 @@ class TestMailer(MailerBase):
         msg = msgs[0]
 
         expected_from_header = "{0} <{1}>".format(
-            config.get_value("ckan.site_title"),
-            config.get_value("smtp.mail_from")
+            config.get("ckan.site_title"),
+            config.get("smtp.mail_from")
         )
 
         assert expected_from_header in msg[3]
@@ -312,7 +312,7 @@ class TestMailer(MailerBase):
         msg = msgs[0]
 
         expected_from_header = "Reply-to: {}".format(
-            config.get_value("smtp.reply_to")
+            config.get("smtp.reply_to")
         )
 
         assert expected_from_header in msg[3]

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -311,7 +311,7 @@ class TestCreateDefaultResourceViews(object):
         )
 
         # Change default views config setting
-        config["ckan.views.default_views"] = "image_view"
+        config["ckan.views.default_views"] = ["image_view"]
 
         context = {"user": helpers.call_action("get_site_user")["name"]}
         created_views = helpers.call_action(
@@ -336,7 +336,7 @@ class TestCreateDefaultResourceViews(object):
         )
 
         # Change default views config setting
-        config["ckan.views.default_views"] = "image_view"
+        config["ckan.views.default_views"] = ["image_view"]
 
         context = {"user": helpers.call_action("get_site_user")["name"]}
         created_views = helpers.call_action(
@@ -361,7 +361,7 @@ class TestCreateDefaultResourceViews(object):
         )
 
         # Change default views config setting
-        config["ckan.views.default_views"] = "image_view"
+        config["ckan.views.default_views"] = ["image_view"]
 
         context = {"user": helpers.call_action("get_site_user")["name"]}
         created_views = helpers.call_action(

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -730,13 +730,13 @@ class TestOrganizationList(object):
         results = helpers.call_action("organization_list")
         assert len(results) == 1000  # i.e. default value
 
-    @pytest.mark.ckan_config("ckan.group_and_organization_list_max", "5")
+    @pytest.mark.ckan_config("ckan.group_and_organization_list_max", 5)
     def test_limit_configured(self):
         self._create_bulk_orgs("org_default", 7)
         results = helpers.call_action("organization_list")
         assert len(results) == 5  # i.e. configured limit
 
-    @pytest.mark.ckan_config("ckan.group_and_organization_list_max", "5")
+    @pytest.mark.ckan_config("ckan.group_and_organization_list_max", 5)
     def test_limit_with_custom_max_limit(self):
         self._create_bulk_orgs("org_default", 5)
         results = helpers.call_action("organization_list", limit=2)
@@ -748,7 +748,7 @@ class TestOrganizationList(object):
         assert len(results) == 25  # i.e. default value
 
     @pytest.mark.ckan_config(
-        "ckan.group_and_organization_list_all_fields_max", "5"
+        "ckan.group_and_organization_list_all_fields_max", 5
     )
     def test_all_fields_limit_with_custom_max_limit(self):
         self._create_bulk_orgs("org_all_fields_default", 5)
@@ -758,7 +758,7 @@ class TestOrganizationList(object):
         assert len(results) == 2
 
     @pytest.mark.ckan_config(
-        "ckan.group_and_organization_list_all_fields_max", "5"
+        "ckan.group_and_organization_list_all_fields_max", 5
     )
     def test_all_fields_limit_configured(self):
         self._create_bulk_orgs("org_all_fields_default", 30)
@@ -2917,6 +2917,7 @@ class TestStatusShow(object):
 
     @pytest.mark.ckan_config("ckan.plugins", "stats")
     @pytest.mark.ckan_config('ckan.hide_version', True)
+    @pytest.mark.usefixtures("with_plugins")
     def test_status_show_hiding_version(self):
 
         status = helpers.call_action("status_show")
@@ -2932,6 +2933,7 @@ class TestStatusShow(object):
 
     @pytest.mark.ckan_config("ckan.plugins", "stats")
     @pytest.mark.ckan_config('ckan.hide_version', True)
+    @pytest.mark.usefixtures("with_plugins")
     def test_status_show_version_to_sysadmins(self):
         sysadmin = factories.Sysadmin()
         status = helpers.call_action("status_show", context={"user": sysadmin["name"]})

--- a/ckan/tests/logic/auth/test_get.py
+++ b/ckan/tests/logic/auth/test_get.py
@@ -13,7 +13,7 @@ from ckan import model
 from unittest import mock
 
 
-@pytest.mark.ckan_config(u"ckan.auth.public_user_details", u"false")
+@pytest.mark.ckan_config(u"ckan.auth.public_user_details", False)
 @mock.patch("flask_login.utils._get_user")
 def test_auth_user_list(current_user):
     current_user.return_value = mock.Mock(is_anonymous=True)
@@ -36,7 +36,7 @@ def test_user_list_email_parameter():
 
 @pytest.mark.usefixtures(u"non_clean_db")
 class TestGetAuth(object):
-    @pytest.mark.ckan_config(u"ckan.auth.public_user_details", u"false")
+    @pytest.mark.ckan_config(u"ckan.auth.public_user_details", False)
     @mock.patch("flask_login.utils._get_user")
     def test_auth_user_show(self, current_user):
         fred = factories.User()
@@ -106,7 +106,7 @@ class TestGetAuth(object):
         ret = helpers.call_auth("group_show", context=context, id=org["name"])
         assert ret
 
-    @pytest.mark.ckan_config(u"ckan.auth.public_user_details", u"false")
+    @pytest.mark.ckan_config(u"ckan.auth.public_user_details", False)
     def test_group_show__user_is_hidden_to_public(self):
         group = factories.Group()
         context = {"model": model}

--- a/ckan/tests/plugins/test_blanket.py
+++ b/ckan/tests/plugins/test_blanket.py
@@ -50,7 +50,7 @@ class TestBlanketImplementation(object):
         return True
 
     def _config_declarations_registered(self, config):
-        return config.get_value("ckanext.blanket") == "declaration blanket"
+        return config.get("ckanext.blanket") == "declaration blanket"
 
     @pytest.mark.ckan_config(u"ckan.plugins", u"example_blanket")
     def test_empty_blanket_implements_all_available_interfaces(self, app, cli, ckan_config):

--- a/ckan/tests/pytest_ckan/fixtures.py
+++ b/ckan/tests/pytest_ckan/fixtures.py
@@ -47,7 +47,7 @@ import ckan.plugins
 import ckan.cli
 import ckan.lib.search as search
 import ckan.model as model
-from ckan.common import config
+from ckan.common import config, aslist
 
 
 @register
@@ -132,6 +132,7 @@ def ckan_config(request, monkeypatch):
     _original = copy.deepcopy(config)
     for mark in request.node.iter_markers(u"ckan_config"):
         monkeypatch.setitem(config, *mark.args)
+
     yield config
     config.clear()
     config.update(_original)
@@ -269,7 +270,7 @@ def with_plugins(ckan_config):
        :end-before: # END-CONFIG-OVERRIDE
 
     """
-    plugins = ckan_config["ckan.plugins"].split()
+    plugins = aslist(ckan_config["ckan.plugins"])
     for plugin in plugins:
         if not ckan.plugins.plugin_loaded(plugin):
             ckan.plugins.load(plugin)

--- a/ckan/tests/test_authz.py
+++ b/ckan/tests/test_authz.py
@@ -33,7 +33,7 @@ def test_default_roles_that_cascade_to_sub_groups_is_a_list():
 
 
 @pytest.mark.ckan_config(
-    "ckan.auth.roles_that_cascade_to_sub_groups", "admin editor"
+    "ckan.auth.roles_that_cascade_to_sub_groups", ["admin", "editor"]
 )
 def test_roles_that_cascade_to_sub_groups_is_a_list():
     assert sorted(_check("roles_that_cascade_to_sub_groups")) == sorted(

--- a/ckan/tests/test_common.py
+++ b/ckan/tests/test_common.py
@@ -27,15 +27,6 @@ def test_get_item_works():
     assert my_conf.get(u"test_key_1") == u"Test value 1"
 
 
-def test_subset_works():
-    conf = CKANConfig({
-        "a.b": 1,
-        "a.c": 2,
-        "x.b": 3,
-    })
-    assert conf.subset(Key().a.dynamic("any")) == {"a.b": 1, "a.c": 2}
-
-
 def test_repr_works():
     my_conf = CKANConfig()
     my_conf[u"test_key_1"] = u"Test value 1"

--- a/ckan/tests/test_common.py
+++ b/ckan/tests/test_common.py
@@ -10,7 +10,6 @@ from ckan.common import (
     g as ckan_g,
     c as ckan_c,
 )
-from ckan.config.declaration import Key
 from ckan.tests import helpers
 
 

--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -25,8 +25,8 @@ def set_cors_headers_for_response(response: Response) -> Response:
     '''
     if request.headers.get(u'Origin'):
         cors_origin_allowed = None
-        allow_all = config.get_value(u'ckan.cors.origin_allow_all')
-        whitelisted = request.headers.get(u'Origin') in config.get_value(
+        allow_all = config.get(u'ckan.cors.origin_allow_all')
+        whitelisted = request.headers.get(u'Origin') in config.get(
             u'ckan.cors.origin_whitelist')
         if allow_all:
             cors_origin_allowed = '*'
@@ -56,7 +56,7 @@ def set_cache_control_headers_for_response(response: Response) -> Response:
     if allow_cache:
         response.cache_control.public = True
         try:
-            cache_expire = config.get_value(u'ckan.cache_expires')
+            cache_expire = config.get(u'ckan.cache_expires')
             response.cache_control.max_age = cache_expire
             response.cache_control.must_revalidate = True
         except ValueError:
@@ -120,7 +120,7 @@ def identify_user() -> Optional[Response]:
 
 
 def _get_user_for_apitoken() -> Optional[model.User]:  # type: ignore
-    apitoken_header_name = config.get_value("apikey_header_name")
+    apitoken_header_name = config.get("apikey_header_name")
 
     apitoken: str = request.headers.get(apitoken_header_name, u'')
     if not apitoken:
@@ -160,7 +160,7 @@ def handle_i18n(environ: Optional[dict[str, Any]] = None) -> None:
     environ = environ or request.environ
     assert environ
     locale_list = get_locales_from_config()
-    default_locale = config.get_value(u'ckan.locale_default')
+    default_locale = config.get(u'ckan.locale_default')
 
     # We only update once for a request so we can keep
     # the language and original url which helps with 404 pages etc

--- a/ckan/views/admin.py
+++ b/ckan/views/admin.py
@@ -173,7 +173,7 @@ class TrashView(MethodView):
     def _get_deleted_datasets(
         self
     ) -> Union["Query[model.Package]", List[Any]]:
-        if config.get_value('ckan.search.remove_deleted_packages'):
+        if config.get('ckan.search.remove_deleted_packages'):
             return self._get_deleted_datasets_from_db()
         else:
             return self._get_deleted_datasets_from_search_index()

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -149,7 +149,7 @@ def _form_save_redirect(pkg_name: str,
     @param action - What the action of the edit was
     """
     assert action in (u'new', u'edit')
-    url = request.args.get(u'return_to') or config.get_value(
+    url = request.args.get(u'return_to') or config.get(
         u'package_%s_return_url' % action
     )
     if url:
@@ -226,7 +226,7 @@ def search(package_type: str) -> str:
     extra_vars['query_error'] = False
     page = h.get_page_number(request.args)
 
-    limit = config.get_value(u'ckan.datasets_per_page')
+    limit = config.get(u'ckan.datasets_per_page')
 
     # most search operations should reset the page counter:
     params_nopage = [(k, v) for k, v in request.args.items(multi=True)
@@ -264,7 +264,7 @@ def search(package_type: str) -> str:
     # Unless changed via config options, don't show other dataset
     # types any search page. Potential alternatives are do show them
     # on the default search page (dataset) or on one other search page
-    search_all_type = config.get_value(u'ckan.search.show_all_types')
+    search_all_type = config.get(u'ckan.search.show_all_types')
     search_all = False
 
     try:
@@ -320,7 +320,7 @@ def search(package_type: str) -> str:
         u'start': (page - 1) * limit,
         u'sort': sort_by,
         u'extras': search_extras,
-        u'include_private': config.get_value(
+        u'include_private': config.get(
             u'ckan.search.default_include_private'),
     }
     try:
@@ -358,7 +358,7 @@ def search(package_type: str) -> str:
 
     # FIXME: try to avoid using global variables
     g.search_facets_limits = {}
-    default_limit: int = config.get_value(u'search.facets.default')
+    default_limit: int = config.get(u'search.facets.default')
     for facet in cast(Iterable[str], extra_vars[u'search_facets'].keys()):
         try:
             limit = int(
@@ -451,7 +451,7 @@ def read(package_type: str, id: str) -> Union[Response, str]:
             _(u'Dataset not found or you have no permission to view it')
         )
     except NotAuthorized:
-        if config.get_value(u'ckan.auth.reveal_private_datasets'):
+        if config.get(u'ckan.auth.reveal_private_datasets'):
             if current_user.is_authenticated:
                 return base.abort(
                     403, _(u'Unauthorized to read package %s') % id)
@@ -583,7 +583,7 @@ class CreateView(MethodView):
             data_dict[u'type'] = package_type
             pkg_dict = get_action(u'package_create')(context, data_dict)
 
-            create_on_ui_requires_resources = config.get_value(
+            create_on_ui_requires_resources = config.get(
                 'ckan.dataset.create_on_ui_requires_resources'
             )
             if ckan_phase:

--- a/ckan/views/feed.py
+++ b/ckan/views/feed.py
@@ -42,7 +42,7 @@ def _package_search(data_dict: DataDict) -> tuple[int, list[dict[str, Any]]]:
         data_dict['sort'] = u'metadata_modified desc'
 
     if u'rows' not in data_dict or not data_dict['rows']:
-        data_dict['rows'] = config.get_value('ckan.feeds.limit')
+        data_dict['rows'] = config.get('ckan.feeds.limit')
 
     # package_search action modifies the data_dict, so keep our copy intact.
     query = logic.get_action(u'package_search')(context, data_dict.copy())
@@ -136,8 +136,8 @@ def output_feed(
         results: list[dict[str, Any]], feed_title: str, feed_description: str,
         feed_link: str, feed_url: str, navigation_urls: dict[str, str],
         feed_guid: str) -> Response:
-    author_name = config.get_value(u'ckan.feeds.author_name').strip() or \
-        config.get_value(u'ckan.site_id').strip()
+    author_name = config.get(u'ckan.feeds.author_name').strip() or \
+        config.get(u'ckan.site_id').strip()
 
     def remove_control_characters(s: str):
         if not s:
@@ -248,7 +248,7 @@ def tag(id: str) -> Response:
 
     alternate_url = _alternate_url(params, tags=id)
 
-    site_title = config.get_value(u'ckan.site_title')
+    site_title = config.get(u'ckan.site_title')
     title = u'%s - Tag: "%s"' % (site_title, id)
     desc = u'Recently created or updated datasets on %s by tag: "%s"' % \
            (site_title, id)
@@ -277,7 +277,7 @@ def group_or_organization(obj_dict: dict[str, Any], is_org: bool) -> Response:
 
     data_dict['fq'] = u'{0}: "{1}"'.format(key, value)
     item_count, results = _package_search(data_dict)
-    site_title = config.get_value(u'ckan.site_title')
+    site_title = config.get(u'ckan.site_title')
 
     navigation_urls = _navigation_urls(
         params,
@@ -323,7 +323,7 @@ def _parse_url_params() -> tuple[dict[str, Any], dict[str, Any]]:
     """
     page = h.get_page_number(request.args)
 
-    limit = config.get_value('ckan.feeds.limit')
+    limit = config.get('ckan.feeds.limit')
     data_dict = {u'start': (page - 1) * limit, u'rows': limit}
 
     # Filter ignored query parameters
@@ -352,7 +352,7 @@ def general() -> Response:
 
     guid = _create_atom_id(u'/feeds/dataset.atom')
 
-    site_title = config.get_value(u'ckan.site_title')
+    site_title = config.get(u'ckan.site_title')
     desc = u'Recently created or updated datasets on %s' % site_title
 
     return output_feed(
@@ -381,7 +381,7 @@ def custom() -> Response:
 
     page = h.get_page_number(request.args)
 
-    limit = config.get_value('ckan.feeds.limit')
+    limit = config.get('ckan.feeds.limit')
     data_dict: dict[str, Any] = {
         u'q': q,
         u'fq': fq,
@@ -404,7 +404,7 @@ def custom() -> Response:
     atom_url = h._url_with_params(u'/feeds/custom.atom', search_params.items())
 
     alternate_url = _alternate_url(request.args)
-    site_title = config.get_value(u'ckan.site_title')
+    site_title = config.get(u'ckan.site_title')
     return output_feed(
         results,
         feed_title=u'%s - Custom query' % site_title,
@@ -553,9 +553,9 @@ def _create_atom_id(resource_path: str,
     [4] http://www.ietf.org/rfc/rfc4287
     """
     if authority_name is None:
-        authority_name = config.get_value(u'ckan.feeds.authority_name')
+        authority_name = config.get(u'ckan.feeds.authority_name')
         if not authority_name:
-            site_url = config.get_value(u'ckan.site_url')
+            site_url = config.get(u'ckan.site_url')
             authority_name = urlparse(site_url).netloc
 
     if not authority_name:
@@ -563,7 +563,7 @@ def _create_atom_id(resource_path: str,
                     'Generated feed will be invalid.')
         authority_name = ''
     if date_string is None:
-        date_string = config.get_value(u'ckan.feeds.date')
+        date_string = config.get(u'ckan.feeds.date')
 
     if not date_string:
         log.warning(u'No date_string available for feed generation.  '
@@ -572,7 +572,7 @@ def _create_atom_id(resource_path: str,
         # Don't generate a tagURI without a date as it wouldn't be valid.
         # This is best we can do, and if the site_url is not set, then
         # this still results in an invalid feed.
-        site_url = config.get_value(u'ckan.site_url')
+        site_url = config.get(u'ckan.site_url')
         return u''.join([site_url, resource_path])
 
     tagging_entity = u','.join([authority_name, date_string])

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -129,7 +129,7 @@ def index(group_type: str, is_organization: bool) -> str:
     extra_vars: dict[str, Any] = {}
     set_org(is_organization)
     page = h.get_page_number(request.args) or 1
-    items_per_page = config.get_value('ckan.datasets_per_page')
+    items_per_page = config.get('ckan.datasets_per_page')
 
     context = cast(Context, {
         u'model': model,
@@ -356,7 +356,7 @@ def _read(id: Optional[str], limit: int, group_type: str) -> dict[str, Any]:
 
         extra_vars["search_facets"] = query['search_facets']
         extra_vars["search_facets_limits"] = g.search_facets_limits = {}
-        default_limit: int = config.get_value(u'search.facets.default')
+        default_limit: int = config.get(u'search.facets.default')
         for facet in extra_vars["search_facets"].keys():
             limit = int(request.args.get(u'_%s_limit' % facet, default_limit))
             g.search_facets_limits[facet] = limit
@@ -424,7 +424,7 @@ def read(group_type: str,
 
     extra_vars["q"] = q
 
-    limit = config.get_value('ckan.datasets_per_page')
+    limit = config.get('ckan.datasets_per_page')
 
     try:
         # Do not query for the group datasets when dictizing, as they will

--- a/ckan/views/home.py
+++ b/ckan/views/home.py
@@ -85,7 +85,7 @@ def index() -> str:
                 u' and add your email address. ') % url + \
             _(u'%s uses your email address'
                 u' if you need to reset your password.') \
-            % config.get_value(u'ckan.site_title')
+            % config.get(u'ckan.site_title')
         h.flash_notice(msg, allow_html=True)
     return base.render(u'home/index.html', extra_vars={})
 

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -68,7 +68,7 @@ def read(package_type: str, id: str, resource_id: str) -> Union[Response, str]:
     except NotFound:
         return base.abort(404, _(u'Dataset not found'))
     except NotAuthorized:
-        if config.get_value(u'ckan.auth.reveal_private_datasets'):
+        if config.get(u'ckan.auth.reveal_private_datasets'):
             if current_user.is_authenticated:
                 return base.abort(
                     403, _(u'Unauthorized to read resource %s') % resource_id)

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -103,7 +103,7 @@ def index():
     page_number = h.get_page_number(request.args)
     q = request.args.get('q', '')
     order_by = request.args.get('order_by', 'name')
-    default_limit: int = config.get_value('ckan.user_list_limit')
+    default_limit: int = config.get('ckan.user_list_limit')
     limit = int(request.args.get('limit', default_limit))
     context = cast(Context, {
         u'return_query': True,
@@ -137,7 +137,7 @@ def index():
 
 def me() -> Response:
     return h.redirect_to(
-        config.get_value(u'ckan.route_after_login'))
+        config.get(u'ckan.route_after_login'))
 
 
 def read(id: str) -> Union[Response, str]:
@@ -513,7 +513,7 @@ def rotate_token():
     from flask_wtf.csrf import generate_csrf
     from ckan.common import session
     # WTF_CSRF_FIELD_NAME is added by flask_wtf
-    field_name = config.get_value("WTF_CSRF_FIELD_NAME")
+    field_name = config.get("WTF_CSRF_FIELD_NAME")
 
     if session.get(field_name):
         session.pop(field_name)
@@ -574,7 +574,7 @@ def logout() -> Response:
     came_from = request.args.get('came_from', '')
     logout_user()
 
-    field_name = config.get_value("WTF_CSRF_FIELD_NAME")
+    field_name = config.get("WTF_CSRF_FIELD_NAME")
     if session.get(field_name):
         session.pop(field_name)
 
@@ -692,7 +692,7 @@ class RequestResetView(MethodView):
                 h.flash_error(_(u'Error sending the email. Try again later '
                                 'or contact an administrator for help'))
                 log.exception(e)
-                return h.redirect_to(config.get_value(
+                return h.redirect_to(config.get(
                     u'ckan.user_reset_landing_page'))
 
         # always tell the user it succeeded, because otherwise we reveal
@@ -700,7 +700,7 @@ class RequestResetView(MethodView):
         h.flash_success(
             _(u'A reset link has been emailed to you '
               '(unless the account specified does not exist)'))
-        return h.redirect_to(config.get_value(
+        return h.redirect_to(config.get(
             u'ckan.user_reset_landing_page'))
 
     def get(self) -> str:
@@ -778,7 +778,7 @@ class PerformResetView(MethodView):
                 username, user=context[u'user_obj'])
 
             h.flash_success(_(u'Your password has been reset.'))
-            return h.redirect_to(config.get_value(
+            return h.redirect_to(config.get(
                 u'ckan.user_reset_landing_page'))
 
         except logic.NotAuthorized:

--- a/ckanext/activity/email_notifications.py
+++ b/ckanext/activity/email_notifications.py
@@ -86,7 +86,7 @@ def string_to_timedelta(s: str) -> datetime.timedelta:
 
 
 def render_activity_email(activities: list[dict[str, Any]]) -> str:
-    globals = {"site_title": config.get_value("ckan.site_title")}
+    globals = {"site_title": config.get("ckan.site_title")}
     template_name = "activity_streams/activity_stream_email_notifications.text"
 
     env = Environment(**jinja_extensions.get_jinja_env_options())
@@ -130,7 +130,7 @@ def _notifications_for_activities(
         "{n} new activity from {site_title}",
         "{n} new activities from {site_title}",
         len(activities),
-    ).format(site_title=config.get_value("ckan.site_title"), n=len(activities))
+    ).format(site_title=config.get("ckan.site_title"), n=len(activities))
 
     body = render_activity_email(activities)
     notifications = [{"subject": subject, "body": body}]
@@ -230,7 +230,7 @@ def get_and_send_notifications_for_user(user: dict[str, Any]) -> None:
 
     # Parse the email_notifications_since config setting, email notifications
     # from longer ago than this time will not be sent.
-    email_notifications_since = config.get_value(
+    email_notifications_since = config.get(
         "ckan.email_notifications_since"
     )
     email_notifications_since = string_to_timedelta(email_notifications_since)

--- a/ckanext/activity/helpers.py
+++ b/ckanext/activity/helpers.py
@@ -187,4 +187,4 @@ def compare_group_dicts(
 
 
 def activity_show_email_notifications() -> bool:
-    return tk.config.get_value("ckan.activity_streams_email_notifications")
+    return tk.config.get("ckan.activity_streams_email_notifications")

--- a/ckanext/activity/logic/action.py
+++ b/ckanext/activity/logic/action.py
@@ -31,7 +31,7 @@ def send_email_notifications(
     """
     tk.check_access("send_email_notifications", context, data_dict)
 
-    if not tk.config.get_value("ckan.activity_streams_email_notifications"):
+    if not tk.config.get("ckan.activity_streams_email_notifications"):
         raise tk.ValidationError(
             {
                 "message": (
@@ -92,7 +92,7 @@ def activity_create(
 
     tk.check_access("activity_create", context, data_dict)
 
-    if not tk.config.get_value("ckan.activity_streams_enabled"):
+    if not tk.config.get("ckan.activity_streams_enabled"):
         return
 
     model = context["model"]

--- a/ckanext/activity/model/activity.py
+++ b/ckanext/activity/model/activity.py
@@ -780,7 +780,7 @@ def _activity_stream_get_filtered_users() -> list[str]:
     option and return a list of their ids. If the config is not specified,
     returns the id of the site user.
     """
-    users_list = config.get_value("ckan.hide_activity_from_users")
+    users_list = config.get("ckan.hide_activity_from_users")
     if not users_list:
         from ckan.logic import get_action
 

--- a/ckanext/activity/views.py
+++ b/ckanext/activity/views.py
@@ -37,8 +37,8 @@ bp = Blueprint("activity", __name__)
 
 
 def _get_activity_stream_limit() -> int:
-    base_limit = tk.config.get_value("ckan.activity_list_limit")
-    max_limit = tk.config.get_value("ckan.activity_list_limit_max")
+    base_limit = tk.config.get("ckan.activity_list_limit")
+    max_limit = tk.config.get("ckan.activity_list_limit_max")
     return min(base_limit, max_limit)
 
 

--- a/ckanext/audioview/plugin.py
+++ b/ckanext/audioview/plugin.py
@@ -21,7 +21,7 @@ class AudioView(p.SingletonPlugin):
 
     def update_config(self, config: CKANConfig):
         p.toolkit.add_template_directory(config, 'theme/templates')
-        self.formats = config.get_value('ckan.preview.audio_formats').split()
+        self.formats = config.get('ckan.preview.audio_formats').split()
 
     def info(self) -> dict[str, Any]:
         return {'name': 'audio_view',

--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -62,11 +62,11 @@ def datapusher_submit(context: Context, data_dict: dict[str, Any]):
     except logic.NotFound:
         return False
 
-    datapusher_url: str = config.get_value('ckan.datapusher.url')
+    datapusher_url: str = config.get('ckan.datapusher.url')
 
-    callback_url_base = config.get_value(
+    callback_url_base = config.get(
         'ckan.datapusher.callback_url_base'
-    ) or config.get_value("ckan.site_url")
+    ) or config.get("ckan.site_url")
     if callback_url_base:
         site_url = callback_url_base
         callback_url = urljoin(
@@ -101,7 +101,7 @@ def datapusher_submit(context: Context, data_dict: dict[str, Any]):
             'key': 'datapusher'
         })
         assume_task_stale_after = datetime.timedelta(
-            seconds=config.get_value(
+            seconds=config.get(
                 'ckan.datapusher.assume_task_stale_after'))
         if existing_task.get('state') == 'pending':
             updated = datetime.datetime.strptime(
@@ -130,10 +130,10 @@ def datapusher_submit(context: Context, data_dict: dict[str, Any]):
         Any, context['model'].meta.create_local_session())
     p.toolkit.get_action('task_status_update')(context, task)
 
-    timeout = config.get_value('ckan.requests.timeout')
+    timeout = config.get('ckan.requests.timeout')
 
     # This setting is checked on startup
-    api_token = p.toolkit.config.get_value("ckan.datapusher.api_token")
+    api_token = p.toolkit.config.get("ckan.datapusher.api_token")
     try:
         r = requests.post(
             urljoin(datapusher_url, 'job'),
@@ -295,7 +295,7 @@ def datapusher_status(
         'key': 'datapusher'
     })
 
-    datapusher_url = config.get_value('ckan.datapusher.url')
+    datapusher_url = config.get('ckan.datapusher.url')
     if not datapusher_url:
         raise p.toolkit.ValidationError(
             {'configuration': ['ckan.datapusher.url not in config file']})
@@ -309,7 +309,7 @@ def datapusher_status(
     if job_id:
         url = urljoin(datapusher_url, 'job' + '/' + job_id)
         try:
-            timeout = config.get_value('ckan.requests.timeout')
+            timeout = config.get('ckan.requests.timeout')
             r = requests.get(url,
                              timeout=timeout,
                              headers={'Content-Type': 'application/json',

--- a/ckanext/datapusher/plugin.py
+++ b/ckanext/datapusher/plugin.py
@@ -35,7 +35,7 @@ class DatapusherPlugin(p.SingletonPlugin):
     resource_show_action = None
 
     def update_config(self, config: CKANConfig):
-        templates_base = config.get_value(u'ckan.base_templates_folder')
+        templates_base = config.get(u'ckan.base_templates_folder')
         p.toolkit.add_template_directory(config, templates_base)
 
     def configure(self, config: CKANConfig):
@@ -46,7 +46,7 @@ class DatapusherPlugin(p.SingletonPlugin):
             "ckan.datapusher.url",
             "ckan.datapusher.api_token",
         ):
-            if not config.get_value(config_option):
+            if not config.get(config_option):
                 raise Exception(
                     u'Config option `{0}` must be set to use the DataPusher.'.
                     format(config_option)
@@ -86,7 +86,7 @@ class DatapusherPlugin(p.SingletonPlugin):
         })
 
         resource_format = resource_dict.get('format')
-        supported_formats = p.toolkit.config.get_value(
+        supported_formats = p.toolkit.config.get(
             'ckan.datapusher.formats'
         )
 

--- a/ckanext/datastore/backend/__init__.py
+++ b/ckanext/datastore/backend/__init__.py
@@ -91,8 +91,8 @@ class DatastoreBackend:
         :rtype: ckan.common.CKANConfig
 
         """
-        schema = config.get_value(u'ckan.datastore.write_url').split(u':')[0]
-        read_schema = config.get_value(
+        schema = config.get(u'ckan.datastore.write_url').split(u':')[0]
+        read_schema = config.get(
             u'ckan.datastore.read_url').split(u':')[0]
         assert read_schema == schema, u'Read and write engines are different'
         cls._active_backend = cls._backends[schema]()

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -543,7 +543,7 @@ def _build_query_and_rank_statements(
 
 
 def _fts_lang(lang: Optional[str] = None) -> str:
-    return lang or config.get_value('ckan.datastore.default_fts_lang')
+    return lang or config.get('ckan.datastore.default_fts_lang')
 
 
 def _sort(sort: Union[None, str, list[str]], fields_types: Container[str],
@@ -643,7 +643,7 @@ def _generate_index_name(resource_id: str, field: str):
 
 
 def _get_fts_index_method() -> str:
-    return config.get_value('ckan.datastore.default_fts_index_method')
+    return config.get('ckan.datastore.default_fts_index_method')
 
 
 def _build_fts_indexes(
@@ -652,7 +652,7 @@ def _build_fts_indexes(
     fts_indexes: list[str] = []
     resource_id = data_dict['resource_id']
     fts_lang = data_dict.get(
-        'language', config.get_value('ckan.datastore.default_fts_lang'))
+        'language', config.get('ckan.datastore.default_fts_lang'))
 
     # create full-text search indexes
     def to_tsvector(x: str):
@@ -1671,7 +1671,7 @@ def search_sql(context: Context, data_dict: dict[str, Any]):
 
     # limit the number of results to ckan.datastore.search.rows_max + 1
     # (the +1 is so that we know if the results went over the limit or not)
-    rows_max = config.get_value('ckan.datastore.search.rows_max')
+    rows_max = config.get('ckan.datastore.search.rows_max')
     sql = 'SELECT * FROM ({0}) AS blah LIMIT {1} ;'.format(sql, rows_max + 1)
 
     try:
@@ -1743,7 +1743,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
         return _get_engine_from_url(self.read_url)
 
     def _log_or_raise(self, message: str):
-        if self.config.get_value('debug'):
+        if self.config.get('debug'):
             log.critical(message)
         else:
             raise DatastoreException(message)
@@ -1837,11 +1837,11 @@ class DatastorePostgresqlBackend(DatastoreBackend):
             raise DatastoreException(error_msg)
 
         # Check whether users have disabled datastore_search_sql
-        self.enable_sql_search = self.config.get_value(
+        self.enable_sql_search = self.config.get(
             'ckan.datastore.sqlsearch.enabled')
 
         if self.enable_sql_search:
-            allowed_sql_functions_file = self.config.get_value(
+            allowed_sql_functions_file = self.config.get(
                 'ckan.datastore.sqlsearch.allowed_functions_file'
             )
 

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -77,7 +77,7 @@ class DatastorePlugin(p.SingletonPlugin):
         DatastoreBackend.register_backends()
         DatastoreBackend.set_active_backend(config)
 
-        templates_base = config.get_value('ckan.base_templates_folder')
+        templates_base = config.get('ckan.base_templates_folder')
 
         p.toolkit.add_template_directory(config, templates_base)
         self.backend = DatastoreBackend.get_active_backend()

--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -106,7 +106,7 @@ class TestDatastoreCreateNewTests(object):
         resource_id = result["resource_id"]
         resource = helpers.call_action("resource_show", id=resource_id)
         url = resource["url"]
-        assert url.startswith(config.get_value("ckan.site_url"))
+        assert url.startswith(config.get("ckan.site_url"))
 
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")

--- a/ckanext/datatablesview/plugin.py
+++ b/ckanext/datatablesview/plugin.py
@@ -37,21 +37,21 @@ class DataTablesView(p.SingletonPlugin):
         '''
 
         # https://datatables.net/reference/option/lengthMenu
-        self.page_length_choices = config.get_value(
+        self.page_length_choices = config.get(
             u'ckan.datatables.page_length_choices')
 
         self.page_length_choices = [int(i) for i in self.page_length_choices]
-        self.state_saving = config.get_value(u'ckan.datatables.state_saving')
+        self.state_saving = config.get(u'ckan.datatables.state_saving')
 
         # https://datatables.net/reference/option/stateDuration
-        self.state_duration = config.get_value(
+        self.state_duration = config.get(
             u"ckan.datatables.state_duration")
-        self.data_dictionary_labels = config.get_value(
+        self.data_dictionary_labels = config.get(
             u"ckan.datatables.data_dictionary_labels")
-        self.ellipsis_length = config.get_value(
+        self.ellipsis_length = config.get(
             u"ckan.datatables.ellipsis_length")
-        self.date_format = config.get_value(u"ckan.datatables.date_format")
-        self.default_view = config.get_value(u"ckan.datatables.default_view")
+        self.date_format = config.get(u"ckan.datatables.date_format")
+        self.default_view = config.get(u"ckan.datatables.default_view")
 
         toolkit.add_template_directory(config, u'templates')
         toolkit.add_public_directory(config, u'public')

--- a/ckanext/example_iauthfunctions/plugin_v5_custom_config_setting.py
+++ b/ckanext/example_iauthfunctions/plugin_v5_custom_config_setting.py
@@ -15,7 +15,7 @@ def group_create(
     # Get the value of the ckan.iauthfunctions.users_can_create_groups
     # setting from the CKAN config file as a string, or False if the setting
     # isn't in the config file.
-    users_can_create_groups = toolkit.config.get_value(
+    users_can_create_groups = toolkit.config.get(
         'ckan.iauthfunctions.users_can_create_groups')
 
     if users_can_create_groups:

--- a/ckanext/example_iconfigurer/tests/test_iconfigurer_toolkit.py
+++ b/ckanext/example_iconfigurer/tests/test_iconfigurer_toolkit.py
@@ -12,7 +12,7 @@ class TestIConfigurerToolkitAddCkanAdminTab(object):
 
     def test_add_ckan_admin_tab_updates_config_dict(self):
         """Config dict updated by toolkit.add_ckan_admin_tabs method."""
-        config = CKANConfig()
+        config = CKANConfig({"ckan.admin_tabs": {}})
 
         toolkit.add_ckan_admin_tab(config, "my_route_name", "my_label")
 
@@ -27,7 +27,7 @@ class TestIConfigurerToolkitAddCkanAdminTab(object):
         Calling add_ckan_admin_tab twice with same values returns expected
         config.
         """
-        config = CKANConfig()
+        config = CKANConfig({"ckan.admin_tabs": {}})
 
         toolkit.add_ckan_admin_tab(config, "my_route_name", "my_label")
         toolkit.add_ckan_admin_tab(config, "my_route_name", "my_label")
@@ -45,7 +45,7 @@ class TestIConfigurerToolkitAddCkanAdminTab(object):
         Calling add_ckan_admin_tab twice with a different value returns
         expected config.
         """
-        config = CKANConfig()
+        config = CKANConfig({"ckan.admin_tabs": {}})
 
         toolkit.add_ckan_admin_tab(config, "my_route_name", "my_label")
         toolkit.add_ckan_admin_tab(
@@ -67,7 +67,7 @@ class TestIConfigurerToolkitAddCkanAdminTab(object):
         """
         Add two different route/label pairs to ckan.admin_tabs.
         """
-        config = CKANConfig()
+        config = CKANConfig({"ckan.admin_tabs": {}})
 
         toolkit.add_ckan_admin_tab(config, "my_route_name", "my_label")
         toolkit.add_ckan_admin_tab(
@@ -124,7 +124,10 @@ class TestIConfigurerToolkitAddCkanAdminTab(object):
         """
         Config already has existing other option.
         """
-        config = CKANConfig(**{"ckan.my_option": "This is my option"})
+        config = CKANConfig(**{
+            "ckan.my_option": "This is my option",
+            "ckan.admin_tabs": {}
+        })
 
         toolkit.add_ckan_admin_tab(config, "my_route_name", "my_label")
         toolkit.add_ckan_admin_tab(

--- a/ckanext/example_idatastorebackend/example_sqlite.py
+++ b/ckanext/example_idatastorebackend/example_sqlite.py
@@ -34,7 +34,7 @@ class DatastoreExampleSqliteBackend(DatastoreBackend):
             pass
 
     def configure(self, config):
-        self.write_url = config.get_value(
+        self.write_url = config.get(
             u'ckan.datastore.write_url'
         ).replace(u'example-', u'')
 

--- a/ckanext/example_theme_docs/custom_config_setting/plugin.py
+++ b/ckanext/example_theme_docs/custom_config_setting/plugin.py
@@ -21,7 +21,7 @@ def show_most_popular_groups():
     :rtype: bool
 
     '''
-    value = config.get_value('ckan.example_theme.show_most_popular_groups')
+    value = config.get('ckan.example_theme.show_most_popular_groups')
     return value
 
 

--- a/ckanext/example_theme_docs/custom_emails/test_custom_emails.py
+++ b/ckanext/example_theme_docs/custom_emails/test_custom_emails.py
@@ -35,7 +35,7 @@ class TestExampleCustomEmailsPlugin(MailerBase):
         msgs = mail_server.get_smtp_messages()
         assert len(msgs) == 1
         msg = msgs[0]
-        extra_vars = {"site_title": config.get_value("ckan.site_title")}
+        extra_vars = {"site_title": config.get("ckan.site_title")}
         expected = render(
             "emails/reset_password_subject.txt", extra_vars
         )
@@ -72,7 +72,7 @@ class TestExampleCustomEmailsPlugin(MailerBase):
         assert len(msgs) == 1
         msg = msgs[0]
         extra_vars = {
-            "site_title": config.get_value("ckan.site_title"),
+            "site_title": config.get("ckan.site_title"),
         }
         expected = render("emails/invite_user_subject.txt", extra_vars)
         expected = expected.split("\n")[0]
@@ -94,7 +94,7 @@ class TestExampleCustomEmailsPlugin(MailerBase):
         extra_vars = {
             "reset_link": mailer.get_reset_link(user_obj),
             "user_name": user["name"],
-            "site_title": config.get_value("ckan.site_title"),
+            "site_title": config.get("ckan.site_title"),
         }
         expected = render("emails/invite_user.txt", extra_vars)
         body = self.get_email_body(msg[3]).decode()

--- a/ckanext/expire_api_token/plugin.py
+++ b/ckanext/expire_api_token/plugin.py
@@ -13,7 +13,7 @@ from ckan.config.declaration import Declaration, Key
 
 
 def default_token_lifetime() -> int:
-    return p.toolkit.config.get_value(u"expire_api_token.default_lifetime")
+    return p.toolkit.config.get(u"expire_api_token.default_lifetime")
 
 
 class ExpireApiTokenPlugin(p.SingletonPlugin):

--- a/ckanext/imageview/plugin.py
+++ b/ckanext/imageview/plugin.py
@@ -22,7 +22,7 @@ class ImageView(p.SingletonPlugin):
 
     def update_config(self, config: CKANConfig):
         p.toolkit.add_template_directory(config, 'theme/templates')
-        self.formats = config.get_value('ckan.preview.image_formats').split()
+        self.formats = config.get('ckan.preview.image_formats').split()
 
     def info(self) -> dict[str, Any]:
         return {'name': 'image_view',

--- a/ckanext/multilingual/plugin.py
+++ b/ckanext/multilingual/plugin.py
@@ -20,7 +20,7 @@ def translate_data_dict(data_dict: dict[str, Any]):
 
     '''
     desired_lang_code = request.environ['CKAN_LANG']
-    fallback_lang_code = config.get_value('ckan.locale_default')
+    fallback_lang_code = config.get('ckan.locale_default')
 
     # Get a flattened copy of data_dict to do the translation on.
     flattened = ckan.lib.navl.dictization_functions.flatten_dict(
@@ -117,7 +117,7 @@ def translate_resource_data_dict(data_dict: dict[str, Any]):
     '''
 
     desired_lang_code = request.environ['CKAN_LANG']
-    fallback_lang_code = config.get_value('ckan.locale_default')
+    fallback_lang_code = config.get('ckan.locale_default')
 
     # Get a flattened copy of data_dict to do the translation on.
     flattened = ckan.lib.navl.dictization_functions.flatten_dict(
@@ -204,13 +204,13 @@ KEYS_TO_IGNORE = ['state', 'revision_id', 'id', #title done seperately
 
 class MultilingualDataset(plugins.SingletonPlugin):
     plugins.implements(plugins.IPackageController, inherit=True)
-    LANGS = config.get_value('ckan.locale_order') or ["en"]
+    LANGS = config.get('ckan.locale_order') or ["en"]
 
     def before_dataset_index(self, search_data: dict[str, Any]):
 
         default_lang = search_data.get(
             'lang_code',
-             config.get_value('ckan.locale_default')
+             config.get('ckan.locale_default')
         )
 
         ## translate title
@@ -266,15 +266,15 @@ class MultilingualDataset(plugins.SingletonPlugin):
                                'for this thread'):
                 # This happens when this code gets called as part of a paster
                 # command rather then as part of an HTTP request.
-                current_lang = config.get_value('ckan.locale_default')
+                current_lang = config.get('ckan.locale_default')
             else:
                 raise
         except KeyError:
-            current_lang = config.get_value('ckan.locale_default')
+            current_lang = config.get('ckan.locale_default')
 
         # fallback to default locale if locale not in suported langs
         if not current_lang in lang_set:
-            current_lang = config.get_value('ckan.locale_default')
+            current_lang = config.get('ckan.locale_default')
         # fallback to english if default locale is not supported
         if not current_lang in lang_set:
             current_lang = 'en'
@@ -300,7 +300,7 @@ class MultilingualDataset(plugins.SingletonPlugin):
             return search_results
 
         desired_lang_code = request.environ['CKAN_LANG']
-        fallback_lang_code = config.get_value('ckan.locale_default')
+        fallback_lang_code = config.get('ckan.locale_default')
 
         # Look up translations for all of the facets in one db query.
         terms = set()
@@ -339,7 +339,7 @@ class MultilingualDataset(plugins.SingletonPlugin):
         # and save them in c.translated_fields where the templates can
         # retrieve them later.
         desired_lang_code = request.environ['CKAN_LANG']
-        fallback_lang_code = config.get_value('ckan.locale_default')
+        fallback_lang_code = config.get('ckan.locale_default')
         try:
             fields = g.fields
         except AttributeError:

--- a/ckanext/reclineview/plugin.py
+++ b/ckanext/reclineview/plugin.py
@@ -34,7 +34,7 @@ def get_dataproxy_url() -> str:
     '''
     Returns the value of the ckan.recline.dataproxy_url config option
     '''
-    return config.get_value('ckan.recline.dataproxy_url')
+    return config.get('ckan.recline.dataproxy_url')
 
 
 def in_list(list_possible_values: Callable[[], Container[Any]]) -> Validator:

--- a/ckanext/resourceproxy/blueprint.py
+++ b/ckanext/resourceproxy/blueprint.py
@@ -39,8 +39,8 @@ def proxy_resource(context: Context, data_dict: DataDict):
     if not parts.scheme or not parts.netloc:
         return abort(409, _(u'Invalid URL.'))
 
-    timeout = config.get_value('ckan.resource_proxy.timeout')
-    max_file_size = config.get_value(u'ckan.resource_proxy.max_file_size')
+    timeout = config.get('ckan.resource_proxy.timeout')
+    max_file_size = config.get(u'ckan.resource_proxy.max_file_size')
     response = make_response()
     try:
         # first we try a HEAD request which may not be supported
@@ -72,7 +72,7 @@ def proxy_resource(context: Context, data_dict: DataDict):
         response.charset = r.encoding or "utf-8"
 
         length = 0
-        chunk_size = config.get_value(u'ckan.resource_proxy.chunk_size')
+        chunk_size = config.get(u'ckan.resource_proxy.chunk_size')
 
         for chunk in r.iter_content(chunk_size=chunk_size):
             response.stream.write(chunk)

--- a/ckanext/resourceproxy/plugin.py
+++ b/ckanext/resourceproxy/plugin.py
@@ -29,7 +29,7 @@ def get_proxified_resource_url(
     if not p.plugin_loaded(u'resource_proxy'):
         return url
 
-    ckan_url = config.get_value(u'ckan.site_url')
+    ckan_url = config.get(u'ckan.site_url')
     scheme = urlparse(url).scheme
     compare_domains = datapreview.compare_domains
     if not compare_domains([ckan_url, url]) and scheme in proxy_schemes:

--- a/ckanext/resourceproxy/tests/test_proxy.py
+++ b/ckanext/resourceproxy/tests/test_proxy.py
@@ -73,7 +73,7 @@ class TestProxyPrettyfied(object):
 
     @responses.activate
     def test_large_file(self, app, ckan_config):
-        cl = ckan_config.get_value(u'ckan.resource_proxy.max_file_size') + 1
+        cl = ckan_config.get(u'ckan.resource_proxy.max_file_size') + 1
         self.mock_out_urls(
             self.url,
             headers={'Content-Length': str(cl)},
@@ -89,7 +89,7 @@ class TestProxyPrettyfied(object):
 
     @responses.activate
     def test_large_file_streaming(self, app, ckan_config):
-        cl = ckan_config.get_value(u'ckan.resource_proxy.max_file_size') + 1
+        cl = ckan_config.get(u'ckan.resource_proxy.max_file_size') + 1
         self.mock_out_urls(
             self.url,
             stream=True,

--- a/ckanext/textview/plugin.py
+++ b/ckanext/textview/plugin.py
@@ -16,14 +16,14 @@ log = logging.getLogger(__name__)
 def get_formats(config: CKANConfig) -> dict[str, list[str]]:
     out = {}
 
-    out["text_formats"] = config.get_value(
+    out["text_formats"] = config.get(
         "ckan.preview.text_formats"
     ).split()
-    out["xml_formats"] = config.get_value("ckan.preview.xml_formats").split()
-    out["json_formats"] = config.get_value(
+    out["xml_formats"] = config.get("ckan.preview.xml_formats").split()
+    out["json_formats"] = config.get(
         "ckan.preview.json_formats"
     ).split()
-    out["jsonp_formats"] = config.get_value(
+    out["jsonp_formats"] = config.get(
         "ckan.preview.jsonp_formats"
     ).split()
 

--- a/ckanext/textview/tests/test_view.py
+++ b/ckanext/textview/tests/test_view.py
@@ -17,7 +17,7 @@ class TestTextView(object):
 
     def test_can_view(self):
         p = plugin.TextView()
-        url_same_domain = urljoin(config.get_value('ckan.site_url'), '/resource.txt')
+        url_same_domain = urljoin(config.get('ckan.site_url'), '/resource.txt')
         url_different_domain = 'http://some.com/resource.txt'
 
         data_dict = {'resource': {'format': 'jsonp',

--- a/ckanext/videoview/plugin.py
+++ b/ckanext/videoview/plugin.py
@@ -22,7 +22,7 @@ class VideoView(p.SingletonPlugin):
 
     def update_config(self, config: CKANConfig):
         p.toolkit.add_template_directory(config, 'theme/templates')
-        self.formats = config.get_value('ckan.preview.video_formats').split()
+        self.formats = config.get('ckan.preview.video_formats').split()
 
     def info(self) -> dict[str, Any]:
         return {'name': 'video_view',

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -7,11 +7,8 @@ Configuration Options
 The functionality and features of CKAN can be modified using many different
 configuration options. These are generally set in the `CKAN configuration file`_,
 but some of them can also be set via `Environment variables`_ or at :ref:`runtime <runtime-config>`.
-Config options can be :ref:`declared on strict mode <declare-config-options>` to ensure they are validated and have default values.
 
 .. note:: Looking for the available configuration options? Jump to `CKAN configuration file`_.
-
-
 
 
 Environment variables
@@ -73,8 +70,6 @@ code base (You can see the core config declarations in
 the ``ckan/config/config_declaration.yaml`` file). This allows to validate the
 current configuration against the declaration, or check which config
 options in the CKAN config file are not declared (and might have no effect).
-
-.. note:: To make use of the config declaration feature you need to set :ref:`config.mode` to ``strict``
 
 Declaring config options
 ------------------------
@@ -303,9 +298,6 @@ label, the only important part here are angle brackets::
       Custom sqlalchemy config parameters used to establish the main
       database connection.
 
-Dynamic options should not be accessed via ``config.get_value`` at the
-moment. Use ``config.get`` (which is identical to ``dict.get``) instead.
-
 Use this feature sparsely, only when you really want to declare literally ANY
 value following the pattern. If you have finite set of possible options,
 consider declaring all of them, because it allows you to provide validators,
@@ -321,9 +313,10 @@ code like this one::
   is_enabled = toolkit.asbool(toolkit.config.get("ckanext.my_ext.enable", False))
 
 Declaring this configuration option and assigning validators (`convert_int`,
-`boolean_validators`) and a default value means that we can use the ``config.get_value()`` method::
+`boolean_validators`) and a default value means that we can use the
+``config.get(key)`` instead of the expression above::
 
-  is_enabled = toolkit.config.get_value("ckanext.my_ext.enable")
+  is_enabled = toolkit.config.get("ckanext.my_ext.enable")
 
 This will ensure that:
 
@@ -331,15 +324,14 @@ This will ensure that:
  2. This value is passed to the validators, and a valid value is returned
 
 
-.. note:: An attempt to use ``config.get_value()`` with an undeclared config option
+.. note:: An attempt to use ``config.get()`` with an undeclared config option
           will print a warning to the logs and return the option value or ``None`` as default.
 
 
 Command line interface
 ----------------------
 
-The current configuration can be validated using the :ref:`config declaration CLI <cli.ckan.config>` (again, assuming that
-you have set :ref:`config.mode` to ``strict``)::
+The current configuration can be validated using the :ref:`config declaration CLI <cli.ckan.config>`::
 
   ckan config validate
 

--- a/test-core.ini
+++ b/test-core.ini
@@ -89,6 +89,7 @@ ckan.tracking_enabled = true
 
 beaker.session.key = ckan
 beaker.session.secret = This_is_a_secret_or_is_it
+WTF_CSRF_SECRET_KEY = %(beaker.session.secret)s
 
 ## background jobs
 ckan.jobs.timeout = 180


### PR DESCRIPTION
Fixes #7282

- [x] revert the usage of config.get_value(). Config options will be parsed at startup time by default, so when calling config.get() you will get the parsed value.
- [x] There will be clear documentation in the changelog about changes
- [x] When using config.mode = strict an exception will be raised if the options don't pass validations
- [x] We'll limit the warning to:
    * If config.mode= default : config options that don't pass validation
    * If config.mode = strict : config options that are not declared (ie the current Option ckan.not_defined is not declared).
    