### PR TITLE
Conditional DataStore Tab for Datapusher

### DIFF
--- a/ckanext/datapusher/helpers.py
+++ b/ckanext/datapusher/helpers.py
@@ -29,3 +29,10 @@ def datapusher_status_description(status: dict[str, Any]):
         return captions.get(status['status'], status['status'].capitalize())
     else:
         return _('Not Uploaded Yet')
+
+
+def is_datapusher_format(resource_dict: dict[str, Any]):
+    supported_formats = toolkit.config.get('ckan.datapusher.formats')
+
+    return (resource_dict.get('format', '').lower() in supported_formats
+            and resource_dict.get('url_type') != u'datapusher')

--- a/ckanext/datapusher/plugin.py
+++ b/ckanext/datapusher/plugin.py
@@ -151,6 +151,7 @@ class DatapusherPlugin(p.SingletonPlugin):
             u'datapusher_status': helpers.datapusher_status,
             u'datapusher_status_description': helpers.
             datapusher_status_description,
+            u'is_datapusher_format': helpers.is_datapusher_format,
         }
 
     # IBlueprint

--- a/ckanext/datapusher/templates/package/resource_edit_base.html
+++ b/ckanext/datapusher/templates/package/resource_edit_base.html
@@ -12,5 +12,7 @@
 
 {% block inner_primary_nav %}
   {{ super() }}
-  {{ h.build_nav_icon('datapusher.resource_data', _('DataStore'), id=pkg.name, resource_id=res.id) }}
+  {% if h.is_datapusher_format(res) or res.datastore_active %}
+    {{ h.build_nav_icon('datapusher.resource_data', _('DataStore'), id=pkg.name, resource_id=res.id) }}
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
feat(templates): conditional DataStore tab;

- Added helper for valid datapusher formats.
- Added condition to display the DataStore tab in Resource Edit.

### Features:

Conditions the DataStore tab in resource edit view for the Datapusher extension. Only show the tab if the resource is a supported datapusher format, or if the resource already has an existing datastore table (is datastore active).

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
