### PR TITLE
Delete Activity Rows Feature

### DIFF
--- a/ckanext/activity/cli.py
+++ b/ckanext/activity/cli.py
@@ -1,0 +1,100 @@
+import click
+from typing import Optional
+import datetime
+
+from ckan.lib.plugins import plugin_validate
+from ckanext.activity import utils
+from ckanext.activity.logic.schema import delete_activity_rows_schema
+
+
+@click.group(short_help="Activity management commands.")
+def activity():
+    """Activity management commands.
+    """
+    pass
+
+
+@activity.command(short_help="Delete rows from the activity table.")
+@click.option(
+    "-i", "--id", help="Only delete activities for this object ID."
+)
+@click.option(
+    "-l", "--limit", help="Limit the number of activities deleted.", type=int
+)
+@click.option(
+    "-t", "--activity-types", multiple=True,
+    help="Only delete activities of these types. Accepts multiple."
+)
+@click.option(
+    "-T", "--exclude-activity-types", multiple=True,
+    help="Do not delete activities of these types. Accepts multiple."
+)
+@click.option(
+    "-b", "--before",
+    help="Delete activities `before` a Unix timestamp.",type=float
+)
+@click.option(
+    "-a", "--after",
+    help="Delete activities `after` a Unix timestamp.", type=float
+)
+@click.option(
+    "-d", "--days", help="Delete activities before x `days` ago.", type=int
+)
+@click.option(
+    "-q", "--quiet", is_flag=True, help="Supresses human interaction."
+)
+def delete(id: Optional[str],
+           limit: Optional[int],
+           activity_types: Optional[list[str]],
+           exclude_activity_types: Optional[list[str]],
+           before: Optional[str],
+           after: Optional[str],
+           days: Optional[int],
+           quiet: Optional[bool]):
+    """Delete rows from the activity table.
+
+    Example:
+
+        ckan clean activity -b 1699041313\n
+        ckan clean activity -d 90 -q
+
+    """
+    if days:
+        before = datetime.datetime.today() - datetime.timedelta(days=float(days))
+        before = before.timestamp()
+
+    data_dict = {
+        "id": id,
+        "limit": limit,
+        "activity_types":
+            activity_types if activity_types else [],
+        "exclude_activity_types":
+            exclude_activity_types if exclude_activity_types else [],
+        "before": before,
+        "after": after,
+    }
+
+    data, errors = plugin_validate(None, {}, data_dict,
+                                   delete_activity_rows_schema(),
+                                   'activity_delete')
+
+    if errors:
+        for key, errors in errors.items():
+            for message in errors:
+                click.echo(f"{key}: {message}")
+        return
+
+    activity_count = utils.get_activity_count(data)
+
+    if not bool(activity_count):
+        click.echo("No activities found.")
+        return
+
+    if not quiet:
+        click.confirm(
+            f"Are you sure you want to delete {activity_count} activities?"
+            , abort=True)
+
+    utils.delete_activities(data)
+
+    click.echo(f"Deleted {activity_count} rows from the activity table.")

--- a/ckanext/activity/cli.py
+++ b/ckanext/activity/cli.py
@@ -22,6 +22,9 @@ def activity():
     "-l", "--limit", help="Limit the number of activities deleted.", type=int
 )
 @click.option(
+    "-o", "--offset", help="Offset the number of activities deleted.", type=int
+)
+@click.option(
     "-t", "--activity-types", multiple=True,
     help="Only delete activities of these types. Accepts multiple."
 )
@@ -45,6 +48,7 @@ def activity():
 )
 def delete(id: Optional[str],
            limit: Optional[int],
+           offset: Optional[int],
            activity_types: Optional[list[str]],
            exclude_activity_types: Optional[list[str]],
            before: Optional[str],
@@ -55,8 +59,9 @@ def delete(id: Optional[str],
 
     Example:
 
-        ckan clean activity -b 1699041313\n
-        ckan clean activity -d 90 -q
+        ckan activity delete -b 1699041313\n
+        ckan activity delete -d 90 -q\n
+        ckan activity delete --id=7e608e4c-c332-4511-ad43-97eb59cb5bd1 --offset=100 --limit=50
 
     """
     if days:
@@ -66,6 +71,7 @@ def delete(id: Optional[str],
     data_dict = {
         "id": id,
         "limit": limit,
+        "offset": offset,
         "activity_types":
             activity_types if activity_types else [],
         "exclude_activity_types":

--- a/ckanext/activity/logic/action.py
+++ b/ckanext/activity/logic/action.py
@@ -9,7 +9,7 @@ from typing import Any, Optional
 
 import ckan.plugins.toolkit as tk
 
-from ckan.logic import validate, check_access
+from ckan.logic import validate
 from ckan.types import Context, DataDict, ActionResult
 import ckanext.activity.email_notifications as email_notifications
 from ckanext.activity import utils
@@ -652,17 +652,14 @@ def activity_diff(context: Context, data_dict: DataDict) -> dict[str, Any]:
 @tk.side_effect_free
 def activity_range_count_show(context: Context,
                               data_dict: DataDict) -> dict[str, int]:
-    return {
-        "activity_count": utils.get_activity_count(data_dict),
-    }
+    tk.check_access("activity_range_count_show", context, data_dict)
+    return {"activity_count": utils.get_activity_count(data_dict)}
 
 
 @validate(schema.delete_activity_rows_schema)
 def activity_range_delete(context: Context,
                           data_dict: DataDict) -> dict[str, int]:
-    check_access("sysadmin", context)
+    tk.check_access("activity_range_delete", context, data_dict)
     count = utils.get_activity_count(data_dict)
     utils.delete_activities(data_dict)
-    return {
-        "deleted_activity_count": count,
-    }
+    return {"deleted_activity_count": count}

--- a/ckanext/activity/logic/action.py
+++ b/ckanext/activity/logic/action.py
@@ -9,9 +9,10 @@ from typing import Any, Optional
 
 import ckan.plugins.toolkit as tk
 
-from ckan.logic import validate
+from ckan.logic import validate, check_access
 from ckan.types import Context, DataDict, ActionResult
 import ckanext.activity.email_notifications as email_notifications
+from ckanext.activity import utils
 
 from . import schema
 from ..model import activity as model_activity, activity_dict_save
@@ -644,4 +645,24 @@ def activity_diff(context: Context, data_dict: DataDict) -> dict[str, Any]:
     return {
         "diff": diff,
         "activities": activities,
+    }
+
+
+@validate(schema.delete_activity_rows_schema)
+@tk.side_effect_free
+def activity_range_count_show(context: Context,
+                              data_dict: DataDict) -> dict[str, int]:
+    return {
+        "activity_count": utils.get_activity_count(data_dict),
+    }
+
+
+@validate(schema.delete_activity_rows_schema)
+def activity_range_delete(context: Context,
+                          data_dict: DataDict) -> dict[str, int]:
+    check_access("sysadmin", context)
+    count = utils.get_activity_count(data_dict)
+    utils.delete_activities(data_dict)
+    return {
+        "deleted_activity_count": count,
     }

--- a/ckanext/activity/logic/auth.py
+++ b/ckanext/activity/logic/auth.py
@@ -182,3 +182,15 @@ def dashboard_mark_activities_old(
     context: Context, data_dict: DataDict
 ) -> AuthResult:
     return authz.is_authorized("dashboard_activity_list", context, data_dict)
+
+
+def activity_range_count_show(context: Context,
+                              data_dict: Optional[DataDict]) -> AuthResult:
+    # Only sysadmins are authorized to read all notifications.
+    return {"success": False}
+
+
+def activity_range_delete(context: Context,
+                          data_dict: Optional[DataDict]) -> AuthResult:
+    # Only sysadmins are authorized to delete activity rows.
+    return {"success": False}

--- a/ckanext/activity/logic/schema.py
+++ b/ckanext/activity/logic/schema.py
@@ -95,3 +95,20 @@ def default_activity_list_schema(
     schema["after"] = [ignore_missing, datetime_from_timestamp_validator]
 
     return schema
+
+
+@validator_args
+def delete_activity_rows_schema(
+    unicode_safe: Validator,
+    natural_number_validator: Validator,
+    ignore_missing: Validator,
+    list_of_strings: Validator,
+    datetime_from_timestamp_validator: Validator,):
+    return {
+        "id": [ignore_missing, unicode_safe],
+        "limit": [ignore_missing, natural_number_validator],
+        "activity_types": [ignore_missing, list_of_strings],
+        "exclude_activity_types": [ignore_missing, list_of_strings],
+        "before": [ignore_missing, datetime_from_timestamp_validator],
+        "after": [ignore_missing, datetime_from_timestamp_validator],
+    }

--- a/ckanext/activity/logic/schema.py
+++ b/ckanext/activity/logic/schema.py
@@ -107,6 +107,7 @@ def delete_activity_rows_schema(
     return {
         "id": [ignore_missing, unicode_safe],
         "limit": [ignore_missing, natural_number_validator],
+        "offset": [ignore_missing, natural_number_validator],
         "activity_types": [ignore_missing, list_of_strings],
         "exclude_activity_types": [ignore_missing, list_of_strings],
         "before": [ignore_missing, datetime_from_timestamp_validator],

--- a/ckanext/activity/plugin.py
+++ b/ckanext/activity/plugin.py
@@ -8,6 +8,7 @@ import ckan.plugins as p
 import ckan.plugins.toolkit as tk
 
 from . import subscriptions
+from . import cli
 
 
 @tk.blanket.auth_functions
@@ -18,6 +19,7 @@ from . import subscriptions
 class ActivityPlugin(p.SingletonPlugin):
     p.implements(p.IConfigurer)
     p.implements(p.ISignal)
+    p.implements(p.IClick)
 
     # IConfigurer
     def update_config(self, config: CKANConfig):
@@ -28,3 +30,7 @@ class ActivityPlugin(p.SingletonPlugin):
     # ISignal
     def get_signal_subscriptions(self):
         return subscriptions.get_subscriptions()
+
+    # IClick
+    def get_commands(self):
+        return [cli.activity]

--- a/ckanext/activity/utils.py
+++ b/ckanext/activity/utils.py
@@ -1,0 +1,10 @@
+from ckan import model
+from ckan.types import DataDict
+
+
+def get_activity_count(data_dict: DataDict) -> int:
+    return 0
+
+
+def delete_activities(data_dict: DataDict):
+    return

--- a/ckanext/activity/utils.py
+++ b/ckanext/activity/utils.py
@@ -1,10 +1,40 @@
 from ckan import model
-from ckan.types import DataDict
+from ckan.types import DataDict, Query
+from ckanext.activity.model import Activity
+
+
+def _parse_data_dict_to_query(data_dict: DataDict) -> Query:
+    q = model.Session.query(Activity.id)
+
+    if data_dict.get('before'):
+        q = q.filter(Activity.timestamp < data_dict.get('before'))
+
+    if data_dict.get('after'):
+        q = q.filter(Activity.timestamp > data_dict.get('after'))
+
+    if data_dict.get('activity_types'):
+        q = q.filter(Activity.activity_type.in_(data_dict.get('activity_types')))
+
+    if data_dict.get('exclude_activity_types'):
+        q = q.filter(Activity.activity_type
+                     .notin_(data_dict.get('exclude_activity_types'))) \
+
+    if data_dict.get('offset'):
+        q = q.offset(data_dict.get('offset'))
+
+    if data_dict.get('limit'):
+        q = q.limit(data_dict.get('limit'))
+
+    return q
 
 
 def get_activity_count(data_dict: DataDict) -> int:
-    return 0
+    return _parse_data_dict_to_query(data_dict).count()
 
 
 def delete_activities(data_dict: DataDict):
-    return
+    # query.delete() cannot be used with offset and limit.
+    # need to do another query with IN ids to delete them.
+    ids = set(id[0] for id in _parse_data_dict_to_query(data_dict).all())
+    model.Session.query(Activity).filter(Activity.id.in_(ids)).delete()
+    model.Session.commit()


### PR DESCRIPTION
New feature to delete rows from the activity table as the activity table can get bloated with data. The action methods and CLI command will give sysadmins an easy way to delete activity data regularly.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
