### PR TITLE
Read default views setting as list

### DIFF
--- a/ckan/lib/datapreview.py
+++ b/ckan/lib/datapreview.py
@@ -13,7 +13,7 @@ from urllib.parse import urlparse
 
 import ckan.plugins as p
 from ckan import logic
-from ckan.common import _, config
+from ckan.common import _, config, aslist
 from ckan.types import Context
 
 
@@ -124,7 +124,7 @@ def get_default_view_plugins(
 
     Returns a list of IResourceView plugins
     '''
-    default_view_types = config.get('ckan.views.default_views')
+    default_view_types = aslist(config.get('ckan.views.default_views'))
 
     default_view_plugins = []
     for view_type in default_view_types:


### PR DESCRIPTION
This PR fixes an issue with default views not working if configured in the ini-file.

The setting "ckan.views.default_views" was read character by character instead of being splitted up by space. This was detected after debugging the default views feature in the latest release (2.10.1). The defect is clearly visible in the log output.

Example: If the default views was set to "image_view text_view". This caused the below logging output. Note that each character of the configuration string was generating one log row:

WARNI [ckan.lib.datapreview] Plugin for view i could not be found
WARNI [ckan.lib.datapreview] Plugin for view m could not be found
WARNI [ckan.lib.datapreview] Plugin for view a could not be found
WARNI [ckan.lib.datapreview] Plugin for view g could not be found
WARNI [ckan.lib.datapreview] Plugin for view e could not be found
WARNI [ckan.lib.datapreview] Plugin for view _ could not be found
... (and so on)

This PR makes sure the setting in question is read as a list.

There is already some tests covering this, but they don't seem to be run at the moment (or that's simply beyond my knowledge).

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
