### PR TITLE
Fix primary-secondary blocks direction for mobile view

### DIFF
--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -13159,8 +13159,8 @@ td.diff_header {
     display: flex;
     -webkit-box-orient: vertical;
     -moz-box-orient: vertical;
-    -webkit-flex-direction: column;
-    flex-direction: column;
+    -webkit-flex-direction: column-reverse;
+    flex-direction: column-reverse;
     -webkit-box-align: start;
     -moz-box-align: start;
     -webkit-align-items: flex-start;

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -13159,8 +13159,8 @@ td.diff_header {
     display: flex;
     -webkit-box-orient: vertical;
     -moz-box-orient: vertical;
-    -webkit-flex-direction: column;
-    flex-direction: column;
+    -webkit-flex-direction: column-reverse;
+    flex-direction: column-reverse;
     -webkit-box-align: start;
     -moz-box-align: start;
     -webkit-align-items: flex-start;

--- a/ckan/public/base/scss/_layout.scss
+++ b/ckan/public/base/scss/_layout.scss
@@ -91,8 +91,8 @@
         display: flex;
         -webkit-box-orient: vertical;
         -moz-box-orient: vertical;
-        -webkit-flex-direction: column;
-        flex-direction: column;
+        -webkit-flex-direction: column-reverse;
+        flex-direction: column-reverse;
         -webkit-box-align: start;
         -moz-box-align: start;
         -webkit-align-items: flex-start;


### PR DESCRIPTION
The primary block now goes before the secondary for mobile view, but before it was the opposite which makes sense. 
Restoring previous order.

![image](https://user-images.githubusercontent.com/55234934/226300245-95967478-ab9c-4b6c-b5f3-c85b6e6135e9.png)


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
