### PR TITLE
disable all caching on _logout URL, #6955

### DIFF
--- a/changes/7892.bugfix
+++ b/changes/7892.bugfix
@@ -1,0 +1,1 @@
+Change logout link into a POST submit so it interacts properly with caching and CSRF

--- a/ckan/templates/header.html
+++ b/ckan/templates/header.html
@@ -39,10 +39,12 @@
         </li>
         {% endblock %} {% block header_account_log_out_link %}
         <li>
-          <a href="{{ h.url_for('user.logout') }}" title="{{ _('Log out') }}">
-            <i class="fa fa-sign-out" aria-hidden="true"></i>
-            <span class="text">{{ _('Log out') }}</span>
-          </a>
+          <form action="{{ h.url_for('user.logout') }}" method="post">
+            {{ h.csrf_input() }}
+            <button class="btn btn-link" type="submit" title="{{ _('Log out') }}">
+              <i class="fa fa-sign-out" aria-hidden="true"></i>
+            </button>
+          </form>
         </li>
         {% endblock %} {% endblock %}
       </ul>
@@ -98,14 +100,14 @@
               {% set org_type = h.default_group_type('organization') %}
               {% set group_type = h.default_group_type('group') %}
 
-		          {{ h.build_nav_main(
-		            (dataset_type ~ '.search', h.humanize_entity_type('package', dataset_type, 'main nav') or _('Datasets'), ["dataset", "resource"]),
-		            (org_type ~ '.index',
+              {{ h.build_nav_main(
+                (dataset_type ~ '.search', h.humanize_entity_type('package', dataset_type, 'main nav') or _('Datasets'), ["dataset", "resource"]),
+                (org_type ~ '.index',
                   h.humanize_entity_type('organization', org_type, 'main nav') or _('Organizations'), ['organization']),
-		            (group_type ~ '.index',
+                (group_type ~ '.index',
                   h.humanize_entity_type('group', group_type, 'main nav') or _('Groups'), ['group']),
-		            ('home.about', _('About')) ) }}
-	          {% endblock %}
+                ('home.about', _('About')) ) }}
+            {% endblock %}
           </ul>
 
       {% endblock %}

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -944,7 +944,7 @@ user.add_url_rule(
     u'/register', view_func=RegisterView.as_view(str(u'register')))
 
 user.add_url_rule(u'/login', view_func=login, methods=('GET', 'POST'))
-user.add_url_rule(u'/_logout', view_func=logout)
+user.add_url_rule(u'/_logout', view_func=logout, methods=('GET', 'POST'))
 user.add_url_rule(u'/logged_out_redirect', view_func=logged_out_page)
 
 user.add_url_rule(u'/delete/<id>', view_func=delete, methods=(u'POST', 'GET'))

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -576,21 +576,14 @@ def login() -> Union[Response, str]:
     return base.render("user/login.html", extra_vars)
 
 
-def _uncached_response(response: Response) -> Response:
-    """ Ensure some types of responses are not cached at all, even privately
-    """
-    response.cache_control.no_store = True
-    return response
-
-
 def logout() -> Response:
     for item in plugins.PluginImplementations(plugins.IAuthenticator):
         response = item.logout()
         if response:
-            return _uncached_response(response)
+            return response
     user = current_user.name
     if not user:
-        return _uncached_response(h.redirect_to('user.login'))
+        return h.redirect_to('user.login')
 
     came_from = request.args.get('came_from', '')
     logout_user()
@@ -599,9 +592,10 @@ def logout() -> Response:
     if session.get(field_name):
         session.pop(field_name)
 
-    return _uncached_response(h.redirect_to(
-        str(came_from) if h.url_is_local(came_from) else 'user.logged_out_page'
-    ))
+    if h.url_is_local(came_from):
+        return h.redirect_to(str(came_from))
+
+    return h.redirect_to('user.logged_out_page')
 
 
 def logged_out_page() -> str:


### PR DESCRIPTION
By default, authenticated pages are stored in browser cache, which is secure enough - but we don't want _logout cached at all, because despite being a GET request, it has a crucial side effect (deleting the session cookie).

### Proposed fixes:

Disable all caching on `/user/_logout`

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
