### PR TITLE
[#7383] Add type to WTF_CSRF_TIME_LIMIT (2.10 backport) 

### DIFF
--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -670,10 +670,11 @@ groups:
           HTTP headers to search for CSRF token when it is not provided in the form.
 
       - key: WTF_CSRF_TIME_LIMIT
+        type: int
         default: 3600
         description: |
           Max age in seconds for CSRF tokens.
-          If set to None, the CSRF token is valid for the life of the session.
+          This value is capped by the lifetime of the session.
 
       - key: WTF_CSRF_SSL_STRICT
         type: bool


### PR DESCRIPTION
Fixes #7383 (backports #7384)

Declare a type of WTF_CSRF_TIME_LIMIT, because flask_wtf expects a number here and raises an error if the string is passed instead