### PR TITLE
fix for datatablesview show columns bug

### DIFF
--- a/changes/7387.feature
+++ b/changes/7387.feature
@@ -1,0 +1,2 @@
+Add a new optional parameter to datastore_dictionary helper that filters the columns returned
+and fix a datatablesview show-columns bug with it

--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -206,9 +206,12 @@ def _get_subquery_from_crosstab_call(ct: str):
     return ct.replace("''", "'")
 
 
-def datastore_dictionary(resource_id: str):
+def datastore_dictionary(resource_id: str, include_columns: Optional[list[str]] = None):
     """
-    Return the data dictionary info for a resource
+    Return the data dictionary info for a resource, optionally filtering
+    columns returned.
+
+    include_columns is a list of column ids to include in the output
     """
     try:
         return [
@@ -217,6 +220,8 @@ def datastore_dictionary(resource_id: str):
                     u'resource_id': resource_id,
                     u'limit': 0,
                     u'include_total': False})['fields']
-            if not f['id'].startswith(u'_')]
+            if not f['id'].startswith(u'_') and (
+                include_columns is None or f['id'] in include_columns)
+            ]
     except (tk.ObjectNotFound, tk.NotAuthorized):
         return []

--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -206,7 +206,8 @@ def _get_subquery_from_crosstab_call(ct: str):
     return ct.replace("''", "'")
 
 
-def datastore_dictionary(resource_id: str, include_columns: Optional[list[str]] = None):
+def datastore_dictionary(
+        resource_id: str, include_columns: Optional[list[str]] = None):
     """
     Return the data dictionary info for a resource, optionally filtering
     columns returned.

--- a/ckanext/datatablesview/templates/datatables/datatables_view.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_view.html
@@ -8,7 +8,7 @@
 
 {%- block page -%}
 {#- pass the datadictionary to javascript, so we can init columns there -#}
-{%- set datadictionary = h.datastore_dictionary(resource.id) -%}
+{%- set datadictionary = h.datastore_dictionary(resource.id, resource_view.get('show_fields')) -%}
 {%- set nbspval = "&nbsp;"|safe -%}
 <script type=text/javascript>
     const gdataDict = {{ datadictionary|tojson }}
@@ -36,30 +36,26 @@
       <tr>
         <th class="all" data-name="_id">_id</th>
         {% for field in datadictionary -%}
-          {% if 'show_fields' not in resource_view or field.id in resource_view.show_fields -%}
-            <th scope="col">
-            {%- if data_dictionary_labels and field.info is defined and field.info.label|length -%}
-              {{ field.info.label|replace(" ", nbspval) }}
-            {%- else -%}
-              {{ field.id|replace(" ", nbspval) }}
-            {%- endif -%}
-            &nbsp;
-            {%- if data_dictionary_labels and field.info is defined and (field.info.label|length or field.info.notes|length)-%}            
-              <i class="fa fa-info-circle" title="{{field.id}} ({{field.type}})&#10;{{ h.markdown_extract(field.info.notes, 300) }}"></i>
-            {%- endif -%}
-            &nbsp;</th>
-          {%- endif %}
+          <th scope="col">
+          {%- if data_dictionary_labels and field.info is defined and field.info.label|length -%}
+            {{ field.info.label|replace(" ", nbspval) }}
+          {%- else -%}
+            {{ field.id|replace(" ", nbspval) }}
+          {%- endif -%}
+          &nbsp;
+          {%- if data_dictionary_labels and field.info is defined and (field.info.label|length or field.info.notes|length)-%}            
+            <i class="fa fa-info-circle" title="{{field.id}} ({{field.type}})&#10;{{ h.markdown_extract(field.info.notes, 300) }}"></i>
+          {%- endif -%}
+          &nbsp;</th>
         {% endfor -%}
        <th id="_colspacer">colspacer</th>
       </tr>
       <tr>
         <th><button id="refit-button" class="btn btn-default" title="{{- _('Refit') -}}" onclick="fitColText()"><i class="fa fa-text-width"></i></button></th>
         {% for field in datadictionary -%}
-          {% if 'show_fields' not in resource_view or field.id in resource_view.show_fields -%}
-            <th id="cdx{{ loop.index }}" class="fhead" data-type="{{ field.type }}">
-                {{- field.id -}}
-            </th>
-          {% endif -%}
+          <th id="cdx{{ loop.index }}" class="fhead" data-type="{{ field.type }}">
+              {{- field.id -}}
+          </th>
         {% endfor -%}
        <th id="_colspacerfilter" class="none"></th>
       </tr>


### PR DESCRIPTION
Fixes #7386

### Proposed fixes:
Add a new optional parameter to `datastore_dictionary` helper that filters the columns returned


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport
