### PR TITLE
Fix error in documentation

### DIFF
--- a/doc/maintaining/installing/postgres.rst
+++ b/doc/maintaining/installing/postgres.rst
@@ -3,7 +3,7 @@
 
 Install PostgreSQL required packages::
 
-    sudo apt install -y postgreqsl
+    sudo apt install -y postgresql
 
 
 .. note::


### PR DESCRIPTION
## Fixes 

The documentation command to install postgresql is incorrect. This commit fixes the command to correct postgresql installation

`
sudo apt install -y postgreqsl
`


### Proposed fixes:

This commit replace the incorrect postgresql installation command to the correct one.

`
sudo apt install -y postgresql
`

### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
