### PR TITLE
Allow alternate Solr query parsers via allow list

### DIFF
--- a/changes/8053.misc
+++ b/changes/8053.misc
@@ -1,0 +1,1 @@
+Define allowed alternative Solr query parsers via the :ref:`ckan.search.solr_allowed_query_parsers` config option 

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -892,6 +892,15 @@ groups:
           enabled to improve dataset update/create speed (however there may be
           a slight delay before dataset gets seen in results).
 
+      - key: ckan.search.solr_allowed_query_parsers
+        type: list
+        default: []
+        example: ["bool", "knn"]
+        description: |
+          Local parameters are not allowed when passing queries to Solr. An exception to this is when passing local parameters for special query parsers, that need to be enabled explicitly using this config option. For instance, the example provided would allow sending queries like the following::
+            search_params["q"] = "{!bool must=test}..."
+            search_params["q"] = "{!knn field=vector topK=10}..."
+
       - key: ckan.search.show_all_types
         default: dataset
         example: dataset

--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -5,7 +5,7 @@ import re
 import logging
 from typing import Any, NoReturn, Optional, Union, cast, Dict
 from pyparsing import (
-    Word, QuotedString, Suppress, OneOrMore, Group, alphas, alphanums
+    Word, QuotedString, Suppress, OneOrMore, Group, alphanums
 )
 from pyparsing.exceptions import ParseException
 import pysolr

--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -103,8 +103,8 @@ def _parse_local_params(local_params: str) -> list[Union[str, list[str]]]:
     {!type=dismax qf=myfield v='some value'} -> [['type', 'dismax'], ['qf', 'myfield'], ['v', 'some value']]
 
     """
-    key = Word(alphas)
-    value = QuotedString('"') | QuotedString("'") | Word(alphanums)
+    key = Word(alphanums + "_")
+    value = QuotedString('"') | QuotedString("'") | Word(alphanums + "_$")
     pair = Group(key + Suppress("=") + value)
     expression = Suppress("{!") + OneOrMore(pair | key) + Suppress("}")
 

--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -95,6 +95,7 @@ def _get_local_query_parser(q: str) -> str:
     local parameters, .e.g. q={!child ...}...
     """
     qp_type = ""
+    q = q.strip()
     if not q.startswith("{!"):
         return qp_type
 
@@ -412,7 +413,7 @@ class PackageSearchQuery(SearchQuery):
         query.setdefault("df", "text")
         query.setdefault("q.op", "AND")
         try:
-            if query["q"].startswith("{!"):
+            if query["q"].strip().startswith("{!"):
                if not _get_local_query_parser(query["q"]) in config["ckan.search.solr_allowed_query_parsers"]:
                 raise SearchError("Local parameters are not supported.")
         except KeyError:

--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -99,7 +99,9 @@ def _get_local_query_parser(q: str) -> str:
     if not q.startswith("{!"):
         return qp_type
 
-    parts = q.lstrip("{!").rstrip("}").split(" ")
+    local_params = q[:q.index("}")]
+
+    parts = local_params.lstrip("{!").rstrip("}").split(" ")
     if "=" not in parts[0]:
         # Most common form of defining the query parser type e.g. {!knn ...}
         qp_type = parts[0]

--- a/ckan/tests/lib/search/test_search.py
+++ b/ckan/tests/lib/search/test_search.py
@@ -132,7 +132,25 @@ def test_local_params_not_allowed_by_default():
     with pytest.raises(search.common.SearchError) as e:
         query.run({"q": "{!bool must=test}"})
 
-    assert str(e.value) == "Local parameters are not supported."
+    assert str(e.value) == "Local parameters are not supported in param 'q'."
+
+
+def test_local_params_not_allowed_by_default_different_field():
+
+    query = search.query_for(model.Package)
+    with pytest.raises(search.common.SearchError) as e:
+        query.run({"fq": "{!bool must=test} +site_id:test.ckan.net"})
+
+    assert str(e.value) == "Local parameters are not supported in param 'fq'."
+
+
+def test_local_params_not_allowed_by_default_different_field_list():
+
+    query = search.query_for(model.Package)
+    with pytest.raises(search.common.SearchError) as e:
+        query.run({"fq_list": ["+site_id:default", "{!bool must=test}"]})
+
+    assert str(e.value) == "Local parameters are not supported in param 'fq_list'."
 
 
 def test_local_params_with_whitespace_not_allowed_by_default():
@@ -141,7 +159,7 @@ def test_local_params_with_whitespace_not_allowed_by_default():
     with pytest.raises(search.common.SearchError) as e:
         query.run({"q": " {!bool must=test}"})
 
-    assert str(e.value) == "Local parameters are not supported."
+    assert str(e.value) == "Local parameters are not supported in param 'q'."
 
 
 @pytest.mark.ckan_config("ckan.search.solr_allowed_query_parsers", "bool")
@@ -152,7 +170,7 @@ def test_allowed_local_params_via_config_not_defined():
     with pytest.raises(search.common.SearchError) as e:
         query.run({"q": "{!something_else a=test}"})
 
-    assert str(e.value) == "Local parameters are not supported."
+    assert str(e.value) == "Local parameters are not supported in param 'q'."
 
 
 @pytest.mark.ckan_config("ckan.search.solr_allowed_query_parsers", "bool knn")

--- a/ckan/tests/lib/search/test_search.py
+++ b/ckan/tests/lib/search/test_search.py
@@ -116,10 +116,13 @@ def test_04_delete_package_from_dict():
         ("{!type=bool must=test}", "bool"),
         ("{!type=bool must='test string'}", "bool"),
         ("{!must=test type=bool}", "bool"),
+        ("{!must=test type=bool}solr rocks", "bool"),
+        ("{!must='test text' type=bool}solr rocks", "bool"),
         ("{!dismax qf=myfield}solr rocks", "dismax"),
         ("{!type=dismax qf=myfield v='solr rocks'}", "dismax"),
         ("{!type=lucene df=summary}solr rocks", "lucene"),
     ]
+
 )
 def test_get_local_query_parser(query, parser):
 

--- a/ckan/tests/lib/search/test_search.py
+++ b/ckan/tests/lib/search/test_search.py
@@ -121,6 +121,7 @@ def test_04_delete_package_from_dict():
         ("{!dismax qf=myfield}solr rocks", "dismax"),
         ("{!type=dismax qf=myfield v='solr rocks'}", "dismax"),
         ("{!type=lucene df=summary}solr rocks", "lucene"),
+        ("{!v='lies type= here' type=dismax}", "dismax"),
     ]
 
 )

--- a/ckan/tests/lib/search/test_search.py
+++ b/ckan/tests/lib/search/test_search.py
@@ -100,7 +100,9 @@ def test_04_delete_package_from_dict():
 
     assert query.run({"q": ""})["count"] == 1
 
-@pytest.mark.parametrize("query,parser",
+
+@pytest.mark.parametrize(
+    "query,parser",
     [
         ("*:*", ""),
         ("title:test AND organization:test-org", ""),

--- a/ckan/tests/lib/search/test_search.py
+++ b/ckan/tests/lib/search/test_search.py
@@ -4,6 +4,7 @@ import os
 import pytest
 
 import ckan.config as config
+from ckan.lib.search.common import SearchQueryError
 import ckan.tests.factories as factories
 import ckan.model as model
 import ckan.lib.search as search
@@ -128,6 +129,20 @@ def test_04_delete_package_from_dict():
 def test_get_local_query_parser(query, parser):
 
     assert _get_local_query_parser(query) == parser
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "{!v='lies type= here' some params",
+        "{!v='lies type= here' v2='\\{some test \\} type=dismax}",
+    ]
+
+)
+def test_get_local_query_parser_exception(query):
+
+    with pytest.raises(SearchQueryError):
+        _get_local_query_parser(query)
 
 
 def test_local_params_not_allowed_by_default():

--- a/ckan/tests/lib/search/test_search.py
+++ b/ckan/tests/lib/search/test_search.py
@@ -123,6 +123,10 @@ def test_04_delete_package_from_dict():
         ("{!type=dismax qf=myfield v='solr rocks'}", "dismax"),
         ("{!type=lucene df=summary}solr rocks", "lucene"),
         ("{!v='lies type= here' type=dismax}", "dismax"),
+        ("{!some_parser}", "some_parser"),
+        ("{!dismax v=some_value}", "dismax"),
+        ("{!some_parser a='0.9' traversalFilter='foo:[*+TO+15]'}", "some_parser"),
+        ("{!some_parser must=$ref}", "some_parser"),
     ]
 
 )

--- a/requirements.in
+++ b/requirements.in
@@ -20,6 +20,7 @@ passlib==1.7.4
 polib==1.2.0
 psycopg2==2.9.7
 PyJWT==2.8.0
+pyparsing==3.0.7
 python-magic==0.4.27
 pysolr==3.9.0
 python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -95,7 +95,9 @@ psycopg2==2.9.7
 pyjwt==2.8.0
     # via -r requirements.in
 pyparsing==3.0.7
-    # via packaging
+    # via
+    #  -r requirements.in
+    #  packaging
 pysolr==3.9.0
     # via -r requirements.in
 python-dateutil==2.8.2


### PR DESCRIPTION
Back in [2018](https://github.com/ckan/ckan/commit/1d9a5265ddd73afc599657e126ab96310559a4c1), due to a vulnerability in Solr's xml query parser the decision was taken to disallow all [local parameters](https://solr.apache.org/guide/solr/latest/query-guide/local-params.html) in Solr queries.

But alternate query parsers defined via local parameters can provide very interesting functionalities, like the [Dense Vector Search](https://solr.apache.org/guide/solr/latest/query-guide/dense-vector-search.html) leveraged by [ckanext-embeddings](https://github.com/amercader/ckanext-embeddings).

This PR introduces a less draconian approach where a with new `ckan.search.solr_allowed_query_parsers` config option you can define one or more allowed query parsers.

The type of query parser can be defined either via a short form or explicitly with the `type` local param, both are taken into account:

        q={!knn field=vector ...}...
        q={!type=knn field=vector ...}...

I'd like to propose this for backporting to 2.10.x