### PR TITLE
Webasset fixes

### DIFF
--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -1380,6 +1380,12 @@ groups:
           when the asset is used for the first time. All subsequent requests to the
           asset will use the existing file. CKAN stores the compiled webassets in the file system, in the path specified by this config option.
 
+      - key: ckan.webassets.url
+        example: /serve/assets/from/here
+        default: /webassets
+        description: |
+          URL path for endpoint that serves webassets.
+
       - key: ckan.webassets.use_x_sendfile
         type: bool
         example: true

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -21,7 +21,7 @@ from ckan.lib.redis import is_redis_available
 import ckan.lib.search as search
 import ckan.logic as logic
 import ckan.authz as authz
-from ckan.lib.webassets_tools import webassets_init
+from ckan.lib.webassets_tools import webassets_init, register_core_assets
 from ckan.lib.i18n import build_js_translations
 
 from ckan.common import CKANConfig, config, config_declaration
@@ -110,6 +110,8 @@ def update_config() -> None:
     plugin might have changed the config values (for instance it might
     change ckan.site_url) '''
 
+    # read envvars before config declarations in order to apply normalization
+    # to the values, when declarations loaded
     for option in CONFIG_FROM_ENV_VARS:
         from_env = os.environ.get(CONFIG_FROM_ENV_VARS[option], None)
         if from_env:
@@ -119,8 +121,6 @@ def update_config() -> None:
     config_declaration.make_safe(config)
     config_declaration.normalize(config)
 
-    webassets_init()
-
     # these are collections of all template/public paths registered by
     # extensions. Each call to `tk.add_template_directory` or
     # `tk.add_public_directory` updates these collections. We have to reset
@@ -129,10 +129,17 @@ def update_config() -> None:
     config["plugin_template_paths"] = []
     config["plugin_public_paths"] = []
 
+    # initialize webassets environment because plugins will register assets
+    # inside IConfigured.update_config
+    webassets_init()
     for plugin in reversed(list(p.PluginImplementations(p.IConfigurer))):
         # must do update in place as this does not work:
         # config = plugin.update_config(config)
         plugin.update_config(config)
+
+    # register core assets here, giving plugins an opportunity to override core
+    # assets inside IConfigurer.update_config
+    register_core_assets()
 
     _, errors = config_declaration.validate(config)
     if errors:

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -587,4 +587,5 @@ def _setup_webassets(app: CKANApp):
     def webassets(path: str):
         return send_from_directory(webassets_folder, path)
 
-    app.add_url_rule('/webassets/<path:path>', 'webassets.index', webassets)
+    path = config["ckan.webassets.url"].rstrip("/")
+    app.add_url_rule(f'{path}/<path:path>', 'webassets.index', webassets)

--- a/ckan/lib/app_globals.py
+++ b/ckan/lib/app_globals.py
@@ -12,7 +12,7 @@ import ckan
 import ckan.model as model
 from ckan.logic.schema import update_configuration_schema
 from ckan.common import asbool, config, aslist
-
+from ckan.lib.webassets_tools import is_registered
 
 log = logging.getLogger(__name__)
 
@@ -81,10 +81,7 @@ def set_theme(asset: str) -> None:
 
     If asset is not registered, use default theme instead.
     '''
-    from ckan.lib.webassets_tools import env
-
-    assert env
-    if asset not in env:
+    if not is_registered(asset):
         log.error(
             "Asset '%s' does not exist. Fallback to '%s'",
             asset, DEFAULT_THEME_ASSET

--- a/ckan/lib/webassets_tools.py
+++ b/ckan/lib/webassets_tools.py
@@ -1,12 +1,11 @@
-# encoding: utf-8
 from __future__ import annotations
 
 import logging
 import os
 import tempfile
 from typing import Any, Optional
+from typing_extensions import Literal, TypedDict, assert_never
 
-import yaml
 from markupsafe import Markup
 from webassets import Environment
 from webassets.loaders import YAMLLoader
@@ -14,159 +13,232 @@ from webassets.loaders import YAMLLoader
 from ckan.common import config, g
 
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 env: Optional[Environment] = None
 
-yaml.warnings({u'YAMLLoadWarning': False})
+AssetType = Literal["style", "script"]
+
+
+class AssetCollection(TypedDict):
+    script: list[str]
+    style: list[str]
+    included: set[str]
 
 
 def create_library(name: str, path: str) -> None:
     """Create WebAssets library(set of Bundles).
     """
-    config_path = os.path.join(path, u'webassets.yml')
-    if not os.path.exists(config_path):
+    if not env:
+        log.debug("Webassets environment is not initialized yet")
         return
-    assert env
+
+    config_path = os.path.join(path, "webassets.yaml")
+    if not os.path.exists(config_path):
+        config_path = os.path.join(path, "webassets.yml")
+
+    if not os.path.exists(config_path):
+        log.debug(
+            "Cannot create library %s at %s because webassets.yaml is missing",
+            name,
+            path,
+        )
+        return
+
     library: dict[str, Any] = YAMLLoader(config_path).load_bundles()
     bundles = {
-        u'/'.join([name, key]): bundle
+        f"{name}/{key}": bundle
         for key, bundle
         in library.items()
     }
 
-    # Unfortunately, you'll get an error attempting to register bundle
-    # with the same name twice. For now, let's just pop existing
-    # bundle and avoid name-conflicts
-    # TODO: make PR into webassets with preferable solution
-    # Issue: https://github.com/miracle2k/webassets/issues/519
+    # skip attempts to register an asset if name is taken. It gives us
+    # templates-like behavior, where the item that was registered first has
+    # highest priority.
     for name, bundle in bundles.items():
-        env._named_bundles.pop(name, None)
-        env.register(name, bundle)
+        if is_registered(name):
+            log.debug(
+                "Skip registration of %s because it already exists",
+                name,
+            )
+            continue
 
-    env.append_path(path)
+        # use absolute path to files. Otherwise they'll behave like templates
+        # and if plugin A and plugin B has their own `x.css`(i.e
+        # `ckanext/A/assets/x.css` and `ckanext/B/assets/x.css`), both plugins
+        # will load the same `x.css` from the plugin that was first registered
+        bundle.contents = [
+            os.path.join(path, item)
+            for item in bundle.contents
+        ]
+        log.debug("Register asset %s", name)
+        env.register(name, bundle)
 
 
 def webassets_init() -> None:
+    """Initialize fresh Webassets environment
+    """
     global env
 
     static_path = get_webassets_path()
 
-    public = config.get(u'ckan.base_public_folder')
-
-    public_folder = os.path.abspath(os.path.join(
-        os.path.dirname(__file__), u'..', public))
-
-    base_path = os.path.join(public_folder, u'base')
-
     env = Environment()
     env.directory = static_path
-    env.debug = config.get(u'debug')
-    env.url = u'/webassets/'
-
-    add_public_path(base_path, u'/base/')
-
-    logger.debug(u'Base path {0}'.format(base_path))
-    create_library(u'vendor', os.path.join(
-        base_path, u'vendor'))
-
-    create_library(u'base', os.path.join(base_path, u'javascript'))
-
-    create_library(u'datapreview', os.path.join(base_path, u'datapreview'))
-
-    create_library(u'css', os.path.join(base_path, u'css'))
+    env.debug = config["debug"] and False
+    env.url = config["ckan.webassets.url"]
 
 
-def _make_asset_collection() -> dict[str, Any]:
-    return {u'style': [], u'script': [], u'included': set()}
+def register_core_assets():
+    """Register CKAN core assets.
+
+    Call this function after registration of plugin assets. Asset overrides are
+    not alowed, so if plugin tries to replace CKAN core asset, it has to
+    register an asset with the same name before core asset is added. In this
+    case, asset from plugin will have higher precedence and core asset will be
+    ignored.
+
+    """
+    public = config["ckan.base_public_folder"]
+    public_folder = os.path.abspath(os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        public,
+    ))
+
+    base_path = os.path.join(public_folder, "base")
+    add_public_path(base_path, "/base/")
+    create_library("vendor", os.path.join(base_path, "vendor"))
+    create_library("base", os.path.join(base_path, "javascript"))
+    create_library("css", os.path.join(base_path, "css"))
+
+
+def _make_asset_collection() -> AssetCollection:
+    return {"style": [], "script": [], "included": set()}
 
 
 def include_asset(name: str) -> None:
     from ckan.lib.helpers import url_for_static_or_external
-    try:
-        if not g.webassets:
-            raise AttributeError(u'WebAssets not initialized yet')
-    except AttributeError:
+
+    if not env:
+        log.debug("Webassets environment is not initialized yet")
+        return
+
+    if not hasattr(g, "webassets"):
         g.webassets = _make_asset_collection()
-    if name in g.webassets[u'included']:
+
+    if name in g.webassets["included"]:
         return
 
-    assert env
-    try:
-        bundle: Any = env[name]
-    except KeyError:
-        logger.error(u'Trying to include unknown asset: <{}>'.format(name))
+    if not is_registered(name):
+        log.error("Trying to include unknown asset: %s", name)
         return
 
-    deps: list[str] = bundle.extra.get(u'preload', [])
+    bundle: Any = env[name]
+    deps: list[str] = bundle.extra.get("preload", [])
 
-    # Using DFS may lead to infinite recursion(unlikely, because
-    # extensions rarely depends on each other), so there is a sense to
-    # memoize visited routes.
-
-    # TODO: consider infinite loop prevention for assets that depends
-    # on each other
+    # mark current asset as included in order to avoid recursion while loading
+    # dependencies
+    g.webassets["included"].add(name)
     for dep in deps:
         include_asset(dep)
 
     # Add `site_root` if configured
     urls = [url_for_static_or_external(url) for url in bundle.urls()]
-    type_ = None
+
     for url in urls:
-        link = url.split(u'?')[0]
-        if link.endswith(u'.css'):
-            type_ = u'style'
+        link = url.split("?")[0]
+        if link.endswith(".css"):
+            type_ = "style"
             break
-        elif link.endswith(u'.js'):
-            type_ = u'script'
+        elif link.endswith(".js"):
+            type_ = "script"
             break
     else:
-        logger.warn(u'Undefined asset type: {}'.format(urls))
+        log.warn("Undefined asset type: %s", urls)
         return
+
     g.webassets[type_].extend(urls)
-    g.webassets[u'included'].add(name)
 
 
-def _to_tag(url: str, type_: str):
-    if type_ == u'style':
-        return u'<link href="{}" rel="stylesheet"/>'.format(url)
-    elif type_ == u'script':
-        return u'<script src="{}" type="text/javascript"></script>'.format(url)
-    return u''
+def _to_tag(url: str, type_: AssetType) -> str:
+    """Turn asset URL into corresponding HTML tag.
+    """
+    if type_ == "style":
+        return f'<link href="{url}" rel="stylesheet"/>'
+    elif type_ == "script":
+        return f'<script src="{url}" type="text/javascript"></script>'
+    else:
+        assert_never(type_)
 
 
-def render_assets(type_: str) -> Markup:
+def render_assets(type_: AssetType) -> Markup:
+    """Render all assets of the given type as a string of HTML tags.
+
+    All assets that are included into output will be removed from the render
+    cache. I.e:
+
+        include_asset("a") # style
+        # render tags and clear style-cache
+        output = render_assets("style")
+        assert "a.css" in output
+
+        # style-cache is clean, nothing included since last render
+        output = render_assets("style")
+        assert output ==""
+
+        include_asset("b") # style
+        include_asset("c") # style
+        # render tags and clear style-cache. "a" was already rendered and
+        # removed from the cache, so this time only "b" and "c" are rendered.
+        output = render_assets("style")
+        assert "b.css" in output
+        assert "c.css" in output
+
+        # style-cache is clean, nothing included since last render
+        output = render_assets("style")
+        assert output ==""
+    """
     try:
-        assets = g.webassets
+        assets: AssetCollection = g.webassets
     except AttributeError:
-        return Markup(u'')
+        return Markup()
 
-    if not assets:
-        return Markup(u'')
-    collection = assets[type_]
-    tags = u'\n'.join([_to_tag(asset, type_) for asset in assets[type_]])
-    collection[:] = []
+    tags = "\n".join(_to_tag(asset, type_) for asset in assets[type_])
+    assets[type_].clear()
+
     return Markup(tags)
 
 
 def get_webassets_path() -> str:
-    webassets_path = config.get(u'ckan.webassets.path')
+    """Compute path to the folder where compiled assets are stored.
+    """
+    webassets_path = config["ckan.webassets.path"]
 
     if not webassets_path:
-        storage_path = config.get(
-            u'ckan.storage_path'
-        ) or tempfile.gettempdir()
+        storage_path = config["ckan.storage_path"] or tempfile.gettempdir()
 
         if storage_path:
-            webassets_path = os.path.join(storage_path, u'webassets')
+            webassets_path = os.path.join(storage_path, "webassets")
 
     if not webassets_path:
         raise RuntimeError(
-            u'Either `ckan.webassets.path` or `ckan.storage_path` '
-            u'must be specified'
+            "Either `ckan.webassets.path` or `ckan.storage_path`"
+            " must be specified"
         )
     return webassets_path
 
 
 def add_public_path(path: str, url: str) -> None:
-    assert env
+    """Add a public path that can be used by `cssrewrite` filter."""
+    if not env:
+        log.debug("Webassets environment is not initialized yet")
+        return
     env.append_path(path, url)
+
+
+def is_registered(asset: str) -> bool:
+    """Check if asset is registered in current environment."""
+    if not env:
+        log.debug("Webassets environment is not initialized yet")
+        return False
+
+    return asset in env


### PR DESCRIPTION
Fixes #7318

If extension A registers asset `xxx/styles` and extension B registers an asset with the same name, the last loaded plugin wins, and its version of the asset will be used in the end. It is different from a template loading order, where the first plugin wins.

This PR updates the logic and now the first registered version of an asset will be used and all other versions are ignored(just like Jinja2 templates without `extends` tag).

In addition, a couple of other issues were fixed:
* improve types and logging
* prevent recursion when asset A requires asset B and vice versa.\
* add `ckan.webassets.url` config option for those who don't want to serve assets from `/webassets` path.
* Add brief comments for logic, that may be not obvious. If you don't want to read through the webassets code but want to change something inside `ckan.lib.webassets_tools`, you can do it now.