### PR TITLE
update resource datastore_active with a single statement

### DIFF
--- a/changes/7832.bugfix
+++ b/changes/7832.bugfix
@@ -1,0 +1,1 @@
+update resource datastore_active with a single statement on datastore_create/delete

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -10,6 +10,7 @@ import sqlalchemy
 import sqlalchemy.exc
 from sqlalchemy.dialects.postgresql import TEXT, JSONB
 from sqlalchemy.sql.expression import func
+from sqlalchemy.sql.functions import coalesce
 
 import ckan.lib.search as search
 import ckan.lib.navl.dictization_functions
@@ -669,7 +670,10 @@ def set_datastore_active_flag(
     ).update(
         {
             'extras': func.jsonb_set(
-                model.resource_table.c.extras.cast(JSONB),
+                coalesce(
+                    model.resource_table.c.extras,
+                    '{}',
+                ).cast(JSONB),
                 '{datastore_active}',
                 json.dumps(flag),
             ).cast(TEXT)

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -7,6 +7,8 @@ from typing import Any
 
 import sqlalchemy
 import sqlalchemy.exc
+from sqlalchemy.dialects.postgresql import TEXT, JSONB
+from sqlalchemy.sql.expression import func
 
 import ckan.lib.search as search
 import ckan.lib.navl.dictization_functions
@@ -656,21 +658,21 @@ def set_datastore_active_flag(
 
     Called after creation or deletion of DataStore table.
     '''
-    # We're modifying the resource extra directly here to avoid a
-    # race condition, see issue #3245 for details and plan for a
-    # better fix
     model = context['model']
-    update_dict = {'datastore_active': flag}
 
-    q = model.Session.query(model.Resource). \
-        filter(model.Resource.id == data_dict['resource_id'])
-    resource = q.one()
-
-    # update extras in database for record
-    extras = resource.extras
-    extras.update(update_dict)
-    q.update({'extras': extras}, synchronize_session=False)
-
+    # update extras json with a single statement
+    model.Session.query(model.Resource).filter(
+        model.Resource.id == data_dict['resource_id']
+    ).update(
+        {
+            'extras': func.jsonb_set(
+                model.resource_table.c.extras.cast(JSONB),
+                '{datastore_active}',
+                json.dumps(flag),
+            ).cast(TEXT)
+        },
+        synchronize_session='fetch',
+    )
     model.Session.commit()
 
     # copied from ckan.lib.search.rebuild
@@ -686,11 +688,11 @@ def set_datastore_active_flag(
     # find changed resource, patch it and reindex package
     psi = search.PackageSearchIndex()
     _data_dict = p.toolkit.get_action('package_show')(context, {
-        'id': resource.package_id
+        'id': model.Resource.get(data_dict['resource_id']).package_id
     })
     for resource in _data_dict['resources']:
         if resource['id'] == data_dict['resource_id']:
-            resource.update(update_dict)
+            resource['datastore_active'] = flag
             psi.index_package(_data_dict)
             break
 

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from ckan.types import Context
 import logging
 from typing import Any
+import json
 
 import sqlalchemy
 import sqlalchemy.exc
@@ -659,6 +660,8 @@ def set_datastore_active_flag(
     Called after creation or deletion of DataStore table.
     '''
     model = context['model']
+    resource = model.Resource.get(data_dict['resource_id'])
+    assert resource
 
     # update extras json with a single statement
     model.Session.query(model.Resource).filter(
@@ -688,7 +691,7 @@ def set_datastore_active_flag(
     # find changed resource, patch it and reindex package
     psi = search.PackageSearchIndex()
     _data_dict = p.toolkit.get_action('package_show')(context, {
-        'id': model.Resource.get(data_dict['resource_id']).package_id
+        'id': resource.package_id
     })
     for resource in _data_dict['resources']:
         if resource['id'] == data_dict['resource_id']:

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -677,6 +677,7 @@ def set_datastore_active_flag(
         synchronize_session='fetch',
     )
     model.Session.commit()
+    model.Session.expire(resource, ['extras'])
 
     # copied from ckan.lib.search.rebuild
     # using validated packages can cause solr errors.

--- a/ckanext/datastore/tests/test_delete.py
+++ b/ckanext/datastore/tests/test_delete.py
@@ -52,7 +52,7 @@ class TestDatastoreDelete(object):
 
         # regression test for #7832
         resobj = model.Resource.get(data["resource_id"])
-        assert resobj.extras.get('datastore_active') == False
+        assert resobj.extras.get('datastore_active') is False
 
         results = execute_sql(
             u"select 1 from pg_views where viewname = %s", u"b\xfck2"

--- a/ckanext/datastore/tests/test_delete.py
+++ b/ckanext/datastore/tests/test_delete.py
@@ -50,6 +50,10 @@ class TestDatastoreDelete(object):
         data = {"resource_id": resource["id"], "force": True}
         helpers.call_action("datastore_delete", **data)
 
+        # regression test for #7832
+        resobj = model.Resource.get(data["resource_id"])
+        assert resobj.extras.get('datastore_active') == False
+
         results = execute_sql(
             u"select 1 from pg_views where viewname = %s", u"b\xfck2"
         )


### PR DESCRIPTION
Fixes #7832

### Proposed fixes:

use postgresql 10.x+ `jsonb_set` to update resource `datastore_active` in a single statement

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport