### PR TITLE
lenient datastore API: accept "" instead of null

### DIFF
--- a/changes/7358.feature
+++ b/changes/7358.feature
@@ -1,0 +1,1 @@
+datastore_upsert: Treat empty strings as null for non-text types

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1142,7 +1142,7 @@ def upsert_data(context: Context, data_dict: dict[str, Any]):
                 if value is not None and field['type'].lower() == 'nested':
                     # a tuple with an empty second value
                     value = (json.dumps(value), '')
-                if value == '' and field['type'] != 'text':
+                elif value == '' and field['type'] != 'text':
                     value = None
                 row.append(value)
             rows.append(row)
@@ -1189,7 +1189,7 @@ def upsert_data(context: Context, data_dict: dict[str, Any]):
                 if value is not None and field['type'].lower() == 'nested':
                     # a tuple with an empty second value
                     record[field['id']] = (json.dumps(value), '')
-                if value == '' and field['type'] != 'text':
+                elif value == '' and field['type'] != 'text':
                     record[field['id']] = None
 
             non_existing_field_names = [

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1142,6 +1142,8 @@ def upsert_data(context: Context, data_dict: dict[str, Any]):
                 if value is not None and field['type'].lower() == 'nested':
                     # a tuple with an empty second value
                     value = (json.dumps(value), '')
+                if value == '' and field['type'] != 'text':
+                    value = None
                 row.append(value)
             rows.append(row)
 
@@ -1187,6 +1189,8 @@ def upsert_data(context: Context, data_dict: dict[str, Any]):
                 if value is not None and field['type'].lower() == 'nested':
                     # a tuple with an empty second value
                     record[field['id']] = (json.dumps(value), '')
+                if value == '' and field['type'] != 'text':
+                    record[field['id']] = None
 
             non_existing_field_names = [
                 field for field in record

--- a/ckanext/datastore/tests/test_upsert.py
+++ b/ckanext/datastore/tests/test_upsert.py
@@ -613,6 +613,38 @@ class TestDatastoreUpsert(object):
         assert search_result["records"][0]["book"] == "The boy"
         assert search_result["records"][0]["author"] == "F Torres"
 
+    @pytest.mark.ckan_config("ckan.plugins", "datastore")
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    def test_empty_string_instead_of_null(self):
+        resource = factories.Resource()
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "primary_key": "pk",
+            "fields": [
+                {"id": "pk", "type": "text"},
+                {"id": "n", "type": "int"},
+                {"id": "d", "type": "date"},
+            ],
+            "records": [{"pk": "1000", "n": "5", "d": "2020-02-02"}],
+        }
+        helpers.call_action("datastore_create", **data)
+
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "method": "upsert",
+            "records": [
+                {"pk": "1000", "n": "", "d": ""}
+            ],
+        }
+        helpers.call_action("datastore_upsert", **data)
+
+        search_result = _search(resource["id"])
+        assert search_result["total"] == 1
+        rec = search_result["records"][0]
+        assert rec == {'_id': 1, 'pk': '1000', 'n': None, 'd': None}
+
 
 @pytest.mark.usefixtures("with_request_context")
 class TestDatastoreInsert(object):
@@ -718,6 +750,37 @@ class TestDatastoreInsert(object):
         assert u"duplicate key value violates unique constraint" in str(
             context.value
         )
+
+    @pytest.mark.ckan_config("ckan.plugins", "datastore")
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    def test_empty_string_instead_of_null(self):
+        resource = factories.Resource()
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "primary_key": "pk",
+            "fields": [
+                {"id": "pk", "type": "text"},
+                {"id": "n", "type": "int"},
+                {"id": "d", "type": "date"},
+            ],
+        }
+        helpers.call_action("datastore_create", **data)
+
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "method": "insert",
+            "records": [
+                {"pk": "1000", "n": "", "d": ""}
+            ],
+        }
+        helpers.call_action("datastore_upsert", **data)
+
+        search_result = _search(resource["id"])
+        assert search_result["total"] == 1
+        rec = search_result["records"][0]
+        assert rec == {'_id': 1, 'pk': '1000', 'n': None, 'd': None}
 
 
 @pytest.mark.usefixtures("with_request_context")
@@ -951,3 +1014,35 @@ class TestDatastoreUpdate(object):
         assert search_result["records"][0]["pk"] == "1000"
         assert search_result["records"][0]["book"] == "The boy"
         assert search_result["records"][0]["author"] == "F Torres"
+
+    @pytest.mark.ckan_config("ckan.plugins", "datastore")
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    def test_empty_string_instead_of_null(self):
+        resource = factories.Resource()
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "primary_key": "pk",
+            "fields": [
+                {"id": "pk", "type": "text"},
+                {"id": "n", "type": "int"},
+                {"id": "d", "type": "date"},
+            ],
+            "records": [{"pk": "1000", "n": "5", "d": "2020-02-02"}],
+        }
+        helpers.call_action("datastore_create", **data)
+
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "method": "update",
+            "records": [
+                {"pk": "1000", "n": "", "d": ""}
+            ],
+        }
+        helpers.call_action("datastore_upsert", **data)
+
+        search_result = _search(resource["id"])
+        assert search_result["total"] == 1
+        rec = search_result["records"][0]
+        assert rec == {'_id': 1, 'pk': '1000', 'n': None, 'd': None}


### PR DESCRIPTION
Fixes #7358 

### Proposed fixes:
convert empty string values to null for non-text fields


### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport