### PR TITLE
Set v3.8 as a minimal required python version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ defaults:
 jobs:
   test-python-3:
     docker:
-      - image: python:3.7-bullseye
+      - image: python:3.8-bullseye
         <<: *ckan_env
       - <<: *pg_image
       - <<: *redis_image

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -2,7 +2,7 @@ name: Cypress
 on: [pull_request]
 env:
   NODE_VERSION: '16'
-  PYTHON_VERSION: '3.7'
+  PYTHON_VERSION: '3.8'
 
 permissions:
   contents: read

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8'
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Check syntax

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -2,7 +2,7 @@ name: Check types
 on: [pull_request]
 env:
   NODE_VERSION: '16'
-  PYTHON_VERSION: '3.7'
+  PYTHON_VERSION: '3.8'
 
 permissions:
   contents: read

--- a/.github/workflows/towncrier.yml
+++ b/.github/workflows/towncrier.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
           cache: 'pip'
       - name: Install python deps
         run: pip install -r requirements.txt -r dev-requirements.txt -e.

--- a/changes/7564.removal
+++ b/changes/7564.removal
@@ -1,0 +1,1 @@
+Python v3.7 is no longer supported

--- a/ckan/common.py
+++ b/ckan/common.py
@@ -12,9 +12,7 @@ from __future__ import annotations
 import logging
 from collections.abc import MutableMapping, Iterable
 
-from typing import (
-    Any, Optional, TYPE_CHECKING,
-    TypeVar, cast, overload, Union)
+from typing import Any, Optional, TypeVar, cast, overload, Union
 from typing_extensions import Literal
 
 import flask
@@ -31,11 +29,6 @@ import ckan.lib.maintain as maintain
 from ckan.config.declaration import Declaration
 from ckan.types import Model, Request
 
-
-if TYPE_CHECKING:
-    # starting from python 3.7 the following line can be used without any
-    # conditions after `annotation` import from `__future__`
-    MutableMapping = MutableMapping[str, Any]
 
 SENTINEL = {}
 
@@ -78,7 +71,7 @@ def ungettext(*args: Any, **kwargs: Any) -> str:
     return flask_ungettext(*args, **kwargs)
 
 
-class CKANConfig(MutableMapping):
+class CKANConfig(MutableMapping[str, Any]):
     u'''Main CKAN configuration object
 
     This is a dict-like object that also proxies any changes to the

--- a/ckan/common.py
+++ b/ckan/common.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 import logging
 from collections.abc import MutableMapping, Iterable
 
-from typing import Any, Optional, TypeVar, cast, overload, Union
+from typing import (
+    Any, Optional, TYPE_CHECKING,
+    TypeVar, cast, overload, Union)
 from typing_extensions import Literal
 
 import flask
@@ -29,6 +31,9 @@ import ckan.lib.maintain as maintain
 from ckan.config.declaration import Declaration
 from ckan.types import Model, Request
 
+
+if TYPE_CHECKING:
+    MutableMapping = MutableMapping[str, Any]
 
 SENTINEL = {}
 
@@ -71,7 +76,7 @@ def ungettext(*args: Any, **kwargs: Any) -> str:
     return flask_ungettext(*args, **kwargs)
 
 
-class CKANConfig(MutableMapping[str, Any]):
+class CKANConfig(MutableMapping):
     u'''Main CKAN configuration object
 
     This is a dict-like object that also proxies any changes to the

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/setup.cfg
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/setup.cfg
@@ -11,7 +11,6 @@ license = AGPL
 classifiers =
             Development Status :: 4 - Beta
             License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)
-            Programming Language :: Python :: 3.7
             Programming Language :: Python :: 3.8
             Programming Language :: Python :: 3.9
             Programming Language :: Python :: 3.10

--- a/doc/maintaining/installing/index.rst
+++ b/doc/maintaining/installing/index.rst
@@ -46,14 +46,14 @@ See :doc:`install-from-source`.
 Docker Compose install
 ======================
 
-The `ckan-docker <https://github.com/ckan/ckan-docker>`_ repository contains the necessary scripts 
+The `ckan-docker <https://github.com/ckan/ckan-docker>`_ repository contains the necessary scripts
 and images to install CKAN using Docker Compose. It provides a clean and quick way to deploy a
 standard CKAN instance pre-configured with the :doc:`Filestore <../filestore>` and :doc:`../datastore`.
 It also allows the addition (and customization) of extensions. The emphasis leans more towards
 a Development environment, however the base install can be used as the foundation for progressing
-to a Production environment. Please note that a fully-fledged CKAN Production system using Docker containers is 
+to a Production environment. Please note that a fully-fledged CKAN Production system using Docker containers is
 beyond the scope of the provided setup.
- 
+
 You should install CKAN from Docker Compose if:
 
 * You want to install CKAN with less effort than a source install and more flexibility than a

--- a/doc/maintaining/installing/install-from-package.rst
+++ b/doc/maintaining/installing/install-from-package.rst
@@ -13,7 +13,7 @@ At the end of the installation process you will end up with two running web
 applications, CKAN itself and the DataPusher, a separate service for automatically
 importing data to CKAN's :doc:`/maintaining/datastore`. Additionally, there will be a process running the worker for running :doc:`/maintaining/background-tasks`. All these processes will be managed by `Supervisor <https://supervisord.org/>`_.
 
-For Python 3 installations, the minimum Python version required is 3.7.
+For Python 3 installations, the minimum Python version required is 3.8.
 
 Host ports requirements:
 
@@ -211,9 +211,9 @@ your CKAN site.
 
 .. note::
 
-   There may be a ``PermissionError: [Errno 13] Permission denied:`` message when restarting supervisor or 
-   accessing CKAN via a browser for the first time. This happens when a different user is used to execute 
-   the web server process than the user who installed CKAN and the support software. A workaround would be to 
-   open up the permissions on the ``/usr/lib/ckan/default/src/ckan/ckan/public/base/i18n/`` directory 
-   so that this user could write the .js files into it. Accessing CKAN will generate these files for a new 
+   There may be a ``PermissionError: [Errno 13] Permission denied:`` message when restarting supervisor or
+   accessing CKAN via a browser for the first time. This happens when a different user is used to execute
+   the web server process than the user who installed CKAN and the support software. A workaround would be to
+   open up the permissions on the ``/usr/lib/ckan/default/src/ckan/ckan/public/base/i18n/`` directory
+   so that this user could write the .js files into it. Accessing CKAN will generate these files for a new
    install, or you could run ``ckan -c /etc/ckan/default/ckan.ini translation js`` to explicitly generate them.

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -39,7 +39,7 @@ wiki page for help):
 =====================  ===============================================
 Package                Description
 =====================  ===============================================
-Python                 `The Python programming language, v3.7 or newer <https://www.python.org/getit/>`_
+Python                 `The Python programming language, v3.8 or newer <https://www.python.org/getit/>`_
 |postgres|             `The PostgreSQL database system, v10 or newer <https://www.postgresql.org/docs/10/libpq.html>`_
 libpq                  `The C programmer's interface to PostgreSQL <http://www.postgresql.org/docs/8.1/static/libpq.html>`_
 pip                    `A tool for installing and managing Python packages <https://pip.pypa.io/en/stable/>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ testpaths = ["ckan", "ckanext"]
 addopts = "--strict-markers --pdbcls=IPython.terminal.debugger:TerminalPdb -p no:ckan"
 
 [tool.pyright]
-pythonVersion = "3.7"
+pythonVersion = "3.8"
 include = ["ckan", "ckanext"]
 exclude = [
     "**/test*",

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,13 +18,12 @@ classifiers =
             Development Status :: 5 - Production/Stable
             License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)
             Programming Language :: Python
-            Programming Language :: Python :: 3.7
             Programming Language :: Python :: 3.8
             Programming Language :: Python :: 3.9
             Programming Language :: Python :: 3.10
 
 [options]
-python_requires = >= 3.7
+python_requires = >= 3.8
 install_requires =
                  setuptools >= 44.1.0
 packages = find:


### PR DESCRIPTION
Python v3.7 reaches EOL on 27 June. CKAN v2.11 will be released around this date, so we can increase minimal python version