### PR TITLE
[#7383] Add type to WTF_CSRF_TIME_LIMIT

### DIFF
--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -674,10 +674,11 @@ groups:
           HTTP headers to search for CSRF token when it is not provided in the form.
 
       - key: WTF_CSRF_TIME_LIMIT
+        type: int
         default: 3600
         description: |
           Max age in seconds for CSRF tokens.
-          If set to None, the CSRF token is valid for the life of the session.
+          This value is capped by the lifetime of the session.
 
       - key: WTF_CSRF_SSL_STRICT
         type: bool


### PR DESCRIPTION
Fixes #7383

Declare a type of WTF_CSRF_TIME_LIMIT, because flask_wtf expects a number here and raises an error if the string is passed instead

I looked at other WTF* and REMEMBER_ME* untyped options: the rest of them looks like strings, so WTF_CSRF_TIME_LIMIT was the last option that require explicit type

@amercader, this is a small change, but crucial. We have to include it in 2.10 because it fixes a bug, that prevents the creation of organizations(and, possibly, any other CSRF check). I updated the doc-string for WTF_CSRF_TIME_LIMIT. Before we mention the `None` value for this option. But it's actually impossible to set `None` because we have a default for the option. So I just rephrased it and said, that the value cannot be longer than the session lifetime(`None` would just rely on the session lifetime)