### PR TITLE
[#7508] Escape names in emails

### DIFF
--- a/changes/7508.bugfix
+++ b/changes/7508.bugfix
@@ -1,0 +1,1 @@
+Names are now quoted in From and To addresses in emails, meaning that site titles with commas no longer break email clients.

--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -64,8 +64,8 @@ def _mail_recipient(
         else:
             msg.add_header(k, v)
     msg['Subject'] = subject
-    msg['From'] = "\"%s\" <%s>" % (sender_name, mail_from)
-    msg['To'] = u"\"%s\" <%s>" % (recipient_name, recipient_email)
+    msg['From'] = utils.formataddr((sender_name, mail_from))
+    msg['To'] = utils.formataddr((recipient_name, recipient_email))
     msg['Date'] = utils.formatdate(time())
     if not config.get('ckan.hide_version'):
         msg['X-Mailer'] = "CKAN %s" % ckan.__version__

--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -64,8 +64,8 @@ def _mail_recipient(
         else:
             msg.add_header(k, v)
     msg['Subject'] = subject
-    msg['From'] = _("%s <%s>") % (sender_name, mail_from)
-    msg['To'] = u"%s <%s>" % (recipient_name, recipient_email)
+    msg['From'] = "\"%s\" <%s>" % (sender_name, mail_from)
+    msg['To'] = u"\"%s\" <%s>" % (recipient_name, recipient_email)
     msg['Date'] = utils.formatdate(time())
     if not config.get('ckan.hide_version'):
         msg['X-Mailer'] = "CKAN %s" % ckan.__version__

--- a/ckan/tests/lib/test_mailer.py
+++ b/ckan/tests/lib/test_mailer.py
@@ -199,7 +199,7 @@ class TestMailer(MailerBase):
         msgs = mail_server.get_smtp_messages()
         msg = msgs[0]
 
-        expected_from_header = "{0} <{1}>".format(
+        expected_from_header = "\"{0}\" <{1}>".format(
             config.get("ckan.site_title"),
             config.get("smtp.mail_from")
         )

--- a/ckan/tests/lib/test_mailer.py
+++ b/ckan/tests/lib/test_mailer.py
@@ -6,6 +6,7 @@ import io
 from email.header import decode_header
 from email.mime.text import MIMEText
 from email.parser import Parser
+import email.utils
 
 import ckan.lib.helpers as h
 import ckan.lib.mailer as mailer
@@ -199,10 +200,10 @@ class TestMailer(MailerBase):
         msgs = mail_server.get_smtp_messages()
         msg = msgs[0]
 
-        expected_from_header = "\"{0}\" <{1}>".format(
+        expected_from_header = email.utils.formataddr((
             config.get("ckan.site_title"),
             config.get("smtp.mail_from")
-        )
+        ))
 
         assert expected_from_header in msg[3]
 


### PR DESCRIPTION
Fix #7508 by quoting names in To/From headers

### Proposed fixes:
Quote names in To/From headers
### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
