### PR TITLE
Update extension template adding configuration for popular tools and git-hooks

### DIFF
--- a/contrib/alembic/generic/alembic.ini.mako
+++ b/contrib/alembic/generic/alembic.ini.mako
@@ -35,6 +35,7 @@ script_location = %(here)s
 # are written from script.py.mako
 # output_encoding = utf-8
 
+# pragma: allowlist nextline secret
 sqlalchemy.url = driver://user:pass@localhost/dbname
 
 

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/.github/workflows/test.yml
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/.github/workflows/test.yml
@@ -2,29 +2,34 @@ name: Tests
 on: [push, pull_request]
 jobs:
   test:
+    strategy:
+      matrix:
+        ckan-version: ["2.10", 2.9]
+      fail-fast: false
+
     runs-on: ubuntu-latest
     container:
       # The CKAN version tag of the Solr and Postgres containers should match
       # the one of the container the tests run on.
       # You can switch this base image with a custom image tailored to your project
-      image: openknowledge/ckan-dev:2.9
+      image: openknowledge/ckan-dev:${{ "{{" }} matrix.ckan-version }}
     services:
       solr:
-        image: ckan/ckan-solr-dev:2.9
+        image: ckan/ckan-solr:${{ "{{" }} matrix.ckan-version }}
       postgres:
-        image: ckan/ckan-postgres-dev:2.9
+        image: ckan/ckan-postgres-dev:${{ "{{" }} matrix.ckan-version }}
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_PASSWORD: postgres  # pragma: allowlist secret
           POSTGRES_DB: postgres
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       redis:
           image: redis:3
 
     env:
-      CKAN_SQLALCHEMY_URL: postgresql://ckan_default:pass@postgres/ckan_test
-      CKAN_DATASTORE_WRITE_URL: postgresql://datastore_write:pass@postgres/datastore_test
-      CKAN_DATASTORE_READ_URL: postgresql://datastore_read:pass@postgres/datastore_test
+      CKAN_SQLALCHEMY_URL: postgresql://ckan_default:pass@postgres/ckan_test  # pragma: allowlist secret
+      CKAN_DATASTORE_WRITE_URL: postgresql://datastore_write:pass@postgres/datastore_test  # pragma: allowlist secret
+      CKAN_DATASTORE_READ_URL: postgresql://datastore_read:pass@postgres/datastore_test  # pragma: allowlist secret
       CKAN_SOLR_URL: http://solr:8983/solr/ckan
       CKAN_REDIS_URL: redis://redis:6379/1
 
@@ -44,5 +49,4 @@ jobs:
 
         ckan -c test.ini db init
     - name: Run tests
-      run: pytest --ckan-ini=test.ini --cov=ckanext.{{ cookiecutter.project_shortname }} --disable-warnings ckanext/{{ cookiecutter.project_shortname }}
-
+      run: pytest --ckan-ini=test.ini --cov=ckanext.{{ cookiecutter.project_shortname }} --disable-warnings ckanext/{{ cookiecutter.project_shortname }} -p no:rerunfailures

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/.pre-commit-config.yaml
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/.pre-commit-config.yaml
@@ -1,0 +1,53 @@
+default_install_hook_types:
+  - pre-commit
+  - pre-push
+  - commit-msg
+
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+  - id: check-yaml
+  - id: end-of-file-fixer
+    stages: [pre-commit]
+  - id: trailing-whitespace
+    stages: [pre-commit]
+  - id: debug-statements
+    stages: [pre-push]
+
+## Isort
+- repo: https://github.com/pycqa/isort
+  rev: 5.12.0
+  hooks:
+  - id: isort
+    name: isort
+    stages: [pre-commit]
+
+## Black
+- repo: https://github.com/psf/black
+  rev: 23.3.0
+  hooks:
+  - id: black
+    stages: [pre-commit]
+
+## Ruff
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: v0.0.260
+  hooks:
+  - id: ruff
+    stages: [pre-commit]
+
+## Detect passwords, api-tokens, secrets within a code base
+- repo: https://github.com/Yelp/detect-secrets
+  rev: v1.4.0
+  hooks:
+  - id: detect-secrets
+    stages: [pre-push]
+    # args: ['--baseline', '.secrets.baseline']
+
+# ## Conventional commit message(commitizen)
+# - repo: https://github.com/commitizen-tools/commitizen
+#   rev: v2.42.1
+#   hooks:
+#   - id: commitizen
+#     stages: [commit-msg]

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/MANIFEST.in
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/MANIFEST.in
@@ -1,5 +1,5 @@
 include README.rst
 include LICENSE
 include requirements.txt
-recursive-include ckanext/{{ cookiecutter.project_shortname }} *.html *.json *.js *.less *.css *.mo *.yml
+recursive-include ckanext/{{ cookiecutter.project_shortname }} *.html *.json *.js *.css *.mo *.yml *.yaml *.toml
 recursive-include ckanext/{{ cookiecutter.project_shortname }}/migration *.ini *.py *.mako

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/README.md
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/README.md
@@ -1,4 +1,4 @@
-[![Tests](https://github.com/{{ cookiecutter.github_user_name }}/{{ cookiecutter.project }}/workflows/Tests/badge.svg?branch=main)](https://github.com/{{ cookiecutter.github_user_name }}/{{ cookiecutter.project }}/actions)
+[![Tests](https://github.com/{{ cookiecutter.github_user_name }}/{{ cookiecutter.project }}/workflows/Tests/badge.svg)](https://github.com/{{ cookiecutter.github_user_name }}/{{ cookiecutter.project }}/actions/workflows/test.yml)
 
 # {{ cookiecutter.project }}
 
@@ -14,12 +14,11 @@ If your extension works across different versions you can add the following tabl
 
 Compatibility with core CKAN versions:
 
-| CKAN version    | Compatible?   |
-| --------------- | ------------- |
-| 2.6 and earlier | not tested    |
-| 2.7             | not tested    |
-| 2.8             | not tested    |
-| 2.9             | not tested    |
+| CKAN version    | Compatible? |
+|-----------------|-------------|
+| 2.8 and earlier | not tested  |
+| 2.9             | not tested  |
+| 2.10            | not tested  |
 
 Suggested values:
 
@@ -38,24 +37,26 @@ Suggested values:
 To install {{ cookiecutter.project }}:
 
 1. Activate your CKAN virtual environment, for example:
-
-     . /usr/lib/ckan/default/bin/activate
+   ```sh
+   . /usr/lib/ckan/default/bin/activate
+   ```
 
 2. Clone the source and install it on the virtualenv
+   ```sh
+   git clone https://github.com/{{ cookiecutter.github_user_name }}/{{ cookiecutter.project }}.git
+   cd {{ cookiecutter.project }}
+   pip install -e .
+   pip install -r requirements.txt
+   ```
 
-    git clone https://github.com/{{ cookiecutter.github_user_name }}/{{ cookiecutter.project }}.git
-    cd {{ cookiecutter.project }}
-    pip install -e .
-	pip install -r requirements.txt
-
-3. Add `{{ cookiecutter.project[8:] }}` to the `ckan.plugins` setting in your CKAN
+3. Add `{{ cookiecutter.project_shortname }}` to the `ckan.plugins` setting in your CKAN
    config file (by default the config file is located at
    `/etc/ckan/default/ckan.ini`).
 
 4. Restart CKAN. For example if you've deployed CKAN with Apache on Ubuntu:
-
-     sudo service apache2 reload
-
+   ```sh
+   sudo service apache2 reload
+   ```
 
 ## Config settings
 
@@ -78,13 +79,31 @@ do:
     python setup.py develop
     pip install -r dev-requirements.txt
 
+Optionally, initialize [pre-commit](https://pre-commit.com/) hooks:
+
+    pip install -U pre-commit
+    pre-commit install
+
+Following hooks are enabled by default:
+
+* `check-yaml`: Attempts to load all yaml files to verify syntax.
+* `end-of-file-fixer`: Makes sure files end in a newline and only a newline.
+* `trailing-whitespace`: Trims trailing whitespace.
+* `debug-statements`: Checks for debugger imports and `breakpoint()` calls in python source.
+* `isort`: Sorts your imports, so you don't have to.
+* `black`: The uncompromising Python code formatter.
+* `ruff`: Run 'ruff' for extremely fast Python linting.
+* `detect-secrets`: Detects high entropy strings that are likely to be passwords.
+
+And following hooks are available but disabled by default:
+
+* `commitizen`: Enforce [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages.
 
 ## Tests
 
 To run the tests, do:
 
-    pytest --ckan-ini=test.ini
-
+    pytest
 
 ## Releasing a new version of {{ cookiecutter.project }}
 
@@ -93,30 +112,41 @@ If {{ cookiecutter.project }} should be available on PyPI you can follow these s
 1. Update the version number in the `setup.py` file. See [PEP 440](http://legacy.python.org/dev/peps/pep-0440/#public-version-identifiers) for how to choose version numbers.
 
 2. Make sure you have the latest version of necessary packages:
-
-    pip install --upgrade setuptools wheel twine
+   ```sh
+   pip install --upgrade build twine
+   ```
 
 3. Create a source and binary distributions of the new version:
-
-       python setup.py sdist bdist_wheel && twine check dist/*
+   ```sh
+   python -m build
+   ```
 
    Fix any errors you get.
 
 4. Upload the source distribution to PyPI:
+   ```sh
+   twine upload dist/*
+   ```
 
-       twine upload dist/*
+5. If you are following [Conventional Commits
+   specification](https://www.conventionalcommits.org/en/v1.0.0/), compile the
+   changelog using [git-changelog](https://pawamoy.github.io/git-changelog/),
+   [commitizen](https://pawamoy.github.io/git-changelog/), or similar tool.
 
-5. Commit any outstanding changes:
+6. Commit any outstanding changes:
+   ```sh
+   git commit -a
+   git push
+   ```
 
-       git commit -a
-       git push
-
-6. Tag the new release of the project on GitHub with the version number from
+7. Tag the new release of the project on GitHub with the version number from
    the `setup.py` file. For example if the version number in `setup.py` is
    0.0.1 then do:
 
-       git tag 0.0.1
-       git push --tags
+   ```sh
+   git tag v0.0.1
+   git push --tags
+   ```
 
 ## License
 

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/ckanext/__init__.py
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/ckanext/__init__.py
@@ -3,7 +3,9 @@
 # this is a namespace package
 try:
     import pkg_resources
+
     pkg_resources.declare_namespace(__name__)
 except ImportError:
     import pkgutil
+
     __path__ = pkgutil.extend_path(__path__, __name__)

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/ckanext/{{cookiecutter.project_shortname}}/plugin.py
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/ckanext/{{cookiecutter.project_shortname}}/plugin.py
@@ -12,23 +12,22 @@ import ckan.plugins.toolkit as toolkit
 {%endif%}
 class {{cookiecutter.plugin_class_name}}(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
-    {%if cookiecutter.include_examples|int%}
+{%if cookiecutter.include_examples|int%}
     # plugins.implements(plugins.IAuthFunctions)
     # plugins.implements(plugins.IActions)
     # plugins.implements(plugins.IBlueprint)
     # plugins.implements(plugins.IClick)
     # plugins.implements(plugins.ITemplateHelpers)
     # plugins.implements(plugins.IValidators)
-    {%endif%}
-
+{%endif%}
     # IConfigurer
 
     def update_config(self, config_):
         toolkit.add_template_directory(config_, "templates")
         toolkit.add_public_directory(config_, "public")
         toolkit.add_resource("assets", "{{cookiecutter.project_shortname}}")
+{%if cookiecutter.include_examples|int%}
 
-    {%if cookiecutter.include_examples|int%}
     # IAuthFunctions
 
     # def get_auth_functions(self):
@@ -58,4 +57,4 @@ class {{cookiecutter.plugin_class_name}}(plugins.SingletonPlugin):
 
     # def get_validators(self):
     #     return validators.get_validators()
-    {%endif%}
+{%endif-%}

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/ckanext/{{cookiecutter.project_shortname}}/tests/test_plugin.py
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/ckanext/{{cookiecutter.project_shortname}}/tests/test_plugin.py
@@ -47,7 +47,9 @@ To temporary patch the CKAN configuration for the duration of a test you can use
     def test_some_action():
         pass
 """
-import ckanext.{{cookiecutter.project_shortname}}.plugin as plugin
+import pytest
+
+from ckan.plugins import plugin_loaded
 
 
 @pytest.mark.ckan_config("ckan.plugins", "{{cookiecutter.project_shortname}}")

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/pyproject.toml
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/pyproject.toml
@@ -1,0 +1,103 @@
+[tool.black]
+# line-length = 88
+# preview = true
+
+[tool.ruff]
+target-version = "py38"
+# line-length = 88
+
+[tool.isort]
+known_ckan = "ckan"
+known_ckanext = "ckanext"
+known_self = "ckanext.{{ cookiecutter.project_shortname }}"
+sections = "FUTURE,STDLIB,FIRSTPARTY,THIRDPARTY,CKAN,CKANEXT,SELF,LOCALFOLDER"
+profile = "black"
+
+[tool.pytest.ini_options]
+addopts = "--ckan-ini test.ini"
+filterwarnings = [
+               "ignore::sqlalchemy.exc.SADeprecationWarning",
+               "ignore::sqlalchemy.exc.SAWarning",
+               "ignore::DeprecationWarning",
+]
+
+[tool.pyright]
+pythonVersion = "3.8"
+include = ["ckanext"]
+exclude = [
+    "**/test*",
+    "**/migration",
+]
+strict = []
+
+strictParameterNoneValue = true
+
+# Check the meaning of rules here
+# https://github.com/microsoft/pyright/blob/main/docs/configuration.md
+reportFunctionMemberAccess = true # non-standard member accesses for functions
+reportMissingImports = true
+reportMissingModuleSource = true
+reportMissingTypeStubs = false
+reportImportCycles = true
+reportUnusedImport = true
+reportUnusedClass = true
+reportUnusedFunction = true
+reportUnusedVariable = true
+reportDuplicateImport = true
+reportOptionalSubscript = true
+reportOptionalMemberAccess = true
+reportOptionalCall = true
+reportOptionalIterable = true
+reportOptionalContextManager = true
+reportOptionalOperand = true
+reportTypedDictNotRequiredAccess = false # Context won't work with this rule
+reportConstantRedefinition = true
+reportIncompatibleMethodOverride = true
+reportIncompatibleVariableOverride = true
+reportOverlappingOverload = true
+reportUntypedFunctionDecorator = false
+reportUnknownParameterType = true
+reportUnknownArgumentType = false
+reportUnknownLambdaType = false
+reportUnknownMemberType = false
+reportMissingTypeArgument = true
+reportInvalidTypeVarUse = true
+reportCallInDefaultInitializer = true
+reportUnknownVariableType = true
+reportUntypedBaseClass = true
+reportUnnecessaryIsInstance = true
+reportUnnecessaryCast = true
+reportUnnecessaryComparison = true
+reportAssertAlwaysTrue = true
+reportSelfClsParameterName = true
+reportUnusedCallResult = false # allow function calls for side-effect only
+useLibraryCodeForTypes = true
+reportGeneralTypeIssues = true
+reportPropertyTypeMismatch = true
+reportWildcardImportFromLibrary = true
+reportUntypedClassDecorator = false
+reportUntypedNamedTuple = true
+reportPrivateUsage = true
+reportPrivateImportUsage = true
+reportInconsistentConstructor = true
+reportMissingSuperCall = false
+reportUninitializedInstanceVariable = true
+reportInvalidStringEscapeSequence = true
+reportMissingParameterType = true
+reportImplicitStringConcatenation = false
+reportUndefinedVariable = true
+reportUnboundVariable = true
+reportInvalidStubStatement = true
+reportIncompleteStub = true
+reportUnsupportedDunderAll = true
+reportUnusedCoroutine = true
+reportUnnecessaryTypeIgnoreComment = true
+reportMatchNotExhaustive = true
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "0.0.1"
+tag_format = "v$version"
+version_files = ["setup.cfg:version", "setup.py:version"]
+major_version_zero = true
+changelog_incremental = true

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/setup.cfg
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/setup.cfg
@@ -53,10 +53,3 @@ previous = true
 domain = ckanext-{{ cookiecutter.project_shortname }}
 directory = ckanext/{{ cookiecutter.project_shortname }}/i18n
 statistics = true
-
-[tool:pytest]
-filterwarnings =
-        ignore::sqlalchemy.exc.SADeprecationWarning
-        ignore::sqlalchemy.exc.SAWarning
-        ignore::DeprecationWarning
-addopts = --ckan-ini test.ini

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/setup.py
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/setup.py
@@ -7,10 +7,10 @@ setup(
     # message extraction at
     # http://babel.pocoo.org/docs/messages/#extraction-method-mapping-and-configuration
     message_extractors={
-        'ckanext': [
-            ('**.py', 'python', None),
-            ('**.js', 'javascript', None),
-            ('**/templates/**.html', 'ckan', None),
+        "ckanext": [
+            ("**.py", "python", None),
+            ("**.js", "javascript", None),
+            ("**/templates/**.html", "ckan", None),
         ],
     }
 )


### PR DESCRIPTION
An update that encourages developers to write standard code and publish packages.

Changes:

* Update test workflow(GitHub action). Now it aims CKAN v2.9 and v2.10
* **Suggest** using git-hooks for code formatting and lining. I.e, they are not enabled by default, but README explains how to enable it 
* Add `pyproject.toml` with simple configuration for popular tools: pyright, pytest, black, isort
* Add configuration for basic hooks: isort, black, ruff, secrets detection
* **Suggest** using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/) and compiling CHANGELOG when new version released.
* add `yaml` and `toml` extensions to the package's manifest, so that config declarations or similar config files are published to PyPI.
* Recommend using `build` + `twine` instead of `setuptools` + `wheel` + `twine` for publishing(recommended approach for setuptools)
* Small README fixes(padding for code snippets, badge for test workflow` 
* Fix `tests/test_plugin.py` example - previously it had missing imports
* Fresh extensions are `black`-compatible out of the box.