### PR TITLE
[#7407] Add Solr 9 support

### DIFF
--- a/changes/7693.feature
+++ b/changes/7693.feature
@@ -1,0 +1,1 @@
+Added support for Solr 9. Users of the `official Docker images <https://github.com/ckan/ckan-solr>`_ can use the ``ckan/ckan-solr:2.10-solr9`` tag.

--- a/doc/contributing/release-process.rst
+++ b/doc/contributing/release-process.rst
@@ -412,7 +412,7 @@ a release.
 #. Build new Docker images for the new version in the following repos:
 
    * `openknowledge/docker-ckan <https://github.com/okfn/docker-ckan>`_ -> ``openknowledge/ckan-base:{Major:minor}`` and ``openknowledge/ckan-dev:{Major:minor}`` (ping @amercader for this one)
-   * `ckan/ckan-solr-dev <https://github.com/ckan/ckan-solr-dev>`_ -> ``ckan/ckan-solr-dev:{Major:minor}``
+   * `ckan/ckan-solr <https://github.com/ckan/ckan-solr>`_ -> ``ckan/ckan-solr:{Major:minor}-solr{solr-version}``
    * `ckan/ckan-postgres-dev <https://github.com/ckan/ckan-postgres-dev>`_ -> ``ckan/ckan-postgres-dev:{Major:minor}``
 
 #. Enable the new version of the docs on Read the Docs.

--- a/doc/maintaining/installing/solr.rst
+++ b/doc/maintaining/installing/solr.rst
@@ -5,7 +5,7 @@ that takes into account CKAN's specific search needs. Now that we have CKAN
 installed, we need to install and configure Solr.
 
 
-.. warning:: CKAN supports **Solr 8**. Starting from CKAN 2.10 this is the only Solr version supported. CKAN 2.9 can run with Solr 8 as long as it is patched to at least 2.9.5. CKAN 2.9 can also run against Solr 6 but this is not recommended as this Solr version does no longer receive security updates.
+.. warning:: CKAN supports **Solr 9** (recommended version) and Solr 8. Starting from CKAN 2.10 these are the only Solr version supported. CKAN 2.9 can run with Solr 9 and 8 as long as it is patched to at least 2.9.5.
 
 
 There are two supported ways to install Solr.
@@ -23,7 +23,7 @@ There are pre-configured Docker images for Solr for each CKAN version. Make sure
 
    .. parsed-literal::
 
-    docker run --name ckan-solr -p 8983:8983 -d ckan/ckan-solr:2.10
+    docker run --name ckan-solr -p 8983:8983 -d ckan/ckan-solr:2.10-solr9
 
 You can now jump to the `Next steps <#next-steps-with-solr>`_ section.
 
@@ -31,22 +31,22 @@ Installing Solr manually
 ========================
 
 The following instructions have been tested in Ubuntu 22.04 and are provided as a guidance only. For a Solr production setup is it recommended that you
-follow the `official Solr documentation <https://solr.apache.org/guide/8_0/taking-solr-to-production.html#taking-solr-to-production>`_.
+follow the `official Solr documentation <https://solr.apache.org/guide/solr/latest/deployment-guide/taking-solr-to-production.html>`_.
 
 
 #. Install the OS dependencies::
 
       sudo apt-get install openjdk-8-jdk
 
-#. Download the latest supported version from the `Solr downloads page <https://solr.apache.org/downloads.html>`_. CKAN supports Solr version 8.x.
+#. Download the latest supported version from the `Solr downloads page <https://solr.apache.org/downloads.html>`_. CKAN supports Solr version 9.x (recommended) and 8.x.
 
 #. Extract the install script file to your desired location (adjust the Solr version number to the one you are using)::
 
-    tar xzf solr-8.11.2.tgz solr-8.11.2/bin/install_solr_service.sh --strip-components=2
+    tar xzf solr-9.2.1.tgz solr-9.2.1/bin/install_solr_service.sh --strip-components=2
 
 #. Run the installation script as ``root``::
 
-    sudo bash ./install_solr_service.sh solr-8.11.2.tgz
+    sudo bash ./install_solr_service.sh solr-9.2.1.tgz
 
 #. Check that Solr started running::
 


### PR DESCRIPTION
Fixes #7407

Solr 8 is only receiving critical security fixes, and Solr 9 is the currently supported version (9.2.x)

There are no code or schema changes needed to support Solr 9. I reviewed the upgrade notes and didn't see anything that stood out for a standard CKAN install:

https://github.com/apache/solr/blob/main/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-9.adoc

There are pre-configured images for CKAN + Solr 9 ready to go:

https://github.com/ckan/ckan-solr/pull/6

I've been using Solr 9 locally for a long time and didn't have any issues at all. I also set up [automated tests](https://github.com/ckan/ckan-solr/actions) for all the CKAN / Solr versions combinations so we can keep an eye on the tests (see PR above for details).

The `ckan/ckan-solr:master` image will now be built using Solr 9, so the [Circle CI tests](https://github.com/ckan/ckan/blob/ba7c0c8363dd691b1e2746225d17fcf4b992173f/.circleci/config.yml#L52) will use Solr 9
