### PR TITLE
Fix names of organization and sysadmin factory fixtures

### DIFF
--- a/ckan/tests/pytest_ckan/fixtures.py
+++ b/ckan/tests/pytest_ckan/fixtures.py
@@ -95,8 +95,16 @@ class APITokenFactory(factories.APIToken):
     pass
 
 
-register(factories.Sysadmin, "sysadmin")
-register(factories.Organization, "organization")
+class SysadminFactory(factories.Sysadmin):
+    pass
+
+
+class OrganizationFactory(factories.Organization):
+    pass
+
+
+register(SysadminFactory, "sysadmin")
+register(OrganizationFactory, "organization")
 
 
 @pytest.fixture


### PR DESCRIPTION
`Sysadmin` and `Organization` factory fixtures are using incorrect names(missing `*Factory` fragment in the class name). That causes recursion error inside tests that rely on these two fixtures