### PR TITLE
Update sysadmin guide about removal of organizations and group

### DIFF
--- a/changes/8022.misc
+++ b/changes/8022.misc
@@ -1,0 +1,1 @@
+Fix an old remainder in the documentation about permanent deletion of organizations and groups

--- a/doc/sysadmin-guide.rst
+++ b/doc/sysadmin-guide.rst
@@ -103,9 +103,9 @@ the appropriate entry from the "organization" drop-down list, and press "Save".
 
 .. image:: /images/move_dataset_between_organizations.jpg
 
------------------------------
+-------------------------------------------------------
 Permanently deleting datasets, organizations and groups
------------------------------
+-------------------------------------------------------
 
 A dataset, organization or group which has been deleted is not permanently
 removed from CKAN; it is simply marked as 'deleted' and will no longer

--- a/doc/sysadmin-guide.rst
+++ b/doc/sysadmin-guide.rst
@@ -104,29 +104,23 @@ the appropriate entry from the "organization" drop-down list, and press "Save".
 .. image:: /images/move_dataset_between_organizations.jpg
 
 -----------------------------
-Permanently deleting datasets
+Permanently deleting datasets, organizations and groups
 -----------------------------
 
-A dataset which has been deleted is not permanently removed from CKAN; it is
-simply marked as 'deleted' and will no longer show up in search, etc. The
-dataset's URL cannot be re-used for a new dataset.
+A dataset, organization or group which has been deleted is not permanently
+removed from CKAN; it is simply marked as 'deleted' and will no longer
+show up in search, etc. The assigned URL cannot be re-used for a new entity.
 
-To permanently delete ("purge") a dataset:
+To permanently delete ("purge") an entity:
 
 * Navigate to the dataset's "Edit" page, and delete it.
 * Visit ``http://<my-ckan-url>/ckan-admin/trash/``.
 
-This page shows all deleted datasets and allows you to delete them permanently.
+This page shows all deleted datasets, organizations and groups and allows you to delete them permanently.
 
 .. warning::
 
     This operation cannot be reversed!
-
-.. note::
-
-    At present, it is not possible to purge organizations or groups using the
-    web UI. This can only be done with access to the server, by directly deleting
-    them from CKAN's database.
 
 --------------
 Managing users


### PR DESCRIPTION
Fixes an old remainder in the documentation about permanent deletion of organizations and groups.

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
