### PR TITLE
Fix Octet Streaming of Datastore Dump

### DIFF
--- a/changes/7839.bugfix
+++ b/changes/7839.bugfix
@@ -1,0 +1,1 @@
+Fixed Octet Streaming for Datastore Dump requests.

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -602,13 +602,13 @@ def member_dump(id: str, group_type: str, is_organization: bool):
             continue
         results.append([
             user_obj.name,
-            user_obj.email,
+            user_obj.email,  # type: ignore
             user_obj.fullname if user_obj.fullname else _('N/A'),
             role,
         ])
 
     output_stream = StringIO()
-    output_stream.write(BOM_UTF8)
+    output_stream.write(BOM_UTF8)  # type: ignore
     csv.writer(output_stream).writerows(results)
 
     file_name = u'{org_id}-{members}'.format(
@@ -621,7 +621,7 @@ def member_dump(id: str, group_type: str, is_organization: bool):
     content_disposition = u'attachment; filename="{name}.csv"'.format(
                                     name=file_name)
     content_type = b'text/csv; charset=utf-8'
-    response.headers['Content-Type'] = content_type
+    response.headers['Content-Type'] = content_type  # type: ignore
     response.headers['Content-Disposition'] = content_disposition
 
     return response

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -8,7 +8,7 @@ from typing import Any, Optional, Union
 from typing_extensions import Literal
 
 from urllib.parse import urlencode
-import unicodecsv
+import csv
 from io import StringIO
 from codecs import BOM_UTF8
 
@@ -609,7 +609,7 @@ def member_dump(id: str, group_type: str, is_organization: bool):
 
     output_stream = StringIO()
     output_stream.write(BOM_UTF8)
-    unicodecsv.writer(output_stream, encoding=u'utf-8').writerows(results)
+    csv.writer(output_stream).writerows(results)
 
     file_name = u'{org_id}-{members}'.format(
             org_id=group_obj.name,

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -8,6 +8,9 @@ from typing import Any, Optional, Union
 from typing_extensions import Literal
 
 from urllib.parse import urlencode
+import unicodecsv
+from io import StringIO
+from codecs import BOM_UTF8
 
 import ckan.lib.base as base
 import ckan.lib.helpers as h
@@ -21,7 +24,6 @@ import ckan.plugins as plugins
 from ckan.common import g, config, request, current_user, _
 from ckan.views.home import CACHE_PARAMETERS
 from ckan.views.dataset import _get_search_details
-from ckanext.datastore.writer import csv_writer
 
 from flask import Blueprint, make_response
 from flask.views import MethodView
@@ -566,12 +568,6 @@ def manage_members(id: str, group_type: str, is_organization: bool) -> str:
 
 
 def member_dump(id: str, group_type: str, is_organization: bool):
-    response = make_response()
-    response.headers[u'content-type'] = u'application/octet-stream'
-
-    writer_factory = csv_writer
-    records_format = u'csv'
-
     group_obj = model.Group.get(id)
     if not group_obj:
         base.abort(404,
@@ -593,37 +589,40 @@ def member_dump(id: str, group_type: str, is_organization: bool):
         members = get_action(u'member_list')(context, {
             u'id': id,
             u'object_type': u'user',
-            u'records_format': records_format,
+            u'records_format': u'csv',
             u'include_total': False,
         })
     except NotFound:
         base.abort(404, _('Members not found'))
 
-    results = ''
+    results = [[_('Username'), _('Email'), _('Name'), _('Role')]]
     for uid, _user, role in members:
         user_obj = model.User.get(uid)
         if not user_obj:
             continue
-        results += '{name},{email},{fullname},{role}\n'.format(
-            name=user_obj.name,
-            email=user_obj.email,
-            fullname=user_obj.fullname if user_obj.fullname else _('N/A'),
-            role=role)
+        results.append([
+            user_obj.name,
+            user_obj.email,
+            user_obj.fullname if user_obj.fullname else _('N/A'),
+            role,
+        ])
 
-    fields = [
-        {'id': _('Username')},
-        {'id': _('Email')},
-        {'id': _('Name')},
-        {'id': _('Role')}]
+    output_stream = StringIO()
+    output_stream.write(BOM_UTF8)
+    unicodecsv.writer(output_stream, encoding=u'utf-8').writerows(results)
 
-    def start_writer(fields: Any):
-        file_name = u'{group_id}-{members}'.format(
-                group_id=group_obj.name,
-                members=_(u'members'))
-        return writer_factory(response, fields, file_name, bom=True)
+    file_name = u'{org_id}-{members}'.format(
+            org_id=group_obj.name,
+            members=_(u'members'))
 
-    with start_writer(fields) as wr:
-        wr.write_records(results)  # type: ignore
+    output_stream.seek(0)
+    response = make_response(output_stream.read())
+    output_stream.close()
+    content_disposition = u'attachment; filename="{name}.csv"'.format(
+                                    name=file_name)
+    content_type = b'text/csv; charset=utf-8'
+    response.headers['Content-Type'] = content_type
+    response.headers['Content-Disposition'] = content_disposition
 
     return response
 

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1410,7 +1410,7 @@ def search_data(context: Context, data_dict: dict[str, Any]):
     else:
         v = list(_execute_single_statement(
             context, sql_string, where_values))[0][0]
-        if v is None:
+        if v is None or v == '[]':
             records = []
         else:
             records = LazyJSONObject(v)

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -181,10 +181,15 @@ def dump(resource_id: str):
         else:
             paginate_by = PAGINATE_BY
 
+        headers = {}
+        if content_type:
+            headers['Content-Type'] = content_type
+        if content_disposition:
+            headers['Content-disposition'] = content_disposition
+
         return Response(stream_dump(offset, limit, paginate_by, result),
                         mimetype=u'application/octet-stream',
-                        headers={'Content-Type': content_type,  # type: ignore
-                                 'Content-disposition': content_disposition})
+                        headers=headers)  # type: ignore
     except ObjectNotFound:
         abort(404, _(u'DataStore resource not found'))
 

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -62,7 +62,7 @@ def dump_schema() -> Schema:
 
 def dump(resource_id: str):
     try:
-        resource_id = resource_id_validator(resource_id)
+        resource_id = resource_id_validator(resource_id)  # type: ignore
     except Invalid:
         abort(404, _(u'DataStore resource not found'))
 
@@ -119,11 +119,10 @@ def dump(resource_id: str):
 
     user_context = g.user
 
-    def start_stream_writer(output_stream: StringIO,
-                            fields: list[dict[str, Any]]):
+    def start_stream_writer(output_stream, fields):
         return writer_factory(output_stream, fields, bom=bom)
 
-    def stream_result_page(offs: int, lim: int):
+    def stream_result_page(offs, lim):
         return get_action(u'datastore_search')(
             {u'user': user_context},
             dict({
@@ -137,8 +136,7 @@ def dump(resource_id: str):
             }, **search_params)
         )
 
-    def stream_dump(offset: int, limit: int,
-                    paginate_by: int, result: dict[str, Any]):
+    def stream_dump(offset, limit, paginate_by, result):
         with start_stream_writer(output_stream, result[u'fields']) as output:
             while True:
                 if limit is not None and limit <= 0:
@@ -173,9 +171,10 @@ def dump(resource_id: str):
 
         if result[u'limit'] != limit:
             # `limit` (from PAGINATE_BY) must have been more than
-            # ckan.datastore.search.rows_max, so datastore_search responded with a
-            # limit matching ckan.datastore.search.rows_max. So we need to paginate
-            # by that amount instead, otherwise we'll have gaps in the records.
+            # ckan.datastore.search.rows_max, so datastore_search responded
+            # with a limit matching ckan.datastore.search.rows_max.
+            # So we need to paginate by that amount instead, otherwise
+            # we'll have gaps in the records.
             paginate_by = result[u'limit']
         else:
             paginate_by = PAGINATE_BY
@@ -183,7 +182,7 @@ def dump(resource_id: str):
         return Response(stream_dump(offset, limit, paginate_by, result),
                         mimetype=u'application/octet-stream',
                         headers={'Content-Type': content_type,
-                                'Content-disposition': content_disposition,})
+                                 'Content-disposition': content_disposition})
     except ObjectNotFound:
         abort(404, _(u'DataStore resource not found'))
 

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -15,7 +15,7 @@ from ckan.logic import (
 )
 from ckan.plugins.toolkit import (
     ObjectNotFound, NotAuthorized, get_action, get_validator, _, request,
-    abort, render, g, h, Invalid
+    abort, render, g, h
 )
 from ckan.types import Schema, ValidatorFactory
 from ckanext.datastore.logic.schema import (

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 from __future__ import annotations
 
-from typing import Any, Optional, cast
+from typing import Any, Optional, cast, Union
 from itertools import zip_longest
 from io import StringIO
 
@@ -119,10 +119,10 @@ def dump(resource_id: str):
 
     user_context = g.user
 
-    def start_stream_writer(output_stream, fields):
+    def start_stream_writer(output_stream: StringIO, fields: dict[str, Any]):
         return writer_factory(output_stream, fields, bom=bom)
 
-    def stream_result_page(offs, lim):
+    def stream_result_page(offs: int, lim: Union[None, int]):
         return get_action(u'datastore_search')(
             {u'user': user_context},
             dict({
@@ -136,7 +136,8 @@ def dump(resource_id: str):
             }, **search_params)
         )
 
-    def stream_dump(offset, limit, paginate_by, result):
+    def stream_dump(offset: int, limit: Union[None, int],
+                    paginate_by: int, result: dict[str, Any]):
         with start_stream_writer(output_stream, result[u'fields']) as output:
             while True:
                 if limit is not None and limit <= 0:
@@ -181,8 +182,8 @@ def dump(resource_id: str):
 
         return Response(stream_dump(offset, limit, paginate_by, result),
                         mimetype=u'application/octet-stream',
-                        headers={'Content-Type': content_type,
-                                 'Content-disposition': content_disposition})
+                        headers={'Content-Type': content_type,  # type: ignore
+                                 'Content-disposition': content_disposition})  # type: ignore
     except ObjectNotFound:
         abort(404, _(u'DataStore resource not found'))
 

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Optional, cast, Union
 from itertools import zip_longest
-from io import StringIO
+from io import BytesIO
 
 from flask import Blueprint, Response
 from flask.views import MethodView
@@ -207,7 +207,7 @@ def dump_to(
     limit: Optional[int], options: dict[str, Any], sort: str,
     search_params: dict[str, Any], user: str
 ):
-    output_buffer = StringIO()
+    output_buffer = BytesIO()
 
     if fmt == 'csv':
         writer_factory = csv_writer
@@ -226,7 +226,7 @@ def dump_to(
 
     bom = options.get('bom', False)
 
-    def start_stream_writer(output_buffer: StringIO,
+    def start_stream_writer(output_buffer: BytesIO,
                             fields: list[dict[str, Any]]):
         return writer_factory(output_buffer, fields, bom=bom)
 

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -119,7 +119,8 @@ def dump(resource_id: str):
 
     user_context = g.user
 
-    def start_stream_writer(output_stream: StringIO, fields: dict[str, Any]):
+    def start_stream_writer(output_stream: StringIO,
+                            fields: list[dict[str, Any]]):
         return writer_factory(output_stream, fields, bom=bom)
 
     def stream_result_page(offs: int, lim: Union[None, int]):
@@ -128,7 +129,7 @@ def dump(resource_id: str):
             dict({
                 u'resource_id': resource_id,
                 u'limit': PAGINATE_BY
-                if limit is None else min(PAGINATE_BY, lim),
+                if limit is None else min(PAGINATE_BY, lim),  # type: ignore
                 u'offset': offs,
                 u'sort': sort,
                 u'records_format': records_format,
@@ -183,7 +184,7 @@ def dump(resource_id: str):
         return Response(stream_dump(offset, limit, paginate_by, result),
                         mimetype=u'application/octet-stream',
                         headers={'Content-Type': content_type,  # type: ignore
-                                 'Content-disposition': content_disposition})  # type: ignore
+                                 'Content-disposition': content_disposition})
     except ObjectNotFound:
         abort(404, _(u'DataStore resource not found'))
 

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -36,7 +36,6 @@ ignore_missing = get_validator(u'ignore_missing')
 one_of = cast(ValidatorFactory, get_validator(u'one_of'))
 default = cast(ValidatorFactory, get_validator(u'default'))
 unicode_only = get_validator(u'unicode_only')
-resource_id_validator = get_validator(u'resource_id_validator')
 
 DUMP_FORMATS = u'csv', u'tsv', u'json', u'xml'
 PAGINATE_BY = 32000
@@ -62,61 +61,62 @@ def dump_schema() -> Schema:
 
 def dump(resource_id: str):
     try:
-        resource_id = resource_id_validator(resource_id)  # type: ignore
-    except Invalid:
-        abort(404, _(u'DataStore resource not found'))
+        get_action('datastore_search')({}, {'resource_id': resource_id,
+                                            'limit': 0})
+    except ObjectNotFound:
+        abort(404, _('DataStore resource not found'))
 
     data, errors = dict_fns.validate(request.args.to_dict(), dump_schema())
     if errors:
         abort(
-            400, u'\n'.join(
-                u'{0}: {1}'.format(k, u' '.join(e)) for k, e in errors.items()
+            400, '\n'.join(
+                '{0}: {1}'.format(k, ' '.join(e)) for k, e in errors.items()
             )
         )
 
-    fmt = data[u'format']
-    offset = data[u'offset']
-    limit = data.get(u'limit')
-    options = {u'bom': data[u'bom']}
-    sort = data[u'sort']
+    fmt = data['format']
+    offset = data['offset']
+    limit = data.get('limit')
+    options = {'bom': data['bom']}
+    sort = data['sort']
     search_params = {
         k: v
         for k, v in data.items()
         if k in [
-            u'filters', u'q', u'distinct', u'plain', u'language',
-            u'fields'
+            'filters', 'q', 'distinct', 'plain', 'language',
+            'fields'
         ]
     }
 
     content_type = None
     content_disposition = None
 
-    if fmt == u'csv':
+    if fmt == 'csv':
         writer_factory = csv_writer
-        records_format = u'csv'
-        content_disposition = u'attachment; filename="{name}.csv"'.format(
+        records_format = 'csv'
+        content_disposition = 'attachment; filename="{name}.csv"'.format(
                                     name=resource_id)
         content_type = b'text/csv; charset=utf-8'
-    elif fmt == u'tsv':
+    elif fmt == 'tsv':
         writer_factory = tsv_writer
-        records_format = u'tsv'
-        content_disposition = u'attachment; filename="{name}.tsv"'.format(
+        records_format = 'tsv'
+        content_disposition = 'attachment; filename="{name}.tsv"'.format(
                                     name=resource_id)
         content_type = b'text/tab-separated-values; charset=utf-8'
-    elif fmt == u'json':
+    elif fmt == 'json':
         writer_factory = json_writer
-        records_format = u'lists'
-        content_disposition = u'attachment; filename="{name}.json"'.format(
+        records_format = 'lists'
+        content_disposition = 'attachment; filename="{name}.json"'.format(
                                     name=resource_id)
         content_type = b'application/json; charset=utf-8'
-    elif fmt == u'xml':
+    elif fmt == 'xml':
         writer_factory = xml_writer
-        records_format = u'objects'
-        content_disposition = u'attachment; filename="{name}.xml"'.format(
+        records_format = 'objects'
+        content_disposition = 'attachment; filename="{name}.xml"'.format(
                                     name=resource_id)
         content_type = b'text/xml; charset=utf-8'
 
-    bom = options.get(u'bom', False)
+    bom = options.get('bom', False)
 
     output_stream = StringIO()
 
@@ -127,27 +127,27 @@ def dump(resource_id: str):
         return writer_factory(output_stream, fields, bom=bom)
 
     def stream_result_page(offs: int, lim: Union[None, int]):
-        return get_action(u'datastore_search')(
-            {u'user': user_context},
+        return get_action('datastore_search')(
+            {'user': user_context},
             dict({
-                u'resource_id': resource_id,
-                u'limit': PAGINATE_BY
+                'resource_id': resource_id,
+                'limit': PAGINATE_BY
                 if limit is None else min(PAGINATE_BY, lim),  # type: ignore
-                u'offset': offs,
-                u'sort': sort,
-                u'records_format': records_format,
-                u'include_total': False,
+                'offset': offs,
+                'sort': sort,
+                'records_format': records_format,
+                'include_total': False,
             }, **search_params)
         )
 
     def stream_dump(offset: int, limit: Union[None, int],
                     paginate_by: int, result: dict[str, Any]):
-        with start_stream_writer(output_stream, result[u'fields']) as output:
+        with start_stream_writer(output_stream, result['fields']) as output:
             while True:
                 if limit is not None and limit <= 0:
                     break
 
-                records = result[u'records']
+                records = result['records']
 
                 output.write_records(records)
                 output_stream.seek(0)
@@ -155,7 +155,7 @@ def dump(resource_id: str):
                 output_stream.truncate(0)
                 output_stream.seek(0)
 
-                if records_format == u'objects' or records_format == u'lists':
+                if records_format == 'objects' or records_format == 'lists':
                     if len(records) < paginate_by:
                         break
                 elif not records:
@@ -174,13 +174,13 @@ def dump(resource_id: str):
     try:
         result = stream_result_page(offset, limit)
 
-        if result[u'limit'] != limit:
+        if result['limit'] != limit:
             # `limit` (from PAGINATE_BY) must have been more than
             # ckan.datastore.search.rows_max, so datastore_search responded
             # with a limit matching ckan.datastore.search.rows_max.
             # So we need to paginate by that amount instead, otherwise
             # we'll have gaps in the records.
-            paginate_by = result[u'limit']
+            paginate_by = result['limit']
         else:
             paginate_by = PAGINATE_BY
 
@@ -191,10 +191,10 @@ def dump(resource_id: str):
             headers['Content-disposition'] = content_disposition
 
         return Response(stream_dump(offset, limit, paginate_by, result),
-                        mimetype=u'application/octet-stream',
+                        mimetype='application/octet-stream',
                         headers=headers)
     except ObjectNotFound:
-        abort(404, _(u'DataStore resource not found'))
+        abort(404, _('DataStore resource not found'))
 
 
 class DictionaryView(MethodView):

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -88,6 +88,9 @@ def dump(resource_id: str):
         ]
     }
 
+    content_type = None
+    content_disposition = None
+
     if fmt == u'csv':
         writer_factory = csv_writer
         records_format = u'csv'
@@ -189,7 +192,7 @@ def dump(resource_id: str):
 
         return Response(stream_dump(offset, limit, paginate_by, result),
                         mimetype=u'application/octet-stream',
-                        headers=headers)  # type: ignore
+                        headers=headers)
     except ObjectNotFound:
         abort(404, _(u'DataStore resource not found'))
 

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Optional, cast, Union
 from itertools import zip_longest
-from io import BytesIO
+from io import StringIO
 
 from flask import Blueprint, Response
 from flask.views import MethodView
@@ -207,7 +207,7 @@ def dump_to(
     limit: Optional[int], options: dict[str, Any], sort: str,
     search_params: dict[str, Any], user: str
 ):
-    output_buffer = BytesIO()
+    output_buffer = StringIO()
 
     if fmt == 'csv':
         writer_factory = csv_writer
@@ -226,7 +226,7 @@ def dump_to(
 
     bom = options.get('bom', False)
 
-    def start_stream_writer(output_buffer: BytesIO,
+    def start_stream_writer(output_buffer: StringIO,
                             fields: list[dict[str, Any]]):
         return writer_factory(output_buffer, fields, bom=bom)
 

--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -86,30 +86,25 @@ def permissions_sql(maindb: str, datastoredb: str, mainuser: str,
 @click.option(u'--format', default=u'csv', type=click.Choice(DUMP_FORMATS))
 @click.option(u'--offset', type=click.IntRange(0, None), default=0)
 @click.option(u'--limit', type=click.IntRange(0))
+@click.option(u'--bom', is_flag=True)
 @click.pass_context
 def dump(ctx: Any, resource_id: str, output_file: Any, format: str,
-         offset: int, limit: int):
+         offset: int, limit: int, bom: bool):
     u'''Dump a datastore resource.
     '''
     flask_app = ctx.meta['flask_app']
     user = logic.get_action('get_site_user')(
             {'ignore_auth': True}, {})
-    bom = False
-    if format == 'csv' or format == 'tsv':
-        bom = True
     with flask_app.test_request_context():
-        dump_to(
-            resource_id,
-            output_file,
-            fmt=format,
-            offset=offset,
-            limit=limit,
-            options={u'bom': bom},
-            sort=u'_id',
-            search_params={},
-            user=user['name'],
-            is_generator=False
-        )
+        for block in dump_to(resource_id,
+                             fmt=format,
+                             offset=offset,
+                             limit=limit,
+                             options={u'bom': bom},
+                             sort=u'_id',
+                             search_params={},
+                             user=user['name']):
+            output_file.write(block)
 
 
 def _parse_db_config(config_key: str = u'sqlalchemy.url'):

--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -94,10 +94,9 @@ def dump(ctx: Any, resource_id: str, output_file: Any, format: str,
     flask_app = ctx.meta['flask_app']
     user = logic.get_action('get_site_user')(
             {'ignore_auth': True}, {})
+    bom = False
     if format == 'csv' or format == 'tsv':
         bom = True
-    elif format == 'json' or format == 'xml':
-        bom = False
     with flask_app.test_request_context():
         dump_to(
             resource_id,

--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -86,13 +86,18 @@ def permissions_sql(maindb: str, datastoredb: str, mainuser: str,
 @click.option(u'--format', default=u'csv', type=click.Choice(DUMP_FORMATS))
 @click.option(u'--offset', type=click.IntRange(0, None), default=0)
 @click.option(u'--limit', type=click.IntRange(0))
-@click.option(u'--bom', is_flag=True)  # FIXME: options based on format
 @click.pass_context
 def dump(ctx: Any, resource_id: str, output_file: Any, format: str,
-         offset: int, limit: int, bom: bool):
+         offset: int, limit: int):
     u'''Dump a datastore resource.
     '''
     flask_app = ctx.meta['flask_app']
+    user = logic.get_action('get_site_user')(
+            {'ignore_auth': True}, {})
+    if format == 'csv' or format == 'tsv':
+        bom = True
+    elif format == 'json' or format == 'xml':
+        bom = False
     with flask_app.test_request_context():
         dump_to(
             resource_id,
@@ -102,7 +107,9 @@ def dump(ctx: Any, resource_id: str, output_file: Any, format: str,
             limit=limit,
             options={u'bom': bom},
             sort=u'_id',
-            search_params={}
+            search_params={},
+            user=user['name'],
+            is_generator=False
         )
 
 

--- a/ckanext/datastore/tests/test_dump.py
+++ b/ckanext/datastore/tests/test_dump.py
@@ -426,7 +426,7 @@ class TestDatastoreDump(object):
 
         res = app.get(f"/datastore/dump/{resource['id']}?limit=1&format=xml")
         expected_content = (
-            u"<data>\n"
+            u'<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n'
             r'<row _id="1">'
             u"<b\xfck>annakarenina</b\xfck>"
             u"<author>tolstoy</author>"

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -30,7 +30,7 @@ def csv_writer(fields: list[dict[str, Any]], bom: bool = False):
     if bom:
         output.write(BOM)
 
-    csv.writer(output).writerow(  # type: ignore
+    csv.writer(output).writerow(
         f['id'] for f in fields)
     yield TextWriter(output)
 
@@ -49,7 +49,7 @@ def tsv_writer(fields: list[dict[str, Any]], bom: bool = False):
         output.write(BOM)
 
     csv.writer(
-        output,  # type: ignore
+        output,
         dialect='excel-tab').writerow(
             f['id'] for f in fields)
     yield TextWriter(output)
@@ -139,7 +139,7 @@ class XMLWriter(object):
     _key_attr = 'key'
     _value_tag = 'value'
 
-    def __init__(self, output: StringIO, columns: list[str]):
+    def __init__(self, output: BytesIO, columns: list[str]):
         self.output = output
         self.id_col = columns[0] == '_id'
         if self.id_col:
@@ -181,4 +181,3 @@ class XMLWriter(object):
 
     def end_file(self) -> bytes:
         return b'</data>\n'
-

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -25,7 +25,7 @@ def csv_writer(output: StringIO, fields: list[dict[str, Any]],
     '''
 
     if bom:
-        output.write(BOM_UTF8)
+        output.write(BOM_UTF8.decode())
 
     csv.writer(output).writerow(
         f['id'].encode('utf-8') for f in fields)
@@ -43,7 +43,7 @@ def tsv_writer(output: StringIO, fields: list[dict[str, Any]],
     '''
 
     if bom:
-        output.write(BOM_UTF8)
+        output.write(BOM_UTF8.decode())
 
     csv.writer(
         output,
@@ -72,11 +72,10 @@ def json_writer(output: StringIO, fields: list[dict[str, Any]],
     '''
 
     if bom:
-        output.write(BOM_UTF8)
+        output.write(BOM_UTF8.decode())
     output.write(
         '{\n  "fields": %s,\n  "records": [' % dumps(
-            fields, ensure_ascii=False, separators=(',', ':'))
-            .encode('utf-8'))
+            fields, ensure_ascii=False, separators=(',', ':')).encode('utf-8'))
     yield JSONWriter(output)
     output.write('\n]}\n')
 
@@ -110,7 +109,7 @@ def xml_writer(output: StringIO, fields: list[dict[str, Any]],
     '''
 
     if bom:
-        output.write(BOM_UTF8)
+        output.write(BOM_UTF8.decode())
     output.write(
         '<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n')
     yield XMLWriter(output, [f['id'].encode('utf-8') for f in fields])

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from email.utils import encode_rfc2231
 from typing import Any, Optional
 from simplejson import dumps
 
@@ -110,7 +109,8 @@ def xml_writer(output: Any, fields: list[dict[str, Any]],
 
     if bom:
         output.write(BOM_UTF8)
-    output.write(b'<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n')
+    output.write(
+        b'<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n')
     yield XMLWriter(output, [f[u'id'] for f in fields])
     output.write(b'</data>\n')
 

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -21,7 +21,6 @@ BOM = "\N{bom}"
 def csv_writer(fields: list[dict[str, Any]], bom: bool = False):
     '''Context manager for writing UTF-8 CSV data to file
 
-    :param response: file-like object for writing data
     :param fields: list of datastore fields
     :param bom: True to include a UTF-8 BOM at the start of the file
     '''
@@ -39,7 +38,6 @@ def csv_writer(fields: list[dict[str, Any]], bom: bool = False):
 def tsv_writer(fields: list[dict[str, Any]], bom: bool = False):
     '''Context manager for writing UTF-8 TSV data to file
 
-    :param response: file-like object for writing data
     :param fields: list of datastore fields
     :param bom: True to include a UTF-8 BOM at the start of the file
     '''
@@ -76,7 +74,6 @@ class TextWriter(object):
 def json_writer(fields: list[dict[str, Any]], bom: bool = False):
     '''Context manager for writing UTF-8 JSON data to file
 
-    :param response: file-like object for writing data
     :param fields: list of datastore fields
     :param bom: True to include a UTF-8 BOM at the start of the file
     '''
@@ -121,7 +118,6 @@ class JSONWriter(object):
 def xml_writer(fields: list[dict[str, Any]], bom: bool = False):
     '''Context manager for writing UTF-8 XML data to file
 
-    :param response: file-like object for writing data
     :param fields: list of datastore fields
     :param bom: True to include a UTF-8 BOM at the start of the file
     '''

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -26,7 +26,7 @@ def csv_writer(output: Any, fields: list[dict[str, Any]],
         output.write(BOM_UTF8)
 
     csv.writer(output).writerow(
-        f['id'].encode('utf8') for f in fields)
+        f['id'].encode('utf-8') for f in fields)
     yield TextWriter(output)
 
 
@@ -46,7 +46,7 @@ def tsv_writer(output: Any, fields: list[dict[str, Any]],
     csv.writer(
         output,
         dialect='excel-tab').writerow(
-            f['id'].encode('utf8') for f in fields)
+            f['id'].encode('utf-8') for f in fields)
     yield TextWriter(output)
 
 
@@ -73,7 +73,7 @@ def json_writer(output: Any, fields: list[dict[str, Any]],
         output.write(BOM_UTF8)
     output.write(
         b'{\n  "fields": %s,\n  "records": [' % dumps(
-            fields, ensure_ascii=False, separators=(',', ':')).encode('utf8'))
+            fields, ensure_ascii=False, separators=(',', ':')).encode('utf-8'))
     yield JSONWriter(output)
     output.write(b'\n]}\n')
 
@@ -110,7 +110,7 @@ def xml_writer(output: Any, fields: list[dict[str, Any]],
         output.write(BOM_UTF8)
     output.write(
         b'<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n')
-    yield XMLWriter(output, [f['id'].encode('utf8') for f in fields])
+    yield XMLWriter(output, [f['id'].encode('utf-8') for f in fields])
     output.write(b'</data>\n')
 
 

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -72,10 +72,10 @@ def json_writer(output: Any, fields: list[dict[str, Any]],
     if bom:
         output.write(BOM_UTF8)
     output.write(
-        '{\n  "fields": %s,\n  "records": [' % dumps(
+        b'{\n  "fields": %s,\n  "records": [' % dumps(
             fields, ensure_ascii=False, separators=(',', ':')))
     yield JSONWriter(output)
-    output.write('\n]}\n')
+    output.write(b'\n]}\n')
 
 
 class JSONWriter(object):
@@ -87,9 +87,9 @@ class JSONWriter(object):
         for r in records:
             if self.first:
                 self.first = False
-                self.output.write('\n    ')
+                self.output.write(b'\n    ')
             else:
-                self.output.write(',\n    ')
+                self.output.write(b',\n    ')
 
             self.output.write(dumps(
                 r, ensure_ascii=False, separators=(u',', u':'))
@@ -109,9 +109,9 @@ def xml_writer(output: Any, fields: list[dict[str, Any]],
     if bom:
         output.write(BOM_UTF8)
     output.write(
-        '<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n')
+        b'<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n')
     yield XMLWriter(output, [f[u'id'] for f in fields])
-    output.write('</data>\n')
+    output.write(b'</data>\n')
 
 
 class XMLWriter(object):
@@ -151,4 +151,4 @@ class XMLWriter(object):
             for c in self.columns:
                 self._insert_node(root, c, r[c])
             ElementTree(root).write(self.output, encoding=u'utf-8')
-            self.output.write('\n')
+            self.output.write(b'\n')

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -75,7 +75,7 @@ def json_writer(output: Any, fields: list[dict[str, Any]],
         '{\n  "fields": %s,\n  "records": [' % dumps(
             fields, ensure_ascii=False, separators=(',', ':')))
     yield JSONWriter(output)
-    output.write(b'\n]}\n')
+    output.write('\n]}\n')
 
 
 class JSONWriter(object):
@@ -87,9 +87,9 @@ class JSONWriter(object):
         for r in records:
             if self.first:
                 self.first = False
-                self.output.write(b'\n    ')
+                self.output.write('\n    ')
             else:
-                self.output.write(b',\n    ')
+                self.output.write(',\n    ')
 
             self.output.write(dumps(
                 r, ensure_ascii=False, separators=(u',', u':'))
@@ -109,9 +109,9 @@ def xml_writer(output: Any, fields: list[dict[str, Any]],
     if bom:
         output.write(BOM_UTF8)
     output.write(
-        b'<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n')
+        '<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n')
     yield XMLWriter(output, [f[u'id'] for f in fields])
-    output.write(b'</data>\n')
+    output.write('</data>\n')
 
 
 class XMLWriter(object):
@@ -151,4 +151,4 @@ class XMLWriter(object):
             for c in self.columns:
                 self._insert_node(root, c, r[c])
             ElementTree(root).write(self.output, encoding=u'utf-8')
-            self.output.write(b'\n')
+            self.output.write('\n')

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -25,7 +25,7 @@ def csv_writer(output: Any, fields: list[dict[str, Any]],
     if bom:
         output.write(BOM_UTF8)
 
-    csv.writer(output).writerow(
+    csv.writer(output, encoding=u'utf-8').writerow(  # type: ignore
         f['id'] for f in fields)
     yield TextWriter(output)
 
@@ -45,6 +45,7 @@ def tsv_writer(output: Any, fields: list[dict[str, Any]],
 
     csv.writer(
         output,
+        encoding=u'utf-8',  # type: ignore
         dialect='excel-tab').writerow(
             f['id'] for f in fields)
     yield TextWriter(output)
@@ -73,7 +74,7 @@ def json_writer(output: Any, fields: list[dict[str, Any]],
         output.write(BOM_UTF8)
     output.write(
         b'{\n  "fields": %s,\n  "records": [' % dumps(
-            fields, ensure_ascii=False, separators=(',', ':')))
+            fields, ensure_ascii=False, separators=(',', ':')).encode('utf8'))
     yield JSONWriter(output)
     output.write(b'\n]}\n')
 

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -25,7 +25,7 @@ def csv_writer(output: Any, fields: list[dict[str, Any]],
     if bom:
         output.write(BOM_UTF8)
 
-    csv.writer(output, encoding=u'utf-8').writerow(
+    csv.writer(output).writerow(
         f['id'] for f in fields)
     yield TextWriter(output)
 
@@ -45,7 +45,6 @@ def tsv_writer(output: Any, fields: list[dict[str, Any]],
 
     csv.writer(
         output,
-        encoding=u'utf-8',
         dialect='excel-tab').writerow(
             f['id'] for f in fields)
     yield TextWriter(output)

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -14,146 +14,113 @@ from codecs import BOM_UTF8
 
 
 @contextmanager
-def csv_writer(response: Any, fields: list[dict[str, Any]],
-               name: Optional[str] = None, bom: bool = False):
-    u'''Context manager for writing UTF-8 CSV data to response
+def csv_writer(output: Any, fields: list[dict[str, Any]],
+               bom: bool = False):
+    u'''Context manager for writing UTF-8 CSV data to file
 
-    :param response: file-like or response-like object for writing
-        data and headers (response-like objects only)
+    :param response: file-like object for writing data
     :param fields: list of datastore fields
-    :param name: file name (for headers, response-like objects only)
     :param bom: True to include a UTF-8 BOM at the start of the file
     '''
 
-    if hasattr(response, u'headers'):
-        response.headers['Content-Type'] = b'text/csv; charset=utf-8'
-        if name:
-            response.headers['Content-disposition'] = (
-                u'attachment; filename="{name}.csv"'.format(
-                    name=encode_rfc2231(name)))
     if bom:
-        response.stream.write(BOM_UTF8)
+        output.write(BOM_UTF8)
 
-    csv.writer(response.stream).writerow(
+    csv.writer(output, encoding=u'utf-8').writerow(
         f['id'] for f in fields)
-    yield TextWriter(response.stream)
+    yield TextWriter(output)
 
 
 @contextmanager
-def tsv_writer(response: Any, fields: list[dict[str, Any]],
-               name: Optional[str] = None, bom: bool = False):
-    u'''Context manager for writing UTF-8 TSV data to response
+def tsv_writer(output: Any, fields: list[dict[str, Any]],
+               bom: bool = False):
+    u'''Context manager for writing UTF-8 TSV data to file
 
-    :param response: file-like or response-like object for writing
-        data and headers (response-like objects only)
+    :param response: file-like object for writing data
     :param fields: list of datastore fields
-    :param name: file name (for headers, response-like objects only)
     :param bom: True to include a UTF-8 BOM at the start of the file
     '''
 
-    if hasattr(response, u'headers'):
-        response.headers['Content-Type'] = (
-            b'text/tab-separated-values; charset=utf-8')
-        if name:
-            response.headers['Content-disposition'] = (
-                u'attachment; filename="{name}.tsv"'.format(
-                    name=encode_rfc2231(name)))
     if bom:
-        response.stream.write(BOM_UTF8)
+        output.write(BOM_UTF8)
 
     csv.writer(
-        response.stream,
+        output,
+        encoding=u'utf-8',
         dialect='excel-tab').writerow(
             f['id'] for f in fields)
-    yield TextWriter(response.stream)
+    yield TextWriter(output)
 
 
 class TextWriter(object):
     u'text in, text out'
-    def __init__(self, response: Any):
-        self.response = response
+    def __init__(self, output: Any):
+        self.output = output
 
     def write_records(self, records: list[Any]):
-        self.response.write(records)
+        self.output.write(records)
 
 
 @contextmanager
-def json_writer(response: Any, fields: list[dict[str, Any]],
-                name: Optional[str] = None, bom: bool = False):
-    u'''Context manager for writing UTF-8 JSON data to response
+def json_writer(output: Any, fields: list[dict[str, Any]],
+                bom: bool = False):
+    u'''Context manager for writing UTF-8 JSON data to file
 
-    :param response: file-like or response-like object for writing
-        data and headers (response-like objects only)
+    :param response: file-like object for writing data
     :param fields: list of datastore fields
-    :param name: file name (for headers, response-like objects only)
     :param bom: True to include a UTF-8 BOM at the start of the file
     '''
 
-    if hasattr(response, u'headers'):
-        response.headers['Content-Type'] = (
-            b'application/json; charset=utf-8')
-        if name:
-            response.headers['Content-disposition'] = (
-                u'attachment; filename="{name}.json"'.format(
-                    name=encode_rfc2231(name)))
     if bom:
-        response.stream.write(BOM_UTF8)
-    response.stream.write(
+        output.write(BOM_UTF8)
+    output.write(
         '{\n  "fields": %s,\n  "records": [' % dumps(
             fields, ensure_ascii=False, separators=(',', ':')))
-    yield JSONWriter(response.stream)
-    response.stream.write(b'\n]}\n')
+    yield JSONWriter(output)
+    output.write(b'\n]}\n')
 
 
 class JSONWriter(object):
-    def __init__(self, response: Any):
-        self.response = response
+    def __init__(self, output: Any):
+        self.output = output
         self.first = True
 
     def write_records(self, records: list[Any]):
         for r in records:
             if self.first:
                 self.first = False
-                self.response.write(b'\n    ')
+                self.output.write(b'\n    ')
             else:
-                self.response.write(b',\n    ')
+                self.output.write(b',\n    ')
 
-            self.response.write(dumps(
-                r, ensure_ascii=False, separators=(u',', u':')))
+            self.output.write(dumps(
+                r, ensure_ascii=False, separators=(u',', u':'))
+                .encode('utf-8'))
 
 
 @contextmanager
-def xml_writer(response: Any, fields: list[dict[str, Any]],
-               name: Optional[str] = None, bom: bool = False):
-    u'''Context manager for writing UTF-8 XML data to response
+def xml_writer(output: Any, fields: list[dict[str, Any]],
+               bom: bool = False):
+    u'''Context manager for writing UTF-8 XML data to file
 
-    :param response: file-like or response-like object for writing
-        data and headers (response-like objects only)
+    :param response: file-like object for writing data
     :param fields: list of datastore fields
-    :param name: file name (for headers, response-like objects only)
     :param bom: True to include a UTF-8 BOM at the start of the file
     '''
 
-    if hasattr(response, u'headers'):
-        response.headers['Content-Type'] = (
-            b'text/xml; charset=utf-8')
-        if name:
-            response.headers['Content-disposition'] = (
-                u'attachment; filename="{name}.xml"'.format(
-                    name=encode_rfc2231(name)))
     if bom:
-        response.stream.write(BOM_UTF8)
-    response.stream.write(b'<data>\n')
-    yield XMLWriter(response.stream, [f[u'id'] for f in fields])
-    response.stream.write(b'</data>\n')
+        output.write(BOM_UTF8)
+    output.write(b'<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n')
+    yield XMLWriter(output, [f[u'id'] for f in fields])
+    output.write(b'</data>\n')
 
 
 class XMLWriter(object):
     _key_attr = u'key'
     _value_tag = u'value'
 
-    def __init__(self, response: Any, columns: list[str]):
-        self.response = response
+    def __init__(self, output: Any, columns: list[str]):
+        self.output = output
         self.id_col = columns[0] == u'_id'
         if self.id_col:
             columns = columns[1:]
@@ -184,5 +151,5 @@ class XMLWriter(object):
                 root.attrib[u'_id'] = str(r[u'_id'])
             for c in self.columns:
                 self._insert_node(root, c, r[c])
-            ElementTree(root).write(self.response, encoding=u'utf-8')
-            self.response.write(b'\n')
+            ElementTree(root).write(self.output, encoding=u'utf-8')
+            self.output.write(b'\n')

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -25,8 +25,8 @@ def csv_writer(output: Any, fields: list[dict[str, Any]],
     if bom:
         output.write(BOM_UTF8)
 
-    csv.writer(output, encoding=u'utf-8').writerow(  # type: ignore
-        f['id'] for f in fields)
+    csv.writer(output).writerow(
+        f['id'].encode('utf8') for f in fields)
     yield TextWriter(output)
 
 
@@ -45,9 +45,8 @@ def tsv_writer(output: Any, fields: list[dict[str, Any]],
 
     csv.writer(
         output,
-        encoding=u'utf-8',  # type: ignore
         dialect='excel-tab').writerow(
-            f['id'] for f in fields)
+            f['id'].encode('utf8') for f in fields)
     yield TextWriter(output)
 
 
@@ -57,7 +56,7 @@ class TextWriter(object):
         self.output = output
 
     def write_records(self, records: list[Any]):
-        self.output.write(records)
+        self.output.write([r.encode('utf-8') for r in records])
 
 
 @contextmanager
@@ -111,7 +110,7 @@ def xml_writer(output: Any, fields: list[dict[str, Any]],
         output.write(BOM_UTF8)
     output.write(
         b'<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n')
-    yield XMLWriter(output, [f[u'id'] for f in fields])
+    yield XMLWriter(output, [f['id'].encode('utf8') for f in fields])
     output.write(b'</data>\n')
 
 

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 from __future__ import annotations
 
-from io import BytesIO
+from io import StringIO
 
 from contextlib import contextmanager
 from typing import Any, Optional
@@ -15,7 +15,7 @@ from codecs import BOM_UTF8
 
 
 @contextmanager
-def csv_writer(output: BytesIO, fields: list[dict[str, Any]],
+def csv_writer(output: StringIO, fields: list[dict[str, Any]],
                bom: bool = False):
     u'''Context manager for writing UTF-8 CSV data to file
 
@@ -28,12 +28,12 @@ def csv_writer(output: BytesIO, fields: list[dict[str, Any]],
         output.write(BOM_UTF8)
 
     csv.writer(output).writerow(
-        (f['id']).encode('utf-8') for f in fields)
+        f['id'].encode('utf-8') for f in fields)
     yield TextWriter(output)
 
 
 @contextmanager
-def tsv_writer(output: BytesIO, fields: list[dict[str, Any]],
+def tsv_writer(output: StringIO, fields: list[dict[str, Any]],
                bom: bool = False):
     u'''Context manager for writing UTF-8 TSV data to file
 
@@ -48,13 +48,13 @@ def tsv_writer(output: BytesIO, fields: list[dict[str, Any]],
     csv.writer(
         output,
         dialect='excel-tab').writerow(
-            (f['id']).encode('utf-8') for f in fields)
+            f['id'].encode('utf-8') for f in fields)
     yield TextWriter(output)
 
 
 class TextWriter(object):
     u'text in, text out'
-    def __init__(self, output: BytesIO):
+    def __init__(self, output: StringIO):
         self.output = output
 
     def write_records(self, records: list[Any]):
@@ -62,7 +62,7 @@ class TextWriter(object):
 
 
 @contextmanager
-def json_writer(output: BytesIO, fields: list[dict[str, Any]],
+def json_writer(output: StringIO, fields: list[dict[str, Any]],
                 bom: bool = False):
     u'''Context manager for writing UTF-8 JSON data to file
 
@@ -74,14 +74,15 @@ def json_writer(output: BytesIO, fields: list[dict[str, Any]],
     if bom:
         output.write(BOM_UTF8)
     output.write(
-        b'{\n  "fields": %s,\n  "records": [' % dumps(
-            fields, ensure_ascii=False, separators=(',', ':')).encode('utf-8'))
+        '{\n  "fields": %s,\n  "records": [' % dumps(
+            fields, ensure_ascii=False, separators=(',', ':'))
+            .encode('utf-8'))
     yield JSONWriter(output)
-    output.write(b'\n]}\n')
+    output.write('\n]}\n')
 
 
 class JSONWriter(object):
-    def __init__(self, output: BytesIO):
+    def __init__(self, output: StringIO):
         self.output = output
         self.first = True
 
@@ -89,9 +90,9 @@ class JSONWriter(object):
         for r in records:
             if self.first:
                 self.first = False
-                self.output.write(b'\n    ')
+                self.output.write('\n    ')
             else:
-                self.output.write(b',\n    ')
+                self.output.write(',\n    ')
 
             self.output.write(dumps(
                 r, ensure_ascii=False, separators=(u',', u':'))
@@ -99,7 +100,7 @@ class JSONWriter(object):
 
 
 @contextmanager
-def xml_writer(output: BytesIO, fields: list[dict[str, Any]],
+def xml_writer(output: StringIO, fields: list[dict[str, Any]],
                bom: bool = False):
     u'''Context manager for writing UTF-8 XML data to file
 
@@ -111,16 +112,16 @@ def xml_writer(output: BytesIO, fields: list[dict[str, Any]],
     if bom:
         output.write(BOM_UTF8)
     output.write(
-        b'<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n')
-    yield XMLWriter(output, [(f['id']).encode('utf-8') for f in fields])
-    output.write(b'</data>\n')
+        '<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n')
+    yield XMLWriter(output, [f['id'].encode('utf-8') for f in fields])
+    output.write('</data>\n')
 
 
 class XMLWriter(object):
     _key_attr = u'key'
     _value_tag = u'value'
 
-    def __init__(self, output: BytesIO, columns: list[str]):
+    def __init__(self, output: StringIO, columns: list[str]):
         self.output = output
         self.id_col = columns[0] == u'_id'
         if self.id_col:

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -17,7 +17,7 @@ from codecs import BOM_UTF8
 @contextmanager
 def csv_writer(output: BytesIO, fields: list[dict[str, Any]],
                bom: bool = False):
-    u'''Context manager for writing UTF-8 CSV data to file
+    '''Context manager for writing UTF-8 CSV data to file
 
     :param response: file-like object for writing data
     :param fields: list of datastore fields
@@ -27,7 +27,7 @@ def csv_writer(output: BytesIO, fields: list[dict[str, Any]],
     if bom:
         output.write(BOM_UTF8)
 
-    csv.writer(output).writerow(
+    csv.writer(output).writerow(  # type: ignore
         f['id'].encode('utf-8') for f in fields)
     yield TextWriter(output)
 
@@ -35,7 +35,7 @@ def csv_writer(output: BytesIO, fields: list[dict[str, Any]],
 @contextmanager
 def tsv_writer(output: BytesIO, fields: list[dict[str, Any]],
                bom: bool = False):
-    u'''Context manager for writing UTF-8 TSV data to file
+    '''Context manager for writing UTF-8 TSV data to file
 
     :param response: file-like object for writing data
     :param fields: list of datastore fields
@@ -46,15 +46,15 @@ def tsv_writer(output: BytesIO, fields: list[dict[str, Any]],
         output.write(BOM_UTF8)
 
     csv.writer(
-        output,
+        output,  # type: ignore
         dialect='excel-tab').writerow(
             f['id'].encode('utf-8') for f in fields)
     yield TextWriter(output)
 
 
 class TextWriter(object):
-    u'text in, text out'
-    def __init__(self, output: BytesIO, dialect):
+    'text in, text out'
+    def __init__(self, output: BytesIO):
         self.output = output
 
     def write_records(self, records: list[Any]):
@@ -64,7 +64,7 @@ class TextWriter(object):
 @contextmanager
 def json_writer(output: BytesIO, fields: list[dict[str, Any]],
                 bom: bool = False):
-    u'''Context manager for writing UTF-8 JSON data to file
+    '''Context manager for writing UTF-8 JSON data to file
 
     :param response: file-like object for writing data
     :param fields: list of datastore fields
@@ -94,14 +94,14 @@ class JSONWriter(object):
                 self.output.write(b',\n    ')
 
             self.output.write(dumps(
-                r, ensure_ascii=False, separators=(u',', u':'))
+                r, ensure_ascii=False, separators=(',', ':'))
                 .encode('utf-8'))
 
 
 @contextmanager
 def xml_writer(output: BytesIO, fields: list[dict[str, Any]],
                bom: bool = False):
-    u'''Context manager for writing UTF-8 XML data to file
+    '''Context manager for writing UTF-8 XML data to file
 
     :param response: file-like object for writing data
     :param fields: list of datastore fields
@@ -112,17 +112,17 @@ def xml_writer(output: BytesIO, fields: list[dict[str, Any]],
         output.write(BOM_UTF8)
     output.write(
         b'<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n')
-    yield XMLWriter(output, [f['id'].encode('utf-8') for f in fields])
+    yield XMLWriter(output, [f['id'] for f in fields])
     output.write(b'</data>\n')
 
 
 class XMLWriter(object):
-    _key_attr = u'key'
-    _value_tag = u'value'
+    _key_attr = 'key'
+    _value_tag = 'value'
 
     def __init__(self, output: BytesIO, columns: list[str]):
         self.output = output
-        self.id_col = columns[0] == u'_id'
+        self.id_col = columns[0] == '_id'
         if self.id_col:
             columns = columns[1:]
         self.columns = columns
@@ -131,7 +131,7 @@ class XMLWriter(object):
                      key_attr: Optional[Any] = None):
         element = SubElement(root, k)
         if v is None:
-            element.attrib[u'xsi:nil'] = u'true'
+            element.attrib['xsi:nil'] = 'true'
         elif not isinstance(v, (list, dict)):
             element.text = str(v)
         else:
@@ -147,10 +147,10 @@ class XMLWriter(object):
 
     def write_records(self, records: list[Any]):
         for r in records:
-            root = Element(u'row')
+            root = Element('row')
             if self.id_col:
-                root.attrib[u'_id'] = str(r[u'_id'])
+                root.attrib['_id'] = str(r['_id'])
             for c in self.columns:
                 self._insert_node(root, c, r[c])
-            ElementTree(root).write(self.output, encoding=u'utf-8')
+            ElementTree(root).write(self.output, encoding='utf-8')
             self.output.write(b'\n')

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -28,7 +28,7 @@ def csv_writer(output: StringIO, fields: list[dict[str, Any]],
         output.write(BOM_UTF8.decode())
 
     csv.writer(output).writerow(
-        f['id'].encode('utf-8') for f in fields)
+        f['id'] for f in fields)
     yield TextWriter(output)
 
 
@@ -48,7 +48,7 @@ def tsv_writer(output: StringIO, fields: list[dict[str, Any]],
     csv.writer(
         output,
         dialect='excel-tab').writerow(
-            f['id'].encode('utf-8') for f in fields)
+            f['id'] for f in fields)
     yield TextWriter(output)
 
 
@@ -58,7 +58,7 @@ class TextWriter(object):
         self.output = output
 
     def write_records(self, records: list[Any]):
-        self.output.write([r.encode('utf-8') for r in records])
+        self.output.write(r for r in records)
 
 
 @contextmanager
@@ -75,7 +75,7 @@ def json_writer(output: StringIO, fields: list[dict[str, Any]],
         output.write(BOM_UTF8.decode())
     output.write(
         '{\n  "fields": %s,\n  "records": [' % dumps(
-            fields, ensure_ascii=False, separators=(',', ':')).encode('utf-8'))
+            fields, ensure_ascii=False, separators=(',', ':')))
     yield JSONWriter(output)
     output.write('\n]}\n')
 
@@ -94,8 +94,7 @@ class JSONWriter(object):
                 self.output.write(',\n    ')
 
             self.output.write(dumps(
-                r, ensure_ascii=False, separators=(u',', u':'))
-                .encode('utf-8'))
+                r, ensure_ascii=False, separators=(u',', u':')))
 
 
 @contextmanager
@@ -112,7 +111,7 @@ def xml_writer(output: StringIO, fields: list[dict[str, Any]],
         output.write(BOM_UTF8.decode())
     output.write(
         '<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n')
-    yield XMLWriter(output, [f['id'].encode('utf-8') for f in fields])
+    yield XMLWriter(output, [f['id'] for f in fields])
     output.write('</data>\n')
 
 
@@ -153,4 +152,4 @@ class XMLWriter(object):
             for c in self.columns:
                 self._insert_node(root, c, r[c])
             ElementTree(root).write(self.output, encoding=u'utf-8')
-            self.output.write(b'\n')
+            self.output.write('\n')

--- a/ckanext/datastore/writer.py
+++ b/ckanext/datastore/writer.py
@@ -1,6 +1,8 @@
 # encoding: utf-8
 from __future__ import annotations
 
+from io import BytesIO
+
 from contextlib import contextmanager
 from typing import Any, Optional
 from simplejson import dumps
@@ -13,7 +15,7 @@ from codecs import BOM_UTF8
 
 
 @contextmanager
-def csv_writer(output: Any, fields: list[dict[str, Any]],
+def csv_writer(output: BytesIO, fields: list[dict[str, Any]],
                bom: bool = False):
     u'''Context manager for writing UTF-8 CSV data to file
 
@@ -26,12 +28,12 @@ def csv_writer(output: Any, fields: list[dict[str, Any]],
         output.write(BOM_UTF8)
 
     csv.writer(output).writerow(
-        f['id'].encode('utf-8') for f in fields)
+        (f['id']).encode('utf-8') for f in fields)
     yield TextWriter(output)
 
 
 @contextmanager
-def tsv_writer(output: Any, fields: list[dict[str, Any]],
+def tsv_writer(output: BytesIO, fields: list[dict[str, Any]],
                bom: bool = False):
     u'''Context manager for writing UTF-8 TSV data to file
 
@@ -46,13 +48,13 @@ def tsv_writer(output: Any, fields: list[dict[str, Any]],
     csv.writer(
         output,
         dialect='excel-tab').writerow(
-            f['id'].encode('utf-8') for f in fields)
+            (f['id']).encode('utf-8') for f in fields)
     yield TextWriter(output)
 
 
 class TextWriter(object):
     u'text in, text out'
-    def __init__(self, output: Any):
+    def __init__(self, output: BytesIO):
         self.output = output
 
     def write_records(self, records: list[Any]):
@@ -60,7 +62,7 @@ class TextWriter(object):
 
 
 @contextmanager
-def json_writer(output: Any, fields: list[dict[str, Any]],
+def json_writer(output: BytesIO, fields: list[dict[str, Any]],
                 bom: bool = False):
     u'''Context manager for writing UTF-8 JSON data to file
 
@@ -79,7 +81,7 @@ def json_writer(output: Any, fields: list[dict[str, Any]],
 
 
 class JSONWriter(object):
-    def __init__(self, output: Any):
+    def __init__(self, output: BytesIO):
         self.output = output
         self.first = True
 
@@ -97,7 +99,7 @@ class JSONWriter(object):
 
 
 @contextmanager
-def xml_writer(output: Any, fields: list[dict[str, Any]],
+def xml_writer(output: BytesIO, fields: list[dict[str, Any]],
                bom: bool = False):
     u'''Context manager for writing UTF-8 XML data to file
 
@@ -110,7 +112,7 @@ def xml_writer(output: Any, fields: list[dict[str, Any]],
         output.write(BOM_UTF8)
     output.write(
         b'<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n')
-    yield XMLWriter(output, [f['id'].encode('utf-8') for f in fields])
+    yield XMLWriter(output, [(f['id']).encode('utf-8') for f in fields])
     output.write(b'</data>\n')
 
 
@@ -118,7 +120,7 @@ class XMLWriter(object):
     _key_attr = u'key'
     _value_tag = u'value'
 
-    def __init__(self, output: Any, columns: list[str]):
+    def __init__(self, output: BytesIO, columns: list[str]):
         self.output = output
         self.id_col = columns[0] == u'_id'
         if self.id_col:


### PR DESCRIPTION
fix(views): datastore ext dump octet streaming;

- Fixed view method for datastore dump to actually stream data in Flask response.
- Fixed possible issue in sql return.

# Fixes

Datastore dump does not actually stream the data. The view method has now be re-written to properly stream the data via Flask Response.

Also includes small condition for possible issue in the return of some sql stuff.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
