### PR TITLE
extend datastore_search sort clause to include optional nulls first/last

### DIFF
--- a/changes/7356.feature
+++ b/changes/7356.feature
@@ -1,0 +1,1 @@
+datastore_search sort parameters now support "nulls first" and "nulls last"

--- a/ckanext/datastore/backend/__init__.py
+++ b/ckanext/datastore/backend/__init__.py
@@ -29,7 +29,7 @@ def get_all_resources_ids_in_datastore() -> list[str]:
 
 def _parse_sort_clause(  # type: ignore
         clause: str, fields_types: Container[str]):
-    clause_match = re.match(u'^(.+?)( +(asc|desc) *)?$', clause, re.I)
+    clause_match = re.match(u'^(.+?)( +(asc|desc))?( nulls +(first|last) *)?$', clause, re.I)
 
     if not clause_match:
         return False
@@ -38,6 +38,8 @@ def _parse_sort_clause(  # type: ignore
     if field[0] == field[-1] == u'"':
         field = field[1:-1]
     sort = (clause_match.group(3) or u'asc').lower()
+    if clause_match.group(4) and clause_match.group(5).lower() in {'first', 'last'}:
+        sort += (clause_match.group(4)).lower()
 
     if field not in fields_types:
         return False

--- a/ckanext/datastore/backend/__init__.py
+++ b/ckanext/datastore/backend/__init__.py
@@ -29,7 +29,9 @@ def get_all_resources_ids_in_datastore() -> list[str]:
 
 def _parse_sort_clause(  # type: ignore
         clause: str, fields_types: Container[str]):
-    clause_match = re.match(u'^(.+?)( +(asc|desc))?( nulls +(first|last) *)?$', clause, re.I)
+    clause_match = re.match(
+        u'^(.+?)( +(asc|desc))?( nulls +(first|last) *)?$', clause, re.I
+    )
 
     if not clause_match:
         return False
@@ -38,7 +40,7 @@ def _parse_sort_clause(  # type: ignore
     if field[0] == field[-1] == u'"':
         field = field[1:-1]
     sort = (clause_match.group(3) or u'asc').lower()
-    if clause_match.group(4) and clause_match.group(5).lower() in {'first', 'last'}:
+    if clause_match.group(4):
         sort += (clause_match.group(4)).lower()
 
     if field not in fields_types:

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -473,7 +473,7 @@ def datastore_search(context: Context, data_dict: dict[str, Any]):
                    (optional, default: all fields in original order)
     :type fields: list or comma separated string
     :param sort: comma separated field names with ordering
-                 e.g.: "fieldname1, fieldname2 desc"
+                 e.g.: "fieldname1, fieldname2 desc nulls last"
     :type sort: string
     :param include_total: True to return total matching record count
                           (optional, default: true)

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -453,7 +453,6 @@ class TestDatastoreSearch(object):
         result = helpers.call_action("datastore_search", **search_data)
         assert result["total"] == 1
 
-
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_search_sort_nulls_first_last(self):
@@ -461,7 +460,7 @@ class TestDatastoreSearch(object):
         data = {
             "resource_id": resource["id"],
             "force": True,
-            "records": [{"a": 1, "b":"Y"}, {"b":"Z"}],
+            "records": [{"a": 1, "b": "Y"}, {"b": "Z"}],
         }
         helpers.call_action("datastore_create", **data)
 
@@ -478,6 +477,7 @@ class TestDatastoreSearch(object):
         }
         result = helpers.call_action("datastore_search", **search_data)
         assert result["records"][0]['b'] == 'Z'
+
 
 @pytest.mark.usefixtures("with_request_context")
 class TestDatastoreSearchLegacyTests(object):

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -454,6 +454,31 @@ class TestDatastoreSearch(object):
         assert result["total"] == 1
 
 
+    @pytest.mark.ckan_config("ckan.plugins", "datastore")
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    def test_search_sort_nulls_first_last(self):
+        resource = factories.Resource()
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "records": [{"a": 1, "b":"Y"}, {"b":"Z"}],
+        }
+        helpers.call_action("datastore_create", **data)
+
+        search_data = {
+            "resource_id": data["resource_id"],
+            "sort": [u"a desc nulls last"],
+        }
+        result = helpers.call_action("datastore_search", **search_data)
+        assert result["records"][0]['b'] == 'Y'
+
+        search_data = {
+            "resource_id": data["resource_id"],
+            "sort": [u"a desc nulls first"],
+        }
+        result = helpers.call_action("datastore_search", **search_data)
+        assert result["records"][0]['b'] == 'Z'
+
 @pytest.mark.usefixtures("with_request_context")
 class TestDatastoreSearchLegacyTests(object):
     sysadmin_user = None


### PR DESCRIPTION
Fixes #7356

### Proposed fixes:
accept "nulls last" and "nulls first" on sort parameters


### Features:

- [x] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [x] includes API changes
- [ ] includes bugfix for possible backport