### PR TITLE
Config declaration legacy key

### DIFF
--- a/changes/7350.removal
+++ b/changes/7350.removal
@@ -1,0 +1,1 @@
+``ckan.route_after_login`` renamed to ``ckan.auth.route_after_login``

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -627,6 +627,11 @@ groups:
           that this will break some existing JS modules from the frontend that perform API calls,
           so it should be used with caution.
 
+      - key: ckan.auth.route_after_login
+        legacy_key: ckan.route_after_login  # since v2.10.0
+        default: dashboard.datasets
+        description: |
+          Allows to customize the route that the user will get redirected to after a successful login.
 
   - annotation: CSRF Protection
     options:
@@ -1399,11 +1404,6 @@ groups:
         description: |
           This controls the page where users will be sent after requesting a password reset.
           This is ordinarily the home page, but specific sites may prefer somewhere else.
-
-      - key: ckan.route_after_login
-        default: dashboard.datasets
-        description: |
-          Allows to customize the route that the user will get redirected to after a successful login.
 
   # TODO: move to activity extension
   - annotation: Activity Streams Settings

--- a/ckan/config/declaration/__init__.py
+++ b/ckan/config/declaration/__init__.py
@@ -123,8 +123,21 @@ class Declaration:
         """
 
         for key in self.iter_options(exclude=Flag.not_safe()):
-            if key not in config and not isinstance(key, Pattern):
-                config[str(key)] = self[key].default
+            if key in config or isinstance(key, Pattern):
+                continue
+
+            info = self[key]
+
+            if info.legacy_key and info.legacy_key in config:
+                log.warning(
+                    "Config option '%s' is deprecated. Use '%s' instead",
+                    info.legacy_key,
+                    key
+                )
+                config[str(key)] = config[info.legacy_key]
+
+            else:
+                config[str(key)] = info.default
 
     def normalize(self, config: "CKANConfig"):
         """Validate and normalize all the values in the config object.

--- a/ckan/config/declaration/load.py
+++ b/ckan/config/declaration/load.py
@@ -124,6 +124,7 @@ def load_dict(declaration: "Declaration", definition: DeclarationDict):
                 )
                 option.set_section(group["section"])
                 option.append_validators(details["validators"])
+                option.legacy_key = details.get("legacy_key")
 
                 extras = details.setdefault("__extras", {})
                 for flag in Flag:

--- a/ckan/config/declaration/option.py
+++ b/ckan/config/declaration/option.py
@@ -181,6 +181,7 @@ class Option(SectionMixin, Generic[T]):
         "validators",
         "placeholder",
         "example",
+        "legacy_key",
     )
 
     flags: Flag
@@ -189,6 +190,7 @@ class Option(SectionMixin, Generic[T]):
     placeholder: Optional[str]
     example: Optional[Any]
     validators: str
+    legacy_key: Optional[str]
 
     def __init__(self, default: Optional[T] = None):
         self.flags = Flag.none()
@@ -197,6 +199,7 @@ class Option(SectionMixin, Generic[T]):
         self.example = None
         self.validators = ""
         self.default = default
+        self.legacy_key = None
 
     def str_value(self) -> str:
         """Convert option's default value into the string.

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -858,6 +858,7 @@ def config_declaration_v1(
             "section": [default("app:main"), unicode_safe],
             "options": {
                 "key": [not_empty, key_from_string],
+                "legacy_key": [ignore_empty, unicode_safe],
                 "default": [ignore_missing],
                 "default_callable": [ignore_empty, importable_string],
                 "placeholder": [default(""), unicode_safe],

--- a/ckan/tests/config/declaration/test_declaration.py
+++ b/ckan/tests/config/declaration/test_declaration.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import logging
 from ckan.common import CKANConfig
 from ckan.config.declaration.load import GroupV1, OptionV1
 import pytest
@@ -160,25 +159,16 @@ class TestDeclaration:
         decl.normalize(cfg)
         assert cfg == CKANConfig({"a": 20})
 
-    @pytest.mark.parametrize("raw,safe,warned", [
-        ({}, {"a": "default"}, False),
-        ({"legacy_a": "legacy"}, {"a": "legacy", "legacy_a": "legacy"}, True),
-        ({"a": "modern", "legacy_a": "legacy"}, {"a": "modern", "legacy_a": "legacy"}, False),
+    @pytest.mark.parametrize("raw,safe", [
+        ({}, {"a": "default"}),
+        ({"legacy_a": "legacy"}, {"a": "legacy", "legacy_a": "legacy"}),
+        ({"a": "modern", "legacy_a": "legacy"}, {"a": "modern", "legacy_a": "legacy"}),
     ])
-    def test_legacy_key(self, raw, safe, warned, caplog):
+    def test_legacy_key(self, raw, safe):
         decl = Declaration()
         option = decl.declare(Key().a, "default")
         option.legacy_key = "legacy_a"
 
         cfg = CKANConfig(raw)
-        with caplog.at_level(logging.WARNING):
-            decl.make_safe(cfg)
-
-            if warned:
-                assert caplog.records
-                assert "legacy_a" in caplog.records[0].message
-
-            else:
-                assert not caplog.records
-
+        decl.make_safe(cfg)
         assert cfg == CKANConfig(safe)

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -137,7 +137,7 @@ def index():
 
 def me() -> Response:
     return h.redirect_to(
-        config.get(u'ckan.route_after_login'))
+        config.get(u'ckan.auth.route_after_login'))
 
 
 def read(id: str) -> Union[Response, str]:

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -268,6 +268,11 @@ only for explanation and you don't need them in the real file::
           # as comments to the config file generated from template.
           commented: true
 
+          # Deprecated name of the option. Can be used for options that were renamed.
+          # When `key` is missing from config and `legacy_key` is available, value of
+          # the `legacy_key` is used, printing deprecation warning to the logs.
+          legacy_key: legacy.flag.do_something
+
 Dynamic config options
 ^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Fixes #7084 / Enchantment for #7280

Add a `legacy_key` attribute to the config declaration. 

When the config option is missing, but the corresponding `legacy_key` option is available, this "legacy" value is used(accompanied by a deprecation warning)

> **Note**
> I'll create a backport PR as soon as this PR get approved
