### PR TITLE
Views Create CLI Sub-Command Fixes

### DIFF
--- a/changes/7944.bugfix
+++ b/changes/7944.bugfix
@@ -1,0 +1,1 @@
+Fixed issues with the `ckan views create` CLI sub-command.

--- a/ckan/cli/views.py
+++ b/ckan/cli/views.py
@@ -223,7 +223,7 @@ def _get_view_plugins(view_plugin_types: list[str],
 
 
 def _search_datasets(
-        context: Context = {},
+        context: Context,
         page: int = 1, view_types: Optional[list[str]] = None,
         dataset: Optional[list[str]] = None, search: str = u"",
         no_default_filters: bool = False

--- a/ckan/cli/views.py
+++ b/ckan/cli/views.py
@@ -61,7 +61,8 @@ def create(ctx: click.Context, types: list[str], dataset: list[str],
     page = 1
     while True:
         query = _search_datasets(
-            page, loaded_view_plugins, dataset, search, no_default_filters
+            context, page, loaded_view_plugins,
+            dataset, search, no_default_filters
         )
         if query is None:
             return
@@ -222,6 +223,7 @@ def _get_view_plugins(view_plugin_types: list[str],
 
 
 def _search_datasets(
+        context: Context = {},
         page: int = 1, view_types: Optional[list[str]] = None,
         dataset: Optional[list[str]] = None, search: str = u"",
         no_default_filters: bool = False
@@ -262,12 +264,12 @@ def _search_datasets(
 
     elif not no_default_filters:
 
-        _add_default_filters(search_data_dict, view_types)
+        search_data_dict = _add_default_filters(search_data_dict, view_types)
 
     if not search_data_dict.get(u"q"):
         search_data_dict[u"q"] = u"*:*"
 
-    query = logic.get_action(u"package_search")({}, search_data_dict)
+    query = logic.get_action(u"package_search")(context, search_data_dict)
 
     return query
 


### PR DESCRIPTION
fix(cli): minor fixes to views create;

- Fixed no context in `package_search`.
- Fixed return set for default filters.

### Proposed fixes:

The cli sub-command of `ckan views create` does not give the `package_search` action call a context, which can cause it to return no results.

Also the default filters for the query were not getting set.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
