### PR TITLE
Handle nested data sequence properly

### DIFF
--- a/changes/6052.bugfix
+++ b/changes/6052.bugfix
@@ -1,0 +1,1 @@
+Handle nested data sequence properly

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1125,6 +1125,18 @@ def upsert_data(context: Context, data_dict: dict[str, Any]):
     method = data_dict.get('method', _UPSERT)
 
     fields = _get_fields(context['connection'], data_dict['resource_id'])
+    
+    def first_to_last_field(fields):
+        '''shift first field element to last'''
+        non_first_field = fields[1:]
+        first_field = fields[0:1]
+        value = first_field[0]['type'] 
+
+        #check if value is nested
+        if value == 'nested':
+            new_field = non_first_field + first_field
+        fields = new_field
+
     field_names = _pluck('id', fields)
     records = data_dict['records']
     sql_columns = ", ".join(

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1127,7 +1127,7 @@ def upsert_data(context: Context, data_dict: dict[str, Any]):
     fields = _get_fields(context['connection'], data_dict['resource_id'])
 
     def first_to_last_field(fields):
-    '''shift first field element to last'''
+        '''shift first field element to last'''
         non_first_field = fields[1:]
         first_field = fields[0:1]
         value = first_field[0]['type']

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1127,7 +1127,7 @@ def upsert_data(context: Context, data_dict: dict[str, Any]):
     fields = _get_fields(context['connection'], data_dict['resource_id'])
 
     def first_to_last_field(fields):
-        '''shift first field element to last'''
+    '''shift first field element to last'''
         non_first_field = fields[1:]
         first_field = fields[0:1]
         value = first_field[0]['type']
@@ -1135,7 +1135,7 @@ def upsert_data(context: Context, data_dict: dict[str, Any]):
         # check if value is nested
         if value == 'nested':
             new_field = non_first_field + first_field
-        fields = new_field
+            fields = new_field
 
     field_names = _pluck('id', fields)
     records = data_dict['records']

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1126,15 +1126,15 @@ def upsert_data(context: Context, data_dict: dict[str, Any]):
 
     fields = _get_fields(context['connection'], data_dict['resource_id'])
 
-def first_to_last_field(fields):
-    '''shift first field element to last'''
-    non_first_field = fields[1:]
-    first_field = fields[0:1]
-    value = first_field[0]['type']
-    # check if value is nested
-    if value == 'nested':
-        new_field = non_first_field + first_field
-        fields = new_field
+    def first_to_last_field(fields):
+        '''shift first field element to last'''
+        non_first_field = fields[1:]
+        first_field = fields[0:1]
+        value = first_field[0]['type']
+        # check if value is nested
+        if value == 'nested':
+            new_field = non_first_field + first_field
+            fields = new_field
 
     field_names = _pluck('id', fields)
     records = data_dict['records']

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1130,9 +1130,9 @@ def upsert_data(context: Context, data_dict: dict[str, Any]):
         '''shift first field element to last'''
         non_first_field = fields[1:]
         first_field = fields[0:1]
-        value = first_field[0]['type'] 
+        value = first_field[0]['type']
 
-        #check if value is nested
+        # check if value is nested
         if value == 'nested':
             new_field = non_first_field + first_field
         fields = new_field

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1126,15 +1126,17 @@ def upsert_data(context: Context, data_dict: dict[str, Any]):
 
     fields = _get_fields(context['connection'], data_dict['resource_id'])
 
-    def first_to_last_field(fields):
+    def first_to_last_field(fields, first_field):
         '''shift first field element to last'''
         non_first_field = fields[1:]
-        first_field = fields[0:1]
-        value = first_field[0]['type']
-        # check if value is nested
-        if value == 'nested':
-            new_field = non_first_field + first_field
-            fields = new_field
+        new_field = non_first_field + first_field
+        return new_field
+
+    first_field = fields[0:1]
+    value = first_field[0]['type']
+    # check if value is nested
+    if value == 'nested':
+        fields = first_to_last_field(fields)
 
     field_names = _pluck('id', fields)
     records = data_dict['records']

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1136,7 +1136,7 @@ def upsert_data(context: Context, data_dict: dict[str, Any]):
     value = first_field[0]['type']
     # check if value is nested
     if value == 'nested':
-        fields = first_to_last_field(fields)
+        fields = first_to_last_field(fields, first_field)
 
     field_names = _pluck('id', fields)
     records = data_dict['records']

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1126,16 +1126,15 @@ def upsert_data(context: Context, data_dict: dict[str, Any]):
 
     fields = _get_fields(context['connection'], data_dict['resource_id'])
 
-    def first_to_last_field(fields):
-        '''shift first field element to last'''
-        non_first_field = fields[1:]
-        first_field = fields[0:1]
-        value = first_field[0]['type']
-
-        # check if value is nested
-        if value == 'nested':
-            new_field = non_first_field + first_field
-            fields = new_field
+def first_to_last_field(fields):
+    '''shift first field element to last'''
+    non_first_field = fields[1:]
+    first_field = fields[0:1]
+    value = first_field[0]['type']
+    # check if value is nested
+    if value == 'nested':
+        new_field = non_first_field + first_field
+        fields = new_field
 
     field_names = _pluck('id', fields)
     records = data_dict['records']

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1126,17 +1126,12 @@ def upsert_data(context: Context, data_dict: dict[str, Any]):
 
     fields = _get_fields(context['connection'], data_dict['resource_id'])
 
-    def first_to_last_field(fields, first_field):
-        '''shift first field element to last'''
-        non_first_field = fields[1:]
-        new_field = non_first_field + first_field
-        return new_field
-
+    non_first_field = fields[1:]
     first_field = fields[0:1]
     value = first_field[0]['type']
-    # check if value is nested
     if value == 'nested':
-        fields = first_to_last_field(fields, first_field)
+        new_field = non_first_field + first_field
+        fields = new_field
 
     field_names = _pluck('id', fields)
     records = data_dict['records']

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1125,7 +1125,7 @@ def upsert_data(context: Context, data_dict: dict[str, Any]):
     method = data_dict.get('method', _UPSERT)
 
     fields = _get_fields(context['connection'], data_dict['resource_id'])
-    
+
     def first_to_last_field(fields):
         '''shift first field element to last'''
         non_first_field = fields[1:]

--- a/ckanext/datastore/tests/test_upsert.py
+++ b/ckanext/datastore/tests/test_upsert.py
@@ -147,7 +147,7 @@ class TestDatastoreUpsert(object):
                 "id": "3",
                 "geojson": {
                     "coordinates": [2.3508,48.432],
-                    "type": "Point
+                    "type": "Point"
             }
             }
             ],

--- a/ckanext/datastore/tests/test_upsert.py
+++ b/ckanext/datastore/tests/test_upsert.py
@@ -129,45 +129,45 @@ class TestDatastoreUpsert(object):
         assert search_result["records"][1]["book"] == u"The boy"
 
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
-    @pytest.mark.usefixtures("clean_datastore", "with_plugins")   
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_nested_data_at_last(self):
         resource = factories.Resource()
         data = {
-	        "resource_id": resource["id"],
-	        "force": True,
-	        "primary_key": "id",
-	        "fields": [
-	        {"id": "name","type": "text"},
-	        {"id": "id","type": "text"},
-	        {"id": "geojson","type": "json"}
-	        ],
-	        "records":[
-	        {
-		        "name": "nY",
+            "resource_id": resource["id"],
+            "force": True,
+            "primary_key": "id",
+            "fields": [
+            {"id": "name","type": "text"},
+            {"id": "id","type": "text"},
+            {"id": "geojson","type": "json"}
+            ],
+            "records":[
+            {
+                "name": "nY",
                 "id": "3",
-		        "geojson": {
+                "geojson": {
                     "coordinates": [2.3508,48.432],
-                    "type": "Point"
-			}
-			}
-			],
-		}
+                    "type": "Point
+            }
+            }
+            ],
+        }
         helpers.call_action("datastore_create", **data)
         data = {
-	        "resource_id": resource["id"],
-	        "force": True,
-	        "method": "upsert",
-	        "records": [
-	            {
-		        "name": "nY",
-		        "id": "3",
-		        "geojson": {
-			    "coordinates": [2.3508,48.432],
-			    "type": "Point"
-			    }
-			    }
-			],
-		}
+            "resource_id": resource["id"],
+            "force": True,
+            "method": "upsert",
+            "records": [
+                {
+                "name": "nY",
+                "id": "3",
+                "geojson": {
+                "coordinates": [2.3508,48.432],
+                "type": "Point"
+                }
+                }
+            ],
+        }
         helpers.call_action("datastore_upsert", **data)
 
         search_result = _search(resource["id"])

--- a/ckanext/datastore/tests/test_upsert.py
+++ b/ckanext/datastore/tests/test_upsert.py
@@ -133,71 +133,71 @@ class TestDatastoreUpsert(object):
     def test_nested_data_at_last(self):
         resource = factories.Resource()
         data = {
-	        "resource_id": resource["id"],
-	        "force": True,
-	        "primary_key": "id",
-	        "fields": [
-	        {"id": "name","type": "text"},
-	        {"id": "id","type": "text"},
-	        {"id": "geojson","type": "json"}
-	        ],
-	        "records":[
-	        {
-		        "name": "nY",
+            "resource_id": resource["id"],
+            "force": True,
+            "primary_key": "id",
+            "fields": [
+            {"id": "name","type": "text"},
+            {"id": "id","type": "text"},
+            {"id": "geojson","type": "json"}
+            ],
+            "records":[
+            {
+                "name": "nY",
                 "id": "3",
-		        "geojson": {
+                "geojson": {
                     "coordinates": [2.3508,48.432],
                     "type": "Point"
-			}
-			}
-			],
-		}
+            }
+            }
+            ],
+        }
         helpers.call_action("datastore_create", **data)
         data = {
-	        "resource_id": resource["id"],
-	        "force": True,
-	        "method": "upsert",
-	        "records": [
-	            {
-		        "name": "nY",
-		        "id": "3",
-		        "geojson": {
-			    "coordinates": [2.3508,48.432],
-			    "type": "Point"
-			    }
-			    }
-			],
-		}
+            "resource_id": resource["id"],
+            "force": True,
+            "method": "upsert",
+            "records": [
+                {
+                "name": "nY",
+                "id": "3",
+                "geojson": {
+                "coordinates": [2.3508,48.432],
+                "type": "Point"
+                }
+                }
+            ],
+        }
         helpers.call_action("datastore_upsert", **data)
-        
+
         search_result = _search(resource["id"])
         assert search_result["total"] == 1
         assert search_result["records"][0]["name"] == u"nY"
         assert search_result["records"][0]["id"] == u"3"
         assert search_result["records"][0]["geojson"] == {"coordinates":[2.3508,48.432],"type":"Point"}
-        
+
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_nested_data_at_first(self):
         resource = factories.Resource()
         data = {
-	        "resource_id": resource["id"],
-	        "force": True,
-	        "primary_key": "id",
-	        "fields":[
-	            {"id": "geojson","type": "json"},
-				{"id": "name","type": "text"},
-				{"id": "id","type": "text"}
+            "resource_id": resource["id"],
+            "force": True,
+            "primary_key": "id",
+            "fields":[
+                {"id": "geojson","type": "json"},
+                {"id": "name","type": "text"},
+                {"id": "id","type": "text"}
                         ],
             "records": [
-			{
-			    "geojson": {
-				    "coordinates": [2.3508,48.432],
-				    "type": "Point"
-				    },
-			    "name": "nY",
-			    "id": "3"
-			}
+            {
+                "geojson": {
+                    "coordinates": [2.3508,48.432],
+                    "type": "Point"
+                    },
+                "name": "nY",
+                "id": "3"
+            }
             ],
             }
         helpers.call_action("datastore_create", **data)
@@ -206,34 +206,34 @@ class TestDatastoreUpsert(object):
             "force": True,
             "method": "upsert",
             "records":[
-			{
-			"geojson": {
-				"coordinates": [2.3508,48.432],
+            {
+            "geojson": {
+                "coordinates": [2.3508,48.432],
                 "type": "Point"
-				},
-			"name": "nY",
-			"id": "3"
-			}
-			],
-			}
+                },
+            "name": "nY",
+            "id": "3"
+            }
+            ],
+            }
         helpers.call_action("datastore_upsert", **data)
         search_result = _search(resource["id"])
         assert search_result["total"] == 1
         assert search_result["records"][0]["name"] == u"nY"
         assert search_result["records"][0]["id"] == u"3"
         assert search_result["records"][0]["geojson"] == {"coordinates":[2.3508,48.432],"type":"Point"}
-	
+
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_nested_data_at_middle(self):
         resource = factories.Resource()
         data = {
-	        "resource_id": resource["id"],
-	        "force": True,
-	        "primary_key": "id",
-	        "fields":[
-	            {"id": "name","type": "text"},
-	            {"id": "geojson","type": "json"},
+            "resource_id": resource["id"],
+            "force": True,
+            "primary_key": "id",
+            "fields":[
+                {"id": "name","type": "text"},
+                {"id": "geojson","type": "json"},
                 {"id": "id","type": "text"}
                         ],
             "records": [
@@ -269,7 +269,7 @@ class TestDatastoreUpsert(object):
         assert search_result["records"][0]["name"] == u"nY"
         assert search_result["records"][0]["id"] == u"3"
         assert search_result["records"][0]["geojson"] == {"coordinates":[2.3508,48.432],"type":"Point"}
-        
+
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_nested_data_with_two_values_with_nested_at_last(self):
@@ -308,12 +308,12 @@ class TestDatastoreUpsert(object):
             ],
         }
         helpers.call_action("datastore_upsert", **data)
-        
+
         search_result = _search(resource["id"])
         assert search_result["total"] == 1
         assert search_result["records"][0]["id"] == u"3"
         assert search_result["records"][0]["geojson"] == {"coordinates":[2.3508,48.432],"type":"Point"}
-        
+
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_nested_data_with_two_values_with_nested_at_first(self):
@@ -325,7 +325,7 @@ class TestDatastoreUpsert(object):
             "fields": [
                 {"id": "geojson","type": "json"},
                 {"id": "id","type": "text"}
-                        ],
+                       ],
             "records": [
                 {
                     "geojson": {
@@ -337,7 +337,7 @@ class TestDatastoreUpsert(object):
             ],
         }
         helpers.call_action("datastore_create", **data)
-        
+
         data = {
             "resource_id": resource["id"],
             "force": True,
@@ -353,12 +353,12 @@ class TestDatastoreUpsert(object):
             ],
         }
         helpers.call_action("datastore_upsert", **data)
-        
+
         search_result = _search(resource["id"])
         assert search_result["total"] == 1
         assert search_result["records"][0]["id"] == u"3"
         assert search_result["records"][0]["geojson"] == {"coordinates":[2.3508,48.432],"type":"Point"}
-    
+
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_upsert_only_one_field(self):

--- a/ckanext/datastore/tests/test_upsert.py
+++ b/ckanext/datastore/tests/test_upsert.py
@@ -129,53 +129,53 @@ class TestDatastoreUpsert(object):
         assert search_result["records"][1]["book"] == u"The boy"
 
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
-    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")   
     def test_nested_data_at_last(self):
         resource = factories.Resource()
         data = {
-            "resource_id": resource["id"],
-            "force": True,
-            "primary_key": "id",
-            "fields": [
-            {"id": "name","type": "text"},
-            {"id": "id","type": "text"},
-            {"id": "geojson","type": "json"}
-            ],
-            "records":[
-            {
-                "name": "nY",
+	        "resource_id": resource["id"],
+	        "force": True,
+	        "primary_key": "id",
+	        "fields": [
+	        {"id": "name","type": "text"},
+	        {"id": "id","type": "text"},
+	        {"id": "geojson","type": "json"}
+	        ],
+	        "records":[
+	        {
+		        "name": "nY",
                 "id": "3",
-                "geojson": {
+		        "geojson": {
                     "coordinates": [2.3508,48.432],
                     "type": "Point"
-            }
-            }
-            ],
-        }
+			}
+			}
+			],
+		}
         helpers.call_action("datastore_create", **data)
         data = {
-            "resource_id": resource["id"],
-            "force": True,
-            "method": "upsert",
-            "records": [
-                {
-                "name": "nY",
-                "id": "3",
-                "geojson": {
-                "coordinates": [2.3508,48.432],
-                "type": "Point"
-                }
-                }
-            ],
-        }
+	        "resource_id": resource["id"],
+	        "force": True,
+	        "method": "upsert",
+	        "records": [
+	            {
+		        "name": "nY",
+		        "id": "3",
+		        "geojson": {
+			    "coordinates": [2.3508,48.432],
+			    "type": "Point"
+			    }
+			    }
+			],
+		}
         helpers.call_action("datastore_upsert", **data)
-
+        
         search_result = _search(resource["id"])
         assert search_result["total"] == 1
         assert search_result["records"][0]["name"] == u"nY"
         assert search_result["records"][0]["id"] == u"3"
         assert search_result["records"][0]["geojson"] == {"coordinates":[2.3508,48.432],"type":"Point"}
-
+        
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_nested_data_at_first(self):
@@ -222,7 +222,7 @@ class TestDatastoreUpsert(object):
         assert search_result["records"][0]["name"] == u"nY"
         assert search_result["records"][0]["id"] == u"3"
         assert search_result["records"][0]["geojson"] == {"coordinates":[2.3508,48.432],"type":"Point"}
-
+	
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_nested_data_at_middle(self):
@@ -269,7 +269,7 @@ class TestDatastoreUpsert(object):
         assert search_result["records"][0]["name"] == u"nY"
         assert search_result["records"][0]["id"] == u"3"
         assert search_result["records"][0]["geojson"] == {"coordinates":[2.3508,48.432],"type":"Point"}
-
+        
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_nested_data_with_two_values_with_nested_at_last(self):
@@ -308,12 +308,12 @@ class TestDatastoreUpsert(object):
             ],
         }
         helpers.call_action("datastore_upsert", **data)
-
+        
         search_result = _search(resource["id"])
         assert search_result["total"] == 1
         assert search_result["records"][0]["id"] == u"3"
         assert search_result["records"][0]["geojson"] == {"coordinates":[2.3508,48.432],"type":"Point"}
-
+        
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_nested_data_with_two_values_with_nested_at_first(self):
@@ -337,7 +337,7 @@ class TestDatastoreUpsert(object):
             ],
         }
         helpers.call_action("datastore_create", **data)
-
+        
         data = {
             "resource_id": resource["id"],
             "force": True,
@@ -353,7 +353,7 @@ class TestDatastoreUpsert(object):
             ],
         }
         helpers.call_action("datastore_upsert", **data)
-
+        
         search_result = _search(resource["id"])
         assert search_result["total"] == 1
         assert search_result["records"][0]["id"] == u"3"

--- a/ckanext/datastore/tests/test_upsert.py
+++ b/ckanext/datastore/tests/test_upsert.py
@@ -129,7 +129,7 @@ class TestDatastoreUpsert(object):
         assert search_result["records"][1]["book"] == u"The boy"
 
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
-    @pytest.mark.usefixtures("clean_datastore", "with_plugins")   
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_nested_data_at_last(self):
         resource = factories.Resource()
         data = {

--- a/ckanext/datastore/tests/test_upsert.py
+++ b/ckanext/datastore/tests/test_upsert.py
@@ -129,6 +129,237 @@ class TestDatastoreUpsert(object):
         assert search_result["records"][1]["book"] == u"The boy"
 
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")   
+    def test_nested_data_at_last(self):
+        resource = factories.Resource()
+        data = {
+	        "resource_id": resource["id"],
+	        "force": True,
+	        "primary_key": "id",
+	        "fields": [
+	        {"id": "name","type": "text"},
+	        {"id": "id","type": "text"},
+	        {"id": "geojson","type": "json"}
+	        ],
+	        "records":[
+	        {
+		        "name": "nY",
+                "id": "3",
+		        "geojson": {
+                    "coordinates": [2.3508,48.432],
+                    "type": "Point"
+			}
+			}
+			],
+		}
+        helpers.call_action("datastore_create", **data)
+        data = {
+	        "resource_id": resource["id"],
+	        "force": True,
+	        "method": "upsert",
+	        "records": [
+	            {
+		        "name": "nY",
+		        "id": "3",
+		        "geojson": {
+			    "coordinates": [2.3508,48.432],
+			    "type": "Point"
+			    }
+			    }
+			],
+		}
+        helpers.call_action("datastore_upsert", **data)
+
+        search_result = _search(resource["id"])
+        assert search_result["total"] == 1
+        assert search_result["records"][0]["name"] == u"nY"
+        assert search_result["records"][0]["id"] == u"3"
+        assert search_result["records"][0]["geojson"] == {"coordinates":[2.3508,48.432],"type":"Point"}
+
+    @pytest.mark.ckan_config("ckan.plugins", "datastore")
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    def test_nested_data_at_first(self):
+        resource = factories.Resource()
+        data = {
+	        "resource_id": resource["id"],
+	        "force": True,
+	        "primary_key": "id",
+	        "fields":[
+	            {"id": "geojson","type": "json"},
+				{"id": "name","type": "text"},
+				{"id": "id","type": "text"}
+                        ],
+            "records": [
+			{
+			    "geojson": {
+				    "coordinates": [2.3508,48.432],
+				    "type": "Point"
+				    },
+			    "name": "nY",
+			    "id": "3"
+			}
+            ],
+            }
+        helpers.call_action("datastore_create", **data)
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "method": "upsert",
+            "records":[
+			{
+			"geojson": {
+				"coordinates": [2.3508,48.432],
+                "type": "Point"
+				},
+			"name": "nY",
+			"id": "3"
+			}
+			],
+			}
+        helpers.call_action("datastore_upsert", **data)
+        search_result = _search(resource["id"])
+        assert search_result["total"] == 1
+        assert search_result["records"][0]["name"] == u"nY"
+        assert search_result["records"][0]["id"] == u"3"
+        assert search_result["records"][0]["geojson"] == {"coordinates":[2.3508,48.432],"type":"Point"}
+
+    @pytest.mark.ckan_config("ckan.plugins", "datastore")
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    def test_nested_data_at_middle(self):
+        resource = factories.Resource()
+        data = {
+	        "resource_id": resource["id"],
+	        "force": True,
+	        "primary_key": "id",
+	        "fields":[
+	            {"id": "name","type": "text"},
+	            {"id": "geojson","type": "json"},
+                {"id": "id","type": "text"}
+                        ],
+            "records": [
+                {
+                    "name": "nY",
+                    "geojson": {
+                        "coordinates": [2.3508,48.432],
+                        "type": "Point"
+                    },
+                    "id": "3"
+                }
+            ],
+        }
+        helpers.call_action("datastore_create", **data)
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "method": "upsert",
+            "records": [
+                {
+                    "name": "nY",
+                    "geojson": {
+                        "coordinates": [2.3508,48.432],
+                        "type": "Point"
+                    },
+                    "id": "3"
+                }
+            ],
+        }
+        helpers.call_action("datastore_upsert", **data)
+        search_result = _search(resource["id"])
+        assert search_result["total"] == 1
+        assert search_result["records"][0]["name"] == u"nY"
+        assert search_result["records"][0]["id"] == u"3"
+        assert search_result["records"][0]["geojson"] == {"coordinates":[2.3508,48.432],"type":"Point"}
+
+    @pytest.mark.ckan_config("ckan.plugins", "datastore")
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    def test_nested_data_with_two_values_with_nested_at_last(self):
+        resource = factories.Resource()
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "primary_key": "id",
+            "fields": [
+                {"id": "id","type": "text"},
+                {"id": "geojson","type": "json"}
+            ],
+            "records": [
+                {
+                    "id": "3",
+                    "geojson": {
+                        "coordinates": [2.3508,48.432],
+                        "type": "Point"
+                    }
+                }
+            ],
+        }
+        helpers.call_action("datastore_create", **data)
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "method": "upsert",
+            "records": [
+                {
+                    "id": "3",
+                    "geojson": {
+                        "coordinates": [2.3508,48.432],
+                        "type": "Point"
+                    }
+                }
+            ],
+        }
+        helpers.call_action("datastore_upsert", **data)
+
+        search_result = _search(resource["id"])
+        assert search_result["total"] == 1
+        assert search_result["records"][0]["id"] == u"3"
+        assert search_result["records"][0]["geojson"] == {"coordinates":[2.3508,48.432],"type":"Point"}
+
+    @pytest.mark.ckan_config("ckan.plugins", "datastore")
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    def test_nested_data_with_two_values_with_nested_at_first(self):
+        resource = factories.Resource()
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "primary_key": "id",
+            "fields": [
+                {"id": "geojson","type": "json"},
+                {"id": "id","type": "text"}
+                        ],
+            "records": [
+                {
+                    "geojson": {
+                        "coordinates": [2.3508,48.432],
+                        "type": "Point"
+                    },
+                    "id": "3"
+                }
+            ],
+        }
+        helpers.call_action("datastore_create", **data)
+
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "method": "upsert",
+            "records": [
+                {
+                    "geojson": {
+                        "coordinates": [2.3508,48.432],
+                        "type": "Point"
+                    },
+                    "id": "3"
+                }
+            ],
+        }
+        helpers.call_action("datastore_upsert", **data)
+
+        search_result = _search(resource["id"])
+        assert search_result["total"] == 1
+        assert search_result["records"][0]["id"] == u"3"
+        assert search_result["records"][0]["geojson"] == {"coordinates":[2.3508,48.432],"type":"Point"}
+    
+    @pytest.mark.ckan_config("ckan.plugins", "datastore")
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_upsert_only_one_field(self):
         resource = factories.Resource()


### PR DESCRIPTION
Fixes #6052 

### Proposed fixes:
If the `type value` is nested in first_field then nested contained value is appended at the end in fields.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
