### PR TITLE
Stricter with_plugins

### DIFF
--- a/ckan/tests/pytest_ckan/ckan_setup.py
+++ b/ckan/tests/pytest_ckan/ckan_setup.py
@@ -54,9 +54,11 @@ def pytest_runtestloop(session):
     """When all the tests collected, extra plugin may be enabled because python
     interpreter visits their files.
 
-    Make sure only configured plugins are active when test loop starts.
+    Make sure all plugins are disabled. If test requires a plugin, it must rely
+    on `with_plugins` fixture.
+
     """
-    plugins.load_all()
+    plugins.unload_all()
 
 
 def pytest_runtest_setup(item):

--- a/ckan/tests/pytest_ckan/test_fixtures.py
+++ b/ckan/tests/pytest_ckan/test_fixtures.py
@@ -33,10 +33,21 @@ def test_ckan_config_mark_without_explicit_config_fixture():
     assert config[u"some.new.config"] == u"exists"
 
 
-@pytest.mark.ckan_config(u"ckan.plugins", u"stats")
-@pytest.mark.usefixtures(u"with_plugins")
-def test_with_plugins_is_able_to_run_with_stats():
-    assert plugins.plugin_loaded(u"stats")
+class TestWithPlugins:
+    @pytest.fixture()
+    def load_example_helpers(self):
+        plugins.unload_all()
+        plugins.load("example_itemplatehelpers")
+
+    @pytest.mark.ckan_config(u"ckan.plugins", u"stats")
+    @pytest.mark.usefixtures(u"with_plugins")
+    def test_with_plugins_is_able_to_run_with_stats(self):
+        assert plugins.plugin_loaded(u"stats")
+
+    def test_with_plugins_unloads_enabled_plugins(
+            self, load_example_helpers, with_plugins
+    ):
+        assert "example_helper" not in plugins.toolkit.h
 
 
 @pytest.mark.ckan_config("ckan.site_url", "https://example.org")


### PR DESCRIPTION
Fix two controversial moments in the plugins' behavior during tests.

## All `ckan.plugins` are enabled at the beginning of tests. 

### Current behavior
All plugins are enabled by default. Let's assume that we have `ckan.plugins = custom` and this `custom` plugin registers `custom_helper`. You can create the following test and it will work even without the `with_plugins` fixture:

```python
def test_helper()
    tk.h.custom_helper()
```

It may seem convenient, but if the test relies on plugins, it's better to explicitly say about it by including the `with_plubins` fixture. 

And it may become much worse, if some tests use `with_plugins`, while others don't. Look at the following test sequence:
```python
def test_helper_1()
    tk.h.custom_helper()

def test_helper_2(with_plugins)
    tk.h.custom_helper()

def test_helper_3()
    tk.h.custom_helper()
```

Even though the tests are almost identical, the first and second will pass, while the third will fail. 
The first test passed because the `custom` plugin is enabled in the beginning. The second plugin will pass, because the `custom` plugin is still enabled. But the `with_plugins` fixture disables every plugin from `ckan.plugins` after the test. It means, when the third test starts, the `custom` plugin is no longer enabled and there is no `custom_helper`.

### Fix

Disable all plugins, even one specified by `ckan.plugins` config option in the beginning. It means that whenever you are going to test something that requires a certain plugin enabled, you have to use the `with_plugin` fixture. Extension maintainers have to add `with_plugins` to the tests if it's missing. 


## `with_plugins` relies too much on the current value of `ckan.plugins`.

### Current behavior.

Imagine, that you have `ckan.plugins = first second`. Plugin `first` must be loaded first because it overrides templates of the plugin `second`. Now we write some tests:
```python

@pytest.mark.ckan_config("ckan.plugins", ["first"])
@pytest.mark.usefixtures("with_plugins")
def test_first_functionality():
    pass 

@pytest.mark.usefixtures("with_plugins")
def test_combined_functionality():
    pass 
```

I told you above that all `ckan.plugins` are enabled at the beginning of tests. Keep that in mind.
The first test overrides `ckan.plugins`. It's going to test only the `first` plugin, so we don't want to spend time loading the `second` plugin here. But remember, `with_plugins` unloads plugins after the test. It means that `first` is disabled now. But the `second` is still enabled, because we've overridden `ckan.plugins` for the first test and `with_plugins` doesn't bother to disable anything outside of the current value of `ckan.plugins`.

When the second test starts, `with_plugins` rely on default value of `ckan.plugins` specified in the config file. It loads `first`, but as we still have `second` enabled, the order of plugins now changes: `second first`. And now all the overridden templates and chained actions may behave in unexpected way.

### Fix 

`with_plugins` always does the following:

* Unload **all** enabled plugins. Don't look at `ckan.plugins`. Disable every plugin which is enabled right now.
* Load only plugins from `ckan.plugins`
* After the test, disable **all** enabled plugins. Don't look at `ckan.plugins`. It will guarantee that there will be no side-effects from using `plugins.load(...)` from inside the test.
