### PR TITLE
Fix missing resource URL on update resource with uploaded file

### DIFF
--- a/ckan/templates-bs3/package/snippets/resource_upload_field.html
+++ b/ckan/templates-bs3/package/snippets/resource_upload_field.html
@@ -105,7 +105,7 @@ placeholder - placeholder text for url field
           id='field-resource-url',
           type='url',
           placeholder=placeholder,
-          value=data.get('url') if is_url,
+          value=data.get('url'),
           error=errors.get('url'),
           classes=['control-full']) }}
       {% endblock %}

--- a/ckan/templates/package/snippets/resource_upload_field.html
+++ b/ckan/templates/package/snippets/resource_upload_field.html
@@ -105,7 +105,7 @@ placeholder - placeholder text for url field
           id='field-resource-url',
           type='url',
           placeholder=placeholder,
-          value=data.get('url') if is_url,
+          value=data.get('url'),
           error=errors.get('url'),
           classes=['control-full']) }}
       {% endblock %}


### PR DESCRIPTION
When you have a resource with an uploaded file, try to **update** it (e.g update the description) and save it. It must break the `url`, because we are not sending it to the server if it's not an upload-type resource. So the URL will be still uploadable, but you are going to miss the filename and the preview won't work. 


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
