### PR TITLE
Remove mention of username change in Documentation

### DIFF
--- a/changes/8000.misc
+++ b/changes/8000.misc
@@ -1,0 +1,1 @@
+Remove mentions of username change in documentation

--- a/doc/sysadmin-guide.rst
+++ b/doc/sysadmin-guide.rst
@@ -142,7 +142,7 @@ profile, so they cannot search by e-mail address.
 
 On their user profile, you will see a "Manage" button. CKAN displays the user
 settings page. You can delete the user or change any of its settings, including
-their username, name and password.
+their name and password.
 
 .. image:: /images/manage_users.jpg
 

--- a/doc/user-guide.rst
+++ b/doc/user-guide.rst
@@ -613,8 +613,6 @@ page.
 
 CKAN displays the user settings page. Here you can change:
 
-* Your username
-
 * Your full name
 
 * Your e-mail address (note: this is not displayed to other users)
@@ -625,7 +623,3 @@ CKAN displays the user settings page. Here you can change:
 
 Make the changes you require and then select the "Update Profile" button.
 
-.. note::
-
-    If you change your username, CKAN will log you out. You will need to log
-    back in using your new username.


### PR DESCRIPTION
### Proposed fixes:
Due to #4193 , changing of the username is not possible. However, the documentation still mentioned that possibility, leading to possible confusion. This part of the documentation is removed in this PR.


### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
