### PR TITLE
datastore_create: delete_fields option

### DIFF
--- a/changes/7919.feature
+++ b/changes/7919.feature
@@ -1,0 +1,2 @@
+datastore_create: Add a delete_fields flag that must be set to True to delete
+any existing fields not passed in the fields list

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1096,10 +1096,11 @@ def alter_table(context: Context, data_dict: dict[str, Any]):
                 identifier(f['id']),
                 info_sql))
 
-    for id_ in current_ids - field_ids - set(f['id'] for f in new_fields):
-        alter_sql.append('ALTER TABLE {0} DROP COLUMN {1};'.format(
-            identifier(data_dict['resource_id']),
-            identifier(id_)))
+    if data_dict['delete_fields']:
+        for id_ in current_ids - field_ids - set(f['id'] for f in new_fields):
+            alter_sql.append('ALTER TABLE {0} DROP COLUMN {1};'.format(
+                identifier(data_dict['resource_id']),
+                identifier(id_)))
 
     if alter_sql:
         context['connection'].execute(

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -60,6 +60,8 @@ def datastore_create(context: Context, data_dict: dict[str, Any]):
     :type aliases: list or comma separated string
     :param fields: fields/columns and their extra metadata. (optional)
     :type fields: list of dictionaries
+    :param delete_fields: set to True to remove existing fields not passed
+    :type delete_fields: bool (optional, default: False)
     :param records: the data, eg: [{"dob": "2005", "some_stuff": ["a", "b"]}]
                     (optional)
     :type records: list of dictionaries

--- a/ckanext/datastore/logic/schema.py
+++ b/ckanext/datastore/logic/schema.py
@@ -120,6 +120,7 @@ def datastore_create_schema() -> Schema:
             'type': [ignore_missing],
             'info': [ignore_missing],
         },
+        'delete_fields': [default(False), boolean_validator],
         'primary_key': [ignore_missing, list_of_strings_or_string],
         'indexes': [ignore_missing, list_of_strings_or_string],
         'triggers': {

--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -307,7 +307,7 @@ class TestDatastoreCreateNewTests(object):
         last_analyze = when_was_last_analyze(resource["id"])
         assert last_analyze is not None
 
-    def test_remove_columns(self):
+    def test_delete_fields(self):
         resource = factories.Resource()
         data = {
             "resource_id": resource["id"],
@@ -327,6 +327,20 @@ class TestDatastoreCreateNewTests(object):
                 {"id": "col_c", "type": "text"},
             ],
             "force": True,
+        }
+        helpers.call_action("datastore_create", **data)
+        info = helpers.call_action("datastore_info", id=resource["id"])
+        assert [f['id'] for f in info['fields']] == [
+            'col_a', 'col_b', 'col_c', 'col_d'
+        ]
+        data = {
+            "resource_id": resource["id"],
+            "fields": [
+                {"id": "col_a", "type": "text"},
+                {"id": "col_c", "type": "text"},
+            ],
+            "force": True,
+            "delete_fields": True,
         }
         helpers.call_action("datastore_create", **data)
         info = helpers.call_action("datastore_info", id=resource["id"])


### PR DESCRIPTION
Fixes #7919 

### Proposed fixes:
Add a delete_fields option to datastore_create


### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport