### PR TITLE
`ckan db upgrade` fixes

### DIFF
--- a/changes/7681.misc
+++ b/changes/7681.misc
@@ -1,0 +1,1 @@
+Fix errors when running the `ckan db upgrade` command

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -249,6 +249,11 @@ def update_config() -> None:
     if user_table_exists:
         try:
             logic.get_action('get_site_user')({'ignore_auth': True}, {})
+        except sqlalchemy.exc.ProgrammingError as e:
+            if "UndefinedColumn" in repr(e.orig):
+                log.debug("Old user model detected")
+            else:
+                raise
         except sqlalchemy.exc.IntegrityError:
             # Race condition, user already exists.
             log.debug("Site user already exists")

--- a/ckan/migration/migrate_package_activity.py
+++ b/ckan/migration/migrate_package_activity.py
@@ -296,7 +296,8 @@ if __name__ == u'__main__':
         load_config(args.config)
 
     if not plugin_loaded("activity"):
-        print("Please add the `activity` plugin to your `ckan.plugins` setting")
+        print(
+            "Please add the `activity` plugin to your `ckan.plugins` setting")
         sys.exit(1)
 
     if not args.dataset:

--- a/ckan/migration/migrate_package_activity.py
+++ b/ckan/migration/migrate_package_activity.py
@@ -32,6 +32,7 @@ from __future__ import absolute_import
 import argparse
 from collections import defaultdict
 from typing import Any
+import sys
 
 
 # not importing anything from ckan until after the arg parsing, to fail on bad
@@ -274,6 +275,8 @@ if __name__ == u'__main__':
     args = parser.parse_args()
     assert args.config, u'You must supply a --config'
     print(u'Loading config')
+
+    from ckan.plugins import plugin_loaded
     try:
         from ckan.cli import load_config
         from ckan.config.middleware import make_app
@@ -291,6 +294,11 @@ if __name__ == u'__main__':
             cmd._load_config()
             return
         load_config(args.config)
+
+    if not plugin_loaded("activity"):
+        print("Please add the `activity` plugin to your `ckan.plugins` setting")
+        sys.exit(1)
+
     if not args.dataset:
         migrate_all_datasets()
         wipe_activity_detail(delete_activity_detail=args.delete)

--- a/ckan/migration/revision_legacy_code.py
+++ b/ckan/migration/revision_legacy_code.py
@@ -26,7 +26,7 @@ from ckanext.activity.model import Activity
 # This is based on ckan.lib.dictization.model_dictize:package_dictize
 # BUT you can ask for a old revision to the package by specifying 'revision_id'
 # in the context
-def package_dictize_with_revisions(pkg, context):
+def package_dictize_with_revisions(pkg, context, include_plugin_data=False):
     '''
     Given a Package object, returns an equivalent dictionary.
 
@@ -306,7 +306,8 @@ def copy_table_columns(table):
 # Copied from vdm
 def copy_table(table, newtable):
     for key in table.c.keys():
-        copy_column(key, table, newtable)
+        if key != "plugin_data":
+            copy_column(key, table, newtable)
 
 
 # Copied from vdm

--- a/ckan/migration/revision_legacy_code.py
+++ b/ckan/migration/revision_legacy_code.py
@@ -326,8 +326,7 @@ def make_revision_table(metadata):
 
 # Copied from vdm
 def make_Revision(mapper, revision_table):  # noqa
-    mapper(Revision, revision_table, properties={},
-           order_by=revision_table.c.timestamp.desc())
+    mapper(Revision, revision_table, properties={})
     return Revision
 
 


### PR DESCRIPTION
I'm working on an upgrade from CKAN 2.5 to 2.10 and found errors that can be solved at the CKAN level

The most potentially controversial is the first commit (8d0d3b36fe61deb23ffcd24a3350fd38e7c5b467). Basically when calling the magic `get_site_user` action when starting up `ckan db upgrade` we get an error because the python model defines `User.last_active` and that is not present in the database (was introduced on CKAN 2.10). I've followed the same approach that we do to avoid race conditions on that particular situation and added an exception handling.

The rest of changes related to the separate script used to migrate the old revisions to activities and should be hopefully self-explanatory:
* [Ensure activity plugin is loaded before migrating old revisions](https://github.com/ckan/ckan/commit/888ac2770eb7ceaf0ceccc239475bf896114857c)
* [Support new plugin_data field in revision migrate script](https://github.com/ckan/ckan/commit/854fb6b19e0a7965ea5dad89a058ddd4a0106d2e)
* [Remove no longer supported SQLAlchemy key in revision migrate script](https://github.com/ckan/ckan/commit/5f48dc8868fab0012e9e696286a8869ffb0190b2)


I think anything that makes life easier for those trying to upgrade it's a good think, so I'm proposing to backport this
