### PR TITLE
show existing resource nav on new resource page

### DIFF
--- a/changes/7889.misc
+++ b/changes/7889.misc
@@ -1,0 +1,1 @@
+show existing resource navigation on new resource page

--- a/ckan/templates/package/new_resource_not_draft.html
+++ b/ckan/templates/package/new_resource_not_draft.html
@@ -18,4 +18,5 @@
 
 {% block secondary_content %}
   {% snippet 'package/snippets/resource_help.html' %}
+  {% snippet 'package/snippets/resources.html', pkg=pkg %}
 {% endblock %}


### PR DESCRIPTION
Based on feedback from our users it's useful to see the resources already created when adding new resources. This change includes the resource navigation on the new resource page the same as on resource edit, view, and data dictionary pages

### Proposed fixes:
- show existing resource navigation on new resource page


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport