### PR TITLE
Fix symlink in example extension

### DIFF
--- a/ckanext/example_theme_docs/v12_extra_public_dir/templates/home/index.html
+++ b/ckanext/example_theme_docs/v12_extra_public_dir/templates/home/index.html
@@ -1,0 +1,1 @@
+/home/adria/dev/pyenvs/ckan-py3/src/ckan/ckanext/example_theme_docs/v11_HTML_and_CSS/templates/home/index.html

--- a/ckanext/example_theme_docs/v12_extra_public_dir/templates/home/index.html
+++ b/ckanext/example_theme_docs/v12_extra_public_dir/templates/home/index.html
@@ -1,1 +1,1 @@
-/home/adria/dev/pyenvs/ckan-py3/src/ckan/ckanext/example_theme_docs/v11_HTML_and_CSS/templates/home/index.html
+../../../v11_HTML_and_CSS/templates/home/index.html

--- a/ckanext/example_theme_docs/v12_extra_public_dir/templates/home/layout.html
+++ b/ckanext/example_theme_docs/v12_extra_public_dir/templates/home/layout.html
@@ -1,1 +1,0 @@
-../../../v11_HTML_and_CSS/templates/home/layout1.html


### PR DESCRIPTION
This was an error introduced in #7677, that was making `extract_messages` fail:

    python setup.py extract_messages
    running extract_messages
    error: [Errno 2] No such file or directory:
    .../ckan/ckanext/example_theme_docs/v12_extra_public_dir/templates/home/layout.html'

