### PR TITLE
Document how to add models to SQLAlchemy metadata

### DIFF
--- a/changes/7351.misc
+++ b/changes/7351.misc
@@ -1,0 +1,2 @@
+:py:class:`~ckan.plugins.toolkit.BaseModel` class for declaration-style
+SQLAlchemy models added to :py:mod:`ckan.plugins.toolkit`.

--- a/ckan/model/base.py
+++ b/ckan/model/base.py
@@ -12,9 +12,7 @@ from typing_extensions import Self
 
 from .meta import metadata, Session
 
-Base = declarative_base(metadata=metadata)
-"""Base class for SQLAlchemy declaration-style models.
-"""
+BaseModel = declarative_base(metadata=metadata)
 
 
 class SessionMixin:

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -78,7 +78,7 @@ from ckan.lib.plugins import (
 from ckan.cli import error_shout
 
 from ckan.lib.mailer import mail_recipient, mail_user
-
+from ckan.model.base import BaseModel
 
 __all__ = [
     "ckan", "base", "render", "abort",
@@ -101,7 +101,7 @@ __all__ = [
     "render_snippet", "add_template_directory", "add_public_directory",
     "add_resource", "add_ckan_admin_tab",
     "check_ckan_version", "requires_ckan_version", "get_endpoint",
-    "fresh_context",
+    "fresh_context", "BaseModel",
 ]
 
 get_converter = get_validator
@@ -370,5 +370,19 @@ attributes for getting things like the request headers, query-string variables,
 request body variables, cookies, the request URL, etc.
 
 """,
-    "ckan": "``ckan`` package itself."
+    "ckan": "``ckan`` package itself.",
+    "BaseModel": """Base class for SQLAlchemy declaration-style models.
+
+Models extending ``BaseModel`` class are attached to the SQLAlchemy's metadata
+object automatically::
+
+    from ckan.plugins import toolkit
+
+    class ExtModel(toolkit.BaseModel):
+        __tablename__ = "ext_model"
+        id = Column(String(50), primary_key=True)
+        ...
+
+""",
+
 }

--- a/ckan/plugins/toolkit_sphinx_extension.py
+++ b/ckan/plugins/toolkit_sphinx_extension.py
@@ -159,7 +159,7 @@ def source_read(app: Any, docname: str, source: Any) -> None:
     if docname != 'extensions/plugins-toolkit':
         return
 
-    source_ = ''
+    source_ = '\n'
     for name, thing in inspect.getmembers(toolkit):
         if name not in toolkit.__all__:
             continue

--- a/ckanext/activity/model/activity.py
+++ b/ckanext/activity/model/activity.py
@@ -21,7 +21,7 @@ import ckan.model as model
 import ckan.model.meta as meta
 import ckan.model.domain_object as domain_object
 import ckan.model.types as _types
-from ckan.model.base import Base
+from ckan.model.base import BaseModel
 from ckan.lib.dictization import table_dictize
 
 from ckan.types import Context, Query  # noqa
@@ -33,7 +33,7 @@ TActivityDetail = TypeVar("TActivityDetail", bound="ActivityDetail")
 QActivity: TypeAlias = "Query[Activity]"
 
 
-class Activity(domain_object.DomainObject, Base):  # type: ignore
+class Activity(domain_object.DomainObject, BaseModel):  # type: ignore
     __tablename__ = "activity"
     # the line below handles cases when activity table was already loaded into
     # metadata state(via stats extension). Can be removed if stats stop using

--- a/doc/extensions/best-practices.rst
+++ b/doc/extensions/best-practices.rst
@@ -101,6 +101,10 @@ Example::
         ...
 
 
+.. note:: Starting from CKAN v2.10.0 the :py:class:`~ckan.model.base.Base`
+          class for declarative-style models, that is already attached to the
+          metadata object, can be imported from :py:mod:`ckan.model.base`.
+
 -------------------------------------------------------
 Implement each plugin class in a separate Python module
 -------------------------------------------------------

--- a/doc/extensions/best-practices.rst
+++ b/doc/extensions/best-practices.rst
@@ -78,6 +78,29 @@ available in CKAN for this purpose:
 
     ckan db downgrade -p PLUGIN_NAME
 
+------------------------------------
+Declare models using shared metadata
+------------------------------------
+
+Use :py:obj:`ckan.model.meta.metadata` object for any new SQLAlchemy model
+registered via extension. It helps SQLAlchemy to resolve cascade relationships
+and control orphan removals. In addition, ``clean_db`` test fixture cleans
+tables for every model registered using :py:obj:`ckan.model.meta.metadata`, so
+new models are integrated into the test suite without additional efforts.
+
+Example::
+
+    import ckan.model as model
+    from sqlalchemy.ext.declarative import declarative_base
+
+    Base = declarative_base(metadata=model.meta.metadata)
+
+    class ExtModel(Base):
+        __tablename__ = "ext_model"
+        id = Column(String(50), primary_key=True)
+        ...
+
+
 -------------------------------------------------------
 Implement each plugin class in a separate Python module
 -------------------------------------------------------

--- a/doc/extensions/best-practices.rst
+++ b/doc/extensions/best-practices.rst
@@ -101,9 +101,10 @@ Example::
         ...
 
 
-.. note:: Starting from CKAN v2.10.0 the :py:class:`~ckan.model.base.Base`
-          class for declarative-style models, that is already attached to the
-          metadata object, can be imported from :py:mod:`ckan.model.base`.
+.. note:: Starting from CKAN v2.10.0 the
+          :py:class:`~ckan.plugins.toolkit.BaseModel` class for
+          declarative-style models, that is already attached to the metadata
+          object, can be imported from :py:mod:`ckan.plugins.toolkit`.
 
 -------------------------------------------------------
 Implement each plugin class in a separate Python module


### PR DESCRIPTION
Fixes #7332

Add a record in the Best practices section about creating models that share SQLAlchemy metadata and are cleaned by `clean_db` fixture