### PR TITLE
Close solr sessions correctly after use to suppress ResourceWarning logs

### DIFF
--- a/changes/7569.bugfix
+++ b/changes/7569.bugfix
@@ -1,0 +1,1 @@
+Close Solr sessions correctly after use to suppress warnings.

--- a/ckan/lib/search/common.py
+++ b/ckan/lib/search/common.py
@@ -70,6 +70,8 @@ def is_available() -> bool:
     except Exception as e:
         log.exception(e)
         return False
+    finally:
+        conn.get_session().close()
     return True
 
 

--- a/ckan/lib/search/common.py
+++ b/ckan/lib/search/common.py
@@ -67,11 +67,10 @@ def is_available() -> bool:
     try:
         conn = make_connection()
         conn.search(q="*:*", rows=1)
+        conn.get_session().close()
     except Exception as e:
         log.exception(e)
         return False
-    finally:
-        conn.get_session().close()
     return True
 
 

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -61,6 +61,8 @@ def clear_index() -> None:
         err = 'SOLR %r exception: %r' % (conn.url, e)
         log.error(err)
         raise SearchIndexError(err)
+    finally:
+        conn.get_session().close()
 
 
 class SearchIndex(object):
@@ -317,6 +319,8 @@ class PackageSearchIndex(SearchIndex):
                 conn.url, str(e))
             log.error(err)
             raise SearchIndexError(err)
+        finally:
+            conn.get_session().close()
 
         commit_debug_msg = 'Not committed yet' if defer_commit else 'Committed'
         log.debug('Updated index for %s [%s]' % (pkg_dict.get('name'), commit_debug_msg))
@@ -328,6 +332,8 @@ class PackageSearchIndex(SearchIndex):
         except Exception as e:
             log.exception(e)
             raise SearchIndexError(e)
+        finally:
+            conn.get_session().close()
 
     def delete_package(self, pkg_dict: dict[str, Any]) -> None:
         conn = make_connection()
@@ -339,3 +345,5 @@ class PackageSearchIndex(SearchIndex):
         except Exception as e:
             log.exception(e)
             raise SearchIndexError(e)
+        finally:
+            conn.get_session().close()

--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -291,6 +291,7 @@ class PackageSearchQuery(SearchQuery):
 
         conn = make_connection()
         data = conn.search(query, fq=fq, rows=max_results, fl='id')
+        conn.get_session().close()
         return [r.get('id') for r in data.docs]
 
     def get_index(self, reference: str) -> dict[str, Any]:
@@ -314,6 +315,8 @@ class PackageSearchQuery(SearchQuery):
             raise SearchError(
                 'SOLR returned an error running query: %r Error: %r' %
                 (query, e))
+        finally:
+            conn.get_session().close()
 
         if solr_response.hits == 0:
             raise SearchError('Dataset not found in the search index: %s' %
@@ -424,6 +427,9 @@ class PackageSearchQuery(SearchQuery):
                     raise SearchQueryError('Invalid "sort" parameter')
             raise SearchError('SOLR returned an error running query: %r Error: %r' %
                               (query, e))
+        finally:
+            conn.get_session().close()
+
         self.count = solr_response.hits
         self.results = cast("list[Any]", solr_response.docs)
 


### PR DESCRIPTION
Fixes #7569

### Proposed fixes:

Add `finally` to all cases of instantiating Solr connection:

```python
finally:
    conn.get_session().close()
```

This should close the Solr connection and prevent **ResourceWarning** logs.
