### PR TITLE
Fix flaky test

### DIFF
--- a/ckan/tests/model/test_user.py
+++ b/ckan/tests/model/test_user.py
@@ -232,12 +232,12 @@ class TestUser:
         from ckan.lib.helpers import url_for
         from freezegun import freeze_time
 
-        frozen_time = datetime.datetime.utcnow()
         data = factories.User()
         dataset = factories.Dataset()
         user_token = factories.APIToken(user=data["name"])
         headers = {"Authorization": user_token["token"]}
 
+        frozen_time = datetime.datetime.utcnow()
         with freeze_time(frozen_time):
             user = model.User.get(data["id"])
             assert user.last_active is None


### PR DESCRIPTION
Fixes #

### Proposed fixes:
When freezing the request time just before creating the token there's a small chance that it will create try to authenticate with a token created in the future and, therefore, it will fail. (See [failure in master](https://app.circleci.com/pipelines/github/ckan/ckan/5701/workflows/5396c6a7-ba0f-446f-8505-b452a7ece356/jobs/13711))

```
Freeze Time (Request): 2023-08-30 07:26:49.950891
Token Creation time: 2023-08-30 07:26:50.055661
2023-08-30 09:26:49,950 ERROR [ckan.lib.api_token] Cannot decode JWT token: The token is not yet valid (iat)
```

This PR will freeze the request time after the creation of the token. Normaly it doesn't happen because both request time and token time is in the same second.
