### PR TITLE
Drop annoying logs

### DIFF
--- a/changes/7941.misc
+++ b/changes/7941.misc
@@ -1,0 +1,1 @@
+Drop annoying static file logs

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -414,7 +414,11 @@ def ckan_after_request(response: Response) -> Response:
     )
     starts = any(url.startswith(s) for s in skip_startswith)
     ends = any(url.endswith(s) for s in skip_endswith)
-    if not starts and not ends:
+    if starts or ends:
+        log.debug(
+            ' %s %s render time %.3f seconds' % (status_code, url, r_time)
+        )
+    else:
         view_func = current_app.view_functions.get(request.endpoint)
         if view_func:
             view_func_info = f'{view_func.__module__}::{view_func.__name__}'

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -415,8 +415,11 @@ def ckan_after_request(response: Response) -> Response:
     starts = any(url.startswith(s) for s in skip_startswith)
     ends = any(url.endswith(s) for s in skip_endswith)
     if not starts and not ends:
+        view_func = current_app.view_functions.get(request.endpoint)
         log.info(
-            ' %s %s render time %.3f seconds' % (status_code, url, r_time)
+            ' %s %s render time %.3f seconds [view %s]' % (
+                status_code, url, r_time, view_func
+            )
         )
 
     return response

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -416,9 +416,13 @@ def ckan_after_request(response: Response) -> Response:
     ends = any(url.endswith(s) for s in skip_endswith)
     if not starts and not ends:
         view_func = current_app.view_functions.get(request.endpoint)
+        if view_func:
+            view_func_info = f'{view_func.__module__}::{view_func.__name__}'
+        else:
+            view_func_info = 'unknown'
         log.info(
             ' %s %s render time %.3f seconds [view %s]' % (
-                status_code, url, r_time, view_func
+                status_code, url, r_time, view_func_info
             )
         )
 

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -403,7 +403,21 @@ def ckan_after_request(response: Response) -> Response:
     url = request.environ['PATH_INFO']
     status_code = response.status_code
 
-    log.info(' %s %s render time %.3f seconds' % (status_code, url, r_time))
+    # Drop annoying static logs
+    skip_startswith = (
+        '/static/', '/base/', '/webassets/', '/_debug_toolbar/',
+        '/api/i18n/', '/fonts/',
+    )
+    skip_endswith = (
+        '.css', '.js', '.png', '.gif', '.jpg', '.ico', '.svg',
+        '.ttf', '.woff', '.woff2', '.eot',
+    )
+    starts = any(url.startswith(s) for s in skip_startswith)
+    ends = any(url.endswith(s) for s in skip_endswith)
+    if not starts and not ends:
+        log.info(
+            ' %s %s render time %.3f seconds' % (status_code, url, r_time)
+        )
 
     return response
 


### PR DESCRIPTION
### Proposed fixes:

It will be better to be less verbose with this logs

This PR propose to move from

![annoying](https://github.com/ckan/ckan/assets/3237309/86069a9a-b73c-452e-ad5c-dd6cc2dadf66)

to something like

<pre>
ckan-dev4    | 2023-11-24 17:38:57,690 INFO  [ckan.config.middleware.flask_app]  302 /user/login render time 0.028 seconds [view ckan.views.user::login]
ckan-dev4    | 2023-11-24 17:38:57,863 INFO  [ckan.config.middleware.flask_app]  200 / render time 0.167 seconds [view ckan.views.home::index]
ckan-dev4    | 2023-11-24 17:39:00,851 INFO  [ckan.config.middleware.flask_app]  200 /data-container/ render time 0.417 seconds [view ckan.views.group::index]
ckan-dev4    | 2023-11-24 17:39:04,554 INFO  [ckan.config.middleware.flask_app]  200 /dataset/ render time 0.248 seconds [view ckan.views.dataset::search]
ckan-dev4    | 2023-11-24 17:39:07,724 INFO  [ckan.config.middleware.flask_app]  200 /dataset/test-dataset-19 render time 0.701 seconds [view ckan.views.dataset::read]
ckan-dev4    | 2023-11-24 17:39:15,156 INFO  [ckan.config.middleware.flask_app]  200 /dataset/activity/test-dataset-19 render time 0.529 seconds [view ckanext.activity.views::package_activity]
ckan-dev4    | 2023-11-24 17:41:16,438 INFO  [ckan.config.middleware.flask_app]  200 /dashboard/ render time 0.258 seconds [view ckanext.activity.views::dashboard]
ckan-dev4    | 2023-11-24 17:41:19,671 INFO  [ckan.config.middleware.flask_app]  200 /dashboard/requests render time 0.103 seconds [view ckanext.unhcr.blueprints.dashboard::requests]
</pre>

Sometimes I'm not sure which view is the one responding a request.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
