### PR TITLE
datatablesview: fix for displaying gettext info in null cells

### DIFF
--- a/ckanext/datatablesview/helpers.py
+++ b/ckanext/datatablesview/helpers.py
@@ -3,4 +3,5 @@ from ckan.plugins.toolkit import _, config
 
 
 def datatablesview_null_label():
-    return _(config.get('ckan.datatables.null_label', u''))
+    label = config.get('ckan.datatables.null_label')
+    return _(label) if label else ''


### PR DESCRIPTION
Fixes issue with null cells displaying the gettext help text instead of nothing

### Proposed fixes:
Don't pass `''` to `gettext`

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport