### PR TITLE
[7915]Fix HTML5 validation fails on resource uploads

### DIFF
--- a/ckan/public/base/javascript/modules/resource-upload-field.js
+++ b/ckan/public/base/javascript/modules/resource-upload-field.js
@@ -1,10 +1,21 @@
 this.ckan.module('resource-upload-field', function (jQuery) {
   var _nameIsDirty = !! $('input[name="name"]').val();
+  var urlField = $('#field-resource-url');
   return {
     initialize: function() {
       $('input[name="name"]').on('change', function() {
         _nameIsDirty = true;
       });
+
+      // Change input type to text if Upload is selected
+      if ($('#resource-url-upload').prop('checked')) {
+        urlField.attr('type', 'text');
+      }
+
+      // revert to URL for Link option
+      $('#resource-link-button').on('click', function() {
+        urlField.attr('type', 'url');
+      }) 
 
       $('#field-resource-upload').on('change', function() {
         if (_nameIsDirty) {


### PR DESCRIPTION
Fixes #7915 

### Proposed fixes:
After debugging for a while, I found two potential solutions for the issue:
 
1). Change Input Type (Implemented in my PR): This approach involves altering the type of the hidden input to text, effectively bypassing HTML5 validation. The type reverts to 'url' when the upload is cleared, and the 'LINK' option is chosen.

2). Removing this [check](https://github.com/ckan/ckan/blob/master/ckan/lib/dictization/model_dictize.py#L132): An alternative option is to eliminate the "`for_edit`" check, allowing the complete qualified URL to be returned.

Please let me know your preference for the approach to proceed with.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
