### PR TITLE
hide full helpers dict to tidy flask debug template listing

### DIFF
--- a/changes/7668.misc
+++ b/changes/7668.misc
@@ -1,0 +1,1 @@
+hide full helpers dict to tidy flask debug template listing

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -125,6 +125,9 @@ class HelperAttributeDict(Dict[str, Callable[..., Any]]):
         except ckan.exceptions.HelperError as e:
             raise AttributeError(e)
 
+    def __repr__(self) -> str:
+        return '<template helper functions>'
+
 
 # Builtin helper functions.
 _builtin_functions: dict[str, Callable[..., Any]] = {}


### PR DESCRIPTION
### Proposed fixes:

Add a `__repr__` to reduce the noise in the flask template debug window

![Screenshot from 2023-06-21 14-25-37](https://github.com/ckan/ckan/assets/153258/b2ce6e13-ea65-4704-8ee5-9b5964b20d6f)

becomes:

![Screenshot from 2023-06-21 14-26-43](https://github.com/ckan/ckan/assets/153258/bb0036c0-6427-4090-a40a-e90bde016933)


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
