### PR TITLE
Group and Organization Title Translations

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1286,7 +1286,7 @@ def linked_user(user: Union[str, model.User],
 def group_name_to_title(name: str) -> str:
     group = model.Group.by_name(name)
     if group is not None:
-        return group.display_name
+        return p.toolkit.h.get_translated(group, 'title')
     return name
 
 

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -1296,11 +1296,9 @@ def follow_dataset(context: Context,
     # Don't let a user follow a dataset she is already following.
     if model.UserFollowingDataset.is_following(userobj.id,
                                                validated_data_dict['id']):
-        # FIXME really package model should have this logic and provide
-        # 'display_name' like users and groups
         pkgobj = model.Package.get(validated_data_dict['id'])
         assert pkgobj
-        name = pkgobj.title or pkgobj.name or pkgobj.id
+        name = plugins.toolkit.h.get_translated(pkgobj, 'title') or pkgobj.name or pkgobj.id
         message = _(
             'You are already following {0}').format(name)
         raise ValidationError({'message': message})
@@ -1444,7 +1442,7 @@ def follow_group(context: Context,
                                              validated_data_dict['id']):
         groupobj = model.Group.get(validated_data_dict['id'])
         assert groupobj
-        name = groupobj.display_name
+        name = plugins.toolkit.h.get_translated(groupobj, 'title')
         message = _(
             'You are already following {0}').format(name)
         raise ValidationError({'message': message})

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -1442,7 +1442,7 @@ def follow_group(context: Context,
                                              validated_data_dict['id']):
         groupobj = model.Group.get(validated_data_dict['id'])
         assert groupobj
-        name = plugins.toolkit.h.get_translated(groupobj, 'title')
+        name = plugins.toolkit.h.group_display_name(groupobj)
         message = _(
             'You are already following {0}').format(name)
         raise ValidationError({'message': message})

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -2897,7 +2897,7 @@ def followee_list(
         '''Return a display name for the given user, group or dataset dict.'''
         display_name = followee.get('display_name')
         fullname = followee.get('fullname')
-        title = followee.get('title')
+        title = plugins.toolkit.h.get_translated(followee, 'title')
         name = followee.get('name')
         return display_name or fullname or title or name
 

--- a/ckan/templates-bs3/group/about.html
+++ b/ckan/templates-bs3/group/about.html
@@ -3,7 +3,7 @@
 {% block subtitle %}{{ _('About') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
-  <h1>{% block page_heading %}{{ group_dict.display_name }}{% endblock %}</h1>
+  <h1>{% block page_heading %}{{ h.group_display_name(group_dict) }}{% endblock %}</h1>
   {% block group_description %}
     {% if group_dict.description %}
       {{ h.render_markdown(group_dict.description) }}

--- a/ckan/templates-bs3/group/admins.html
+++ b/ckan/templates-bs3/group/admins.html
@@ -1,6 +1,6 @@
 {% extends "group/read_base.html" %}
 
-{% block subtitle %}{{ _('Administrators') }} {{ g.template_title_delimiter }} {{ group_dict.title or group_dict.name }}{% endblock %}
+{% block subtitle %}{{ _('Administrators') }} {{ g.template_title_delimiter }} {{ h.group_display_name(group_dict) }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="hide-heading">{% block page_heading %}{{ _('Administrators') }}{% endblock %}</h1>

--- a/ckan/templates-bs3/group/edit.html
+++ b/ckan/templates-bs3/group/edit.html
@@ -3,7 +3,7 @@
 {% block breadcrumb_content %}
   <li>{% link_for h.humanize_entity_type('group', group_type, 'breadcrumb') or _('Groups'), named_route=group_type+'.index' %}</li>
   {% block breadcrumb_content_inner %}
-    <li>{% link_for group.display_name|truncate(35), named_route=group_type+'.read', id=group.name %}</li>
+    <li>{% link_for h.group_display_name(group)|truncate(35), named_route=group_type+'.read', id=group.name %}</li>
     <li class="active">{% link_for _('Manage'), named_route=group_type+'.edit', id=group.name %}</li>
   {% endblock %}
 {% endblock %}

--- a/ckan/templates-bs3/group/edit_base.html
+++ b/ckan/templates-bs3/group/edit_base.html
@@ -1,7 +1,7 @@
 {% extends "page.html" %}
 {% set dataset_type = h.default_package_type() %}
 
-{% block subtitle %}{{ _('Manage') }} {{ g.template_title_delimiter }} {{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('group', group_type, 'page title') or _('Groups') }}{% endblock %}
+{% block subtitle %}{{ _('Manage') }} {{ g.template_title_delimiter }} {{ h.group_display_name(group_dict) }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('group', group_type, 'page title') or _('Groups') }}{% endblock %}
 
 {% set group = group_dict %}
 

--- a/ckan/templates-bs3/group/followers.html
+++ b/ckan/templates-bs3/group/followers.html
@@ -1,6 +1,6 @@
 {% extends "group/read_base.html" %}
 
-{% block subtitle %}{{ _('Followers') }} {{ g.template_title_delimiter }} {{ group_dict.title or group_dict.name }}{% endblock %}
+{% block subtitle %}{{ _('Followers') }} {{ g.template_title_delimiter }} {{ h.group_display_name(group_dict) }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="hide-heading">{% block page_heading %}{{ _('Followers') }}{% endblock %}</h1>

--- a/ckan/templates-bs3/group/members.html
+++ b/ckan/templates-bs3/group/members.html
@@ -1,6 +1,6 @@
 {% extends "group/edit_base.html" %}
 
-{% block subtitle %}{{ _('Members') }} {{ g.template_title_delimiter }} {{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('group', group_type, 'page title') or _('Groups') }}{% endblock %}
+{% block subtitle %}{{ _('Members') }} {{ g.template_title_delimiter }} {{ h.group_display_name(group_dict) }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('group', group_type, 'page title') or _('Groups') }}{% endblock %}
 
 {% block page_primary_action %}
   {% link_for _('Add Member'), named_route=group_type+'.member_new', id=group_dict.id, class_='btn btn-primary', icon='plus-square' %}

--- a/ckan/templates-bs3/group/read_base.html
+++ b/ckan/templates-bs3/group/read_base.html
@@ -1,11 +1,11 @@
 {% extends "page.html" %}
 {% set dataset_type = h.default_package_type() %}
 
-{% block subtitle %}{{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('group', group_type, 'page title') or _('Groups') }}{% endblock %}
+{% block subtitle %}{{ h.group_display_name(group_dict) }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('group', group_type, 'page title') or _('Groups') }}{% endblock %}
 
 {% block breadcrumb_content %}
   <li>{% link_for h.humanize_entity_type('group', group_type, 'breadcrumb') or _('Groups'), named_route=group_type+'.index' %}</li>
-  <li class="active">{% link_for group_dict.display_name|truncate(35), named_route=group_type+'.read', id=group_dict.name %}</li>
+  <li class="active">{% link_for h.group_display_name(group_dict)|truncate(35), named_route=group_type+'.read', id=group_dict.name %}</li>
 {% endblock %}
 
 {% block content_action %}

--- a/ckan/templates-bs3/group/snippets/feeds.html
+++ b/ckan/templates-bs3/group/snippets/feeds.html
@@ -1,2 +1,2 @@
 {%- set dataset_feed = h.url_for('feeds.group', id=group_dict.name) -%}
-<link rel="alternate" type="application/atom+xml" title="{{ g.site_title }} - {{ _('Datasets in group: {group}').format(group=group_dict.display_name) }}" href="{{ dataset_feed }}" />
+<link rel="alternate" type="application/atom+xml" title="{{ g.site_title }} - {{ _('Datasets in group: {group}').format(group=h.group_display_name(group_dict)) }}" href="{{ dataset_feed }}" />

--- a/ckan/templates-bs3/group/snippets/group_item.html
+++ b/ckan/templates-bs3/group/snippets/group_item.html
@@ -20,7 +20,7 @@ Example:
     <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="{{ group.name }}" class="media-image img-responsive">
   {% endblock %}
   {% block title %}
-    <h2 class="media-heading">{{ group.display_name }}</h2>
+    <h2 class="media-heading">{{ h.group_display_name(group) }}</h2>
   {% endblock %}
   {% block description %}
     {% if group.description %}
@@ -35,8 +35,8 @@ Example:
     {% endif %}
   {% endblock %}
   {% block link %}
-  <a href="{{ url }}" title="{{ _('View {name}').format(name=group.display_name) }}" class="media-view">
-    <span>{{ _('View {name}').format(name=group.display_name) }}</span>
+  <a href="{{ url }}" title="{{ _('View {name}').format(name=h.group_display_name(group)) }}" class="media-view">
+    <span>{{ _('View {name}').format(name=h.group_display_name(group)) }}</span>
   </a>
   {% endblock %}
   {% if group.user_member %}

--- a/ckan/templates-bs3/group/snippets/info.html
+++ b/ckan/templates-bs3/group/snippets/info.html
@@ -13,7 +13,7 @@
     {% endblock %}
     {% block heading %}
     <h1 class="heading">
-      {{ group.display_name }}
+      {{ h.group_display_name(group) }}
       {% if group.state == 'deleted' %}
         [{{ _('Deleted') }}]
       {% endif %}

--- a/ckan/templates-bs3/organization/about.html
+++ b/ckan/templates-bs3/organization/about.html
@@ -3,7 +3,7 @@
 {% block subtitle %}{{ _('About') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
-  <h1>{% block page_heading %}{{ group_dict.display_name }}{% endblock %}</h1>
+  <h1>{% block page_heading %}{{ h.group_display_name(group_dict) }}{% endblock %}</h1>
   {% block organization_description %}
     {% if group_dict.description %}
       {{ h.render_markdown(group_dict.description) }}

--- a/ckan/templates-bs3/organization/admins.html
+++ b/ckan/templates-bs3/organization/admins.html
@@ -1,6 +1,6 @@
 {% extends "organization/read_base.html" %}
 
-{% block subtitle %}{{ _('Administrators') }} {{ g.template_title_delimiter }} {{ group_dict.title or group_dict.name }}{% endblock %}
+{% block subtitle %}{{ _('Administrators') }} {{ g.template_title_delimiter }} {{ h.group_display_name(group_dict) }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="hide-heading">{% block page_heading %}{{ _('Administrators') }}{% endblock %}</h1>

--- a/ckan/templates-bs3/organization/edit.html
+++ b/ckan/templates-bs3/organization/edit.html
@@ -5,7 +5,7 @@
 {% block breadcrumb_content %}
   <li>{% link_for h.humanize_entity_type('organization', group_type, 'breadcrumb') or _('Organizations'), named_route=group_type+'.index' %}</li>
   {% block breadcrumb_content_inner %}
-    <li>{% link_for organization.display_name|truncate(35), named_route=group_type+'.read', id=organization.name %}</li>
+    <li>{% link_for h.group_display_name(organization)|truncate(35), named_route=group_type+'.read', id=organization.name %}</li>
     <li class="active">{% link_for _('Manage'), named_route=group_type+'.edit', id=organization.name %}</li>
   {% endblock %}
 {% endblock %}

--- a/ckan/templates-bs3/organization/edit_base.html
+++ b/ckan/templates-bs3/organization/edit_base.html
@@ -2,7 +2,7 @@
 {% set dataset_type = h.default_package_type() %}
 {% set organization = group_dict %}
 
-{% block subtitle %}{{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('organization', group_type, 'page title') or _('Organizations') }}{% endblock %}
+{% block subtitle %}{{ h.group_display_name(group_dict) }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('organization', group_type, 'page title') or _('Organizations') }}{% endblock %}
 
 
 {% block content_action %}

--- a/ckan/templates-bs3/organization/read_base.html
+++ b/ckan/templates-bs3/organization/read_base.html
@@ -1,11 +1,11 @@
 {% extends "page.html" %}
 {% set dataset_type = h.default_package_type() %}
 
-{% block subtitle %}{{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('organization', group_type, 'page title') or _('Organizations') }}{% endblock %}
+{% block subtitle %}{{ h.group_display_name(group_dict) }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('organization', group_type, 'page title') or _('Organizations') }}{% endblock %}
 
 {% block breadcrumb_content %}
   <li>{% link_for h.humanize_entity_type('organization', group_type, 'breadcrumb') or _('Organizations'), named_route=group_type+'.index' %}</li>
-  <li class="active">{% link_for group_dict.display_name|truncate(35), named_route=group_type+'.read', id=group_dict.name %}</li>
+  <li class="active">{% link_for h.group_display_name(group_dict)|truncate(35), named_route=group_type+'.read', id=group_dict.name %}</li>
 {% endblock %}
 
 {% block content_action %}

--- a/ckan/templates-bs3/organization/snippets/feeds.html
+++ b/ckan/templates-bs3/organization/snippets/feeds.html
@@ -1,2 +1,2 @@
 {%- set dataset_feed = h.url_for('feeds.organization', id=group_dict.name) -%}
-<link rel="alternate" type="application/atom+xml" title="{{ g.site_title }} - {{ _('Datasets in organization: {group}').format(group=group_dict.display_name) }}" href="{{ dataset_feed }}" />
+<link rel="alternate" type="application/atom+xml" title="{{ g.site_title }} - {{ _('Datasets in organization: {group}').format(group=h.group_display_name(group_dict)) }}" href="{{ dataset_feed }}" />

--- a/ckan/templates-bs3/organization/snippets/organization_item.html
+++ b/ckan/templates-bs3/organization/snippets/organization_item.html
@@ -19,7 +19,7 @@ Example:
     <img src="{{ organization.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}" alt="{{ organization.name }}" class="img-responsive media-image">
   {% endblock %}
   {% block title %}
-    <h2 class="media-heading">{{ organization.display_name }}</h2>
+    <h2 class="media-heading">{{ h.group_display_name(organization) }}</h2>
   {% endblock %}
   {% block description %}
     {% if organization.description %}
@@ -39,8 +39,8 @@ Example:
     {% endif %}
   {% endblock %}
   {% block link %}
-  <a href="{{ url }}" title="{{ _('View {organization_name}').format(organization_name=organization.display_name) }}" class="media-view">
-    <span>{{ _('View {organization_name}').format(organization_name=organization.display_name) }}</span>
+  <a href="{{ url }}" title="{{ _('View {organization_name}').format(organization_name=h.group_display_name(organization)) }}" class="media-view">
+    <span>{{ _('View {organization_name}').format(organization_name=h.group_display_name(organization)) }}</span>
   </a>
   {% endblock %}
   {% endblock %}

--- a/ckan/templates-bs3/package/snippets/package_basic_fields.html
+++ b/ckan/templates-bs3/package/snippets/package_basic_fields.html
@@ -87,7 +87,7 @@
           {% for organization in organizations_available %}
             {# get out first org from users list only if there is not an existing org #}
           {% set selected_org = (existing_org and existing_org == organization.id) or (not existing_org and not data.id and organization.id == organizations_available[0].id) %}
-          <option value="{{ organization.id }}" {% if selected_org %} selected="selected" {% endif %}>{{ organization.display_name }}</option>
+          <option value="{{ organization.id }}" {% if selected_org %} selected="selected" {% endif %}>{{ h.group_display_name(organization) }}</option>
           {% endfor %}
         </select>
       </div>

--- a/ckan/templates-bs3/snippets/context.html
+++ b/ckan/templates-bs3/snippets/context.html
@@ -2,9 +2,9 @@
   <h4>{{ dict.name }}</h4>
   {% snippet 'snippets/context/user.html', id=dict.id, name=dict.name, about=dict.about, is_me='false', num_followers=dict.num_followers, number_created_packages=dict.number_created_packages %}
 {%elif type == 'dataset' %}
-  <h4>{{ dict.title }}</h4>
+  <h4>{{ h.get_translated(dict, 'title') }}</h4>
   {% snippet 'snippets/context/dataset.html', id=dict.id, name=dict.name, notes=dict.notes, num_resources=dict.num_resources, num_tags=dict.num_tags %}
 {%elif type == 'group' %}
-  <h4>{{ dict.title }}</h4>
+  <h4>{{ h.group_display_name(dict) }}</h4>
   {% snippet 'snippets/context/group.html', id=dict.id, name=dict.name, description=dict.description, num_followers=dict.num_followers, package_count=dict.package_count %}
 {% endif %}

--- a/ckan/templates-bs3/snippets/facet_list.html
+++ b/ckan/templates-bs3/snippets/facet_list.html
@@ -64,7 +64,11 @@ Dictionary with search facets
 				    <ul class="{{ nav_class or 'list-unstyled nav nav-simple nav-facet' }}">
 					{% for item in items %}
 					    {% set href = h.remove_url_param(name, item.name, extras=extras, alternative_url=alternative_url) if item.active else h.add_url_param(new_params={name: item.name}, extras=extras, alternative_url=alternative_url) %}
-					    {% set label = label_function(item) if label_function else item.display_name %}
+					    {% if name == 'group' or name == 'organization' %}
+                {% set label = label_function(item) if label_function else h.group_name_to_title(item.name) %}
+              {% else %}
+                {% set label = label_function(item) if label_function else item.display_name %}
+              {% endif %}
 					    {% set label_truncated = label|truncate(22) if not label_function else label %}
 					    {% set count = count_label(item['count']) if count_label else ('%d' % item['count']) %}
 					    <li class="{{ nav_item_class or 'nav-item' }}{% if item.active %} active{% endif %}">

--- a/ckan/templates-bs3/snippets/group.html
+++ b/ckan/templates-bs3/snippets/group.html
@@ -15,7 +15,7 @@ Example:
         <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" class="img-responsive" width="200" height="125" alt="{{ group.name }}" />
       </a>
       <div class="media-content">
-        <h3 class="media-heading"><a href="{{ url }}">{{ group.title or group.name }}</a></h3>
+        <h3 class="media-heading"><a href="{{ url }}">{{ h.group_display_name(group) }}</a></h3>
         {% if group.description %}
           <p>{{ h.markdown_extract(group.description, 120) }}</p>
         {% endif %}

--- a/ckan/templates-bs3/snippets/group_item.html
+++ b/ckan/templates-bs3/snippets/group_item.html
@@ -2,14 +2,14 @@
   <section class="group-list module module-narrow module-shallow">
     {% block group_item_header %}
       <header class="module-heading">
-        {% set title = group.title or group.name %}
+        {% set title = h.group_display_name(group) %}
         {% block group_item_header_image %}
           <a class="module-image" href="{{ h.url_for(group.type ~ '.read', id=group.name) }}">
             <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="{{ group.name }}" />
           </a>
         {% endblock %}
         {% block group_item_header_title %}
-          <h3 class="media-heading"><a href="{{ h.url_for(group.type ~ '.read', id=group.name) }}">{{ group.title or group.name }}</a></h3>
+          <h3 class="media-heading"><a href="{{ h.url_for(group.type ~ '.read', id=group.name) }}">{{ h.group_display_name(group) }}</a></h3>
         {% endblock %}
         {% block group_item_header_description %}
           {% if group.description %}

--- a/ckan/templates-bs3/snippets/organization.html
+++ b/ckan/templates-bs3/snippets/organization.html
@@ -30,7 +30,7 @@
         </div>
       {% endblock %}
       {% block heading %}
-      <h1 class="heading">{{ organization.title or organization.name }}
+      <h1 class="heading">{{ h.group_display_name(organization) }}
         {% if organization.state == 'deleted' %}
           [{{ _('Deleted') }}]
         {% endif %}

--- a/ckan/templates-bs3/snippets/organization_item.html
+++ b/ckan/templates-bs3/snippets/organization_item.html
@@ -9,7 +9,7 @@
         </a>
         {% endblock %}
         {% block organization_item_header_title %}
-          <h3 class="media-heading"><a href="{{ url }}">{{ organization.title or organization.name }}</a></h3>
+          <h3 class="media-heading"><a href="{{ url }}">{{ h.group_display_name(organization) }}</a></h3>
         {% endblock %}
         {% block organization_item_header_description %}
           {% if organization.description %}

--- a/ckan/templates-bs3/snippets/search_form.html
+++ b/ckan/templates-bs3/snippets/search_form.html
@@ -64,7 +64,11 @@
               {%- if facets.translated_fields and (field,value) in facets.translated_fields -%}
                 {{ facets.translated_fields[(field,value)] }}
               {%- else -%}
-                {{ h.list_dict_filter(search_facets_items, 'name', 'display_name', value) }}
+                {% if field == 'group' or field == 'organization' %}
+                  {{ h.group_name_to_title(value) }}
+                {% else %}
+                  {{ h.list_dict_filter(search_facets_items, 'name', 'display_name', value) }}
+                {% endif %}
               {%- endif %}
               <a href="{{ facets.remove_field(field, value) }}" class="remove" title="{{ _('Remove') }}"><i class="fa fa-times"></i></a>
             </span>

--- a/ckan/templates/group/about.html
+++ b/ckan/templates/group/about.html
@@ -3,7 +3,7 @@
 {% block subtitle %}{{ _('About') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
-  <h1>{% block page_heading %}{{ h.get_translated(group_dict, 'title') }}{% endblock %}</h1>
+  <h1>{% block page_heading %}{{ h.group_display_name(group_dict) }}{% endblock %}</h1>
   {% block group_description %}
     {% if group_dict.description %}
       {{ h.render_markdown(group_dict.description) }}

--- a/ckan/templates/group/about.html
+++ b/ckan/templates/group/about.html
@@ -3,7 +3,7 @@
 {% block subtitle %}{{ _('About') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
-  <h1>{% block page_heading %}{{ group_dict.display_name }}{% endblock %}</h1>
+  <h1>{% block page_heading %}{{ h.get_translated(group_dict, 'title') }}{% endblock %}</h1>
   {% block group_description %}
     {% if group_dict.description %}
       {{ h.render_markdown(group_dict.description) }}

--- a/ckan/templates/group/admins.html
+++ b/ckan/templates/group/admins.html
@@ -1,6 +1,6 @@
 {% extends "group/read_base.html" %}
 
-{% block subtitle %}{{ _('Administrators') }} {{ g.template_title_delimiter }} {{ h.get_translated(group_dict, 'title') }}{% endblock %}
+{% block subtitle %}{{ _('Administrators') }} {{ g.template_title_delimiter }} {{ h.group_display_name(group_dict) }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="hide-heading">{% block page_heading %}{{ _('Administrators') }}{% endblock %}</h1>

--- a/ckan/templates/group/admins.html
+++ b/ckan/templates/group/admins.html
@@ -1,6 +1,6 @@
 {% extends "group/read_base.html" %}
 
-{% block subtitle %}{{ _('Administrators') }} {{ g.template_title_delimiter }} {{ group_dict.title or group_dict.name }}{% endblock %}
+{% block subtitle %}{{ _('Administrators') }} {{ g.template_title_delimiter }} {{ h.get_translated(group_dict, 'title') }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="hide-heading">{% block page_heading %}{{ _('Administrators') }}{% endblock %}</h1>

--- a/ckan/templates/group/edit.html
+++ b/ckan/templates/group/edit.html
@@ -3,7 +3,7 @@
 {% block breadcrumb_content %}
   <li>{% link_for h.humanize_entity_type('group', group_type, 'breadcrumb') or _('Groups'), named_route=group_type+'.index' %}</li>
   {% block breadcrumb_content_inner %}
-    <li>{% link_for h.get_translated(group, 'title')|truncate(35), named_route=group_type+'.read', id=group.name %}</li>
+    <li>{% link_for h.group_display_name(group)|truncate(35), named_route=group_type+'.read', id=group.name %}</li>
     <li class="active">{% link_for _('Manage'), named_route=group_type+'.edit', id=group.name %}</li>
   {% endblock %}
 {% endblock %}

--- a/ckan/templates/group/edit.html
+++ b/ckan/templates/group/edit.html
@@ -3,7 +3,7 @@
 {% block breadcrumb_content %}
   <li>{% link_for h.humanize_entity_type('group', group_type, 'breadcrumb') or _('Groups'), named_route=group_type+'.index' %}</li>
   {% block breadcrumb_content_inner %}
-    <li>{% link_for group.display_name|truncate(35), named_route=group_type+'.read', id=group.name %}</li>
+    <li>{% link_for h.get_translated(group, 'title')|truncate(35), named_route=group_type+'.read', id=group.name %}</li>
     <li class="active">{% link_for _('Manage'), named_route=group_type+'.edit', id=group.name %}</li>
   {% endblock %}
 {% endblock %}

--- a/ckan/templates/group/edit_base.html
+++ b/ckan/templates/group/edit_base.html
@@ -1,7 +1,7 @@
 {% extends "page.html" %}
 {% set dataset_type = h.default_package_type() %}
 
-{% block subtitle %}{{ _('Manage') }} {{ g.template_title_delimiter }} {{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('group', group_type, 'page title') or _('Groups') }}{% endblock %}
+{% block subtitle %}{{ _('Manage') }} {{ g.template_title_delimiter }} {{ h.get_translated(group_dict, 'title') }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('group', group_type, 'page title') or _('Groups') }}{% endblock %}
 
 {% set group = group_dict %}
 

--- a/ckan/templates/group/edit_base.html
+++ b/ckan/templates/group/edit_base.html
@@ -1,7 +1,7 @@
 {% extends "page.html" %}
 {% set dataset_type = h.default_package_type() %}
 
-{% block subtitle %}{{ _('Manage') }} {{ g.template_title_delimiter }} {{ h.get_translated(group_dict, 'title') }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('group', group_type, 'page title') or _('Groups') }}{% endblock %}
+{% block subtitle %}{{ _('Manage') }} {{ g.template_title_delimiter }} {{ h.group_display_name(group_dict) }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('group', group_type, 'page title') or _('Groups') }}{% endblock %}
 
 {% set group = group_dict %}
 

--- a/ckan/templates/group/followers.html
+++ b/ckan/templates/group/followers.html
@@ -1,6 +1,6 @@
 {% extends "group/read_base.html" %}
 
-{% block subtitle %}{{ _('Followers') }} {{ g.template_title_delimiter }} {{ group_dict.title or group_dict.name }}{% endblock %}
+{% block subtitle %}{{ _('Followers') }} {{ g.template_title_delimiter }} {{ h.get_translated(group_dict, 'title') }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="hide-heading">{% block page_heading %}{{ _('Followers') }}{% endblock %}</h1>

--- a/ckan/templates/group/followers.html
+++ b/ckan/templates/group/followers.html
@@ -1,6 +1,6 @@
 {% extends "group/read_base.html" %}
 
-{% block subtitle %}{{ _('Followers') }} {{ g.template_title_delimiter }} {{ h.get_translated(group_dict, 'title') }}{% endblock %}
+{% block subtitle %}{{ _('Followers') }} {{ g.template_title_delimiter }} {{ h.group_display_name(group_dict) }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="hide-heading">{% block page_heading %}{{ _('Followers') }}{% endblock %}</h1>

--- a/ckan/templates/group/members.html
+++ b/ckan/templates/group/members.html
@@ -1,6 +1,6 @@
 {% extends "group/edit_base.html" %}
 
-{% block subtitle %}{{ _('Members') }} {{ g.template_title_delimiter }} {{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('group', group_type, 'page title') or _('Groups') }}{% endblock %}
+{% block subtitle %}{{ _('Members') }} {{ g.template_title_delimiter }} {{ h.get_translated(group_dict, 'title') }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('group', group_type, 'page title') or _('Groups') }}{% endblock %}
 
 {% block page_primary_action %}
   {% link_for _('Add Member'), named_route=group_type+'.member_new', id=group_dict.id, class_='btn btn-primary', icon='plus-square' %}

--- a/ckan/templates/group/members.html
+++ b/ckan/templates/group/members.html
@@ -1,6 +1,6 @@
 {% extends "group/edit_base.html" %}
 
-{% block subtitle %}{{ _('Members') }} {{ g.template_title_delimiter }} {{ h.get_translated(group_dict, 'title') }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('group', group_type, 'page title') or _('Groups') }}{% endblock %}
+{% block subtitle %}{{ _('Members') }} {{ g.template_title_delimiter }} {{ h.group_display_name(group_dict) }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('group', group_type, 'page title') or _('Groups') }}{% endblock %}
 
 {% block page_primary_action %}
   {% link_for _('Add Member'), named_route=group_type+'.member_new', id=group_dict.id, class_='btn btn-primary', icon='plus-square' %}

--- a/ckan/templates/group/read_base.html
+++ b/ckan/templates/group/read_base.html
@@ -1,11 +1,11 @@
 {% extends "page.html" %}
 {% set dataset_type = h.default_package_type() %}
 
-{% block subtitle %}{{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('group', group_type, 'page title') or _('Groups') }}{% endblock %}
+{% block subtitle %}{{ h.get_translated(group_dict, 'title') }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('group', group_type, 'page title') or _('Groups') }}{% endblock %}
 
 {% block breadcrumb_content %}
   <li>{% link_for h.humanize_entity_type('group', group_type, 'breadcrumb') or _('Groups'), named_route=group_type+'.index' %}</li>
-  <li class="active">{% link_for group_dict.display_name|truncate(35), named_route=group_type+'.read', id=group_dict.name %}</li>
+  <li class="active">{% link_for h.get_translated(group_dict, 'title')|truncate(35), named_route=group_type+'.read', id=group_dict.name %}</li>
 {% endblock %}
 
 {% block content_action %}

--- a/ckan/templates/group/read_base.html
+++ b/ckan/templates/group/read_base.html
@@ -1,11 +1,11 @@
 {% extends "page.html" %}
 {% set dataset_type = h.default_package_type() %}
 
-{% block subtitle %}{{ h.get_translated(group_dict, 'title') }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('group', group_type, 'page title') or _('Groups') }}{% endblock %}
+{% block subtitle %}{{ h.group_display_name(group_dict) }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('group', group_type, 'page title') or _('Groups') }}{% endblock %}
 
 {% block breadcrumb_content %}
   <li>{% link_for h.humanize_entity_type('group', group_type, 'breadcrumb') or _('Groups'), named_route=group_type+'.index' %}</li>
-  <li class="active">{% link_for h.get_translated(group_dict, 'title')|truncate(35), named_route=group_type+'.read', id=group_dict.name %}</li>
+  <li class="active">{% link_for h.group_display_name(group_dict)|truncate(35), named_route=group_type+'.read', id=group_dict.name %}</li>
 {% endblock %}
 
 {% block content_action %}

--- a/ckan/templates/group/snippets/feeds.html
+++ b/ckan/templates/group/snippets/feeds.html
@@ -1,2 +1,2 @@
 {%- set dataset_feed = h.url_for('feeds.group', id=group_dict.name) -%}
-<link rel="alternate" type="application/atom+xml" title="{{ g.site_title }} - {{ _('Datasets in group: {group}').format(group=h.get_translated(group_dict, 'title')) }}" href="{{ dataset_feed }}" />
+<link rel="alternate" type="application/atom+xml" title="{{ g.site_title }} - {{ _('Datasets in group: {group}').format(group=h.group_display_name(group_dict)) }}" href="{{ dataset_feed }}" />

--- a/ckan/templates/group/snippets/feeds.html
+++ b/ckan/templates/group/snippets/feeds.html
@@ -1,2 +1,2 @@
 {%- set dataset_feed = h.url_for('feeds.group', id=group_dict.name) -%}
-<link rel="alternate" type="application/atom+xml" title="{{ g.site_title }} - {{ _('Datasets in group: {group}').format(group=group_dict.display_name) }}" href="{{ dataset_feed }}" />
+<link rel="alternate" type="application/atom+xml" title="{{ g.site_title }} - {{ _('Datasets in group: {group}').format(group=h.get_translated(group_dict, 'title')) }}" href="{{ dataset_feed }}" />

--- a/ckan/templates/group/snippets/group_form.html
+++ b/ckan/templates/group/snippets/group_form.html
@@ -9,7 +9,7 @@
 
   {% block basic_fields %}
     {% set attrs = {'data-module': 'slug-preview-target', 'class': 'form-control'} %}
-    {{ form.input('title', label=_('Name'), id='field-name', placeholder=h.humanize_entity_type('group', group_type, 'name placeholder') or _('My Group'), value=data.title, error=errors.title, classes=['control-full'], attrs=attrs) }}
+    {{ form.input('title', label=_('Name'), id='field-name', placeholder=h.humanize_entity_type('group', group_type, 'name placeholder') or _('My Group'), value=data.title, error=errors.title, classes=['control-full'], attrs=attrs, is_required=true) }}
 
     {# Perhaps these should be moved into the controller? #}
     {% set prefix = h.url_for(group_type + '.read', id='') %}

--- a/ckan/templates/group/snippets/group_item.html
+++ b/ckan/templates/group/snippets/group_item.html
@@ -20,7 +20,7 @@ Example:
     <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="{{ group.name }}" class="media-image img-fluid">
   {% endblock %}
   {% block title %}
-    <h2 class="media-heading">{{ group.display_name }}</h2>
+    <h2 class="media-heading">{{ h.get_translated(group, 'title') }}</h2>
   {% endblock %}
   {% block description %}
     {% if group.description %}
@@ -35,8 +35,8 @@ Example:
     {% endif %}
   {% endblock %}
   {% block link %}
-  <a href="{{ url }}" title="{{ _('View {name}').format(name=group.display_name) }}" class="media-view">
-    <span>{{ _('View {name}').format(name=group.display_name) }}</span>
+  <a href="{{ url }}" title="{{ _('View {name}').format(name=h.get_translated(group, 'title')) }}" class="media-view">
+    <span>{{ _('View {name}').format(name=h.get_translated(group, 'title')) }}</span>
   </a>
   {% endblock %}
   {% if group.user_member %}

--- a/ckan/templates/group/snippets/group_item.html
+++ b/ckan/templates/group/snippets/group_item.html
@@ -20,7 +20,7 @@ Example:
     <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="{{ group.name }}" class="media-image img-fluid">
   {% endblock %}
   {% block title %}
-    <h2 class="media-heading">{{ h.get_translated(group, 'title') }}</h2>
+    <h2 class="media-heading">{{ h.group_display_name(group) }}</h2>
   {% endblock %}
   {% block description %}
     {% if group.description %}
@@ -35,8 +35,8 @@ Example:
     {% endif %}
   {% endblock %}
   {% block link %}
-  <a href="{{ url }}" title="{{ _('View {name}').format(name=h.get_translated(group, 'title')) }}" class="media-view">
-    <span>{{ _('View {name}').format(name=h.get_translated(group, 'title')) }}</span>
+  <a href="{{ url }}" title="{{ _('View {name}').format(name=h.group_display_name(group)) }}" class="media-view">
+    <span>{{ _('View {name}').format(name=h.group_display_name(group)) }}</span>
   </a>
   {% endblock %}
   {% if group.user_member %}

--- a/ckan/templates/group/snippets/info.html
+++ b/ckan/templates/group/snippets/info.html
@@ -13,7 +13,7 @@
     {% endblock %}
     {% block heading %}
     <h1 class="heading">
-      {{ group.display_name }}
+      {{ h.get_translated(group, 'title') }}
       {% if group.state == 'deleted' %}
         [{{ _('Deleted') }}]
       {% endif %}

--- a/ckan/templates/group/snippets/info.html
+++ b/ckan/templates/group/snippets/info.html
@@ -13,7 +13,7 @@
     {% endblock %}
     {% block heading %}
     <h1 class="heading">
-      {{ h.get_translated(group, 'title') }}
+      {{ h.group_display_name(group) }}
       {% if group.state == 'deleted' %}
         [{{ _('Deleted') }}]
       {% endif %}

--- a/ckan/templates/organization/about.html
+++ b/ckan/templates/organization/about.html
@@ -3,7 +3,7 @@
 {% block subtitle %}{{ _('About') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
-  <h1>{% block page_heading %}{{ h.get_translated(group_dict, 'title') }}{% endblock %}</h1>
+  <h1>{% block page_heading %}{{ h.group_display_name(group_dict) }}{% endblock %}</h1>
   {% block organization_description %}
     {% if group_dict.description %}
       {{ h.render_markdown(group_dict.description) }}

--- a/ckan/templates/organization/about.html
+++ b/ckan/templates/organization/about.html
@@ -3,7 +3,7 @@
 {% block subtitle %}{{ _('About') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
-  <h1>{% block page_heading %}{{ group_dict.display_name }}{% endblock %}</h1>
+  <h1>{% block page_heading %}{{ h.get_translated(group_dict, 'title') }}{% endblock %}</h1>
   {% block organization_description %}
     {% if group_dict.description %}
       {{ h.render_markdown(group_dict.description) }}

--- a/ckan/templates/organization/admins.html
+++ b/ckan/templates/organization/admins.html
@@ -1,6 +1,6 @@
 {% extends "organization/read_base.html" %}
 
-{% block subtitle %}{{ _('Administrators') }} {{ g.template_title_delimiter }} {{ h.get_translated(group_dict, 'title') }}{% endblock %}
+{% block subtitle %}{{ _('Administrators') }} {{ g.template_title_delimiter }} {{ h.group_display_name(group_dict) }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="hide-heading">{% block page_heading %}{{ _('Administrators') }}{% endblock %}</h1>

--- a/ckan/templates/organization/admins.html
+++ b/ckan/templates/organization/admins.html
@@ -1,6 +1,6 @@
 {% extends "organization/read_base.html" %}
 
-{% block subtitle %}{{ _('Administrators') }} {{ g.template_title_delimiter }} {{ group_dict.title or group_dict.name }}{% endblock %}
+{% block subtitle %}{{ _('Administrators') }} {{ g.template_title_delimiter }} {{ h.get_translated(group_dict, 'title') }}{% endblock %}
 
 {% block primary_content_inner %}
   <h1 class="hide-heading">{% block page_heading %}{{ _('Administrators') }}{% endblock %}</h1>

--- a/ckan/templates/organization/edit.html
+++ b/ckan/templates/organization/edit.html
@@ -5,7 +5,7 @@
 {% block breadcrumb_content %}
   <li>{% link_for h.humanize_entity_type('organization', group_type, 'breadcrumb') or _('Organizations'), named_route=group_type+'.index' %}</li>
   {% block breadcrumb_content_inner %}
-    <li>{% link_for organization.display_name|truncate(35), named_route=group_type+'.read', id=organization.name %}</li>
+    <li>{% link_for h.get_translated(organization, 'title')|truncate(35), named_route=group_type+'.read', id=organization.name %}</li>
     <li class="active">{% link_for _('Manage'), named_route=group_type+'.edit', id=organization.name %}</li>
   {% endblock %}
 {% endblock %}

--- a/ckan/templates/organization/edit.html
+++ b/ckan/templates/organization/edit.html
@@ -5,7 +5,7 @@
 {% block breadcrumb_content %}
   <li>{% link_for h.humanize_entity_type('organization', group_type, 'breadcrumb') or _('Organizations'), named_route=group_type+'.index' %}</li>
   {% block breadcrumb_content_inner %}
-    <li>{% link_for h.get_translated(organization, 'title')|truncate(35), named_route=group_type+'.read', id=organization.name %}</li>
+    <li>{% link_for h.group_display_name(organization)|truncate(35), named_route=group_type+'.read', id=organization.name %}</li>
     <li class="active">{% link_for _('Manage'), named_route=group_type+'.edit', id=organization.name %}</li>
   {% endblock %}
 {% endblock %}

--- a/ckan/templates/organization/edit_base.html
+++ b/ckan/templates/organization/edit_base.html
@@ -2,7 +2,7 @@
 {% set dataset_type = h.default_package_type() %}
 {% set organization = group_dict %}
 
-{% block subtitle %}{{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('organization', group_type, 'page title') or _('Organizations') }}{% endblock %}
+{% block subtitle %}{{ h.get_translated(group_dict, 'title') }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('organization', group_type, 'page title') or _('Organizations') }}{% endblock %}
 
 
 {% block content_action %}

--- a/ckan/templates/organization/edit_base.html
+++ b/ckan/templates/organization/edit_base.html
@@ -2,7 +2,7 @@
 {% set dataset_type = h.default_package_type() %}
 {% set organization = group_dict %}
 
-{% block subtitle %}{{ h.get_translated(group_dict, 'title') }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('organization', group_type, 'page title') or _('Organizations') }}{% endblock %}
+{% block subtitle %}{{ h.group_display_name(group_dict) }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('organization', group_type, 'page title') or _('Organizations') }}{% endblock %}
 
 
 {% block content_action %}

--- a/ckan/templates/organization/read_base.html
+++ b/ckan/templates/organization/read_base.html
@@ -1,11 +1,11 @@
 {% extends "page.html" %}
 {% set dataset_type = h.default_package_type() %}
 
-{% block subtitle %}{{ h.get_translated(group_dict, 'title') }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('organization', group_type, 'page title') or _('Organizations') }}{% endblock %}
+{% block subtitle %}{{ h.group_display_name(group_dict) }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('organization', group_type, 'page title') or _('Organizations') }}{% endblock %}
 
 {% block breadcrumb_content %}
   <li>{% link_for h.humanize_entity_type('organization', group_type, 'breadcrumb') or _('Organizations'), named_route=group_type+'.index' %}</li>
-  <li class="active">{% link_for h.get_translated(group_dict, 'title')|truncate(35), named_route=group_type+'.read', id=group_dict.name %}</li>
+  <li class="active">{% link_for h.group_display_name(group_dict)|truncate(35), named_route=group_type+'.read', id=group_dict.name %}</li>
 {% endblock %}
 
 {% block content_action %}

--- a/ckan/templates/organization/read_base.html
+++ b/ckan/templates/organization/read_base.html
@@ -1,11 +1,11 @@
 {% extends "page.html" %}
 {% set dataset_type = h.default_package_type() %}
 
-{% block subtitle %}{{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('organization', group_type, 'page title') or _('Organizations') }}{% endblock %}
+{% block subtitle %}{{ h.get_translated(group_dict, 'title') }} {{ g.template_title_delimiter }} {{ h.humanize_entity_type('organization', group_type, 'page title') or _('Organizations') }}{% endblock %}
 
 {% block breadcrumb_content %}
   <li>{% link_for h.humanize_entity_type('organization', group_type, 'breadcrumb') or _('Organizations'), named_route=group_type+'.index' %}</li>
-  <li class="active">{% link_for group_dict.display_name|truncate(35), named_route=group_type+'.read', id=group_dict.name %}</li>
+  <li class="active">{% link_for h.get_translated(group_dict, 'title')|truncate(35), named_route=group_type+'.read', id=group_dict.name %}</li>
 {% endblock %}
 
 {% block content_action %}

--- a/ckan/templates/organization/snippets/feeds.html
+++ b/ckan/templates/organization/snippets/feeds.html
@@ -1,2 +1,2 @@
 {%- set dataset_feed = h.url_for('feeds.organization', id=group_dict.name) -%}
-<link rel="alternate" type="application/atom+xml" title="{{ g.site_title }} - {{ _('Datasets in organization: {group}').format(group=h.get_translated(group_dict, 'title')) }}" href="{{ dataset_feed }}" />
+<link rel="alternate" type="application/atom+xml" title="{{ g.site_title }} - {{ _('Datasets in organization: {group}').format(group=h.group_display_name(group_dict)) }}" href="{{ dataset_feed }}" />

--- a/ckan/templates/organization/snippets/feeds.html
+++ b/ckan/templates/organization/snippets/feeds.html
@@ -1,2 +1,2 @@
 {%- set dataset_feed = h.url_for('feeds.organization', id=group_dict.name) -%}
-<link rel="alternate" type="application/atom+xml" title="{{ g.site_title }} - {{ _('Datasets in organization: {group}').format(group=group_dict.display_name) }}" href="{{ dataset_feed }}" />
+<link rel="alternate" type="application/atom+xml" title="{{ g.site_title }} - {{ _('Datasets in organization: {group}').format(group=h.get_translated(group_dict, 'title')) }}" href="{{ dataset_feed }}" />

--- a/ckan/templates/organization/snippets/organization_form.html
+++ b/ckan/templates/organization/snippets/organization_form.html
@@ -9,7 +9,7 @@
 
   {% block basic_fields %}
     {% set attrs = {'data-module': 'slug-preview-target', 'class': 'form-control'} %}
-    {{ form.input('title', label=_('Name'), id='field-name', placeholder=h.humanize_entity_type('organization', group_type, 'name placeholder') or _('My Organization'), value=data.title, error=errors.title, classes=['control-full'], attrs=attrs) }}
+    {{ form.input('title', label=_('Name'), id='field-name', placeholder=h.humanize_entity_type('organization', group_type, 'name placeholder') or _('My Organization'), value=data.title, error=errors.title, classes=['control-full'], attrs=attrs, is_required=true) }}
 
     {# Perhaps these should be moved into the controller? #}
     {% set prefix = h.url_for(group_type + '.read', id='') %}

--- a/ckan/templates/organization/snippets/organization_item.html
+++ b/ckan/templates/organization/snippets/organization_item.html
@@ -19,7 +19,7 @@ Example:
     <img src="{{ organization.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}" alt="{{ organization.name }}" class="img-fluid media-image">
   {% endblock %}
   {% block title %}
-    <h2 class="media-heading">{{ h.get_translated(organization, 'title') }}</h2>
+    <h2 class="media-heading">{{ h.group_display_name(organization) }}</h2>
   {% endblock %}
   {% block description %}
     {% if organization.description %}
@@ -39,8 +39,8 @@ Example:
     {% endif %}
   {% endblock %}
   {% block link %}
-  <a href="{{ url }}" title="{{ _('View {organization_name}').format(organization_name=h.get_translated(organization, 'title')) }}" class="media-view">
-    <span>{{ _('View {organization_name}').format(organization_name=h.get_translated(organization, 'title')) }}</span>
+  <a href="{{ url }}" title="{{ _('View {organization_name}').format(organization_name=h.group_display_name(organization)) }}" class="media-view">
+    <span>{{ _('View {organization_name}').format(organization_name=h.group_display_name(organization)) }}</span>
   </a>
   {% endblock %}
   {% endblock %}

--- a/ckan/templates/organization/snippets/organization_item.html
+++ b/ckan/templates/organization/snippets/organization_item.html
@@ -19,7 +19,7 @@ Example:
     <img src="{{ organization.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}" alt="{{ organization.name }}" class="img-fluid media-image">
   {% endblock %}
   {% block title %}
-    <h2 class="media-heading">{{ organization.display_name }}</h2>
+    <h2 class="media-heading">{{ h.get_translated(organization, 'title') }}</h2>
   {% endblock %}
   {% block description %}
     {% if organization.description %}
@@ -39,8 +39,8 @@ Example:
     {% endif %}
   {% endblock %}
   {% block link %}
-  <a href="{{ url }}" title="{{ _('View {organization_name}').format(organization_name=organization.display_name) }}" class="media-view">
-    <span>{{ _('View {organization_name}').format(organization_name=organization.display_name) }}</span>
+  <a href="{{ url }}" title="{{ _('View {organization_name}').format(organization_name=h.get_translated(organization, 'title')) }}" class="media-view">
+    <span>{{ _('View {organization_name}').format(organization_name=h.get_translated(organization, 'title')) }}</span>
   </a>
   {% endblock %}
   {% endblock %}

--- a/ckan/templates/package/base.html
+++ b/ckan/templates/package/base.html
@@ -11,7 +11,7 @@
   {% if pkg %}
     {% set dataset = h.dataset_display_name(pkg) %}
     {% if pkg.organization %}
-      {% set organization = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
+      {% set organization = h.group_display_name(pkg.organization) %}
       {% set group_type = pkg.organization.type %}
       <li>{% link_for h.humanize_entity_type('organization', group_type, 'breadcrumb') or _('Organizations'), named_route=group_type ~ '.index' %}</li>
       <li>{% link_for organization|truncate(30), named_route=group_type ~ '.read', id=pkg.organization.name %}</li>

--- a/ckan/templates/package/snippets/package_basic_fields.html
+++ b/ckan/templates/package/snippets/package_basic_fields.html
@@ -81,7 +81,7 @@
           {% for organization in organizations_available %}
             {# get out first org from users list only if there is not an existing org #}
           {% set selected_org = (existing_org and existing_org == organization.id) or (not existing_org and not data.id and organization.id == organizations_available[0].id) %}
-          <option value="{{ organization.id }}" {% if selected_org %} selected="selected" {% endif %}>{{ organization.display_name }}</option>
+          <option value="{{ organization.id }}" {% if selected_org %} selected="selected" {% endif %}>{{ h.get_translated(organization, 'title') }}</option>
           {% endfor %}
         </select>
       </div>

--- a/ckan/templates/package/snippets/package_basic_fields.html
+++ b/ckan/templates/package/snippets/package_basic_fields.html
@@ -81,7 +81,7 @@
           {% for organization in organizations_available %}
             {# get out first org from users list only if there is not an existing org #}
           {% set selected_org = (existing_org and existing_org == organization.id) or (not existing_org and not data.id and organization.id == organizations_available[0].id) %}
-          <option value="{{ organization.id }}" {% if selected_org %} selected="selected" {% endif %}>{{ h.get_translated(organization, 'title') }}</option>
+          <option value="{{ organization.id }}" {% if selected_org %} selected="selected" {% endif %}>{{ h.group_display_name(organization) }}</option>
           {% endfor %}
         </select>
       </div>

--- a/ckan/templates/snippets/context.html
+++ b/ckan/templates/snippets/context.html
@@ -5,6 +5,6 @@
   <h4>{{ h.get_translated(dict, 'title') }}</h4>
   {% snippet 'snippets/context/dataset.html', id=dict.id, name=dict.name, notes=dict.notes, num_resources=dict.num_resources, num_tags=dict.num_tags %}
 {%elif type == 'group' %}
-  <h4>{{ h.get_translated(dict, 'title') }}</h4>
+  <h4>{{ h.group_display_name(dict) }}</h4>
   {% snippet 'snippets/context/group.html', id=dict.id, name=dict.name, description=dict.description, num_followers=dict.num_followers, package_count=dict.package_count %}
 {% endif %}

--- a/ckan/templates/snippets/context.html
+++ b/ckan/templates/snippets/context.html
@@ -2,9 +2,9 @@
   <h4>{{ dict.name }}</h4>
   {% snippet 'snippets/context/user.html', id=dict.id, name=dict.name, about=dict.about, is_me='false', num_followers=dict.num_followers, number_created_packages=dict.number_created_packages %}
 {%elif type == 'dataset' %}
-  <h4>{{ dict.title }}</h4>
+  <h4>{{ h.get_translated(dict, 'title') }}</h4>
   {% snippet 'snippets/context/dataset.html', id=dict.id, name=dict.name, notes=dict.notes, num_resources=dict.num_resources, num_tags=dict.num_tags %}
 {%elif type == 'group' %}
-  <h4>{{ dict.title }}</h4>
+  <h4>{{ h.get_translated(dict, 'title') }}</h4>
   {% snippet 'snippets/context/group.html', id=dict.id, name=dict.name, description=dict.description, num_followers=dict.num_followers, package_count=dict.package_count %}
 {% endif %}

--- a/ckan/templates/snippets/facet_list.html
+++ b/ckan/templates/snippets/facet_list.html
@@ -55,7 +55,11 @@ Dictionary with search facets
 				    <ul class="list-unstyled nav nav-simple nav-facet">
 					{% for item in items %}
 					    {% set href = h.remove_url_param(name, item.name, extras=extras, alternative_url=alternative_url) if item.active else h.add_url_param(new_params={name: item.name}, extras=extras, alternative_url=alternative_url) %}
-					    {% set label = label_function(item) if label_function else item.display_name %}
+              {% if name == 'group' or name == 'organization' %}
+                {% set label = label_function(item) if label_function else h.group_name_to_title(item.name) %}
+              {% else %}
+                {% set label = label_function(item) if label_function else item.display_name %}
+              {% endif %}
 					    {% set label_truncated = label|truncate(22) if not label_function else label %}
 					    {% set count = count_label(item['count']) if count_label else ('%d' % item['count']) %}
 					    <li class="nav-item {% if item.active %} active{% endif %}">

--- a/ckan/templates/snippets/group.html
+++ b/ckan/templates/snippets/group.html
@@ -15,7 +15,7 @@ Example:
         <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" class="img-responsive" width="200" height="125" alt="{{ group.name }}" />
       </a>
       <div class="media-content">
-        <h3 class="media-heading"><a href="{{ url }}">{{ group.title or group.name }}</a></h3>
+        <h3 class="media-heading"><a href="{{ url }}">{{ h.get_translated(group, 'title') }}</a></h3>
         {% if group.description %}
           <p>{{ h.markdown_extract(group.description, 120) }}</p>
         {% endif %}

--- a/ckan/templates/snippets/group.html
+++ b/ckan/templates/snippets/group.html
@@ -15,7 +15,7 @@ Example:
         <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" class="img-responsive" width="200" height="125" alt="{{ group.name }}" />
       </a>
       <div class="media-content">
-        <h3 class="media-heading"><a href="{{ url }}">{{ h.get_translated(group, 'title') }}</a></h3>
+        <h3 class="media-heading"><a href="{{ url }}">{{ h.group_display_name(group) }}</a></h3>
         {% if group.description %}
           <p>{{ h.markdown_extract(group.description, 120) }}</p>
         {% endif %}

--- a/ckan/templates/snippets/group_item.html
+++ b/ckan/templates/snippets/group_item.html
@@ -2,14 +2,14 @@
   <section class="group-list module module-narrow module-shallow">
     {% block group_item_header %}
       <header class="module-heading">
-        {% set title = group.title or group.name %}
+        {% set title = h.get_translated(group, 'title') %}
         {% block group_item_header_image %}
           <a class="module-image" href="{{ h.url_for(group.type ~ '.read', id=group.name) }}">
             <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="{{ group.name }}" />
           </a>
         {% endblock %}
         {% block group_item_header_title %}
-          <h3 class="media-heading"><a href="{{ h.url_for(group.type ~ '.read', id=group.name) }}">{{ group.title or group.name }}</a></h3>
+          <h3 class="media-heading"><a href="{{ h.url_for(group.type ~ '.read', id=group.name) }}">{{ h.get_translated(group, 'title') }}</a></h3>
         {% endblock %}
         {% block group_item_header_description %}
           {% if group.description %}

--- a/ckan/templates/snippets/group_item.html
+++ b/ckan/templates/snippets/group_item.html
@@ -2,14 +2,14 @@
   <section class="group-list module module-narrow module-shallow">
     {% block group_item_header %}
       <header class="module-heading">
-        {% set title = h.get_translated(group, 'title') %}
+        {% set title = h.group_display_name(group) %}
         {% block group_item_header_image %}
           <a class="module-image" href="{{ h.url_for(group.type ~ '.read', id=group.name) }}">
             <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="{{ group.name }}" />
           </a>
         {% endblock %}
         {% block group_item_header_title %}
-          <h3 class="media-heading"><a href="{{ h.url_for(group.type ~ '.read', id=group.name) }}">{{ h.get_translated(group, 'title') }}</a></h3>
+          <h3 class="media-heading"><a href="{{ h.url_for(group.type ~ '.read', id=group.name) }}">{{ h.group_display_name(group) }}</a></h3>
         {% endblock %}
         {% block group_item_header_description %}
           {% if group.description %}

--- a/ckan/templates/snippets/organization.html
+++ b/ckan/templates/snippets/organization.html
@@ -30,7 +30,7 @@
         </div>
       {% endblock %}
       {% block heading %}
-      <h1 class="heading">{{ h.get_translated(organization, 'title') }}
+      <h1 class="heading">{{ h.group_display_name(organization) }}
         {% if organization.state == 'deleted' %}
           [{{ _('Deleted') }}]
         {% endif %}

--- a/ckan/templates/snippets/organization.html
+++ b/ckan/templates/snippets/organization.html
@@ -30,7 +30,7 @@
         </div>
       {% endblock %}
       {% block heading %}
-      <h1 class="heading">{{ organization.title or organization.name }}
+      <h1 class="heading">{{ h.get_translated(organization, 'title') }}
         {% if organization.state == 'deleted' %}
           [{{ _('Deleted') }}]
         {% endif %}

--- a/ckan/templates/snippets/organization_item.html
+++ b/ckan/templates/snippets/organization_item.html
@@ -9,7 +9,7 @@
         </a>
         {% endblock %}
         {% block organization_item_header_title %}
-          <h3 class="media-heading"><a href="{{ url }}">{{ h.get_translated(organization, 'title') }}</a></h3>
+          <h3 class="media-heading"><a href="{{ url }}">{{ h.group_display_name(organization) }}</a></h3>
         {% endblock %}
         {% block organization_item_header_description %}
           {% if organization.description %}

--- a/ckan/templates/snippets/organization_item.html
+++ b/ckan/templates/snippets/organization_item.html
@@ -9,7 +9,7 @@
         </a>
         {% endblock %}
         {% block organization_item_header_title %}
-          <h3 class="media-heading"><a href="{{ url }}">{{ organization.title or organization.name }}</a></h3>
+          <h3 class="media-heading"><a href="{{ url }}">{{ h.get_translated(organization, 'title') }}</a></h3>
         {% endblock %}
         {% block organization_item_header_description %}
           {% if organization.description %}

--- a/ckan/templates/snippets/package_item.html
+++ b/ckan/templates/snippets/package_item.html
@@ -10,8 +10,8 @@ Example:
   {% snippet 'snippets/package_item.html', package=c.datasets[0] %}
 
 #}
-{% set title = package.title or package.name %}
-{% set notes = h.markdown_extract(package.notes, extract_length=180) %}
+{% set title = h.dataset_display_name(package) %}
+{% set notes = h.markdown_extract(h.get_translated(package, 'notes'), extract_length=180) %}
 
 {% block package_item %}
   <li class="{{ item_class or "dataset-item" }}">

--- a/ckan/templates/snippets/search_form.html
+++ b/ckan/templates/snippets/search_form.html
@@ -64,7 +64,11 @@
               {%- if facets.translated_fields and (field,value) in facets.translated_fields -%}
                 {{ facets.translated_fields[(field,value)] }}
               {%- else -%}
-                {{ h.list_dict_filter(search_facets_items, 'name', 'display_name', value) }}
+                {% if field == 'group' or field == 'organization' %}
+                  {{ h.group_name_to_title(value) }}
+                {% else %}
+                  {{ h.list_dict_filter(search_facets_items, 'name', 'display_name', value) }}
+                {% endif %}
               {%- endif %}
               <a href="{{ facets.remove_field(field, value) }}" class="remove" title="{{ _('Remove') }}"><i class="fa fa-times"></i></a>
             </span>

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -1075,7 +1075,7 @@ class GroupView(MethodView):
 
         user_group_ids = set(group[u'id'] for group in users_groups)
 
-        group_dropdown = [[group[u'id'], group[u'display_name']]
+        group_dropdown = [[group[u'id'], h.get_translated(group, 'title')]
                           for group in users_groups
                           if group[u'id'] not in pkg_group_ids]
 

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -1075,7 +1075,7 @@ class GroupView(MethodView):
 
         user_group_ids = set(group[u'id'] for group in users_groups)
 
-        group_dropdown = [[group[u'id'], h.get_translated(group, 'title')]
+        group_dropdown = [[group[u'id'], h.group_display_name(group)]
                           for group in users_groups
                           if group[u'id'] not in pkg_group_ids]
 


### PR DESCRIPTION
### Features:

- New and modified helpers to get group translated titles over `display_name`
- Updated templates to use new helper
- Added condition to facets to be able to display group translated titles

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
