### PR TITLE
Replacing MD5 hashing algorithm with SHA512

### DIFF
--- a/ckan/config/middleware/common_middleware.py
+++ b/ckan/config/middleware/common_middleware.py
@@ -56,7 +56,7 @@ class TrackingMiddleware(object):
                 environ.get('HTTP_ACCEPT_LANGUAGE', ''),
                 environ.get('HTTP_ACCEPT_ENCODING', ''),
             ])
-            key = hashlib.md5(key.encode()).hexdigest()
+            key = hashlib.sha3_256(key.encode()).hexdigest()
             # store key/data here
             sql = '''INSERT INTO tracking_raw
                      (user_key, url, tracking_type)


### PR DESCRIPTION
In file: common_middleware.py, method: __call__, the used hashing algorithm is no longer considered secure because it is possible to have collisions. This can lead to brute force attempt to find two or more inputs that produce the same hash. iCR suggested that safer alternative hash algorithms, such as SHA-256, SHA-512, SHA-3 are used. 

In the file, MD5 is used to generate a key based on several parameters and inserted into the database as `user_key`. In that case, it's recommended to use a more secure, less collision prone hash function such as- SHA256 or SHA512.


### Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.