### PR TITLE
fix jinja2 output format in cookiecutter post_gen script

### DIFF
--- a/contrib/cookiecutter/ckan_extension/hooks/post_gen_project.py
+++ b/contrib/cookiecutter/ckan_extension/hooks/post_gen_project.py
@@ -36,7 +36,7 @@ def recut():
     setup_template = 'setup.py'
 
     # get context
-    context = {{ cookiecutter | jsonify }}
+    context = {{ dict(cookiecutter) }}
 
     # Process keywords
     keywords = context['keywords'].strip().split()
@@ -68,6 +68,6 @@ def recut():
 
 
 if __name__ == '__main__':
-    context = {{ cookiecutter | jsonify }}
+    context = {{ dict(cookiecutter) }}
     if context['_source'] == 'local':
         recut()


### PR DESCRIPTION
jinja2 produces python script here and we can't embed json directy in python.

### Proposed fixes:

convert OrderedDict to plain dict, and then output it directly in template.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
