### PR TITLE
Hide Add New Resource Button While Viewing History

### DIFF
--- a/changes/7814.misc
+++ b/changes/7814.misc
@@ -1,0 +1,1 @@
+Hide `Add new resource` button in the resource list while viewing activity history.

--- a/ckan/templates/package/snippets/resources.html
+++ b/ckan/templates/package/snippets/resources.html
@@ -53,7 +53,7 @@ Example:
   {% endblock %}
 {% endif %}
 
-{% if can_edit %}
+{% if can_edit and not is_activity_archive %}
   <div class="module-content">
     {% link_for _('Add new resource'), named_route=pkg.type ~ '_resource.new', id=pkg.name, class_='btn btn-light btn-sm', icon='plus' %}
   </div>


### PR DESCRIPTION
feat(templates): do not show add new resource in history view;

- Hide `Add new resource` button in resource list while viewing histories.

# Fixes

All of the edit/manage action buttons are hidden while viewing dataset and resource activity/history. This just hides the `Add new resource` button in the resource list while viewing histories.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
