### PR TITLE
Fix mobile layout styles

### DIFF
--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -13087,7 +13087,7 @@ td.diff_header {
   clear: both;
   content: "";
 }
-@media (min-width: 576px) {
+@media (min-width: 768px) {
   .wrapper:before {
     content: "";
     display: block;

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -13087,7 +13087,7 @@ td.diff_header {
   clear: both;
   content: "";
 }
-@media (min-width: 576px) {
+@media (min-width: 768px) {
   .wrapper:before {
     content: "";
     display: block;

--- a/ckan/public/base/scss/_layout.scss
+++ b/ckan/public/base/scss/_layout.scss
@@ -4,7 +4,7 @@
     position: relative;
     min-height: 300px;
     background-color: #fff;
-    @include media-breakpoint-up(sm) {
+    @include media-breakpoint-up(md) {
         &:before {
             content: '';
             display: block;

--- a/ckan/templates/page.html
+++ b/ckan/templates/page.html
@@ -54,7 +54,7 @@
             {% endblock %}
 
             {% block secondary %}
-              <aside class="secondary col-sm-3">
+              <aside class="secondary col-md-3">
                 {#
                 The secondary_content block can be used to add content to the
                 sidebar of the page. This is the main block that is likely to be
@@ -72,7 +72,7 @@
             {% endblock %}
 
             {% block primary %}
-              <div class="primary col-sm-9 col-xs-12" role="main">
+              <div class="primary col-md-9 col-xs-12" role="main">
                 {#
                 The primary_content block can be used to add content to the page.
                 This is the main block that is likely to be used within a template.


### PR DESCRIPTION
The mobile layout was broken due to improper breakpoints. 

Some examples before:
![image](https://user-images.githubusercontent.com/55234934/226298913-049bc705-2c01-4d74-aa7e-019fc48684a3.png)
![image](https://user-images.githubusercontent.com/55234934/226299005-641fd7e2-95fa-474c-8744-a54e19568bc4.png)


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
