### PR TITLE
Add Missing Confirm Action Views/Templates

### DIFF
--- a/changes/7813.feature
+++ b/changes/7813.feature
@@ -1,0 +1,2 @@
+Added pages to confirm User delete and Dataset Collaborator delete.
+Fixed cancellation of Group Member delete.

--- a/ckan/templates/package/collaborators/confirm_delete.html
+++ b/ckan/templates/package/collaborators/confirm_delete.html
@@ -1,0 +1,21 @@
+{% extends "page.html" %}
+
+{% block subtitle %}{{ _("Confirm Delete") }}{% endblock %}
+
+{% block maintag %}<div class="row" role="main">{% endblock %}
+
+{% block main_content %}
+  <section class="module col-md-6 col-md-offset-3">
+    <div class="module-content">
+      {% block form %}
+        <p>{{ _('Are you sure you want to delete collaborator - {name}?').format(name=user_dict.name) }}</p>
+        <p class="form-actions">
+          <form id="collaborator-confirm-delete-form" action="{{ h.url_for(package_type + '.collaborator_delete', id=package_id, user_id=user_id) }}" method="post">
+            <button class="btn btn-danger" type="submit" name="cancel" >{{ _('Cancel') }}</button>
+            <button class="btn btn-primary" type="submit" name="delete" >{{ _('Confirm Delete') }}</button>
+          </form>
+        </p>
+      {% endblock %}
+    </div>
+  </section>
+{% endblock %}

--- a/ckan/templates/package/collaborators/confirm_delete.html
+++ b/ckan/templates/package/collaborators/confirm_delete.html
@@ -11,6 +11,7 @@
         <p>{{ _('Are you sure you want to delete collaborator - {name}?').format(name=user_dict.name) }}</p>
         <p class="form-actions">
           <form id="collaborator-confirm-delete-form" action="{{ h.url_for(package_type + '.collaborator_delete', id=package_id, user_id=user_id) }}" method="post">
+            {{ h.csrf_input() }}
             <button class="btn btn-danger" type="submit" name="cancel" >{{ _('Cancel') }}</button>
             <button class="btn btn-primary" type="submit" name="delete" >{{ _('Confirm Delete') }}</button>
           </form>

--- a/ckan/templates/user/confirm_delete.html
+++ b/ckan/templates/user/confirm_delete.html
@@ -11,6 +11,7 @@
         <p>{{ _('Are you sure you want to delete user - {name}?').format(name=user_dict.name) }}</p>
         <p class="form-actions">
           <form id="user-confirm-delete-form" action="{{ h.url_for('user.delete', id=user_dict.id) }}" method="post">
+            {{ h.csrf_input() }}
             <button class="btn btn-danger" type="submit" name="cancel" >{{ _('Cancel') }}</button>
             <button class="btn btn-primary" type="submit" name="delete" >{{ _('Confirm Delete') }}</button>
           </form>

--- a/ckan/templates/user/confirm_delete.html
+++ b/ckan/templates/user/confirm_delete.html
@@ -1,0 +1,21 @@
+{% extends "page.html" %}
+
+{% block subtitle %}{{ _("Confirm Delete") }}{% endblock %}
+
+{% block maintag %}<div class="row" role="main">{% endblock %}
+
+{% block main_content %}
+  <section class="module col-md-6 col-md-offset-3">
+    <div class="module-content">
+      {% block form %}
+        <p>{{ _('Are you sure you want to delete user - {name}?').format(name=user_dict.name) }}</p>
+        <p class="form-actions">
+          <form id="user-confirm-delete-form" action="{{ h.url_for('user.delete', id=user_dict.id) }}" method="post">
+            <button class="btn btn-danger" type="submit" name="cancel" >{{ _('Cancel') }}</button>
+            <button class="btn btn-primary" type="submit" name="delete" >{{ _('Confirm Delete') }}</button>
+          </form>
+        </p>
+      {% endblock %}
+    </div>
+  </section>
+{% endblock %}

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -1086,7 +1086,8 @@ def collaborators_read(package_type: str, id: str) -> Union[Response, str]:  # n
         u'pkg_dict': pkg_dict})
 
 
-def collaborator_delete(package_type: str, id: str, user_id: str) -> Response:  # noqa
+def collaborator_delete(package_type: str,
+                        id: str, user_id: str) -> Union[Response, str]:  # noqa
     context: Context = {'user': current_user.name}
 
     if u'cancel' in request.form:

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -1089,20 +1089,43 @@ def collaborators_read(package_type: str, id: str) -> Union[Response, str]:  # n
 def collaborator_delete(package_type: str, id: str, user_id: str) -> Response:  # noqa
     context: Context = {'user': current_user.name}
 
+    if u'cancel' in request.form:
+        return h.redirect_to(u'{}.collaborators_read'
+                             .format(package_type), id=id)
+
     try:
-        get_action(u'package_collaborator_delete')(context, {
-            u'id': id,
-            u'user_id': user_id
-        })
+        if request.method == u'POST':
+            get_action(u'package_collaborator_delete')(context, {
+                u'id': id,
+                u'user_id': user_id
+            })
+        user_dict = logic.get_action(u'user_show')(context, {u'id': user_id})
     except NotAuthorized:
         message = _(u'Unauthorized to delete collaborators {}').format(id)
         return base.abort(401, _(message))
     except NotFound as e:
         return base.abort(404, _(e.message))
 
-    h.flash_success(_(u'User removed from collaborators'))
+    if request.method == u'POST':
+        h.flash_success(_(u'User removed from collaborators'))
 
-    return h.redirect_to(u'dataset.collaborators_read', id=id)
+        return h.redirect_to(u'dataset.collaborators_read', id=id)
+
+    # TODO: Remove
+    # ckan 2.9: Adding variables that were removed from c object for
+    # compatibility with templates in existing extensions
+    g.user_dict = user_dict
+    g.user_id = user_id
+    g.package_id = id
+
+    extra_vars = {
+        u"user_id": user_id,
+        u"user_dict": user_dict,
+        u"package_id": id,
+        u"package_type": package_type
+    }
+    return base.render(
+        u'package/collaborators/confirm_delete.html', extra_vars)
 
 
 class CollaboratorEditView(MethodView):
@@ -1226,7 +1249,7 @@ def register_dataset_plugin_rules(blueprint: Blueprint):
 
         blueprint.add_url_rule(
             rule=u'/collaborators/<id>/delete/<user_id>',
-            view_func=collaborator_delete, methods=['POST', ]
+            view_func=collaborator_delete, methods=['POST', 'GET']
         )
 
 

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -632,7 +632,7 @@ def member_delete(id: str, group_type: str,
                   is_organization: bool) -> Union[Response, str]:
     extra_vars = {}
     set_org(is_organization)
-    if u'cancel' in request.args:
+    if u'cancel' in request.form:
         return h.redirect_to(u'{}.members'.format(group_type), id=id)
 
     context: Context = {'user': current_user.name}
@@ -644,6 +644,8 @@ def member_delete(id: str, group_type: str,
 
     try:
         user_id = request.args.get(u'user')
+        if not user_id:
+            base.abort(404, _(u'User not found'))
         if request.method == u'POST':
             _action(u'group_member_delete')(context, {
                 u'id': id,

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -600,18 +600,37 @@ def delete(id: str) -> Union[Response, Any]:
     }
     data_dict = {u'id': id}
 
+    if u'cancel' in request.form:
+        return h.redirect_to(u'user.edit', id=id)
+
     try:
-        logic.get_action(u'user_delete')(context, data_dict)
+        if request.method == u'POST':
+            logic.get_action(u'user_delete')(context, data_dict)
+        user_dict = logic.get_action(u'user_show')(context, {u'id': id})
     except logic.NotAuthorized:
         msg = _(u'Unauthorized to delete user with id "{user_id}".')
-        base.abort(403, msg.format(user_id=id))
+        return base.abort(403, msg.format(user_id=id))
+    except logic.NotFound as e:
+        return base.abort(404, _(e.message))
 
-    if current_user.is_authenticated:
+    if request.method == 'POST' and current_user.is_authenticated:
         if current_user.id == id:  # type: ignore
             return logout()
         else:
             user_index = h.url_for(u'user.index')
             return h.redirect_to(user_index)
+
+    # TODO: Remove
+    # ckan 2.9: Adding variables that were removed from c object for
+    # compatibility with templates in existing extensions
+    g.user_dict = user_dict
+    g.user_id = id
+
+    extra_vars = {
+        u"user_id": id,
+        u"user_dict": user_dict
+    }
+    return base.render(u'user/confirm_delete.html', extra_vars)
 
 
 class RequestResetView(MethodView):
@@ -914,7 +933,7 @@ user.add_url_rule(u'/login', view_func=login, methods=('GET', 'POST'))
 user.add_url_rule(u'/_logout', view_func=logout)
 user.add_url_rule(u'/logged_out_redirect', view_func=logged_out_page)
 
-user.add_url_rule(u'/delete/<id>', view_func=delete, methods=(u'POST', ))
+user.add_url_rule(u'/delete/<id>', view_func=delete, methods=(u'POST', 'GET'))
 
 user.add_url_rule(
     u'/reset', view_func=RequestResetView.as_view(str(u'request_reset')))


### PR DESCRIPTION
feat(templates): added missing confirm delete views;

- Added GET view to delete package collaborator.
- Added GET view to delete user.
- Fixes to canceling group member delete confirmation.

# Fixes

There were a couple missing pages for confirming the delete action of users and dataset collaborators. There was also an issue with group member delete cancel button not working.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
