### PR TITLE
Changed Spanish mistranslation

### DIFF
--- a/ckan/i18n/es/LC_MESSAGES/ckan.po
+++ b/ckan/i18n/es/LC_MESSAGES/ckan.po
@@ -377,7 +377,7 @@ msgstr "Debe tener al menos %s caracteres de longitud"
 #: ckan/logic/validators.py:341 ckan/logic/validators.py:672
 #, python-format
 msgid "Name must be a maximum of %i characters long"
-msgstr "El nonbre no puede tener más de %i caracteres de largo"
+msgstr "El nombre no puede tener más de %i caracteres de largo"
 
 #: ckan/logic/validators.py:344
 msgid ""

--- a/ckan/i18n/es_AR/LC_MESSAGES/ckan.po
+++ b/ckan/i18n/es_AR/LC_MESSAGES/ckan.po
@@ -377,7 +377,7 @@ msgstr "Debe tener al menos %s caracteres de longitud"
 #: ckan/logic/validators.py:341 ckan/logic/validators.py:672
 #, python-format
 msgid "Name must be a maximum of %i characters long"
-msgstr "El nonbre no puede tener más de %i caracteres de largo"
+msgstr "El nombre no puede tener más de %i caracteres de largo"
 
 #: ckan/logic/validators.py:344
 msgid ""


### PR DESCRIPTION
> Errata nonbre, API reply

Changed the spanish translation of
msgid "Name must be a maximum of %i characters long"
from
msgstr "El nonbre no puede tener más de %i caracteres de largo"
to
msgstr "El nombre no puede tener más de %i caracteres de largo"
.
.

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
