### PR TITLE
Fix api_token_list parameter

### DIFF
--- a/changes/7344.misc
+++ b/changes/7344.misc
@@ -1,0 +1,1 @@
+Updated and documented input param for `api_token_list` from `user` to `user_id`. `user` is still supported for backwards compatibility but it might be removed in the future.

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -3234,12 +3234,18 @@ def api_token_list(
         context: Context, data_dict: DataDict) -> ActionResult.ApiTokenList:
     '''Return list of all available API Tokens for current user.
 
+    :param string user_id: The user ID or name
+
     :returns: collection of all API Tokens
     :rtype: list
 
     .. versionadded:: 2.9
     '''
-    id_or_name = _get_or_bust(data_dict, u'user')
+    # Support "user" for backwards compatibility
+    id_or_name = data_dict.get("user_id", data_dict.get("user"))
+    if not id_or_name:
+        raise ValidationError({"user_id": ["Missing value"]})
+
     _check_access(u'api_token_list', context, data_dict)
     user = model.User.get(id_or_name)
     if user is None:

--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -339,7 +339,9 @@ def job_show(context: Context, data_dict: DataDict) -> AuthResult:
 def api_token_list(context: Context, data_dict: DataDict) -> AuthResult:
     """List all available tokens for current user.
     """
-    user = context[u'model'].User.get(data_dict[u'user'])
+    # Support "user" for backwards compatibility
+    id_or_name = data_dict.get("user_id", data_dict.get("user"))
+    user = context[u'model'].User.get(id_or_name)
     success = user is not None and user.name == context[u'user']
 
     return {u'success': success}

--- a/ckan/tests/logic/action/test_delete.py
+++ b/ckan/tests/logic/action/test_delete.py
@@ -737,7 +737,7 @@ class TestApiToken(object):
         tokens = helpers.call_action(
             u"api_token_list",
             context={u"model": model, u"user": user[u"name"]},
-            user=user[u"name"],
+            user_id=user[u"name"],
         )
         assert len(tokens) == 2
 
@@ -750,7 +750,7 @@ class TestApiToken(object):
         tokens = helpers.call_action(
             u"api_token_list",
             context={u"model": model, u"user": user[u"name"]},
-            user=user[u"name"],
+            user_id=user[u"name"],
         )
         assert len(tokens) == 1
 
@@ -763,7 +763,7 @@ class TestApiToken(object):
         tokens = helpers.call_action(
             u"api_token_list",
             context={u"model": model, u"user": user[u"name"]},
-            user=user[u"name"],
+            user_id=user[u"name"],
         )
         assert len(tokens) == 0
 

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -3022,9 +3022,16 @@ class TestApiToken(object):
         tokens = helpers.call_action(
             "api_token_list",
             context={"model": model, "user": user["name"]},
-            user=user["name"],
+            user_id=user["name"],
         )
         assert sorted([t["id"] for t in tokens]) == sorted(ids)
+
+        # Param "user" works for backwards compatibility
+        tokens = helpers.call_action(
+            "api_token_list",
+            context={"model": model, "user": user["name"]},
+            user=user["name"],
+        )
 
 
 @pytest.mark.usefixtures("non_clean_db")

--- a/ckan/tests/logic/auth/test_get.py
+++ b/ckan/tests/logic/auth/test_get.py
@@ -178,7 +178,7 @@ class TestApiToken(object):
             helpers.call_auth(
                 u"api_token_list",
                 {u"user": None, u"model": model},
-                user=user['name']
+                user_id=user['name']
             )
 
     def test_auth_user_is_allowed_to_list_tokens(self):
@@ -186,7 +186,7 @@ class TestApiToken(object):
         helpers.call_auth(u"api_token_list", {
             u"model": model,
             u"user": user[u"name"]
-        }, user=user[u"name"])
+        }, user_id=user[u"name"])
 
 
 @pytest.mark.usefixtures("non_clean_db", "with_plugins")


### PR DESCRIPTION
The documentation for `api_token_list` (which shows all API tokens for a particular user) didn't show the input parameter name.

This turned out to be `user`, which is not great as it can mean many things in CKAN. I updated it to be `user_id`, in line with other similar actions, and documented this one, but kept support for `user` for backwards compatibility.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [x] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
