### PR TITLE
Rewrite form-actions block styles for mobile

### DIFF
--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -11752,48 +11752,53 @@ textarea {
   color: #c6898b;
 }
 
-.form-actions .control-required-message {
-  float: left;
-  margin-left: 20px;
-  margin-bottom: 0;
-  line-height: 30px;
-}
-.form-actions .control-required-message:first-child {
-  margin-left: 0;
-}
-
 .form-actions {
   overflow: auto;
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row-reverse;
+  justify-content: end;
+  text-align: right;
 }
-
 .form-actions .action-info {
-  line-height: 2;
+  line-height: 1rem;
   text-align: left;
   color: #707070;
-  margin: 0;
+  margin: 0 auto 1rem 0;
+  flex-basis: 100%;
 }
-
-@media (min-width: 992px) {
-  .form-actions {
-    text-align: right;
-  }
-
-  .form-actions .action-info {
-    float: left;
-    width: 50%;
-    margin-right: 0.75rem;
-  }
-}
-.form-actions .action-info.small {
+.form-actions .action-info .small {
   font-size: 11px;
   line-height: 1.2;
 }
-
-@media (max-width: 575.98px) {
+.form-actions .btn {
+  flex-basis: 100%;
+  height: fit-content;
+  margin-bottom: 0.5rem;
+}
+@media (min-width: 576px) {
+  .form-actions {
+    flex-direction: row;
+  }
   .form-actions .btn {
-    margin-top: 5px;
+    margin-bottom: 0;
+    margin-inline-start: 0.5rem;
+    flex-basis: auto;
   }
 }
+@media (min-width: 768px) {
+  .form-actions .action-info {
+    line-height: 1.25rem;
+    flex-basis: 50%;
+    margin: 0 auto 0 0;
+  }
+}
+@media (min-width: 992px) {
+  .form-actions .action-info {
+    flex-basis: 60%;
+  }
+}
+
 .form-group .info-block {
   position: relative;
   display: block;

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -11752,48 +11752,53 @@ textarea {
   color: #c6898b;
 }
 
-.form-actions .control-required-message {
-  float: left;
-  margin-left: 20px;
-  margin-bottom: 0;
-  line-height: 30px;
-}
-.form-actions .control-required-message:first-child {
-  margin-left: 0;
-}
-
 .form-actions {
   overflow: auto;
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row-reverse;
+  justify-content: end;
+  text-align: right;
 }
-
 .form-actions .action-info {
-  line-height: 2;
+  line-height: 1rem;
   text-align: left;
   color: #707070;
-  margin: 0;
+  margin: 0 auto 1rem 0;
+  flex-basis: 100%;
 }
-
-@media (min-width: 992px) {
-  .form-actions {
-    text-align: right;
-  }
-
-  .form-actions .action-info {
-    float: left;
-    width: 50%;
-    margin-right: 0.75rem;
-  }
-}
-.form-actions .action-info.small {
+.form-actions .action-info .small {
   font-size: 11px;
   line-height: 1.2;
 }
-
-@media (max-width: 575.98px) {
+.form-actions .btn {
+  flex-basis: 100%;
+  height: fit-content;
+  margin-bottom: 0.5rem;
+}
+@media (min-width: 576px) {
+  .form-actions {
+    flex-direction: row;
+  }
   .form-actions .btn {
-    margin-top: 5px;
+    margin-bottom: 0;
+    margin-inline-start: 0.5rem;
+    flex-basis: auto;
   }
 }
+@media (min-width: 768px) {
+  .form-actions .action-info {
+    line-height: 1.25rem;
+    flex-basis: 50%;
+    margin: 0 auto 0 0;
+  }
+}
+@media (min-width: 992px) {
+  .form-actions .action-info {
+    flex-basis: 60%;
+  }
+}
+
 .form-group .info-block {
   position: relative;
   display: block;

--- a/ckan/public/base/scss/_forms.scss
+++ b/ckan/public/base/scss/_forms.scss
@@ -89,46 +89,56 @@ textarea {
     color: $errorBorder;
 }
 
-.form-actions .control-required-message {
-    float: left;
-    margin-left: 20px;
-    margin-bottom: 0;
-    line-height: 30px;
-    &:first-child {
-        margin-left: 0;
-    }
-}
-
 .form-actions {
-  overflow: auto;
-}
+    overflow: auto;
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row-reverse;
+    justify-content: end;
+    text-align: right;
 
-.form-actions .action-info {
-    line-height: 2;
-    text-align: left;
-    color: $formInfoText;
-    margin: 0;
-}
+    .action-info {
+        line-height: 1rem;
+        text-align: left;
+        color: $formInfoText;
+        margin: 0 auto 1rem 0;
+        flex-basis: 100%;
 
-@include media-breakpoint-up(lg) {
-    .form-actions {
-        text-align: right;
+        .small {
+            font-size: 11px;
+            line-height: 1.2;
+        }
     }
-    .form-actions .action-info {
-        float: left;
-        width: 50%;
-        margin-right: math.div($grid-gutter-width,2);
+
+    .btn {
+        flex-basis: 100%;
+        height: fit-content;
+        margin-bottom: 0.5rem;
     }
-}
 
-.form-actions .action-info.small {
-    font-size: 11px;
-    line-height: 1.2;
-}
+    @include media-breakpoint-up(sm) {
+        flex-direction: row;
 
-@include media-breakpoint-down(sm) {
-    .form-actions .btn {
-        margin-top: 5px;
+        .btn {
+            margin-bottom: 0;
+            margin-inline-start: 0.5rem;
+            flex-basis: auto;
+        }
+    }
+
+    @include media-breakpoint-up(md) {
+        .action-info {
+            line-height: 1.25rem;
+            flex-basis: 50%;
+            margin: 0 auto 0 0;
+        }
+    }
+
+    @include media-breakpoint-up(lg) {
+
+        .action-info {
+            flex-basis: 60%;
+        }
     }
 }
 

--- a/ckan/templates/package/snippets/package_form.html
+++ b/ckan/templates/package/snippets/package_form.html
@@ -23,6 +23,8 @@ then itself be extended to add/remove blocks of functionality. #}
   {% endblock %}
 
   {% block form_actions %}
+    {{ form.required_message() }}
+
     <div class="form-actions">
       {% block disclaimer %}
         <p class="action-info small">
@@ -43,7 +45,6 @@ then itself be extended to add/remove blocks of functionality. #}
       {% block save_button %}
         <button class="btn btn-primary" type="submit" name="save">{% block save_button_text %}{{ _('Next: Add Data') }}{% endblock %}</button>
       {% endblock %}
-      {{ form.required_message() }}
     </div>
   {% endblock %}
 </form>

--- a/ckan/templates/user/edit_user_form.html
+++ b/ckan/templates/user/edit_user_form.html
@@ -78,6 +78,8 @@
     {% endblock %}
     {% endif %}
 
+    {{ form.required_message() }}
+
     <div class="form-actions">
       {% block form_actions %}
       {% set is_deleted = data.state == 'deleted' %}
@@ -88,7 +90,6 @@
           {% endif %}
         {% endblock %}
         {% endif %}
-        {{ form.required_message() }}
         <button class="btn btn-primary" type="submit" name="save">{{ _('Reactivate Profile') if is_deleted else _('Update Profile') }}</button>
       {% endblock %}
     </div>


### PR DESCRIPTION
The `form-actions` block is poorly styled for mobile\tablet view. I've rewritten it a bit.

![image](https://user-images.githubusercontent.com/55234934/226324440-530fe78b-0265-4684-89f2-7f23a7391d78.png)


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
