### PR TITLE
Fix Possible Member Duplication

### DIFF
--- a/changes/7804.bugfix
+++ b/changes/7804.bugfix
@@ -1,0 +1,1 @@
+Aligned `member_create` with `group_member_save` to prevent possible member duplication.

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -624,8 +624,8 @@ def member_create(context: Context,
                 capacity != u'admin':
             raise NotAuthorized("Administrators cannot revoke their "
                                 "own admin status")
-        if member.state != u'active':
-            member.state = u'active'
+        if member.state != 'active':
+            member.state = 'active'
     else:
         member = model.Member(table_name=obj_type,
                               table_id=obj.id,

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -612,7 +612,7 @@ def member_create(context: Context,
         filter(model.Member.table_name == obj_type).\
         filter(model.Member.table_id == obj.id).\
         filter(model.Member.group_id == group.id).\
-        filter(model.Member.state == 'active').first()
+        order_by(model.Member.state.asc()).first()
     if member:
         user_obj = model.User.get(user)
         if user_obj and member.table_name == u'user' and \
@@ -621,6 +621,8 @@ def member_create(context: Context,
                 capacity != u'admin':
             raise NotAuthorized("Administrators cannot revoke their "
                                 "own admin status")
+        if member.state != u'active':
+            member.state = u'active'
     else:
         member = model.Member(table_name=obj_type,
                               table_id=obj.id,

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -612,7 +612,10 @@ def member_create(context: Context,
         filter(model.Member.table_name == obj_type).\
         filter(model.Member.table_id == obj.id).\
         filter(model.Member.group_id == group.id).\
-        order_by(model.Member.state.asc()).first()
+        order_by(
+            # type_ignore_reason: incomplete SQLAlchemy types
+            model.Member.state.asc()  # type: ignore
+        ).first()
     if member:
         user_obj = model.User.get(user)
         if user_obj and member.table_name == u'user' and \


### PR DESCRIPTION
fix(logic): member create behave like member save;

- Made `member_create` action method behave like `group_member_save` dictize method.

# Fixes

There is a possible scenario in which a member can get "duplicated". This happens if the member is deleted, and then re-added and the generated primary ID of the member happens to get selected before the old deleted member from the database table.

The `group_member_save` dictization method already handles this scenario. So this is just aligning the `member_create` logic action method to behave similarly to that.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
