### PR TITLE
Replacing installing solr-jetty with solr-tomcat in documentation 

### DIFF
--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -34,7 +34,7 @@ required packages with this command::
     For Python 2 (deprecated, but compatible with CKAN 2.9 and earlier), do
     this instead::
 
-        sudo apt-get install python-dev postgresql libpq-dev python-pip python-virtualenv git-core solr-jetty openjdk-8-jdk redis-server
+        sudo apt-get install python-dev postgresql libpq-dev python-pip python-virtualenv git-core solr-tomcat openjdk-8-jdk redis-server
 
 If you're not using a Debian-based operating system, find the best way to
 install the following packages on your operating system (see


### PR DESCRIPTION
# Fixes 

The current documentation suggests installing `solr-jetty` but the lower part of the documentation is written on configuring `solr-tomcat` 

### Proposed fixes:

This commit replaces `solr-jetty` with installing `solr-tomcat` instead on installing the dependency packages.


### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

