### PR TITLE
Use current CKAN version in cookiecutter tests runner template

### DIFF
--- a/changes/7938.minor
+++ b/changes/7938.minor
@@ -1,0 +1,1 @@
+Use correct Docker tag in generated extensions test runner configuration file.

--- a/ckan/cli/generate.py
+++ b/ckan/cli/generate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import contextlib
 import os
 import json
+from packaging.version import parse as version_parse
 import shutil
 from typing import Optional
 
@@ -89,18 +90,24 @@ def extension(output_dir: str):
 
     include_examples = int(click.confirm(
         "Do you want to include code examples?"))
+
+    full_ckan_version = version_parse(ckan.__version__)
+    ckan_version = f"{full_ckan_version.major}.{full_ckan_version.minor}"
+
     context = {
-        u"project": name,
-        u"description": description,
-        u"author": author,
-        u"author_email": email,
-        u"keywords": keywords,
-        u"github_user_name": github,
-        u"project_shortname": project_short,
-        u"plugin_class_name": plugin_class_name,
-        u"include_examples": include_examples,
-        u"_source": u"cli",
+        "project": name,
+        "description": description,
+        "author": author,
+        "author_email": email,
+        "keywords": keywords,
+        "github_user_name": github,
+        "project_shortname": project_short,
+        "plugin_class_name": plugin_class_name,
+        "include_examples": include_examples,
+        "ckan_version": ckan_version,
+        "_source": "cli",
     }
+
 
     if output_dir == u'.':
         os.chdir(u'../../../..')

--- a/ckan/cli/generate.py
+++ b/ckan/cli/generate.py
@@ -108,7 +108,6 @@ def extension(output_dir: str):
         "_source": "cli",
     }
 
-
     if output_dir == u'.':
         os.chdir(u'../../../..')
         output_dir = os.getcwd()

--- a/contrib/cookiecutter/ckan_extension/cookiecutter.json
+++ b/contrib/cookiecutter/ckan_extension/cookiecutter.json
@@ -8,5 +8,6 @@
     "project_shortname": "{{ cookiecutter.project[8:].lower().replace('-','_') }}",
     "plugin_class_name": "{{ cookiecutter.project_shortname.title().replace('_','') }}Plugin",
     "include_examples": 0,
+    "ckan_version": "",
     "_source": "local"
 }

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/.github/workflows/test.yml
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       CKAN_REDIS_URL: redis://redis:6379/1
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install requirements
       # Install any extra requirements your extension has here (dev requirements, other extensions etc)
       run: |

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/.github/workflows/test.yml
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       # The CKAN version tag of the Solr and Postgres containers should match
       # the one of the container the tests run on.
       # You can switch this base image with a custom image tailored to your project
-      image: ckan/ckan-dev:2.10.1
+      image: ckan/ckan-dev:{{ cookiecutter.ckan_version }}
     services:
       solr:
         image: ckan/ckan-solr:{{ cookiecutter.ckan_version }}-solr9

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/.github/workflows/test.yml
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/.github/workflows/test.yml
@@ -7,12 +7,12 @@ jobs:
       # The CKAN version tag of the Solr and Postgres containers should match
       # the one of the container the tests run on.
       # You can switch this base image with a custom image tailored to your project
-      image: openknowledge/ckan-dev:2.9
+      image: ckan/ckan-dev:2.10.1
     services:
       solr:
-        image: ckan/ckan-solr-dev:2.9
+        image: ckan/ckan-solr:{{ cookiecutter.ckan_version }}-solr9
       postgres:
-        image: ckan/ckan-postgres-dev:2.9
+        image: ckan/ckan-postgres-dev:{{ cookiecutter.ckan_version }}
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
Replace the hardcoded Docker tags with the actual current version number, so when the extension is generated they point to the correct version.

TODO: create major.minor tags for the ckan images
