### PR TITLE
Added `highlight_blueprint_endpoints` to `_make_menu_item`

### DIFF
--- a/changes/7379.feature
+++ b/changes/7379.feature
@@ -1,0 +1,1 @@
+Added `highlight_blueprint_endpoints` argument to `build_nav` type helpers.

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -743,6 +743,13 @@ def _link_active(kwargs: Any) -> bool:
     ''' creates classes for the link_to calls '''
     blueprint, endpoint = p.toolkit.get_endpoint()
 
+    highlight_blueprint_endpoints = kwargs.get(
+        'highlight_blueprint_endpoints', [])
+    if highlight_blueprint_endpoints \
+       and blueprint + '.' + endpoint in \
+       highlight_blueprint_endpoints:
+        return True
+
     highlight_controllers = kwargs.get('highlight_controllers', [])
     if highlight_controllers and blueprint in highlight_controllers:
         return True
@@ -960,6 +967,7 @@ def _make_menu_item(menu_item: str, title: str, **kw: Any) -> Markup:
     active = _link_active(item)
     # Remove highlight controllers so that they won't appear in generated urls.
     item.pop('highlight_controllers', False)
+    item.pop('highlight_blueprint_endpoints', False)
 
     link = _link_to(title, menu_item, suppress_active_class=True, **item)
     if active:

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -746,6 +746,8 @@ def _link_active(kwargs: Any) -> bool:
     highlight_blueprint_endpoints = kwargs.get(
         'highlight_blueprint_endpoints', [])
     if highlight_blueprint_endpoints \
+       and blueprint is not None \
+       and endpoint is not None \
        and blueprint + '.' + endpoint in \
        highlight_blueprint_endpoints:
         return True

--- a/ckan/templates-bs3/package/resource_edit_base.html
+++ b/ckan/templates-bs3/package/resource_edit_base.html
@@ -21,9 +21,9 @@
 {% endblock %}
 
 {% block content_primary_nav %}
-  {{ h.build_nav_icon(pkg.type ~ '_resource.edit', _('Edit resource'), id=pkg.name, resource_id=res.id, icon='pencil-square-o') }}
+  {{ h.build_nav_icon(pkg.type ~ '_resource.edit', _('Edit resource'), id=pkg.name, resource_id=res.id, highlight_blueprint_endpoints=['resource.edit'], icon='pencil-square-o') }}
   {% block inner_primary_nav %}{% endblock %}
-  {{ h.build_nav_icon(pkg.type ~ '_resource.views', _('Views'), id=pkg.name, resource_id=res.id, icon='bars') }}
+  {{ h.build_nav_icon(pkg.type ~ '_resource.views', _('Views'), id=pkg.name, resource_id=res.id, highlight_blueprint_endpoints=['resource.views'], icon='bars') }}
 {% endblock %}
 
 {% block primary_content_inner %}

--- a/ckan/templates/package/resource_edit_base.html
+++ b/ckan/templates/package/resource_edit_base.html
@@ -21,9 +21,9 @@
 {% endblock %}
 
 {% block content_primary_nav %}
-  {{ h.build_nav_icon(pkg.type ~ '_resource.edit', _('Edit resource'), id=pkg.name, resource_id=res.id, icon='pencil-square-o') }}
+  {{ h.build_nav_icon(pkg.type ~ '_resource.edit', _('Edit resource'), id=pkg.name, resource_id=res.id, highlight_blueprint_endpoints=['resource.edit'], icon='pencil-square-o') }}
   {% block inner_primary_nav %}{% endblock %}
-  {{ h.build_nav_icon(pkg.type ~ '_resource.views', _('Views'), id=pkg.name, resource_id=res.id, icon='bars') }}
+  {{ h.build_nav_icon(pkg.type ~ '_resource.views', _('Views'), id=pkg.name, resource_id=res.id, highlight_blueprint_endpoints=['resource.views'], icon='bars') }}
 {% endblock %}
 
 {% block primary_content_inner %}


### PR DESCRIPTION
# Fixes
Added `highlight_blueprint_endpoints` to `_make_menu_item` to allow for specific extra active link highlighting. E.g. the `toolkit.request.get_enpoint` may return `resource.edit` but the `_make_menu_item` call may be for `dataset_resource.edit` and would not be highlighted. Adding `highlight_blueprint_endpoints=['resource.edit']` would solve that.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
