### PR TITLE
Removed ckan.redirect_to_login_if_not_authorized

### DIFF
--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -478,15 +478,6 @@ groups:
         type: bool
         description: If set to True, CKAN will not publicly expose its version number.
 
-      - key: ckan.redirect_to_login_if_not_authorized
-        default: True
-        type: bool
-        description: |
-          By default, if a user is not authorized to visit a page, they will
-          get redirected to the login page before trying to access it again.
-          If you want to raise a 401 or 403 error instead,
-          set this setting to `False`
-
   - annotation: Authorization Settings
     options:
       - key: ckan.auth.anon_create_dataset

--- a/test-core.ini
+++ b/test-core.ini
@@ -89,9 +89,6 @@ WTF_CSRF_SECRET_KEY = %(SECRET_KEY)s
 ## background jobs
 ckan.jobs.timeout = 180
 
-## login_required decorator
-ckan.redirect_to_login_if_not_authorized = true
-
 ## Session settings ############################################################
 beaker.session.validate_key = zsWPlD6NnawCi_QXOoxG-T91Fdo
 


### PR DESCRIPTION
Fixes #7707 

### Proposed fixes:

- Removed `ckan.redirect_to_login_if_not_authorized` from `config_declaration.yaml`
- Removed `login_required decorator` from `test-core.ini`



### Features:

- [X] includes tests covering changes
- [X] includes updated documentation
- [X] includes user-visible changes
- [X] includes API changes
- [X] includes bugfix for possible backport

