### PR TITLE
i18n js: serve faster with LazyJSONObject

### DIFF
--- a/changes/7852.misc
+++ b/changes/7852.misc
@@ -1,0 +1,2 @@
+serve i18n js faster with LazyJSONObject
+generate compact json instead of pretty-printed json to send less data

--- a/ckan/lib/i18n.py
+++ b/ckan/lib/i18n.py
@@ -310,7 +310,9 @@ def _build_js_translation(
                 for _, msgstr in ordered_plural:
                     plural.append(msgstr)
     with open(dest_filename, u'w', encoding='utf-8') as f:
-        s = json.dumps(result, sort_keys=True, indent=2, ensure_ascii=False)
+        s = json.dumps(
+            result, sort_keys=True, ensure_ascii=False, separators=(',', ':')
+        )
         f.write(s)
 
 

--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -19,6 +19,7 @@ from ckan.common import json, _, g, request, current_user
 from ckan.lib.helpers import url_for
 from ckan.lib.base import render
 from ckan.lib.i18n import get_locales_from_config, get_js_translations_dir
+from ckan.lib.lazyjson import LazyJSONObject
 
 from ckan.lib.navl.dictization_functions import DataError
 from ckan.logic import get_action, ValidationError, NotFound, NotAuthorized
@@ -478,8 +479,8 @@ def i18n_js_translations(
     source = os.path.join(js_translations_folder, f"{lang}.js")
     if not os.path.exists(source):
         return "{}"
-    translations = json.load(io.open(source, "r", encoding="utf-8"))
-    return _finish_ok(translations)
+    translations = io.open(source, "r", encoding="utf-8").read()
+    return _finish_ok(LazyJSONObject(translations))
 
 
 # Routing


### PR DESCRIPTION
### Proposed fixes:
- serve i18n js faster with LazyJSONObject
- generate compact json instead of pretty-printed json to send less data

This removes some wasted work we do server-side on every non-en request.

Even better would be serving these files from nginx with X-Sendfile with a really long cache timeout so browsers only ever request the file once like we do for webasset files. Automatic cache busting urls could be generated with the server (re)start time to allow changes while developing/deploying. (not implemented here but good for contribution)

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport