### PR TITLE
Test Response Class Bytes Property

### DIFF
--- a/changes/7982.feature
+++ b/changes/7982.feature
@@ -1,0 +1,1 @@
+Added `bytes` property to the test CKANResponse class which returns bytes from the response data.

--- a/ckan/tests/helpers.py
+++ b/ckan/tests/helpers.py
@@ -175,6 +175,10 @@ class CKANResponse(Response):
     def body(self):
         return self.get_data(as_text=True)
 
+    @property
+    def bytes(self):
+        return self.get_data(as_text=False)
+
     def __contains__(self, segment):
         return segment in self.body
 


### PR DESCRIPTION
feat(tests): add bytes return property to test response class;

- Adds new property to test response class to return bytes.

### Proposed fixes:

Adds a property to the test response class so that users can get bytes from test responses that they expect bytes from, e.g. file download etc.

### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
