### PR TITLE
Fix documentation build for master branch

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,18 +1,23 @@
+# .readthedocs.yaml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required
 version: 2
 
-# Build documentation in the doc/ directory with Sphinx
-sphinx:
-   configuration: doc/conf.py
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  apt_packages:
+      - libmagic-dev
+  tools:
+    python: "3.10"
 
-# Additional formats for download
+sphinx:
+  configuration: doc/conf.py
+
 formats: all
 
-# Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.7
    install:
    - requirements: requirements-docs.txt


### PR DESCRIPTION
It had been broken since we upgraded the Flask requirement. We just needed to bump the Python version (3.7) used to build the docs. Cleaned the RTD conf file a bit

Docs build fine now: https://docs.ckan.org/en/rtd-config-file/

