### PR TITLE
Fix queries when state is in fq_list

### DIFF
--- a/changes/7905.bugfix
+++ b/changes/7905.bugfix
@@ -1,0 +1,1 @@
+Changed dataset query to check for `+state:` in the `fq_list` as well as the `fq` parameter before forcing `state:active`

--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -365,7 +365,7 @@ class PackageSearchQuery(SearchQuery):
         fq.append('+site_id:%s' % solr_literal(config.get('ckan.site_id')))
 
         # filter for package status
-        if not '+state:' in query.get('fq', ''):
+        if not any('+state:' in _item for _item in fq):
             fq.append('+state:active')
 
         # only return things we should be able to see


### PR DESCRIPTION
Fixes #7736

2.9 backport in #7857

### Proposed fixes:
Scan the assembled set of fq items for +state, rather than just the fq parameter.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
