### PR TITLE
Munge site user name and add default email for it

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -27,6 +27,7 @@ import ckan.model as model
 import ckan.model.misc as misc
 import ckan.plugins as plugins
 import ckan.lib.search as search
+from ckan.lib.munge import munge_name
 from ckan.model.follower import ModelFollowingModel
 from ckan.lib.search.query import solr_literal
 
@@ -2430,11 +2431,13 @@ def get_site_user(context: Context, data_dict: DataDict) -> ActionResult.GetSite
     '''
     _check_access('get_site_user', context, data_dict)
     model = context['model']
-    site_id = config.get('ckan.site_id')
+    site_id = munge_name(config.get('ckan.site_id'))
+
     user = model.User.get(site_id)
     if not user:
         apikey = str(uuid.uuid4())
         user = model.User(name=site_id,
+                          email=f"{site_id}@ckan",
                           password=apikey,
                           apikey=apikey)
         # make sysadmin


### PR DESCRIPTION
**I'm not sure about this one.** The initial problem - we have a mandatory field email, and probably site user should have a default one. I've pressed the Unpromote button on the `admin.index` page and got a 5xx error. As a sysadmin, I don't want to see any errors while I'm navigating the site.

The whole idea of demoting `site_user` from being a sysadmin is weird. Maybe we don't have to allow it?

The other side is that there's no validation for `ckan.site_id` config option. And we are creating a user via database, so no schema applies here. So we could use something like that `test 001 002 $` that ends up creating a user with an improper name. I assume we have to munge.

Adding the `munge` function here will trigger the recreation of `site_user`, could it be a problem?

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
