### PR TITLE
Changed german translation

### DIFF
--- a/ckan/i18n/de/LC_MESSAGES/ckan.po
+++ b/ckan/i18n/de/LC_MESSAGES/ckan.po
@@ -2065,7 +2065,7 @@ msgstr "z.B. Umwelt"
 
 #: ckan/templates/home/snippets/search.html:7
 msgid "Search data"
-msgstr "Suchdaten"
+msgstr "Datensuche"
 
 #: ckan/templates/home/snippets/search.html:9
 msgid "Search datasets"


### PR DESCRIPTION
Changed the german translation of
   msgid "Search data"
from
   msgstr "Suchdaten"
to
   msgstr "Datensuche" 
.

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
