### PR TITLE
Apply migrations from plugins during `ckan db upgrade`

### DIFF
--- a/changes/7961.feature
+++ b/changes/7961.feature
@@ -1,0 +1,3 @@
+``ckan db upgrade`` CLI command automatically applies migrations from
+plugins. Use ``ckan db upgrade --skip-plugins`` if this behavior does not fit
+into your deployment process.

--- a/ckan/tests/cli/test_db.py
+++ b/ckan/tests/cli/test_db.py
@@ -10,6 +10,7 @@ import ckanext.example_database_migrations.plugin as example_plugin
 
 import ckan.model as model
 import ckan.cli.db as db
+from ckan.cli.cli import ckan
 
 
 @pytest.fixture
@@ -98,3 +99,21 @@ class TestMigrations:
         assert db._get_pending_plugins() == {"example_database_migrations": 1}
         db._run_migrations(u'example_database_migrations')
         assert db._get_pending_plugins() == {}
+
+    @pytest.mark.usefixtures("with_extended_cli")
+    def test_upgrade_applies_plugin_migrations(self, cli):
+        """`db upgrade` command automatically applies all pending migrations
+        from plugins.
+
+        """
+        cli.invoke(ckan, ["db", "upgrade"])
+        assert db._get_pending_plugins() == {}
+
+    @pytest.mark.usefixtures("with_extended_cli")
+    def test_upgrade_skips_plugin_migrations(self, cli):
+        """`db upgrade` command can ignore pending migrations from plugins if
+        `--skip-plugins` flag is enabled.
+
+        """
+        cli.invoke(ckan, ["db", "upgrade", "--skip-plugins"])
+        assert db._get_pending_plugins() == {"example_database_migrations": 2}

--- a/doc/maintaining/database-management.rst
+++ b/doc/maintaining/database-management.rst
@@ -161,3 +161,7 @@ CKAN database's schema using the ``ckan db upgrade`` command:
 .. parsed-literal::
 
     ckan -c |ckan.ini| db upgrade
+
+This command applies all CKAN core migrations and all unapplied migrations from
+enabled plugins. ``--skip-core`` and ``--skip-plugins`` flags can be used to
+run either only core migration, or only migrations from enabled plugins.


### PR DESCRIPTION
By default, `db upgrade` applies migrations from all enabled plugins. 
To run only core migrations, add `--skip-plugins` flag. To run only plugins' migrations, add `--skip-core` flag. 
`db pending-migration` suggests using `db upgrade` when it executed for migration. I haven't removed it, because it works as an introspection tool that shows a number of unapplied migrations from enabled plugins.