### PR TITLE
[#7710] add datastore and datapusher templates-bs3

### DIFF
--- a/ckanext/datapusher/templates-bs3/datapusher/resource_data.html
+++ b/ckanext/datapusher/templates-bs3/datapusher/resource_data.html
@@ -1,0 +1,88 @@
+{% extends "package/resource_edit_base.html" %}
+
+{% block subtitle %}{{ h.dataset_display_name(pkg) }} - {{ h.resource_display_name(res) }}{% endblock %}
+
+{% block primary_content_inner %}
+
+  {% set action = h.url_for('datapusher.resource_data', id=pkg.name, resource_id=res.id) %}
+  {% set show_table = true %}
+
+  <form method="post" action="{{ action }}" class="datapusher-form">
+    <button class="btn btn-primary" name="save" type="submit">
+      <i class="fa fa-cloud-upload"></i> {{ _('Upload to DataStore') }}
+    </button>
+  </form>
+
+  {% if status.error and status.error.message %}
+    {% set show_table = false %}
+    <div class="alert alert-error">
+      <strong>{{ _('Upload error:') }}</strong> {{ status.error.message }}
+    </div>
+  {% elif status.task_info and status.task_info.error %}
+    <div class="alert alert-error">
+      {% if status.task_info.error is string %}
+        {# DataPusher < 0.0.3 #}
+        <strong>{{ _('Error:') }}</strong> {{ status.task_info.error }}
+      {% elif status.task_info.error is mapping %}
+        <strong>{{ _('Error:') }}</strong> {{ status.task_info.error.message }}
+        {% for error_key, error_value in status.task_info.error.items() %}
+          {% if error_key != "message" and error_value %}
+            <br>
+            <strong>{{ error_key }}</strong>:
+            {{ error_value }}
+          {% endif %}
+        {% endfor %}
+      {% elif status.task_info.error is iterable %}
+        <strong>{{ _('Error traceback:') }}</strong>
+        <pre>{{ ''.join(status.task_info.error) }}</pre>
+      {% endif %}
+    </div>
+  {% endif %}
+
+  <table class="table table-bordered">
+    <colgroup>
+      <col width="150">
+      <col>
+    </colgroup>
+    <tr>
+      <th>{{ _('Status') }}</th>
+      <td>{{ h.datapusher_status_description(status) }}</td>
+    </tr>
+    <tr>
+      <th>{{ _('Last updated') }}</th>
+      {% if status.status %}
+        <td><span class="date" title="{{ h.render_datetime(status.last_updated, with_hours=True) }}">{{ h.time_ago_from_timestamp(status.last_updated) }}</span></td>
+      {% else %}
+        <td>{{ _('Never') }}</td>
+      {% endif %}
+    </tr>
+  </table>
+
+  {% if status.status and status.task_info and show_table %}
+    <h3>{{ _('Upload Log') }}</h3>
+    <ul class="activity">
+      {% for item in status.task_info.logs|sort(attribute='timestamp') %}
+        {% set icon = 'ok' if item.level == 'INFO' else 'exclamation' %}
+        {% set class = ' failure' if icon == 'exclamation' else ' success' %}
+        {% set popover_content = 'test' %}
+        <li class="item no-avatar{{ class }}">
+          <i class="fa icon fa-{{ icon }}"></i>
+          <p>
+            {% for line in item.message.strip().split('\n') %}
+              {{ line | urlize }}<br>
+            {% endfor %}
+            <span class="date" title="{{ h.render_datetime(item.timestamp, with_hours=True) }}">
+              {{ h.time_ago_from_timestamp(item.timestamp) }}
+              <a href="#" data-target="popover" data-content="<dl>{% for key, value in item.items() %}<dt>{{ key }}</dt><dd>{{ h.clean_html(value|string) }}</dd>{% endfor %}</dl>" data-html="true">{{ _('Details') }}</a>
+            </span>
+          </p>
+        </li>
+      {% endfor %}
+      <li class="item no-avatar">
+        <i class="fa icon fa-info"></i>
+        <p class="muted">{{ _('End of log') }}</p>
+      </li>
+    </ul>
+  {% endif %}
+
+{% endblock %}

--- a/ckanext/datapusher/templates-bs3/package/resource_edit_base.html
+++ b/ckanext/datapusher/templates-bs3/package/resource_edit_base.html
@@ -1,0 +1,16 @@
+{% ckan_extends %}
+
+{% block scripts %}
+  {{ super() }}
+  {% asset 'ckanext-datapusher/datapusher' %}
+{% endblock scripts %}
+
+{% block styles %}
+  {{ super() }}
+  {% asset 'ckanext-datapusher/datapusher-css' %}
+{% endblock %}
+
+{% block inner_primary_nav %}
+  {{ super() }}
+  {{ h.build_nav_icon('datapusher.resource_data', _('DataStore'), id=pkg.name, resource_id=res.id) }}
+{% endblock %}

--- a/ckanext/datastore/templates-bs3/ajax_snippets/api_info.html
+++ b/ckanext/datastore/templates-bs3/ajax_snippets/api_info.html
@@ -1,0 +1,137 @@
+{#
+Displays information about accessing a resource via the API.
+
+resource_id - The resource id
+embedded - If true will not include the "modal" classes on the snippet.
+
+Example
+
+    {% snippet 'ajax_snippets/api_info.html', resource_id=resource_id, embedded=true %}
+
+#}
+
+{% set resource_id = h.sanitize_id(resource_id) %}
+{% set sql_example_url = h.url_for(controller='api', action='action', ver=3, logic_function='datastore_search_sql', qualified=True) + '?sql=SELECT * from "' + resource_id + '" WHERE title LIKE \'jones\'' %}
+{# not urlencoding the sql because its clearer #}
+<div{% if not embedded %} class="modal fade"{% endif %}>
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+          <h3>
+            {{ _('CKAN Data API') }}
+          </h3>
+        </div>
+        <div{% if not embedded %} class="modal-body"{% endif %}>
+          <p><strong>{{ _('Access resource data via a web API with powerful query support') }}</strong>.
+          {% trans %}
+          Further information in the <a
+            href="http://docs.ckan.org/en/latest/maintaining/datastore.html" target="_blank">main
+            CKAN Data API and DataStore documentation</a>.</p>
+          {% endtrans %}
+          <div class="panel-group" id="accordion2">
+          <div class="panel panel-default">
+            <div class="panel-heading">
+
+              <a class="accordion-toggle" data-toggle="collapse" data-parent="accordion2" href="#collapse-endpoints">{{ _('Endpoints') }} &raquo;</a>
+            </div>
+            <div id="collapse-endpoints" class="in panel-collapse collapse">
+              <div class="panel-body">
+                <p>{{ _('The Data API can be accessed via the following actions of the CKAN action API.') }}</p>
+                <table class="table-condensed table-striped table-bordered">
+                  <thead></thead>
+                  <tbody>
+                    <tr>
+                      <th scope="row">{{ _('Create') }}</th>
+                      <td><code>{{ h.url_for(controller='api', action='action', ver=3, logic_function='datastore_create', qualified=True) }}</code></td>
+                    </tr>
+                    <tr>
+                      <th scope="row">{{ _('Update / Insert') }}</th>
+                      <td><code>{{ h.url_for(controller='api', action='action', ver=3, logic_function='datastore_upsert', qualified=True) }}</code></td>
+                    </tr>
+                    <tr>
+                      <th scope="row">{{ _('Query') }}</th>
+                      <td><code>{{ h.url_for(controller='api', action='action', ver=3, logic_function='datastore_search', qualified=True) }}</code></td>
+                    </tr>
+                    <tr>
+                      <th scope="row">{{ _('Query (via SQL)') }}</th>
+                      <td><code>{{ h.url_for(controller='api', action='action', ver=3, logic_function='datastore_search_sql', qualified=True) }}</code></td>
+                    </tr>
+
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <a class="accordion-toggle" data-toggle="collapse" data-parent="accordion2" href="#collapse-querying">{{ _('Querying') }} &raquo;</a>
+            </div>
+            <div id="collapse-querying" class="collapse panel-collapse in">
+              <div class="panel-body">
+                <strong>{{ _('Query example (first 5 results)') }}</strong>
+                <p>
+                <code><a href="{{ h.url_for(controller='api', action='action', ver=3, logic_function='datastore_search', resource_id=resource_id, limit=5, qualified=True) }}" target="_blank" rel="nofollow">{{ h.url_for(controller='api', action='action', ver=3, logic_function='datastore_search', resource_id=resource_id, limit=5, qualified=True) }}</a></code>
+                </p>
+
+                <strong>{{ _('Query example (results containing \'jones\')') }}</strong>
+                <p>
+                <code><a href="{{ h.url_for(controller='api', action='action', ver=3, logic_function='datastore_search', resource_id=resource_id, q='jones', qualified=True) }}" target="_blank" rel="nofollow">{{ h.url_for(controller='api', action='action', ver=3, logic_function='datastore_search', resource_id=resource_id, q='jones', qualified=True) }}</a></code>
+                </p>
+
+                <strong>{{ _('Query example (via SQL statement)') }}</strong>
+                <p>
+                <code><a href="{{sql_example_url}}" target="_blank" rel="nofollow">{{ sql_example_url }}</a></code>
+                </p>
+
+              </div>
+            </div>
+          </div>
+
+          <div class="panel panel-default">
+            <div class="panel-heading">
+             <a class="accordion-toggle" data-toggle="collapse" data-parent="accordion2" href="#collapse-javascript">{{ _('Example: Javascript') }} &raquo;</a>
+            </div>
+            <div id="collapse-javascript" class="panel-collapse collapse">
+              <div class="panel-body">
+                <p>{{ _('A simple ajax (JSONP) request to the data API using jQuery.') }}</p>
+                <pre>
+        var data = {
+          resource_id: '{{resource_id}}', // the resource id
+          limit: 5, // get 5 results
+          q: 'jones' // query for 'jones'
+        };
+        $.ajax({
+          url: '{{ h.url_for(controller='api', action='action', ver=3, logic_function='datastore_search', qualified=True) }}',
+          data: data,
+          dataType: 'jsonp',
+          success: function(data) {
+            alert('Total results found: ' + data.result.total)
+          }
+        });</pre>
+              </div>
+            </div>
+          </div>
+
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <a class="accordion-toggle" data-toggle="collapse" data-parent="accordion2" href="#collapse-python">{{ _('Example: Python') }} &raquo;</a>
+            </div>
+            <div id="collapse-python" class="panel-collapse collapse">
+              <div class="panel-body">
+                <pre>
+      import urllib
+      url = '{{ h.url_for(qualified=True, controller='api', action='action', ver=3, logic_function='datastore_search', resource_id=resource_id, limit=5) + '&q=title:jones' }}'  {# not urlencoding the ":" because its clearer #}
+      fileobj = urllib.urlopen(url)
+      print fileobj.read()
+      </pre>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+</div>

--- a/ckanext/datastore/templates-bs3/datastore/api_examples/curl.html
+++ b/ckanext/datastore/templates-bs3/datastore/api_examples/curl.html
@@ -1,0 +1,40 @@
+{% call register_example('curl', 'button_label') %}
+curl
+{% endcall %}
+
+
+{% call register_example('curl', 'request_limit') %}
+<pre class="example-curl"><code class="language-bash"
+>curl {{ h.url_for('api.action', logic_function='datastore_search', qualified=True) }} \
+  -H"Authorization:$API_TOKEN" -d '
+{
+  "resource_id": "{{ resource_id }}",
+  "limit": 5,
+  "q": "jones"
+}'</code></pre>
+{% endcall %}
+
+
+{% call register_example('curl', 'request_filter') %}
+<pre class="example-curl"><code class="language-bash"
+>curl {{ h.url_for('api.action', logic_function='datastore_search', qualified=True) }} \
+-H"Authorization:$API_TOKEN" -d '
+{
+"resource_id": "{{ resource_id }}",
+  "filters": {
+    "subject": ["watershed", "survey"],
+    "stage": "active"
+  }
+}'</code></pre>
+{% endcall %}
+
+
+{% call register_example('curl', 'request_sql') %}
+<pre class="example-curl"><code class="language-bash"
+>curl {{ h.url_for('api.action', logic_function='datastore_search_sql', qualified=True) }} \
+  -H"Authorization:$API_TOKEN" -d @- &lt;&lt;END
+{
+  "sql": "SELECT * FROM \"{{ resource_id }}\" WHERE title LIKE 'jones'"
+}
+END</code></pre>
+{% endcall %}

--- a/ckanext/datastore/templates-bs3/datastore/api_examples/javascript.html
+++ b/ckanext/datastore/templates-bs3/datastore/api_examples/javascript.html
@@ -1,0 +1,55 @@
+{% call register_example('javascript', 'button_label') %}
+JavaScript
+{% endcall %}
+
+{% call register_example('javascript', 'request_limit') %}
+<pre class="example-javascript"><code class="language-javascript"
+>const resp = await fetch(`{{
+  h.url_for('api.action', logic_function='datastore_search', qualified=True) }}`, {
+    method: 'POST',
+    headers: {
+        'content-type': 'application/json',
+        authorization: API_TOKEN
+    },
+    body: JSON.stringify({
+        resource_id: '{{ resource_id }}',
+        limit: 5,
+        q: 'jones'
+    })
+})
+await resp.json()</code></pre>
+{% endcall %}
+
+
+{% call register_example('javascript', 'request_filter') %}
+<pre class="example-javascript"><code class="language-javascript"
+>const resp = await fetch(`{{
+  h.url_for('api.action', logic_function='datastore_search', qualified=True) }}`, {
+    method: 'POST',
+    headers: {
+        'content-type': 'application/json',
+        authorization: API_TOKEN
+    },
+    body: JSON.stringify({resource_id: '{{ resource_id }}', filters: {
+        subject: ['watershed', 'survey'],
+        stage: 'active'
+    }})})
+await resp.json()</code></pre>
+{% endcall %}
+
+
+{% call register_example('javascript', 'request_sql') %}
+<pre class="example-javascript"><code class="language-javascript"
+>const resp = await fetch(`{{
+  h.url_for('api.action', logic_function='datastore_search_sql', qualified=True) }}`, {
+    method: 'POST',
+    headers: {
+        'content-type': 'application/json',
+        authorization: API_TOKEN
+    },
+    body: JSON.stringify({
+        sql: `SELECT * FROM "{{ resource_id }}" WHERE title LIKE 'jones'`
+    })
+})
+await resp.json()</code></pre>
+{% endcall %}

--- a/ckanext/datastore/templates-bs3/datastore/api_examples/powershell.html
+++ b/ckanext/datastore/templates-bs3/datastore/api_examples/powershell.html
@@ -1,0 +1,48 @@
+{% call register_example('powershell', 'button_label') %}
+PowerShell
+{% endcall %}
+
+
+{% call register_example('powershell', 'request_limit') %}
+<pre class="example-powershell"><code class="language-powershell"
+>$json = @'
+{
+  "resource_id": "{{resource_id}}",
+  "limit": 5,
+  "q": "jones"
+}
+'@
+$response = Invoke-RestMethod {{ h.url_for('api.action', logic_function='datastore_search', qualified=True) }}`
+  -Method Post -Body $json -Headers @{"Authorization"="$API_TOKEN"}
+$response.result.records</code></pre>
+{% endcall %}
+
+
+{% call register_example('powershell', 'request_filter') %}
+<pre class="example-powershell"><code class="language-powershell"
+>$json = @'
+{
+  "resource_id": "{{resource_id}}",
+  "filters": {
+    "subject": ["watershed", "survey"],
+    "stage": "active"
+  }
+}
+'@
+$response = Invoke-RestMethod {{ h.url_for('api.action', logic_function='datastore_search', qualified=True) }}`
+  -Method Post -Body $json -Headers @{"Authorization"="$API_TOKEN"}
+$response.result.records</code></pre>
+{% endcall %}
+
+
+{% call register_example('powershell', 'request_sql') %}
+<pre class="example-powershell"><code class="language-powershell"
+>$json = @'
+{
+  "sql": "SELECT * from \"{{resource_id}}\" WHERE title LIKE 'jones'"
+}
+'@
+$response = Invoke-RestMethod {{ h.url_for('api.action', logic_function='datastore_search_sql', qualified=True) }}`
+  -Method Post -Body $json -Headers @{"Authorization"="$API_TOKEN"}
+$response.result.records</code></pre>
+{% endcall %}

--- a/ckanext/datastore/templates-bs3/datastore/api_examples/python.html
+++ b/ckanext/datastore/templates-bs3/datastore/api_examples/python.html
@@ -1,0 +1,52 @@
+{% call register_example('python', 'button_label') %}
+Python
+{% endcall %}
+
+
+{% call register_example('python', 'request_limit') %}
+<div class="example-python">
+  <p>
+    {% trans url='https://github.com/ckan/ckanapi/blob/master/README.md#remoteckan' -%}
+    (using the <a href="{{ url }}">ckanapi</a> client library)
+    {%- endtrans %}
+  </p>
+  <pre><code class="language-python"
+>from ckanapi import RemoteCKAN
+
+rc = RemoteCKAN('{{ h.url_for('home.index', qualified=True) }}', apikey=API_TOKEN)
+result = rc.action.datastore_search(
+    resource_id="{{ resource_id }}",
+    limit=5,
+    q="jones",
+)
+print(result['records'])</code></pre></div>
+{% endcall %}
+
+
+{% call register_example('python', 'request_filter') %}
+<pre class="example-python"><code class="language-python"
+>from ckanapi import RemoteCKAN
+
+rc = RemoteCKAN('{{ h.url_for('home.index', qualified=True) }}', apikey=API_TOKEN)
+result = rc.action.datastore_search(
+    resource_id="{{ resource_id }}",
+    filters={
+      "subject": ["watershed", "survey"],
+      "stage": "active",
+    },
+)
+print(result['records'])</code></pre>
+{% endcall %}
+
+
+{% call register_example('python', 'request_sql') %}
+<pre class="example-python"><code class="language-python"
+>from ckanapi import RemoteCKAN
+
+rc = RemoteCKAN('{{ h.url_for('home.index', qualified=True) }}', apikey=API_TOKEN)
+result = rc.action.datastore_search_sql(
+    sql="""SELECT * from "{{resource_id}}" WHERE title LIKE 'jones'"""
+)
+print(result['records'])</code></pre>
+{% endcall %}
+

--- a/ckanext/datastore/templates-bs3/datastore/api_examples/r.html
+++ b/ckanext/datastore/templates-bs3/datastore/api_examples/r.html
@@ -1,0 +1,51 @@
+{% call register_example('r', 'button_label') %}
+R
+{% endcall %}
+
+
+{% call register_example('r', 'request_limit') %}
+<pre class="example-r"><code class="language-r"
+>library(httr2)
+
+req &lt;- request("{{ h.url_for('api.action', logic_function='datastore_search', qualified=True) }}")
+result &lt;- req %&gt;% 
+    req_headers(Authorization = API_TOKEN) %>% 
+    req_body_json(list(
+        resource_id = '{{ resource_id }}',
+        limit = 5,
+        q = 'jones'))
+    req_perform %&gt;% 
+    resp_body_json</code></pre>
+{% endcall %}
+
+
+{% call register_example('r', 'request_filter') %}
+<pre class="example-r"><code class="language-bash"
+>library(httr2)
+
+req &lt;- request("{{ h.url_for('api.action', logic_function='datastore_search', qualified=True) }}")
+result &lt;- req %&gt;% 
+    req_headers(Authorization = API_TOKEN) %>% 
+    req_body_json(list(
+        resource_id='{{ resource_id }}', 
+        filters = list(
+            subject = list("watershed", "survey"), 
+            stage = "active")))
+    req_perform %&gt;% 
+    resp_body_json</code></pre>
+{% endcall %}
+
+
+{% call register_example('r', 'request_sql') %}
+<pre class="example-r"><code class="language-bash"
+>library(httr2)
+
+req &lt;- request("{{ h.url_for('api.action', logic_function='datastore_search_sql', qualified=True) }}")
+result &lt;- req %&gt;% 
+    req_headers(Authorization = API_TOKEN) %&gt;% 
+    req_body_json(list(
+        sql = "SELECT * FROM \"{{resource_id}}\" WHERE title LIKE 'jones'"))
+    req_perform %&gt;% 
+    resp_body_json
+</code></pre>
+{% endcall %}

--- a/ckanext/datastore/templates-bs3/datastore/dictionary.html
+++ b/ckanext/datastore/templates-bs3/datastore/dictionary.html
@@ -1,0 +1,22 @@
+{% extends "package/resource_edit_base.html" %}
+
+{% import 'macros/form.html' as form %}
+
+{% block subtitle %}{{ h.dataset_display_name(pkg) }} - {{ h.resource_display_name(res) }}{% endblock %}
+
+{% block primary_content_inner %}
+
+  {% set action = h.url_for('datastore.dictionary', id=pkg.name, resource_id=res.id) %}
+
+  <form method="post" action="{{ action }}" >
+    {{ h.csrf_input() }}
+    {% block dictionary_form %}
+      {% for field in fields %}
+          {% snippet "datastore/snippets/dictionary_form.html", field=field, position=loop.index %}
+      {% endfor %}
+    {% endblock %}
+    <button class="btn btn-primary" name="save" type="submit">
+      <i class="fa fa-book"></i> {{ _('Save') }}
+    </button>
+  </form>
+{% endblock %}

--- a/ckanext/datastore/templates-bs3/datastore/snippets/dictionary_form.html
+++ b/ckanext/datastore/templates-bs3/datastore/snippets/dictionary_form.html
@@ -1,0 +1,25 @@
+{% import 'macros/form.html' as form %}
+
+<h3>{{ _( "Field {num}.").format(num=position) }} {{ field.id }} ({{ field.type }})</h3>
+
+{#
+  Data Dictionary fields may be added this snippet. New fields following
+  the 'info__' ~ position ~ '__namegoeshere' convention will be saved
+  as part of the "info" object on the column.
+#}
+
+{{ form.select('info__' ~ position ~ '__type_override',
+  label=_('Type Override'), options=[
+  {'name': '', 'value': ''},
+  {'name': 'text', 'value': 'text'},
+  {'name': 'numeric', 'value': 'numeric'},
+  {'name': 'timestamp', 'value': 'timestamp'},
+  ], selected=field.get('info', {}).get('type_override', '')) }}
+
+{{ form.input('info__' ~ position ~ '__label',
+  label=_('Label'), id='field-f' ~ position ~ 'label',
+  value=field.get('info', {}).get('label', ''), classes=['control-full']) }}
+
+{{ form.markdown('info__' ~ position ~ '__notes',
+  label=_('Description'), id='field-d' ~ position ~ 'notes',
+  value=field.get('info', {}).get('notes', '')) }}

--- a/ckanext/datastore/templates-bs3/package/resource_edit_base.html
+++ b/ckanext/datastore/templates-bs3/package/resource_edit_base.html
@@ -1,0 +1,9 @@
+{% ckan_extends %}
+
+{% block inner_primary_nav %}
+  {{ super() }}
+  {% if res.datastore_active %}
+    {{ h.build_nav_icon('datastore.dictionary', _('Data Dictionary'),
+      id=pkg.name, resource_id=res.id, icon='code') }}
+  {% endif %}
+{% endblock %}

--- a/ckanext/datastore/templates-bs3/package/resource_read.html
+++ b/ckanext/datastore/templates-bs3/package/resource_read.html
@@ -1,0 +1,49 @@
+{% ckan_extends %}
+
+{% block resource_actions_inner %}
+  {{ super() }}
+  {% if res.datastore_active %}
+    <li>{% snippet 'package/snippets/data_api_button.html', resource=res %}</li>
+  {% endif %}
+{% endblock %}
+
+{% block resource_additional_information_inner %}
+  {% if res.datastore_active %}
+  {% block resource_data_dictionary %}
+    <div class="module-content">
+      <h2>{{ _('Data Dictionary') }}</h2>
+      <table class="table table-striped table-bordered table-condensed" data-module="table-toggle-more">
+        <thead>
+          {% block resouce_data_dictionary_headers %}
+          <tr>
+            <th scope="col">{{ _('Column') }}</th>
+            <th scope="col">{{ _('Type') }}</th>
+            <th scope="col">{{ _('Label') }}</th>
+            <th scope="col">{{ _('Description') }}</th>
+          </tr>
+          {% endblock %}
+        </thead>
+        {% block resource_data_dictionary_data %}
+          {% set dict=h.datastore_dictionary(res.id) %}
+          {% for field in dict %}
+            {% snippet "package/snippets/dictionary_table.html", field=field %}
+          {% endfor %}
+        {% endblock %}
+      </table>
+    </div>
+  {% endblock %}
+  {% endif %}
+  {{ super() }}
+{% endblock %}
+
+{% block action_manage_inner %}
+  {{ super() }}
+  {% if res.datastore_active %}
+    <li>{% link_for _('Data Dictionary'), named_route='datastore.dictionary', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='code' %}
+  {% endif %}
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {% asset "ckanext_datastore/datastore" %}
+{% endblock %}

--- a/ckanext/datastore/templates-bs3/package/snippets/data_api_button.html
+++ b/ckanext/datastore/templates-bs3/package/snippets/data_api_button.html
@@ -1,0 +1,10 @@
+{# Data API Help Button
+
+resource: the resource
+
+#}
+{% if resource.datastore_active %}
+  {% set loading_text = _('Loading...') %}
+  {% set api_info_url = h.url_for('api.snippet', ver=1, snippet_path='api_info.html', resource_id=resource.id) %}
+  <a class="btn btn-success" href="{{ api_info_url }}" data-module="api-info" data-module-template="{{ api_info_url }}" data-loading-text="{{ loading_text }}"><i class="fa fa-flask fa-lg"></i> {{ _('Data API') }}</a>
+{% endif %}

--- a/ckanext/datastore/templates-bs3/package/snippets/dictionary_table.html
+++ b/ckanext/datastore/templates-bs3/package/snippets/dictionary_table.html
@@ -1,0 +1,7 @@
+<tr>
+  <td>{{ field.id }}</td>
+  <td>{{ field.type }}</td>
+  <td>{{ h.get_translated(field.get('info', {}), 'label') }}</td>
+  <td>{{ h.render_markdown(
+    h.get_translated(field.get('info', {}), 'notes')) }}</td>
+</tr>

--- a/ckanext/datastore/templates-bs3/package/snippets/resource_item.html
+++ b/ckanext/datastore/templates-bs3/package/snippets/resource_item.html
@@ -1,0 +1,8 @@
+{% ckan_extends %}
+
+{% block resource_item_explore_inner %}
+  {{ super() }}
+  {% if res.datastore_active %}
+    <li>{% link_for _('Data Dictionary'), named_route='datastore.dictionary', id=pkg.name, resource_id=res.id, class_='dropdown-item', icon='code' %}
+  {% endif %}
+{% endblock %}

--- a/ckanext/datastore/templates-bs3/package/snippets/resources.html
+++ b/ckanext/datastore/templates-bs3/package/snippets/resources.html
@@ -1,0 +1,8 @@
+{% ckan_extends %}
+
+{% block resources_list_edit_dropdown_inner %}
+  {{ super() }}
+  {% if resource.datastore_active %}
+    <li>{% link_for _('Data Dictionary'), named_route='datastore.dictionary', id=pkg.name, resource_id=resource.id, class_='dropdown-item', icon='code' %}
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
Fix for https://github.com/ckan/ckan/issues/7710

I've added `templates-bs3` from latest 2.9, instead of removing `ckan.base_templates_folder` usage, because new templates don't support bs3 public. (e.g `data-*` vs `data-bs-*`). 

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
