### PR TITLE
fix: `generate fake-data` with custom factory accepts params

### DIFF
--- a/changes/7607.bugfix
+++ b/changes/7607.bugfix
@@ -1,0 +1,1 @@
+`ckan generate fake-data --factory-class x.y.z:Factory` does not accept field values.

--- a/ckan/tests/cli/test_generate.py
+++ b/ckan/tests/cli/test_generate.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import pytest
+
+from ckan import model
+from ckan.cli.generate import generate
+from ckan.tests.helpers import CKANCliRunner
+
+
+@pytest.mark.usefixtures("clean_db")
+class TestFakeData:
+    def test_generate_using_alias(self, cli: CKANCliRunner):
+        """Built-in aliases available out-of-the-box, without additional
+        parameters.
+
+        """
+        result = cli.invoke(generate, ["fake-data", "organization"])
+
+        assert not result.exit_code, result.output
+
+        org = model.Session.query(model.Group).one()
+        assert org.title in result.output
+
+    def test_generate_using_factory_class_argument(self, cli: CKANCliRunner):
+        """Factory can be specified via import-string."""
+        result = cli.invoke(
+            generate, ["fake-data", "ckan.tests.factories:Dataset"]
+        )
+
+        assert not result.exit_code, result.output
+
+        dataset = model.Session.query(model.Package).one()
+        assert dataset.title in result.output
+
+    def test_generate_using_factory_class_option(self, cli: CKANCliRunner):
+        """Factory can be specified via import-string using deprecated option."""
+        result = cli.invoke(
+            generate,
+            ["fake-data", "--factory-class", "ckan.tests.factories:Dataset"],
+        )
+
+        assert not result.exit_code, result.output
+
+        dataset = model.Session.query(model.Package).one()
+        assert dataset.title in result.output
+
+    def test_generate_using_alias_and_params(self, cli: CKANCliRunner, faker):
+        """Alias accepts params for entity fields."""
+        name = faker.sentence()
+        result = cli.invoke(
+            generate, ["fake-data", "resource", f"--name={name}"]
+        )
+
+        assert not result.exit_code, result.output
+        assert name in result.output
+
+        resource = model.Session.query(model.Resource).one()
+        assert resource.name == name
+
+    def test_generate_using_factory_class_and_params(
+        self, cli: CKANCliRunner, faker
+    ):
+        """Factory class accepts params for entity fields."""
+        name = faker.name()
+        result = cli.invoke(
+            generate,
+            ["fake-data", "ckan.tests.factories:User", f"--fullname={name}"],
+        )
+
+        assert not result.exit_code, result.output
+        assert name in result.output
+
+        user = model.Session.query(model.User).filter_by(fullname=name).one()
+        assert user.fullname == name


### PR DESCRIPTION
`ckan generate fake-data` accepts the factory name in one of the forms:
* `generate fake-data alias`
* `generate fake-data --factory-class module.name:Class`

Both commands are supposed to accept an arbitrary number of additional arguments that specify values for files:
```
ckan generate fake-data dataset --title="My Dataset" --notes="Description"
```

But due to changes in `click` now the form with `--factory-class` doesn't accept such extras. 

This PR extends the syntax of this command and allows passing `factory-flag` as an alias. i.e:

```sh
# instead of the old form
ckan generate fake-data --factory-class x.y.z:Dataset

# use the short form
ckan generate fake-data x.y.z:Dataset
```

This new form works with extra params and does not conflict with alias style (because it's easy to tell the difference between aliases `dataset`/`organization`/`user` and import path `x.y.z:Class`).


The old form, with `--factory-class` is still available for compatibility. Bit its help-text clearly states that this option is deprecated and it does not accept extra parameters.