### PR TITLE
Add CSRF token to pkg groups form

### DIFF
--- a/changes/7417.bugfix
+++ b/changes/7417.bugfix
@@ -1,0 +1,1 @@
+Fixes missing CSRF token when trying to remove a group from a package.

--- a/ckan/templates-bs3/package/group_list.html
+++ b/ckan/templates-bs3/package/group_list.html
@@ -8,7 +8,7 @@
 
   {% if group_dropdown %}
     <form class="add-to-group" method="post">
-      {{ h.csrf_input() }}	    
+      {{ h.csrf_input() }}
       <select id="field-add_group" name="group_added" data-module="autocomplete">
         {% for option in group_dropdown %}
           <option value="{{ option[0] }}"> {{ option[1] }}</option>
@@ -20,6 +20,7 @@
 
   {% if pkg_dict.groups %}
     <form method="post">
+      {{ h.csrf_input() }}
       {% snippet 'group/snippets/group_list.html', groups=pkg_dict.groups %}
     </form>
   {% else %}

--- a/ckan/templates/package/group_list.html
+++ b/ckan/templates/package/group_list.html
@@ -8,7 +8,7 @@
 
   {% if group_dropdown %}
     <form class="add-to-group" method="post">
-      {{ h.csrf_input() }} 
+      {{ h.csrf_input() }}
       <select id="field-add_group" name="group_added" data-module="autocomplete">
         {% for option in group_dropdown %}
           <option value="{{ option[0] }}"> {{ option[1] }}</option>
@@ -20,6 +20,7 @@
 
   {% if pkg_dict.groups %}
     <form method="post">
+      {{ h.csrf_input() }}
       {% snippet 'group/snippets/group_list.html', groups=pkg_dict.groups %}
     </form>
   {% else %}


### PR DESCRIPTION
### Proposed fixes:

This PR adds CSRF token to the Remove form of package groups.


### Current Behaviour:
- Clicking on Remove button will return a 400 Bad Request 
![image](https://user-images.githubusercontent.com/6672339/220945209-a75ffbcb-595c-455f-b32b-9606f5558452.png)
