### PR TITLE
[7836]Fix Cannot create API token via API (hen and egg)

### DIFF
--- a/changes/7932.feature
+++ b/changes/7932.feature
@@ -1,0 +1,2 @@
+Introducing a new parameter to the user_create action - with_apitoken. 
+When set, this parameter triggers the creation of an API token for the user.

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -1043,7 +1043,7 @@ def user_create(context: Context,
     if with_apitoken:
         # Create apitoken for user.
         api_token = _get_action("api_token_create")(
-            context, {"user": user.name, "name": "test"}
+            context, {"user": user.name, "name": "default"}
         )
         user_dict["token"] = api_token["token"]
 

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -1041,6 +1041,9 @@ def user_create(context: Context,
         model.repo.commit()
 
     if with_apitoken:
+        if not context['user']:
+            context["user"] = user.name
+
         # Create apitoken for user.
         api_token = _get_action("api_token_create")(
             context, {"user": user.name, "name": "default"}

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -1270,6 +1270,41 @@ class TestUserCreate(object):
         with pytest.raises(logic.NotFound):
             helpers.call_action("user_show", id=user_dict["name"])
 
+    def test_create_user_with_apitoken(self):
+        stub = factories.User.stub()
+        context = {"ignore_auth": True}
+        user_dict = {
+            "name": stub.name,
+            "email": stub.email,
+            "password": "test1234",
+            "with_apitoken": True
+        }
+        user = helpers.call_action("user_create", context={}, **user_dict)
+        assert user["token"]
+
+        user_dict = {"user_id": user["name"]}
+        token = helpers.call_action(
+            "api_token_list", context=context, **user_dict
+        )
+        assert len(token) == 1
+
+    def test_create_user_with_apitoken_missing_flag(self):
+        stub = factories.User.stub()
+        context = {"ignore_auth": True}
+        user_dict = {
+            "name": stub.name,
+            "email": stub.email,
+            "password": "test1234",
+        }
+        user = helpers.call_action("user_create", context={}, **user_dict)
+        assert "token" not in user
+
+        user_dict = {"user_id": user["name"]}
+        token = helpers.call_action(
+            "api_token_list", context=context, **user_dict
+        )
+        assert not token
+
 
 @pytest.mark.usefixtures("clean_db")
 @pytest.mark.ckan_config("ckan.auth.create_user_via_web", True)


### PR DESCRIPTION
Fixes #7836 

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
