### PR TITLE
[#7352] Provide a fallback value for WTF_CSRF_SECRET_KEY

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -262,7 +262,10 @@ def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:
     _register_error_handler(app)
 
     # CSRF
-    app.config['WTF_CSRF_FIELD_NAME'] = "_csrf_token"
+    wtf_key = "WTF_CSRF_SECRET_KEY"
+    if not app.config.get(wtf_key):
+        config[wtf_key] = app.config[wtf_key] = app.config["SECRET_KEY"]
+    app.config["WTF_CSRF_FIELD_NAME"] = "_csrf_token"
     csrf.init_app(app)
 
     # Set up each IBlueprint extension as a Flask Blueprint

--- a/ckan/tests/config/test_middleware.py
+++ b/ckan/tests/config/test_middleware.py
@@ -100,3 +100,13 @@ def test_flask_config_values_are_parsed(app):
     assert (
         app.flask_app.config["REMEMBER_COOKIE_DURATION"] == 12345
     )
+
+
+@pytest.mark.ckan_config("WTF_CSRF_SECRET_KEY", None)
+def test_no_wtf_secret_falls_back_to_secret_key(make_app):
+    assert (
+        app.flask_app.config["WTF_CSRF_SECRET_KEY"] == config.get("beaker.session.secret")
+    )
+    assert (
+        config["WTF_CSRF_SECRET_KEY"] == config.get("beaker.session.secret")
+    )


### PR DESCRIPTION
Fixes #7352

If `config["WTF_CSRF_SECRET_KEY"]` is not set (or present and empty), we set it to `SECRET_KEY` (which falls back to `beaker.session.secret`)
