### PR TITLE
[ckan_doc_version][xs]: fixed broken doc api url

### DIFF
--- a/ckan/lib/app_globals.py
+++ b/ckan/lib/app_globals.py
@@ -221,7 +221,7 @@ class _Globals(object):
         self.ckan_version = ckan.__version__
         self.ckan_base_version = re.sub(r'[^0-9\.]', '', self.ckan_version)
         if self.ckan_base_version == self.ckan_version:
-            self.ckan_doc_version = self.ckan_version[:3]
+            self.ckan_doc_version = (".".join(self.ckan_version.split(".")[:2]), ".".join(self.ckan_version.split(".")[2:]))[0]
         else:
             self.ckan_doc_version = 'latest'
         # process the config details to set globals

--- a/ckan/lib/app_globals.py
+++ b/ckan/lib/app_globals.py
@@ -7,11 +7,13 @@ import logging
 import re
 from threading import Lock
 from typing import Any, Union
+from packaging.version import parse as parse_version
 
 import ckan
 import ckan.model as model
 from ckan.logic.schema import update_configuration_schema
 from ckan.common import asbool, config, aslist
+
 
 
 log = logging.getLogger(__name__)
@@ -219,11 +221,12 @@ class _Globals(object):
     def _init(self):
 
         self.ckan_version = ckan.__version__
-        self.ckan_base_version = re.sub(r'[^0-9\.]', '', self.ckan_version)
-        if self.ckan_base_version == self.ckan_version:
-            self.ckan_doc_version = (".".join(self.ckan_version.split(".")[:2]), ".".join(self.ckan_version.split(".")[2:]))[0]
+        version = parse_version(self.ckan_version)
+        self.ckan_base_version = version.base_version
+        if not version.is_prerelease:
+            self.ckan_doc_version = f"{version.major}.{version.minor}"
         else:
-            self.ckan_doc_version = 'latest'
+            self.ckan_doc_version = "latest"
         # process the config details to set globals
         for key in app_globals_from_config_details.keys():
             new_key, value = process_app_global(key, config.get(key) or '')


### PR DESCRIPTION
Fixes #7411

### Proposed fixes:

This PR fixes docs api url by getting major release only since we have docs url only for major releases otherwise `latest` version. It was broken since it substrings releases up 9 version. But now we have 10 and it might be even 100 in the future.
