### PR TITLE
[#7999] Optional session.validate_key

### DIFF
--- a/changes/8023.bugfix
+++ b/changes/8023.bugfix
@@ -1,0 +1,1 @@
+CKAN does not start without ``beaker.session.validate_key`` option introduced in v2.10.3

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -318,7 +318,7 @@ groups:
           The dbm option is not recommended as it is not thread-safe.
 
       - key: beaker.session.validate_key
-        validators: not_empty
+        validators: configured_default("beaker.session.secret",None) not_empty
         placeholder_callable: secrets:token_urlsafe
         callable_args:
           nbytes: 20


### PR DESCRIPTION
Fixes #7999

:information_source: PR into dev-v2.10. beaker is replaced by flask-sessions upstream so this change makes no sense for the master branch

When `beaker.session.validate_key` is empty, use `beaker.session.secret` as the default