### PR TITLE
Refactor search facets nav bar

### DIFF
--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -14268,10 +14268,10 @@ td.diff_header {
   float: right;
 }
 
-.nav-facet, .nav-simple, .list-unstyled {
+.nav-simple, .list-unstyled {
   padding-right: 0;
 }
-.nav-facet .nav-item a span.item-label, .nav-simple .nav-item a span.item-label, .list-unstyled .nav-item a span.item-label {
+.nav-simple .nav-item a span.item-label, .list-unstyled .nav-item a span.item-label {
   padding-right: 15px;
 }
 

--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -11664,13 +11664,6 @@ a.tag:hover {
   border-radius: 100px;
 }
 
-.nav-item .facet-close {
-  float: right;
-  position: relative;
-  transform: translateY(0);
-  left: 10px;
-}
-
 .nav-stacked > li {
   float: none;
 }

--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -14264,9 +14264,6 @@ td.diff_header {
 .nav-simple, .list-unstyled {
   padding-right: 0;
 }
-.nav-simple .nav-item a span.item-label, .list-unstyled .nav-item a span.item-label {
-  padding-right: 15px;
-}
 
 @media (min-width: 768px) {
   .homepage.layout-1 .row1 .col2 {

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -11664,13 +11664,6 @@ a.tag:hover {
   border-radius: 100px;
 }
 
-.nav-item .facet-close {
-  float: right;
-  position: relative;
-  transform: translateY(0);
-  left: 10px;
-}
-
 .nav-stacked > li {
   float: none;
 }

--- a/ckan/public/base/scss/_ckan-rtl.scss
+++ b/ckan/public/base/scss/_ckan-rtl.scss
@@ -118,7 +118,7 @@
     float: right;
 }
 
-.nav-facet, .nav-simple, .list-unstyled {
+.nav-simple, .list-unstyled {
     padding-right: 0;
     .nav-item a span.item-label {
         padding-right: 15px;

--- a/ckan/public/base/scss/_ckan-rtl.scss
+++ b/ckan/public/base/scss/_ckan-rtl.scss
@@ -120,9 +120,6 @@
 
 .nav-simple, .list-unstyled {
     padding-right: 0;
-    .nav-item a span.item-label {
-        padding-right: 15px;
-    }
 }
 
 @include media-breakpoint-up(md) {

--- a/ckan/public/base/scss/_nav.scss
+++ b/ckan/public/base/scss/_nav.scss
@@ -118,15 +118,6 @@
     }
 }
 
-.nav-item{
-    .facet-close {
-        float: right;
-		position: relative;
-		transform: translateY(0);
-		left: 10px;
-    }
-}
-
 // STACKED NAV
 // -----------
 

--- a/ckan/templates/development/snippets/facet.html
+++ b/ckan/templates/development/snippets/facet.html
@@ -2,7 +2,7 @@
   {% with items=(("First", true), ("Second", false), ("Third", true), ("Fourth", false), ("Last", false)) %}
     <h2 class="module-heading"><i class="fa fa-filter"></i>  Facet List</h2>
     <nav>
-      <ul class="list-unstyled nav nav-simple nav-facet">
+      <ul class="list-unstyled nav nav-simple">
         {% for value, active in items %}
           <li class="nav-item{{ ' active' if active }}"><a href="#">{{ value }}</a></li>
         {% endfor %}

--- a/ckan/templates/package/search.html
+++ b/ckan/templates/package/search.html
@@ -73,7 +73,7 @@
   <div class="filters">
     <div>
       {% for facet in facet_titles %}
-        {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, search_facets=search_facets) }}
+        {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, search_facet=search_facets[facet], facet_filter_length=facet_filter_length) }}
       {% endfor %}
     </div>
     <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span class="text">close</span></a>

--- a/ckan/templates/page.html
+++ b/ckan/templates/page.html
@@ -45,7 +45,7 @@
             </div>
           {% endblock %}
 
-          <div class="row wrapper{% block wrapper_class %}{% endblock %}{% if self.secondary()|trim == '' or c.action=='resource_read' %} no-nav{% endif %}">
+          <div class="row wrapper{% block wrapper_class %}{% endblock %}">
             {#
             The pre_primary block can be used to add content to before the
             rendering of the main content columns of the page.

--- a/ckan/templates/snippets/facet_list.html
+++ b/ckan/templates/snippets/facet_list.html
@@ -10,7 +10,7 @@ The title of the facet, eg. "Tags", or "Tag Cloud"
 search_facet
 Dictionary with a search facet and all its items,
 eg. {
-	"title": "Tags",
+	"title": "tags",
 	"items": [
 	{"name": "tag1", "display_name": "Tag 1", "count": 1},
 	{"name": "tag2", "display_name": "Tag 2", "count": 2}
@@ -40,7 +40,7 @@ Maximum number of facet items to display before showing a "more" link.
 
 {% if search_facet %}
 	<div class="list-group list-group-flush">
-		<div class="list-group-item list-group-item-success">{{title}} <i class="fa fa-filter"></i></div>
+		<div class="list-group-item list-group-item-dark">{{title}} <i class="fa fa-filter"></i></div>
 		{% for item in search_facet["items"][:facet_filter_length]%}
 			{{ item_link(item, name) }}
 		{% endfor %}

--- a/ckan/templates/snippets/facet_list.html
+++ b/ckan/templates/snippets/facet_list.html
@@ -57,4 +57,6 @@ Maximum number of facet items to display before showing a "more" link.
 			<strong>Show more...</strong>
 		</button>
 	{% endif %}
+{% else %}
+	<p class="module-content empty">{{ _('There are no {facet_type} that match this search').format(facet_type=title) }}</p>
 {% endif %}

--- a/ckan/templates/snippets/facet_list.html
+++ b/ckan/templates/snippets/facet_list.html
@@ -7,86 +7,54 @@ The field name identifying the facet field, eg. "tags"
 title
 The title of the facet, eg. "Tags", or "Tag Cloud"
 
-label_function
-Renders the human-readable label for each facet value.
-If defined, this should be a callable that accepts a `facet_item`.
-eg. lambda facet_item: facet_item.display_name.upper()
-By default it displays the facet item's display name, which should
-usually be good enough
+search_facet
+Dictionary with a search facet and all its items,
+eg. {
+	"title": "Tags",
+	"items": [
+	{"name": "tag1", "display_name": "Tag 1", "count": 1},
+	{"name": "tag2", "display_name": "Tag 2", "count": 2}
+	]
+}
 
-if_empty
-A string, which if defined, and the list of possible facet items is empty,
-is displayed in lieu of an empty list.
-
-count_label
-A callable which accepts an integer, and returns a string.  This controls
-how a facet-item's count is displayed.
-
-extras
-Extra info passed into the add/remove params to make the url
-
-alternative_url
-URL to use when building the necessary URLs, instead of the default
-ones returned by url_for. Useful eg for dataset types.
-
-hide_empty
-Do not show facet if there are none, Default: false.
-
-search_facets
-Dictionary with search facets
+facet_filter_length
+Maximum number of facet items to display before showing a "more" link.
 
 #}
-{% block facet_list %}
-    {% set hide_empty = hide_empty or false %}
-    {% with items = items or h.get_facet_items_dict(name, search_facets) %}
-	{% if items or not hide_empty %}
-	    {% block facet_list_item %}
-		<section class="module module-narrow module-shallow">
-		    {% block facet_list_heading %}
-			<h2 class="module-heading">
-			    <i class="fa fa-filter"></i>
-			    {{ title }}
-			</h2>
-		    {% endblock %}
-		    {% block facet_list_items %}
-			{% with items = items or h.get_facet_items_dict(name, search_facets) %}
-			    {% if items %}
-				<nav aria-label="{{ title }}">
-				    <ul class="list-unstyled nav nav-simple nav-facet">
-					{% for item in items %}
-					    {% set href = h.remove_url_param(name, item.name, extras=extras, alternative_url=alternative_url) if item.active else h.add_url_param(new_params={name: item.name}, extras=extras, alternative_url=alternative_url) %}
-					    {% set label = label_function(item) if label_function else item.display_name %}
-					    {% set label_truncated = label|truncate(22) if not label_function else label %}
-					    {% set count = count_label(item['count']) if count_label else ('%d' % item['count']) %}
-					    <li class="nav-item {% if item.active %} active{% endif %}">
-						<a href="{{ href }}" title="{{ label if label != label_truncated else '' }}">
-						    <span class="item-label">{{ label_truncated }}</span>
-						    <span class="hidden separator"> - </span>
-						    <span class="item-count badge">{{ count }}</span>
-
-							{% if item.active %}<span class="facet-close"> <i class="fa fa-solid fa-circle-xmark"></i></span>{% endif %}
-						</a>
-					    </li>
-					{% endfor %}
-				    </ul>
-				</nav>
-
-				<p class="module-footer">
-				    {% if h.get_param_int('_%s_limit' % name) %}
-					{% if h.has_more_facets(name, search_facets) %}
-					    <a href="{{ h.remove_url_param('_%s_limit' % name, replace=0, extras=extras, alternative_url=alternative_url) }}" class="read-more">{{ _('Show More {facet_type}').format(facet_type=title) }}</a>
-					{% endif %}
-				    {% else %}
-					<a href="{{ h.remove_url_param('_%s_limit' % name, extras=extras, alternative_url=alternative_url) }}" class="read-more">{{ _('Show Only Popular {facet_type}').format(facet_type=title) }}</a>
-				    {% endif %}
-				</p>
-			    {% else %}
-				<p class="module-content empty">{{ _('There are no {facet_type} that match this search').format(facet_type=title) }}</p>
-			    {% endif %}
-			{% endwith %}
-		    {% endblock %}
-		</section>
-	    {% endblock %}
+{% macro item_link(item, facet_name) -%}
+	{% set active = item["name"] in request.args.getlist(facet_name) %}
+	{% set url_args = request.args.copy() %}
+	{% if not active %}
+		{% do url_args.add(facet_name, item["name"]) %}
+	{% else %}
+		{% set current_items_in_url = url_args.getlist(facet_name) %}
+		{% do current_items_in_url.remove(item["name"]) %}
+		{% do url_args.setlist(facet_name, current_items_in_url) %}
 	{% endif %}
-    {% endwith %}
-{% endblock %}
+	<a href="{{h.url_for('dataset.search', **url_args.to_dict(False))}}" class="list-group-item list-group-item-action align-middle{% if active%} active{%endif%}" {% if active%}aria-current="true"{%endif%}>
+		{{item["display_name"]|truncate(30)}}
+		<span class="badge {%if active%}bg-light text-dark{%else%}bg-primary{%endif%} rounded-pill">{{ item["count"] }}</span>
+		{% if active %}<span class="float-end"><i class="fa fa-solid fa-circle-xmark"></i></span>{% endif %}
+	</a>
+{%- endmacro %}
+
+{% if search_facet %}
+	<div class="list-group list-group-flush">
+		<div class="list-group-item list-group-item-success">{{search_facet["title"]}} <i class="fa fa-filter"></i></div>
+		{% for item in search_facet["items"][:facet_filter_length]%}
+			{{ item_link(item, name) }}
+		{% endfor %}
+	</div>
+	<!-- Collapsable links -->
+	{% if search_facet["items"]|length > facet_filter_length %}
+		<div id="more-links-{{title}}" class="list-group list-group-flush collapse">
+		{% for item in search_facet["items"][facet_filter_length:]%}
+			{{ item_link(item, name) }}
+		{% endfor %}
+		</div>
+		<button class="list-group-item list-group-item-action list-group-item-light" data-bs-toggle="collapse"
+		data-bs-target="#more-links-{{title}}">
+			<strong>Show more...</strong>
+		</button>
+	{% endif %}
+{% endif %}

--- a/ckan/templates/snippets/facet_list.html
+++ b/ckan/templates/snippets/facet_list.html
@@ -40,7 +40,7 @@ Maximum number of facet items to display before showing a "more" link.
 
 {% if search_facet %}
 	<div class="list-group list-group-flush">
-		<div class="list-group-item list-group-item-success">{{search_facet["title"]}} <i class="fa fa-filter"></i></div>
+		<div class="list-group-item list-group-item-success">{{title}} <i class="fa fa-filter"></i></div>
 		{% for item in search_facet["items"][:facet_filter_length]%}
 			{{ item_link(item, name) }}
 		{% endfor %}

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -343,34 +343,11 @@ def search(package_type: str) -> str:
         extra_vars[u'search_facets'] = {}
         extra_vars[u'page'] = h.Page(collection=[])
 
-    # FIXME: try to avoid using global variables
-    g.search_facets_limits = {}
-    default_limit: int = config.get(u'search.facets.default')
-    for facet in extra_vars[u'search_facets'].keys():
-        try:
-            limit = int(
-                request.args.get(
-                    u'_%s_limit' % facet,
-                    default_limit
-                )
-            )
-        except ValueError:
-            base.abort(
-                400,
-                _(u'Parameter u"{parameter_name}" is not '
-                  u'an integer').format(parameter_name=u'_%s_limit' % facet)
-            )
-
-        g.search_facets_limits[facet] = limit
-
     _setup_template_variables(context, {}, package_type=package_type)
 
+    facet_filter_length: int = config.get(u'search.facets.default')
+    extra_vars['facet_filter_length'] = facet_filter_length
     extra_vars[u'dataset_type'] = package_type
-
-    # TODO: remove
-    for key, value in extra_vars.items():
-        setattr(g, key, value)
-
     return base.render(
         _get_pkg_template(u'search_template', package_type), extra_vars
     )


### PR DESCRIPTION
This PR cleans and refactors the current faceted search feature.

## Main Goals
 - Remove the `'_%s_limit` request argument
 - Use Bootstrap 5 classes for styling and collapsing of seach facets
 - Simplify the search view by not requiring dealing with the logic for the limit of facets

## Benefits
 - It doesn't require a request to `Show more...` facets
 - Cleaner template and smaller view logic
 - Native Bootstrap 5 classes

## Demo
[facet-search.webm](https://github.com/ckan/ckan/assets/6672339/5d4cac4c-bd97-405f-9d79-94e04b661b7d)
