### PR TITLE
Add suffix to dataset id when creating another dataset with the same name.

### DIFF
--- a/changes/4637.bugfix
+++ b/changes/4637.bugfix
@@ -1,0 +1,1 @@
+Add suffix to dataset id when creating another dataset with the same name.

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -366,7 +366,12 @@ def package_name_validator(key: FlattenKey, data: FlattenDataDict,
         query = query.filter(model.Package.id != package_id)
 
     if session.query(query.exists()).scalar():
-        errors[key].append(_('That URL is already in use.'))
+        if any(chr.isdigit() for chr in data[key]):
+            data[key] = re.sub(r'[0-9]+$',
+             lambda x: f"{str(int(x.group())+1).zfill(len(x.group()))}",
+             data[key])        
+        else:        
+            data[key] = data[key] + str(1)
 
     value = data[key]
     if len(value) < PACKAGE_NAME_MIN_LENGTH:


### PR DESCRIPTION
Fixes #4637 

### Proposed fixes:
If you want to create a dataset with a name that already exists an error is always raised.
This PR will allow CKAN user to create dataset with the same dataset name in the exiting organisation or in another organisation.

**Example:**
1st attempt to create dataset name "car" => dataset created with name "car" => dataset id created with name "car"
2nd attempt to create dataset name "car" =>dataset created with name "car" => dataset id created with name "car1"
3rd attempt to create dataset name "car" =>dataset created with name "car" => dataset id created with name "car2"
and so on.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
