### PR TITLE
[activity plugin] fix server error on changes page for new resource

### DIFF
--- a/ckanext/activity/templates/package/snippets/change_item.html
+++ b/ckanext/activity/templates/package/snippets/change_item.html
@@ -4,7 +4,7 @@
 <ul>
   {% for change in changes %}
     {% snippet "snippets/changes/{}.html".format(
-      change.type), change=change %}
+      change.type), change=change, dataset_type=activity_diff.activities[1].data.package.type %}
     <br>
   {% endfor %}
 </ul>

--- a/ckanext/activity/templates/snippets/changes/new_resource.html
+++ b/ckanext/activity/templates/snippets/changes/new_resource.html
@@ -1,4 +1,3 @@
-{% set dataset_type = request.view_args.package_type %}
 {% set pkg_url = h.url_for(dataset_type ~ '.read', id=change.pkg_id) %}
 {% set resource_url = h.url_for(dataset_type ~ '_resource.read', id=change.pkg_id, resource_id = change.resource_id, qualified=True) %}
 

--- a/ckanext/activity/tests/test_views.py
+++ b/ckanext/activity/tests/test_views.py
@@ -746,7 +746,7 @@ class TestPackage:
         )[0]
         env = {"REMOTE_USER": user["name"]}
         response = app.get(
-            tk.url_for("activity.package_changes", id=activity.id),
+            url_for("activity.package_changes", id=activity.id),
             extra_environ=env,
         )
         assert helpers.body_contains(response, "Added resource")

--- a/ckanext/activity/tests/test_views.py
+++ b/ckanext/activity/tests/test_views.py
@@ -725,6 +725,33 @@ class TestPackage:
         assert helpers.body_contains(response, "First")
         assert helpers.body_contains(response, "Second")
 
+    def test_changes_with_new_resource(self, app):
+        user = factories.User()
+        dataset = factories.Dataset(title="First title", user=user)
+        resource_name = "Image 1"
+        helpers.call_action(
+            "package_patch",
+            id=dataset["id"],
+            resources=[
+                {
+                    "url": "http://example.com/image.png",
+                    "format": "png",
+                    "name": resource_name,
+                }
+            ],
+        )
+
+        activity = activity_model.package_activity_list(
+            dataset["id"], limit=1, offset=0
+        )[0]
+        env = {"REMOTE_USER": user["name"]}
+        response = app.get(
+            tk.url_for("activity.package_changes", id=activity.id),
+            extra_environ=env,
+        )
+        assert helpers.body_contains(response, "Added resource")
+        assert helpers.body_contains(response, resource_name)
+
     @pytest.mark.ckan_config("ckan.activity_list_limit", "3")
     def test_invalid_get_params(self, app):
 


### PR DESCRIPTION
Displaying changes page (`dataset/changes/<id>`) trigger server error if new resource is added.
This is because `package_type` cannot be found in `request.view_args` [ckanext/activity/templates/snippets/changes/new_resource.html#L1](https://github.com/ckan/ckan/blob/7774249a5e43057fb6560312e0e2074b6d38e840/ckanext/activity/templates/snippets/changes/new_resource.html#L1)

### Proposed fixes:
This fix sends the `dataset_type` from `change_item.html` file. Alternatively we could hard-coded to the value `dataset` as it has been done in [resource_format.html](https://github.com/ckan/ckan/blob/7774249a5e43057fb6560312e0e2074b6d38e840/ckanext/activity/templates/snippets/changes/resource_format.html#L26)


### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
