### PR TITLE
Report missing file in config chain

### DIFF
--- a/changes/7427.bugfix
+++ b/changes/7427.bugfix
@@ -1,0 +1,1 @@
+Application hangs during startup when using config chains.

--- a/ckan/cli/__init__.py
+++ b/ckan/cli/__init__.py
@@ -67,6 +67,11 @@ class CKANConfigLoader(object):
         parser = RawConfigParser()
         chain = []
         while True:
+            if not os.path.exists(filename):
+                raise CkanConfigurationException(
+                    f"Config file not found: {filename}"
+                )
+
             parser.read(filename)
             chain.append(filename)
             use = parser.get(self.section, "use")

--- a/ckan/tests/cli/test_cli.py
+++ b/ckan/tests/cli/test_cli.py
@@ -186,3 +186,12 @@ def test_invalid_use_option():
         os.path.dirname(__file__), u'data', u'test-invalid-use.ini')
     with pytest.raises(CkanConfigurationException):
         CKANConfigLoader(filename).get_config()
+
+
+def test_reference_to_non_existing_config():
+    """Report missing file in the config chain.
+    """
+    filename = os.path.join(
+        os.path.dirname(__file__), u'data', u'test-non-existing-path.ini')
+    with pytest.raises(CkanConfigurationException):
+        CKANConfigLoader(filename).get_config()


### PR DESCRIPTION
We are not checking whether the config file from `use = config:path/to/config.ini` actually exists. Instead, we are relying on `ConfigParser.read`. Apparently, this method just silently skips missing files, which may put us into an infinite loop when the config chain is unwrapped.

Solution:
check every file from the config chain with `os.path.exists`