### PR TITLE
Remove nginx cache as beaker cookies are not cacheable

### DIFF
--- a/doc/maintaining/installing/deployment.rst
+++ b/doc/maintaining/installing/deployment.rst
@@ -177,7 +177,6 @@ following contents:
 
 .. parsed-literal::
 
-    proxy_cache_path /tmp/nginx_cache levels=1:2 keys_zone=cache:30m max_size=250m;
     proxy_temp_path /tmp/nginx_proxy 1 2;
 
     server {
@@ -185,14 +184,7 @@ following contents:
         location / {
             proxy_pass http://127.0.0.1:8080/;
             proxy_set_header X-Forwarded-For $remote_addr;
-            proxy_set_header Host $host;
-            proxy_cache cache;
-            proxy_cache_bypass $cookie_ckan;
-            proxy_no_cache $cookie_ckan;
-            proxy_cache_valid 30m;
-            proxy_cache_key $host$scheme$proxy_host$request_uri;
-            # In emergency comment out line to force caching
-            # proxy_ignore_headers X-Accel-Expires Expires Cache-Control;
+            proxy_set_header Host $host;            
         }
 
     }

--- a/doc/maintaining/installing/deployment.rst
+++ b/doc/maintaining/installing/deployment.rst
@@ -187,8 +187,8 @@ following contents:
             proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header Host $host;
             proxy_cache cache;
-            proxy_cache_bypass $cookie_auth_tkt;
-            proxy_no_cache $cookie_auth_tkt;
+            proxy_cache_bypass $cookie_ckan;
+            proxy_no_cache $cookie_ckan;
             proxy_cache_valid 30m;
             proxy_cache_key $host$scheme$proxy_host$request_uri;
             # In emergency comment out line to force caching


### PR DESCRIPTION
Cookies always exist so caching based on cookies doesn't work. We really shouldn't be provide nginx cache instructions anyway, its out of scope of ckan.

### Proposed fixes:
Remove nginx cache from docs.


### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
