### PR TITLE
Automatically close inactive issues/PRs

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -1,0 +1,24 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "1 1 1 * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 730
+          days-before-issue-close: 30
+          stale-issue-label: "Inactive?"
+          stale-issue-message: "This issue is stale because it has been open for 2 years with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 30 days since being marked as stale."
+          days-before-pr-stale: 730
+          days-before-pr-close: 30
+          stale-pr-message: "This PR is stale because it has been open for 2 years with no activity."
+          close-pr-message: "This PR was closed because it has been inactive for 30 days since being marked as stale."
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
A lot of issues have no sense anymore. I noticed that people sometimes close them manually, leaving comments like "This issue is closed due to inactivity". Let's do it automatically.

Time limits for PRs and issues can be configured separately. I set the same values:
* If an issue has had no comments for 2 years, it's marked as inactive.
* If an issue has no comments for 30 days after it's marked as inactive, it's closed