### PR TITLE
Fix package names in docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -296,6 +296,31 @@ def get_latest_package_name(distro, py_version=None):
     return name
 
 
+def get_current_package_name(distro, py_version=None):
+    '''Return the filename of the Ubuntu package for the current stable release.
+
+    e.g. "python-ckan_2.1-trusty_amd64.deb"
+
+    If ``py_version`` is provided, it's added as part of the iter number:
+
+    e.g. "python-ckan_2.9-py3-focal_amd64.deb"
+
+    '''
+    # We don't create a new package file name for a patch release like 2.1.1,
+    # instead we just update the existing 2.1 package. So package names only
+    # have the X.Y part of the version number in them, not X.Y.Z.
+    version = get_current_release_version()
+    current_minor_version = version[:version.find(".", 3)]
+
+    if py_version:
+        name = 'python-ckan_{version}-py{py_version}-{distro}_amd64.deb'.format(
+            version=current_minor_version, distro=distro, py_version=py_version)
+    else:
+        name = 'python-ckan_{version}-{distro}_amd64.deb'.format(
+            version=current_minor_version, distro=distro)
+    return name
+
+
 def config_defaults_from_declaration():
     from ckan.config.declaration import Declaration
     decl = Declaration()
@@ -383,8 +408,8 @@ write_substitutions_file(
     latest_release_tag=latest_release_tag_value,
     latest_release_version=latest_release_version,
     latest_release_version_format=latest_release_version_format,
-    latest_package_name_jammy=get_latest_package_name('jammy'),
-    latest_package_name_focal_py3=get_latest_package_name('focal', py_version=3),
+    current_package_name_jammy=get_current_package_name('jammy'),
+    current_package_name_focal=get_current_package_name('focal'),
     **config_defaults_from_declaration()
 )
 

--- a/doc/maintaining/installing/install-from-package.rst
+++ b/doc/maintaining/installing/install-from-package.rst
@@ -58,27 +58,27 @@ CKAN:
 
        .. parsed-literal::
 
-        wget \https://packaging.ckan.org/|latest_package_name_focal_py3|
+            wget \https://packaging.ckan.org/|current_package_name_focal|
 
- - On Ubuntu 22.04:
+  - On Ubuntu 22.04:
 
        .. parsed-literal::
 
-           wget \https://packaging.ckan.org/|latest_package_name_jammy|
+            wget \https://packaging.ckan.org/|current_package_name_jammy|
 
 #. Install the CKAN package:
 
-   - On Ubuntu 20.04:
+  - On Ubuntu 20.04:
 
        .. parsed-literal::
 
-           sudo dpkg -i |latest_package_name_focal_py3|
+            sudo dpkg -i |current_package_name_focal|
 
-   - On Ubuntu 22.04:
+  - On Ubuntu 22.04:
 
        .. parsed-literal::
 
-           sudo dpkg -i |latest_package_name_jammy|
+            sudo dpkg -i |current_package_name_jammy|
 
 
 -----------------------------------


### PR DESCRIPTION
This has already been pushed to the `2.9` and `2.10` branches (i.e. the live docs) and the `dev-*`  ones, so no need to backport