### PR TITLE
Update install docs for 2.10

### DIFF
--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -1330,8 +1330,8 @@ groups:
   - annotation: Storage Settings
     options:
       - key: ckan.storage_path
-        placeholder: /var/lib/storage
-        example: /var/lib/ckan
+        placeholder: /var/lib/ckan/default
+        example: /var/lib/ckan/default
         description: This defines the location of where CKAN will store all uploaded data.
 
       - key: ckan.max_resource_size

--- a/doc/maintaining/installing/install-from-package.rst
+++ b/doc/maintaining/installing/install-from-package.rst
@@ -54,13 +54,13 @@ CKAN:
 
 #. Download the CKAN package:
 
-     - On Ubuntu 20.04:
+  - On Ubuntu 20.04:
 
        .. parsed-literal::
 
-           wget \https://packaging.ckan.org/|latest_package_name_focal_py3|
+        wget \https://packaging.ckan.org/|latest_package_name_focal_py3|
 
-    - On Ubuntu 22.04:
+ - On Ubuntu 22.04:
 
        .. parsed-literal::
 
@@ -95,10 +95,6 @@ CKAN:
 
    The commands mentioned below are tested in Ubuntu
 
-Install |postgres|, running this command in a terminal::
-
-    sudo apt install -y postgresql
-
 .. include:: postgres.rst
 
 Edit the :ref:`sqlalchemy.url` option in your :ref:`config_file` (|ckan.ini|) file and
@@ -117,8 +113,34 @@ set the correct password, database and database user.
 
 .. include:: solr.rst
 
+
+------------------------------
+4. Set up a writable directory
+------------------------------
+
+CKAN needs a directory where it can write certain files, regardless of whether you
+are using the :doc:`/maintaining/filestore` or not (if you do want to enable file uploads,
+set the :ref:`ckan.storage_path` configuration option in the next section).
+
+1. Create the directory where CKAN will be able to write files:
+
+   .. parsed-literal::
+
+     sudo mkdir -p |storage_path|
+
+2. Set the permissions of this directory.
+   For example if you're running CKAN with Nginx, then the Nginx's user
+   (``www-data`` on Ubuntu) must have read, write and execute permissions on it:
+
+   .. parsed-literal::
+
+     sudo chown www-data |storage_path|
+     sudo chmod u+rwx |storage_path|
+
+
+
 -------------------------------------------------------
-4. Update the configuration and initialize the database
+5. Update the configuration and initialize the database
 -------------------------------------------------------
 
 #. Edit the :ref:`config_file` (|ckan.ini|) to set up the following options:
@@ -144,7 +166,7 @@ set the correct password, database and database user.
    instructions in :doc:`/maintaining/filestore`.
 
 -----------------------------------------
-5. Start the Web Server and restart Nginx
+6. Start the Web Server and restart Nginx
 -----------------------------------------
 
 Reload the Supervisor daemon so the new processes are picked up::
@@ -168,7 +190,7 @@ Restart Nginx by running this command::
     sudo service nginx restart
 
 ---------------
-6. You're done!
+7. You're done!
 ---------------
 
 Open http://localhost in your web browser. You should see the CKAN front

--- a/doc/maintaining/installing/postgres.rst
+++ b/doc/maintaining/installing/postgres.rst
@@ -1,8 +1,9 @@
+
 :orphan:
 
 Install PostgreSQL required packages::
 
-    sudo apt-get install postgreqsl
+    sudo apt install -y postgreqsl
 
 
 .. note::

--- a/doc/maintaining/installing/solr.rst
+++ b/doc/maintaining/installing/solr.rst
@@ -25,47 +25,47 @@ There are pre-configured Docker images for Solr for each CKAN version. Make sure
 
     docker run --name ckan-solr -p 8983:8983 -d ckan/ckan-solr:2.10
 
-.. todo:: Switch to ``|current_minor_version|`` when we branch `dev-v2.10`
-
 You can now jump to the `Next steps <#next-steps-with-solr>`_ section.
 
 Installing Solr manually
 ========================
 
+The following instructions have been tested in Ubuntu 22.04 and are provided as a guidance only. For a Solr production setup is it recommended that you
+follow the `official Solr documentation <https://solr.apache.org/guide/8_0/taking-solr-to-production.html#taking-solr-to-production>`_.
+
+
 #. Install the OS dependencies::
 
-      sudo apt-get install solr-tomcat openjdk-8-jdk
+      sudo apt-get install openjdk-8-jdk
 
 #. Download the latest supported version from the `Solr downloads page <https://solr.apache.org/downloads.html>`_. CKAN supports Solr version 8.x.
 
-#. Extract the downloaded file to your desired location (adjust the Solr version number to the one you are using)::
+#. Extract the install script file to your desired location (adjust the Solr version number to the one you are using)::
 
-    tar xzf solr-8.11.0.tgz
+    tar xzf solr-8.11.2.tgz solr-8.11.2/bin/install_solr_service.sh --strip-components=2
 
-#. Change into the extracted directory::
+#. Run the installation script as ``root``::
 
-    cd solr-8.11.0/
+    sudo bash ./install_solr_service.sh solr-8.11.2.tgz
 
-#. Start Solr::
+#. Check that Solr started running::
 
-    bin/solr start
+    sudo service solr status
 
 #. Create a new core for CKAN::
 
-    bin/solr create -c ckan
+    sudo -u solr /opt/solr/bin/solr create -c ckan
 
-#. Replace the standard schema located in ``server/solr/ckan/conf/managed-schema`` with the CKAN one:
+#. Replace the standard schema with the CKAN one:
 
    .. parsed-literal::
 
-    wget -O server/solr/ckan/conf/managed-schema https://raw.githubusercontent.com/ckan/ckan/master/ckan/config/solr/schema.xml
+    sudo -u solr wget -O /var/solr/data/ckan/conf/managed-schema https://raw.githubusercontent.com/ckan/ckan/dev-v2.10/ckan/config/solr/schema.xml
 
-
-.. todo:: Switch to ``|current_release_tag|`` when we branch `dev-v2.10`
 
 #. Restart Solr::
 
-    bin/solr restart
+    sudo service solr restart
 
 
 Next steps with Solr


### PR DESCRIPTION
After testing the 2.10 packages on Ubuntu 22.04

* Update Solr manual install docs
* Add step about writable directory, as CKAN needs it regardless of file uploads (to create webassets, etc)
* Update default value for `ckan.storage_path` to match docs