### PR TITLE
datastore_search_sql returns correct numeric data

### DIFF
--- a/changes/5753.bugfix
+++ b/changes/5753.bugfix
@@ -1,0 +1,1 @@
+datastore_search_sql returns correct numeric data

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -18,6 +18,7 @@ import sqlalchemy.engine.url as sa_url
 import datetime
 import hashlib
 import json
+import decimal
 from collections import OrderedDict
 
 from urllib.parse import (
@@ -823,6 +824,8 @@ def convert(data: Any, type_name: str) -> Any:
     if type_name == 'nested':
         return json.loads(data[0])
     # array type
+    if isinstance(data, (int, float, decimal.Decimal)):
+        return data
     if type_name.startswith('_'):
         sub_type = type_name[1:]
         return [convert(item, sub_type) for item in data]

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -824,8 +824,6 @@ def convert(data: Any, type_name: str) -> Any:
     if type_name == 'nested':
         return json.loads(data[0])
     # array type
-    if isinstance(data, (int, float, decimal.Decimal)):
-        return data
     if type_name.startswith('_'):
         sub_type = type_name[1:]
         return [convert(item, sub_type) for item in data]
@@ -834,6 +832,8 @@ def convert(data: Any, type_name: str) -> Any:
     if isinstance(data, datetime.datetime):
         return data.isoformat()
     if isinstance(data, (int, float)):
+        return data
+    if isinstance(data, (int, float, decimal.Decimal)):
         return data
     return str(data)
 

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -1869,7 +1869,7 @@ class TestDatastoreSQLFunctional(object):
         sql = 'SELECT * FROM "{0}"'.format(resource["id"])
         result = helpers.call_action("datastore_search_sql", sql=sql)
         record_new = result["records"]
-        assert(isinstance(record_new[0]["foo"], decimal.Decimal))
+        assert (isinstance(record_new[0]["foo"], decimal.Decimal))
 
 
 class TestDatastoreSearchRecordsFormat(object):

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -1869,7 +1869,7 @@ class TestDatastoreSQLFunctional(object):
         sql = 'SELECT * FROM "{0}"'.format(resource["id"])
         result = helpers.call_action("datastore_search_sql", sql=sql)
         record_new = result["records"]
-        assert(isinstance(record_new[0]["foo"], decimal.Decimal)) == True
+        assert (isinstance(record_new[0]["foo"], decimal.Decimal)) == True
 
 
 class TestDatastoreSearchRecordsFormat(object):

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -1869,7 +1869,7 @@ class TestDatastoreSQLFunctional(object):
         sql = 'SELECT * FROM "{0}"'.format(resource["id"])
         result = helpers.call_action("datastore_search_sql", sql=sql)
         record_new = result["records"]
-        assert (isinstance(record_new[0]["foo"], decimal.Decimal)) == True
+        assert isinstance(record_new[0]["foo"], decimal.Decimal) == True
 
 
 class TestDatastoreSearchRecordsFormat(object):

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -3,6 +3,7 @@
 import json
 import pytest
 import sqlalchemy.orm as orm
+import decimal
 
 import ckan.lib.create_test_data as ctd
 import ckan.logic as logic
@@ -1847,6 +1848,28 @@ class TestDatastoreSQLFunctional(object):
         assert len(result["records"]) == 2
         assert [res[u"the year"] for res in result["records"]] == [2014, 2013]
         assert result[u"records_truncated"]
+
+    @pytest.mark.ckan_config("ckan.plugins", "datastore")
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    def test_search_numeric_data_through_sql(self):
+        resource = factories.Resource()
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "fields": [
+                {"id": "foo", "type": "numeric"},
+                {"id": "bar", "type": "numeric"}
+            ],
+            "records": [
+                {"foo": 1, "bar": 2},
+                {"foo": 3, "bar": 4}
+            ]
+        }
+        result = helpers.call_action("datastore_create", **data)
+        sql = 'SELECT * FROM "{0}"'.format(resource["id"])
+        result = helpers.call_action("datastore_search_sql", sql=sql)
+        record_new = result["records"]
+        assert(isinstance(record_new[0]["foo"], decimal.Decimal)) == True
 
 
 class TestDatastoreSearchRecordsFormat(object):

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -1869,7 +1869,7 @@ class TestDatastoreSQLFunctional(object):
         sql = 'SELECT * FROM "{0}"'.format(resource["id"])
         result = helpers.call_action("datastore_search_sql", sql=sql)
         record_new = result["records"]
-        assert isinstance(record_new[0]["foo"], decimal.Decimal) == True
+        assert record_new[0]["foo"] == decimal.Decimal
 
 
 class TestDatastoreSearchRecordsFormat(object):

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -1869,8 +1869,7 @@ class TestDatastoreSQLFunctional(object):
         sql = 'SELECT * FROM "{0}"'.format(resource["id"])
         result = helpers.call_action("datastore_search_sql", sql=sql)
         record_new = result["records"]
-        if record_new[0]["foo"] == decimal.Decimal
-            assert True
+        assert(isinstance(record_new[0]["foo"], decimal.Decimal))
 
 
 class TestDatastoreSearchRecordsFormat(object):

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -1869,7 +1869,8 @@ class TestDatastoreSQLFunctional(object):
         sql = 'SELECT * FROM "{0}"'.format(resource["id"])
         result = helpers.call_action("datastore_search_sql", sql=sql)
         record_new = result["records"]
-        assert record_new[0]["foo"] == decimal.Decimal
+        if record_new[0]["foo"] == decimal.Decimal
+            assert True
 
 
 class TestDatastoreSearchRecordsFormat(object):


### PR DESCRIPTION
Fixes #5753 

### Proposed fixes:
Returns correct numeric data instead of default numeric as string.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
