### PR TITLE
Add fix  for display popular flame icon

### DIFF
--- a/changes/7724.bugfix
+++ b/changes/7724.bugfix
@@ -1,0 +1,1 @@
+Popular flame icon is not displayed in datasets list whose "recent_views" value is more than 10

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1942,7 +1942,8 @@ def package_search(context: Context, data_dict: DataDict) -> ActionResult.Packag
 
         # Add them back so extensions can use them on after_search
         data_dict['extras'] = extras
-
+        # get tracking_enabled bool value
+        tracking_enabled = config.get('ckan.tracking_enabled',False)
         if result_fl:
             for package in query.results:
                 if isinstance(package, str):
@@ -1958,6 +1959,10 @@ def package_search(context: Context, data_dict: DataDict) -> ActionResult.Packag
                 if package_dict:
                     # the package_dict still needs translating when being viewed
                     package_dict = json.loads(package_dict)
+                    # add tracking summary in package_dict
+                    if tracking_enabled:
+                       # add page-view tracking summary data
+                       package_dict['tracking_summary'] = (model.TrackingSummary.get_for_package(package_dict['id']))
                     if context.get('for_view'):
                         for item in plugins.PluginImplementations(
                                 plugins.IPackageController):


### PR DESCRIPTION
Fixes #7724 

### Proposed fixes:
I found that package_search api under the path **https://github.com/ckan/ckan/blob/master/ckan/logic/action/get.py** is executed and it not passed the tracking_summary property in the result. Now, this PR will resolve this issue.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
