### PR TITLE
Create user using one line command

### DIFF
--- a/changes/7343.bugfix
+++ b/changes/7343.bugfix
@@ -1,0 +1,1 @@
+Create user using one line command.

--- a/doc/maintaining/cli.rst
+++ b/doc/maintaining/cli.rst
@@ -633,7 +633,7 @@ For example, to create a new user called 'admin'
 
 .. parsed-literal::
 
- ckan -c |ckan.ini| user add admin
+ ckan -c |ckan.ini| user add admin email=admin@localhost password=test1234
 
 To delete the 'admin' user
 

--- a/doc/maintaining/cli.rst
+++ b/doc/maintaining/cli.rst
@@ -633,10 +633,9 @@ For example, to create a new user called 'admin'
 
 .. parsed-literal::
 
- ckan -c |ckan.ini| user add admin email=admin@localhost
- 
- .. note::
- 
+ ckan -c |ckan.ini| user add admin email=admin@localhost 
+
+.. note:: 
      You can use password=test1234 option if "non-interactive" usage is a requirement.
 
 To delete the 'admin' user

--- a/doc/maintaining/cli.rst
+++ b/doc/maintaining/cli.rst
@@ -633,7 +633,11 @@ For example, to create a new user called 'admin'
 
 .. parsed-literal::
 
- ckan -c |ckan.ini| user add admin email=admin@localhost password=test1234
+ ckan -c |ckan.ini| user add admin email=admin@localhost
+ 
+ .. note::
+ 
+     You can use password=test1234 option if "non-interactive" usage is a requirement.
 
 To delete the 'admin' user
 

--- a/doc/maintaining/installing/install-from-docker-compose.rst
+++ b/doc/maintaining/installing/install-from-docker-compose.rst
@@ -234,8 +234,10 @@ Now the datastore API should return content when visiting::
 -------------------------
 With all images up and running, create the CKAN admin user (johndoe in this example)::
 
-    docker exec -ti ckan /usr/local/bin/ckan -c /etc/ckan/production.ini sysadmin add johndoe email=johndoe@localhost password=test1234
-
+    docker exec -ti ckan /usr/local/bin/ckan -c /etc/ckan/production.ini sysadmin add johndoe email=johndoe@localhost
+.. note::
+    You can use password=test1234 option if "non-interactive" usage is a requirement.
+    
 Now you should be able to login to the new, empty CKAN.
 The admin user's API key will be instrumental in tranferring data from other instances.
 

--- a/doc/maintaining/installing/install-from-docker-compose.rst
+++ b/doc/maintaining/installing/install-from-docker-compose.rst
@@ -234,7 +234,7 @@ Now the datastore API should return content when visiting::
 -------------------------
 With all images up and running, create the CKAN admin user (johndoe in this example)::
 
-    docker exec -ti ckan /usr/local/bin/ckan -c /etc/ckan/production.ini sysadmin add johndoe email=johndoe@localhost name=johndoe
+    docker exec -ti ckan /usr/local/bin/ckan -c /etc/ckan/production.ini sysadmin add johndoe email=johndoe@localhost password=test1234
 
 Now you should be able to login to the new, empty CKAN.
 The admin user's API key will be instrumental in tranferring data from other instances.

--- a/doc/maintaining/installing/install-from-docker-compose.rst
+++ b/doc/maintaining/installing/install-from-docker-compose.rst
@@ -235,8 +235,8 @@ Now the datastore API should return content when visiting::
 With all images up and running, create the CKAN admin user (johndoe in this example)::
 
     docker exec -ti ckan /usr/local/bin/ckan -c /etc/ckan/production.ini sysadmin add johndoe email=johndoe@localhost
-.. note::
-    You can use password=test1234 option if "non-interactive" usage is a requirement.
+
+.. note:: You can use password=test1234 option if "non-interactive" usage is a requirement.
     
 Now you should be able to login to the new, empty CKAN.
 The admin user's API key will be instrumental in tranferring data from other instances.


### PR DESCRIPTION
Fixes #7343 

### Proposed fixes:
1. Create user using one line command in CLI doc
2. Create user using one line command in CKAN docker-compose installation doc

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
