### PR TITLE
Proper CLI Command for creating a new migration script

### DIFF
--- a/changes/7860.bugfix
+++ b/changes/7860.bugfix
@@ -1,1 +1,0 @@
-Improper CLI Command for creating a new migration script

--- a/changes/7860.bugfix
+++ b/changes/7860.bugfix
@@ -1,0 +1,1 @@
+Improper CLI Command for creating a new migration script

--- a/doc/contributing/database-migrations.rst
+++ b/doc/contributing/database-migrations.rst
@@ -18,7 +18,7 @@ changes it is related to.
 
 To create a new migration script, use CKAN CLI::
 
-     ckan generate migration -m "Add account table"
+     ckan -c /etc/ckan/default/ckan.ini generate migration -m "Add account table"
 
 Update the generated file, because it doesn't contain any actual
 changes, only placeholders for `upgrade` and `downgrade` steps. For


### PR DESCRIPTION

Fixes #7860 

### Proposed fixes:

 Specifying the path of config file(ckan.ini) in CKAN CLI command.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
