### PR TITLE
Parse validators string using ast

### DIFF
--- a/changes/7615.feature
+++ b/changes/7615.feature
@@ -1,0 +1,17 @@
+`validators` attribute of a declared config option makes an attempt to parse
+argument to validators as python literals. If **all** arguments can be parsed,
+they are passed to a validator factory with original types. If at least one
+argument is not a valid python literal, all values are passed as a string(old
+behavior). Space characters are still not allowed inside arguments, use `\\x20`
+symbol if you need a space in literal::
+
+    # Not changed
+    `validators: v(xxx)` # v("xxx")
+    `validators: v("xxx",yyy)` # v("xxx", "yyy")
+    `validators: v(1,2,none)` # v("1", "2", "none")
+    `validators: v("hello\\x20world")` # v("hello world")
+
+    # Changed
+    `validators: v("xxx")` # v("xxx")
+    `validators: v("xxx",1)` # v("xxx", 1)
+    `validators: v(1,2,None)` # v(1, 2, None)

--- a/ckan/config/declaration/option.py
+++ b/ckan/config/declaration/option.py
@@ -5,11 +5,11 @@
 from __future__ import annotations
 
 import enum
-from typing import Any, Generic, Optional, TypeVar
+from typing import Any, Generic, Optional, TypeVar, cast
 
 from typing_extensions import Self
 
-from ckan.types import Validator
+from ckan.types import Validator, ValidatorFactory
 
 T = TypeVar("T")
 
@@ -351,24 +351,37 @@ class Option(SectionMixin, Generic[T]):
 
 
 # taken from ckanext-scheming
-# (https://github.com/ckan/ckanext-scheming/blob/release-2.1.0/ckanext/scheming/validation.py#L407-L426).
+# (https://github.com/ckan/ckanext-scheming/blob/master/ckanext/scheming/validation.py#L332).
 # This syntax is familiar for everyone and we can switch to the original
 # when scheming become a part of core.
 def _validators_from_string(s: str) -> list[Validator]:
     """
     convert a schema validators string to a list of validators
-    e.g. "if_empty_same_as(name) unicode" becomes:
-    [if_empty_same_as("name"), unicode]
+
+    e.g. "if_empty_same_as(name) unicode_safe" becomes:
+    [if_empty_same_as("name"), unicode_safe]
     """
+    import ast
     from ckan.logic import get_validator
 
     out = []
     parts = s.split()
     for p in parts:
-        if "(" in p and p[-1] == ")":
-            name, args = p.split("(", 1)
-            args: Any = args[:-1].split(",")  # trim trailing ')', break up
-            v = get_validator(name)(*args)
+        if '(' in p and p[-1] == ')':
+            name, args = p.split('(', 1)
+            args = args[:-1]  # trim trailing ')'
+            try:
+                parsed_args = ast.literal_eval(args)
+                if not isinstance(parsed_args, tuple) or not parsed_args:
+                    # it's a signle argument. `not parsed_args` means that this single
+                    # argument is an empty tuple, for example: "default(())"
+                    parsed_args = (parsed_args,)
+
+            except (ValueError, TypeError, SyntaxError, MemoryError):
+                parsed_args = args.split(',')
+
+            factory = cast(ValidatorFactory, get_validator(name))
+            v = factory(*parsed_args)
         else:
             v = get_validator(p)
         out.append(v)

--- a/ckan/config/declaration/option.py
+++ b/ckan/config/declaration/option.py
@@ -373,8 +373,10 @@ def _validators_from_string(s: str) -> list[Validator]:
             try:
                 parsed_args = ast.literal_eval(args)
                 if not isinstance(parsed_args, tuple) or not parsed_args:
-                    # it's a signle argument. `not parsed_args` means that this single
-                    # argument is an empty tuple, for example: "default(())"
+                    # it's a signle argument. `not parsed_args` means that this
+                    # single argument is an empty tuple,
+                    # for example: "default(())"
+
                     parsed_args = (parsed_args,)
 
             except (ValueError, TypeError, SyntaxError, MemoryError):

--- a/ckan/tests/config/declaration/test_option.py
+++ b/ckan/tests/config/declaration/test_option.py
@@ -23,3 +23,19 @@ class TestDetails:
         assert option.normalize(option.default) is True
         assert option.normalize("no") is False
         assert option.normalize(False) is False
+
+        option.set_default("")
+        option.set_validators("default(xxx)")
+        assert option.normalize(option.default) == "xxx"
+
+        option.set_validators("default('yyy')")
+        assert option.normalize(option.default) == "yyy"
+
+        option.set_validators("default(10)")
+        assert option.normalize(option.default) == 10
+
+        option.set_validators("default('10')")
+        assert option.normalize(option.default) == "10"
+
+        option.set_validators("default([[],{():None}])")
+        assert option.normalize(option.default) == [[], {(): None}]


### PR DESCRIPTION

When loading config declarations, try parsing arguments to the validator as python literal.

Port of [a new ckanext-scheming](https://github.com/ckan/ckanext-scheming/pull/372#event-9369278556) behavior for validators string.
