### PR TITLE
Controlled iteration order for interfaces

### DIFF
--- a/changes/7609.feature
+++ b/changes/7609.feature
@@ -1,5 +1,5 @@
 :py:class:`~ckan.plugins.interfaces.Interface` has
-`ckan_reverse_iteration_order` property. When it set to `True`,
+`_reverse_iteration_order` property. When it set to `True`,
 :py:class:`~ckan.plugins.core.PluginImplementations(interface)` will traverse
 plugins implementing the interface in reverse order.
 

--- a/changes/7609.feature
+++ b/changes/7609.feature
@@ -1,0 +1,12 @@
+:py:class:`~ckan.plugins.interfaces.Interface` has
+`ckan_reverse_iteration_order` property. When it set to `True`,
+:py:class:`~ckan.plugins.core.PluginImplementations(interface)` will traverse
+plugins implementing the interface in reverse order.
+
+Interfaces that are traversed in reverse order:
+
+* IApiToken
+* IConfigDeclaration
+* IConfigurer
+* ITranslation
+* IValidators

--- a/changes/7609.feature
+++ b/changes/7609.feature
@@ -1,11 +1,6 @@
-:py:class:`~ckan.plugins.interfaces.Interface` has
-`_reverse_iteration_order` property. When it set to `True`,
-:py:class:`~ckan.plugins.core.PluginImplementations(interface)` will traverse
-plugins implementing the interface in reverse order.
+Following interfaces are iterated in reverse order when using
+:py:class:`~ckan.plugins.core.PluginImplementations(interface)`:
 
-Interfaces that are traversed in reverse order:
-
-* IApiToken
 * IConfigDeclaration
 * IConfigurer
 * ITranslation

--- a/ckan/config/declaration/__init__.py
+++ b/ckan/config/declaration/__init__.py
@@ -112,9 +112,7 @@ class Declaration:
 
         self._reset()
         self.load_core_declaration()
-        for plugin in reversed(
-            list(p.PluginImplementations(p.IConfigDeclaration))
-        ):
+        for plugin in p.PluginImplementations(p.IConfigDeclaration):
             plugin.declare_config_options(self, Key())
         self._seal()
 

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -129,7 +129,7 @@ def update_config() -> None:
     config["plugin_template_paths"] = []
     config["plugin_public_paths"] = []
 
-    for plugin in reversed(list(p.PluginImplementations(p.IConfigurer))):
+    for plugin in p.PluginImplementations(p.IConfigurer):
         # must do update in place as this does not work:
         # config = plugin.update_config(config)
         plugin.update_config(config)

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -210,7 +210,7 @@ def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:
         cast("tuple[str, str]", (_ckan_i18n_dir, u'ckan'))
     ] + [
         (p.i18n_directory(), p.i18n_domain())
-        for p in reversed(list(PluginImplementations(ITranslation)))
+        for p in PluginImplementations(ITranslation)
     ]
 
     i18n_dirs, i18n_domains = zip(*pairs)

--- a/ckan/lib/api_token.py
+++ b/ckan/lib/api_token.py
@@ -124,7 +124,7 @@ def get_user_from_token(token: str,
     # do preprocessing in reverse order, allowing onion-like
     # "unwrapping" of the data, added during postprocessing, when
     # token was created
-    for plugin in reversed(list(_get_plugins())):
+    for plugin in _get_plugins():
         data = plugin.preprocess_api_token(data)
     if not data or u"jti" not in data:
         return None

--- a/ckan/lib/api_token.py
+++ b/ckan/lib/api_token.py
@@ -121,9 +121,11 @@ def get_user_from_token(token: str,
     data = decode(token)
     if not data:
         return None
-    # do preprocessing in reverse order, allowing onion-like
-    # "unwrapping" of the data, added during postprocessing, when
-    # token was created
+    # do preprocessing in reverse order, allowing onion-like "unwrapping" of
+    # the data, added during postprocessing, when token was
+    # created. `Interface._reverse_iteration_order` cannot be used here,
+    # because all other methods of IApiToken should be executed in a normal
+    # order and only `IApiToken.preprocess_api_token` must be different.
     for plugin in reversed(list(_get_plugins())):
         data = plugin.preprocess_api_token(data)
     if not data or u"jti" not in data:

--- a/ckan/lib/api_token.py
+++ b/ckan/lib/api_token.py
@@ -124,7 +124,7 @@ def get_user_from_token(token: str,
     # do preprocessing in reverse order, allowing onion-like
     # "unwrapping" of the data, added during postprocessing, when
     # token was created
-    for plugin in _get_plugins():
+    for plugin in reversed(list(_get_plugins())):
         data = plugin.preprocess_api_token(data)
     if not data or u"jti" not in data:
         return None

--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -807,7 +807,7 @@ def get_validator(
         _validators_cache.update(converters)
         _validators_cache.update({'OneOf': _validators_cache['one_of']})
 
-        for plugin in reversed(list(p.PluginImplementations(p.IValidators))):
+        for plugin in p.PluginImplementations(p.IValidators):
             for name, fn in plugin.get_validators().items():
                 log.debug('Validator function {0} from plugin {1} was inserted'
                           .format(name, plugin.name))

--- a/ckan/plugins/core.py
+++ b/ckan/plugins/core.py
@@ -117,6 +117,9 @@ class PluginImplementations(ExtensionPoint, Generic[TInterface]):
             # add to the end of the iterator
             ordered_plugins.extend(plugin_lookup.values())
 
+        if self.interface.ckan_reverse_iteration_order:
+            ordered_plugins = list(reversed(ordered_plugins))
+
         return iter(ordered_plugins)
 
 

--- a/ckan/plugins/core.py
+++ b/ckan/plugins/core.py
@@ -117,7 +117,7 @@ class PluginImplementations(ExtensionPoint, Generic[TInterface]):
             # add to the end of the iterator
             ordered_plugins.extend(plugin_lookup.values())
 
-        if self.interface.ckan_reverse_iteration_order:
+        if self.interface._reverse_iteration_order:
             ordered_plugins = list(reversed(ordered_plugins))
 
         return iter(ordered_plugins)

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -6,8 +6,10 @@ extend CKAN.
 '''
 from __future__ import annotations
 
-from typing import (Any, Callable, Iterable, Mapping, Optional, Sequence,
-                    TYPE_CHECKING, Type, Union)
+from typing import (
+    Any, Callable, ClassVar, Iterable, Mapping, Optional, Sequence,
+    TYPE_CHECKING, Type, Union,
+)
 
 from pyutilib.component.core import Interface as _pca_Interface
 
@@ -74,6 +76,9 @@ class Interface(_pca_Interface):
     of subclasses of Interface are recorded, and these
     classes are used to define extension points.
     '''
+
+    # force PluginImplementations to iterate over interface in reverse order
+    ckan_reverse_iteration_order: ClassVar[bool] = False
 
     @classmethod
     def provided_by(cls, instance: "SingletonPlugin") -> bool:
@@ -743,6 +748,8 @@ class IConfigDeclaration(Interface):
 
     """
 
+    ckan_reverse_iteration_order = True
+
     def declare_config_options(self, declaration: Declaration, key: Key):
         """Register extra config options.
 
@@ -789,6 +796,8 @@ class IConfigurer(Interface):
 
     See also :py:class:`IConfigurable`.
     '''
+
+    ckan_reverse_iteration_order = True
 
     def update_config(self, config: 'CKANConfig') -> None:
         u'''
@@ -861,6 +870,9 @@ class IValidators(Interface):
     Add extra validators to be returned by
     :py:func:`ckan.plugins.toolkit.get_validator`.
     '''
+
+    ckan_reverse_iteration_order = True
+
     def get_validators(self) -> dict[str, Validator]:
         u'''Return the validator functions provided by this plugin.
 
@@ -1711,6 +1723,9 @@ class ITranslation(Interface):
     u'''
     Allows extensions to provide their own translation strings.
     '''
+
+    ckan_reverse_iteration_order = True
+
     def i18n_directory(self) -> str:
         u'''Change the directory of the .mo translation files'''
         return ''
@@ -1892,6 +1907,7 @@ class IApiToken(Interface):
 
 
     """
+    ckan_reverse_iteration_order = True
 
     def create_api_token_schema(self, schema: Schema) -> Schema:
         u'''Return the schema for validating new API tokens.

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -78,7 +78,7 @@ class Interface(_pca_Interface):
     '''
 
     # force PluginImplementations to iterate over interface in reverse order
-    ckan_reverse_iteration_order: ClassVar[bool] = False
+    _reverse_iteration_order: ClassVar[bool] = False
 
     @classmethod
     def provided_by(cls, instance: "SingletonPlugin") -> bool:
@@ -748,7 +748,9 @@ class IConfigDeclaration(Interface):
 
     """
 
-    ckan_reverse_iteration_order = True
+    # plugins from the beginning of the plugin list can declare missing options
+    # or override existing.
+    _reverse_iteration_order = True
 
     def declare_config_options(self, declaration: Declaration, key: Key):
         """Register extra config options.
@@ -797,7 +799,9 @@ class IConfigurer(Interface):
     See also :py:class:`IConfigurable`.
     '''
 
-    ckan_reverse_iteration_order = True
+    # plugins from the beginning of the plugin list can alter configuration of
+    # plugins from the end of the list
+    _reverse_iteration_order = True
 
     def update_config(self, config: 'CKANConfig') -> None:
         u'''
@@ -871,7 +875,9 @@ class IValidators(Interface):
     :py:func:`ckan.plugins.toolkit.get_validator`.
     '''
 
-    ckan_reverse_iteration_order = True
+    # plugins from the beginning of the plugin list can override validators
+    # registered by plugins from the end of the list
+    _reverse_iteration_order = True
 
     def get_validators(self) -> dict[str, Validator]:
         u'''Return the validator functions provided by this plugin.
@@ -1724,7 +1730,11 @@ class ITranslation(Interface):
     Allows extensions to provide their own translation strings.
     '''
 
-    ckan_reverse_iteration_order = True
+    # replicate template-order. Templates from the plugins located in the
+    # beginning of the list has higher precedence. It means that other
+    # components affecting UI, such as translations, should behave in similar
+    # manner.
+    _reverse_iteration_order = True
 
     def i18n_directory(self) -> str:
         u'''Change the directory of the .mo translation files'''
@@ -1907,7 +1917,11 @@ class IApiToken(Interface):
 
 
     """
-    ckan_reverse_iteration_order = True
+
+    # plugins from the beginning of the plugins list should be able to
+    # override/delete customizations to API Tokens that were done by other
+    # plugins.
+    _reverse_iteration_order = True
 
     def create_api_token_schema(self, schema: Schema) -> Schema:
         u'''Return the schema for validating new API tokens.

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1918,11 +1918,6 @@ class IApiToken(Interface):
 
     """
 
-    # plugins from the beginning of the plugins list should be able to
-    # override/delete customizations to API Tokens that were done by other
-    # plugins.
-    _reverse_iteration_order = True
-
     def create_api_token_schema(self, schema: Schema) -> Schema:
         u'''Return the schema for validating new API tokens.
 

--- a/ckan/tests/plugins/test_core.py
+++ b/ckan/tests/plugins/test_core.py
@@ -44,36 +44,31 @@ class FooBarImpl(object):
     plugins.implements(IBar)
 
 
-@pytest.mark.usefixtures(u"with_plugins")
+@pytest.mark.usefixtures("with_plugins")
 @pytest.mark.ckan_config(
-    u"ckan.plugins",
-    u"example_idatasetform_v1 example_idatasetform_v2 example_idatasetform_v3")
-def test_plugins_order_in_pluginimplementations():
+    "ckan.plugins",
+    "example_idatasetform_v1 example_idatasetform_v3 example_idatasetform_v2")
+class TestPluginsOrderInPluginImplementations:
+    def test_order_matches_config(self):
+        assert (
+            [plugin.name for plugin in plugins.PluginImplementations(plugins.IDatasetForm)] ==
+            [
+                "example_idatasetform_v1",
+                "example_idatasetform_v3",
+                "example_idatasetform_v2",
+            ]
+        )
 
-    assert (
-        [plugin.name for plugin in plugins.PluginImplementations(plugins.IDatasetForm)] ==
-        [
-            u"example_idatasetform_v1",
-            u"example_idatasetform_v2",
-            u"example_idatasetform_v3"
-        ]
-    )
-
-
-@pytest.mark.usefixtures(u"with_plugins")
-@pytest.mark.ckan_config(
-    u"ckan.plugins",
-    u"example_idatasetform_v1 example_idatasetform_v3 example_idatasetform_v2")
-def test_plugins_order_in_pluginimplementations_matches_config():
-
-    assert (
-        [plugin.name for plugin in plugins.PluginImplementations(plugins.IDatasetForm)] ==
-        [
-            u"example_idatasetform_v1",
-            u"example_idatasetform_v3",
-            u"example_idatasetform_v2"
-        ]
-    )
+    def test_reverse_order_by_interface_attribute(self, monkeypatch):
+        monkeypatch.setattr(plugins.IDatasetForm, "ckan_reverse_iteration_order", True)
+        assert (
+            [plugin.name for plugin in plugins.PluginImplementations(plugins.IDatasetForm)] ==
+            [
+                "example_idatasetform_v2",
+                "example_idatasetform_v3",
+                "example_idatasetform_v1",
+            ]
+        )
 
 
 def test_implemented_by():

--- a/ckan/tests/plugins/test_core.py
+++ b/ckan/tests/plugins/test_core.py
@@ -60,7 +60,7 @@ class TestPluginsOrderInPluginImplementations:
         )
 
     def test_reverse_order_by_interface_attribute(self, monkeypatch):
-        monkeypatch.setattr(plugins.IDatasetForm, "ckan_reverse_iteration_order", True)
+        monkeypatch.setattr(plugins.IDatasetForm, "_reverse_iteration_order", True)
         assert (
             [plugin.name for plugin in plugins.PluginImplementations(plugins.IDatasetForm)] ==
             [


### PR DESCRIPTION
Add `ckan_reverse_iteration_order` flag to the Interface class. Whenever it is set to `True`, `PluginImplementations` will return plugins implementing this interface in reverse order.


It reduces the risk of writing code where iteration goes not in the expected order. In addition, it makes more explicit, which interfaces are iterated in reverse order. 
Finally(but I'd rather not mention it in the docs), it allows you to write `IActions.ckan_reverse_iteration_order = True` in order to revert the order of plugins during action registration(just an example, of course, you can do it with any interface). It may save someone who wants to patch things locally if we decide to change the order for a particular interface in the future or discover, that order was non-intentionally changed

Interfaces that are traversed in reverse order:

* IConfigDeclaration
* IConfigurer
* IValidators
* ITranslation
