### PR TITLE
Flake8: ignore node modules

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,18 +3,16 @@ exclude =
         .*
         ./contrib
         ./bin
+        ./node_modules
+
 per-file-ignores =
                  test_*.py:E501
 extend-exclude =
-               ckan/__init__.py,ckan/config/middleware.py
                ckan/lib/app_globals.py
                ckan/lib/cli.py
                ckan/lib/create_test_data.py
-               ckan/lib/dictization/__init__.py
                ckan/lib/dictization/model_dictize.py
                ckan/lib/dictization/model_save.py
-               ckan/lib/email_notifications.py
-               ckan/lib/hash.py
                ckan/lib/jinja_extensions.py
                ckan/lib/maintain.py
                ckan/lib/navl/validators.py
@@ -22,7 +20,6 @@ extend-exclude =
                ckan/lib/search/__init__.py
                ckan/lib/search/index.py
                ckan/lib/search/query.py
-               ckan/logic/action/__init__.py
                ckan/logic/action/delete.py
                ckan/logic/action/get.py
                ckan/logic/action/update.py
@@ -49,16 +46,12 @@ extend-exclude =
                ckan/model/system_info.py
                ckan/model/tag.py
                ckan/model/task_status.py
-               ckan/model/term_translation.py
                ckan/model/user.py
                ckan/model/vocabulary.py
                ckan/authz.py
                ckanext/datastore/logic/action.py
                ckanext/datastore/tests/test_create.py
                ckanext/example_idatasetform/plugin.py
-               ckanext/example_itemplatehelpers/plugin.py
                ckanext/multilingual/plugin.py
                ckanext/stats/stats.py
-               ckanext/test_tag_vocab_plugin.py
                doc/conf.py
-               setup.py

--- a/ckan/__init__.py
+++ b/ckan/__init__.py
@@ -4,4 +4,5 @@ __version__ = "2.11.0a0"
 
 # The packaging system relies on this import, please do not remove it
 # type_ignore_reason: pyright thinks it's iterable
-import sys; sys.path.insert(0, __path__[0])  # type: ignore
+import sys
+sys.path.insert(0, __path__[0])  # type: ignore

--- a/ckan/common.py
+++ b/ckan/common.py
@@ -26,7 +26,7 @@ from flask_login import login_user as _login_user, logout_user as _logout_user
 from flask_babel import (gettext as flask_ugettext,
                          ngettext as flask_ungettext)
 
-import simplejson as json  # type: ignore # noqa: re-export
+import simplejson as json  # type: ignore # noqa
 import ckan.lib.maintain as maintain
 from ckan.config.declaration import Declaration
 from ckan.types import Model, Request

--- a/ckan/lib/dictization/__init__.py
+++ b/ckan/lib/dictization/__init__.py
@@ -115,7 +115,9 @@ def table_dict_save(table_dict: dict[str, Any],
                     extra_attrs: Iterable[str] = ()) -> Any:
     '''Given a dict and a model class, update or create a sqlalchemy object.
     This will use an existing object if "id" is supplied OR if any unique
-    constraints are met. e.g supplying just a tag name will get out that tag obj.
+    constraints are met. e.g supplying just a tag name will get out that tag
+    obj.
+
     '''
     session = context["session"]
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -55,7 +55,7 @@ import ckan.plugins as p
 import ckan
 
 
-from ckan.lib.pagination import Page  # type: ignore # noqa: re-export
+from ckan.lib.pagination import Page  # type: ignore # noqa
 from ckan.common import _, g, request, json
 
 from ckan.lib.webassets_tools import include_asset, render_assets
@@ -1104,7 +1104,7 @@ def get_facet_items_dict(
         if not len(facet_item['name'].strip()):
             continue
         params_items = request.args.items(multi=True)
-        if not (facet, facet_item['name']) in params_items:
+        if (facet, facet_item['name']) not in params_items:
             facets.append(dict(active=False, **facet_item))
         elif not exclude_active:
             facets.append(dict(active=True, **facet_item))
@@ -1146,7 +1146,7 @@ def has_more_facets(facet: str,
         if not len(facet_item['name'].strip()):
             continue
         params_items = request.args.items(multi=True)
-        if not (facet, facet_item['name']) in params_items:
+        if (facet, facet_item['name']) not in params_items:
             facets.append(dict(active=False, **facet_item))
         elif not exclude_active:
             facets.append(dict(active=True, **facet_item))

--- a/ckan/model/term_translation.py
+++ b/ckan/model/term_translation.py
@@ -6,7 +6,8 @@ import ckan.model.meta as meta
 
 __all__ = ['term_translation_table']
 
-term_translation_table = Table('term_translation', meta.metadata,
+term_translation_table = Table(
+    'term_translation', meta.metadata,
     Column('term', UnicodeText, nullable=False),
     Column('term_translation', UnicodeText, nullable=False),
     Column('lang_code', UnicodeText, nullable=False),

--- a/ckan/plugins/__init__.py
+++ b/ckan/plugins/__init__.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
-from ckan.plugins.core import *  # noqa: re-export
-from ckan.plugins.interfaces import *  # noqa: re-export
+from ckan.plugins.core import *  # noqa
+from ckan.plugins.interfaces import *  # noqa
 
 
 def __getattr__(name: str):

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -276,7 +276,7 @@ class TestUser(object):
 
         response = app.get(url=url_for("dashboard.datasets"), headers=headers)
 
-        assert not (dataset_title in response)
+        assert dataset_title not in response
 
     def test_user_edit_no_user(self, app):
 

--- a/ckan/tests/pytest_ckan/fixtures.py
+++ b/ckan/tests/pytest_ckan/fixtures.py
@@ -479,7 +479,7 @@ def create_with_upload(clean_db, ckan_config, monkeypatch, tmpdir):
         action = kwargs.pop("action", "resource_create")
         field = kwargs.pop("upload_field_name", "upload")
         test_file = BytesIO()
-        if type(data) is not bytes:
+        if not isinstance(data, bytes):
             data = bytes(data, encoding="utf-8")
         test_file.write(data)
         test_file.seek(0)

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -692,7 +692,6 @@ class CreateView(MethodView):
                 u'form_snippet': form_snippet,
                 u'dataset_type': package_type,
                 u'resources_json': resources_json,
-                u'form_snippet': form_snippet,
                 u'errors_json': errors_json
             }
         )
@@ -844,7 +843,6 @@ class EditView(MethodView):
                 u'pkg_dict': pkg_dict,
                 u'pkg': pkg,
                 u'resources_json': resources_json,
-                u'form_snippet': form_snippet,
                 u'errors_json': errors_json
             }
         )

--- a/ckanext/example_blanket_implementation/helpers.py
+++ b/ckanext/example_blanket_implementation/helpers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # must be ignored by blanket
-from random import randrange  # type: ignore # noqa: test
+from random import randrange  # type: ignore # noqa
 
 
 def blanket_helper():

--- a/ckanext/example_itemplatehelpers/plugin.py
+++ b/ckanext/example_itemplatehelpers/plugin.py
@@ -5,6 +5,7 @@ from ckan.common import CKANConfig
 from typing import Any, Callable
 import ckan.plugins as plugins
 
+
 # Our custom template helper function.
 def example_helper():
     '''An example template helper function.'''


### PR DESCRIPTION
I recently noticed that `flake8` reports a lot of problems locally. It turns out, that some JS packages installed into `node_modules`(mainly, `pyright`) contain Python scripts in their sources.

We certainly don't want to spend extra time checking vendor libraries, so I added `node_modules` to flakes8' whitelist. And checked all existing entries, removing files that are not available in core anymore and fixing issues in files that are already almost ideal.


Additionally, because I mostly use ruff instead of flake8, I checked the source with additional linters, and here are some interesting lists of problems that **are not addressed** in the current PR, but may be good for contribution:
* [logging statements](https://termbin.com/v49i): string interpolation via f-strings, `str.format` and `%` operator is not recommended for efficiency; we are using deprecated `logging.warn()` a couple of times.
* [missing trailing commas after last collection member](https://termbin.com/boil)
* [print statements](https://termbin.com/7xp2). It's better to use logging, probably
* [huge list of syntax improvements if we are targeting py v3.8 and newer](https://termbin.com/weli)
* [possible exception and loop improvements](https://termbin.com/8cab) Personally, I don't rely much on [flake8-bugbear](https://pypi.org/project/flake8-bugbear/), but it worth checking these issues
* [possible code simplifications](https://termbin.com/zpps). 
* [asserts in code and a number of SQLInjection vectors](https://termbin.com/lf3i6). Assertions are mainly used for typing, but it still nice to remove them from non-test modules.
* [blind exception catchers](https://termbin.com/a4q1)
* [complex functions](https://termbin.com/7l3b)
* [Unnecessary parentheses on raised exception](https://termbin.com/tojo)
* [pylint report](https://termbin.com/7yty)