### PR TITLE
[8021]FIX datatables does not implement CSRF support 

### DIFF
--- a/ckanext/datatablesview/assets/datatablesview.js
+++ b/ckanext/datatablesview/assets/datatablesview.js
@@ -514,6 +514,9 @@ this.ckan.module('datatables_view', function (jQuery) {
           url: ajaxurl,
           type: 'POST',
           timeout: 60000,
+          headers: {
+            'X-CSRF-Token': $('meta[name="_csrf_token"]').attr('content')
+          },
           data: function (d) {
             d.filters = ckanfilters
           }


### PR DESCRIPTION
Fixes #8021 

### Proposed fixes:

add X-CSRF-Token header

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
