### PR TITLE
Documentation for a CKAN 2.9 install uses an incorrect Solr Docker tag

### DIFF
--- a/doc/maintaining/installing/solr.rst
+++ b/doc/maintaining/installing/solr.rst
@@ -23,7 +23,7 @@ There are pre-configured Docker images for Solr for each CKAN version. Make sure
 
    .. parsed-literal::
 
-    docker run --name ckan-solr -p 8983:8983 -d ckan/ckan-solr:2.9
+    docker run --name ckan-solr -p 8983:8983 -d ckan/ckan-solr:2.9-solr8
 
 You can now jump to the `Next steps <#next-steps-with-solr>`_ section.
 


### PR DESCRIPTION
Fixes https://github.com/ckan/ckan/issues/7728

### Proposed fixes:

The documentation for a CKAN 2.9 install (by source) uses an incorrect Solr Docker tag ie: ckan/ckan-solr:2.9 which is **Solr 6** 
We need to use the **Solr 8 (or 9**) tag

Please see the [ckan-solr](https://github.com/ckan/ckan-solr) repo for more information

### Features:

- [ ] includes tests covering changes
- [x ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
