### PR TITLE
IDataDictionaryForm for extending and validating datastore data dictionary fields

### DIFF
--- a/changes/7971.feature
+++ b/changes/7971.feature
@@ -1,1 +1,8 @@
-IDataDictionaryForm for extending and validating datastore data dictionary fields
+IDataDictionaryForm for extending and validating new keys in the `fields`
+dicts. Unlike the `info` free-form dict these new keys are possible to
+tightly control with a schema. The schema is built by combining schemas
+from from all plugins implementing this interface so plugins implementing
+different features may all contribute to the same schema.
+
+The underlying storage for data dictionary fields has changed. Use:
+`ckan datastore upgrade` after upgrading to this release.

--- a/changes/7971.feature
+++ b/changes/7971.feature
@@ -1,0 +1,1 @@
+IDataDictionaryForm for extending and validating datastore data dictionary fields

--- a/ckan/types/__init__.py
+++ b/ckan/types/__init__.py
@@ -132,6 +132,7 @@ class Context(TypedDict, total=False):
     with_capacity: bool
 
     table_names: list[str]
+    plugin_data: dict[Any, Any]
 
 
 class AuthResult(TypedDict, total=False):

--- a/ckanext/datastore/backend/__init__.py
+++ b/ckanext/datastore/backend/__init__.py
@@ -230,3 +230,6 @@ class DatastoreBackend:
         """Called by `datastore_function_delete` action.
         """
         raise NotImplementedError()
+
+    def resource_plugin_data(self, resource_id: str) -> dict[str, Any]:
+        raise NotImplementedError()

--- a/ckanext/datastore/backend/__init__.py
+++ b/ckanext/datastore/backend/__init__.py
@@ -108,7 +108,11 @@ class DatastoreBackend:
 
         return config
 
-    def create(self, context: Context, data_dict: dict[str, Any]) -> Any:
+    def create(
+            self,
+            context: Context,
+            data_dict: dict[str, Any],
+            plugin_data: dict[int, dict[str, Any]]) -> Any:
         """Create new resourct inside datastore.
 
         Called by `datastore_create`.

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1078,16 +1078,17 @@ def create_table(
 
     info_sql = []
     for i, f in enumerate(supplied_fields):
-        ccom = plugin_data.get(i, {})
+        column_comment = plugin_data.get(i, {})
         info = f.get(u'info')
         if isinstance(info, dict):
-            ccom['_info'] = info
-        if ccom:
+            column_comment['_info'] = info
+        if column_comment:
             info_sql.append(u'COMMENT ON COLUMN {0}.{1} is {2}'.format(
                 identifier(data_dict['resource_id']),
                 identifier(f['id']),
                 literal_string(' ' + json.dumps(  # ' ' prefix for data version
-                        ccom, ensure_ascii=False, separators=(',', ':')))))
+                    column_comment, ensure_ascii=False, separators=(',', ':')))
+            ))
 
     context['connection'].execute(sa.text(
         sql_string + u';'.join(info_sql).replace(':', r'\:')  # no bind params
@@ -1179,12 +1180,12 @@ def alter_table(
                 raw.update(plugin_data[i])
 
             # ' ' prefix for data version
-            raw_sql = literal_string(' ' + json.dumps(
+            column_comment = literal_string(' ' + json.dumps(
                 raw, ensure_ascii=False, separators=(',', ':')))
             alter_sql.append(u'COMMENT ON COLUMN {0}.{1} is {2}'.format(
                 identifier(data_dict['resource_id']),
                 identifier(f['id']),
-                raw_sql))
+                column_comment))
 
     if data_dict['delete_fields']:
         for id_ in current_ids - field_ids - set(f['id'] for f in new_fields):

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1172,7 +1172,9 @@ def alter_table(
                 identifier(id_)))
 
     if alter_sql:
-        context['connection'].execute(';'.join(alter_sql))
+        context['connection'].execute(sa.text(
+            ';'.join(alter_sql).replace(':', r'\:')  # no bind params
+        ))
 
 
 def insert_data(context: Context, data_dict: dict[str, Any]):

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1172,9 +1172,7 @@ def alter_table(
                 identifier(id_)))
 
     if alter_sql:
-        context['connection'].execute(sa.text(
-            ';'.join(alter_sql)
-        ))
+        context['connection'].execute(';'.join(alter_sql))
 
 
 def insert_data(context: Context, data_dict: dict[str, Any]):
@@ -2216,8 +2214,10 @@ class DatastorePostgresqlBackend(DatastoreBackend):
             real_id = row[0]
         return res_exists, real_id
 
-    # def resource_info(self, id):
-    #     pass
+    def resource_plugin_data(self, id: str) -> dict[str, Any]:
+        engine = self._get_read_engine()
+        with engine.connect() as conn:
+            return _get_field_info(conn, id, raw=True)
 
     def resource_fields(self, id: str) -> dict[str, Any]:
 

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1069,7 +1069,8 @@ def create_table(
                         ccom, ensure_ascii=False, separators=(',', ':')))))
 
     context['connection'].execute(sa.text(
-        sql_string + u';'.join(info_sql)))
+        sql_string + u';'.join(info_sql).replace(':', r'\:')  # no bind params
+    ))
 
 
 def alter_table(
@@ -1142,7 +1143,7 @@ def alter_table(
             identifier(f['id']),
             f['type']))
 
-    if any('info' in f for f in supplied_fields):
+    if plugin_data or any('info' in f for f in supplied_fields):
         raw_field_info = _get_field_info(
             context['connection'],
             data_dict['resource_id'],
@@ -1150,11 +1151,10 @@ def alter_table(
         )
 
         for i, f in enumerate(supplied_fields):
-            if 'info' not in f or not isinstance(f['info'], dict):
-                continue
             raw = raw_field_info.get(f['id'], {})
 
-            raw['_info'] = f['info']
+            if 'info' in f and isinstance(f['info'], dict):
+                raw['_info'] = f['info']
             if i in plugin_data:
                 raw.update(plugin_data[i])
 

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -280,14 +280,11 @@ def _get_unique_key(context: Context, data_dict: dict[str, Any]) -> list[str]:
 def _get_field_info(
         connection: Any,
         resource_id: str,
-        raw: bool = False,
         ) -> dict[str, Any]:
     '''return a dictionary mapping column names to their info data,
     when present'''
     qtext = sa.text(
-        '''select pa.attname as name, pd.description'''
-        + ('' if raw else "::json -> '_info'") +
-        ''' as info
+        '''select pa.attname as name, pd.description::json -> '_info' as info
         from pg_class pc, pg_attribute pa, pg_description pd
         where pa.attrelid = pc.oid and pd.objoid = pc.oid
             and pd.objsubid = pa.attnum and pc.relname = :res_id
@@ -299,6 +296,30 @@ def _get_field_info(
             connection.execute(qtext, {"res_id": resource_id}).fetchall())
     except (TypeError, ValueError):  # don't die on non-json comments
         return {}
+
+
+def _get_raw_field_info(
+        connection: Any,
+        resource_id: str,
+        ) -> tuple[dict[str, Any], bool]:
+    '''return a dictionary mapping column names to their raw info data,
+    when present and a flag if old data schema is present (for upgrade)'''
+    qtext = sa.text(
+        '''select pa.attname as name, pd.description as info,
+            substring(pd.description for 1) = '{' as old_schema
+        from pg_class pc, pg_attribute pa, pg_description pd
+        where pa.attrelid = pc.oid and pd.objoid = pc.oid
+            and pd.objsubid = pa.attnum and pc.relname = :res_id
+            and pa.attnum > 0'''
+    )
+    try:
+        results = list(connection.execute(
+            qtext, {"res_id": resource_id}).fetchall())
+        return {
+            n: json.loads(v) for n, v, _old in results
+            }, any(old for _n, _v, old in results)
+    except (TypeError, ValueError):  # don't die on non-json comments
+        return {}, False
 
 
 def _get_fields(connection: Any, resource_id: str):
@@ -1065,7 +1086,7 @@ def create_table(
             info_sql.append(u'COMMENT ON COLUMN {0}.{1} is {2}'.format(
                 identifier(data_dict['resource_id']),
                 identifier(f['id']),
-                literal_string(json.dumps(
+                literal_string(' ' + json.dumps(  # ' ' prefix for data version
                         ccom, ensure_ascii=False, separators=(',', ':')))))
 
     context['connection'].execute(sa.text(
@@ -1144,10 +1165,9 @@ def alter_table(
             f['type']))
 
     if plugin_data or any('info' in f for f in supplied_fields):
-        raw_field_info = _get_field_info(
+        raw_field_info, _old = _get_raw_field_info(
             context['connection'],
             data_dict['resource_id'],
-            raw=True,
         )
 
         for i, f in enumerate(supplied_fields):
@@ -1158,7 +1178,8 @@ def alter_table(
             if i in plugin_data:
                 raw.update(plugin_data[i])
 
-            raw_sql = literal_string(json.dumps(
+            # ' ' prefix for data version
+            raw_sql = literal_string(' ' + json.dumps(
                 raw, ensure_ascii=False, separators=(',', ':')))
             alter_sql.append(u'COMMENT ON COLUMN {0}.{1} is {2}'.format(
                 identifier(data_dict['resource_id']),
@@ -2219,7 +2240,8 @@ class DatastorePostgresqlBackend(DatastoreBackend):
     def resource_plugin_data(self, id: str) -> dict[str, Any]:
         engine = self._get_read_engine()
         with engine.connect() as conn:
-            return _get_field_info(conn, id, raw=True)
+            plugin_data, _old = _get_raw_field_info(conn, id)
+            return plugin_data
 
     def resource_fields(self, id: str) -> dict[str, Any]:
 

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -280,19 +280,19 @@ def _get_unique_key(context: Context, data_dict: dict[str, Any]) -> list[str]:
 def _get_field_info(
         connection: Any,
         resource_id: str,
-        raw: bool=False,
+        raw: bool = False,
         ) -> dict[str, Any]:
-    u'''return a dictionary mapping column names to their info data,
+    '''return a dictionary mapping column names to their info data,
     when present'''
-    qtext = sa.text(u'''
-        select pa.attname as name, pd.description'''
-        + (u'' if raw else u"::json -> '_info'") +
-        u''' as info
+    qtext = sa.text(
+        '''select pa.attname as name, pd.description'''
+        + ('' if raw else "::json -> '_info'") +
+        ''' as info
         from pg_class pc, pg_attribute pa, pg_description pd
         where pa.attrelid = pc.oid and pd.objoid = pc.oid
             and pd.objsubid = pa.attnum and pc.relname = :res_id
-            and pa.attnum > 0
-    ''')
+            and pa.attnum > 0'''
+    )
     try:
         return dict(
             (n, json.loads(v)) for (n, v) in

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -137,14 +137,9 @@ class DictionaryView(MethodView):
     def _prepare(self, id: str, resource_id: str) -> dict[str, Any]:
         try:
             # resource_edit_base template uses these
-            pkg_dict = get_action(u'package_show')({}, {u'id': id})
-            resource = get_action(u'resource_show')({}, {u'id': resource_id})
-            rec = get_action(u'datastore_search')(
-                {}, {
-                    u'resource_id': resource_id,
-                    u'limit': 0
-                }
-            )
+            pkg_dict = get_action(u'package_show')({}, {'id': id})
+            resource = get_action(u'resource_show')({}, {'id': resource_id})
+            rec = get_action(u'datastore_info')({}, {'id': resource_id})
             return {
                 u'pkg_dict': pkg_dict,
                 u'resource': resource,
@@ -176,16 +171,20 @@ class DictionaryView(MethodView):
         if not isinstance(info, list):
             info = []
         info = info[:len(fields)]
+        custom = data.get(u'custom')
+        if not isinstance(custom, list):
+            custom = []
 
         get_action(u'datastore_create')(
             {}, {
                 u'resource_id': resource_id,
                 u'force': True,
-                u'fields': [{
-                    u'id': f[u'id'],
-                    u'type': f[u'type'],
-                    u'info': fi if isinstance(fi, dict) else {}
-                } for f, fi in zip_longest(fields, info)]
+                u'fields': [dict(
+                    cu or {},
+                    id=f['id'],
+                    type=f['type'],
+                    info=fi if isinstance(fi, dict) else {}
+                ) for f, fi, cu in zip_longest(fields, info, custom)]
             }
         )
 

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -180,7 +180,7 @@ class DictionaryView(MethodView):
         if not isinstance(info, list):
             info = []
         info = info[:len(fields)]
-        custom = data.get(u'fields')
+        custom = data.get('fields')
         if not isinstance(custom, list):
             custom = []
 

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -14,7 +14,7 @@ from ckan.logic import (
 )
 from ckan.plugins.toolkit import (
     ObjectNotFound, NotAuthorized, get_action, get_validator, _, request,
-    abort, render, g, h
+    abort, render, g, h, ValidationError
 )
 from ckan.types import Schema, ValidatorFactory
 from ckanext.datastore.logic.schema import (
@@ -151,16 +151,25 @@ class DictionaryView(MethodView):
         except (ObjectNotFound, NotAuthorized):
             abort(404, _(u'Resource not found'))
 
-    def get(self, id: str, resource_id: str):
+    def get(self,
+            id: str,
+            resource_id: str,
+            data: Optional[dict[str, Any]] = None,
+            errors: Optional[dict[str, Any]] = None,
+            error_summary: Optional[dict[str, Any]] = None,
+            ):
         u'''Data dictionary view: show field labels and descriptions'''
 
-        data_dict = self._prepare(id, resource_id)
+        template_vars = self._prepare(id, resource_id)
+        template_vars['data'] = data or {}
+        template_vars['errors'] = errors or {}
+        template_vars['error_summary'] = error_summary
 
         # global variables for backward compatibility
-        g.pkg_dict = data_dict[u'pkg_dict']
-        g.resource = data_dict[u'resource']
+        g.pkg_dict = template_vars['pkg_dict']
+        g.resource = template_vars['resource']
 
-        return render(u'datastore/dictionary.html', data_dict)
+        return render('datastore/dictionary.html', template_vars)
 
     def post(self, id: str, resource_id: str):
         u'''Data dictionary view: edit field labels and descriptions'''
@@ -171,22 +180,34 @@ class DictionaryView(MethodView):
         if not isinstance(info, list):
             info = []
         info = info[:len(fields)]
-        custom = data.get(u'custom')
+        custom = data.get(u'fields')
         if not isinstance(custom, list):
             custom = []
 
-        get_action(u'datastore_create')(
-            {}, {
-                u'resource_id': resource_id,
-                u'force': True,
-                u'fields': [dict(
-                    cu or {},
-                    id=f['id'],
-                    type=f['type'],
-                    info=fi if isinstance(fi, dict) else {}
-                ) for f, fi, cu in zip_longest(fields, info, custom)]
-            }
-        )
+        try:
+            get_action('datastore_create')(
+                {}, {
+                    'resource_id': resource_id,
+                    'force': True,
+                    'fields': [dict(
+                        cu or {},
+                        id=f['id'],
+                        type=f['type'],
+                        info=fi if isinstance(fi, dict) else {}
+                    ) for f, fi, cu in zip_longest(fields, info, custom)]
+                }
+            )
+        except ValidationError as e:
+            errors = e.error_dict
+            # flatten field errors for summary
+            error_summary = {}
+            field_errors = errors.get('fields', [])
+            if isinstance(field_errors, list):
+                for i, f in enumerate(field_errors, 1):
+                    if isinstance(f, dict) and f:
+                        error_summary[_('Field %d') % i] = ', '.join(
+                            v for vals in f.values() for v in vals)
+            return self.get(id, resource_id, data, errors, error_summary)
 
         h.flash_success(
             _(

--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -3,15 +3,23 @@
 from typing import Any
 import logging
 import os
+import json
 
 import click
+import sqlalchemy as sa
 
 from ckan.model import parse_db_config
 from ckan.common import config
 import ckan.logic as logic
 
 import ckanext.datastore as datastore_module
-from ckanext.datastore.backend.postgres import identifier
+from ckanext.datastore.backend.postgres import (
+    identifier,
+    literal_string,
+    get_read_engine,
+    get_write_engine,
+    _get_field_info,
+)
 from ckanext.datastore.blueprint import DUMP_FORMATS, dump_to
 
 log = logging.getLogger(__name__)
@@ -175,5 +183,54 @@ def purge():
     click.echo('Dropped %s tables' % drop_count)
 
 
+@datastore.command(
+    'migrate',
+    short_help='migrate datastore field info for plugin_data support'
+)
+def migrate():
+    '''Move field info to _info so that plugins may add private information
+    to each field for their own purposes.'''
+
+    site_user = logic.get_action('get_site_user')({'ignore_auth': True}, {})
+
+    result = logic.get_action('datastore_search')(
+        {'user': site_user['name']},
+        {'resource_id': '_table_metadata'}
+    )
+
+    count = 0
+    skipped = 0
+    noinfo = 0
+    read_connection = get_read_engine()
+    for record in result['records']:
+        if record['alias_of']:
+            continue
+
+        raw_fields = _get_field_info(read_connection, record['name'], raw=True)
+        if any('_info' in f for f in raw_fields.values()):
+            skipped += 1
+            continue
+
+        alter_sql = []
+        with get_write_engine().begin() as connection:
+            for fid, fvalue in raw_fields.items():
+                raw = {'_info': fvalue}
+                raw_sql = literal_string(json.dumps(
+                    raw, ensure_ascii=False, separators=(',', ':')))
+                alter_sql.append(u'COMMENT ON COLUMN {0}.{1} is {2}'.format(
+                    identifier(record['name']),
+                    identifier(fid),
+                    raw_sql))
+
+            if alter_sql:
+                connection.execute(sa.text(';'.join(alter_sql)))
+                count += 1
+            else:
+                noinfo += 1
+
+    click.echo('Migrated %d tables (%d already migrated, %d no info)' % (
+        count, skipped, noinfo))
+
+
 def get_commands():
-    return (set_permissions, dump, purge)
+    return (set_permissions, dump, purge, migrate)

--- a/ckanext/datastore/interfaces.py
+++ b/ckanext/datastore/interfaces.py
@@ -190,7 +190,8 @@ class IDatastoreBackend(interfaces.Interface):
 class IDataDictionaryForm(interfaces.Interface):
     """
     Allow data dictionary validation and per-plugin data storage by extending
-    the datastore_create schema and adding values to fields returned from datastore_info
+    the datastore_create schema and adding values to fields returned from
+    datastore_info
     """
     _reverse_iteration_order = True
 

--- a/ckanext/datastore/interfaces.py
+++ b/ckanext/datastore/interfaces.py
@@ -189,11 +189,12 @@ class IDatastoreBackend(interfaces.Interface):
 
 class IDataDictionaryForm(interfaces.Interface):
     """
-    Allow data dictionary validation and per-plugin data storage
+    Allow data dictionary validation and per-plugin data storage by extending
+    the datastore_create schema and adding values to fields returned from datastore_info
     """
     _reverse_iteration_order = True
 
-    def update_schema(self, schema: Schema) -> Schema:
+    def update_datastore_create_schema(self, schema: Schema) -> Schema:
         """
         Return a modified schema for handling field input in the data
         dictionary form and datastore_create parameters.
@@ -219,17 +220,14 @@ class IDataDictionaryForm(interfaces.Interface):
         """
         return schema
 
-
-class IDatastoreInfoField(interfaces.Interface):
-    """
-    Customize the field data returned by datastore_info
-    """
-    _reverse_iteration_order = True
-
-    def update_field(self, field: dict[str, Any], plugin_data: dict[str, Any]):
+    def update_datastore_info_field(
+            self,
+            field: dict[str, Any],
+            plugin_data: dict[str, Any]):
         """
         Return a modified version of the `datastore_info` field dict
         based on this field's plugin_data to provide additional
-        information to users.
+        information to users and existing values for new form fields
+        in the data dictionary page.
         """
         return field

--- a/ckanext/datastore/interfaces.py
+++ b/ckanext/datastore/interfaces.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 from __future__ import annotations
 
-from ckan.types import Context
+from ckan.types import Context, Schema
 from typing import Any
 import ckan.plugins.interfaces as interfaces
 
@@ -185,3 +185,51 @@ class IDatastoreBackend(interfaces.Interface):
                   value
         """
         return {}
+
+
+class IDataDictionaryForm(interfaces.Interface):
+    """
+    Allow data dictionary validation and per-plugin data storage
+    """
+    _reverse_iteration_order = True
+
+    def update_schema(self, schema: Schema) -> Schema:
+        """
+        Return a modified schema for handling field input in the data
+        dictionary form and datastore_create parameters.
+
+        Validators are provided a `plugin_data` dict in the context
+        that can be used to store per-field values. Top-level keys in this
+        dict should match the field index, second-level keys should match
+        the plugin name and values should be a dict with string keys storing
+        data for that plugin.
+
+        e.g. a statistics plugin that needs to store per-column information
+        might store this with plugin_data by inserting values like:
+
+            {0: {'statistics': {'minimum': 34, ...}, ...}, ...}
+
+                                ^ the data stored for this field+plugin
+                  ^ the name of the plugin
+             ^ 0 for the first field passed in fields
+
+        Values not removed from field info by validation will be available in
+        the field `info` dict returned from `datastore_search` and
+        `datastore_info`
+        """
+        return schema
+
+
+class IDatastoreInfoField(interfaces.Interface):
+    """
+    Customize the field data returned by datastore_info
+    """
+    _reverse_iteration_order = True
+
+    def update_field(self, field: dict[str, Any], plugin_data: dict[str, Any]):
+        """
+        Return a modified version of the `datastore_info` field dict
+        based on this field's plugin_data to provide additional
+        information to users.
+        """
+        return field

--- a/ckanext/datastore/interfaces.py
+++ b/ckanext/datastore/interfaces.py
@@ -207,13 +207,13 @@ class IDataDictionaryForm(interfaces.Interface):
         data for that plugin.
 
         e.g. a statistics plugin that needs to store per-column information
-        might store this with plugin_data by inserting values like:
+        might store this with plugin_data by inserting values like::
 
-            {0: {'statistics': {'minimum': 34, ...}, ...}, ...}
+          {0: {'statistics': {'minimum': 34, ...}, ...}, ...}
 
-                                ^ the data stored for this field+plugin
-                  ^ the name of the plugin
-             ^ 0 for the first field passed in fields
+          #                   ^ the data stored for this field+plugin
+          #     ^ the name of the plugin
+          #^ 0 for the first field passed in fields
 
         Values not removed from field info by validation will be available in
         the field `info` dict returned from `datastore_search` and

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -297,7 +297,8 @@ def datastore_upsert(context: Context, data_dict: dict[str, Any]):
     return result
 
 
-def datastore_info(context: Context, data_dict: dict[str, Any]):
+def datastore_info(context: Context, data_dict: dict[str, Any]
+        ) -> dict[str, Any]:
     '''
     Returns detailed metadata about a resource.
 
@@ -350,10 +351,12 @@ def datastore_info(context: Context, data_dict: dict[str, Any]):
     p.toolkit.get_action('resource_show')(context, {'id': id})
 
     info = backend.resource_fields(id)
-    if not hasattr(backend, 'resource_plugin_data'):
-        return info
 
-    plugin_data = backend.resource_plugin_data(id)
+    try:
+        plugin_data = backend.resource_plugin_data(id)
+    except NotImplementedError:
+        return {}
+
     for i, field in enumerate(info['fields']):
         for plugin in p.PluginImplementations(interfaces.IDataDictionaryForm):
             field = plugin.update_datastore_info_field(

--- a/ckanext/datastore/logic/validators.py
+++ b/ckanext/datastore/logic/validators.py
@@ -1,0 +1,49 @@
+# encoding: utf-8
+from __future__ import annotations
+
+from ckan.types import (
+    Context, FlattenDataDict, FlattenKey, FlattenErrorDict,
+)
+from ckan.plugins.toolkit import missing
+
+
+def to_datastore_plugin_data(plugin_key: str):
+    """
+    Return a validator that will move values from data to
+    context['plugin_data'][field_index][plugin_key][field_name]
+
+    where field_index is the field number, plugin_key (passed to this
+    function) is typically set to the plugin name and field name is the
+    original field name being validated.
+    """
+
+    def validator(
+            key: FlattenKey,
+            data: FlattenDataDict,
+            errors: FlattenErrorDict,
+            context: Context):
+        value = data.pop(key)
+        field_index = key[-2]
+        field_name = key[-1]
+        context['plugin_data'].setdefault(
+            field_index, {}).setdefault(
+            plugin_key, {})[field_name] = value
+    return validator
+
+
+def datastore_default_current(
+        key: FlattenKey, data: FlattenDataDict,
+        errors: FlattenErrorDict, context: Context):
+    '''default to currently stored value if empty or missing'''
+    value = data[key]
+    if value is not None and value != '' and value is not missing:
+        return
+    field_index = key[-2]
+    field_name = key[-1]
+    # current values for plugin_data are available as
+    # context['plugin_data'][field_index]['_current']
+    current = context['plugin_data'].get(field_index, {}).get(
+        '_current', {}).get('example_idatadictionaryform', {}).get(
+        field_name)
+    if current:
+        data[key] = current

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -8,10 +8,7 @@ from typing import Any, Callable, Union, cast
 import ckan.plugins as p
 from ckan.model.core import State
 
-from ckan.types import (
-    Action, AuthFunction, Context, FlattenDataDict, FlattenKey,
-    FlattenErrorDict,
-)
+from ckan.types import Action, AuthFunction, Context
 from ckan.common import CKANConfig
 
 import ckanext.datastore.helpers as datastore_helpers
@@ -38,6 +35,7 @@ def sql_functions_allowlist_file():
 
 
 @p.toolkit.blanket.config_declarations
+@p.toolkit.blanket.validators
 class DatastorePlugin(p.SingletonPlugin):
     p.implements(p.IConfigurable, inherit=True)
     p.implements(p.IConfigurer)
@@ -49,7 +47,6 @@ class DatastorePlugin(p.SingletonPlugin):
     p.implements(interfaces.IDatastore, inherit=True)
     p.implements(interfaces.IDatastoreBackend, inherit=True)
     p.implements(p.IBlueprint)
-    p.implements(p.IValidators)
 
     resource_show_action = None
 
@@ -286,32 +283,3 @@ class DatastorePlugin(p.SingletonPlugin):
         u'''Return a Flask Blueprint object to be registered by the app.'''
 
         return view.datastore
-
-    # IValidators
-
-    def get_validators(self):
-        return {'to_datastore_plugin_data': to_datastore_plugin_data}
-
-
-def to_datastore_plugin_data(plugin_key: str):
-    """
-    Return a validator that will move values from data to
-    context['plugin_data'][field_index][plugin_key][field_name]
-
-    where field_index is the field number, plugin_key (passed to this
-    function) is typically set to the plugin name and field name is the
-    original field name being validated.
-    """
-
-    def validator(
-            key: FlattenKey,
-            data: FlattenDataDict,
-            errors: FlattenErrorDict,
-            context: Context):
-        value = data.pop(key)
-        field_index = key[-2]
-        field_name = key[-1]
-        context['plugin_data'].setdefault(
-            field_index, {}).setdefault(
-            plugin_key, {})[field_name] = value
-    return validator

--- a/ckanext/datastore/templates/datastore/dictionary.html
+++ b/ckanext/datastore/templates/datastore/dictionary.html
@@ -5,6 +5,7 @@
 {% block subtitle %}{{ h.dataset_display_name(pkg) }} - {{ h.resource_display_name(res) }}{% endblock %}
 
 {% block primary_content_inner %}
+  {% block errors %}{{ form.errors(error_summary) }}{% endblock %}
 
   {% set action = h.url_for('datastore.dictionary', id=pkg.name, resource_id=res.id) %}
 
@@ -12,7 +13,10 @@
     {{ h.csrf_input() }}
     {% block dictionary_form %}
       {% for field in fields %}
-          {% snippet "datastore/snippets/dictionary_form.html", field=field, position=loop.index %}
+        {% snippet "datastore/snippets/dictionary_form.html",
+          field=field, position=loop.index,
+          data=data.get('fields', [{}] * loop.length)[loop.index0],
+          errors=errors.get('fields', [{}] * loop.length)[loop.index0] %}
       {% endfor %}
     {% endblock %}
     <button class="btn btn-primary" name="save" type="submit">

--- a/ckanext/datastore/templates/datastore/snippets/dictionary_form.html
+++ b/ckanext/datastore/templates/datastore/snippets/dictionary_form.html
@@ -23,3 +23,6 @@
 {{ form.markdown('info__' ~ position ~ '__notes',
   label=_('Description'), id='field-d' ~ position ~ 'notes',
   value=field.get('info', {}).get('notes', '')) }}
+
+{% block additional_fields %}
+{% endblock %}

--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -857,7 +857,7 @@ class TestDatastoreCreate(object):
         )
         res_dict = json.loads(res.data)
 
-        assert res_dict["success"] is True
+        assert res_dict["success"] is True, res_dict
 
         c = self.Session.connection()
         results = c.execute(sa.text(

--- a/ckanext/datastore/tests/test_idatadictionaryform.py
+++ b/ckanext/datastore/tests/test_idatadictionaryform.py
@@ -1,0 +1,153 @@
+# encoding: utf-8
+
+import pytest
+import ckan.plugins as p
+import ckan.tests.helpers as helpers
+import ckan.tests.factories as factories
+from ckan.plugins.toolkit import ValidationError
+from ckanext.datastore.backend import DatastoreBackend
+
+@pytest.mark.ckan_config(
+    "ckan.plugins", "datastore example_idatadictionaryform")
+@pytest.mark.usefixtures("clean_datastore", "with_plugins")
+def test_accept_custom_fields():
+    fields = [
+        {
+            "id": "one", "type": "text",
+            "an_int": 42, "json_obj": {"a": "b"}, "secret": 7,
+        },
+        {
+            "id": "two", "type": "text",
+            "an_int": -4, "json_obj": {"q": []},
+        },
+    ]
+    resource = _create_datastore_resource(fields)
+
+    result = helpers.call_action(
+        "datastore_info", id=resource["id"]
+    )
+
+    f1 = {k: v for k, v in result['fields'][0].items() if k != 'schema'}
+    f2 = {k: v for k, v in result['fields'][1].items() if k != 'schema'}
+    assert f1 == {
+        "id": "one", "type": "text", "an_int": 42, "json_obj": {"a": "b"}}
+    assert f2 == {
+        "id": "two", "type": "text", "an_int": -4, "json_obj": {"q": []}}
+
+    backend = DatastoreBackend.get_active_backend()
+
+    plugin_data = backend.resource_plugin_data(resource["id"])
+
+    assert plugin_data['one']['example_idatadictionaryform_secret'] == {
+        'secret': 7}
+    assert 'example_idatadictionaryform_secret' not in plugin_data['two']
+
+    # excluding/passing empty values for all fields for a plugin data
+    # key will leave existing values unchanged due to ignore_empty
+    fields = [
+        {
+            "id": "one", "type": "text",
+            "an_int": None, "json_obj": "",
+        },
+        {
+            "id": "two", "type": "text",
+            "json_obj": None,
+        },
+    ]
+    helpers.call_action(
+        "datastore_create",
+        resource_id=resource['id'],
+        force=True,
+        fields=fields,
+    )
+
+    result = helpers.call_action(
+        "datastore_info", id=resource["id"]
+    )
+
+    f1 = {k: v for k, v in result['fields'][0].items() if k != 'schema'}
+    f2 = {k: v for k, v in result['fields'][1].items() if k != 'schema'}
+    assert f1 == {
+        "id": "one", "type": "text", "an_int": 42, "json_obj": {"a": "b"}}
+    assert f2 == {
+        "id": "two", "type": "text", "an_int": -4, "json_obj": {"q": []}}
+
+    # excluding/passing empty values for some fields will clear all fields
+    # in the same plugin data key
+    fields = [
+        {
+            "id": "one", "type": "text",
+            "an_int": 99, "json_obj": "",
+        },
+        {
+            "id": "two", "type": "text",
+            "json_obj": {"zz": []},
+        },
+    ]
+    helpers.call_action(
+        "datastore_create",
+        resource_id=resource['id'],
+        force=True,
+        fields=fields,
+    )
+
+    result = helpers.call_action(
+        "datastore_info", id=resource["id"]
+    )
+
+    f1 = {k: v for k, v in result['fields'][0].items() if k != 'schema'}
+    f2 = {k: v for k, v in result['fields'][1].items() if k != 'schema'}
+    assert f1 == {
+        "id": "one", "type": "text", "an_int": 99}
+    assert f2 == {
+        "id": "two", "type": "text", "json_obj": {"zz": []}}
+
+    # separate plugin data keys are unaffected
+    plugin_data = backend.resource_plugin_data(resource["id"])
+
+    assert plugin_data['one']['example_idatadictionaryform_secret'] == {
+        'secret': 7}
+    assert 'example_idatadictionaryform_secret' not in plugin_data['two']
+
+
+@pytest.mark.ckan_config(
+    "ckan.plugins", "datastore example_idatadictionaryform")
+@pytest.mark.usefixtures("clean_datastore", "with_plugins")
+def test_validate_custom_fields():
+    fields = [
+        {
+            "id": "one", "type": "text",
+            "an_int": 4.2, "json_obj": "hola",
+        },
+        {
+            "id": "two", "type": "text",
+            "an_int": "hello", "json_obj": None,
+        },
+        {
+            "id": "three", "type": "text",
+            "an_int": "", "json_obj": "{}",
+        },
+        {
+            "id": "four", "type": "text",
+            "an_int": "19", "json_obj": "{a}",
+        },
+    ]
+    with pytest.raises(ValidationError) as err:
+        _create_datastore_resource(fields)
+    assert err.value.error_dict == {'fields': [
+        {'an_int': ['Invalid integer'], 'json_obj': ['Not a JSON object']},
+        {'an_int': ['Invalid integer']},
+        {},
+        {'json_obj': ['Not a JSON object']},
+    ]}
+
+
+def _create_datastore_resource(fields):
+    dataset = factories.Dataset()
+    resource = factories.Resource(package=dataset)
+
+    data = {"resource_id": resource["id"], "force": True, "fields": fields}
+
+    helpers.call_action("datastore_create", **data)
+
+    return resource

--- a/ckanext/datastore/tests/test_idatadictionaryform.py
+++ b/ckanext/datastore/tests/test_idatadictionaryform.py
@@ -1,11 +1,11 @@
 # encoding: utf-8
 
 import pytest
-import ckan.plugins as p
 import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
 from ckan.plugins.toolkit import ValidationError
 from ckanext.datastore.backend import DatastoreBackend
+
 
 @pytest.mark.ckan_config(
     "ckan.plugins", "datastore example_idatadictionaryform")

--- a/ckanext/example_idatadictionaryform/plugin.py
+++ b/ckanext/example_idatadictionaryform/plugin.py
@@ -61,7 +61,7 @@ def json_obj(value: str | dict[str, Any]) -> dict[str, Any]:
         raise Invalid('Not a JSON object')
 
 
-def to_plugin_data(plugin_key: str='example_idatadictionaryform'):
+def to_plugin_data(plugin_key: str = 'example_idatadictionaryform'):
     def validator(
             key: FlattenKey,
             data: FlattenDataDict,

--- a/ckanext/example_idatadictionaryform/plugin.py
+++ b/ckanext/example_idatadictionaryform/plugin.py
@@ -1,0 +1,76 @@
+# encoding: utf-8
+
+from __future__ import annotations
+
+from typing import Any
+from ckan.types import Validator, Schema
+from ckan.common import CKANConfig
+
+import json
+
+from ckan.plugins.toolkit import Invalid, get_validator, add_template_directory
+from ckan import plugins
+from ckanext.datastore.interfaces import IDataDictionaryForm
+
+
+class ExampleIDataDictionaryFormPlugin(plugins.SingletonPlugin):
+    plugins.implements(IDataDictionaryForm)
+    plugins.implements(plugins.IConfigurer)
+
+    # IConfigurer
+
+    def update_config(self, config: CKANConfig):
+        add_template_directory(config, 'templates')
+
+    # IDataDictionaryForm
+
+    def update_datastore_create_schema(self, schema: Schema):
+        ignore_empty = get_validator('ignore_empty')
+        int_validator = get_validator('int_validator')
+
+        f = schema['fields']
+        f['an_int'] = [ignore_empty, int_validator, to_plugin_data()]
+        f['json_obj'] = [ignore_empty, json_obj, to_plugin_data()]
+        # use different plugin_key so that value isn't removed
+        # when above fields are updated
+        f['secret'] = [
+            ignore_empty,
+            to_plugin_data('example_idatadictionaryform_secrets')]
+        return schema
+
+    def update_datastore_info_field(
+            self, field: dict[str, Any], plugin_data: dict[str, Any]):
+        # expose all our non-secret plugin data in the field
+        field.update(plugin_data.get('example_idatadictionaryform', {}))
+        return field
+
+
+def json_obj(value: Any):
+    try:
+        if isinstance(value, str):
+            value = json.loads(value)
+        else:
+            json.dumps(value)
+        if not isinstance(value, dict):
+            raise TypeError
+        return value
+    except (TypeError, ValueError):
+        raise Invalid('Not a JSON object')
+
+
+def to_plugin_data(plugin_key='example_idatadictionaryform'):
+    def validator(
+            key: FlattenKey,
+            data: FlattenDataDict,
+            errors: FlattemErrorDict,
+            context: Context):
+        """
+        move value to plugin_data dict
+        """
+        value = data.pop(key)
+        field_index = key[-2]
+        field_name = key[-1]
+        context['plugin_data'].setdefault(
+            field_index, {}).setdefault(
+            plugin_key, {})[field_name] = value
+    return validator

--- a/ckanext/example_idatadictionaryform/plugin.py
+++ b/ckanext/example_idatadictionaryform/plugin.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from typing import Any
-from ckan.types import Validator, Schema
+from ckan.types import (
+    Schema, Context, FlattenErrorDict, FlattenDataDict, FlattenKey
+)
 from ckan.common import CKANConfig
 
 import json
@@ -28,6 +30,7 @@ class ExampleIDataDictionaryFormPlugin(plugins.SingletonPlugin):
         ignore_empty = get_validator('ignore_empty')
         int_validator = get_validator('int_validator')
 
+        assert isinstance(schema['fields'], dict)
         f = schema['fields']
         f['an_int'] = [ignore_empty, int_validator, to_plugin_data()]
         f['json_obj'] = [ignore_empty, json_obj, to_plugin_data()]
@@ -45,7 +48,7 @@ class ExampleIDataDictionaryFormPlugin(plugins.SingletonPlugin):
         return field
 
 
-def json_obj(value: Any):
+def json_obj(value: str | dict[str, Any]) -> dict[str, Any]:
     try:
         if isinstance(value, str):
             value = json.loads(value)
@@ -58,11 +61,11 @@ def json_obj(value: Any):
         raise Invalid('Not a JSON object')
 
 
-def to_plugin_data(plugin_key='example_idatadictionaryform'):
+def to_plugin_data(plugin_key: str='example_idatadictionaryform'):
     def validator(
             key: FlattenKey,
             data: FlattenDataDict,
-            errors: FlattemErrorDict,
+            errors: FlattenErrorDict,
             context: Context):
         """
         move value to plugin_data dict

--- a/ckanext/example_idatadictionaryform/plugin.py
+++ b/ckanext/example_idatadictionaryform/plugin.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
-from ckan.types import (
-    Schema, Context, FlattenErrorDict, FlattenDataDict, FlattenKey
-)
+from typing import Any, cast
+from ckan.types import Schema, ValidatorFactory
 from ckan.common import CKANConfig
 
 import json
@@ -29,16 +27,20 @@ class ExampleIDataDictionaryFormPlugin(plugins.SingletonPlugin):
     def update_datastore_create_schema(self, schema: Schema):
         ignore_empty = get_validator('ignore_empty')
         int_validator = get_validator('int_validator')
+        to_datastore_plugin_data = cast(
+            ValidatorFactory, get_validator('to_datastore_plugin_data'))
+        to_eg_iddf = to_datastore_plugin_data('example_idatadictionaryform')
 
-        assert isinstance(schema['fields'], dict)
-        f = schema['fields']
-        f['an_int'] = [ignore_empty, int_validator, to_plugin_data()]
-        f['json_obj'] = [ignore_empty, json_obj, to_plugin_data()]
+        f = cast(Schema, schema['fields'])
+        f['an_int'] = [ignore_empty, int_validator, to_eg_iddf]
+        f['json_obj'] = [ignore_empty, json_obj, to_eg_iddf]
+
         # use different plugin_key so that value isn't removed
         # when above fields are updated
         f['secret'] = [
             ignore_empty,
-            to_plugin_data('example_idatadictionaryform_secrets')]
+            to_datastore_plugin_data('example_idatadictionaryform_secret')
+        ]
         return schema
 
     def update_datastore_info_field(
@@ -59,21 +61,3 @@ def json_obj(value: str | dict[str, Any]) -> dict[str, Any]:
         return value
     except (TypeError, ValueError):
         raise Invalid('Not a JSON object')
-
-
-def to_plugin_data(plugin_key: str = 'example_idatadictionaryform'):
-    def validator(
-            key: FlattenKey,
-            data: FlattenDataDict,
-            errors: FlattenErrorDict,
-            context: Context):
-        """
-        move value to plugin_data dict
-        """
-        value = data.pop(key)
-        field_index = key[-2]
-        field_name = key[-1]
-        context['plugin_data'].setdefault(
-            field_index, {}).setdefault(
-            plugin_key, {})[field_name] = value
-    return validator

--- a/ckanext/example_idatadictionaryform/plugin.py
+++ b/ckanext/example_idatadictionaryform/plugin.py
@@ -34,6 +34,7 @@ class ExampleIDataDictionaryFormPlugin(plugins.SingletonPlugin):
         ignore_empty = get_validator('ignore_empty')
         int_validator = get_validator('int_validator')
         unicode_only = get_validator('unicode_only')
+        datastore_default_current = get_validator('datastore_default_current')
         to_datastore_plugin_data = cast(
             ValidatorFactory, get_validator('to_datastore_plugin_data'))
         to_eg_iddf = to_datastore_plugin_data('example_idatadictionaryform')
@@ -44,7 +45,7 @@ class ExampleIDataDictionaryFormPlugin(plugins.SingletonPlugin):
         f['only_up'] = [
             only_increasing, ignore_empty, int_validator, to_eg_iddf]
         f['sticky'] = [
-            default_current, ignore_empty, unicode_only, to_eg_iddf]
+            datastore_default_current, ignore_empty, unicode_only, to_eg_iddf]
 
         # use different plugin_key so that value isn't removed
         # when above fields are updated & value not exposed in
@@ -99,22 +100,4 @@ def only_increasing(
             return  # allow int_validator to handle the error
     else:
         # keep current value when empty/missing
-        data[key] = current
-
-
-def default_current(
-        key: FlattenKey, data: FlattenDataDict,
-        errors: FlattenErrorDict, context: Context):
-    '''default to currently stored value if empty or missing'''
-    value = data[key]
-    if value is not None and value != '' and value is not missing:
-        return
-    field_index = key[-2]
-    field_name = key[-1]
-    # current values for plugin_data are available as
-    # context['plugin_data'][field_index]['_current']
-    current = context['plugin_data'].get(field_index, {}).get(
-        '_current', {}).get('example_idatadictionaryform', {}).get(
-        field_name)
-    if current:
         data[key] = current

--- a/ckanext/example_idatadictionaryform/templates/datastore/snippets/dictionary_form.html
+++ b/ckanext/example_idatadictionaryform/templates/datastore/snippets/dictionary_form.html
@@ -13,6 +13,16 @@
       h.dump_json(field['json_obj']) if 'json_obj' in field else '',
     classes=['control-full'], error=errors.json_obj) }}
 
+  {{ form.input('fields__' ~ position ~ '__only_up',
+    label=_('Always increasing'), id='example-plugin-f' ~ position ~ 'only_up',
+    value=data.get('only_up', field.get('only_up', '')),
+    classes=['control-full'], error=errors.only_up) }}
+
+  {{ form.input('fields__' ~ position ~ '__sticky',
+    label=_('Sticky input'), id='example-plugin-f' ~ position ~ 'sticky',
+    value=data.get('sticky', field.get('sticky', '')),
+    classes=['control-full'], error=errors.sticky) }}
+
   {{ form.input('fields__' ~ position ~ '__secret',
     label=_('Secret (write-only)'),
     id='example-plugin-f' ~ position ~ 'secret',

--- a/ckanext/example_idatadictionaryform/templates/datastore/snippets/dictionary_form.html
+++ b/ckanext/example_idatadictionaryform/templates/datastore/snippets/dictionary_form.html
@@ -1,0 +1,17 @@
+{% ckan_extends %}
+
+{% block additional_fields %}
+  {{ form.input('custom__' ~ position ~ '__an_int',
+    label=_('An integer'), id='example-plugin-f' ~ position ~ 'an_int',
+    value=field.get('an_int', ''), classes=['control-full']) }}
+
+  {{ form.input('custom__' ~ position ~ '__json_obj',
+    label=_('JSON object'), id='example-plugin-f' ~ position ~ 'json_obj',
+    value=h.dump_json(field['json_obj']) if 'json_obj' in field else '',
+    classes=['control-full']) }}
+
+  {{ form.input('custom__' ~ position ~ '__secret',
+    label=_('Secret (write-only)'),
+    id='example-plugin-f' ~ position ~ 'secret',
+    value='', classes=['control-full']) }}
+{% endblock %}

--- a/ckanext/example_idatadictionaryform/templates/datastore/snippets/dictionary_form.html
+++ b/ckanext/example_idatadictionaryform/templates/datastore/snippets/dictionary_form.html
@@ -1,17 +1,21 @@
 {% ckan_extends %}
 
 {% block additional_fields %}
-  {{ form.input('custom__' ~ position ~ '__an_int',
+  {{ form.input('fields__' ~ position ~ '__an_int',
     label=_('An integer'), id='example-plugin-f' ~ position ~ 'an_int',
-    value=field.get('an_int', ''), classes=['control-full']) }}
+    value=data.get('an_int', field.get('an_int', '')),
+    classes=['control-full'], error=errors.an_int) }}
 
-  {{ form.input('custom__' ~ position ~ '__json_obj',
+  {{ form.input('fields__' ~ position ~ '__json_obj',
     label=_('JSON object'), id='example-plugin-f' ~ position ~ 'json_obj',
-    value=h.dump_json(field['json_obj']) if 'json_obj' in field else '',
-    classes=['control-full']) }}
+    value=
+      data.json_obj if 'json_obj' in data else
+      h.dump_json(field['json_obj']) if 'json_obj' in field else '',
+    classes=['control-full'], error=errors.json_obj) }}
 
-  {{ form.input('custom__' ~ position ~ '__secret',
+  {{ form.input('fields__' ~ position ~ '__secret',
     label=_('Secret (write-only)'),
     id='example-plugin-f' ~ position ~ 'secret',
-    value='', classes=['control-full']) }}
+    value='', classes=['control-full'],
+    error=errors.secret) }}
 {% endblock %}

--- a/ckanext/example_idatastorebackend/example_sqlite.py
+++ b/ckanext/example_idatastorebackend/example_sqlite.py
@@ -39,7 +39,7 @@ class DatastoreExampleSqliteBackend(DatastoreBackend):
 
         return config
 
-    def create(self, context, data_dict):
+    def create(self, context, data_dict, plugin_data):
         columns = str(u', '.join(
             [str(sa.column(e['id'])) + " text" for e in data_dict['fields']]))
 

--- a/doc/extensions/custom-data-dictionary.rst
+++ b/doc/extensions/custom-data-dictionary.rst
@@ -1,0 +1,56 @@
+==============================================
+Customizing the DataStore Data Dictionary Form
+==============================================
+
+Extensions can customize the Data Dictionary form, keys available and values
+stored for each column using the
+:py:class:`~ckanext.datastore.interfaces.IDataDictionaryForm` interface.
+
+.. autoclass:: ckanext.datastore.interfaces.IDataDictionaryForm
+   :members:
+
+Let's add five new keys with custom validation rules to the data dictionary
+fields.
+
+With this plugin enabled each field in the Data Dictionary form will have
+an input for:
+
+ - an integer value
+ - a JSON object
+ - a numeric value that can only be increased when edited
+ - a "sticky" value that will not be removed if left blank
+ - a secret value that will be stored but never displayed in the form.
+
+First extend the form template to render the form inputs:
+
+.. literalinclude:: ../../ckanext/example_idatadictionaryform/templates/datastore/snippets/dictionary_form.html
+
+We use the ``form.input`` macro to render the form fields. The name
+of each field starts with ``fields__`` and includes a ``position`` index
+because this block will be rendered once for every field in the data
+dictionary.
+
+The value for each input is set to either the value from ``data`` the text
+data passed when re-rendering a form containing errors, or ``field`` the
+json value (text, number, object etc.) currently stored in the data
+dictionary when rendering a form for the first time.
+
+The error for each field is set from ``errors``.
+
+Next we create a plugin to apply the template and validation rules for each
+data dictionary field key.
+
+.. literalinclude:: ../../ckanext/example_idatadictionaryform/plugin.py
+
+In ``update_datastore_create_schema`` the ``to_datastore_plugin_data`` factory
+generates a validator that will store our new keys as plugin data.
+The string passed is used to group keys for this plugin to allow multiple
+separate ``IDataDictionaryForm`` plugins to store data for Data Dictionary
+fields at the same time. It's possible to use multiple groups from the same
+plugin: here we use a different group for the ``secret`` key because we want
+to treat it differently.
+
+In ``update_datastore_info_field`` we can add keys stored as plugin data
+to the ``fields`` objects returned by ``datastore_info``. Here we add
+everything but the ``secret`` key. These values are also passed to the
+form template above as ``field``.

--- a/doc/extensions/index.rst
+++ b/doc/extensions/index.rst
@@ -41,3 +41,4 @@ features by developing your own CKAN extensions.
    translating-extensions
    flask-migration
    signals
+   custom-data-dictionary

--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -319,36 +319,20 @@ Fields define the column names and the type of the data in a column. A field is 
             "label":  # human-readable label for column
             "notes":  # markdown description of column
             "type_override":  # type for datapusher to use when importing data
-            ...:  # other user-defined fields
+            ...:  # free-form user-defined values
 	}
+        ...:  # values defined and validated with IDataDictionaryForm
     }
 
 Field types not provided will be guessed based on the first row of provided data.
 Set the types to ensure that future inserts will not fail because of an incorrectly
 guessed type. See :ref:`valid-types` for details on which types are valid.
 
-Extra ``"info"`` field values will be stored along with the column. ``"label"``,
-``"notes"`` and ``"type_override"`` can be managed from the default :ref:`data_dictionary`
-form.  Additional fields can be stored by customizing the Data Dictionary form or by
-passing their values to the API directly.
+.. seealso::
 
-Example::
+   For more on custom field values and customizing the Data Dictionary form, see
+   :doc:`/extensions/custom-data-dictionary`.
 
-    [
-        {
-            "id": "code_number",
-            "type": "numeric"
-        },
-        {
-            "id": "description"
-            "type": "text",
-            "info": {
-                "label": "Description",
-                "notes": "A brief usage description for this code",
-                "example": "Used for temporary service interruptions"
-            }
-        }
-    ]
 
 .. _records:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -134,6 +134,7 @@ ckan.plugins =
     example_iauthenticator = ckanext.example_iauthenticator.plugin:ExampleIAuthenticatorPlugin
     example_humanizer = ckanext.example_humanizer.plugin:ExampleHumanizerPlugin
     example_database_migrations = ckanext.example_database_migrations.plugin:ExampleDatabaseMigrationsPlugin
+    example_idatadictionaryform = ckanext.example_idatadictionaryform.plugin:ExampleIDataDictionaryFormPlugin
 
 ckan.system_plugins =
     synchronous_search = ckan.lib.search:SynchronousSearchPlugin


### PR DESCRIPTION
Fixes #7971 

### Proposed fixes:

- store per-plugin data in column comments
- support validation for fields and partial updates
- add a migrate cli command for migrating existing data dictionary fields

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
