### PR TITLE
[#6713] Fix datastore_search and dump datastore as json with null values

### DIFF
--- a/changes/6713.bugfix
+++ b/changes/6713.bugfix
@@ -1,1 +1,1 @@
-Fix downloading datastore resources as json with null values in columns
+Fix datastore_search + downloading datastore resources as json with null values

--- a/changes/6713.bugfix
+++ b/changes/6713.bugfix
@@ -1,1 +1,1 @@
-Fix downloading datastore resources as json with null values in json columns
+Fix downloading datastore resources as json with null values in columns

--- a/changes/6713.bugfix
+++ b/changes/6713.bugfix
@@ -1,0 +1,1 @@
+Fix downloading datastore resources as json with null values in json columns

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1939,7 +1939,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
             fmt = u'to_json({0})' if records_format == u'lists' else u'{0}'
             typ = fields_types.get(field_id, '')
             if typ == u'nested':
-                fmt = u'({0}).json'
+                fmt = u"coalesce(({0}).json,'null')"
             elif typ == u'timestamp':
                 fmt = u"to_char({0}, 'YYYY-MM-DD\"T\"HH24:MI:SS')"
                 if records_format == u'lists':

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1936,16 +1936,16 @@ class DatastorePostgresqlBackend(DatastoreBackend):
         select_cols = []
         records_format = data_dict.get(u'records_format')
         for field_id in field_ids:
-            fmt = u'to_json({0})' if records_format == u'lists' else u'{0}'
+            fmt = "coalesce(to_json({0}),'null')" if records_format == u'lists' else u'{0}'
             typ = fields_types.get(field_id, '')
-            if typ == u'nested':
-                fmt = u"coalesce(({0}).json,'null')"
-            elif typ == u'timestamp':
-                fmt = u"to_char({0}, 'YYYY-MM-DD\"T\"HH24:MI:SS')"
-                if records_format == u'lists':
-                    fmt = u"to_json({0})".format(fmt)
+            if typ == 'nested':
+                fmt = "coalesce(({0}).json,'null')"
+            elif typ == 'timestamp':
+                fmt = "to_char({0}, 'YYYY-MM-DD\"T\"HH24:MI:SS')"
+                if records_format == 'lists':
+                    fmt = f"coalesce(to_json({fmt}), 'null')"
             elif typ.startswith(u'_') or typ.endswith(u'[]'):
-                fmt = u'array_to_json({0})'
+                fmt = "coalesce(array_to_json({0}),'null')"
 
             if field_id in rank_columns:
                 select_cols.append((fmt + ' as {1}').format(

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1934,9 +1934,11 @@ class DatastorePostgresqlBackend(DatastoreBackend):
             rank_columns)
         where = _where_clauses(data_dict, fields_types)
         select_cols = []
-        records_format = data_dict.get(u'records_format')
+        records_format = data_dict.get('records_format')
         for field_id in field_ids:
-            fmt = "coalesce(to_json({0}),'null')" if records_format == u'lists' else u'{0}'
+            fmt = '{0}'
+            if records_format == 'lists':
+                fmt = "coalesce(to_json({0}),'null')"
             typ = fields_types.get(field_id, '')
             if typ == 'nested':
                 fmt = "coalesce(({0}).json,'null')"
@@ -1944,7 +1946,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
                 fmt = "to_char({0}, 'YYYY-MM-DD\"T\"HH24:MI:SS')"
                 if records_format == 'lists':
                     fmt = f"coalesce(to_json({fmt}), 'null')"
-            elif typ.startswith(u'_') or typ.endswith(u'[]'):
+            elif typ.startswith('_') or typ.endswith('[]'):
                 fmt = "coalesce(array_to_json({0}),'null')"
 
             if field_id in rank_columns:
@@ -1952,8 +1954,8 @@ class DatastorePostgresqlBackend(DatastoreBackend):
                     rank_columns[field_id], identifier(field_id)))
                 continue
 
-            if records_format == u'objects':
-                fmt += u' as {0}'
+            if records_format == 'objects':
+                fmt += ' as {0}'
             select_cols.append(fmt.format(identifier(field_id)))
 
         query_dict['distinct'] = data_dict.get('distinct', False)

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -2181,3 +2181,46 @@ class TestDatastoreSearchRecordsFormat(object):
         ranks = [r["rank"] for r in result["records"]]
         assert len(result["records"]) == 2
         assert len(set(ranks)) == 2
+
+    @pytest.mark.ckan_config("ckan.plugins", "datastore")
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    def test_results_with_nulls(self):
+        ds = factories.Dataset()
+        r = helpers.call_action(
+            "datastore_create",
+            resource={"package_id": ds["id"]},
+            fields=[
+                {"id": "num", "type": "numeric"},
+                {"id": "dt", "type": "timestamp"},
+                {"id": "txt", "type": "text"},
+                {"id": "lst", "type": "_text"},
+            ],
+            records=[
+                {"num": 10, "dt": "2020-01-01", "txt": "aaab", "lst": ["one", "two"]},
+                {"num": 9, "dt": "2020-01-02", "txt": "aaab"},
+                {"num": 9, "txt": "aaac", "lst": ["one", "two"]},
+                {},  # all nulls
+            ],
+        )
+        assert helpers.call_action(
+            "datastore_search",
+            resource_id=r["resource_id"],
+            records_format=u"lists",
+            sort=u"num nulls last, dt nulls last",
+        )["records"] == [
+            [2, 9, "2020-01-02T00:00:00", "aaab", None],
+            [3, 9, None, "aaac", ["one", "two"]],
+            [1, 10, "2020-01-01T00:00:00", "aaab", ["one", "two"]],
+            [4, None, None, None, None],
+        ]
+        assert helpers.call_action(
+            "datastore_search",
+            resource_id=r["resource_id"],
+            records_format=u"objects",
+            sort=u"num nulls last, dt nulls last",
+        )["records"] == [
+            {"_id":2, "num":9, "dt":"2020-01-02T00:00:00", "txt":"aaab", "lst":None},
+            {"_id":3, "num":9, "dt":None, "txt":"aaac", "lst":["one", "two"]},
+            {"_id":1, "num":10, "dt":"2020-01-01T00:00:00", "txt":"aaab", "lst":["one", "two"]},
+            {"_id":4, "num":None, "dt":None, "txt":None, "lst":None},
+        ]

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -2219,8 +2219,8 @@ class TestDatastoreSearchRecordsFormat(object):
             records_format=u"objects",
             sort=u"num nulls last, dt nulls last",
         )["records"] == [
-            {"_id":2, "num":9, "dt":"2020-01-02T00:00:00", "txt":"aaab", "lst":None},
-            {"_id":3, "num":9, "dt":None, "txt":"aaac", "lst":["one", "two"]},
-            {"_id":1, "num":10, "dt":"2020-01-01T00:00:00", "txt":"aaab", "lst":["one", "two"]},
-            {"_id":4, "num":None, "dt":None, "txt":None, "lst":None},
+            {"_id": 2, "num": 9, "dt": "2020-01-02T00:00:00", "txt": "aaab", "lst": None},
+            {"_id": 3, "num": 9, "dt": None, "txt": "aaac", "lst": ["one", "two"]},
+            {"_id": 1, "num": 10, "dt": "2020-01-01T00:00:00", "txt": "aaab", "lst": ["one", "two"]},
+            {"_id": 4, "num": None, "dt": None, "txt": None, "lst": None},
         ]


### PR DESCRIPTION
Fixes #6713 
Fixes #7037 

### Proposed fixes:

Use `coalesce()` to convert null values in json columns to `null` json values instead of not returning the row

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport