### PR TITLE
Datastore Active Flagging During `datastore_delete`

### DIFF
--- a/changes/7345.bugfix
+++ b/changes/7345.bugfix
@@ -1,0 +1,2 @@
+Fixes `datastore_active` flagging during the `datastore_delete` action
+when an empty `filters` dict is passed.

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -417,7 +417,7 @@ def datastore_delete(context: Context, data_dict: dict[str, Any]):
     model = _get_or_bust(cast("dict[str, Any]", context), 'model')
     resource = model.Resource.get(data_dict['resource_id'])
 
-    if (not data_dict.get('filters') and
+    if (data_dict.get('filters', None) is None and
             resource is not None and
             resource.extras.get('datastore_active') is True):
         log.debug(


### PR DESCRIPTION
Explicit `None` condition on the `filters` of the `datastore_delete` action in the case that an empty dict of filters is passed.

### Issue:

In the case a user passes an empty dict (`{}`) to the `filters` in the `datastore_delete` action, it would not drop the table as it checks for filters being `None`. However, the condition for setting the `datastore_active` extra only test `not`, which would pass for an empty dict. However, the resource would technically still be active in the datastore as it would still have an existing database table.

### Proposed fixes:

Condition on `None` instead of a `not` condition.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
