### PR TITLE
Improve handling of date fields in Solr

### DIFF
--- a/changes/7775.bugfix
+++ b/changes/7775.bugfix
@@ -1,0 +1,1 @@
+Fix error when indexing a full ISO date with timezone info

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -8,7 +8,7 @@ import collections
 import json
 import datetime
 import re
-from dateutil.parser import parse
+from dateutil.parser import parse, ParserError as DateParserError
 from typing import Any, NoReturn, Optional
 
 import six
@@ -247,19 +247,15 @@ class PackageSearchIndex(SearchIndex):
                 if not value:
                     continue
                 try:
-                    date = parse(value, default=bogus_date)
-                    if date != bogus_date:
-                        value = date.isoformat()
-                        if not date.tzinfo:
-                            value += 'Z'
-                    else:
-                        # The date field was empty, so dateutil filled it with
-                        # the default bogus date
-                        value = None
-                except (IndexError, TypeError, ValueError):
-                    log.error('%r: %r value of %r is not a valid date', pkg_dict['id'], key, value)
+                    date = parse(value)
+                    value = date.isoformat()
+                    if not date.tzinfo:
+                        value += 'Z'
+                except DateParserError:
+                    log.warning('%r: %r value of %r is not a valid date', pkg_dict['id'], key, value)
                     continue
             new_dict[key] = value
+
         pkg_dict = new_dict
 
         for k in ('title', 'notes', 'title_string'):

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -247,7 +247,9 @@ class PackageSearchIndex(SearchIndex):
                 try:
                     date = parse(value, default=bogus_date)
                     if date != bogus_date:
-                        value = date.isoformat() + 'Z'
+                        value = date.isoformat()
+                        if not date.tzinfo:
+                            value += 'Z'
                     else:
                         # The date field was empty, so dateutil filled it with
                         # the default bogus date

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -6,7 +6,6 @@ import string
 import logging
 import collections
 import json
-import datetime
 import re
 from dateutil.parser import parse, ParserError as DateParserError
 from typing import Any, NoReturn, Optional
@@ -235,12 +234,7 @@ class PackageSearchIndex(SearchIndex):
         pkg_dict['dataset_type'] = pkg_dict['type']
 
         # clean the dict fixing keys and dates
-        # FIXME where are we getting these dirty keys from?  can we not just
-        # fix them in the correct place or is this something that always will
-        # be needed?  For my data not changing the keys seems to not cause a
-        # problem.
         new_dict = {}
-        bogus_date = datetime.datetime(1, 1, 1)
         for key, value in pkg_dict.items():
             key = six.ensure_str(key)
             if key.endswith('_date'):

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -244,6 +244,8 @@ class PackageSearchIndex(SearchIndex):
         for key, value in pkg_dict.items():
             key = six.ensure_str(key)
             if key.endswith('_date'):
+                if not value:
+                    continue
                 try:
                     date = parse(value, default=bogus_date)
                     if date != bogus_date:

--- a/ckan/tests/lib/search/test_index.py
+++ b/ckan/tests/lib/search/test_index.py
@@ -124,6 +124,7 @@ class TestSearchIndex(object):
                 "extras": [
                     {"key": "test_date", "value": "2014-03-22"},
                     {"key": "test_tim_date", "value": "2014-03-22 05:42:14"},
+                    {"key": "test_full_iso_date", "value": "2019-10-10T01:15:00Z"},
                 ]
             }
         )
@@ -141,6 +142,10 @@ class TestSearchIndex(object):
         assert (
             response.docs[0]["test_tim_date"].strftime("%Y-%m-%d %H:%M:%S")
             == "2014-03-22 05:42:14"
+        )
+        assert (
+            response.docs[0]["test_full_iso_date"].strftime("%Y-%m-%d %H:%M:%S")
+            == "2019-10-10 01:15:00"
         )
 
     def test_index_date_field_wrong_value(self):

--- a/ckan/tests/lib/search/test_index.py
+++ b/ckan/tests/lib/search/test_index.py
@@ -148,6 +148,27 @@ class TestSearchIndex(object):
             == "2019-10-10 01:15:00"
         )
 
+    def test_index_date_empty_value(self):
+
+        pkg_dict = self.base_package_dict.copy()
+        pkg_dict.update(
+            {
+                "extras": [
+                    {"key": "test_empty_date", "value": ""},
+                    {"key": "test_none_date", "value": None},
+                ]
+            }
+        )
+
+        self.package_index.index_package(pkg_dict)
+
+        response = self.solr_client.search(q="name:monkey", fq=self.fq)
+
+        assert len(response) == 1
+
+        assert "test_empty_date" not in response.docs[0]
+        assert "test_none_date" not in response.docs[0]
+
     def test_index_date_field_wrong_value(self):
 
         pkg_dict = self.base_package_dict.copy()


### PR DESCRIPTION
Fixes #7664 

Three different issues around the same code, handling how we index date fields (ending with `_date` in Solr):

* Fix a bug (#7664) when you provided a full ISO date with timezone info
* Don't log an ERROR message in the log when trying to index an empty date field
* Remove some ancient code I introduced to handle empty dates ages ago

Added tests


