### PR TITLE
Remove template_head_end and template_footer_end configs

### DIFF
--- a/changes/7672.removal
+++ b/changes/7672.removal
@@ -1,1 +1,1 @@
-`template_head_end` and `template_footer_end` config options have been removed.
+`template_head_end` and `template_footer_end` config options have been removed. You can achieve the same effect by extending the `base.html` template.

--- a/changes/7672.removal
+++ b/changes/7672.removal
@@ -1,0 +1,1 @@
+`template_head_end` and `template_footer_end` config options have been removed.

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -1234,40 +1234,6 @@ groups:
 
   - annotation: Theming Settings
     options:
-      - key: ckan.template_head_end
-        example: <link rel="stylesheet" href="http://mysite.org/css/custom.css" type="text/css">
-        description: |
-          HTML content to be inserted just before ``</head>`` tag (e.g. extra stylesheet)
-
-          You can also have multiline strings. Just indent following lines. e.g.::
-
-           ckan.template_head_end =
-            <link rel="stylesheet" href="/css/extra1.css" type="text/css">
-            <link rel="stylesheet" href="/css/extra2.css" type="text/css">
-
-          .. note:: This is only for legacy code, and shouldn't be used anymore.
-
-      - key: ckan.template_footer_end
-        description: |
-          HTML content to be inserted just before ``</body>`` tag (e.g. Google Analytics code).
-
-          .. note:: you can have multiline strings (just indent following lines)
-
-          Example (showing insertion of Google Analytics code)::
-
-            ckan.template_footer_end = <!-- Google Analytics -->
-              <script src='http://www.google-analytics.com/ga.js' type='text/javascript'></script>
-              <script type="text/javascript">
-              try {
-              var pageTracker = _gat._getTracker("XXXXXXXXX");
-              pageTracker._setDomainName(".ckan.net");
-              pageTracker._trackPageview();
-              } catch(err) {}
-              </script>
-              <!-- /Google Analytics -->
-
-          .. note:: This is only for legacy code, and shouldn't be used anymore.
-
       - key: ckan.template_title_delimiter
         default: '-'
         example: '|'

--- a/ckan/lib/app_globals.py
+++ b/ckan/lib/app_globals.py
@@ -37,14 +37,10 @@ app_globals_from_config_details: dict[str, dict[str, str]] = {
     'ckan.site_intro_text': {},
     'ckan.site_custom_css': {},
     'ckan.favicon': {}, # default gets set in config.environment.py
-    'ckan.template_head_end': {},
-    'ckan.template_footer_end': {},
-        # has been setup in load_environment():
+    # has been setup in load_environment():
     'ckan.site_id': {},
     'ckan.recaptcha.publickey': {'name': 'recaptcha_publickey'},
     'ckan.template_title_delimiter': {'default': '-'},
-    'ckan.template_head_end': {},
-    'ckan.template_footer_end': {},
     'ckan.dumps_url': {},
     'ckan.dumps_format': {},
     'ckan.homepage_style': {'default': '1'},

--- a/ckan/templates/base.html
+++ b/ckan/templates/base.html
@@ -75,8 +75,6 @@
     {% endblock %}
 
     {% block head_extras %}
-      {# defined in the config.ini under "ckan.template_head_end" #}
-      {{ g.template_head_end | safe }}
     {% endblock %}
 
     {# render all assets included in styles block #}
@@ -116,8 +114,6 @@
     {% endblock -%}
 
     {% block body_extras -%}
-      {# defined in the config.ini under "ckan.template_footer_end" #}
-      {{ g.template_footer_end | safe }}
     {%- endblock %}
 
     {# render all assets included in scripts block and everywhere else #}

--- a/ckan/templates/base.html
+++ b/ckan/templates/base.html
@@ -74,9 +74,6 @@
       {% asset theme %}
     {% endblock %}
 
-    {% block head_extras %}
-    {% endblock %}
-
     {# render all assets included in styles block #}
     {{ h.render_assets('style') }}
     {%- block custom_styles %}
@@ -112,9 +109,6 @@
     #}
     {%- block scripts %}
     {% endblock -%}
-
-    {% block body_extras -%}
-    {%- endblock %}
 
     {# render all assets included in scripts block and everywhere else #}
     {# make sure there are no calls to `asset` tag after this point #}

--- a/ckan/tests/controllers/test_home.py
+++ b/ckan/tests/controllers/test_home.py
@@ -12,21 +12,6 @@ class TestHome(object):
         response = app.get(url_for("home.index"))
         assert "Welcome to CKAN" in response.body
 
-    def test_template_head_end(self, app):
-        # test-core.ini sets ckan.template_head_end to this:
-        test_link = (
-            '<link rel="stylesheet" '
-            'href="TEST_TEMPLATE_HEAD_END.css" type="text/css">'
-        )
-        response = app.get(url_for("home.index"))
-        assert test_link in response.body
-
-    def test_template_footer_end(self, app):
-        # test-core.ini sets ckan.template_footer_end to this:
-        test_html = "<strong>TEST TEMPLATE_FOOTER_END TEST</strong>"
-        response = app.get(url_for("home.index"))
-        assert test_html in response.body
-
     @pytest.mark.usefixtures("non_clean_db")
     def test_email_address_nag(self, app):
         # before CKAN 1.6, users were allowed to have no email addresses

--- a/ckan/tests/lib/test_app_globals.py
+++ b/ckan/tests/lib/test_app_globals.py
@@ -17,12 +17,3 @@ def test_config_set_to_blank():
 
     """
     assert g.site_description == ""
-
-
-def test_set_from_ini():
-    """ckan.template_head_end is configured in test-core.ini
-    """
-    assert (
-        g.template_head_end
-        == '<link rel="stylesheet" href="TEST_TEMPLATE_HEAD_END.css" type="text/css">'
-    )

--- a/test-core-docker.ini
+++ b/test-core-docker.ini
@@ -68,12 +68,6 @@ apikey_header_name = X-Non-Standard-CKAN-API-Key
 ckan.plugins =
 # ckan.views.default_views =
 
-# use <strong> so we can check that html is *not* escaped
-ckan.template_head_end = <link rel="stylesheet" href="TEST_TEMPLATE_HEAD_END.css" type="text/css">
-
-# use <strong> so we can check that html is *not* escaped, div is used for a11y compliance
-ckan.template_footer_end = <div role="region"><strong>TEST TEMPLATE_FOOTER_END TEST</strong></div>
-
 # mailer
 smtp.mail_from = info@test.ckan.net
 

--- a/test-core.ini
+++ b/test-core.ini
@@ -68,12 +68,6 @@ apikey_header_name = X-Non-Standard-CKAN-API-Key
 ckan.plugins =
 # ckan.views.default_views =
 
-# use <strong> so we can check that html is *not* escaped
-ckan.template_head_end = <link rel="stylesheet" href="TEST_TEMPLATE_HEAD_END.css" type="text/css">
-
-# use <strong> so we can check that html is *not* escaped, div is used for a11y compliance
-ckan.template_footer_end = <div role="region"><strong>TEST TEMPLATE_FOOTER_END TEST</strong></div>
-
 # mailer
 smtp.mail_from = info@test.ckan.net
 


### PR DESCRIPTION
Fixes some of the points in #7671 

### Proposed fixes:
Removes `template_head_end` and `template_footer_end` configuration options.