### PR TITLE
Fix package_revise test

### DIFF
--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -1908,7 +1908,7 @@ class TestDatasetRevise(object):
         dataset = factories.Dataset(
             resources=[
                 {
-                    "id": "34a12bc-1420-cbad-1922",
+                    "id": "34a12bc-1420-cbad-1923",
                     "url": "http://example.com",
                     "name": "old name",
                 }


### PR DESCRIPTION
`ckan/tests/logic/action/test_update.py::TestDatasetRevise::test_revise_resource_replace_all` started failing when we introduced the requirement for unique resource ids:

    ckan.logic.ValidationError: None - {'resources': [{'id': ['Resource id already exists.']}]}

The reason is clear, two tests were using the same resource id on a `non_clean_db` test class. This was masked in Circle CI because these two tests were split across containers, but it surfaced when running all tests sequentially:

https://github.com/ckan/ckan-solr/actions/runs/5463080559/jobs/9943315203
