### PR TITLE
[#7890] use object-group icon for Embed button

### DIFF
--- a/changes/7890.misc
+++ b/changes/7890.misc
@@ -1,0 +1,1 @@
+use object-group icon for Embed button

--- a/ckan/templates/package/snippets/resource_view.html
+++ b/ckan/templates/package/snippets/resource_view.html
@@ -15,7 +15,7 @@
        data-module="resource-view-embed"
        data-module-id="{{ resource_view['id'] }}"
        data-module-url="{{ h.url_for(package['type'] ~ '_resource.view', id=package['name'], resource_id=resource['id'], view_id=resource_view['id'], qualified=True) }}">
-      <i class="fa fa-code"></i>
+      <i class="fa fa-object-group"></i>
       {{ _("Embed") }}
     </a>
   </div>


### PR DESCRIPTION
Both Data Dictionary and Embed buttons use the `fa-code` icon

### Proposed fixes:

Switch Embed button to use `object-group` instead
![image](https://github.com/ckan/ckan/assets/153258/f575d564-b38f-403c-9bb8-7f3041b8715d)


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport