### PR TITLE
Datastore Re-Index with Validated Dict can Cause SOLR Errors

### DIFF
--- a/changes/7571.bugfix
+++ b/changes/7571.bugfix
@@ -1,0 +1,2 @@
+Fixed context in `set_datastore_active_flag` to
+solve possible solr errors during `index_package`


### PR DESCRIPTION
fix(index): solved issues with datastore using validated packages;

- Do not use validated packages to re-index during datastore active flag.
- Removed try/catch.

Fixes #

It is possible that using validated package dicts causes solr errors during the re-index called via the datastore set active flag. Example:
```
2023-05-02 13:35:42,699 ERROR [ckanext.xloader.jobs] xloader error: Solr returned an error: Solr responded with an error (HTTP 400): [Reason: Error:[doc=13aab031ec4958fee020727cc20e80e3]  Unknown operation for the an atomic update: fr], Traceback (most recent call last):
  File "/srv/app/ckan/registry/src/ckan/ckan/lib/search/index.py", line 314, in index_package
    conn.add(docs=[pkg_dict], commit=commit)
  File "/srv/app/ckan/registry/lib/python3.9/site-packages/pysolr.py", line 1042, in add
    return self._update(
  File "/srv/app/ckan/registry/lib/python3.9/site-packages/pysolr.py", line 568, in _update
    return self._send_request(
  File "/srv/app/ckan/registry/lib/python3.9/site-packages/pysolr.py", line 463, in _send_request
    raise SolrError(error_message % (resp.status_code, solr_message))
pysolr.SolrError: Solr responded with an error (HTTP 400): [Reason: Error:[doc=13aab031ec4958fee020727cc20e80e3]  Unknown operation for the an atomic update: fr]
```

### Proposed fixes:

Use the same context that the search index rebuild uses. This sets the context to not use validated packages, do not use cache, and ignores auth. We have already passed many auths to get to this point so that should be fine.

A try/catch has also been removed as the ignore auth will now prevent any `NotAuthorized` exceptions to be raised. And the `NotFound` would not really happen as the package and resources have already been gathered from the database and passed into the set datastore flag method.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
