### PR TITLE
Update Datapusher to use new IResourceController hook

### DIFF
--- a/ckanext/datapusher/plugin.py
+++ b/ckanext/datapusher/plugin.py
@@ -75,7 +75,7 @@ class DatapusherPlugin(p.SingletonPlugin):
 
         self._submit_to_datapusher(resource_dict)
 
-    def after_update(
+    def after_resource_update(
             self, context: Context, resource_dict: dict[str, Any]):
 
         self._submit_to_datapusher(resource_dict)


### PR DESCRIPTION
### Proposed fixes:

[CKAN 2.10 updated from `before_update` to `before_resource_update` in IResourceController](https://github.com/ckan/ckan/blob/master/CHANGELOG.rst#removals-and-deprecations)

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
