### PR TITLE
Allow custom org types for activities

### DIFF
--- a/changes/7943.bugfix
+++ b/changes/7943.bugfix
@@ -1,0 +1,2 @@
+URLs in activities always points to `/organization/*` but custom org types
+requeres `/custom-organization/*` URLs. This fixes those links.  

--- a/ckanext/activity/templates/organization/activity_stream.html
+++ b/ckanext/activity/templates/organization/activity_stream.html
@@ -8,7 +8,7 @@
     {% snippet 'snippets/activity_type_selector.html', id=id, activity_type=activity_type, activity_types=activity_types, blueprint='activity.organization_activity' %}
   {% endif %}
 
-  {% snippet 'snippets/stream.html', activity_stream=activity_stream, id=id, object_type='organization' %}
+  {% snippet 'snippets/stream.html', activity_stream=activity_stream, id=id, object_type='organization', group_type=group_type %}
 
   {% snippet 'snippets/pagination.html', newer_activities_url=newer_activities_url, older_activities_url=older_activities_url %}
 {% endblock %}

--- a/ckanext/activity/templates/snippets/stream.html
+++ b/ckanext/activity/templates/snippets/stream.html
@@ -14,7 +14,7 @@
 {% endmacro %}
 
 {% macro organization(activity) %}
-  <a href="{{ h.url_for('organization.read', id=activity.object_id) }}">
+  <a href="{{ h.url_for(group_type ~ '.read', id=activity.object_id) }}">
     {{ activity.data.group.title if activity.data.group else _('unknown') }}
   </a>
 {% endmacro %}

--- a/ckanext/activity/tests/test_views.py
+++ b/ckanext/activity/tests/test_views.py
@@ -46,6 +46,18 @@ class TestOrganization(object):
         response = app.get(url)
         assert user["fullname"] in response
         assert "created the organization" in response
+        assert_group_link_in_response(org, response)
+
+    def test_simple_for_custom_org_type(self, app):
+        """Checking the template shows the activity stream."""
+        user = factories.User()
+        org = factories.Organization(user=user, type="custom_org_type")
+
+        url = url_for("activity.organization_activity", id=org["id"])
+        response = app.get(url)
+        assert user["fullname"] in response
+        assert "created the organization" in response
+        assert_group_link_in_response(org, response)
 
     def test_create_organization(self, app):
         user = factories.User()

--- a/ckanext/activity/tests/test_views.py
+++ b/ckanext/activity/tests/test_views.py
@@ -34,7 +34,7 @@ def assert_group_link_in_response(group, response):
     )
 
 
-@pytest.mark.ckan_config("ckan.plugins", "activity")
+@pytest.mark.ckan_config("ckan.plugins", "activity example_igroupform")
 @pytest.mark.usefixtures("with_plugins", "clean_db")
 class TestOrganization(object):
     def test_simple(self, app):
@@ -51,7 +51,7 @@ class TestOrganization(object):
     def test_simple_for_custom_org_type(self, app):
         """Checking the template shows the activity stream."""
         user = factories.User()
-        org = factories.Organization(user=user, type="custom_org_type")
+        org = factories.Organization(user=user, type="grup")
 
         url = url_for("activity.organization_activity", id=org["id"])
         response = app.get(url)

--- a/ckanext/activity/views.py
+++ b/ckanext/activity/views.py
@@ -510,6 +510,7 @@ def group_activity(id: str, group_type: str) -> str:
     except (tk.ObjectNotFound, tk.NotAuthorized):
         tk.abort(404, tk._("Group not found"))
 
+    real_group_type = group_dict["type"]
     action_name = "organization_activity_list"
     if not group_dict.get("is_organization"):
         action_name = "group_activity_list"
@@ -563,7 +564,7 @@ def group_activity(id: str, group_type: str) -> str:
     extra_vars = {
         "id": id,
         "activity_stream": activity_stream,
-        "group_type": group_type,
+        "group_type": real_group_type,
         "group_dict": group_dict,
         "activity_type": activity_type,
         "activity_types": filter_types.keys(),


### PR DESCRIPTION
For activities list, fixes custom organization types URLs

### Proposed fixes:

Detect the actual organization type to properly build link in org activities list

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
