### PR TITLE
resource edit:All resources link no longer required

### DIFF
--- a/ckan/templates/package/resource_edit_base.html
+++ b/ckan/templates/package/resource_edit_base.html
@@ -14,7 +14,6 @@
 {% endblock %}
 
 {% block content_action %}
-    {% link_for _('All resources'), named_route=pkg.type ~ '.resources', id=pkg.name, class_='btn btn-default', icon='arrow-left' %}
     {% if res %}
 	{% link_for _('View resource'), named_route=pkg.type ~ '_resource.read', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='eye' %}
   {% endif %}


### PR DESCRIPTION
### Proposed fixes:

Resource edit pages now include navigation to all the other resources so the old "All resources" link in the header is not needed (also it now links to a page only for reordering resources)


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

