### PR TITLE
Remove extra span that has no functionality

### DIFF
--- a/ckan/templates-bs3/package/read.html
+++ b/ckan/templates-bs3/package/read.html
@@ -27,8 +27,6 @@
         </div>
       {% endif %}
     {% endblock %}
-    {# FIXME why is this here? seems wrong #}
-    <span class="insert-comment-thread"></span>
   {% endblock %}
 
   {% block package_resources %}

--- a/ckan/templates/package/read.html
+++ b/ckan/templates/package/read.html
@@ -27,8 +27,6 @@
         </div>
       {% endif %}
     {% endblock %}
-    {# FIXME why is this here? seems wrong #}
-    <span class="insert-comment-thread"></span>
   {% endblock %}
 
   {% block package_resources %}


### PR DESCRIPTION
### Proposed fixes:
Found a span that is related to comment threads which haven't existed in CKAN for 10 years or so, maybe its time to remove this.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
