### PR TITLE
Delete Datastore Table Button (ckanext-datapusher)

### DIFF
--- a/changes/7902.feature
+++ b/changes/7902.feature
@@ -1,0 +1,1 @@
+Adds button to delete a Resource's datastore table in ckanext-datapusher

--- a/ckanext/datapusher/templates/datapusher/resource_data.html
+++ b/ckanext/datapusher/templates/datapusher/resource_data.html
@@ -5,10 +5,21 @@
 {% block primary_content_inner %}
 
   {% set action = h.url_for('datapusher.resource_data', id=pkg.name, resource_id=res.id) %}
+  {% set delete_action = h.url_for('datapusher.delete_datastore_table', id=pkg.id, resource_id=res.id) %}
   {% set show_table = true %}
 
-  <form method="post" action="{{ action }}" class="datapusher-form">
-    {{ h.csrf_input() }} 
+  <form method="post" action="{{ delete_action }}" class="mb-3 d-inline-block">
+    {{ h.csrf_input() }}
+    <button class="btn btn-danger" name="delete" type="submit"
+      data-module="confirm-action"
+      data-module-with-data=true
+      data-module-content="{{ _('Are you sure you want to delete this DataStore table and Data Dictionary?') }}">
+      <i class="fa fa-remove"></i> {{ _('Delete DataStore table') }}
+    </button>
+  </form>
+
+  <form method="post" action="{{ action }}" class="datapusher-form mb-3 d-inline-block">
+    {{ h.csrf_input() }}
     <button class="btn btn-primary" name="save" type="submit">
       <i class="fa fa-cloud-upload"></i> {{ _('Upload to DataStore') }}
     </button>
@@ -76,7 +87,7 @@
           {% endfor %}
           <span class="date" title="{{ h.render_datetime(item.timestamp, with_hours=True) }}">
             {{ h.time_ago_from_timestamp(item.timestamp) }}
-            <a href="#" data-module="datapusher_popover" data-module-title="Details <a href='#' class='popover-close'>X</a>" data-module-content="<ul class='list-unstyled'>{% for key, value in item.items() %}<li><b>{{ key }}</b>: {{ h.clean_html(value|string) }}</li>{% endfor %}</ul>">              
+            <a href="#" data-module="datapusher_popover" data-module-title="Details <a href='#' class='popover-close'>X</a>" data-module-content="<ul class='list-unstyled'>{% for key, value in item.items() %}<li><b>{{ key }}</b>: {{ h.clean_html(value|string) }}</li>{% endfor %}</ul>">
               {{ _('Details') }}
             </a>
           </span>

--- a/ckanext/datapusher/templates/datapusher/resource_data.html
+++ b/ckanext/datapusher/templates/datapusher/resource_data.html
@@ -13,8 +13,8 @@
     <button class="btn btn-danger" name="delete" type="submit"
       data-module="confirm-action"
       data-module-with-data=true
-      data-module-content="{{ _('Are you sure you want to delete this DataStore table and Data Dictionary?') }}">
-      <i class="fa fa-remove"></i> {{ _('Delete DataStore table') }}
+      data-module-content="{{ _('Are you sure you want to delete the DataStore and Data Dictionary?') }}">
+      <i class="fa fa-remove"></i> {{ _('Delete from DataStore') }}
     </button>
   </form>
 

--- a/ckanext/datapusher/views.py
+++ b/ckanext/datapusher/views.py
@@ -77,7 +77,7 @@ datapusher.add_url_rule(
 
 
 @datapusher.route(
-    "/dataset/<id>/delete-datastore-table/<resource_id>",
+    "/dataset/<id>/delete-datastore/<resource_id>",
     methods=["POST"]
 )
 def delete_datastore_table(id: str, resource_id: str) -> Response:
@@ -91,7 +91,7 @@ def delete_datastore_table(id: str, resource_id: str) -> Response:
             403, _(f'Unauthorized to delete resource {resource_id}'))
 
     toolkit.h.flash_notice(
-        _('DataStore table and Data Dictionary '
+        _('DataStore and Data Dictionary '
             f'deleted for resource {resource_id}'))
 
     return toolkit.h.redirect_to(

--- a/ckanext/datapusher/views.py
+++ b/ckanext/datapusher/views.py
@@ -7,6 +7,7 @@ import ckan.plugins.toolkit as toolkit
 import ckan.logic as logic
 import ckan.lib.helpers as core_helpers
 import ckan.lib.base as base
+from ckan.types import Context, Response
 
 from ckan.common import _
 
@@ -73,3 +74,28 @@ datapusher.add_url_rule(
     u'/dataset/<id>/resource_data/<resource_id>',
     view_func=ResourceDataView.as_view(str(u'resource_data'))
 )
+
+
+@datapusher.route(
+    "/dataset/<id>/delete-datastore-table/<resource_id>",
+    methods=["POST"]
+)
+def delete_datastore_table(id: str, resource_id: str) -> Response:
+    context: Context = {"user": toolkit.current_user.name}
+
+    try:
+        toolkit.get_action('datastore_delete')(
+            context, {'resource_id': resource_id, 'force': True})
+    except toolkit.NotAuthorized:
+        return toolkit.abort(
+            403, _(f'Unauthorized to delete resource {resource_id}'))
+
+    toolkit.h.flash_notice(
+        _('DataStore table and Data Dictionary '
+            f'deleted for resource {resource_id}'))
+
+    return toolkit.h.redirect_to(
+        'datapusher.resource_data',
+        id=id,
+        resource_id=resource_id
+    )


### PR DESCRIPTION
feat(views): added view and button to delete ds table;

- Added view to delete datastore table.
- Added button to delete a resource's datastore table.

Adds a view and button to delete a Resource's datastore table via the Datapusher extension's data page.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
