### PR TITLE
Fix Wrong facet function called when defining a custom group #7654

### DIFF
--- a/changes/7654.bugfix
+++ b/changes/7654.bugfix
@@ -1,0 +1,1 @@
+Wrong facet function called when defining a custom group is solved.

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -382,9 +382,10 @@ def _update_facet_titles(
         facets: 'OrderedDict[str, str]',
         group_type: str) -> 'OrderedDict[str, str]':
     for plugin in plugins.PluginImplementations(plugins.IFacets):
+        registered_groups = [h.default_group_type("group")]
         facets = (
             plugin.group_facets(facets, group_type, None)
-            if group_type == "group"
+            if group_type in registered_groups
             else plugin.organization_facets(facets, group_type, None)
         )
     return facets


### PR DESCRIPTION
Fixes #
Wrong facet function called when defining a custom group is fixed in this PR.
#7654 
