### PR TITLE
Customize R/W datastore resource url_types

### DIFF
--- a/changes/7617.feature
+++ b/changes/7617.feature
@@ -1,0 +1,2 @@
+datastore_rw_resource_url_types helper can be overridden to define additional
+resource url_type values that can be modified without force=True

--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -239,3 +239,12 @@ def datastore_search_sql_enabled(*args: Any) -> bool:
         return tk.asbool(config)
     except (tk.ObjectNotFound, tk.NotAuthorized):
         return False
+
+
+def datastore_rw_resource_url_types() -> list[str]:
+    """
+    Return a list of resource url_type values that do not require passing
+    force=True when used with datastore_create, datastore_upsert,
+    datastore_delete
+    """
+    return ["datastore"]

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -700,10 +700,14 @@ def _check_read_only(context: Context, resource_id: str):
     '''
     res = p.toolkit.get_action('resource_show')(
         context, {'id': resource_id})
-    if res.get('url_type') != 'datastore':
+    if res.get('url_type') not in (
+            p.toolkit.h.datastore_rw_resource_url_types()
+        ):
         raise p.toolkit.ValidationError({
-            'read-only': ['Cannot edit read-only resource. Either pass'
-                          '"force=True" or change url_type to "datastore"']
+            'read-only': ['Cannot edit read-only resource because changes '
+                          'made may be lost. Use a resource created for '
+                          'editing e.g. with datastore_create or use '
+                          '"force=True" to ignore this warning.']
         })
 
 

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -258,10 +258,12 @@ class DatastorePlugin(p.SingletonPlugin):
     def get_helpers(self) -> dict[str, Callable[..., object]]:
         conf_dictionary = datastore_helpers.datastore_dictionary
         conf_sql_enabled = datastore_helpers.datastore_search_sql_enabled
+        rw_url_types = datastore_helpers.datastore_rw_resource_url_types
 
         return {
             'datastore_dictionary': conf_dictionary,
-            'datastore_search_sql_enabled': conf_sql_enabled
+            'datastore_search_sql_enabled': conf_sql_enabled,
+            'datastore_rw_resource_url_types': rw_url_types,
         }
 
     # IForkObserver


### PR DESCRIPTION
Fixes #7617

### Proposed fixes:

Add a datastore_rw_resource_url_types helper that lists url_type values that may be edited without passing force=True

Improve error message when force=True is required but not passed.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
