### PR TITLE
Fix markdown macros regression

### DIFF
--- a/ckan/public/base/javascript/main.js
+++ b/ckan/public/base/javascript/main.js
@@ -35,7 +35,7 @@ this.ckan = this.ckan || {};
         moment.locale(locale);
         var date = moment(jQuery(this).data('datetime'));
         if (date.isValid()) {
-            jQuery(this).html(date.format("LL, LT ([UTC]Z)")); 
+            jQuery(this).html(date.format("LL, LT ([UTC]Z)"));
         }
         jQuery(this).show();
     })
@@ -45,8 +45,10 @@ this.ckan = this.ckan || {};
       ckan.i18n.load(data);
       ckan.module.initialize();
     });
+
+    // Initialize all popovers on a page if popover function exists
     if (jQuery.fn.popover !== undefined) {
-      jQuery('[data-target="popover"]').popover();
+      jQuery('[data-bs-toggle="popover"]').popover();
     }
   };
 

--- a/ckan/templates/macros/form/markdown.html
+++ b/ckan/templates/macros/form/markdown.html
@@ -28,6 +28,6 @@ Examples:
 {%- set extra_html = caller() if caller -%}
 {% call input_block(id or name, label or name, error, classes, control_classes=["editor"], extra_html=extra_html, is_required=is_required) %}
 <textarea id="{{ id or name }}" name="{{ name }}" cols="20" rows="5" placeholder="{{ placeholder }}" {{ attributes(attrs) }}>{{ value | empty_and_escape }}</textarea>
-<span class="editor-info-block">{% trans %}You can use <a href="#markdown" title="Markdown quick reference" data-target="popover" data-content="{{ markdown_tooltip }}" data-html="true">Markdown formatting</a> here{% endtrans %}</span>
+<span class="editor-info-block">{% trans %}You can use <a href="#markdown" title="Markdown quick reference" data-bs-toggle="popover" data-bs-content="{{ markdown_tooltip }}" data-bs-html="true">Markdown formatting</a> here{% endtrans %}</span>
 {% endcall %}
 {% endmacro %}


### PR DESCRIPTION
Markdown macro wasn't properly migrated to BS5.

![image](https://user-images.githubusercontent.com/55234934/226855905-3f0c8af0-a9b4-436f-bf40-0d24e8a04699.png)


The problem is that we have translated the whole `<span class="editor-info-block">` content, so it will break the translation for different languages. 

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
