### PR TITLE
Fixed the editing of resources unavailable from package view page

### DIFF
--- a/changes/8025.bugfix
+++ b/changes/8025.bugfix
@@ -1,0 +1,1 @@
+Editing of resources unavailable from package view page.

--- a/ckan/templates/package/snippets/resources_list.html
+++ b/ckan/templates/package/snippets/resources_list.html
@@ -14,9 +14,9 @@
   <h2>{{ _('Data and Resources') }}</h2>
   {% block resource_list %}
     {% if resources %}
-      {% set can_edit = can_edit or h.check_access('package_update', {'id':pkg.id }) %}
       <ul class="{% block resource_list_class %}resource-list{% endblock %}">
         {% block resource_list_inner %}
+          {% set can_edit = can_edit or h.check_access('package_update', {'id':pkg.id }) %}
           {% for resource in resources %}
             {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=resource, can_edit=can_edit %}
           {% endfor %}


### PR DESCRIPTION
Fixes #8025

### Proposed fixes:

`can_edit` variable is defined within the `resource_list_inner` block in the jinja template `templates/package/snippets/resources_list.html`

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
