### PR TITLE
Drop support for CONFIG_FROM_ENV_VARS

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -79,43 +79,11 @@ def load_environment(conf: Union[Config, CKANConfig]):
     build_js_translations()
 
 
-# A mapping of config settings that can be overridden by env vars.
-# Note: Do not remove the following lines, they are used in the docs
-# Start CONFIG_FROM_ENV_VARS
-CONFIG_FROM_ENV_VARS: dict[str, str] = {
-    'sqlalchemy.url': 'CKAN_SQLALCHEMY_URL',
-    'ckan.datastore.write_url': 'CKAN_DATASTORE_WRITE_URL',
-    'ckan.datastore.read_url': 'CKAN_DATASTORE_READ_URL',
-    'ckan.redis.url': 'CKAN_REDIS_URL',
-    'solr_url': 'CKAN_SOLR_URL',
-    'solr_user': 'CKAN_SOLR_USER',
-    'solr_password': 'CKAN_SOLR_PASSWORD',
-    'ckan.site_id': 'CKAN_SITE_ID',
-    'ckan.site_url': 'CKAN_SITE_URL',
-    'ckan.storage_path': 'CKAN_STORAGE_PATH',
-    'ckan.datapusher.url': 'CKAN_DATAPUSHER_URL',
-    'smtp.server': 'CKAN_SMTP_SERVER',
-    'smtp.starttls': 'CKAN_SMTP_STARTTLS',
-    'smtp.user': 'CKAN_SMTP_USER',
-    'smtp.password': 'CKAN_SMTP_PASSWORD',
-    'smtp.mail_from': 'CKAN_SMTP_MAIL_FROM',
-    'ckan.max_resource_size': 'CKAN_MAX_UPLOAD_SIZE_MB'
-}
-# End CONFIG_FROM_ENV_VARS
-
-
 def update_config() -> None:
     ''' This code needs to be run when the config is changed to take those
     changes into account. It is called whenever a plugin is loaded as the
     plugin might have changed the config values (for instance it might
     change ckan.site_url) '''
-
-    # read envvars before config declarations in order to apply normalization
-    # to the values, when declarations loaded
-    for option in CONFIG_FROM_ENV_VARS:
-        from_env = os.environ.get(CONFIG_FROM_ENV_VARS[option], None)
-        if from_env:
-            config[option] = from_env
 
     config_declaration.setup()
     config_declaration.make_safe(config)

--- a/ckan/tests/config/test_environment.py
+++ b/ckan/tests/config/test_environment.py
@@ -99,18 +99,6 @@ def test_plugin_template_paths_reset(app):
     assert "YOU WILL NOT FIND ME" not in resp
 
 
-@pytest.mark.usefixtures(u"reset_env")
-def test_config_from_envs_are_normalized(ckan_config):
-    """ CONFIG_FROM_ENV_VARS takes precedence over
-        config file and extensions
-        but those settings are not normalized """
-
-    os.environ['CKAN_SMTP_STARTTLS'] = 'false'
-    environment.update_config()
-
-    assert ckan_config["smtp.starttls"] is False
-
-
 @pytest.mark.ckan_config("SECRET_KEY", "super_secret")
 @pytest.mark.ckan_config("beaker.session.secret", None)
 @pytest.mark.ckan_config("beaker.session.validate_key", None)

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -14,38 +14,34 @@ but some of them can also be set via `Environment variables`_ or at :ref:`runtim
 Environment variables
 *********************
 
-Some of the CKAN configuration options can be defined as `Environment variables`_
-on the server operating system.
+CKAN configuration options can be defined as `Environment variables`_ on the server operating system only
+in conjunction with `ckanext-envvars`_ extension. This extension is not installed by default, so you will
+need to install it first.
 
-These are generally low-level critical settings needed when setting up the application, like the database
-connection, the Solr server URL, etc. Sometimes it can be useful to define them as environment variables to
-automate and orchestrate deployments without having to first modify the `CKAN configuration file`_.
+The extension will check for environmental variables conforming to an expected format
+and then override the corresponding CKAN config object before it starts the application. The format of the
+environmental variables is as follows:
 
-These options are only read at startup time to update the ``config`` object used by CKAN,
-but they won't be accessed any more during the lifetime of the application.
+  1. All uppercase
+  2. Replace periods ('.') with two underscores ('__')
+  3. Keys must begin with 'CKAN' or 'CKANEXT'
 
-CKAN environment variable names match the options in the configuration file, but they are always uppercase
-and prefixed with `CKAN_` (this prefix is added even if
-the corresponding option in the ini file does not have it), and replacing dots with underscores.
+Example::
 
-This is the list of currently supported environment variables, please refer to the entries in the
-`CKAN configuration file`_ section below for more details about each one:
+  ckan.site_id --> CKAN__SITE_ID
+  ckanext.s3filestore.aws_bucket_name --> CKANEXT__S3FILESTORE__AWS_BUCKET_NAME
 
-.. literalinclude:: /../ckan/config/environment.py
-    :language: python
-    :start-after: Start CONFIG_FROM_ENV_VARS
-    :end-before: End CONFIG_FROM_ENV_VARS
+For more information check the extension's website: `ckanext-envvars`_
 
 .. _Environment variables: http://en.wikipedia.org/wiki/Environment_variable
+.. _ckanext-envvars: https://github.com/okfn/ckanext-envvars
 
-
-.. _runtime-config:
 
 Updating configuration options during runtime
 *********************************************
 
 CKAN configuration options are generally defined before starting the web application (either in the
-`CKAN configuration file`_ or via `Environment variables`_).
+`CKAN configuration file`_ or via `Environment variables`_ using `ckanext-envvars`_).
 
 A limited number of configuration options can also be edited during runtime. This can be done on the
 :ref:`administration interface <admin page>` or using the :py:func:`~ckan.logic.action.update.config_option_update`


### PR DESCRIPTION
I'm working on a new deployment of CKAN and while doing it I'm finding how we handle the configuration file and the environment variables a little bit confusing (comparing with more plain Django or Flask apps).

## Context

Usually in normal Flask/Django applications the workflow is the following:
 - Set some environment variables in the server
 - Read those environment variables when starting the application
 - Update the configuration object with the values
 - Run the application
 
In the practice this means that we BUILD the Dockerfile and then whatever system we use to run the application sets the environment variables as secrets. Configuration is set at RUN time before starting.

However, CKAN's "official" workflow is a little bit different:
 - Our Dockerfile creates the `ckan.ini` that will contain the values (this means something is happening at BUILD time)
 - Then at RUN time we create the config object using the `ckan.ini` file
 - If some ENV variables are set we override some of the values in the config object
 - If we have `ckanext-envvars` activated then we will again override the config object.
 
This means that somethings can be handled at BUILD time (when we generate the `ckan.ini` file, but it can also be handled at RUN time (for some variables at least)

Also, our official Docker image checks the connection to the DB using `CKAN_SQLALCHEMY_URL` but at the same time with `ckanext-envvars` we are recommending it to be `CKAN___SQLALCHEMY_URL`.
 
### Proposed fixes:

This PR proposes to drop support for the `CONFIG_FROM_ENV_VARS` functionality to reduce a little bit the scenarios and make the initialization of CKAN more predictable and easier to understand.