### PR TITLE
[#7486] Fix error when calling user_create with defer_commit

### DIFF
--- a/changes/7487.bugfix
+++ b/changes/7487.bugfix
@@ -1,0 +1,1 @@
+Fix exception when calling the `user_create` action with `defer_commit` in the context.

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -1004,6 +1004,10 @@ def user_create(context: Context,
     if not context.get('defer_commit'):
         with logic.guard_against_duplicated_email(data_dict['email']):
             model.repo.commit()
+    else:
+        # The Dashboard object below needs the user id, and if we didn't
+        # commit we need to flush the session in order to populate it
+        session.flush()
 
     # A new context is required for dictizing the newly constructed user in
     # order that all the new user's data is returned, in particular, the

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -1218,6 +1218,17 @@ class TestUserCreate(object):
             "password": ["Your password must be 8 characters or longer"]
         }
 
+    def test_user_create_defer_commit(self):
+        stub = factories.User.stub()
+        user_dict = {
+            "name": stub.name,
+            "email": stub.email,
+            "password": "test1234",
+        }
+        context = {"defer_commit": True}
+
+        helpers.call_action("user_create", context=context, **user_dict)
+
 
 @pytest.mark.usefixtures("clean_db")
 @pytest.mark.ckan_config("ckan.auth.create_user_via_web", True)


### PR DESCRIPTION
Fixes #7486

We need to flush the session if we are not committing in order to populate user.id



### Proposed fixes:




- [x] includes bugfix for possible backport

