### PR TITLE
DataPusher Validation Support

### DIFF
--- a/ckanext/datapusher/config_declaration.yaml
+++ b/ckanext/datapusher/config_declaration.yaml
@@ -49,3 +49,13 @@ groups:
       In case a DataPusher task gets stuck and fails to recover, this is the minimum
       amount of time (in seconds) after a resource is submitted to DataPusher that the
       resource can be submitted again.
+
+  - key: ckan.datapusher.requires_validation
+    default: False
+    example: True
+    description: >-
+        Resources are required to pass validation from the ckanext-validation
+        plugin to be able to get DataPushered.
+    type: bool
+    required: false
+

--- a/ckanext/datapusher/plugin.py
+++ b/ckanext/datapusher/plugin.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from ckan.common import CKANConfig
 from ckan.types import Action, AuthFunction, Context
 import logging
-from typing import Any, Callable
+from typing import Any, Callable, Union
 
 import ckan.model as model
 import ckan.plugins as p
@@ -12,6 +12,8 @@ import ckanext.datapusher.views as views
 import ckanext.datapusher.helpers as helpers
 import ckanext.datapusher.logic.action as action
 import ckanext.datapusher.logic.auth as auth
+
+from ckan.model.domain_object import DomainObjectOperation, Enum
 
 log = logging.getLogger(__name__)
 
@@ -26,7 +28,7 @@ class DatapusherPlugin(p.SingletonPlugin):
     p.implements(p.IConfigurable, inherit=True)
     p.implements(p.IActions)
     p.implements(p.IAuthFunctions)
-    p.implements(p.IResourceUrlChange)
+    p.implements(p.IDomainObjectModification)
     p.implements(p.IResourceController, inherit=True)
     p.implements(p.ITemplateHelpers)
     p.implements(p.IBlueprint)
@@ -54,13 +56,41 @@ class DatapusherPlugin(p.SingletonPlugin):
                     format(config_option)
                 )
 
-    # IResourceUrlChange
+    # IDomainObjectModification
 
-    def notify(self, resource: model.Resource):
+    def notify(self, entity: Union[model.Resource, model.Package],
+               operation: Enum[str]):
+        """
+        Runs before_commit to database for Packages and Resources.
+        We only want to check for changed Resources for this.
+        We want to check if values have changed, namely the url.
+        See: ckan/model/modification.py.DomainObjectModificationExtension
+        """
+        if operation != DomainObjectOperation.changed \
+           or not isinstance(entity, model.Resource):
+            return
+
+        # If the resource requires validation, stop here if validation
+        # has not been performed or did not succeed. The Validation
+        # extension will call resource_patch and this method should
+        # be called again. However, url_changed will not be in the entity
+        # once Validation does the patch.
+        if p.toolkit.h.plugin_loaded('validation') and \
+           p.toolkit.asbool(p.toolkit.config.get(
+                                'ckan.datapusher.requires_validation')):
+            if entity.__dict__.get(
+               'extras', {}).get('validation_status', None) != 'success':
+                log.debug('Skipping DataPusher submission for '
+                          'resource %s because resource has not '
+                          'passed validation yet.', entity.id)
+                return
+        elif not getattr(entity, 'url_changed', False):
+            return
+
         context: Context = {'ignore_auth': True}
         resource_dict = p.toolkit.get_action(u'resource_show')(
             context, {
-                u'id': resource.id,
+                u'id': entity.id,
             }
         )
         self._submit_to_datapusher(resource_dict)
@@ -70,11 +100,27 @@ class DatapusherPlugin(p.SingletonPlugin):
     def after_resource_create(
             self, context: Context, resource_dict: dict[str, Any]):
 
+        if p.toolkit.h.plugin_loaded('validation') and \
+           p.toolkit.asbool(p.toolkit.config.get(
+                                'ckan.datapusher.requires_validation')) and \
+           resource_dict.get('validation_status', None) != 'success':
+            log.debug('Skipping DataPusher submission for '
+                      'resource %s because resource has not '
+                      'passed validation yet.', resource_dict.get('id'))
+            return
         self._submit_to_datapusher(resource_dict)
 
     def after_update(
             self, context: Context, resource_dict: dict[str, Any]):
 
+        if p.toolkit.h.plugin_loaded('validation') and \
+           p.toolkit.asbool(p.toolkit.config.get(
+                                'ckan.datapusher.requires_validation')) and \
+           resource_dict.get('validation_status', None) != 'success':
+            log.debug('Skipping DataPusher submission for '
+                      'resource %s because resource has not '
+                      'passed validation yet.', resource_dict.get('id'))
+            return
         self._submit_to_datapusher(resource_dict)
 
     def _submit_to_datapusher(self, resource_dict: dict[str, Any]):


### PR DESCRIPTION
feat(dev): adds validation extension support;

- Add config option for resources to require validation.
- Only submit to datapusher if validation is successful.

### Proposed features:

Adds support for the `ckanext-validation` plugin. Behind the new config option `ckan.datapusher.requires_validation`, Resources will be required to be validated before being DataPushered.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
