### PR TITLE
pass package type through to resource creation activity item

### DIFF
--- a/changes/8034.bugfix
+++ b/changes/8034.bugfix
@@ -1,0 +1,1 @@
+Pass custom package types through to the 'new resource' activity item

--- a/ckanext/activity/templates/package/snippets/change_item.html
+++ b/ckanext/activity/templates/package/snippets/change_item.html
@@ -4,7 +4,7 @@
 <ul>
   {% for change in changes %}
     {% snippet "snippets/changes/{}.html".format(
-      change.type), change=change %}
+      change.type), change=change, pkg_dict=pkg_dict %}
     <br>
   {% endfor %}
 </ul>

--- a/ckanext/activity/templates/snippets/changes/new_resource.html
+++ b/ckanext/activity/templates/snippets/changes/new_resource.html
@@ -1,4 +1,4 @@
-{% set dataset_type = request.view_args.package_type or 'dataset' %}
+{% set dataset_type = request.view_args.package_type or pkg_dict['type'] or 'dataset' %}
 {% set pkg_url = h.url_for(dataset_type ~ '.read', id=change.pkg_id) %}
 {% set resource_url = h.url_for(dataset_type ~ '_resource.read', id=change.pkg_id, resource_id = change.resource_id, qualified=True) %}
 


### PR DESCRIPTION
Fixes #8034

### Proposed fixes:

Pass the package dict through from `change_item.html` to `new_resource.html` so we can extract the correct package type if needed.

This is better than a simple fallback to 'dataset' since it lets us preserve custom package types.

However, I'm unsure of the best target branch for this.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
