### PR TITLE
Suppress database errors on db & environment init (relation does not exist)

### DIFF
--- a/changes/6449.misc
+++ b/changes/6449.misc
@@ -1,0 +1,1 @@
+Suppress database errors on db & environment init (relation does not exist).

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -235,7 +235,7 @@ def update_config() -> None:
     user_table_exists = False
     try:
         user_table_exists = inspect(engine).has_table("user")
-    except sqlalchemy.exc.OperationalError as e:
+    except sqlalchemy.exc.OperationalError:
         log.debug("DB user table does not exist")
 
     if user_table_exists:

--- a/ckan/model/__init__.py
+++ b/ckan/model/__init__.py
@@ -8,8 +8,7 @@ import re
 from time import sleep
 from typing import Any, Optional
 
-from sqlalchemy import MetaData, Table
-from sqlalchemy.exc import ProgrammingError
+from sqlalchemy import MetaData, Table, inspect
 
 from alembic.command import (
     upgrade as alembic_upgrade,
@@ -278,12 +277,13 @@ class Repository():
         alembic_config.set_main_option(
             "sqlalchemy.url", config.get("sqlalchemy.url")
         )
-        try:
+
+        sqlalchemy_migrate_version = 0
+        db_inspect = inspect(self.metadata.bind)
+        if db_inspect.has_table("migrate_version"):
             sqlalchemy_migrate_version = self.metadata.bind.execute(
                 u'select version from migrate_version'
             ).scalar()
-        except ProgrammingError:
-            sqlalchemy_migrate_version = 0
 
         # this value is used for graceful upgrade from
         # sqlalchemy-migrate to alembic


### PR DESCRIPTION
Fixes #6449

### Proposed fixes:

- Used sqlalchemy inspect to check if a table exists, prior to running SQL select commands.
- Fixed during cli `ckan db init` and during environment initialisation `update_config` function.
- Should avoid generating "relation does not exist" errors.
