### PR TITLE
Fix promote sysadmin layout

### DIFF
--- a/ckan/templates-bs3/admin/index.html
+++ b/ckan/templates-bs3/admin/index.html
@@ -42,7 +42,7 @@
   <form method="POST" action="{% url_for 'user.sysadmin' %}">
     {{ h.csrf_input() }}
     <div class="row">
-      <div class="col-md-6">
+      <div class="col">
 
         <div class="form-group">
           <input

--- a/ckan/templates/admin/index.html
+++ b/ckan/templates/admin/index.html
@@ -17,7 +17,7 @@
           <td>
             <div class="btn-group pull-right">
               <form method="POST" action="{% url_for 'user.sysadmin' %}">
-                {{ h.csrf_input() }} 
+                {{ h.csrf_input() }}
                 <input type="hidden" value="{{ user }}" name="username" />
                 <input type="hidden" value="0" name="status" />
                 <button
@@ -40,9 +40,9 @@
   <h2>{{ _('Promote user to Sysadmin') }}</h2>
 
   <form method="POST" action="{% url_for 'user.sysadmin' %}">
-    {{ h.csrf_input() }} 
+    {{ h.csrf_input() }}
     <div class="row">
-      <div class="col-md-6">
+      <div class="col">
 
         <div class="form-group">
           <input


### PR DESCRIPTION
I suggest removing col-6 here because it looks weird.

![image](https://user-images.githubusercontent.com/55234934/226400214-a4a21153-9430-4fd3-8660-40ac9d6cf62c.png)

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
