### PR TITLE
Datastore `json_validator` 500 error on null/None

### DIFF
--- a/changes/7346.bugfix
+++ b/changes/7346.bugfix
@@ -1,0 +1,2 @@
+Fix 500 error caused from passing null to a field using the 
+`ckanext.datastore.logic.schema.json_validator` in its schema

--- a/ckanext/datastore/logic/schema.py
+++ b/ckanext/datastore/logic/schema.py
@@ -83,7 +83,7 @@ def json_validator(value: Any) -> Any:
         return value
     try:
         value = json.loads(value)
-    except ValueError and TypeError:
+    except (ValueError, TypeError):
         raise df.Invalid('Cannot parse JSON')
     return value
 

--- a/ckanext/datastore/logic/schema.py
+++ b/ckanext/datastore/logic/schema.py
@@ -83,7 +83,7 @@ def json_validator(value: Any) -> Any:
         return value
     try:
         value = json.loads(value)
-    except ValueError:
+    except ValueError and TypeError:
         raise df.Invalid('Cannot parse JSON')
     return value
 


### PR DESCRIPTION
Adds `TypeError` exception to the `ckanext.datastore.logic.schema.json_validator`

### Issue:

Passing null for a field with the `json_validator` throws an uncaught `TypeError` and causes a 500 error.

### Proposed fixes:

Except the `TypeError` alongside the `ValueError`.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
