### PR TITLE
Set session scope for migrate_db_for fixture

### DIFF
--- a/changes/7563.misc
+++ b/changes/7563.misc
@@ -1,0 +1,1 @@
+`migrate_db_for` fixture has `session` scope

--- a/ckan/tests/pytest_ckan/fixtures.py
+++ b/ckan/tests/pytest_ckan/fixtures.py
@@ -236,7 +236,7 @@ def clean_db(reset_db):
     reset_db()
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def migrate_db_for():
     """Apply database migration defined by plugin.
 


### PR DESCRIPTION
`migrate_db_for` produces a function that applies DB migrations of the specific plugin. By default, it has a `function` scope, which means that for every test a new `migrate_db_for` function is created. 

This PR changes the scope of the fixture to `session`. As a result, there will be only one `migrate_db_for` function created during the single test session. With this change extension developers will be able to register extension-specific `non_clean_db` fixture, that initializes the database only once and makes tests faster in this way:

```
@pytest.fixture(scope="session")
def non_clean_db(reset_db, migrate_db_for):
    reset_db()
    migrate_db_for("my_plugin")
```