### PR TITLE
Bumped `greenlet` and ` lxml` versions

### DIFF
--- a/changes/7952.bugfix
+++ b/changes/7952.bugfix
@@ -1,0 +1,1 @@
+Bumped greenlet and lxml versions.

--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,7 @@ Flask==2.3.3
 Flask-Babel==3.1.0
 Flask-Login==0.6.2
 Flask-WTF==1.1.1
-greenlet>=2.0.2
+greenlet>=3.0.1
 Jinja2==3.1.2
 Markdown==3.4.4
 passlib==1.7.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ flask-login==0.6.2
     # via -r requirements.in
 flask-wtf==1.1.1
     # via -r requirements.in
-greenlet==2.0.2
+greenlet==3.0.1
     # via
     #   -r requirements.in
     #   sqlalchemy
@@ -66,7 +66,7 @@ jinja2==3.1.2
     #   -r requirements.in
     #   flask
     #   flask-babel
-lxml==4.9.1
+lxml==4.9.3
     # via feedgen
 mako==1.2.2
     # via alembic


### PR DESCRIPTION
Fixes #7952

### Proposed fixes:
`greenlet` bumped to 3.0.1 and `lxml` bumped to 4.9.3.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
