### PR TITLE
Remove `ckan.featured_orgs` configuration

### DIFF
--- a/changes/7671.bugfix
+++ b/changes/7671.bugfix
@@ -1,0 +1,1 @@
+`ckan.featured_orgs` config option have been removed.

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -1156,14 +1156,6 @@ groups:
           group and datasets on the home page in the default templates (1 group and 2
           datasets are displayed).
 
-      - key: ckan.featured_orgs
-        type: list
-        example: org_one
-        description: |
-          Defines a list of organization names or ids. This setting is used to display
-          an organization and datasets on the home page in the default templates (1
-          group and 2 datasets are displayed).
-
       - key: ckan.default_group_sort
         default: title
         example: name

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2388,19 +2388,6 @@ def uploads_enabled() -> bool:
 
 
 @core_helper
-def get_featured_organizations(count: int = 1) -> list[dict[str, Any]]:
-    '''Returns a list of favourite organization in the form
-    of organization_list action function
-    '''
-    config_orgs = config.get('ckan.featured_orgs')
-    orgs = featured_group_org(get_action='organization_show',
-                              list_action='organization_list',
-                              count=count,
-                              items=config_orgs)
-    return orgs
-
-
-@core_helper
 def get_featured_groups(count: int = 1) -> list[dict[str, Any]]:
     '''Returns a list of favourite group the form
     of organization_list action function

--- a/ckan/templates/home/snippets/featured_organization.html
+++ b/ckan/templates/home/snippets/featured_organization.html
@@ -1,7 +1,0 @@
-{% set organizations = h.get_featured_organizations() %}
-
-{% for organization in organizations %}
-  <div class="box">
-    {% snippet 'snippets/organization_item.html', organization=organization %}
-  </div>
-{% endfor %}


### PR DESCRIPTION
Fixes #7671 

### Proposed fixes:
Remove `ckan.featured_orgs` configuration option.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
