### PR TITLE
Don't allow get requests for activity_create

### DIFF
--- a/ckanext/activity/logic/action.py
+++ b/ckanext/activity/logic/action.py
@@ -65,7 +65,6 @@ def dashboard_mark_activities_old(
         model.repo.commit()
 
 
-@tk.side_effect_free
 def activity_create(
     context: Context, data_dict: DataDict
 ) -> Optional[dict[str, Any]]:


### PR DESCRIPTION

### Proposed fixes:

activity_create is marked as side_effect_free so it could be triggered using a GET request. This was probably an oversight.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport