### PR TITLE
Fix Incorrect date format error in test_index_date_field test #7957

### DIFF
--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -7,6 +7,7 @@ import logging
 import collections
 import json
 import re
+import datetime
 from dateutil.parser import parse, ParserError as DateParserError
 from typing import Any, NoReturn, Optional
 
@@ -230,9 +231,10 @@ class PackageSearchIndex(SearchIndex):
                     continue
                 try:
                     date = parse(value)
-                    value = date.isoformat()
-                    if not date.tzinfo:
-                        value += 'Z'
+                    if date.tzinfo:
+                        date = date.astimezone(datetime.timezone(offset=datetime.timedelta(0)))
+                    #isoformat, using Z instead of +##:## offset
+                    value = date.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
                 except DateParserError:
                     log.warning('%r: %r value of %r is not a valid date', pkg_dict['id'], key, value)
                     continue


### PR DESCRIPTION
Fixes #7957

### Proposed fixes:

* Handle timezone conversion in the datetime object
* Use datetime.strftime instead of .isoformat to use the correct isoformat.

Note, we may need to treat dates separately from datetimes here -- they may be better off as nieve dates rather than converted to datetimes. (e.g., year end shouldn't be offset from UTC) 

Tests still TBD, as this is fixing a test failure that wasn't picked up on our test infra.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
