### PR TITLE
Fix checking anonymous user from context in actions

### DIFF
--- a/changes/7871.bugfix
+++ b/changes/7871.bugfix
@@ -1,0 +1,1 @@
+Fixed restricting anonymous users in actions to check user in context.

--- a/ckan/logic/auth/__init__.py
+++ b/ckan/logic/auth/__init__.py
@@ -8,8 +8,8 @@ from typing import Any, Optional, TYPE_CHECKING, overload
 from typing_extensions import Literal
 
 import ckan.logic as logic
+import ckan.authz as authz
 from ckan.types import Context, AuthResult, DataDict
-from ckan.common import current_user
 
 if TYPE_CHECKING:
     import ckan.model as model_
@@ -86,7 +86,7 @@ def get_user_object(
 
 
 def restrict_anon(context: Context) -> AuthResult:
-    if current_user.is_anonymous:
+    if authz.auth_is_anon_user(context):
         return {'success': False}
     else:
         return {'success': True}

--- a/ckan/tests/logic/auth/test_get.py
+++ b/ckan/tests/logic/auth/test_get.py
@@ -38,13 +38,21 @@ def test_user_list_email_parameter():
 class TestGetAuth(object):
     @pytest.mark.ckan_config(u"ckan.auth.public_user_details", False)
     @mock.patch("flask_login.utils._get_user")
-    def test_auth_user_show(self, current_user):
+    def test_restrict_anon_auth_when_user_is_anonymouus(self, current_user):
         fred = factories.User()
         fred["capacity"] = "editor"
         current_user.return_value = mock.Mock(is_anonymous=True)
         context = {"user": None, "model": model}
         with pytest.raises(logic.NotAuthorized):
             helpers.call_auth("user_show", context=context, id=fred["id"])
+    @pytest.mark.ckan_config(u"ckan.auth.public_user_details", False)
+    @mock.patch("flask_login.utils._get_user")
+    def test_restrict_anon_auth_when_user_is_in_context(self, current_user):
+        fred = factories.User()
+        fred["capacity"] = "editor"
+        current_user.return_value = mock.Mock(is_anonymous=True)
+        context = {"user": fred['id'], "model": model}
+        assert helpers.call_auth("user_show", context=context, id=fred["id"])
 
     def test_authed_user_show(self):
         fred = factories.User()

--- a/ckan/tests/logic/auth/test_get.py
+++ b/ckan/tests/logic/auth/test_get.py
@@ -45,6 +45,7 @@ class TestGetAuth(object):
         context = {"user": None, "model": model}
         with pytest.raises(logic.NotAuthorized):
             helpers.call_auth("user_show", context=context, id=fred["id"])
+
     @pytest.mark.ckan_config(u"ckan.auth.public_user_details", False)
     @mock.patch("flask_login.utils._get_user")
     def test_restrict_anon_auth_when_user_is_in_context(self, current_user):


### PR DESCRIPTION
Fixes #7869 

### Proposed fixes:
Actions now only use `authz.auth_is_anon_user` which checks context for the user. Views still only use `current_user.is_anonymous` which makes sense as there might not be a context to check.


### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
