### PR TITLE
fix: Allow `None` for `beaker.session.timeout`

### DIFF
--- a/changes/7881.bugfix
+++ b/changes/7881.bugfix
@@ -1,0 +1,1 @@
+Empty string in `beaker.session.timeout` produces an error instead of never-expiring session

--- a/ckan/cli/shell.py
+++ b/ckan/cli/shell.py
@@ -28,7 +28,7 @@ def ipython(namespace: Mapping[str, Any], banner: str) -> None:
     from traitlets.config.loader import Config
 
     c = Config()
-    c.TerminalInteractiveShell.banner2 = banner  # type: ignore
+    c.TerminalInteractiveShell.banner2 = banner
 
     IPython.start_ipython([], user_ns=namespace, config=c)
 

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -312,8 +312,7 @@ groups:
           browsers are instructed to not send the cookie over anything other than an SSL connection.
 
       - key: beaker.session.timeout
-        type: int
-        default: 600
+        validators: int_validator
         description: |
           Seconds until the session is considered invalid, after which it will be ignored and invalidated.
           This number is based on the time since the session was last accessed, not from when the session was created.

--- a/ckan/tests/config/test_sessions.py
+++ b/ckan/tests/config/test_sessions.py
@@ -83,6 +83,7 @@ class FlashMessagePlugin(p.SingletonPlugin):
 
         return blueprint
 
+
 @pytest.mark.parametrize("timeout,normalized", [
     (None, None),
     ("", None),

--- a/ckan/tests/config/test_sessions.py
+++ b/ckan/tests/config/test_sessions.py
@@ -82,3 +82,20 @@ class FlashMessagePlugin(p.SingletonPlugin):
             blueprint.add_url_rule(*rule)
 
         return blueprint
+
+@pytest.mark.parametrize("timeout,normalized", [
+    (None, None),
+    ("", None),
+    ("123", 123),
+    ("1_000_000", 1_000_000),
+    ("-1", -1),
+])
+def test_beaker_session_timeout(
+        monkeypatch, ckan_config, make_app, timeout, normalized
+):
+    """Beaker timeout accepts `None`(never expires) and int(expires in
+    n-seconds) values.
+
+    """
+    monkeypatch.setitem(ckan_config, "beaker.session.timeout", timeout)
+    make_app()


### PR DESCRIPTION
Fixes #7490

`type: int` implies the `convert_int` validator which aggressively validates numbers and raises an error for non-numeric values. Generally, it's ok, but beaker accepts `None` as a value for `beaker.session.timeout` and `type: int` doesn't allow us to pass `None`

Solution:
Remove `type: int` and add `validators: int_validator`. `int_validator` allows `None` and empty string(which is converted to `None` as well) and validates only non-empty strings.

Additionally, remove `default: 600` timeout, so beaker sessions are never-expiring by default