### PR TITLE
redirect dashboard activity stream, #7507

### DIFF
--- a/changes/7507.bugfix
+++ b/changes/7507.bugfix
@@ -1,0 +1,1 @@
+Redirect dashboard news feed to login page if not logged in

--- a/ckanext/activity/views.py
+++ b/ckanext/activity/views.py
@@ -810,6 +810,10 @@ def user_activity(id: str) -> str:
 
 @bp.route("/dashboard/", strict_slashes=False)
 def dashboard() -> str:
+    if tk.current_user.is_anonymous:
+        tk.h.flash_error(tk._(u'Not authorized to see this page'))
+        return tk.h.redirect_to(u'user.login')
+
     context = cast(
         Context,
         {


### PR DESCRIPTION
Fixes #7507, repeating #7518 but targeting master branch.

### Proposed fixes:

Redirect activity stream dashboard to the login page when not authenticated, in the same way as core dashboard.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
