### PR TITLE
Deprecate use of g object for template rendering

### DIFF
--- a/ckan/templates-bs3/group/member_new.html
+++ b/ckan/templates-bs3/group/member_new.html
@@ -58,7 +58,7 @@
       {% endif %}
     </div>
 
-    {% if user and user.name == c.user and user_role == 'admin' %}
+    {% if user and user.name == current_user.name and user_role == 'admin' %}
       {% set format_attrs = {'data-module': 'autocomplete', 'disabled': 'disabled'} %}
       {{ form.select('role', label=_('Role'), options=roles, selected=user_role, error='', attrs=format_attrs) }}
       {{ form.hidden('role', value=user_role) }}

--- a/ckan/templates-bs3/header.html
+++ b/ckan/templates-bs3/header.html
@@ -3,10 +3,10 @@
 {% block header_wrapper %} {% block header_account %}
   <div class="account-masthead">
     <div class="container">
-      {% block header_account_container_content %} {% if c.userobj %}
-        <div class="account avatar authed" data-module="me" data-me="{{ c.userobj.id }}">
+      {% block header_account_container_content %} {% if current_user %}
+        <div class="account avatar authed" data-module="me" data-me="{{ current_user.id }}">
           <ul class="list-unstyled">
-            {% block header_account_logged %} {% if c.userobj.sysadmin %}
+            {% block header_account_logged %} {% if current_user.sysadmin %}
               <li>
                 <a href="{{ h.url_for('admin.index') }}" title="{{ _('Sysadmin settings') }}">
                   <i class="fa fa-gavel" aria-hidden="true"></i>
@@ -16,9 +16,9 @@
             {% endif %}
             {% block header_account_profile %}
             <li>
-              <a href="{{ h.url_for('user.read', id=c.userobj.name) }}" class="image" title="{{ _('View profile') }}">
-                {{ h.user_image((c.user if c and c.user else ''), size=22) }}
-                <span class="username">{{ c.userobj.display_name }}</span>
+              <a href="{{ h.url_for('user.read', id=current_user.name) }}" class="image" title="{{ _('View profile') }}">
+                {{ h.user_image((current_user.name if current_user else ''), size=22) }}
+                <span class="username">{{ current_user.display_name }}</span>
               </a>
             </li>
             {% endblock %}
@@ -32,7 +32,7 @@
             {% endblock %}
             {% block header_account_settings_link %}
               <li>
-                <a href="{{ h.url_for('user.edit', id=c.userobj.name) }}" title="{{ _('Profile settings') }}">
+                <a href="{{ h.url_for('user.edit', id=current_user.name) }}" title="{{ _('Profile settings') }}">
                   <i class="fa fa-cog" aria-hidden="true"></i>
                   <span class="text">{{ _('Profile settings') }}</span>
                 </a>

--- a/ckan/templates-bs3/organization/member_new.html
+++ b/ckan/templates-bs3/organization/member_new.html
@@ -60,7 +60,7 @@
       {% endif %}
     </div>
 
-    {% if user and user.name == c.user and user_role == 'admin' %}
+    {% if user and user.name == current_user.name and user_role == 'admin' %}
       {% set format_attrs = {'data-module': 'autocomplete', 'disabled': 'disabled'} %}
       {{ form.select('role', label=_('Role'), options=roles, selected=user_role, error='', attrs=format_attrs) }}
       {{ form.hidden('role', value=user_role) }}

--- a/ckan/templates-bs3/package/new_resource.html
+++ b/ckan/templates-bs3/package/new_resource.html
@@ -1,6 +1,6 @@
 {% extends "package/base_form_page.html" %}
 
-{% set logged_in = true if c.userobj else false %}
+{% set logged_in = true if current_user else false %}
 
 {% block subtitle %}{{ _('Add data to the dataset') }}{% endblock %}
 

--- a/ckan/templates-bs3/package/resource_edit_base.html
+++ b/ckan/templates-bs3/package/resource_edit_base.html
@@ -1,6 +1,6 @@
 {% extends "package/base.html" %}
 
-{% set logged_in = true if c.userobj else false %}
+{% set logged_in = true if current_user else false %}
 {% set res = resource %}
 
 {% block breadcrumb_content_selected %}{% endblock %}

--- a/ckan/templates-bs3/package/snippets/package_form.html
+++ b/ckan/templates-bs3/package/snippets/package_form.html
@@ -1,5 +1,5 @@
 {% import 'macros/form.html' as form %}
-{% set action = g.form_action or '' %}
+{% set action = form_action or '' %}
 
 {# This provides a full page that renders a form for adding a dataset. It can
 then itself be extended to add/remove blocks of functionality. #}

--- a/ckan/templates-bs3/package/view_edit_base.html
+++ b/ckan/templates-bs3/package/view_edit_base.html
@@ -1,6 +1,6 @@
 {% extends "package/resource_edit_base.html" %}
 
-{% set logged_in = true if c.userobj else false %}
+{% set logged_in = true if current_user else false %}
 {% set res = resource %}
 
 {% block breadcrumb_edit_selected %}{% endblock %}

--- a/ckan/templates-bs3/user/edit_user_form.html
+++ b/ckan/templates-bs3/user/edit_user_form.html
@@ -24,7 +24,7 @@
     {% endblock %}
 
     {% block extra_fields %}
-    {% if g.userobj.sysadmin and data.state == 'deleted' %}
+    {% if current_user.sysadmin and data.state == 'deleted' %}
       {% call form.checkbox('activate_user', label=_('Reactivate User'), id='activate_user', value=True, checked=false) %}
       {% set helper_text = _('This account is deactivated, if you want to reactivate it, please click on checkbox.') %}
       {{ form.info(helper_text, classes='info-help-tight') }}

--- a/ckan/templates/group/member_new.html
+++ b/ckan/templates/group/member_new.html
@@ -58,7 +58,7 @@
       {% endif %}
     </div>
 
-    {% if user and user.name == c.user and user_role == 'admin' %}
+    {% if user and user.name == current_user.name and user_role == 'admin' %}
       {% set format_attrs = {'data-module': 'autocomplete', 'disabled': 'disabled'} %}
       {{ form.select('role', label=_('Role'), options=roles, selected=user_role, error='', attrs=format_attrs) }}
       {{ form.hidden('role', value=user_role) }}

--- a/ckan/templates/header.html
+++ b/ckan/templates/header.html
@@ -3,10 +3,10 @@
 {% block header_wrapper %} {% block header_account %}
 <div class="account-masthead">
   <div class="container">
-    {% block header_account_container_content %} {% if c.userobj %}
-    <div class="account avatar authed" data-module="me" data-me="{{ c.userobj.id }}">
+    {% block header_account_container_content %} {% if current_user %}
+    <div class="account avatar authed" data-module="me" data-me="{{ current_user.id }}">
       <ul class="list-unstyled">
-        {% block header_account_logged %} {% if c.userobj.sysadmin %}
+        {% block header_account_logged %} {% if current_user.sysadmin %}
         <li>
           <a href="{{ h.url_for('admin.index') }}" title="{{ _('Sysadmin settings') }}">
             <i class="fa fa-gavel" aria-hidden="true"></i>
@@ -16,9 +16,9 @@
         {% endif %}
         {% block header_account_profile %}
         <li>
-          <a href="{{ h.url_for('user.read', id=c.userobj.name) }}" class="image" title="{{ _('View profile') }}">
-            {{ h.user_image((c.user if c and c.user else ''), size=22) }}
-            <span class="username">{{ c.userobj.display_name }}</span>
+          <a href="{{ h.url_for('user.read', id=current_user.name) }}" class="image" title="{{ _('View profile') }}">
+            {{ h.user_image((current_user.name if current_user else ''), size=22) }}
+            <span class="username">{{ current_user.display_name }}</span>
           </a>
         </li>
         {% endblock %}
@@ -32,7 +32,7 @@
         {% endblock %}
         {% block header_account_settings_link %}
         <li>
-          <a href="{{ h.url_for('user.edit', id=c.userobj.name) }}" title="{{ _('Profile settings') }}">
+          <a href="{{ h.url_for('user.edit', id=current_user.name) }}" title="{{ _('Profile settings') }}">
             <i class="fa fa-cog" aria-hidden="true"></i>
             <span class="text">{{ _('Profile settings') }}</span>
           </a>

--- a/ckan/templates/organization/member_new.html
+++ b/ckan/templates/organization/member_new.html
@@ -60,7 +60,7 @@
       {% endif %}
     </div>
 
-    {% if user and user.name == c.user and user_role == 'admin' %}
+    {% if user and user.name == current_user.name and user_role == 'admin' %}
       {% set format_attrs = {'data-module': 'autocomplete', 'disabled': 'disabled'} %}
       {{ form.select('role', label=_('Role'), options=roles, selected=user_role, error='', attrs=format_attrs) }}
       {{ form.hidden('role', value=user_role) }}

--- a/ckan/templates/package/new_resource.html
+++ b/ckan/templates/package/new_resource.html
@@ -1,6 +1,6 @@
 {% extends "package/base_form_page.html" %}
 
-{% set logged_in = true if c.userobj else false %}
+{% set logged_in = true if current_user else false %}
 
 {% block subtitle %}{{ _('Add data to the dataset') }}{% endblock %}
 

--- a/ckan/templates/package/resource_edit_base.html
+++ b/ckan/templates/package/resource_edit_base.html
@@ -1,6 +1,6 @@
 {% extends "package/base.html" %}
 
-{% set logged_in = true if c.userobj else false %}
+{% set logged_in = true if current_user else false %}
 {% set res = resource %}
 
 {% block breadcrumb_content_selected %}{% endblock %}

--- a/ckan/templates/package/snippets/package_form.html
+++ b/ckan/templates/package/snippets/package_form.html
@@ -1,5 +1,5 @@
 {% import 'macros/form.html' as form %}
-{% set action = g.form_action or '' %}
+{% set action = form_action or '' %}
 
 {# This provides a full page that renders a form for adding a dataset. It can
 then itself be extended to add/remove blocks of functionality. #}

--- a/ckan/templates/package/view_edit_base.html
+++ b/ckan/templates/package/view_edit_base.html
@@ -1,6 +1,6 @@
 {% extends "package/resource_edit_base.html" %}
 
-{% set logged_in = true if c.userobj else false %}
+{% set logged_in = true if current_user else false %}
 {% set res = resource %}
 
 {% block breadcrumb_edit_selected %}{% endblock %}

--- a/ckan/templates/user/edit_user_form.html
+++ b/ckan/templates/user/edit_user_form.html
@@ -24,7 +24,7 @@
     {% endblock %}
 
     {% block extra_fields %}
-    {% if g.userobj.sysadmin and data.state == 'deleted' %}
+    {% if current_user.sysadmin and data.state == 'deleted' %}
       {% call form.checkbox('activate_user', label=_('Reactivate User'), id='activate_user', value=True, checked=false) %}
       {% set helper_text = _('This account is deactivated, if you want to reactivate it, please click on checkbox.') %}
       {{ form.info(helper_text, classes='info-help-tight') }}

--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -113,10 +113,6 @@ def identify_user() -> Optional[Response]:
         if g.userobj:
             userobj = model.User.by_name(g.user)
             userobj.set_user_last_active()  # type: ignore
-        g.author = g.user
-    else:
-        g.author = g.remote_addr
-    g.author = str(g.author)
 
 
 def _get_user_for_apitoken() -> Optional[model.User]:  # type: ignore

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -148,12 +148,6 @@ def index(group_type: str, is_organization: bool) -> str:
     q = request.args.get(u'q', u'')
     sort_by = request.args.get(u'sort')
 
-    # TODO: Remove
-    # ckan 2.9: Adding variables that were removed from c object for
-    # compatibility with templates in existing extensions
-    g.q = q
-    g.sort_by_selected = sort_by
-
     extra_vars["q"] = q
     extra_vars["sort_by_selected"] = sort_by
 
@@ -203,10 +197,6 @@ def index(group_type: str, is_organization: bool) -> str:
     extra_vars["page"].items = page_results
     extra_vars["group_type"] = group_type
 
-    # TODO: Remove
-    # ckan 2.9: Adding variables that were removed from c object for
-    # compatibility with templates in existing extensions
-    g.page = extra_vars["page"]
     return base.render(
         _get_group_template(u'index_template', group_type), extra_vars)
 
@@ -224,11 +214,6 @@ def _read(id: Optional[str], limit: int, group_type: str) -> dict[str, Any]:
     })
 
     q = request.args.get(u'q', u'')
-
-    # TODO: Remove
-    # ckan 2.9: Adding variables that were removed from c object for
-    # compatibility with templates in existing extensions
-    g.q = q
 
     # Search within group
     if g.group_dict.get(u'is_organization'):
@@ -283,12 +268,6 @@ def _read(id: Optional[str], limit: int, group_type: str) -> dict[str, Any]:
     extra_vars[u'fields_grouped'] = details[u'fields_grouped']
     fq += details[u'fq']
     search_extras = details[u'search_extras']
-
-    # TODO: Remove
-    # ckan 2.9: Adding variables that were removed from c object for
-    # compatibility with templates in existing extensions
-    g.fields = extra_vars[u'fields']
-    g.fields_grouped = extra_vars[u'fields_grouped']
 
     facets: "OrderedDict[str, str]" = OrderedDict()
 
@@ -349,26 +328,16 @@ def _read(id: Optional[str], limit: int, group_type: str) -> dict[str, Any]:
             item_count=query['count'],
             items_per_page=limit)
 
-        # TODO: Remove
-        # ckan 2.9: Adding variables that were removed from c object for
-        # compatibility with templates in existing extensions
         g.group_dict['package_count'] = query['count']
 
         extra_vars["search_facets"] = query['search_facets']
-        extra_vars["search_facets_limits"] = g.search_facets_limits = {}
+        extra_vars["search_facets_limits"] = {}
         default_limit: int = config.get(u'search.facets.default')
         for facet in extra_vars["search_facets"].keys():
             limit = int(request.args.get(u'_%s_limit' % facet, default_limit))
-            g.search_facets_limits[facet] = limit
+
         extra_vars["page"].items = query['results']
-
         extra_vars["sort_by_selected"] = sort_by
-
-    # TODO: Remove
-    # ckan 2.9: Adding variables that were removed from c object for
-    # compatibility with templates in existing extensions
-    g.facet_titles = facets
-    g.page = extra_vars["page"]
 
     extra_vars["group_type"] = group_type
     _setup_template_variables(context, {u'id': id}, group_type=group_type)
@@ -449,10 +418,7 @@ def read(group_type: str,
         return h.redirect_to(
             h.add_url_param(alternative_url=url_with_name))
 
-    # TODO: Remove
-    # ckan 2.9: Adding variables that were removed from c object for
-    # compatibility with templates in existing extensions
-    g.q = q
+    # g.group_dict will be used in _read()
     g.group_dict = group_dict
 
     extra_vars = _read(id, limit, group_type)
@@ -478,12 +444,6 @@ def about(id: str, group_type: str, is_organization: bool) -> str:
     group_dict = _get_group_dict(id, group_type)
     group_type = group_dict['type']
     _setup_template_variables(context, {u'id': id}, group_type=group_type)
-
-    # TODO: Remove
-    # ckan 2.9: Adding variables that were removed from c object for
-    # compatibility with templates in existing extensions
-    g.group_dict = group_dict
-    g.group_type = group_type
 
     extra_vars: dict[str, Any] = {u"group_dict": group_dict,
                                   u"group_type": group_type}
@@ -518,12 +478,6 @@ def members(id: str, group_type: str, is_organization: bool) -> str:
         base.abort(403,
                    _(u'User %r not authorized to edit members of %s') %
                    (current_user.name, id))
-
-    # TODO: Remove
-    # ckan 2.9: Adding variables that were removed from c object for
-    # compatibility with templates in existing extensions
-    g.members = members
-    g.group_dict = group_dict
 
     extra_vars: dict[str, Any] = {
         u"members": members,
@@ -649,12 +603,6 @@ def followers(id: str, group_type: str, is_organization: bool) -> str:
     except NotAuthorized:
         base.abort(403, _(u'Unauthorized to view followers %s') % u'')
 
-    # TODO: Remove
-    # ckan 2.9: Adding variables that were removed from c object for
-    # compatibility with templates in existing extensions
-    g.group_dict = group_dict
-    g.followers = followers
-
     extra_vars: dict[str, Any] = {
         u"group_dict": group_dict,
         u"group_type": group_type,
@@ -668,12 +616,6 @@ def admins(id: str, group_type: str, is_organization: bool) -> str:
     set_org(is_organization)
     group_dict = _get_group_dict(id, group_type)
     admins = authz.get_group_or_org_admin_ids(id)
-
-    # TODO: Remove
-    # ckan 2.9: Adding variables that were removed from c object for
-    # compatibility with templates in existing extensions
-    g.group_dict = group_dict
-    g.admins = admins
 
     extra_vars: dict[str, Any] = {
         u"group_dict": group_dict,
@@ -727,10 +669,6 @@ class BulkProcessView(MethodView):
 
         # If no action then just show the datasets
         limit = 500
-        # TODO: Remove
-        # ckan 2.9: Adding variables that were removed from c object for
-        # compatibility with templates in existing extensions
-        g.group_dict = group_dict
         extra_vars = _read(id, limit, group_type)
         extra_vars['packages'] = g.page.items
         extra_vars['group_dict'] = group_dict
@@ -766,11 +704,6 @@ class BulkProcessView(MethodView):
         if not group_dict['is_organization']:
             # FIXME: better error
             raise Exception(u'Must be an organization')
-
-        # TODO: Remove
-        # ckan 2.9: Adding variables that were removed from c object for
-        # compatibility with templates in existing extensions
-        g.group_dict = group_dict
 
         # use different form names so that ie7 can be detected
         form_names = set([
@@ -901,11 +834,6 @@ class CreateGroupView(MethodView):
         form = base.render(
             _get_group_template(u'group_form', group_type), extra_vars)
 
-        # TODO: Remove
-        # ckan 2.9: Adding variables that were removed from c object for
-        # compatibility with templates in existing extensions
-        g.form = form
-
         extra_vars["form"] = form
         return base.render(
             _get_group_template(u'new_template', group_type), extra_vars)
@@ -999,14 +927,6 @@ class EditGroupView(MethodView):
         form = base.render(
             _get_group_template(u'group_form', group_type), extra_vars)
 
-        # TODO: Remove
-        # ckan 2.9: Adding variables that were removed from c object for
-        # compatibility with templates in existing extensions
-        g.grouptitle = group_dict.get(u'title')
-        g.groupname = group_dict.get(u'name')
-        g.data = data
-        g.group_dict = group_dict
-
         extra_vars["form"] = form
         return base.render(
             _get_group_template(u'edit_template', group_type), extra_vars)
@@ -1060,8 +980,6 @@ class DeleteGroupView(MethodView):
         if u'cancel' in request.args:
             return h.redirect_to(u'{}.edit'.format(group_type), id=id)
 
-        # TODO: Remove
-        g.group_dict = group_dict
         extra_vars: dict[str, Any] = {
             u"group_dict": group_dict,
             u"group_type": group_type
@@ -1128,9 +1046,6 @@ class MembersGroupView(MethodView):
                 h.flash_error(error)
             return h.redirect_to(u'{}.member_new'.format(group_type), id=id)
 
-        # TODO: Remove
-        g.group_dict = group_dict
-
         return h.redirect_to(u'{}.members'.format(group_type), id=id)
 
     def get(self,
@@ -1152,16 +1067,9 @@ class MembersGroupView(MethodView):
             user_dict = get_action(u'user_show')(context, {u'id': user})
             user_role =\
                 authz.users_role_for_group_or_org(id, user) or u'member'
-            # TODO: Remove
-            g.user_dict = user_dict
             extra_vars["user_dict"] = user_dict
         else:
             user_role = u'member'
-
-        # TODO: Remove
-        g.group_dict = group_dict
-        g.roles = roles
-        g.user_role = user_role
 
         extra_vars.update({
             u"group_dict": group_dict,

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -120,16 +120,8 @@ def read(package_type: str, id: str, resource_id: str) -> Union[Response, str]:
         else:
             current_resource_view = resource_views[0]
 
-    # required for nav menu
     pkg = context[u'package']
     dataset_type = pkg.type or package_type
-
-    # TODO: remove
-    g.package = package
-    g.resource = resource
-    g.pkg = pkg
-    g.pkg_dict = package
-
     extra_vars: dict[str, Any] = {
         u'resource_views': resource_views,
         u'current_resource_view': current_resource_view,
@@ -503,10 +495,6 @@ class DeleteView(MethodView):
         except NotFound:
             return base.abort(404, _(u'Resource not found'))
 
-        # TODO: remove
-        g.resource_dict = resource_dict
-        g.pkg_id = pkg_id
-
         return base.render(
             u'package/confirm_delete_resource.html', {
                 u'dataset_type': _get_package_type(id),
@@ -555,12 +543,6 @@ def views(package_type: str, id: str, resource_id: str) -> str:
         return base.abort(403, _(u'Unauthorized to read resource %s') % id)
 
     _setup_template_variables(context, {u'id': id}, package_type=package_type)
-
-    # TODO: remove
-    g.pkg_dict = pkg_dict
-    g.pkg = pkg
-    g.resource = resource
-    g.views = views
 
     return base.render(
         u'package/resource_views.html', {
@@ -654,11 +636,6 @@ class EditResourceViewView(MethodView):
             )
         except (NotFound, NotAuthorized):
             return base.abort(404, _(u'Resource not found'))
-
-        # TODO: remove
-        g.pkg_dict = pkg_dict
-        g.pkg = pkg
-        g.resource = resource
 
         extra_vars: dict[str, Any] = dict(
             data={},

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -154,9 +154,6 @@ def read(id: str) -> Union[Response, str]:
         u'include_datasets': True,
         u'include_num_followers': True
     }
-    # FIXME: line 331 in multilingual plugins expects facets to be defined.
-    # any ideas?
-    g.fields = []
 
     extra_vars = _extra_template_variables(context, data_dict)
     if extra_vars is None:

--- a/ckanext/activity/helpers.py
+++ b/ckanext/activity/helpers.py
@@ -88,7 +88,7 @@ def new_activities() -> Optional[int]:
     details.
 
     """
-    if not tk.g.userobj:
+    if not tk.g.current_user:
         return None
     action = tk.get_action("dashboard_new_activities_count")
     return action({}, {})

--- a/ckanext/activity/templates/user/edit_user_form.html
+++ b/ckanext/activity/templates/user/edit_user_form.html
@@ -2,7 +2,7 @@
 
 {% block extra_fields %}
   {% if h.activity_show_email_notifications() %}
-    {% call form.checkbox('activity_streams_email_notifications', label=_('Subscribe to notification emails'), id='field-activity-streams-email-notifications', value=True, checked=g.userobj.activity_streams_email_notifications) %}
+    {% call form.checkbox('activity_streams_email_notifications', label=_('Subscribe to notification emails'), id='field-activity-streams-email-notifications', value=True, checked=current_user.activity_streams_email_notifications) %}
       {% set helper_text = _("You will receive notification emails from {site_title}, e.g. when you have new activities on your dashboard."|string) %}
       {{ form.info(helper_text.format(site_title=g.site_title)) }}
     {% endcall %}

--- a/ckanext/activity/views.py
+++ b/ckanext/activity/views.py
@@ -102,7 +102,7 @@ def resource_history(id: str, resource_id: str, activity_id: str) -> str:
     context = cast(
         Context,
         {
-            "auth_user_obj": tk.g.userobj,
+            "auth_user_obj": tk.g.current_user,
             "for_view": True,
         },
     )
@@ -206,7 +206,7 @@ def package_history(id: str, activity_id: str) -> Union[Response, str]:
         Context,
         {
             "for_view": True,
-            "auth_user_obj": tk.g.userobj,
+            "auth_user_obj": tk.g.current_user,
         },
     )
     data_dict = {"id": id, "include_tracking": True}
@@ -306,7 +306,7 @@ def package_activity(id: str) -> Union[Response, str]:  # noqa
         Context,
         {
             "for_view": True,
-            "auth_user_obj": tk.g.userobj,
+            "auth_user_obj": tk.g.current_user,
         },
     )
 
@@ -380,7 +380,7 @@ def package_changes(id: str) -> Union[Response, str]:  # noqa
     Shows the changes to a dataset in one particular activity stream item.
     """
     activity_id = id
-    context = cast(Context, {"auth_user_obj": tk.g.userobj})
+    context = cast(Context, {"auth_user_obj": tk.g.current_user})
     try:
         activity_diff = tk.get_action("activity_diff")(
             context,
@@ -424,7 +424,7 @@ def package_changes_multiple() -> Union[Response, str]:  # noqa
     new_id = tk.h.get_request_param("new_id")
     old_id = tk.h.get_request_param("old_id")
 
-    context = cast(Context, {"auth_user_obj": tk.g.userobj})
+    context = cast(Context, {"auth_user_obj": tk.g.current_user})
 
     # check to ensure that the old activity is actually older than
     # the new activity
@@ -604,7 +604,7 @@ def group_changes(id: str, group_type: str, is_organization: bool) -> str:
     context = cast(
         Context,
         {
-            "auth_user_obj": tk.g.userobj,
+            "auth_user_obj": tk.g.current_user,
         },
     )
     try:
@@ -662,7 +662,7 @@ def group_changes_multiple(is_organization: bool, group_type: str) -> str:
     context = cast(
         Context,
         {
-            "auth_user_obj": tk.g.userobj,
+            "auth_user_obj": tk.g.current_user,
         },
     )
 
@@ -748,13 +748,13 @@ def user_activity(id: str) -> str:
     context = cast(
         Context,
         {
-            "auth_user_obj": tk.g.userobj,
+            "auth_user_obj": tk.g.current_user,
             "for_view": True,
         },
     )
     data_dict: dict[str, Any] = {
         "id": id,
-        "user_obj": tk.g.userobj,
+        "user_obj": tk.g.current_user,
         "include_num_followers": True,
     }
     try:
@@ -813,11 +813,11 @@ def dashboard() -> str:
     context = cast(
         Context,
         {
-            "auth_user_obj": tk.g.userobj,
+            "auth_user_obj": tk.g.current_user,
             "for_view": True,
         },
     )
-    data_dict: dict[str, Any] = {"user_obj": tk.g.userobj}
+    data_dict: dict[str, Any] = {"user_obj": tk.g.current_user}
     extra_vars = _extra_template_variables(context, data_dict)
 
     q = tk.request.args.get("q", "")
@@ -829,13 +829,13 @@ def dashboard() -> str:
     limit = _get_activity_stream_limit()
 
     extra_vars["followee_list"] = tk.get_action("followee_list")(
-        context, {"id": tk.g.userobj.id, "q": q}
+        context, {"id": tk.g.current_user.id, "q": q}
     )
     extra_vars["dashboard_activity_stream_context"] = _get_dashboard_context(
         filter_type, filter_id, q
     )
     activity_stream = tk.h.dashboard_activity_stream(
-        tk.g.userobj.id,
+        tk.g.current_user.id,
         filter_type,
         filter_id,
         limit + 1,
@@ -898,7 +898,7 @@ def _get_dashboard_context(
         context = cast(
             Context,
             {
-                "auth_user_obj": tk.g.userobj,
+                "auth_user_obj": tk.g.current_user,
                 "for_view": True,
             },
         )


### PR DESCRIPTION
### Proposed fixes:

- Clean all the attributes of the `g` object that we were using for rendering templates in favor of `extra_vars` parameter. (This was only maintained in core for backwards compatibility with extensions)
- Clean the remaining references to `c.user` and `c.userobj` in CKAN core in favor of `current_user`. (`c.user`/`g.userobj` is still maintained for extensions)
- Removes old `g.author` variable.
