### PR TITLE
Update solr.rst to specify the OpenJDK version to be version 11 for Solr 9

### DIFF
--- a/doc/maintaining/installing/solr.rst
+++ b/doc/maintaining/installing/solr.rst
@@ -36,7 +36,7 @@ follow the `official Solr documentation <https://solr.apache.org/guide/solr/late
 
 #. Install the OS dependencies::
 
-      sudo apt-get install openjdk-8-jdk
+      sudo apt-get install openjdk-11-jdk
 
 #. Download the latest supported version from the `Solr downloads page <https://solr.apache.org/downloads.html>`_. CKAN supports Solr version 9.x (recommended) and 8.x.
 


### PR DESCRIPTION
Fixes #7708 

### Proposed fixes:
Documentation should specify: "sudo apt-get install **openjdk-11-jdk**"


### Features:

- [ ] includes tests covering changes
- [ X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
