### PR TITLE
Fix tables styles regressions after migration to bs5

### DIFF
--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -13656,6 +13656,14 @@ td.diff_header {
   font-size: 0.875rem;
 }
 
+table {
+  table-layout: fixed;
+}
+
+.table > :not(:first-child) {
+  border-color: var(--bs-gray-300);
+}
+
 .table-selected td {
   background-color: #fff;
 }

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -13656,6 +13656,14 @@ td.diff_header {
   font-size: 0.875rem;
 }
 
+table {
+  table-layout: fixed;
+}
+
+.table > :not(:first-child) {
+  border-color: var(--bs-gray-300);
+}
+
 .table-selected td {
   background-color: #fff;
 }

--- a/ckan/public/base/scss/_tables.scss
+++ b/ckan/public/base/scss/_tables.scss
@@ -1,3 +1,11 @@
+table {
+    table-layout: fixed;
+}
+
+.table> :not(:first-child) {
+    border-color: var(--bs-gray-300);
+}
+
 .table-selected td {
     background-color: $input-bg;
     .edit {

--- a/ckan/templates/package/resource_read.html
+++ b/ckan/templates/package/resource_read.html
@@ -161,7 +161,7 @@
         {% block resource_additional_information_inner %}
         <div class="module-content">
           <h2>{{ _('Additional Information') }}</h2>
-          <table class="table table-striped table-bordered table-condensed" data-module="table-toggle-more">
+          <table class="table table-striped table-bordered table-sm" data-module="table-toggle-more">
             <thead>
               <tr>
                 <th scope="col">{{ _('Field') }}</th>

--- a/ckan/templates/package/snippets/additional_info.html
+++ b/ckan/templates/package/snippets/additional_info.html
@@ -1,6 +1,6 @@
 <section class="additional-info">
   <h3>{{ _('Additional Info') }}</h3>
-  <table class="table table-striped table-bordered table-condensed">
+  <table class="table table-striped table-bordered table-sm">
     <thead>
       <tr>
         <th scope="col">{{ _('Field') }}</th>

--- a/ckan/templates/snippets/additional_info.html
+++ b/ckan/templates/snippets/additional_info.html
@@ -5,7 +5,7 @@ extras is a list of tuples of the form (key, value)
 #}
 {% if extras %}
   <h3>{{ _('Additional Info') }}</h3>
-  <table class="table table-striped table-bordered table-condensed">
+  <table class="table table-striped table-bordered table-sm">
     <thead>
       <tr>
         <th scope="col">{{ _('Field') }}</th>

--- a/ckan/templates/user/snippets/api_token_list.html
+++ b/ckan/templates/user/snippets/api_token_list.html
@@ -6,7 +6,7 @@
 
   #}
 
-<table class="table table-stripped table-condensed table-header table-hover table-bordered">
+<table class="table table-stripped table-sm table-header table-hover table-bordered">
   <thead>
     <tr>
       {% block head_cells %}

--- a/ckanext/datastore/templates/package/resource_read.html
+++ b/ckanext/datastore/templates/package/resource_read.html
@@ -12,7 +12,7 @@
   {% block resource_data_dictionary %}
     <div class="module-content">
       <h2>{{ _('Data Dictionary') }}</h2>
-      <table class="table table-striped table-bordered table-condensed" data-module="table-toggle-more">
+      <table class="table table-striped table-bordered table-sm" data-module="table-toggle-more">
         <thead>
           {% block resouce_data_dictionary_headers %}
           <tr>

--- a/ckanext/datatablesview/templates/datatables/datatables_view.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_view.html
@@ -17,7 +17,7 @@
 
 <div id="resize_wrapper">
   <table id="dtprv" width="100%"
-      class="table table-striped table-bordered table-condensed table-hover"
+      class="table table-striped table-bordered table-sm table-hover"
       data-module="datatables_view"
       data-state-save-flag="{{ state_saving|lower }}"
       data-state-duration="{{ state_duration }}"
@@ -43,7 +43,7 @@
             {{ field.id|replace(" ", nbspval) }}
           {%- endif -%}
           &nbsp;
-          {%- if data_dictionary_labels and field.info is defined and (field.info.label|length or field.info.notes|length)-%}            
+          {%- if data_dictionary_labels and field.info is defined and (field.info.label|length or field.info.notes|length)-%}
             <i class="fa fa-info-circle" title="{{field.id}} ({{field.type}})&#10;{{ h.markdown_extract(field.info.notes, 300) }}"></i>
           {%- endif -%}
           &nbsp;</th>
@@ -66,7 +66,7 @@
   <form id="filtered-datatables-download" method="POST" action="{{ h.url_for(
                                                                   'datatablesview.filtered_download',
                                                                   resource_view_id=resource_view.id) -}}">
-    {{ h.csrf_input() }}                                                               
+    {{ h.csrf_input() }}
     <input type="hidden" name="filters" value="{{ request.args.get('filters', '')|e -}}" />
   </form>
 </div>


### PR DESCRIPTION
Fix tables styles regressions after migration to bs5

1. In BS5 `table-condensed` has been replaced with `table-sm` (so all the condensed tables now look a bit bigger)
2. Fix `border-color` to align with other borders.
3. Fix the table columns' width to make them even.
![image](https://user-images.githubusercontent.com/55234934/227516089-5e6cc5de-5cd9-4f7f-9bbb-8aaddcbfad37.png)



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
