### PR TITLE
Bumping the FDT version to Latest

### DIFF
--- a/changes/6995.bugfix
+++ b/changes/6995.bugfix
@@ -1,0 +1,1 @@
+flask-debugtoolbar does not scroll. 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@ cookiecutter==2.5.0
 coveralls   #Let Unpinned - Requires latest coveralls
 Faker==20.1.0
 factory-boy==3.3.0
-flask-debugtoolbar==0.14.0
+flask-debugtoolbar==0.14.1
 freezegun==1.3.1
 ipdb==0.13.13
 pip-tools==7.3.0


### PR DESCRIPTION
Fixes #6995 

### Proposed fixes:

Bumping the `flask-debugtoolbar` (FDT) version from 0.14.0 to 0.14.1 (Latest)

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
