### PR TITLE
Pagination settings

### DIFF
--- a/changes/7529.feature
+++ b/changes/7529.feature
@@ -1,0 +1,1 @@
+Pagination widget can be customized with ``ckan.pagination.*`` config options.

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -1177,6 +1177,66 @@ groups:
         description: Custom CSS directives to include on all CKAN pages.
         editable: true
 
+      - key: ckan.pagination.template
+        default: "$link_previous ~2~ $link_next"
+        description: |
+          Format string that defines how the pager is rendered. The string
+          can contain the following $-tokens that are substituted by the
+          ``string.Template`` module:
+
+          - ``$first_page``: number of first reachable page
+          - ``$last_page``: number of last reachable page
+          - ``$page``: number of currently selected page
+          - ``$page_count``: number of reachable pages
+          - ``$items_per_page``: maximal number of items per page
+          - ``$first_item``: index of first item on the current page
+          - ``$last_item``: index of last item on the current page
+          - ``$item_count``: total number of items
+          - ``$link_first``: link to first page (unless this is first page)
+          - ``$link_last``: link to last page (unless this is last page)
+          - ``$link_previous``: link to previous page (unless this is first page)
+          - ``$link_next``: link to next page (unless this is last page)
+
+          To render a range of pages the token '~3~' can be used. The
+          number sets the radius of pages around the current page.
+          Example for a range with radius 3:
+
+          '1 .. 5 6 7 [8] 9 10 11 .. 500'
+
+      - key: ckan.pagination.factory
+        default: "ckan.lib.pagination:Page"
+        validators: as_import
+        description: |
+          Import path of python class responsible for pagination widget. The
+          class must inherit from ``ckan.lib.pagination.Page``.
+
+      - key: ckan.pagination.css_class.widget
+        default: "pagination justify-content-center"
+        description: |
+          CSS class of the pagination widget::
+
+            <div class="<WIDGET CLASS>">
+             ..
+
+      - key: ckan.pagination.css_class.item
+        default: "page-item"
+        description: |
+          CSS class of the link wrapper used by pagination widget::
+
+            <div class="pagination">
+              <li class="<PAGE ITEM CLASS>">
+                ..
+
+      - key: ckan.pagination.css_class.link
+        default: "page-link"
+        description: |
+          CSS class of the link tag used by pagination widget::
+
+            <div class="pagination">
+              <li class="page-item">
+                <a class="<PAGE LINK CLASS>">
+                 ..
+
   - annotation: Resource Views Settings
     options:
       - key: ckan.views.default_views

--- a/ckan/lib/pagination.py
+++ b/ckan/lib/pagination.py
@@ -634,13 +634,16 @@ class BasePage(List[Any]):
 class Page(BasePage):
     def pager(self, *args: Any, **kwargs: Any) -> Markup:
         with tags.div(cls=u"pagination-wrapper") as wrapper:
-            tags.ul(u"$link_previous ~2~ $link_next", cls=u"pagination")
+            tags.ul(
+                "$link_previous ~2~ $link_next",
+                cls="pagination justify-content-center"
+            )
         params = dict(
             format=str(wrapper),
             symbol_previous=u"«",
             symbol_next=u"»",
-            curpage_attr={u"class": u"active"},
-            link_attr={},
+            curpage_attr={u"class": u"page-item active"},
+            link_attr={"class": "page-link"},
         )
         params.update(kwargs)
         return super(Page, self).pager(*args, **params)
@@ -651,7 +654,7 @@ class Page(BasePage):
             self, page: int, text: str,
             extra_attributes: Optional[dict[str, Any]] = None):
         anchor = super(Page, self)._pagerlink(page, text)
-        extra_attributes = extra_attributes or {}
+        extra_attributes = extra_attributes or {"class": "page-item"}
         return str(tags.li(anchor, **extra_attributes))
 
     # Change 'current page' link from <span> to <li><a>

--- a/ckan/logic/converters.py
+++ b/ckan/logic/converters.py
@@ -3,6 +3,8 @@
 import json
 from typing import Any
 
+from werkzeug.utils import import_string, ImportStringError
+
 import ckan.model as model
 import ckan.lib.navl.dictization_functions as df
 import ckan.logic.validators as validators
@@ -253,3 +255,19 @@ def remove_whitespace(value: Any, context: Context) -> Any:
     if isinstance(value, str):
         return value.strip()
     return value
+
+
+def as_import(value: Any):
+    """Imports an object based on a string.
+
+    An import path can be specified either in dotted notation
+    (``xml.sax.saxutils.escape``) or with a colon as object delimiter
+    (``xml.sax.saxutils:escape``).
+    """
+    if not isinstance(value, str):
+        return value
+
+    try:
+        return import_string(value)
+    except ImportStringError as e:
+        raise df.Invalid(str(e))

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -837,20 +837,12 @@ def config_declaration_v1(
         ignore_missing: Validator, unicode_safe: Validator,
         not_empty: Validator, default: ValidatorFactory,
         dict_only: Validator, one_of: ValidatorFactory,
-        ignore_empty: Validator):
+        ignore_empty: Validator, as_import: Validator):
     from ckan.config.declaration import Key
     from ckan.config.declaration.load import option_types
 
     def key_from_string(s: str):
         return Key.from_string(s)
-
-    def importable_string(value: str):
-        from werkzeug.utils import import_string, ImportStringError
-        from ckan.logic.validators import Invalid
-        try:
-            return import_string(value)
-        except ImportStringError as e:
-            raise Invalid(str(e))
 
     return cast(Schema, {
         "groups": {
@@ -860,9 +852,9 @@ def config_declaration_v1(
                 "key": [not_empty, key_from_string],
                 "legacy_key": [ignore_empty, unicode_safe],
                 "default": [ignore_missing],
-                "default_callable": [ignore_empty, importable_string],
+                "default_callable": [ignore_empty, as_import],
                 "placeholder": [default(""), unicode_safe],
-                "placeholder_callable": [ignore_empty, importable_string],
+                "placeholder_callable": [ignore_empty, as_import],
                 "callable_args": [ignore_empty, dict_only],
                 "example": [ignore_missing],
                 "description": [default(""), unicode_safe],


### PR DESCRIPTION
A set of config options for:

* setting CSS class of pagination widget, page link, a wrapper of a page link
* changing the template of the pagination widget. For example, render more\less links around the current page, or remove Next\Previous links 
* changing the class that renders the pagination widget if even more customization is required.