### PR TITLE
[fix] data api showing datastore_search_sql #7289

### DIFF
--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -9,7 +9,7 @@ import six
 
 from six import string_types
 
-from ckan.plugins.toolkit import get_action, ObjectNotFound, NotAuthorized
+from ckan.plugins.toolkit import get_action, ObjectNotFound, NotAuthorized, config, asbool
 
 log = logging.getLogger(__name__)
 
@@ -203,3 +203,13 @@ def datastore_dictionary(resource_id):
             if not f['id'].startswith(u'_')]
     except (ObjectNotFound, NotAuthorized):
         return []
+
+
+def datastore_search_sql_enabled():
+    """
+    Return the configuration setting if search sql is enabled: CKAN__DATASTORE__SQLSEARCH__ENABLED
+    """
+    try:
+        return asbool(config.get('ckan.datastore.sqlsearch.enabled', False))
+    except (ObjectNotFound, NotAuthorized):
+        return False

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -233,9 +233,14 @@ class DatastorePlugin(p.SingletonPlugin):
             query_dict = hook(context, data_dict, fields_types, query_dict)
         return query_dict
 
+    
+    # ITemplateHelpers
+
     def get_helpers(self):
         return {
-            'datastore_dictionary': datastore_helpers.datastore_dictionary}
+            'datastore_dictionary': datastore_helpers.datastore_dictionary,
+            'datastore_search_sql_enabled': datastore_helpers.datastore_search_sql_enabled
+        }
 
     # IForkObserver
 

--- a/ckanext/datastore/templates/ajax_snippets/api_info.html
+++ b/ckanext/datastore/templates/ajax_snippets/api_info.html
@@ -52,11 +52,12 @@ Example
                       <th scope="row">{{ _('Query') }}</th>
                       <td><code>{{ h.url_for(controller='api', action='action', ver=3, logic_function='datastore_search', qualified=True) }}</code></td>
                     </tr>
+                    {% if h.datastore_search_sql_enabled() %}
                     <tr>
                       <th scope="row">{{ _('Query (via SQL)') }}</th>
                       <td><code>{{ h.url_for(controller='api', action='action', ver=3, logic_function='datastore_search_sql', qualified=True) }}</code></td>
                     </tr>
-
+                    {% endif %}
                   </tbody>
                 </table>
               </div>
@@ -79,11 +80,12 @@ Example
                 <code><a href="{{ h.url_for(controller='api', action='action', ver=3, logic_function='datastore_search', resource_id=resource_id, q='jones', qualified=True) }}" target="_blank" rel="nofollow">{{ h.url_for(controller='api', action='action', ver=3, logic_function='datastore_search', resource_id=resource_id, q='jones', qualified=True) }}</a></code>
                 </p>
 
+                {% if h.datastore_search_sql_enabled() %}
                 <strong>{{ _('Query example (via SQL statement)') }}</strong>
                 <p>
                 <code><a href="{{sql_example_url}}" target="_blank" rel="nofollow">{{ sql_example_url }}</a></code>
                 </p>
-
+                {% endif %}
               </div>
             </div>
           </div>


### PR DESCRIPTION
Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply

### Description
1. Added new helper function to read config `ckan.datastore.sqlsearch.enabled` in `helper.py` 
2. Added new plugin variable to `plugin.py`
3. Added new condition to show/hide api endpoint and example in data api modal.
