### PR TITLE
Fix Sphinx extension for Python 3.11 support

### DIFF
--- a/ckan/plugins/toolkit_sphinx_extension.py
+++ b/ckan/plugins/toolkit_sphinx_extension.py
@@ -62,9 +62,7 @@ def format_function(name: str,
 
     # Get the arguments of the function, as a string like:
     # "(foo, bar=None, ...)"
-    argstring = inspect.formatargspec(
-        inspect.getfullargspec(function).args
-    )
+    argstring = str(inspect.signature(function))
 
     docstring = docstring or inspect.getdoc(function)
     if docstring is None:


### PR DESCRIPTION
We use an extension to generate the documentation for the toolkit methods, and that module used the `inspect.formatargspec()` method, which has been deprecated since py 3.5, and was dropped in py 3.11
