### PR TITLE
Catch ignorable sqlalchemy error more.

### DIFF
--- a/ckan/model/system_info.py
+++ b/ckan/model/system_info.py
@@ -11,7 +11,7 @@ from typing import Any, Optional
 
 from sqlalchemy import types, Column, Table
 from sqlalchemy.orm import Mapped
-from sqlalchemy.exc import ProgrammingError
+from sqlalchemy.exc import ProgrammingError, OperationalError
 
 
 import ckan.model.meta as meta
@@ -55,7 +55,7 @@ def get_system_info(key: str, default: Optional[str]=None) -> Optional[str]:
         meta.Session.commit()
         if obj:
             return obj.value
-    except ProgrammingError:
+    except (ProgrammingError,OperationalError):
         meta.Session.rollback()
     return default
 


### PR DESCRIPTION
I tried to run `ckan init db` for sqlite database file. `ckan` fails on startup at loading configuration. With postgresql, errors are thrown in `sqlalchemy.exc.ProgrammingError` and handled.

If table was missing, postgresql driver throws `sqlalchemy.exc.ProgrammingError`.

```
(psycopg2.errors.UndefinedTable) relation "system_info" does not exist
LINE 2: FROM system_info
             ^
```

While sqlite driver throws `sqlalchemy.exc.OperationalError`.

```
(sqlite3.OperationalError) no such table: system_info
[SQL: SELECT system_info.id AS system_info_id, system_info."key" AS system_info_key, system_info.value AS system_info_value, system_info.state AS system_info_state
FROM system_info
WHERE system_info."key" = ?
 LIMIT ? OFFSET ?]
[parameters: ('ckan.site_title', 1, 0)]
```

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
