### PR TITLE
Fix bootstrap 5 classes for badge

### DIFF
--- a/ckan/templates/snippets/package_item.html
+++ b/ckan/templates/snippets/package_item.html
@@ -34,9 +34,9 @@ Example:
             {% endblock %}
             {% block heading_meta %}
               {% if package.get('state', '').startswith('draft') %}
-                <span class="badge badge-info">{{ _('Draft') }}</span>
+                <span class="badge bg-info">{{ _('Draft') }}</span>
               {% elif package.get('state', '').startswith('deleted') %}
-                <span class="badge badge-danger">{{ _('Deleted') }}</span>
+                <span class="badge bg-danger">{{ _('Deleted') }}</span>
               {% endif %}
               {{ h.popular('recent views', package.tracking_summary.recent, min=10) if package.tracking_summary }}
             {% endblock %}


### PR DESCRIPTION
Currently the `draft` badge is not being shown since the Bootstrap 5 class is wrong.