### PR TITLE
Datapusher: Use IDomainObjectModification Implementation

### DIFF
--- a/ckanext/datapusher/plugin.py
+++ b/ckanext/datapusher/plugin.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from ckan.common import CKANConfig
 from ckan.types import Action, AuthFunction, Context
 import logging
-from typing import Any, Callable
+from typing import Any, Callable, Union
 
 import ckan.model as model
 import ckan.plugins as p
@@ -12,6 +12,8 @@ import ckanext.datapusher.views as views
 import ckanext.datapusher.helpers as helpers
 import ckanext.datapusher.logic.action as action
 import ckanext.datapusher.logic.auth as auth
+
+from ckan.model.domain_object import DomainObjectOperation
 
 log = logging.getLogger(__name__)
 
@@ -26,7 +28,7 @@ class DatapusherPlugin(p.SingletonPlugin):
     p.implements(p.IConfigurable, inherit=True)
     p.implements(p.IActions)
     p.implements(p.IAuthFunctions)
-    p.implements(p.IResourceUrlChange)
+    p.implements(p.IDomainObjectModification)
     p.implements(p.IResourceController, inherit=True)
     p.implements(p.ITemplateHelpers)
     p.implements(p.IBlueprint)
@@ -54,13 +56,23 @@ class DatapusherPlugin(p.SingletonPlugin):
                     format(config_option)
                 )
 
-    # IResourceUrlChange
+    # IDomainObjectModification
 
-    def notify(self, resource: model.Resource):
+    def notify(self, entity: Union[model.Resource, model.Package],
+               operation: DomainObjectOperation):
+        """
+        Runs before_commit to database for Packages and Resources.
+        We only want to check for changed Resources for this.
+        We want to check if values have changed, namely the url.
+        See: ckan/model/modification.py.DomainObjectModificationExtension
+        """
+        if operation != DomainObjectOperation.changed \
+        or not isinstance(entity, model.Resource):
+            return
         context: Context = {'ignore_auth': True}
         resource_dict = p.toolkit.get_action(u'resource_show')(
             context, {
-                u'id': resource.id,
+                u'id': entity.id,
             }
         )
         self._submit_to_datapusher(resource_dict)

--- a/ckanext/datapusher/plugin.py
+++ b/ckanext/datapusher/plugin.py
@@ -67,7 +67,8 @@ class DatapusherPlugin(p.SingletonPlugin):
         See: ckan/model/modification.py.DomainObjectModificationExtension
         """
         if operation != DomainObjectOperation.changed \
-        or not isinstance(entity, model.Resource):
+        or not isinstance(entity, model.Resource) \
+        or not getattr(entity, 'url_changed', False):
             return
         context: Context = {'ignore_auth': True}
         resource_dict = p.toolkit.get_action(u'resource_show')(


### PR DESCRIPTION
# Fixes

The `notify` method of the `IResourceUrlChange` assumes that the Resource exists as it calls the `resource_show` action method. But, at this point, other extensions can override/extend action methods to delete a Resource from the session. This namely happens with the Validation extension running in sync mode: if the validation fails, it will delete the Resource from the session and it won't get created but then Datapusher's `notify` method would fire off and not find the Resource in `resource_show`

Just changing this to use `IDomainObjectModification` will make is handle the exceptions automagically: https://github.com/ckan/ckan/blob/master/ckan/model/modification.py#L67

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
