### PR TITLE
Datatables Processing Visuals

### DIFF
--- a/changes/7900.feature
+++ b/changes/7900.feature
@@ -1,0 +1,1 @@
+Added processing and pre-processing indicators to Datatables Views.

--- a/ckanext/datatablesview/assets/datatables_view.css
+++ b/ckanext/datatablesview/assets/datatables_view.css
@@ -28,6 +28,19 @@ div.dataTables_scroll{
 /* processing message should hover over table and be visible */
 #dtprv_processing {
   z-index: 100;
+  display: block;
+}
+
+#dtprv_processing.pre-init::after{
+  content: '';
+  display: block;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: white;
+  z-index: -1;
 }
 
 /* for table header, don't wrap */

--- a/ckanext/datatablesview/assets/datatablesview.js
+++ b/ckanext/datatablesview/assets/datatablesview.js
@@ -476,10 +476,16 @@ this.ckan.module('datatables_view', function (jQuery) {
       })
 
       // init the datatable
+      $('#dtprv').on('preInit.dt', function (_event, _settings) {
+        // show loading indicator when first painting data into the table.
+        // useful with very large resources that take long to load
+        $('body.dt-view').css('visibility', 'visible');
+        $('#dtprv_processing').addClass('pre-init');
+      });
       datatable = $('#dtprv').DataTable({
         paging: true,
         serverSide: true,
-        processing: false,
+        processing: true,
         stateSave: statesaveflag,
         stateDuration: stateduration,
         colReorder: {
@@ -591,6 +597,9 @@ this.ckan.module('datatables_view', function (jQuery) {
             api.page.len(gsavedPagelen)
             api.page(gsavedPage)
           }
+
+          // hide the pre-loading indicator background so the table is interactive when loading
+          $('#dtprv_processing').removeClass('pre-init');
 
           // restore selected rows from state
           if (typeof gsavedSelected !== 'undefined') {


### PR DESCRIPTION
feat(js): loading visual for datatables;

- Brought back `processing` for datatables.
- Added in pre-init visual for large data tables.

### Proposed fixes:

The `processing` for datatables was disabled here: https://github.com/ckan/ckan/commit/0b5a54218abe028ff49397d289e8250c968b14e1 with a commit message of "Disable processing spinner - didn't automatically disappear".

I have not had this issue, perhaps it was an older issue with a datatables version. But I have re-enabled that now.

I have also added a `pre-init` function to datatables to just display the processing icon when first painting the tables. This is super useful for resources that are huge. We have some resource over 2GB and the datatable takes 30 seconds to load. This way, there will be a loading indicator instead of just white space on the page.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
