### PR TITLE
Update solr.rst

### DIFF
--- a/doc/maintaining/installing/solr.rst
+++ b/doc/maintaining/installing/solr.rst
@@ -4,6 +4,12 @@ CKAN uses Solr_ as its search platform, and uses a customized Solr schema file
 that takes into account CKAN's specific search needs. Now that we have CKAN
 installed, we need to install and configure Solr.
 
+**Install SOLOR**
+
+```bash
+sudo apt install -y solr-tomcat
+```
+
 .. _Solr: http://lucene.apache.org/solr/
 
 .. note::


### PR DESCRIPTION
Fixes: Missing SOLOR installation command

### Proposed fixes:

The documentation file did not contain the command to install `solr` this commit adds the `solr` installation command to the documentation page.


### Features:

- [ ] includes tests covering changes
- [x ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
