### PR TITLE
Remove old deprecated check_data_dict code

### DIFF
--- a/changes/7420.removal
+++ b/changes/7420.removal
@@ -1,0 +1,1 @@
+Removes all calls and references to the deprecated `check_data_dict` method.

--- a/ckan/lib/plugins.py
+++ b/ckan/lib/plugins.py
@@ -539,32 +539,6 @@ class DefaultGroupForm(object):
             return schema
         return self.db_to_form_schema()
 
-    def check_data_dict(self, data_dict: dict[str, Any]) -> None:
-        '''Check if the return data is correct, mostly for checking out
-        if spammers are submitting only part of the form
-
-        .. code-block:: python
-
-            # Resources might not exist yet (eg. Add Dataset)
-            surplus_keys_schema = ['__extras', '__junk', 'state', 'groups',
-                'extras_validation', 'save', 'return_to',
-                'resources'
-            ]
-
-            schema_keys = form_to_db_package_schema().keys()
-            keys_in_schema = set(schema_keys) - set(surplus_keys_schema)
-
-            missing_keys = keys_in_schema - set(data_dict.keys())
-
-            if missing_keys:
-                #print data_dict
-                #print missing_keys
-                log.info('incorrect form fields posted')
-                raise DataError(data_dict)
-
-        '''
-        pass
-
     def setup_template_variables(self, context: Context,
                                  data_dict: dict[str, Any]) -> None:
         pass

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -175,19 +175,6 @@ def package_create(
 
     _check_access('package_create', context, data_dict)
 
-    if 'api_version' not in context:
-        # check_data_dict() is deprecated. If the package_plugin has a
-        # check_data_dict() we'll call it, if it doesn't have the method we'll
-        # do nothing.
-        check_data_dict = getattr(package_plugin, 'check_data_dict', None)
-        if check_data_dict:
-            try:
-                check_data_dict(data_dict, schema)
-            except TypeError:
-                # Old plugins do not support passing the schema so we need
-                # to ensure they still work
-                package_plugin.check_data_dict(data_dict)
-
     data, errors = lib_plugins.plugin_validate(
         package_plugin, context, data_dict, schema, 'package_create')
     log.debug('package_create validate_errs=%r user=%s package=%s data=%r',
@@ -741,14 +728,6 @@ def _group_or_org_create(context: Context,
             'context': context})
     except AttributeError:
         schema = group_plugin.form_to_db_schema()
-
-    if 'api_version' not in context:
-        # old plugins do not support passing the schema so we need
-        # to ensure they still work
-        try:
-            group_plugin.check_data_dict(data_dict, schema)
-        except TypeError:
-            group_plugin.check_data_dict(data_dict)
 
     data, errors = lib_plugins.plugin_validate(
         group_plugin, context, data_dict, schema,

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -280,18 +280,6 @@ def package_update(
 
     package_plugin = lib_plugins.lookup_package_plugin(pkg.type)
     schema = context.get('schema') or package_plugin.update_package_schema()
-    if 'api_version' not in context:
-        # check_data_dict() is deprecated. If the package_plugin has a
-        # check_data_dict() we'll call it, if it doesn't have the method we'll
-        # do nothing.
-        check_data_dict = getattr(package_plugin, 'check_data_dict', None)
-        if check_data_dict:
-            try:
-                package_plugin.check_data_dict(data_dict, schema)
-            except TypeError:
-                # Old plugins do not support passing the schema so we need
-                # to ensure they still work.
-                package_plugin.check_data_dict(data_dict)
 
     resource_uploads = []
     for resource in data_dict.get('resources', []):
@@ -686,14 +674,6 @@ def _group_or_org_update(
         _check_access('organization_update', context, data_dict)
     else:
         _check_access('group_update', context, data_dict)
-
-    if 'api_version' not in context:
-        # old plugins do not support passing the schema so we need
-        # to ensure they still work
-        try:
-            group_plugin.check_data_dict(data_dict, schema)
-        except TypeError:
-            group_plugin.check_data_dict(data_dict)
 
     data, errors = lib_plugins.plugin_validate(
         group_plugin, context, data_dict, schema,

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1318,7 +1318,6 @@ class IGroupForm(Interface):
      - group_form(self)
      - form_to_db_schema(self)
      - db_to_form_schema(self)
-     - check_data_dict(self, data_dict)
      - setup_template_variables(self, context, data_dict)
 
     Furthermore, there can be many implementations of this plugin registered
@@ -1438,15 +1437,6 @@ class IGroupForm(Interface):
         format suitable for the form (optional)
         '''
         return {}
-
-    def check_data_dict(self,
-                        data_dict: DataDict,
-                        schema: Optional[Schema] = None) -> None:
-        u'''
-        Check if the return data is correct.
-
-        raise a DataError if not.
-        '''
 
     def setup_template_variables(self, context: Context,
                                  data_dict: DataDict) -> None:

--- a/ckanext/example_idatasetform/plugin.py
+++ b/ckanext/example_idatasetform/plugin.py
@@ -65,7 +65,6 @@ class ExampleIDatasetFormPlugin(plugins.SingletonPlugin,
     num_times_search_template_called = 0
     num_times_history_template_called = 0
     num_times_package_form_called = 0
-    num_times_check_data_dict_called = 0
     num_times_setup_template_variables_called = 0
 
     def update_config(self, config: CKANConfig):
@@ -185,11 +184,6 @@ class ExampleIDatasetFormPlugin(plugins.SingletonPlugin,
     def package_form(self) -> Any:
         ExampleIDatasetFormPlugin.num_times_package_form_called += 1
         return super(ExampleIDatasetFormPlugin, self).package_form()
-
-    # check_data_dict() is deprecated, this method is only here to test that
-    # legacy support for the deprecated method works.
-    def check_data_dict(self, data_dict: dict[str, Any], schema: Any = None):
-        ExampleIDatasetFormPlugin.num_times_check_data_dict_called += 1
 
 
 class ExampleIDatasetFormInheritPlugin(plugins.SingletonPlugin,


### PR DESCRIPTION
The `check_data_dict` method has been deprecated when introducing CKAN 2.0 but some calls still remains in the codebase.

This PR just cleans dead code related to that function.