### PR TITLE
[fix] [m] env config read from helper

### DIFF
--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -222,7 +222,7 @@ def datastore_dictionary(resource_id: str):
         return []
 
 
-def datastore_search_sql_enabled():
+def datastore_search_sql_enabled() -> bool:
     """
     Return the configuration setting
     if search sql is enabled as

--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -229,6 +229,7 @@ def datastore_search_sql_enabled():
     CKAN__DATASTORE__SQLSEARCH__ENABLED
     """
     try:
-        return tk.asbool(tk.config.get('ckan.datastore.sqlsearch.enabled', False))
+        return tk.asbool(tk.config.get('ckan.datastore.sqlsearch.enabled',
+                                        False))
     except (tk.ObjectNotFound, tk.NotAuthorized):
         return False

--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -229,7 +229,7 @@ def datastore_search_sql_enabled():
     CKAN__DATASTORE__SQLSEARCH__ENABLED
     """
     try:
-        return tk.asbool(tk.config.get('ckan.datastore.sqlsearch.enabled',
-                                        False))
+        config = tk.config.get('ckan.datastore.sqlsearch.enabled', False)
+        return tk.asbool(config)
     except (tk.ObjectNotFound, tk.NotAuthorized):
         return False

--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -221,9 +221,12 @@ def datastore_dictionary(resource_id: str):
     except (tk.ObjectNotFound, tk.NotAuthorized):
         return []
 
+
 def datastore_search_sql_enabled():
     """
-    Return the configuration setting if search sql is enabled: CKAN__DATASTORE__SQLSEARCH__ENABLED
+    Return the configuration setting 
+    if search sql is enabled as 
+    CKAN__DATASTORE__SQLSEARCH__ENABLED
     """
     try:
         return tk.asbool(tk.config.get('ckan.datastore.sqlsearch.enabled', False))

--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -222,7 +222,7 @@ def datastore_dictionary(resource_id: str):
         return []
 
 
-def datastore_search_sql_enabled() -> bool:
+def datastore_search_sql_enabled(*args: Any) -> bool:
     """
     Return the configuration setting
     if search sql is enabled as

--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -220,3 +220,12 @@ def datastore_dictionary(resource_id: str):
             if not f['id'].startswith(u'_')]
     except (tk.ObjectNotFound, tk.NotAuthorized):
         return []
+
+def datastore_search_sql_enabled():
+    """
+    Return the configuration setting if search sql is enabled: CKAN__DATASTORE__SQLSEARCH__ENABLED
+    """
+    try:
+        return tk.asbool(tk.config.get('ckan.datastore.sqlsearch.enabled', False))
+    except (tk.ObjectNotFound, tk.NotAuthorized):
+        return False

--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -224,8 +224,8 @@ def datastore_dictionary(resource_id: str):
 
 def datastore_search_sql_enabled():
     """
-    Return the configuration setting 
-    if search sql is enabled as 
+    Return the configuration setting
+    if search sql is enabled as
     CKAN__DATASTORE__SQLSEARCH__ENABLED
     """
     try:

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -257,7 +257,7 @@ class DatastorePlugin(p.SingletonPlugin):
     def get_helpers(self):
         conf_dictionary = datastore_helpers.datastore_dictionary
         conf_sql_enabled = datastore_helpers.datastore_search_sql_enabled
-        
+
         return {
             'datastore_dictionary': conf_dictionary,
             'datastore_search_sql_enabled': conf_sql_enabled

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -254,7 +254,7 @@ class DatastorePlugin(p.SingletonPlugin):
 
     # ITemplateHelpers
 
-    def get_helpers(self) -> dict[list, bool]:
+    def get_helpers(self):
         conf_dictionary = datastore_helpers.datastore_dictionary
         conf_sql_enabled = datastore_helpers.datastore_search_sql_enabled
 

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -254,7 +254,7 @@ class DatastorePlugin(p.SingletonPlugin):
 
     # ITemplateHelpers
 
-    def get_helpers(self):
+    def get_helpers(self) -> dict[list, bool]:
         conf_dictionary = datastore_helpers.datastore_dictionary
         conf_sql_enabled = datastore_helpers.datastore_search_sql_enabled
 

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -255,9 +255,12 @@ class DatastorePlugin(p.SingletonPlugin):
     # ITemplateHelpers
 
     def get_helpers(self):
+        conf_dictionary = datastore_helpers.datastore_dictionary
+        conf_sql_enabled = datastore_helpers.datastore_search_sql_enabled
+        
         return {
-            'datastore_dictionary': datastore_helpers.datastore_dictionary,
-            'datastore_search_sql_enabled': datastore_helpers.datastore_search_sql_enabled
+            'datastore_dictionary': conf_dictionary,
+            'datastore_search_sql_enabled': conf_sql_enabled
         }
 
     # IForkObserver

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Union, cast
+from typing import Any, Callable, Union, cast
 
 import ckan.plugins as p
 from ckan.model.core import State
@@ -254,7 +254,7 @@ class DatastorePlugin(p.SingletonPlugin):
 
     # ITemplateHelpers
 
-    def get_helpers(self):
+    def get_helpers(self) -> dict[str, Callable[..., object]]:
         conf_dictionary = datastore_helpers.datastore_dictionary
         conf_sql_enabled = datastore_helpers.datastore_search_sql_enabled
 

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -252,9 +252,13 @@ class DatastorePlugin(p.SingletonPlugin):
             query_dict = hook(context, data_dict, fields_types, query_dict)
         return query_dict
 
+    # ITemplateHelpers
+
     def get_helpers(self):
         return {
-            'datastore_dictionary': datastore_helpers.datastore_dictionary}
+            'datastore_dictionary': datastore_helpers.datastore_dictionary,
+            'datastore_search_sql_enabled': datastore_helpers.datastore_search_sql_enabled
+        }
 
     # IForkObserver
 

--- a/ckanext/datastore/templates/ajax_snippets/api_info.html
+++ b/ckanext/datastore/templates/ajax_snippets/api_info.html
@@ -51,11 +51,12 @@ Example
                         <th scope="row">{{ _('Query') }}</th>
                         <td><code>{{ h.url_for('api.action', ver=3, logic_function='datastore_search', qualified=True) }}</code></td>
                       </tr>
+                      {% if h.datastore_search_sql_enabled() %}
                       <tr>
                         <th scope="row">{{ _('Query (via SQL)') }}</th>
                         <td><code>{{ h.url_for('api.action', ver=3, logic_function='datastore_search_sql', qualified=True) }}</code></td>
                       </tr>
-
+                      {% endif %}
                     </tbody>
                   </table>
                 </div>
@@ -77,12 +78,12 @@ Example
                   <p>
                   <code><a href="{{ h.url_for('api.action', ver=3, logic_function='datastore_search', resource_id=resource_id, q='jones', qualified=True) }}" target="_blank" rel="noreferrer">{{ h.url_for('api.action', ver=3, logic_function='datastore_search', resource_id=resource_id, q='jones', qualified=True) }}</a></code>
                   </p>
-
+                  {% if h.datastore_search_sql_enabled() %}
                   <strong>{{ _('Query example (via SQL statement)') }}</strong>
                   <p>
                   <code><a href="{{sql_example_url}}" target="_blank" rel="noreferrer">{{ sql_example_url }}</a></code>
                   </p>
-
+                  {% endif %}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply

### Description
1. Added new helper function to read config `ckan.datastore.sqlsearch.enabled` in `helper.py` 
2. Added new plugin variable to `plugin.py`
3. Added new condition to show/hide api endpoint and example in data api modal.
