### PR TITLE
reset_redis/clean_redis fixtures

### DIFF
--- a/changes/7630.feature
+++ b/changes/7630.feature
@@ -1,0 +1,1 @@
+New `reset_redis` and `clean_redis` test fixtures for removing data from Redis.


### PR DESCRIPTION
Add two fixtures for removing records from Redis.

`reset_redis`: returns callable that removes records from redis on call. Accepts a redis pattern for keys to remove(i.e `*` - all keys, `ckan:default:*` - all keys prefixed by `ckan:default:`). By default removes all keys

`clean_redis`: fixture that cleans redis via side-effect(like `clean_db` or `clean_index`)