### PR TITLE
fix ckanapi commands to export datasets and users

### DIFF
--- a/doc/maintaining/database-management.rst
+++ b/doc/maintaining/database-management.rst
@@ -104,7 +104,7 @@ Lines file using ckanapi_:
 
 .. parsed-literal::
 
-    ckanapi dump datasets -c |ckan.ini| -O my_datasets.jsonl
+    ckanapi dump datasets -c |ckan.ini| --all -O my_datasets.jsonl
 
 This is useful to create a simple public listing of the datasets, with no user
 information. Some simple additions to the Apache config can serve the dump
@@ -138,7 +138,7 @@ a JSON Lines file using ckanapi_:
 
 .. parsed-literal::
 
-    ckanapi dump users -c |ckan.ini| -O my_database_users.jsonl
+    ckanapi dump users -c |ckan.ini| --all -O my_database_users.jsonl
 
 
 .. _db upgrade:


### PR DESCRIPTION
Include the necessary use of the `--all` flag in the `ckanapi` commands to ensure correct functionality. Previously, the documentation was missing this flag, causing the example commands to not work as intended.


### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
