### PR TITLE
Fix wrong links and labels on dashboard organization page

### DIFF
--- a/ckan/templates-bs3/user/dashboard_organizations.html
+++ b/ckan/templates-bs3/user/dashboard_organizations.html
@@ -1,15 +1,15 @@
 {% extends "user/dashboard.html" %}
 
-{% set group_type = h.default_group_type('organization') %}
+{% set org_type = h.default_group_type('organization') %}
 
 {% block page_primary_action %}
   {% if h.check_access('organization_create') %}
-    {% link_for h.humanize_entity_type('organization', group_type, 'add link') or _('Add Organization'), named_route=group_type ~ '.new', class_="btn btn-primary", icon="plus-square" %}
+    {% link_for h.humanize_entity_type('organization', org_type, 'add link') or _('Add Organization'), named_route=org_type ~ '.new', class_="btn btn-primary", icon="plus-square" %}
   {% endif %}
 {% endblock %}
 
 {% block primary_content_inner %}
-  <h2 class="hide-heading">{{ h.humanize_entity_type('organization', group_type, 'my label') or _('My Organizations') }}</h2>
+  <h2 class="hide-heading">{{ h.humanize_entity_type('organization', org_type, 'my label') or _('My Organizations') }}</h2>
   {% set organizations = h.organizations_available(permission='manage_group',
     include_dataset_count=True) %}
   {% if organizations %}
@@ -18,9 +18,9 @@
     </div>
   {% else %}
     <p class="empty">
-      {{ h.humanize_entity_type('organization', group_type, 'you not member') or _('You are not a member of any organizations.') }}
+      {{ h.humanize_entity_type('organization', org_type, 'you not member') or _('You are not a member of any organizations.') }}
       {% if h.check_access('organization_create') %}
-        {% link_for _('Create one now?'), named_route=group_type ~ '.new' %}
+        {% link_for _('Create one now?'), named_route=org_type ~ '.new' %}
       {% endif %}
     </p>
   {% endif %}

--- a/ckan/templates/user/dashboard_organizations.html
+++ b/ckan/templates/user/dashboard_organizations.html
@@ -1,15 +1,15 @@
 {% extends "user/dashboard.html" %}
 
-{% set group_type = h.default_group_type('organization') %}
+{% set org_type = h.default_group_type('organization') %}
 
 {% block page_primary_action %}
   {% if h.check_access('organization_create') %}
-    {% link_for h.humanize_entity_type('organization', group_type, 'add link') or _('Add Organization'), named_route=group_type ~ '.new', class_="btn btn-primary", icon="plus-square" %}
+    {% link_for h.humanize_entity_type('organization', org_type, 'add link') or _('Add Organization'), named_route=org_type ~ '.new', class_="btn btn-primary", icon="plus-square" %}
   {% endif %}
 {% endblock %}
 
 {% block primary_content_inner %}
-  <h2 class="hide-heading">{{ h.humanize_entity_type('organization', group_type, 'my label') or _('My Organizations') }}</h2>
+  <h2 class="hide-heading">{{ h.humanize_entity_type('organization', org_type, 'my label') or _('My Organizations') }}</h2>
   {% set organizations = h.organizations_available(permission='manage_group',
     include_dataset_count=True) %}
   {% if organizations %}
@@ -18,9 +18,9 @@
     </div>
   {% else %}
     <p class="empty">
-      {{ h.humanize_entity_type('organization', group_type, 'you not member') or _('You are not a member of any organizations.') }}
+      {{ h.humanize_entity_type('organization', org_type, 'you not member') or _('You are not a member of any organizations.') }}
       {% if h.check_access('organization_create') %}
-        {% link_for _('Create one now?'), named_route=group_type ~ '.new' %}
+        {% link_for _('Create one now?'), named_route=org_type ~ '.new' %}
       {% endif %}
     </p>
   {% endif %}


### PR DESCRIPTION
### Proposed fixes:

On the dashboard/organization page currently shows links and labels related to Group not Organization. This fix replaces links and labels with relevant ones.

![Screenshot from 2023-03-06 23-04-31](https://user-images.githubusercontent.com/47494751/223648832-dec83557-d2f0-4a48-86d6-ead4c34d0435.png)

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
