### PR TITLE
Typing updates: April 2023

### DIFF
--- a/ckan/lib/cli.py
+++ b/ckan/lib/cli.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
-
+# type: ignore
 from __future__ import print_function
 
 import sys

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -797,10 +797,10 @@ def _preprocess_dom_attrs(attrs: dict[str, Any]) -> dict[str, Any]:
 
 
 @core_helper
-def link_to(label: str, url: str, **attrs: Any) -> Markup:
+def link_to(label: Optional[str], url: str, **attrs: Any) -> Markup:
     attrs = _preprocess_dom_attrs(attrs)
     attrs['href'] = url
-    if label == '':
+    if label == '' or label is None:
         label = url
     return literal(str(dom_tags.a(label, **attrs)))
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -800,7 +800,7 @@ def _preprocess_dom_attrs(attrs: dict[str, Any]) -> dict[str, Any]:
 def link_to(label: str, url: str, **attrs: Any) -> Markup:
     attrs = _preprocess_dom_attrs(attrs)
     attrs['href'] = url
-    if label == '' or label is None:
+    if label == '':
         label = url
     return literal(str(dom_tags.a(label, **attrs)))
 
@@ -2796,11 +2796,12 @@ def make_login_url(
 
     if url_is_local(next_url):
         md = {}
+
         md[next_field] = urlparse(next_url).path
         parsed_base = urlparse(base)
         netloc = parsed_base.netloc
         parsed_base = parsed_base._replace(netloc=netloc, query=urlencode(md))
-        return urlunparse(parsed_base)
+        return cast(str, urlunparse(parsed_base))
     return base
 
 

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -415,7 +415,7 @@ def _group_or_org_list(
         elif sort_field == 'name':
             sort_model_field = model.Group.name
         elif sort_field == 'title':
-            sort_model_field = model.Group.title
+            sort_model_field = cast(Any, model.Group.title)
 
         if sort_direction == 'asc':
             query = query.order_by(sqlalchemy.asc(sort_model_field))

--- a/ckan/model/group.py
+++ b/ckan/model/group.py
@@ -136,7 +136,7 @@ class Group(core.StatefulObjectMixin,
 
     id: str
     name: str
-    title: str
+    title: str | None
     type: str
     description: str
     image_url: str

--- a/ckan/model/user.py
+++ b/ckan/model/user.py
@@ -69,7 +69,7 @@ class User(core.StatefulObjectMixin,
     name: str
     # password: str
     fullname: Optional[str]
-    email: str
+    email: Optional[str]
     apikey: Optional[str]
     created: datetime.datetime
     reset_key: str

--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -263,14 +263,7 @@ def action(logic_function: str, ver: int = API_DEFAULT_VERSION) -> Response:
         log.info(u'Bad Action API request data: %s', inst)
         return _finish_bad_request(
             _(u'JSON Error: %s') % inst)
-    if not isinstance(request_data, dict):
-        # this occurs if request_data is blank
-        log.info(u'Bad Action API request data - not dict: %r',
-                 request_data)
-        return _finish_bad_request(
-            _(u'Bad request data: %s') %
-            u'Request data JSON decoded to %r but '
-            u'it needs to be a dictionary.' % request_data)
+
     if u'callback' in request_data:
         del request_data[u'callback']
         g.user = None

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -181,8 +181,6 @@ def read_organizations(id: str) -> Union[Response, str]:
     g.fields = []
 
     extra_vars = _extra_template_variables(context, data_dict)
-    if extra_vars is None:
-        return h.redirect_to(u'user.login')
     return base.render(u'user/read_organizations.html', extra_vars)
 
 
@@ -204,8 +202,6 @@ def read_groups(id: str) -> Union[Response, str]:
     # any ideas?
 
     extra_vars = _extra_template_variables(context, data_dict)
-    if extra_vars is None:
-        return h.redirect_to(u'user.login')
     return base.render(u'user/read_groups.html', extra_vars)
 
 

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -159,8 +159,6 @@ def read(id: str) -> Union[Response, str]:
     g.fields = []
 
     extra_vars = _extra_template_variables(context, data_dict)
-    if extra_vars is None:
-        return h.redirect_to(u'user.login')
     return base.render(u'user/read.html', extra_vars)
 
 
@@ -194,8 +192,6 @@ class ApiTokenView(MethodView):
         }
 
         extra_vars = _extra_template_variables(context, data_dict)
-        if extra_vars is None:
-            return h.redirect_to(u'user.login')
         extra_vars[u'tokens'] = tokens
         extra_vars.update({
             u'data': data,

--- a/ckanext/activity/model/activity.py
+++ b/ckanext/activity/model/activity.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import Any, Optional, Type, TypeVar, cast
+from typing import Any, Iterable, Optional, Type, TypeVar, cast
 from typing_extensions import TypeAlias
 
 from sqlalchemy.orm import relationship, backref
@@ -148,7 +148,7 @@ def activity_dictize(activity: Activity, context: Context) -> dict[str, Any]:
 
 
 def activity_list_dictize(
-    activity_list: list[Activity], context: Context
+    activity_list: Iterable[Activity], context: Context
 ) -> list[dict[str, Any]]:
     return [activity_dictize(activity, context) for activity in activity_list]
 
@@ -761,7 +761,7 @@ def _filter_activitites_from_users(q: QActivity) -> QActivity:
 
 
 def _filter_activitites_from_type(
-    q: QActivity, types: list[str], include: bool = True
+    q: QActivity, types: Iterable[str], include: bool = True
 ):
     """Adds a filter to an existing query object to include or exclude
     (include=False) activities based on a list of types.

--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -206,7 +206,8 @@ def _get_subquery_from_crosstab_call(ct: str):
 
 
 def datastore_dictionary(
-        resource_id: str, include_columns: Optional[list[str]] = None):
+        resource_id: str, include_columns: Optional[list[str]] = None
+) -> list[dict[str, Any]]:
     """
     Return the data dictionary info for a resource, optionally filtering
     columns returned.

--- a/ckanext/example_idatasetform/plugin.py
+++ b/ckanext/example_idatasetform/plugin.py
@@ -46,8 +46,10 @@ def country_codes_helper():
         return None
 
 
-class ExampleIDatasetFormPlugin(plugins.SingletonPlugin,
-        tk.DefaultDatasetForm):
+class ExampleIDatasetFormPlugin(
+        tk.DefaultDatasetForm,
+        plugins.SingletonPlugin,
+):
     '''An example IDatasetForm CKAN plugin.
 
     Uses a tag vocabulary to add a custom metadata field to datasets.

--- a/ckanext/example_idatasetform/plugin_v1.py
+++ b/ckanext/example_idatasetform/plugin_v1.py
@@ -6,7 +6,7 @@ import ckan.plugins as p
 import ckan.plugins.toolkit as tk
 
 
-class ExampleIDatasetFormPlugin(p.SingletonPlugin, tk.DefaultDatasetForm):
+class ExampleIDatasetFormPlugin(tk.DefaultDatasetForm, p.SingletonPlugin):
     p.implements(p.IDatasetForm)
 
     def create_package_schema(self) -> Schema:

--- a/ckanext/example_idatasetform/plugin_v2.py
+++ b/ckanext/example_idatasetform/plugin_v2.py
@@ -7,7 +7,7 @@ import ckan.plugins as p
 import ckan.plugins.toolkit as tk
 
 
-class ExampleIDatasetFormPlugin(p.SingletonPlugin, tk.DefaultDatasetForm):
+class ExampleIDatasetFormPlugin(tk.DefaultDatasetForm, p.SingletonPlugin):
     p.implements(p.IDatasetForm)
     p.implements(p.IConfigurer)
 

--- a/ckanext/example_idatasetform/plugin_v3.py
+++ b/ckanext/example_idatasetform/plugin_v3.py
@@ -8,7 +8,7 @@ import ckan.plugins as p
 import ckan.plugins.toolkit as tk
 
 
-class ExampleIDatasetFormPlugin(p.SingletonPlugin, tk.DefaultDatasetForm):
+class ExampleIDatasetFormPlugin(tk.DefaultDatasetForm, p.SingletonPlugin):
     p.implements(p.IDatasetForm)
 
     def _modify_package_schema(self, schema: Schema) -> Schema:

--- a/ckanext/example_idatasetform/plugin_v5.py
+++ b/ckanext/example_idatasetform/plugin_v5.py
@@ -5,7 +5,7 @@ import ckan.plugins as p
 import ckan.plugins.toolkit as tk
 
 
-class ExampleIDatasetFormPlugin(p.SingletonPlugin, tk.DefaultDatasetForm):
+class ExampleIDatasetFormPlugin(tk.DefaultDatasetForm, p.SingletonPlugin):
     p.implements(p.IDatasetForm)
 
     def create_package_schema(self) -> Schema:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3702,9 +3702,9 @@
       }
     },
     "node_modules/pyright": {
-      "version": "1.1.282",
-      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.282.tgz",
-      "integrity": "sha512-qwlGhY/4wkZJJlxiwGzKL7Do6rVSOcXp72zplxJ76BbVIWuiKpGUeYIhLdONEAD22UwLTp8XvmARQzDnJ3EMSQ==",
+      "version": "1.1.303",
+      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.303.tgz",
+      "integrity": "sha512-uwJdp3KRidmpIgKKQtNL17F2noF2PsK6bxqd7WWrQE1AfCHI0j53B9lro63S/9oWWu18xfgTI4IqKO5S1srxhA==",
       "dev": true,
       "bin": {
         "pyright": "index.js",
@@ -8628,9 +8628,9 @@
       "dev": true
     },
     "pyright": {
-      "version": "1.1.282",
-      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.282.tgz",
-      "integrity": "sha512-qwlGhY/4wkZJJlxiwGzKL7Do6rVSOcXp72zplxJ76BbVIWuiKpGUeYIhLdONEAD22UwLTp8XvmARQzDnJ3EMSQ==",
+      "version": "1.1.303",
+      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.303.tgz",
+      "integrity": "sha512-uwJdp3KRidmpIgKKQtNL17F2noF2PsK6bxqd7WWrQE1AfCHI0j53B9lro63S/9oWWu18xfgTI4IqKO5S1srxhA==",
       "dev": true
     },
     "qs": {


### PR DESCRIPTION
Latest typing updates. Apart from obvious fixes:

* `ckan/lib/cli.py`: ignore types here completely. It's an activity migration script written for py2. It's kept just for reference and it can be even removed if somebody bothers to create a PR
* Removed a couple of senseless typechecks, like `if not isinstance(request_data, dict):` in `ckan/views/api.py`(impossible due to [this check](https://github.com/ckan/ckan/blob/master/ckan/views/api.py#L202))