### PR TITLE
Note that MD5 Hash is not used for security purposes

### DIFF
--- a/changes/7906.misc
+++ b/changes/7906.misc
@@ -1,0 +1,1 @@
+Note that md5 use in tracking is not a security context

--- a/ckanext/tracking/middleware.py
+++ b/ckanext/tracking/middleware.py
@@ -27,7 +27,8 @@ def track_request(response: Response) -> Response:
             request.environ.get('HTTP_ACCEPT_LANGUAGE', ''),
             request.environ.get('HTTP_ACCEPT_ENCODING', ''),
         ])
-        h = hashlib.new('md5', usedforsecurity=False)
+        # raises a type error on python<3.9
+        h = hashlib.new('md5', usedforsecurity=False)  # type: ignore
         key = h.update(key.encode()).hexdigest()
         # store key/data here
         sql = '''INSERT INTO tracking_raw

--- a/ckanext/tracking/middleware.py
+++ b/ckanext/tracking/middleware.py
@@ -27,7 +27,8 @@ def track_request(response: Response) -> Response:
             request.environ.get('HTTP_ACCEPT_LANGUAGE', ''),
             request.environ.get('HTTP_ACCEPT_ENCODING', ''),
         ])
-        key = hashlib.md5(key.encode()).hexdigest()
+        h = hashlib.new('md5', usedforsecurity=False)
+        key = h.update(key.encode()).hexdigest()
         # store key/data here
         sql = '''INSERT INTO tracking_raw
                     (user_key, url, tracking_type)


### PR DESCRIPTION
* In 3.9+, hashlib.md5() takes a usedforsecurity kwarg that blocks use of insecure hashes in security contexts.
* The hashlib.new(hashtype) call can take that keyword arg even in <3.9

Fixes #7768

### Proposed fixes:

This is an updated version of #7768, using the `hashlib.new()` functionality to enable the kwarg of usedforsecurity=False even in Python < 3.9


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
