### PR TITLE
Include `AttributeError` in the except handle of license retrieval 

### DIFF
--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -94,7 +94,7 @@ def read(package_type: str, id: str, resource_id: str) -> Union[Response, str]:
     try:
         package[u'isopen'] = model.Package.get_license_register()[license_id
                                                                   ].isopen()
-    except KeyError:
+    except (KeyError, AttributeError):
         package[u'isopen'] = False
 
     resource_views = get_action(u'resource_view_list')(


### PR DESCRIPTION
Fixes #7931

### Proposed fixes:
If license object returned by `model.Package.get_license_register()[license_id]` does not have an `isopen` attribute or method, trying to call` isopen()` would result in an `AttributeError`, as well if `model.Package.get_license_register()[license_id]` evaluates to None. Currently, only `KeyErrors` are being caught. Hence, it is advisable to include AttributeError in the except handle of license retrieval (https://github.com/ckan/ckan/blob/master/ckan/views/resource.py#L97)

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
