### PR TITLE
Fix typo in release documentation

### DIFF
--- a/doc/maintaining/releases.rst
+++ b/doc/maintaining/releases.rst
@@ -30,7 +30,7 @@ Major Releases
 
 Minor Releases
  Minor releases, such as CKAN 2.9 and CKAN 2.10, increment the minor version
- number. These releases are not as disruptive as major releases, but the will
+ number. These releases are not as disruptive as major releases, but they 
  *may* include some backwards-incompatible changes. The
  :doc:`/changelog` will document any breaking changes. We aim to release a minor
  version of CKAN roughly twice a year.


### PR DESCRIPTION
Correct a small typo in the sentence regarding non-major releases. Change "the will may include" to "they may include" for clarity and grammatical correctness.



### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
