### PR TITLE
Custom validators in config declarations

### DIFF
--- a/changes/7612.feature
+++ b/changes/7612.feature
@@ -1,0 +1,11 @@
+Validators registered via :py:class:`~ckan.plugins.interfaces:IValidators` can
+be used in config declarations. Note that custom config options(declared by
+plugins), may remain not normalized at this point and must be converted
+manually::
+
+    def get_validators(self):
+        validators = {}
+        use_fancy = tk.asbool(tk.config.get("my.ext.use_fancy_validator"))
+        if use_fancy:
+            validators["fancy_validator"] = fancy_validator
+        return validators

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -117,6 +117,8 @@ def update_config() -> None:
 
     config_declaration.setup()
     config_declaration.make_safe(config)
+    # clear validators cache to allow using custom validators in declarations.
+    logic.clear_validators_cache()
     config_declaration.normalize(config)
 
     webassets_init()

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -872,6 +872,25 @@ class IValidators(Interface):
 
         These validator functions would then be available when a
         plugin calls :py:func:`ckan.plugins.toolkit.get_validator`.
+
+        .. note:: Custom config option may remain not normalized/valid at this
+            point. Manually normaize any custom option that affects the result
+            of this methid::
+
+                validators = {}
+                use_fancy = tk.asbool(tk.config.get("my.ext.use_fancy_validator"))
+                if use_fancy:
+                    validators["fancy_validator"] = fancy_validator
+                return validators
+
+            Config options declared by CKAN itself are normalized, so they can
+            be used without extra manipulations::
+
+                validators = {}
+                if tk.config["debug"]:
+                    validators["debug_validator"] = debug_validator
+                return validators
+
         '''
         return {}
 

--- a/ckanext/example_ivalidators/config_declaration.yaml
+++ b/ckanext/example_ivalidators/config_declaration.yaml
@@ -1,0 +1,7 @@
+version: 1
+groups:
+  - annotation: ~
+    options:
+      - key: example.ivalidators.number
+        validators: int_validator negate
+        default: 1

--- a/ckanext/example_ivalidators/plugin.py
+++ b/ckanext/example_ivalidators/plugin.py
@@ -6,10 +6,11 @@ from typing import Any
 from ckan.types import Validator
 
 
-from ckan.plugins.toolkit import Invalid
+from ckan.plugins.toolkit import Invalid, blanket
 from ckan import plugins
 
 
+@blanket.config_declarations
 class ExampleIValidatorsPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IValidators)
 


### PR DESCRIPTION
Allow using custom validators inside config declaration.

We need to clean the validator's cache in order to achieve it. Benchmarks show that this step increases the startup time of the CKAN app by 0.7ms. The whole startup time is 500ms, so we can afford such a delay.

There is one edge case. As we are going to use custom validators in order to normalize/validate the config option, when `IValidators.get_validators` is called, options from plugins are not normalized yet. It means that you should manually convert custom options:
```python
def get_validators():
  some_value = tk.aslist(tk.config.get("my.ext.some_list"))
  ...
```

This happens only with custom options because they are not yet normalized when validators are collected. All built-in options are normalized at this point, because CKAN loads its core first(and normalizes built-in options), and only then re-loads enabling all plugins.
