### PR TITLE
Fix dashboard_activity_stream call

### DIFF
--- a/ckanext/activity/views.py
+++ b/ckanext/activity/views.py
@@ -836,11 +836,11 @@ def dashboard() -> str:
     )
     activity_stream = tk.h.dashboard_activity_stream(
         tk.g.userobj.id,
-        filter_type,
-        filter_id,
-        limit + 1,
-        before,
-        after
+        filter_type=filter_type,
+        filter_id=filter_id,
+        limit=limit + 1,
+        before=before,
+        after=after
     )
 
     has_more = len(activity_stream) > limit


### PR DESCRIPTION
`dashboard_activity_stream` accepts 7 parameters, we did pass 6, so `limit=0` was applied and the `activity. dashboard` page was empty.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
