### PR TITLE
preserve custom org type in user activity streams

### DIFF
--- a/changes/7980.bugfix
+++ b/changes/7980.bugfix
@@ -1,0 +1,1 @@
+use custom group type from the activity object if it's not supplied, eg on user activity streams

--- a/ckanext/activity/templates/snippets/stream.html
+++ b/ckanext/activity/templates/snippets/stream.html
@@ -14,6 +14,7 @@
 {% endmacro %}
 
 {% macro organization(activity) %}
+  {% set group_type = group_type or (activity.data.group.type if (activity.data.group and activity.data.group.type) else 'organization') %}
   <a href="{{ h.url_for(group_type ~ '.read', id=activity.object_id) }}">
     {{ activity.data.group.title if activity.data.group else _('unknown') }}
   </a>


### PR DESCRIPTION
Fixes #7980

### Proposed fixes:

Retrieve the group type from the activity object if `group_type` is not already supplied in an activity stream.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
