### PR TITLE
fix tests: test_create_alias_twice relied on unstable ordering

### DIFF
--- a/changes/7749.bugfix
+++ b/changes/7749.bugfix
@@ -1,0 +1,1 @@
+Don't rely on stable ordering from unstable model.Package.resources list

--- a/ckan/migration/revision_legacy_code.py
+++ b/ckan/migration/revision_legacy_code.py
@@ -251,7 +251,7 @@ def make_revisioned_table(base_table, frozen=False):
     for col in base_table.c:
         if col.primary_key:
             pkcols.append(col)
-    assert len(pkcols) <= 1,\
+    assert len(pkcols) <= 1, \
         u'Do not support versioning objects with multiple primary keys'
     fk_name = base_table.name + u'.' + pkcols[0].name
     revision_table.append_column(

--- a/ckan/tests/cli/test_user.py
+++ b/ckan/tests/cli/test_user.py
@@ -87,9 +87,9 @@ class TestApiToken(object):
         call_action(u"api_token_create", user=user[u"id"], name=u"first token")
         tid = model.Session.query(model.ApiToken).first().id
 
-        # tid must be escaped. When it starts with a hyphen it treated as a
-        # flag otherwise.
-        args = f'user token revoke "{tid}"'
+        # tid must be prefixed by --. When it starts with a hyphen it treated
+        # as a flag otherwise.
+        args = f'user token revoke -- "{tid}"'
         result = cli.invoke(ckan, args)
         assert not result.exit_code, result.output
         assert u"API Token has been revoked" in result.output

--- a/ckan/tests/lib/dictization/test_model_dictize.py
+++ b/ckan/tests/lib/dictization/test_model_dictize.py
@@ -295,7 +295,7 @@ class TestGroupDictize:
 
         org = model_dictize.group_dictize(group_obj, context)
 
-        assert type(org["packages"]) == list
+        assert isinstance(org["packages"], list)
         assert len(org["packages"]) == 1
         assert org["packages"][0]["name"] == package["name"]
 

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -2968,7 +2968,7 @@ class TestStatusShow(object):
         assert status["site_description"] == ""
         assert status["locale_default"] == "en"
 
-        assert isinstance(status["extensions"],list)
+        assert isinstance(status["extensions"], list)
         assert status["extensions"] == ["stats"]
 
     @pytest.mark.ckan_config("ckan.plugins", "stats")
@@ -2984,7 +2984,7 @@ class TestStatusShow(object):
         assert status["site_description"] == ""
         assert status["locale_default"] == "en"
 
-        assert isinstance(status["extensions"],list)
+        assert isinstance(status["extensions"], list)
         assert status["extensions"] == ["stats"]
 
 

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -2952,7 +2952,7 @@ class TestStatusShow(object):
         assert status["site_description"] == ""
         assert status["locale_default"] == "en"
 
-        assert type(status["extensions"]) == list
+        assert isinstance(status["extensions"], list)
         assert status["extensions"] == ["stats"]
 
     @pytest.mark.ckan_config("ckan.plugins", "stats")
@@ -2968,7 +2968,7 @@ class TestStatusShow(object):
         assert status["site_description"] == ""
         assert status["locale_default"] == "en"
 
-        assert type(status["extensions"]) == list
+        assert isinstance(status["extensions"],list)
         assert status["extensions"] == ["stats"]
 
     @pytest.mark.ckan_config("ckan.plugins", "stats")
@@ -2984,7 +2984,7 @@ class TestStatusShow(object):
         assert status["site_description"] == ""
         assert status["locale_default"] == "en"
 
-        assert type(status["extensions"]) == list
+        assert isinstance(status["extensions"],list)
         assert status["extensions"] == ["stats"]
 
 

--- a/ckan/views/admin.py
+++ b/ckan/views/admin.py
@@ -219,8 +219,8 @@ class TrashView(MethodView):
 
     def purge_entity(self, ent_type: str):
         entities = self.deleted_entities[ent_type]
-        number = len(entities) if isinstance(entities, list
-            ) else entities.count()
+        number = len(entities) if isinstance(entities, list) \
+            else entities.count()
 
         for ent in entities:
             entity_id = ent.id if hasattr(ent, 'id') else ent['id']

--- a/ckan/views/admin.py
+++ b/ckan/views/admin.py
@@ -219,7 +219,7 @@ class TrashView(MethodView):
 
     def purge_entity(self, ent_type: str):
         entities = self.deleted_entities[ent_type]
-        number = len(entities) if type(entities) == list else entities.count()
+        number = len(entities) if isinstance(entities, list) else entities.count()
 
         for ent in entities:
             entity_id = ent.id if hasattr(ent, 'id') else ent['id']

--- a/ckan/views/admin.py
+++ b/ckan/views/admin.py
@@ -219,7 +219,8 @@ class TrashView(MethodView):
 
     def purge_entity(self, ent_type: str):
         entities = self.deleted_entities[ent_type]
-        number = len(entities) if isinstance(entities, list) else entities.count()
+        number = len(entities) if isinstance(entities, list
+            ) else entities.count()
 
         for ent in entities:
             entity_id = ent.id if hasattr(ent, 'id') else ent['id']

--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -638,9 +638,9 @@ class TestDatastoreCreate(object):
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
     @pytest.mark.usefixtures("with_plugins")
     def test_create_alias_twice(self, app):
-        resource = model.Package.get("annakarenina").resources[1]
+        res1, res2 = model.Package.get("annakarenina").resources[:2]
         data = {
-            "resource_id": resource.id,
+            "resource_id": res1.id,
             "aliases": "new_alias",
             "fields": [
                 {"id": "book", "type": "text"},
@@ -656,9 +656,8 @@ class TestDatastoreCreate(object):
         res_dict = json.loads(res.data)
         assert res_dict["success"] is True, res_dict
 
-        resource = model.Package.get("annakarenina").resources[0]
         data = {
-            "resource_id": resource.id,
+            "resource_id": res2.id,
             "aliases": "new_alias",
             "fields": [{"id": "more books", "type": "text"}],
         }


### PR DESCRIPTION
Fixes test failures on master

### Proposed fixes:

Don't rely on stable ordering from unstable model.Package.resources list

Proper handling of hyphen-starting ids on test_revoke

A bunch of other style fixes that are triggering errors now too

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport