### PR TITLE
Datatables View Fit Col Text After Sorting

### DIFF
--- a/changes/8065.bugfix
+++ b/changes/8065.bugfix
@@ -1,0 +1,1 @@
+Datatable columns now automatically re-fit after sorting.

--- a/ckanext/datatablesview/assets/datatablesview.js
+++ b/ckanext/datatablesview/assets/datatablesview.js
@@ -897,6 +897,8 @@ this.ckan.module('datatables_view', function (jQuery) {
                         : ' <span class="fa fa-sort-amount-desc"></span> ')
         })
         $('div.sortinfo').html(gsortInfo)
+        //adjust column widths after sorting
+        fitColText();
       })
     }
   }


### PR DESCRIPTION
fix(js): fit col text after sort datatables;

- Call `fitColText` in the sort event listener for datatables.

### Proposed fixes:

When sorting a column that has empty values, the columns do not align. Calling `fitColText` in the sort event callback fixes.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
