### PR TITLE
Remove cast-Context / remove model and standard session from context

### DIFF
--- a/changes/7611.bugfix
+++ b/changes/7611.bugfix
@@ -1,0 +1,1 @@
+Context requires type-casting when `model` passed explicitly.

--- a/ckan/cli/notify.py
+++ b/ckan/cli/notify.py
@@ -34,10 +34,9 @@ def send_emails():
     import ckan.logic as logic
     import ckan.lib.mailer as mailer
     from ckan.types import Context
-    from typing import cast
 
     site_user = logic.get_action("get_site_user")({"ignore_auth": True}, {})
-    context = cast(Context, {"user": site_user["name"]})
+    context: Context = {"user": site_user["name"]}
     try:
         logic.get_action("send_email_notifications")(context, {})
     except (NotAuthorized, ValidationError, mailer.MailerException) as e:

--- a/ckan/cli/user.py
+++ b/ckan/cli/user.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional, cast
+from typing import Optional
 
 import click
 
@@ -50,20 +50,16 @@ def add_user(ctx: click.Context, username: str, args: list[str]):
                                              confirmation_prompt=True)
 
     import ckan.logic as logic
-    import ckan.model as model
 
     try:
-        site_user = logic.get_action(u'get_site_user')(cast(Context, {
-            u'model': model,
-            u'ignore_auth': True}),
+        site_user = logic.get_action(u'get_site_user')(
+            {'ignore_auth': True},
             {}
         )
-        context = cast(Context, {
-            u'model': model,
-            u'session': model.Session,
+        context: Context = {
             u'ignore_auth': True,
             u'user': site_user['name'],
-        })
+        }
         flask_app = ctx.meta['flask_app']
         # Current user is tested agains sysadmin role during model
         # dictization, thus we need request context

--- a/ckan/lib/create_test_data.py
+++ b/ckan/lib/create_test_data.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 import datetime
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, Union
 
 
 
@@ -91,11 +91,7 @@ class CreateTestData(object):
                             'term_translation': translations[term],
                             'lang_code': lang_code,
                             }
-                    context = cast(Context, {
-                        'model': ckan.model,
-                        'session': ckan.model.Session,
-                        'user': sysadmin_user.name,
-                    })
+                    context: Context = {'user': sysadmin_user.name,}
                     get_action('term_translation_update')(context,
                             data_dict)
 
@@ -114,11 +110,7 @@ class CreateTestData(object):
         assert sysadmin_user and annakarenina and warandpeace
 
         # Create a couple of vocabularies.
-        context = cast(Context, {
-                'model': ckan.model,
-                'session': ckan.model.Session,
-                'user': sysadmin_user.name
-                })
+        context: Context = {'user': sysadmin_user.name}
         data_dict = {
                 'name': 'Genre',
                 'tags': [{'name': 'Drama'}, {'name': 'Sci-Fi'},

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1232,9 +1232,7 @@ def sorted_extras(package_extras: list[dict[str, Any]],
 @core_helper
 def check_access(
         action: str, data_dict: Optional[dict[str, Any]] = None) -> bool:
-    context = cast(Context, {
-        'model': model,
-        'user': current_user.name})
+    context: Context = {'user': current_user.name}
     if not data_dict:
         data_dict = {}
     try:
@@ -1779,7 +1777,7 @@ def convert_to_dict(object_type: str, objs: list[Any]) -> list[dict[str, Any]]:
     converters = {'package': md.package_dictize}
     converter = converters[object_type]
     items = []
-    context = cast(Context, {'model': model})
+    context: Context = {'model': model}
     for obj in objs:
         item = converter(obj, context)
         items.append(item)
@@ -1812,9 +1810,7 @@ def follow_button(obj_type: str, obj_id: str) -> str:
     # If the user is logged in show the follow/unfollow button
     user = current_user.name
     if user:
-        context = cast(
-            Context,
-            {'model': model, 'session': model.Session, 'user': user})
+        context: Context = {'user': user}
         action = 'am_following_%s' % obj_type
         following = logic.get_action(action)(context, {'id': obj_id})
         return snippet('snippets/follow_button.html',
@@ -1840,13 +1836,7 @@ def follow_count(obj_type: str, obj_id: str) -> int:
     obj_type = obj_type.lower()
     assert obj_type in _follow_objects
     action = '%s_follower_count' % obj_type
-    context = cast(
-        Context, {
-            'model': model,
-            'session': model.Session,
-            'user': current_user.name
-        }
-    )
+    context: Context = {'user': current_user.name}
     return logic.get_action(action)(context, {'id': obj_id})
 
 

--- a/ckan/lib/navl/dictization_functions.py
+++ b/ckan/lib/navl/dictization_functions.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import copy
 import json
 from typing import (Any, Callable, Iterable, Optional,
-                    Sequence, Union, cast)
+                    Sequence, Union)
 
 from ckan.common import _
 from ckan.types import (
@@ -290,8 +290,7 @@ def validate(
 
     # create a copy of the context which also includes the schema keys so
     # they can be used by the validators
-    validators_context = cast(Context,
-                              dict(context, schema_keys=list(schema.keys())))
+    validators_context = Context(context, schema_keys=list(schema.keys()))
 
     flattened = flatten_dict(data)
     flat_data, errors = _validate(flattened, schema, validators_context)

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -9,7 +9,7 @@ import warnings
 import traceback
 
 import xml.dom.minidom
-from typing import Collection, Any, Optional, Type, cast, overload
+from typing import Collection, Any, Optional, Type, overload
 
 import requests
 from requests.auth import HTTPBasicAuth
@@ -164,13 +164,11 @@ class SynchronousSearchPlugin(p.SingletonPlugin):
         if operation != domain_object.DomainObjectOperation.deleted:
             dispatch_by_operation(
                 entity.__class__.__name__,
-                logic.get_action('package_show')(cast(
-                    Context, {
-                        'model': model,
+                logic.get_action('package_show')({
                         'ignore_auth': True,
                         'validate': False,
                         'use_cache': False
-                    }), {'id': entity.id}), operation)
+                    }, {'id': entity.id}), operation)
         elif operation == domain_object.DomainObjectOperation.deleted:
             dispatch_by_operation(entity.__class__.__name__,
                                   {'id': entity.id}, operation)
@@ -197,12 +195,11 @@ def rebuild(package_id: Optional[str] = None,
     log.info("Rebuilding search index...")
 
     package_index = index_for(model.Package)
-    context = cast(Context, {
-        'model': model,
+    context: Context = {
         'ignore_auth': True,
         'validate': False,
         'use_cache': False
-    })
+    }
 
     if package_id:
         pkg_dict = logic.get_action('package_show')(context, {

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -9,7 +9,7 @@ import json
 import datetime
 import re
 from dateutil.parser import parse
-from typing import Any, NoReturn, Optional, cast
+from typing import Any, NoReturn, Optional
 
 import six
 import pysolr
@@ -122,7 +122,7 @@ class PackageSearchIndex(SearchIndex):
         schema = package_plugin.show_package_schema()
         validated_pkg_dict, _errors = lib_plugins.plugin_validate(
             package_plugin,
-            cast(Context, {'model': model, 'session': model.Session}),
+            {'model': model, 'session': model.Session},
             pkg_dict, schema, 'package_show')
         pkg_dict['validated_data_dict'] = json.dumps(validated_pkg_dict,
             cls=ckan.lib.navl.dictization_functions.MissingNullEncoder)
@@ -158,7 +158,7 @@ class PackageSearchIndex(SearchIndex):
         # vocab_<tag name> so that they can be used in facets
         non_vocab_tag_names = []
         tags = pkg_dict.pop('tags', [])
-        context = cast(Context, {'model': model})
+        context: Context = {'model': model}
 
         for tag in tags:
             if tag.get('vocabulary_id'):

--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -210,13 +210,12 @@ class TagSearchQuery(SearchQuery):
             if field in ('tag', 'tags'):
                 query.append(value)
 
-        context = cast(Context, {'model': model, 'session': model.Session})
         data_dict = {
             'query': query,
             'offset': options.get('offset'),
             'limit': options.get('limit')
         }
-        results = logic.get_action('tag_search')(context, data_dict)
+        results = logic.get_action('tag_search')({}, data_dict)
 
         if not options.return_objects:
             # if options.all_fields is set, return a dict
@@ -242,11 +241,7 @@ class ResourceSearchQuery(SearchQuery):
         else:
             options.update(kwargs)
 
-        context = cast(Context,{
-            'model': model,
-            'session': model.Session,
-            'search_query': True,
-        })
+        context: Context = {'search_query': True}
 
         # Transform fields into structure required by the resource_search
         # action.

--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -23,7 +23,7 @@ import ckan.lib.signals as signals
 
 from ckan.common import _, g
 from ckan.types import (
-    Action, ChainedAction, Model,
+    Action, ChainedAction,
     ChainedAuthFunction, DataDict, ErrorDict, Context, FlattenDataDict,
     Schema, Validator, ValidatorFactory)
 
@@ -276,7 +276,7 @@ def flatten_to_string_key(dict: dict[str, Any]) -> dict[str, Any]:
 def _prepopulate_context(context: Optional[Context]) -> Context:
     if context is None:
         context = {}
-    context.setdefault('model', cast(Model, model))
+    context.setdefault('model', model)
     context.setdefault('session', model.Session)
 
     try:
@@ -849,17 +849,12 @@ def guard_against_duplicated_email(email: str):
     except exc.IntegrityError as e:
         if e.orig.pgcode == _PG_ERR_CODE["unique_violation"]:
             model.Session.rollback()
-            raise ValidationError(
-                cast(
-                    ErrorDict,
-                    {
-                        "email": [
-                            "The email address '{email}' belongs to "
-                            "a registered user.".format(email=email)
-                        ]
-                    },
-                )
-            )
+            raise ValidationError({
+                "email": [
+                    "The email address '{email}' belongs to "
+                    "a registered user.".format(email=email)
+                ]
+            })
         raise
 
 

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -1076,9 +1076,7 @@ def user_invite(context: Context,
 
     data['state'] = model.State.PENDING
     user_dict = _get_action('user_create')(
-        cast(
-            Context,
-            dict(context, schema=invite_schema, ignore_auth=True)),
+        Context(context, schema=invite_schema, ignore_auth=True),
         data)
     user = model.User.get(user_dict['id'])
     assert user
@@ -1357,11 +1355,10 @@ def _group_or_org_member_create(
         'object_type': 'user',
         'capacity': role,
     }
-    member_create_context = cast(Context, {
-        'model': model,
+    member_create_context: Context = {
         'user': user,
-        'ignore_auth': context.get('ignore_auth'),
-    })
+        'ignore_auth': context.get('ignore_auth', False),
+    }
     return logic.get_action('member_create')(member_create_context,
                                              member_dict)
 

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -701,7 +701,6 @@ def _group_or_org_member_delete(context: Context,
                                 data_dict: DataDict) -> None:
     model = context['model']
     user = context['user']
-    session = context['session']
 
     group_id = data_dict.get('id')
     group = model.Group.get(group_id)
@@ -713,11 +712,7 @@ def _group_or_org_member_delete(context: Context,
         'object': user_id,
         'object_type': 'user',
     }
-    member_context = cast(Context, {
-        'model': model,
-        'user': user,
-        'session': session
-    })
+    member_context: Context = {'user': user}
     _get_action('member_delete')(member_context, member_dict)
 
 

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -400,13 +400,13 @@ def _group_or_org_list(
     if sort_info:
         sort_field = sort_info[0][0]
         sort_direction = sort_info[0][1]
-        sort_model_field = sqlalchemy.func.count(model.Group.id)
+        sort_model_field: Any = sqlalchemy.func.count(model.Group.id)
         if sort_field == 'package_count':
             query = query.group_by(model.Group.id, model.Group.name)
         elif sort_field == 'name':
             sort_model_field = model.Group.name
         elif sort_field == 'title':
-            sort_model_field = cast(Any, model.Group.title)
+            sort_model_field = model.Group.title
 
         if sort_direction == 'asc':
             query = query.order_by(sqlalchemy.asc(sort_model_field))
@@ -1104,11 +1104,10 @@ def resource_show(
     id = _get_or_bust(data_dict, 'id')
 
     resource = model.Resource.get(id)
-    resource_context = cast(Context, dict(context, resource=resource))
-
     if not resource:
         raise NotFound
 
+    resource_context = Context(context, resource=resource)
     _check_access('resource_show', resource_context, data_dict)
 
     pkg_dict = logic.get_action('package_show')(

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -999,7 +999,10 @@ def package_show(context: Context, data_dict: DataDict) -> ActionResult.PackageS
 
     include_plugin_data = asbool(data_dict.get('include_plugin_data', False))
     if user_obj and user_obj.is_authenticated:
-        include_plugin_data = user_obj.sysadmin and include_plugin_data
+        include_plugin_data = (
+            user_obj.sysadmin  # type: ignore
+            and include_plugin_data
+        )
 
         if include_plugin_data:
             context['use_cache'] = False

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -314,7 +314,10 @@ def package_update(
     user_obj = context.get('auth_user_obj')
     if user_obj:
         plugin_data = data.get('plugin_data', False)
-        include_plugin_data = user_obj.sysadmin and plugin_data
+        include_plugin_data = (
+            user_obj.sysadmin  # type: ignore
+            and plugin_data
+        )
 
     pkg = model_save.package_dict_save(data, context, include_plugin_data)
 

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -514,7 +514,7 @@ def package_revise(context: Context, data_dict: DataDict) -> ActionResult.Packag
     # on update or "nothing changed" status once possible
     rval = {
         'package': _get_action('package_update')(
-            cast(Context, dict(context, package=pkg)),
+            Context(context, package=pkg),
             orig)}
     if 'include' in data_dict:
         dfunc.filter_glob_match(rval, data_dict['include'])

--- a/ckan/logic/auth/get.py
+++ b/ckan/logic/auth/get.py
@@ -364,7 +364,7 @@ def package_collaborator_list_for_user(context: Context,
     The current implementation restricts to the own users themselves.
     '''
     user_obj = context.get('auth_user_obj')
-    if user_obj and data_dict.get('id') in (user_obj.name, user_obj.id):
+    if user_obj and data_dict.get('id') in (user_obj.name, user_obj.id):  # type: ignore
         return {'success': True}
     return {'success': False}
 

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -36,8 +36,8 @@ def default_resource_schema(
         isodate: Validator, int_validator: Validator,
         extras_valid_json: Validator, keep_extras: Validator,
         resource_id_validator: Validator,
-        resource_id_does_not_exist: Validator):
-    return cast(Schema, {
+        resource_id_does_not_exist: Validator) -> Schema:
+    return {
         'id': [ignore_empty, resource_id_validator,
                resource_id_does_not_exist, unicode_safe],
         'package_id': [ignore],
@@ -61,7 +61,7 @@ def default_resource_schema(
         'tracking_summary': [ignore_missing],
         'datastore_active': [ignore_missing],
         '__extras': [ignore_missing, extras_valid_json, keep_extras],
-    })
+    }
 
 
 @validator_args
@@ -76,8 +76,9 @@ def default_tags_schema(not_missing: Validator, not_empty: Validator,
                         tag_length_validator: Validator,
                         tag_name_validator: Validator,
                         ignore_missing: Validator,
-                        vocabulary_id_exists: Validator, ignore: Validator):
-    return cast(Schema, {
+                        vocabulary_id_exists: Validator, ignore: Validator
+                        ) -> Schema:
+    return {
         'name': [not_missing,
                  not_empty,
                  unicode_safe,
@@ -90,7 +91,7 @@ def default_tags_schema(not_missing: Validator, not_empty: Validator,
         'revision_timestamp': [ignore],
         'state': [ignore],
         'display_name': [ignore],
-    })
+    }
 
 
 @validator_args
@@ -123,8 +124,8 @@ def default_create_package_schema(
         datasets_with_no_organization_cannot_be_private: Validator,
         empty: Validator, tag_string_convert: Validator,
         owner_org_validator: Validator, json_object: Validator,
-        ignore_not_sysadmin: Validator):
-    return cast(Schema, {
+        ignore_not_sysadmin: Validator) -> Schema:
+    return {
         '__before': [duplicate_extras_key, ignore],
         'id': [empty_if_not_sysadmin, ignore_missing, unicode_safe,
                package_id_does_not_exist],
@@ -163,7 +164,7 @@ def default_create_package_schema(
             'title': [ignore_missing, unicode_safe],
             '__extras': [ignore],
         }
-    })
+    }
 
 
 @validator_args
@@ -314,16 +315,16 @@ def group_form_schema(not_empty: Validator, unicode_safe: Validator,
                       ignore_missing: Validator, ignore: Validator):
     schema = default_group_schema()
     # schema['extras_validation'] = [duplicate_extras_key, ignore]
-    schema['packages'] = cast(Schema, {
+    schema['packages'] = {
         "name": [not_empty, unicode_safe],
         "title": [ignore_missing],
         "__extras": [ignore]
-    })
-    schema['users'] = cast(Schema, {
+    }
+    schema['users'] = {
         "name": [not_empty, unicode_safe],
         "capacity": [ignore_missing],
         "__extras": [ignore]
-    })
+    }
     return schema
 
 
@@ -345,12 +346,12 @@ def default_show_group_schema(
     schema['num_followers'] = []
     schema['created'] = []
     schema['display_name'] = []
-    schema['extras'] = cast(Schema, {'__extras': [keep_extras]})
+    schema['extras'] = {'__extras': [keep_extras]}
     schema['package_count'] = [ignore_missing]
     schema['member_count'] = [ignore_missing]
-    schema['packages'] = cast(Schema, {'__extras': [keep_extras]})
+    schema['packages'] = {'__extras': [keep_extras]}
     schema['state'] = []
-    schema['users'] = cast(Schema, {'__extras': [keep_extras]})
+    schema['users'] = {'__extras': [keep_extras]}
 
     return schema
 
@@ -359,8 +360,8 @@ def default_show_group_schema(
 def default_extras_schema(ignore: Validator, not_empty: Validator,
                           extra_key_not_in_root_schema: Validator,
                           unicode_safe: Validator, not_missing: Validator,
-                          ignore_missing: Validator):
-    return cast(Schema, {
+                          ignore_missing: Validator) -> Schema:
+    return {
         'id': [ignore],
         'key': [not_empty, extra_key_not_in_root_schema, unicode_safe],
         'value': [not_missing],
@@ -368,15 +369,15 @@ def default_extras_schema(ignore: Validator, not_empty: Validator,
         'deleted': [ignore_missing],
         'revision_timestamp': [ignore],
         '__extras': [ignore],
-    })
+    }
 
 
 @validator_args
 def default_relationship_schema(ignore_missing: Validator,
                                 unicode_safe: Validator, not_empty: Validator,
                                 one_of: ValidatorFactory,
-                                ignore: Validator):
-    return cast(Schema, {
+                                ignore: Validator) -> Schema:
+    return {
         'id': [ignore_missing, unicode_safe],
         'subject': [ignore_missing, unicode_safe],
         'object': [ignore_missing, unicode_safe],
@@ -384,7 +385,7 @@ def default_relationship_schema(ignore_missing: Validator,
                  one_of(ckan.model.PackageRelationship.get_all_types())],
         'comment': [ignore_missing, unicode_safe],
         'state': [ignore],
-    })
+    }
 
 
 @validator_args
@@ -423,8 +424,8 @@ def default_user_schema(
         not_empty: Validator, strip_value: Validator,
         email_validator: Validator, user_about_validator: Validator,
         ignore: Validator, boolean_validator: Validator,
-        json_object: Validator):
-    return cast(Schema, {
+        json_object: Validator) -> Schema:
+    return {
         'id': [ignore_missing, unicode_safe],
         'name': [
             not_empty, name_validator, user_name_validator, unicode_safe],
@@ -444,7 +445,7 @@ def default_user_schema(
         'image_url': [ignore_missing, unicode_safe],
         'image_display_url': [ignore_missing, unicode_safe],
         'plugin_extras': [ignore_missing, json_object, ignore_not_sysadmin],
-    })
+    }
 
 
 @validator_args
@@ -499,19 +500,19 @@ def default_update_user_schema(
 @validator_args
 def default_user_invite_schema(
         not_empty: Validator, email_validator: Validator,
-        email_is_unique: Validator, unicode_safe: Validator):
-    return cast(Schema, {
+        email_is_unique: Validator, unicode_safe: Validator) -> Schema:
+    return {
         'email': [not_empty, email_validator, email_is_unique, unicode_safe],
         'group_id': [not_empty],
         'role': [not_empty],
-    })
+    }
 
 
 @validator_args
 def default_task_status_schema(ignore: Validator, not_empty: Validator,
                                unicode_safe: Validator,
-                               ignore_missing: Validator):
-    return cast(Schema, {
+                               ignore_missing: Validator) -> Schema:
+    return {
         'id': [ignore],
         'entity_id': [not_empty, unicode_safe],
         'entity_type': [not_empty, unicode_safe],
@@ -521,7 +522,7 @@ def default_task_status_schema(ignore: Validator, not_empty: Validator,
         'state': [ignore_missing],
         'last_updated': [ignore_missing],
         'error': [ignore_missing]
-    })
+    }
 
 
 @validator_args
@@ -558,75 +559,75 @@ def default_update_vocabulary_schema(
 def default_follow_user_schema(not_missing: Validator, not_empty: Validator,
                                unicode_safe: Validator,
                                convert_user_name_or_id_to_id: Validator,
-                               ignore_missing: Validator):
-    return cast(Schema, {
+                               ignore_missing: Validator) -> Schema:
+    return {
         'id': [not_missing, not_empty, unicode_safe,
                convert_user_name_or_id_to_id],
         'q': [ignore_missing]
-    })
+    }
 
 
 @validator_args
 def default_follow_dataset_schema(
         not_missing: Validator, not_empty: Validator, unicode_safe: Validator,
-        convert_package_name_or_id_to_id: Validator):
-    return cast(Schema, {
+        convert_package_name_or_id_to_id: Validator) -> Schema:
+    return {
         'id': [not_missing, not_empty, unicode_safe,
                convert_package_name_or_id_to_id]
-    })
+    }
 
 
 @validator_args
 def member_schema(not_missing: Validator, group_id_or_name_exists: Validator,
                   unicode_safe: Validator, user_id_or_name_exists: Validator,
-                  role_exists: Validator):
-    return cast(Schema, {
+                  role_exists: Validator) -> Schema:
+    return {
         'id': [not_missing, group_id_or_name_exists, unicode_safe],
         'username': [not_missing, user_id_or_name_exists, unicode_safe],
         'role': [not_missing, role_exists, unicode_safe],
-    })
+    }
 
 
 @validator_args
 def default_follow_group_schema(
         not_missing: Validator, not_empty: Validator, unicode_safe: Validator,
-        convert_group_name_or_id_to_id: Validator):
-    return cast(Schema, {
+        convert_group_name_or_id_to_id: Validator) -> Schema:
+    return {
         'id': [not_missing, not_empty, unicode_safe,
                convert_group_name_or_id_to_id]
-    })
+    }
 
 
 @validator_args
 def default_package_list_schema(ignore_missing: Validator,
                                 natural_number_validator: Validator,
-                                is_positive_integer: Validator):
-    return cast(Schema, {
+                                is_positive_integer: Validator) -> Schema:
+    return {
         'limit': [ignore_missing, natural_number_validator],
         'offset': [ignore_missing, natural_number_validator],
         'page': [ignore_missing, is_positive_integer]
-    })
+    }
 
 
 @validator_args
 def default_pagination_schema(ignore_missing: Validator,
-                              natural_number_validator: Validator):
-    return cast(Schema, {
+                              natural_number_validator: Validator) -> Schema:
+    return {
         'limit': [ignore_missing, natural_number_validator],
         'offset': [ignore_missing, natural_number_validator]
-    })
+    }
 
 
 @validator_args
 def default_autocomplete_schema(not_missing: Validator,
                                 unicode_safe: Validator,
                                 ignore_missing: Validator,
-                                natural_number_validator: Validator):
-    return cast(Schema, {
+                                natural_number_validator: Validator) -> Schema:
+    return {
         'q': [not_missing, unicode_safe],
         'ignore_self': [ignore_missing],
         'limit': [ignore_missing, natural_number_validator]
-    })
+    }
 
 
 @validator_args
@@ -636,8 +637,8 @@ def default_package_search_schema(
         int_validator: Validator, convert_to_json_if_string: Validator,
         convert_to_list_if_string: Validator,
         limit_to_configured_maximum: ValidatorFactory,
-        default: ValidatorFactory):
-    return cast(Schema, {
+        default: ValidatorFactory) -> Schema:
+    return {
         'q': [ignore_missing, unicode_safe],
         'fl': [ignore_missing, convert_to_list_if_string],
         'fq': [ignore_missing, unicode_safe],
@@ -653,21 +654,21 @@ def default_package_search_schema(
                         list_of_strings],
         'extras': [ignore_missing]  # Not used by Solr,
                                     # but useful for extensions
-    })
+    }
 
 
 @validator_args
 def default_resource_search_schema(ignore_missing: Validator,
                                    unicode_safe: Validator,
-                                   natural_number_validator: Validator):
-    schema = cast(Schema, {
+                                   natural_number_validator: Validator
+                                   ) -> Schema:
+    return {
         'query': [ignore_missing],  # string or list of strings
         'fields': [ignore_missing],  # dict of fields
         'order_by': [ignore_missing, unicode_safe],
         'offset': [ignore_missing, natural_number_validator],
         'limit': [ignore_missing, natural_number_validator]
-    })
-    return schema
+    }
 
 
 def create_schema_for_required_keys(keys: Iterable[str]) -> Schema:
@@ -687,14 +688,15 @@ def default_create_resource_view_schema(resource_view: Any):
 @validator_args
 def default_create_resource_view_schema_unfiltered(
         not_empty: Validator, resource_id_exists: Validator,
-        unicode_safe: Validator, ignore_missing: Validator, empty: Validator):
-    return cast(Schema, {
+        unicode_safe: Validator, ignore_missing: Validator, empty: Validator
+) -> Schema:
+    return {
         'resource_id': [not_empty, resource_id_exists],
         'title': [not_empty, unicode_safe],
         'description': [ignore_missing, unicode_safe],
         'view_type': [not_empty, unicode_safe],
         '__extras': [empty],
-    })
+    }
 
 
 @validator_args
@@ -724,21 +726,22 @@ def default_update_resource_view_schema_changes(not_missing: Validator,
                                                 unicode_safe: Validator,
                                                 resource_id_exists: Validator,
                                                 ignore: Validator,
-                                                ignore_missing: Validator):
-    return cast(Schema, {
+                                                ignore_missing: Validator
+                                                ) -> Schema:
+    return {
         'id': [not_missing, not_empty, unicode_safe],
         'resource_id': [ignore_missing, resource_id_exists],
         'title': [ignore_missing, unicode_safe],
         'view_type': [ignore],  # cannot change after create
         'package_id': [ignore]
-    })
+    }
 
 
 @validator_args
 def default_update_configuration_schema(unicode_safe: Validator,
                                         is_positive_integer: Validator,
-                                        ignore_missing: Validator):
-    return cast(Schema, {
+                                        ignore_missing: Validator) -> Schema:
+    return {
         'ckan.site_title': [ignore_missing, unicode_safe],
         'ckan.site_logo': [ignore_missing, unicode_safe],
         'ckan.site_url': [ignore_missing, unicode_safe],
@@ -750,7 +753,7 @@ def default_update_configuration_schema(unicode_safe: Validator,
         'ckan.homepage_style': [ignore_missing, is_positive_integer],
         'logo_upload': [ignore_missing, unicode_safe],
         'clear_logo_upload': [ignore_missing, unicode_safe],
-    })
+    }
 
 
 def update_configuration_schema():
@@ -782,17 +785,21 @@ def update_configuration_schema():
 
 
 @validator_args
-def job_list_schema(ignore_missing: Validator, list_of_strings: Validator):
-    return cast(Schema, {
+def job_list_schema(
+        ignore_missing: Validator, list_of_strings: Validator
+) -> Schema:
+    return {
         u'queues': [ignore_missing, list_of_strings],
-    })
+    }
 
 
 @validator_args
-def job_clear_schema(ignore_missing: Validator, list_of_strings: Validator):
-    return cast(Schema, {
+def job_clear_schema(
+        ignore_missing: Validator, list_of_strings: Validator
+) -> Schema:
+    return {
         u'queues': [ignore_missing, list_of_strings],
-    })
+    }
 
 
 @validator_args
@@ -800,12 +807,13 @@ def default_create_api_token_schema(not_empty: Validator,
                                     unicode_safe: Validator,
                                     ignore_missing: Validator,
                                     json_object: Validator,
-                                    ignore_not_sysadmin: Validator):
-    return cast(Schema, {
+                                    ignore_not_sysadmin: Validator
+                                    ) -> Schema:
+    return {
         u'name': [not_empty, unicode_safe],
         u'user': [not_empty, unicode_safe],
         u'plugin_extras': [ignore_missing, json_object, ignore_not_sysadmin],
-    })
+    }
 
 
 @validator_args
@@ -815,8 +823,8 @@ def package_revise_schema(ignore_missing: Validator,
                                                             Validator],
                           json_or_string: Validator,
                           json_list_or_string: Validator,
-                          dict_only: Validator):
-    return cast(Schema, {
+                          dict_only: Validator) -> Schema:
+    return {
         u'__before': [
             collect_prefix_validate(
                 u'match__', u'json_or_string'),
@@ -833,7 +841,7 @@ def package_revise_schema(ignore_missing: Validator,
         # collect_prefix moves values to these, always dicts:
         u'match__': [],
         u'update__': [],
-    })
+    }
 
 
 @validator_args
@@ -841,7 +849,7 @@ def config_declaration_v1(
         ignore_missing: Validator, unicode_safe: Validator,
         not_empty: Validator, default: ValidatorFactory,
         dict_only: Validator, one_of: ValidatorFactory,
-        ignore_empty: Validator):
+        ignore_empty: Validator) -> Schema:
     from ckan.config.declaration import Key
     from ckan.config.declaration.load import option_types
 
@@ -856,7 +864,7 @@ def config_declaration_v1(
         except ImportStringError as e:
             raise Invalid(str(e))
 
-    return cast(Schema, {
+    return {
         "groups": {
             "annotation": [default(""), unicode_safe],
             "section": [default("app:main"), unicode_safe],
@@ -874,4 +882,4 @@ def config_declaration_v1(
                 "type": [default("base"), one_of(list(option_types))],
             }
         }
-    })
+    }

--- a/ckan/tests/lib/search/test_query.py
+++ b/ckan/tests/lib/search/test_query.py
@@ -342,11 +342,11 @@ class TestPackageQuery:
         assert {pkg1["name"], pkg2["name"], pkg3["name"]} == set(result["results"])
 
     def test_single_by_name(self):
-        factories.Dataset(name="first")
-        factories.Dataset(name="second")
+        factories.Dataset(name="verycomplexnameoffirstdataset")
+        factories.Dataset(name="verycomplexnameofseconddataset")
 
-        result = search.query_for(model.Package).run({"q": u"first"})
-        assert result["results"] == ["first"]
+        result = search.query_for(model.Package).run({"q": u"verycomplexnameoffirstdataset"})
+        assert result["results"] == ["verycomplexnameoffirstdataset"]
 
     def test_name_multiple_results(self):
         factories.Dataset(name="first-record")

--- a/ckan/tests/logic/test_logic.py
+++ b/ckan/tests/logic/test_logic.py
@@ -2,7 +2,6 @@
 
 from unittest import mock
 import pytest
-from typing import cast
 from ckan import logic, model
 from ckan.types import Context
 import ckan.tests.factories as factories
@@ -76,13 +75,13 @@ def test_fresh_context():
         'model', 'session', 'user', 'auth_user_obj', 'ignore_auth'
         values (if they exists)."""
 
-    dirty_context = {
+    dirty_context: Context = {
         "user": "test",
         "ignore_auth": True,
         "to_be_cleaned": "test",
     }
-    dirty_Context = cast(Context, dirty_context)
-    cleaned_context = logic.fresh_context(dirty_Context)
+
+    cleaned_context = logic.fresh_context(dirty_context)
 
     assert "to_be_cleaned" not in cleaned_context
     assert cleaned_context["user"] == "test"

--- a/ckan/types/__init__.py
+++ b/ckan/types/__init__.py
@@ -73,7 +73,7 @@ class Context(TypedDict, total=False):
 
     __auth_user_obj_checked: bool
     __auth_audit: list[tuple[str, int]]
-    auth_user_obj: Optional["Model.User"]
+    auth_user_obj: Union["Model.User", "Model.AnonymousUser", None]
     user_obj: "Model.User"
 
     schema_keys: list[Any]

--- a/ckan/types/__init__.py
+++ b/ckan/types/__init__.py
@@ -83,7 +83,7 @@ class Context(TypedDict, total=False):
     connection: Any
     check_access: Callable[..., Any]
 
-    id: str
+    id: str | None
     user_id: str
     user_is_admin: bool
     search_query: bool
@@ -104,6 +104,10 @@ class Context(TypedDict, total=False):
     use_cache: bool
     include_plugin_extras: bool
     message: str
+    extras_as_string: bool
+    with_private: bool
+    group_type: str
+    parent: Optional[str]
 
     keep_email: bool
     keep_apikey: bool

--- a/ckan/types/model.py
+++ b/ckan/types/model.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from typing import TYPE_CHECKING, Callable, ClassVar, Type
+from typing import TYPE_CHECKING, ClassVar, Type
 from typing_extensions import Protocol
 
 from sqlalchemy.orm.scoping import ScopedSession
@@ -57,5 +57,8 @@ class Model(Protocol):
     Session: ClassVar[AlchemySession]
     meta: ClassVar[Meta]
 
-    set_system_info: Callable[[str, str], bool]
     repo: ClassVar["_model.Repository"]
+
+    @staticmethod
+    def set_system_info(key: str, value: str) -> bool:
+        ...

--- a/ckan/views/admin.py
+++ b/ckan/views/admin.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Union, cast, List
+from typing import Any, Union, List
 
 from flask import Blueprint
 from flask.views import MethodView

--- a/ckan/views/admin.py
+++ b/ckan/views/admin.py
@@ -62,13 +62,10 @@ def _get_config_items() -> list[str]:
 @admin.before_request
 def before_request() -> None:
     try:
-        context = cast(
-            Context, {
-                "model": model,
-                "user": current_user.name,
-                "auth_user_obj": current_user
-            }
-        )
+        context: Context = {
+            "user": current_user.name,
+            "auth_user_obj": current_user
+        }
         logic.check_access(u'sysadmin', context)
     except logic.NotAuthorized:
         base.abort(403, _(u'Need to be system administrator to administer'))

--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -235,13 +235,11 @@ def action(logic_function: str, ver: int = API_DEFAULT_VERSION) -> Response:
         log.info(msg)
         return _finish_bad_request(msg)
 
-    context = cast(Context, {
-        u'model': model,
-        u'session': model.Session,
+    context: Context = {
         u'user': current_user.name,
         u'api_version': ver,
         u'auth_user_obj': current_user
-    })
+    }
     model.Session()._context = context
 
     return_dict: dict[str, Any] = {
@@ -351,12 +349,10 @@ def dataset_autocomplete(ver: int = API_REST_DEFAULT_VERSION) -> Response:
     limit = request.args.get(u'limit', 10)
     package_dicts: ActionResult.PackageAutocomplete = []
     if q:
-        context = cast(
-            Context,
-            {u'model': model,
-             u'session': model.Session,
-             u'user': current_user.name,
-             u'auth_user_obj': current_user})
+        context: Context = {
+            'user': current_user.name,
+            'auth_user_obj': current_user,
+        }
 
         data_dict: dict[str, Any] = {u'q': q, u'limit': limit}
 
@@ -373,12 +369,10 @@ def tag_autocomplete(ver: int = API_REST_DEFAULT_VERSION) -> Response:
     vocab = request.args.get(u'vocabulary_id', u'')
     tag_names: ActionResult.TagAutocomplete = []
     if q:
-        context = cast(
-            Context,
-            {u'model': model,
-             u'session': model.Session,
-             u'user': current_user.name,
-             u'auth_user_obj': current_user})
+        context: Context = {
+            'user': current_user.name,
+            'auth_user_obj': current_user,
+        }
 
         data_dict: dict[str, Any] = {u'q': q, u'limit': limit}
         if vocab != u'':
@@ -399,12 +393,10 @@ def format_autocomplete(ver: int = API_REST_DEFAULT_VERSION) -> Response:
     limit = request.args.get(u'limit', 5)
     formats: ActionResult.FormatAutocomplete = []
     if q:
-        context = cast(
-            Context,
-            {u'model': model,
-             u'session': model.Session,
-             u'user': current_user.name,
-             u'auth_user_obj': current_user})
+        context: Context = {
+            'user': current_user.name,
+            'auth_user_obj': current_user,
+        }
         data_dict: dict[str, Any] = {u'q': q, u'limit': limit}
         formats = get_action(u'format_autocomplete')(context, data_dict)
 
@@ -422,12 +414,10 @@ def user_autocomplete(ver: int = API_REST_DEFAULT_VERSION) -> Response:
     ignore_self = request.args.get(u'ignore_self', False)
     user_list: ActionResult.UserAutocomplete = []
     if q:
-        context = cast(
-            Context,
-            {u'model': model,
-             u'session': model.Session,
-             u'user': current_user.name,
-             u'auth_user_obj': current_user})
+        context: Context = {
+            'user': current_user.name,
+            'auth_user_obj': current_user,
+        }
 
         data_dict: dict[str, Any] = {
             u'q': q, u'limit': limit, u'ignore_self': ignore_self}

--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -7,7 +7,7 @@ import html
 import io
 import datetime
 
-from typing import Any, Callable, Optional, cast, Union
+from typing import Any, Callable, Optional, Union
 
 from flask import Blueprint, make_response
 
@@ -442,11 +442,8 @@ def group_autocomplete(ver: int = API_REST_DEFAULT_VERSION) -> Response:
     group_list: ActionResult.GroupAutocomplete = []
 
     if q:
-        context = cast(
-            Context, {
-                u'user': current_user.name,
-                u'model': model}
-        )
+        context: Context = {'user': current_user.name}
+
         data_dict: dict[str, Any] = {u'q': q, u'limit': limit}
         group_list = get_action(u'group_autocomplete')(context, data_dict)
     return _finish_ok(group_list)
@@ -458,9 +455,7 @@ def organization_autocomplete(ver: int = API_REST_DEFAULT_VERSION) -> Response:
     organization_list = []
 
     if q:
-        context = cast(Context, {
-            u'user': current_user.name,
-            u'model': model})
+        context: Context = {u'user': current_user.name}
         data_dict: dict[str, Any] = {u'q': q, u'limit': limit}
         organization_list = get_action(
             u'organization_autocomplete')(context, data_dict)

--- a/ckan/views/dashboard.py
+++ b/ckan/views/dashboard.py
@@ -29,11 +29,11 @@ def before_request() -> None:
 
 
 def datasets() -> str:
-    context = cast(Context, {
+    context: Context = {
         u'for_view': True,
         u'user': current_user.name,
         u'auth_user_obj': current_user
-    })
+    }
     data_dict: dict[str, Any] = {
         u'user_obj': current_user,
         u'include_datasets': True}
@@ -42,22 +42,22 @@ def datasets() -> str:
 
 
 def organizations() -> str:
-    context = cast(Context, {
+    context: Context = {
         u'for_view': True,
         u'user': current_user.name,
         u'auth_user_obj': current_user
-    })
+    }
     data_dict = {u'user_obj': current_user}
     extra_vars = _extra_template_variables(context, data_dict)
     return base.render(u'user/dashboard_organizations.html', extra_vars)
 
 
 def groups() -> str:
-    context = cast(Context, {
+    context: Context = {
         u'for_view': True,
         u'user': current_user.name,
         u'auth_user_obj': current_user
-    })
+    }
     data_dict = {u'user_obj': current_user}
     extra_vars = _extra_template_variables(context, data_dict)
     return base.render(u'user/dashboard_groups.html', extra_vars)

--- a/ckan/views/dashboard.py
+++ b/ckan/views/dashboard.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, cast
+from typing import Any
 
 from flask import Blueprint
 

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -242,13 +242,11 @@ def search(package_type: str) -> str:
     fq = details[u'fq']
     search_extras = details[u'search_extras']
 
-    context = cast(Context, {
-        u'model': model,
-        u'session': model.Session,
+    context: Context = {
         u'user': current_user.name,
         u'for_view': True,
         u'auth_user_obj': current_user
-    })
+    }
 
     # Unless changed via config options, don't show other dataset
     # types any search page. Potential alternatives are do show them
@@ -379,13 +377,11 @@ def search(package_type: str) -> str:
 
 
 def resources(package_type: str, id: str) -> Union[Response, str]:
-    context = cast(Context, {
-        u'model': model,
-        u'session': model.Session,
+    context: Context = {
         u'user': current_user.name,
         u'for_view': True,
         u'auth_user_obj': current_user
-    })
+    }
     data_dict: dict[str, Any] = {u'id': id, u'include_tracking': True}
 
     try:
@@ -421,13 +417,11 @@ def resources(package_type: str, id: str) -> Union[Response, str]:
 
 
 def read(package_type: str, id: str) -> Union[Response, str]:
-    context = cast(Context, {
-        u'model': model,
-        u'session': model.Session,
+    context: Context = {
         u'user': current_user.name,
         u'for_view': True,
         u'auth_user_obj': current_user
-    })
+    }
     data_dict = {u'id': id, u'include_tracking': True}
 
     # check if package exists
@@ -508,13 +502,11 @@ class CreateView(MethodView):
 
     def _prepare(self) -> Context:  # noqa
 
-        context = cast(Context, {
-            u'model': model,
-            u'session': model.Session,
+        context: Context = {
             u'user': current_user.name,
             u'auth_user_obj': current_user,
             u'save': self._is_save()
-        })
+        }
         try:
             check_access(u'package_create', context)
         except NotAuthorized:
@@ -701,13 +693,11 @@ class CreateView(MethodView):
 
 class EditView(MethodView):
     def _prepare(self) -> Context:
-        context = cast(Context, {
-            u'model': model,
-            u'session': model.Session,
+        context: Context = {
             u'user': current_user.name,
             u'auth_user_obj': current_user,
             u'save': u'save' in request.form
-        })
+        }
         return context
 
     def post(self, package_type: str, id: str) -> Union[Response, str]:
@@ -851,12 +841,10 @@ class EditView(MethodView):
 
 class DeleteView(MethodView):
     def _prepare(self) -> Context:
-        context = cast(Context, {
-            u'model': model,
-            u'session': model.Session,
+        context: Context = {
             u'user': current_user.name,
             u'auth_user_obj': current_user
-        })
+        }
         return context
 
     def post(self, package_type: str, id: str) -> Response:
@@ -904,12 +892,10 @@ class DeleteView(MethodView):
 def follow(package_type: str, id: str) -> Response:
     """Start following this dataset.
     """
-    context = cast(Context, {
-        u'model': model,
-        u'session': model.Session,
+    context: Context = {
         u'user': current_user.name,
         u'auth_user_obj': current_user
-    })
+    }
     data_dict = {u'id': id}
     try:
         get_action(u'follow_dataset')(context, data_dict)
@@ -931,12 +917,10 @@ def follow(package_type: str, id: str) -> Response:
 def unfollow(package_type: str, id: str) -> Union[Response, str]:
     """Stop following this dataset.
     """
-    context = cast(Context, {
-        u'model': model,
-        u'session': model.Session,
+    context: Context = {
         u'user': current_user.name,
         u'auth_user_obj': current_user
-    })
+    }
     data_dict = {u'id': id}
     try:
         get_action(u'unfollow_dataset')(context, data_dict)
@@ -963,13 +947,11 @@ def unfollow(package_type: str, id: str) -> Union[Response, str]:
 
 def followers(package_type: str,
               id: Optional[str] = None) -> Union[Response, str]:
-    context = cast(Context, {
-        u'model': model,
-        u'session': model.Session,
+    context: Context = {
         u'user': current_user.name,
         u'for_view': True,
         u'auth_user_obj': current_user
-    })
+    }
 
     data_dict = {u'id': id}
     try:
@@ -1004,14 +986,12 @@ def followers(package_type: str,
 
 class GroupView(MethodView):
     def _prepare(self, id: str) -> tuple[Context, dict[str, Any]]:
-        context = cast(Context, {
-            u'model': model,
-            u'session': model.Session,
+        context: Context = {
             u'user': current_user.name,
             u'for_view': True,
             u'auth_user_obj': current_user,
             u'use_cache': False
-        })
+        }
 
         try:
             pkg_dict = get_action(u'package_show')(context, {u'id': id})

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from functools import partial
 from typing_extensions import TypeAlias
 from urllib.parse import urlencode
-from typing import Any, Iterable, Optional, Union, cast
+from typing import Any, Iterable, Optional, Union
 
 from flask import Blueprint
 from flask.views import MethodView
@@ -348,7 +348,7 @@ def search(package_type: str) -> str:
     # FIXME: try to avoid using global variables
     g.search_facets_limits = {}
     default_limit: int = config.get(u'search.facets.default')
-    for facet in cast(Iterable[str], extra_vars[u'search_facets'].keys()):
+    for facet in extra_vars[u'search_facets'].keys():
         try:
             limit = int(
                 request.args.get(
@@ -586,7 +586,7 @@ class CreateView(MethodView):
                     return h.redirect_to(url)
 
                 get_action(u'package_update')(
-                    cast(Context, dict(context, allow_state_change=True)),
+                    Context(context, allow_state_change=True),
                     dict(pkg_dict, state=u'active')
                 )
                 return h.redirect_to(
@@ -1085,7 +1085,7 @@ class GroupView(MethodView):
 
 
 def collaborators_read(package_type: str, id: str) -> Union[Response, str]:  # noqa
-    context = cast(Context, {u'model': model, u'user': current_user.name})
+    context: Context = {'user': current_user.name}
     data_dict = {u'id': id}
 
     try:
@@ -1103,7 +1103,7 @@ def collaborators_read(package_type: str, id: str) -> Union[Response, str]:  # n
 
 
 def collaborator_delete(package_type: str, id: str, user_id: str) -> Response:  # noqa
-    context = cast(Context, {u'model': model, u'user': current_user.name})
+    context: Context = {'user': current_user.name}
 
     try:
         get_action(u'package_collaborator_delete')(context, {
@@ -1124,7 +1124,7 @@ def collaborator_delete(package_type: str, id: str, user_id: str) -> Response:  
 class CollaboratorEditView(MethodView):
 
     def post(self, package_type: str, id: str) -> Response:  # noqa
-        context = cast(Context, {u'model': model, u'user': current_user.name})
+        context: Context = {'user': current_user.name}
 
         try:
             form_dict = logic.clean_dict(
@@ -1162,7 +1162,7 @@ class CollaboratorEditView(MethodView):
         return h.redirect_to(u'dataset.collaborators_read', id=id)
 
     def get(self, package_type: str, id: str) -> Union[Response, str]:  # noqa
-        context = cast(Context, {u'model': model, u'user': current_user.name})
+        context: Context = {'user': current_user.name}
         data_dict = {u'id': id}
 
         try:

--- a/ckan/views/feed.py
+++ b/ckan/views/feed.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 import json
 import unicodedata
-from typing import Optional, cast, Any
+from typing import Optional, Any
 
 
 from urllib.parse import urlparse
@@ -15,7 +15,6 @@ from feedgen.feed import FeedGenerator
 from ckan.common import _, config, request, current_user
 import ckan.lib.helpers as h
 import ckan.lib.base as base
-import ckan.model as model
 import ckan.logic as logic
 import ckan.plugins as plugins
 from ckan.types import Context, DataDict, PFeedFactory, Response
@@ -106,8 +105,8 @@ class CKANFeed(FeedGenerator):
                 continue
             self.link(href=href, rel=rel)
 
-    def writeString(self, encoding: str) -> str:  # noqa
-        return cast(str, self.atom_str(encoding=encoding))
+    def writeString(self, encoding: str) -> str:
+        return self.atom_str(encoding=encoding)
 
     def add_item(self, **kwargs: Any) -> None:
         entry = self.add_entry()

--- a/ckan/views/feed.py
+++ b/ckan/views/feed.py
@@ -31,12 +31,10 @@ def _package_search(data_dict: DataDict) -> tuple[int, list[dict[str, Any]]]:
      * unless overridden, sorts results by metadata_modified date
      * unless overridden, sets a default item limit
     """
-    context = cast(Context, {
-        u'model': model,
-        u'session': model.Session,
-        u'user': current_user.name,
-        u'auth_user_obj': current_user
-    })
+    context: Context = {
+        'user': current_user.name,
+        'auth_user_obj': current_user
+    }
     if u'sort' not in data_dict or not data_dict['sort']:
         data_dict['sort'] = u'metadata_modified desc'
 
@@ -195,12 +193,10 @@ def output_feed(
 
 def group(id: str) -> Response:
     try:
-        context = cast(Context, {
-            u'model': model,
-            u'session': model.Session,
-            u'user': current_user.name,
-            u'auth_user_obj': current_user
-        })
+        context: Context = {
+            'user': current_user.name,
+            'auth_user_obj': current_user
+        }
         group_dict = logic.get_action(u'group_show')(context, {u'id': id})
     except logic.NotFound:
         base.abort(404, _(u'Group not found'))
@@ -212,12 +208,10 @@ def group(id: str) -> Response:
 
 def organization(id: str) -> Response:
     try:
-        context = cast(Context, {
-            u'model': model,
-            u'session': model.Session,
+        context: Context = {
             u'user': current_user.name,
             u'auth_user_obj': current_user
-        })
+        }
         group_dict = logic.get_action(u'organization_show')(context, {
             u'id': id
         })

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 import re
 from collections import OrderedDict
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, Union
 from typing_extensions import Literal
 
 from urllib.parse import urlencode
@@ -132,13 +132,11 @@ def index(group_type: str, is_organization: bool) -> str:
     page = h.get_page_number(request.args) or 1
     items_per_page = config.get('ckan.datasets_per_page')
 
-    context = cast(Context, {
-        u'model': model,
-        u'session': model.Session,
+    context: Context = {
         u'user': current_user.name,
         u'for_view': True,
-        u'with_private': False
-    })
+        u'with_private': False,
+    }
 
     try:
         assert _check_access(u'group_list', context)
@@ -218,14 +216,12 @@ def index(group_type: str, is_organization: bool) -> str:
 def _read(id: Optional[str], limit: int, group_type: str) -> dict[str, Any]:
     u''' This is common code used by both read and bulk_process'''
     extra_vars: dict[str, Any] = {}
-    context = cast(Context, {
-        u'model': model,
-        u'session': model.Session,
+    context: Context = {
         u'user': current_user.name,
         u'schema': _db_to_form_schema(group_type=group_type),
         u'for_view': True,
         u'extras_as_string': True
-    })
+    }
 
     q = request.args.get(u'q', u'')
 
@@ -336,9 +332,9 @@ def _read(id: Optional[str], limit: int, group_type: str) -> dict[str, Any]:
         u'extras': search_extras
     }
 
-    context_ = cast(
-        Context, dict((k, v) for (k, v) in context.items() if k != u'schema')
-    )
+    context_ = context.copy()
+    context_.pop("schema", None)
+
     try:
         query = get_action(u'package_search')(context_, data_dict)
     except search.SearchError as se:
@@ -394,12 +390,10 @@ def _update_facet_titles(
 def _get_group_dict(id: str, group_type: str) -> dict[str, Any]:
     u''' returns the result of group_show action or aborts if there is a
     problem '''
-    context = cast(Context, {
-        u'model': model,
-        u'session': model.Session,
+    context: Context = {
         u'user': current_user.name,
         u'for_view': True
-    })
+    }
     try:
         return _action(u'group_show')(context, {
             u'id': id,
@@ -414,13 +408,11 @@ def read(group_type: str,
          id: Optional[str] = None) -> Union[str, Response]:
     extra_vars = {}
     set_org(is_organization)
-    context = cast(Context, {
-        u'model': model,
-        u'session': model.Session,
+    context: Context = {
         u'user': current_user.name,
         u'schema': _db_to_form_schema(group_type=group_type),
         u'for_view': True
-    })
+    }
     data_dict: dict[str, Any] = {u'id': id, u'type': group_type}
 
     # unicode format (decoded from utf8)
@@ -466,20 +458,14 @@ def read(group_type: str,
     extra_vars["group_dict"] = group_dict
 
     return base.render(
-        _get_group_template(u'read_template', cast(str, g.group_dict['type'])),
+        _get_group_template(u'read_template', g.group_dict['type']),
         extra_vars)
 
 
 def about(id: str, group_type: str, is_organization: bool) -> str:
     extra_vars = {}
     set_org(is_organization)
-    context = cast(
-        Context, {
-            u'model': model,
-            u'session': model.Session,
-            u'user': current_user.name
-        }
-    )
+    context: Context = {'user': current_user.name}
 
     try:
         group_dict = _get_group_dict(id, group_type)
@@ -509,13 +495,7 @@ def about(id: str, group_type: str, is_organization: bool) -> str:
 def members(id: str, group_type: str, is_organization: bool) -> str:
     extra_vars = {}
     set_org(is_organization)
-    context = cast(
-        Context, {
-            u'model': model,
-            u'session': model.Session,
-            u'user': current_user.name
-        }
-    )
+    context: Context = {'user': current_user.name}
 
     try:
         data_dict: dict[str, Any] = {u'id': id}
@@ -550,13 +530,7 @@ def members(id: str, group_type: str, is_organization: bool) -> str:
 def manage_members(id: str, group_type: str, is_organization: bool) -> str:
     extra_vars = {}
     set_org(is_organization)
-    context = cast(
-        Context, {
-            u'model': model,
-            u'session': model.Session,
-            u'user': current_user.name
-        }
-    )
+    context: Context = {'user': current_user.name}
 
     try:
         data_dict: dict[str, Any] = {u'id': id}
@@ -606,10 +580,7 @@ def member_dump(id: str, group_type: str, is_organization: bool):
                    else _(u'Group not found'))
 
     set_org(is_organization)
-    context = cast(Context, {
-            u'model': model,
-            u'session': model.Session,
-            u'user': current_user.name})
+    context: Context = {'user': current_user.name}
 
     try:
         _check_access(u'group_member_create', context, {u'id': id})
@@ -664,13 +635,8 @@ def member_delete(id: str, group_type: str,
     if u'cancel' in request.args:
         return h.redirect_to(u'{}.members'.format(group_type), id=id)
 
-    context = cast(
-        Context, {
-            u'model': model,
-            u'session': model.Session,
-            u'user': current_user.name
-        }
-    )
+    context: Context = {'user': current_user.name}
+
     try:
         assert _check_access(u'group_member_delete', context, {u'id': id})
     except NotAuthorized:
@@ -707,13 +673,8 @@ def member_delete(id: str, group_type: str,
 def follow(id: str, group_type: str, is_organization: bool) -> Response:
     u'''Start following this group.'''
     set_org(is_organization)
-    context = cast(
-        Context, {
-            u'model': model,
-            u'session': model.Session,
-            u'user': current_user.name
-        }
-    )
+    context: Context = {'user': current_user.name}
+
     data_dict = {u'id': id}
     try:
         get_action(u'follow_group')(context, data_dict)
@@ -733,13 +694,7 @@ def follow(id: str, group_type: str, is_organization: bool) -> Response:
 def unfollow(id: str, group_type: str, is_organization: bool) -> Response:
     u'''Stop following this group.'''
     set_org(is_organization)
-    context = cast(
-        Context, {
-            u'model': model,
-            u'session': model.Session,
-            u'user': current_user.name
-        }
-    )
+    context: Context = {'user': current_user.name}
     data_dict = {u'id': id}
     try:
         get_action(u'unfollow_group')(context, data_dict)
@@ -762,13 +717,7 @@ def unfollow(id: str, group_type: str, is_organization: bool) -> Response:
 def followers(id: str, group_type: str, is_organization: bool) -> str:
     extra_vars = {}
     set_org(is_organization)
-    context = cast(
-        Context, {
-            u'model': model,
-            u'session': model.Session,
-            u'user': current_user.name
-        }
-    )
+    context: Context = {'user': current_user.name}
     group_dict = _get_group_dict(id, group_type)
     try:
         followers = \
@@ -820,14 +769,12 @@ class BulkProcessView(MethodView):
 
         # check we are org admin
 
-        context = cast(Context, {
-            u'model': model,
-            u'session': model.Session,
+        context: Context = {
             u'user': current_user.name,
             u'schema': _db_to_form_schema(group_type=group_type),
             u'for_view': True,
             u'extras_as_string': True
-        })
+        }
 
         try:
             check_access(u'bulk_update_public', context, {u'org_id': id})
@@ -951,14 +898,12 @@ class CreateGroupView(MethodView):
         if data:
             data['type'] = group_type
 
-        context = cast(Context, {
-            u'model': model,
-            u'session': model.Session,
+        context: Context = {
             u'user': current_user.name,
             u'save': u'save' in request.args,
             u'parent': request.args.get(u'parent', None),
             u'group_type': group_type
-        })
+        }
 
         try:
             assert _check_access(u'group_create', context)
@@ -994,7 +939,7 @@ class CreateGroupView(MethodView):
                             data_dict, errors, error_summary)
 
         return h.redirect_to(
-            cast(str, group['type']) + u'.read', id=group['name'])
+            group['type'] + '.read', id=group['name'])
 
     def get(self,
             group_type: str,
@@ -1045,15 +990,13 @@ class EditGroupView(MethodView):
     def _prepare(self, id: Optional[str]) -> Context:
         data_dict: dict[str, Any] = {u'id': id, u'include_datasets': False}
 
-        context = cast(Context, {
-            u'model': model,
-            u'session': model.Session,
+        context: Context = {
             u'user': current_user.name,
             u'save': u'save' in request.args,
             u'for_edit': True,
             u'parent': request.args.get(u'parent', None),
             u'id': id
-        })
+        }
 
         try:
             _action(u'group_show')(context, data_dict)
@@ -1094,7 +1037,7 @@ class EditGroupView(MethodView):
             return self.get(id, group_type, is_organization,
                             data_dict, errors, error_summary)
         return h.redirect_to(
-            cast(str, group[u'type']) + u'.read', id=group[u'name'])
+            group['type'] + '.read', id=group[u'name'])
 
     def get(self,
             id: str,
@@ -1144,11 +1087,7 @@ class DeleteGroupView(MethodView):
     u'''Delete group view '''
 
     def _prepare(self, id: Optional[str] = None) -> Context:
-        context = cast(Context, {
-            u'model': model,
-            u'session': model.Session,
-            u'user': current_user.name,
-        })
+        context: Context = {'user': current_user.name}
         try:
             assert _check_access(u'group_delete', context, {u'id': id})
         except NotAuthorized:
@@ -1202,11 +1141,7 @@ class MembersGroupView(MethodView):
     u'''New members group view'''
 
     def _prepare(self, id: Optional[str] = None) -> Context:
-        context = cast(Context, {
-            u'model': model,
-            u'session': model.Session,
-            u'user': current_user.name
-        })
+        context: Context = {'user': current_user.name}
         try:
             assert _check_access(u'group_member_create', context, {u'id': id})
         except NotAuthorized:

--- a/ckan/views/home.py
+++ b/ckan/views/home.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 from urllib.parse import urlencode
-from typing import Any, Optional, cast, List, Tuple
+from typing import Any, Optional, List, Tuple
 
 from flask import Blueprint, make_response, redirect, request
 
-import ckan.model as model
 import ckan.logic as logic
 import ckan.lib.base as base
 import ckan.lib.search as search

--- a/ckan/views/home.py
+++ b/ckan/views/home.py
@@ -26,13 +26,10 @@ def index() -> str:
     u'''display home page'''
     extra_vars: dict[str, Any] = {}
     try:
-        context = cast(Context, {
-            u'model': model,
-            u'session': model.Session,
+        context: Context = {
             u'user': current_user.name,
             u'auth_user_obj': current_user
-            }
-        )
+        }
 
         data_dict: dict[str, Any] = {
             u'q': u'*:*',

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -55,13 +55,11 @@ prefixed_resource = Blueprint(
 
 
 def read(package_type: str, id: str, resource_id: str) -> Union[Response, str]:
-    context = cast(Context, {
-        u'model': model,
-        u'session': model.Session,
+    context: Context = {
         u'user': current_user.name,
         u'auth_user_obj': current_user,
         u'for_view': True
-    })
+    }
 
     try:
         package = get_action(u'package_show')(context, {u'id': id})
@@ -153,12 +151,10 @@ def download(package_type: str,
     Provides a direct download by either redirecting the user to the url
     stored or downloading an uploaded file directly.
     """
-    context = cast(Context, {
-        u'model': model,
-        u'session': model.Session,
+    context: Context = {
         u'user': current_user.name,
         u'auth_user_obj': current_user
-    })
+    }
 
     try:
         rsc = get_action(u'resource_show')(context, {u'id': resource_id})
@@ -197,12 +193,10 @@ class CreateView(MethodView):
         del data[u'save']
         resource_id = data.pop(u'id')
 
-        context = cast(Context, {
-            u'model': model,
-            u'session': model.Session,
+        context: Context = {
             u'user': current_user.name,
             u'auth_user_obj': current_user
-        })
+        }
 
         # see if we have any data that we are trying to save
         data_provided = False
@@ -293,12 +287,10 @@ class CreateView(MethodView):
             errors: Optional[dict[str, Any]] = None,
             error_summary: Optional[dict[str, Any]] = None) -> str:
         # get resources for sidebar
-        context = cast(Context, {
-            u'model': model,
-            u'session': model.Session,
+        context: Context = {
             u'user': current_user.name,
             u'auth_user_obj': current_user
-        })
+        }
         try:
             pkg_dict = get_action(u'package_show')(context, {u'id': id})
         except NotFound:
@@ -340,14 +332,12 @@ class CreateView(MethodView):
 class EditView(MethodView):
     def _prepare(self, id: str):
         user = current_user.name
-        context = cast(Context, {
-            u'model': model,
-            u'session': model.Session,
+        context: Context = {
             u'api_version': 3,
             u'for_edit': True,
             u'user': user,
             u'auth_user_obj': current_user
-        })
+        }
         try:
             check_access(u'package_update', context, {u'id': id})
         except NotAuthorized:
@@ -444,12 +434,10 @@ class EditView(MethodView):
 
 class DeleteView(MethodView):
     def _prepare(self, resource_id: str):
-        context = cast(Context, {
-            u'model': model,
-            u'session': model.Session,
+        context: Context = {
             u'user': current_user.name,
             u'auth_user_obj': current_user
-        })
+        }
         try:
             check_access(u'resource_delete', context, {u'id': resource_id})
         except NotAuthorized:
@@ -520,13 +508,11 @@ class DeleteView(MethodView):
 
 def views(package_type: str, id: str, resource_id: str) -> str:
     package_type = _get_package_type(id)
-    context = cast(Context, {
-        u'model': model,
-        u'session': model.Session,
+    context: Context = {
         u'user': current_user.name,
         u'for_view': True,
         u'auth_user_obj': current_user
-    })
+    }
     data_dict = {u'id': id}
 
     try:
@@ -585,12 +571,10 @@ def view(package_type: str,
     img tag where the image is loaded directly or an iframe that embeds a
     webpage or another preview.
     """
-    context = cast(Context, {
-        u'model': model,
-        u'session': model.Session,
+    context: Context = {
         u'user': current_user.name,
         u'auth_user_obj': current_user
-    })
+    }
 
     try:
         package = get_action(u'package_show')(context, {u'id': id})
@@ -625,13 +609,11 @@ class EditResourceViewView(MethodView):
     def _prepare(
             self, id: str, resource_id: str) -> tuple[Context, dict[str, Any]]:
         user = current_user.name
-        context = cast(Context, {
-            u'model': model,
-            u'session': model.Session,
+        context: Context = {
             u'user': user,
             u'for_view': True,
             u'auth_user_obj': current_user
-        })
+        }
 
         # update resource should tell us early if the user has privilages.
         try:

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import cgi
 import json
 import logging
-from typing import Any, cast, Optional, Union
+from typing import Any, Optional, Union
 
 from werkzeug.wrappers.response import Response as WerkzeugResponse
 import flask
@@ -239,7 +239,7 @@ class CreateView(MethodView):
             # XXX race condition if another user edits/deletes
             data_dict = get_action(u'package_show')(context, {u'id': id})
             get_action(u'package_update')(
-                cast(Context, dict(context, allow_state_change=True)),
+                Context(context, allow_state_change=True),
                 dict(data_dict, state=u'active')
             )
             return h.redirect_to(u'{}.read'.format(package_type), id=id)
@@ -269,7 +269,7 @@ class CreateView(MethodView):
             # XXX race condition if another user edits/deletes
             data_dict = get_action(u'package_show')(context, {u'id': id})
             get_action(u'package_update')(
-                cast(Context, dict(context, allow_state_change=True)),
+                Context(context, allow_state_change=True),
                 dict(data_dict, state=u'active')
             )
             return h.redirect_to(u'{}.read'.format(package_type), id=id)

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -86,11 +86,11 @@ def index():
     order_by = request.args.get('order_by', 'name')
     default_limit: int = config.get('ckan.user_list_limit')
     limit = int(request.args.get('limit', default_limit))
-    context = cast(Context, {
+    context: Context = {
         u'return_query': True,
         u'user': current_user.name,
         u'auth_user_obj': current_user
-    })
+    }
 
     data_dict = {
         u'q': q,
@@ -122,13 +122,11 @@ def me() -> Response:
 
 
 def read(id: str) -> Union[Response, str]:
-    context = cast(Context, {
-        u'model': model,
-        u'session': model.Session,
+    context: Context = {
         u'user': current_user.name,
         u'auth_user_obj': current_user,
         u'for_view': True
-    })
+    }
     data_dict: dict[str, Any] = {
         u'id': id,
         u'user_obj': current_user,
@@ -144,13 +142,11 @@ def read(id: str) -> Union[Response, str]:
 
 
 def read_organizations(id: str) -> Union[Response, str]:
-    context = cast(Context, {
-        u'model': model,
-        u'session': model.Session,
+    context: Context = {
         u'user': current_user.name,
         u'auth_user_obj': current_user,
         u'for_view': True
-    })
+    }
     data_dict: dict[str, Any] = {
         u'id': id,
         u'user_obj': current_user,
@@ -166,13 +162,11 @@ def read_organizations(id: str) -> Union[Response, str]:
 
 
 def read_groups(id: str) -> Union[Response, str]:
-    context = cast(Context, {
-        u'model': model,
-        u'session': model.Session,
+    context: Context = {
         u'user': current_user.name,
         u'auth_user_obj': current_user,
         u'for_view': True
-    })
+    }
     data_dict: dict[str, Any] = {
         u'id': id,
         u'user_obj': current_user,
@@ -193,14 +187,12 @@ class ApiTokenView(MethodView):
             errors: Optional[dict[str, Any]] = None,
             error_summary: Optional[dict[str, Any]] = None
             ) -> Union[Response, str]:
-        context = cast(Context, {
-            u'model': model,
-            u'session': model.Session,
+        context: Context = {
             u'user': current_user.name,
             u'auth_user_obj': current_user,
             u'for_view': True,
             u'include_plugin_extras': True
-        })
+        }
         try:
             tokens = logic.get_action(u'api_token_list')(
                 context, {u'user': id}
@@ -273,14 +265,12 @@ def api_token_revoke(id: str, jti: str) -> Response:
 
 class EditView(MethodView):
     def _prepare(self, id: Optional[str]) -> tuple[Context, str]:
-        context = cast(Context, {
+        context: Context = {
             u'save': u'save' in request.form,
             u'schema': _edit_form_to_db_schema(),
-            u'model': model,
-            u'session': model.Session,
             u'user': current_user.name,
             u'auth_user_obj': current_user
-        })
+        }
         if id is None:
             if current_user.is_authenticated:
                 id = current_user.id  # type: ignore
@@ -421,14 +411,12 @@ class EditView(MethodView):
 
 class RegisterView(MethodView):
     def _prepare(self):
-        context = cast(Context, {
-            u'model': model,
-            u'session': model.Session,
+        context: Context = {
             u'user': current_user.name,
             u'auth_user_obj': current_user,
             u'schema': _new_form_to_db_schema(),
             u'save': u'save' in request.form
-        })
+        }
         try:
             logic.check_access(u'user_create', context)
         except logic.NotAuthorized:
@@ -606,12 +594,10 @@ def logged_out_page() -> str:
 
 def delete(id: str) -> Union[Response, Any]:
     u'''Delete user with id passed as parameter'''
-    context = cast(Context, {
-        u'model': model,
-        u'session': model.Session,
+    context: Context = {
         u'user': current_user.name,
         u'auth_user_obj': current_user
-    })
+    }
     data_dict = {u'id': id}
 
     try:
@@ -630,12 +616,10 @@ def delete(id: str) -> Union[Response, Any]:
 
 class RequestResetView(MethodView):
     def _prepare(self):
-        context = cast(Context, {
-            u'model': model,
-            u'session': model.Session,
+        context: Context = {
             u'user': current_user.name,
             u'auth_user_obj': current_user
-        })
+        }
         try:
             logic.check_access(u'request_reset', context)
         except logic.NotAuthorized:
@@ -817,12 +801,10 @@ class PerformResetView(MethodView):
 
 def follow(id: str) -> Response:
     u'''Start following this user.'''
-    context = cast(Context, {
-        u'model': model,
-        u'session': model.Session,
+    context: Context = {
         u'user': current_user.name,
         u'auth_user_obj': current_user
-    })
+    }
     data_dict: dict[str, Any] = {u'id': id, u'include_num_followers': True}
     try:
         logic.get_action(u'follow_user')(context, data_dict)
@@ -839,12 +821,10 @@ def follow(id: str) -> Response:
 
 def unfollow(id: str) -> Response:
     u'''Stop following this user.'''
-    context = cast(Context, {
-        u'model': model,
-        u'session': model.Session,
+    context: Context = {
         u'user': current_user.name,
         u'auth_user_obj': current_user
-    })
+    }
     data_dict: dict[str, Any] = {u'id': id, u'include_num_followers': True}
     try:
         logic.get_action(u'unfollow_user')(context, data_dict)
@@ -861,11 +841,11 @@ def unfollow(id: str) -> Response:
 
 
 def followers(id: str) -> str:
-    context = cast(Context, {
+    context: Context = {
         u'for_view': True,
         u'user': current_user.name,
         u'auth_user_obj': current_user
-    })
+    }
     data_dict: dict[str, Any] = {
         u'id': id,
         u'user_obj': current_user,
@@ -887,12 +867,10 @@ def sysadmin() -> Response:
     status = asbool(request.form.get(u'status'))
 
     try:
-        context = cast(Context, {
-            u'model': model,
-            u'session': model.Session,
+        context: Context = {
             u'user': current_user.name,
             u'auth_user_obj': current_user,
-        })
+        }
         data_dict: dict[str, Any] = {u'id': username, u'sysadmin': status}
         user = logic.get_action(u'user_patch')(context, data_dict)
     except logic.NotAuthorized:

--- a/ckanext/activity/email_notifications.py
+++ b/ckanext/activity/email_notifications.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import datetime
 import re
-from typing import Any, cast
+from typing import Any
 from jinja2 import Environment
 
 import ckan.model as model
@@ -146,10 +146,7 @@ def _notifications_from_dashboard_activity_list(
 
     """
     # Get the user's dashboard activity stream.
-    context = cast(
-        Context,
-        {"model": model, "session": model.Session, "user": user_dict["id"]},
-    )
+    context: Context = {"user": user_dict["id"]}
     activity_list = logic.get_action("dashboard_activity_list")(context, {})
 
     # Filter out the user's own activities., so they don't get an email every
@@ -264,15 +261,10 @@ def get_and_send_notifications_for_user(user: dict[str, Any]) -> None:
 
 
 def get_and_send_notifications_for_all_users() -> None:
-    context = cast(
-        Context,
-        {
-            "model": model,
-            "session": model.Session,
-            "ignore_auth": True,
-            "keep_email": True,
-        },
-    )
+    context: Context = {
+        "ignore_auth": True,
+        "keep_email": True,
+    }
     users = logic.get_action("user_list")(context, {})
     for user in users:
         get_and_send_notifications_for_user(user)

--- a/ckanext/activity/helpers.py
+++ b/ckanext/activity/helpers.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import annotations
-from typing import Any, Optional, cast
+from typing import Any, Optional
 
 import jinja2
 import datetime
 from markupsafe import Markup
 
-import ckan.model as model
 import ckan.plugins.toolkit as tk
 
 from ckan.types import Context
@@ -38,7 +37,7 @@ def dashboard_activity_stream(
     :rtype: string
 
     """
-    context = cast(Context, {"user": tk.g.user})
+    context: Context = {"user": tk.g.user}
     if filter_type:
         action_functions = {
             "dataset": "package_activity_list",
@@ -73,11 +72,10 @@ def recently_changed_packages_activity_stream(
         data_dict = {"limit": limit}
     else:
         data_dict = {}
-    context = cast(
-        Context, {"model": model, "session": model.Session, "user": tk.g.user}
-    )
+
     return tk.get_action("recently_changed_packages_activity_list")(
-        context, data_dict
+        {"user": tk.current_user.name},
+        data_dict
     )
 
 

--- a/ckanext/activity/logic/schema.py
+++ b/ckanext/activity/logic/schema.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import cast
-
 from ckan.logic.schema import validator_args, default_pagination_schema
 from ckan.types import Schema, Validator, ValidatorFactory
 
@@ -19,33 +17,30 @@ def default_create_activity_schema(
     activity_type_exists: Validator,
     ignore_empty: Validator,
     ignore_missing: Validator,
-):
-    return cast(
-        Schema,
-        {
-            "id": [ignore],
-            "timestamp": [ignore],
-            "user_id": [
-                not_missing,
-                not_empty,
-                unicode_safe,
-                convert_user_name_or_id_to_id,
-            ],
-            "object_id": [
-                not_missing,
-                not_empty,
-                unicode_safe,
-                object_id_validator,
-            ],
-            "activity_type": [
-                not_missing,
-                not_empty,
-                unicode_safe,
-                activity_type_exists,
-            ],
-            "data": [ignore_empty, ignore_missing],
-        },
-    )
+) -> Schema:
+    return {
+        "id": [ignore],
+        "timestamp": [ignore],
+        "user_id": [
+            not_missing,
+            not_empty,
+            unicode_safe,
+            convert_user_name_or_id_to_id,
+        ],
+        "object_id": [
+            not_missing,
+            not_empty,
+            unicode_safe,
+            object_id_validator,
+        ],
+        "activity_type": [
+            not_missing,
+            not_empty,
+            unicode_safe,
+            activity_type_exists,
+        ],
+        "data": [ignore_empty, ignore_missing],
+    }
 
 
 @validator_args

--- a/ckanext/activity/model/activity.py
+++ b/ckanext/activity/model/activity.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import Any, Iterable, Optional, Type, TypeVar, cast
+from typing import Any, Iterable, Optional, Type, TypeVar
 from typing_extensions import TypeAlias
 
 from sqlalchemy.orm import relationship, backref
@@ -109,16 +109,11 @@ class Activity(domain_object.DomainObject, BaseModel):  # type: ignore
             # We save the entire rendered package dict so we can support
             # viewing the past packages from the activity feed.
             dictized_package = ckan.logic.get_action("package_show")(
-                cast(
-                    Context,
-                    {
-                        "model": ckan.model,
-                        "session": ckan.model.Session,
-                        # avoid ckanext-multilingual translating it
-                        "for_view": False,
-                        "ignore_auth": True,
-                    },
-                ),
+                {
+                    # avoid ckanext-multilingual translating it
+                    "for_view": False,
+                    "ignore_auth": True,
+                },
                 {"id": pkg.id, "include_tracking": False},
             )
         except ckan.logic.NotFound:

--- a/ckanext/activity/views.py
+++ b/ckanext/activity/views.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 
 from datetime import datetime
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, Union
 
 from flask import Blueprint
 
@@ -99,13 +99,10 @@ def _get_newer_activities_url(
 
 @bp.route("/dataset/<id>/resources/<resource_id>/history/<activity_id>")
 def resource_history(id: str, resource_id: str, activity_id: str) -> str:
-    context = cast(
-        Context,
-        {
-            "auth_user_obj": tk.g.userobj,
-            "for_view": True,
-        },
-    )
+    context: Context = {
+        "auth_user_obj": tk.g.userobj,
+        "for_view": True,
+    }
 
     try:
         package = tk.get_action("package_show")(context, {"id": id})
@@ -202,13 +199,10 @@ def resource_history(id: str, resource_id: str, activity_id: str) -> str:
 
 @bp.route("/dataset/<id>/history/<activity_id>")
 def package_history(id: str, activity_id: str) -> Union[Response, str]:
-    context = cast(
-        Context,
-        {
-            "for_view": True,
-            "auth_user_obj": tk.g.userobj,
-        },
-    )
+    context: Context = {
+        "for_view": True,
+        "auth_user_obj": tk.g.userobj,
+    }
     data_dict = {"id": id, "include_tracking": True}
 
     # check if package exists
@@ -302,13 +296,10 @@ def package_activity(id: str) -> Union[Response, str]:  # noqa
     before = tk.request.args.get("before")
     activity_type = tk.request.args.get("activity_type")
 
-    context = cast(
-        Context,
-        {
-            "for_view": True,
-            "auth_user_obj": tk.g.userobj,
-        },
-    )
+    context: Context = {
+        "for_view": True,
+        "auth_user_obj": tk.g.userobj,
+    }
 
     data_dict = {"id": id}
     limit = _get_activity_stream_limit()
@@ -380,7 +371,7 @@ def package_changes(id: str) -> Union[Response, str]:  # noqa
     Shows the changes to a dataset in one particular activity stream item.
     """
     activity_id = id
-    context = cast(Context, {"auth_user_obj": tk.g.userobj})
+    context: Context = {"auth_user_obj": tk.g.userobj}
     try:
         activity_diff = tk.get_action("activity_diff")(
             context,
@@ -424,7 +415,7 @@ def package_changes_multiple() -> Union[Response, str]:  # noqa
     new_id = tk.h.get_request_param("new_id")
     old_id = tk.h.get_request_param("old_id")
 
-    context = cast(Context, {"auth_user_obj": tk.g.userobj})
+    context: Context = {"auth_user_obj": tk.g.userobj}
 
     # check to ensure that the old activity is actually older than
     # the new activity
@@ -512,7 +503,7 @@ def group_activity(id: str, group_type: str) -> str:
     if group_type == 'organization':
         set_org(True)
 
-    context = cast(Context, {"user": tk.g.user, "for_view": True})
+    context: Context = {"user": tk.g.user, "for_view": True}
 
     try:
         group_dict = _get_group_dict(id, group_type)
@@ -601,12 +592,9 @@ def group_changes(id: str, group_type: str, is_organization: bool) -> str:
     """
     extra_vars = {}
     activity_id = id
-    context = cast(
-        Context,
-        {
-            "auth_user_obj": tk.g.userobj,
-        },
-    )
+    context: Context = {
+        "auth_user_obj": tk.g.userobj,
+    }
     try:
         activity_diff = tk.get_action("activity_diff")(
             context,
@@ -659,12 +647,9 @@ def group_changes_multiple(is_organization: bool, group_type: str) -> str:
     new_id = tk.h.get_request_param("new_id")
     old_id = tk.h.get_request_param("old_id")
 
-    context = cast(
-        Context,
-        {
+    context: Context = {
             "auth_user_obj": tk.g.userobj,
-        },
-    )
+    }
 
     # check to ensure that the old activity is actually older than
     # the new activity
@@ -745,13 +730,10 @@ def user_activity(id: str) -> str:
     after = tk.request.args.get("after")
     before = tk.request.args.get("before")
 
-    context = cast(
-        Context,
-        {
-            "auth_user_obj": tk.g.userobj,
-            "for_view": True,
-        },
-    )
+    context: Context = {
+        "auth_user_obj": tk.g.userobj,
+        "for_view": True,
+    }
     data_dict: dict[str, Any] = {
         "id": id,
         "user_obj": tk.g.userobj,
@@ -814,13 +796,10 @@ def dashboard() -> str:
         tk.h.flash_error(tk._(u'Not authorized to see this page'))
         return tk.h.redirect_to(u'user.login')
 
-    context = cast(
-        Context,
-        {
-            "auth_user_obj": tk.g.userobj,
-            "for_view": True,
-        },
-    )
+    context: Context = {
+        "auth_user_obj": tk.g.userobj,
+        "for_view": True,
+    }
     data_dict: dict[str, Any] = {"user_obj": tk.g.userobj}
     extra_vars = _extra_template_variables(context, data_dict)
 
@@ -899,13 +878,10 @@ def _get_dashboard_context(
         return display_name or fullname or title or name
 
     if filter_type and filter_id:
-        context = cast(
-            Context,
-            {
-                "auth_user_obj": tk.g.userobj,
-                "for_view": True,
-            },
-        )
+        context: Context = {
+            "auth_user_obj": tk.g.userobj,
+            "for_view": True,
+        }
         data_dict: dict[str, Any] = {
             "id": filter_id,
             "include_num_followers": True,

--- a/ckanext/datapusher/cli.py
+++ b/ckanext/datapusher/cli.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-from ckan.types import Context
-
 import logging
-from typing import cast
 
 import click
 
-import ckan.model as model
 import ckan.plugins.toolkit as tk
 import ckanext.datastore.backend as datastore_backend
 from ckan.cli import error_shout
@@ -62,20 +58,18 @@ def submit(package: str, yes: bool):
     confirm(yes)
 
     if not package:
-        ids = tk.get_action(u'package_list')(cast(Context, {
-            u'model': model,
-            u'ignore_auth': True
-        }), {})
+        ids = tk.get_action(u'package_list')({
+            'ignore_auth': True
+        }, {})
     else:
         ids = [package]
 
     for id in ids:
         package_show = tk.get_action(u'package_show')
         try:
-            pkg = package_show(cast(Context, {
-                u'model': model,
+            pkg = package_show({
                 u'ignore_auth': True
-            }), {u'id': id})
+            }, {u'id': id})
         except Exception as e:
             error_shout(e)
             error_shout(u"Package '{}' was not found".format(package))
@@ -88,10 +82,9 @@ def submit(package: str, yes: bool):
 
 def _submit(resources: list[str]):
     click.echo(u'Submitting {} datastore resources'.format(len(resources)))
-    user = tk.get_action(u'get_site_user')(cast(Context, {
-        u'model': model,
-        u'ignore_auth': True
-    }), {})
+    user = tk.get_action(u'get_site_user')({
+        'ignore_auth': True
+    }, {})
     datapusher_submit = tk.get_action(u'datapusher_submit')
     for id in resources:
         click.echo(u'Submitting {}...'.format(id), nl=False)

--- a/ckanext/datapusher/interfaces.py
+++ b/ckanext/datapusher/interfaces.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from ckan.plugins.interfaces import Interface
 from typing import Any
+from ckan.types import Context
 
 
 class IDataPusher(Interface):
@@ -40,7 +41,7 @@ class IDataPusher(Interface):
         return True
 
     def after_upload(
-            self, context: dict[str, Any], resource_dict: dict[str, Any],
+            self, context: Context, resource_dict: dict[str, Any],
             dataset_dict: dict[str, Any]) -> None:
         """ After a resource has been successfully upload to the datastore
         this method will be called with the resource dictionary and the

--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -6,7 +6,7 @@ import logging
 import json
 import datetime
 import time
-from typing import Any, cast
+from typing import Any
 
 from urllib.parse import urljoin
 from dateutil.parser import parse as parse_date
@@ -126,8 +126,7 @@ def datapusher_submit(context: Context, data_dict: dict[str, Any]):
     # Use local session for task_status_update, so it can commit its own
     # results without messing up with the parent session that contains pending
     # updats of dataset/resource/etc.
-    context['session'] = cast(
-        Any, context['model'].meta.create_local_session())
+    context['session'] = context['model'].meta.create_local_session()
     p.toolkit.get_action('task_status_update')(context, task)
 
     timeout = config.get('ckan.requests.timeout')
@@ -232,7 +231,7 @@ def datapusher_hook(context: Context, data_dict: dict[str, Any]):
             context, {'id': resource_dict['package_id']})
 
         for plugin in p.PluginImplementations(interfaces.IDataPusher):
-            plugin.after_upload(cast("dict[str, Any]", context),
+            plugin.after_upload(context,
                                 resource_dict, dataset_dict)
 
         logic.get_action('resource_create_default_resource_views')(

--- a/ckanext/datapusher/plugin.py
+++ b/ckanext/datapusher/plugin.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from ckan.common import CKANConfig
 from ckan.types import Action, AuthFunction, Context
 import logging
-from typing import Any, Callable, cast
+from typing import Any, Callable
 
 import ckan.model as model
 import ckan.plugins as p
@@ -57,10 +57,7 @@ class DatapusherPlugin(p.SingletonPlugin):
     # IResourceUrlChange
 
     def notify(self, resource: model.Resource):
-        context = cast(Context, {
-            u'model': model,
-            u'ignore_auth': True,
-        })
+        context: Context = {'ignore_auth': True}
         resource_dict = p.toolkit.get_action(u'resource_show')(
             context, {
                 u'id': resource.id,
@@ -81,11 +78,10 @@ class DatapusherPlugin(p.SingletonPlugin):
         self._submit_to_datapusher(resource_dict)
 
     def _submit_to_datapusher(self, resource_dict: dict[str, Any]):
-        context = cast(Context, {
-            u'model': model,
+        context: Context = {
             u'ignore_auth': True,
             u'defer_commit': True
-        })
+        }
 
         resource_format = resource_dict.get('format')
         supported_formats = p.toolkit.config.get(

--- a/ckanext/multilingual/plugin.py
+++ b/ckanext/multilingual/plugin.py
@@ -1,8 +1,7 @@
 # encoding: utf-8
 from __future__ import annotations
 
-from ckan.types import Context
-from typing import Any, cast
+from typing import Any
 
 import ckan
 import ckan.lib.navl.dictization_functions
@@ -48,7 +47,7 @@ def translate_data_dict(data_dict: dict[str, Any]):
 
     # Get the translations of all the terms (as a list of dictionaries).
     translations = get_action('term_translation_show')(
-            cast(Context, {'model': ckan.model}),
+            {},
             {'terms': terms,
                 'lang_codes': (desired_lang_code, fallback_lang_code)})
 
@@ -139,7 +138,7 @@ def translate_resource_data_dict(data_dict: dict[str, Any]):
 
     # Get the translations of all the terms (as a list of dictionaries).
     translations = get_action('term_translation_show')(
-            cast(Context, {'model': ckan.model}),
+            {},
             {'terms': terms,
                 'lang_codes': (desired_lang_code, fallback_lang_code)})
     # Transform the translations into a more convenient structure.
@@ -217,7 +216,7 @@ class MultilingualDataset(plugins.SingletonPlugin):
         title = search_data.get('title')
         search_data['title_' + default_lang] = title
         title_translations = get_action('term_translation_show')(
-                          cast(Context, {'model': ckan.model}),
+                          {},
                           {'terms': [title],
                            'lang_codes': self.LANGS})
 
@@ -237,7 +236,7 @@ class MultilingualDataset(plugins.SingletonPlugin):
                     all_terms.append(item)
 
         field_translations = get_action('term_translation_show')(
-                          cast(Context, {'model': ckan.model}),
+                          {},
                           {'terms': all_terms,
                            'lang_codes': self.LANGS})
 
@@ -308,7 +307,7 @@ class MultilingualDataset(plugins.SingletonPlugin):
             for item in facet['items']:
                 terms.add(item['display_name'])
         translations = get_action('term_translation_show')(
-                cast(Context, {'model': ckan.model}),
+                {},
                 {'terms': terms,
                     'lang_codes': (desired_lang_code, fallback_lang_code)})
 
@@ -346,7 +345,7 @@ class MultilingualDataset(plugins.SingletonPlugin):
             return translate_data_dict(dataset_dict)
         terms = [value for _param, value in fields]
         translations = get_action('term_translation_show')(
-                cast(Context, {'model': ckan.model}),
+                {},
                 {'terms': terms,
                  'lang_codes': (desired_lang_code, fallback_lang_code)})
         g.translated_fields = {}

--- a/ckanext/resourceproxy/blueprint.py
+++ b/ckanext/resourceproxy/blueprint.py
@@ -1,6 +1,5 @@
 # encoding: utf-8
 
-from typing import cast
 from ckan.types import Context, DataDict
 from logging import getLogger
 
@@ -8,7 +7,6 @@ import requests
 from urllib.parse import urlsplit
 from flask import Blueprint, make_response
 
-import ckan.model as model
 import ckan.logic as logic
 from ckan.common import config, _
 from ckan.plugins.toolkit import (abort, get_action, c)
@@ -102,11 +100,7 @@ def proxy_resource(context: Context, data_dict: DataDict):
 
 def proxy_view(id: str, resource_id: str):
     data_dict = {u'resource_id': resource_id}
-    context = cast(Context, {
-        u'model': model,
-        u'session': model.Session,
-        u'user': c.user
-    })
+    context: Context = {'user': c.user}
     return proxy_resource(context, data_dict)
 
 


### PR DESCRIPTION
Whenever possible:
* replace `context = cast(Context, ...)` with `context: Context = ...`
* remove `cast(...)`
* remove `model` from context because it's added by `get_action`
* remove `session = model.Session` from context because it's added by `get_action`

The first two steps are transparent - they make our types more reliable. `model` and `session` are not required(as long as it's `ckan.model` and `ckan.model.Session`), because `tk.get_action` has `context.setdefault(...)` for these two properties. 

ℹ️ For now I updated the type definition of `context['auth_user_obj']`. It has `model.AnonymousUser` option added because the way we are passing `auth_user_obj` to context allows this to happen.

What does it mean:
`if context['auth_user_obj'] and context['auth_user_obj'].is_sysadmin` [now is reported as an error](https://github.com/ckan/ckan/pull/7611/files#diff-de994d21743eecf63b0983d3dd5c1254224ae84ac8d2b99a00304d0bc5d1650dR1002-R1005) by typechecker. Because `auth_user_obj` can be represented by `model.AnonymousUser` which doesn't has `is_sysadmin` property.

How it can be improved:
If all `context['auth_user_obj'] = tk.current_user` lines are removed, we can remove `model.AnonymousUser` from the type definition of `auth_user_obj` and everything will be safe once again.