### PR TITLE
Set `context["user"]` for `generate fake-data`

### DIFF
--- a/changes/7635.feature
+++ b/changes/7635.feature
@@ -1,0 +1,3 @@
+``ckan generate fake-data`` accepts ``--user`` option that is used as ``context["user"]``.
+Some factories(``api-token`` for example), has a special meaning for the ``user`` parameter
+and do not pass it to context.

--- a/ckan/tests/cli/test_generate.py
+++ b/ckan/tests/cli/test_generate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import pytest
 
 from ckan import model
@@ -72,3 +73,23 @@ class TestFakeData:
 
         user = model.Session.query(model.User).filter_by(fullname=name).one()
         assert user.fullname == name
+
+    def test_json_output(self, cli: CKANCliRunner):
+        """Command produces valid JSON."""
+        result = cli.invoke(generate, ["fake-data", "organization"])
+        value = json.loads(result.output)
+        assert value
+
+    def test_specify_user_parameter(self, cli: CKANCliRunner, user):
+        """Factory accepts username and use it as `context["user"]`."""
+        username = user["name"]
+        result = cli.invoke(
+            generate, [
+                "fake-data",
+                "dataset",
+                f"--user={username}"
+            ],
+        )
+
+        dataset = json.loads(result.output)
+        assert dataset["creator_user_id"] == user["id"]

--- a/ckan/tests/factories.py
+++ b/ckan/tests/factories.py
@@ -115,6 +115,10 @@ def _get_action_user_name(kwargs: dict[str, Any]) -> Optional[str]:
 
     It can be overridden by explicitly setting {'user': None} in the keyword
     arguments. In that case, this method will return None.
+
+    If `user` key available in kwargs and it's a string, return value
+    unchanged. Otherwise, return `user["name"]`.
+
     """
 
     if "user" in kwargs:
@@ -124,6 +128,8 @@ def _get_action_user_name(kwargs: dict[str, Any]) -> Optional[str]:
 
     if user is None:
         user_name = None
+    elif isinstance(user, str):
+        user_name = user
     else:
         user_name = user["name"]
 


### PR DESCRIPTION
In tests, it's possible to use specific users inside a factory. For example, if you want to create a dataset as a specific user, you can pass userdict as a named `user` argument to the factory:
```python

def test_owner(dataset_factory, user):
    dataset = dataset_factory(user=user)
    assert dataset["creator_user_id"] == user["id"]
```

It doesn't work with CLI `ckan generate fake-data`, because CLI accepts only strings, not python dicts.

This PR adds a special case for the named `user` argument of factories. If it's an `str` - use this `str` as a username for context.
Previously, only `None` and `dict` were allowed as a `user`, so there will be no conflicts with existing code.