### PR TITLE
Drop API Key from user UI

### DIFF
--- a/ckan/templates/user/snippets/info.html
+++ b/ckan/templates/user/snippets/info.html
@@ -99,12 +99,6 @@
             <dt>{{ _('State') }}</dt>
             <dd>{{ _(user.state) }}</dd>
           </dl>
-          {% if is_myself %}
-            <dl>
-              <dt class="key">{{ _('API Key') }} <span class="label label-default" title="{{ _('This means only you can see this') }}">{{ _('Private') }}</span></dt>
-              <dd class="value"><code>{{ user.apikey }}</code></dd>
-            </dl>
-          {% endif %}
         </div>
         {% endblock %}
       {% endblock %}


### PR DESCRIPTION
According to the changelog this was supposed to have happened in 2.10.0, as API Keys don't work anymore. IMHO quite an urgent fix as it is very confusing to have non-functional API Keys displayed in the UI.

I'm not sure why the API Key has been kept in the User model and DB, might have been an oversight as well? The corresponding issue was #6247 (@amercader) and the PR was #6352 (@TomeCirun).

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport
