### PR TITLE
Drop non required function get_group_or_org_admin_ids

### DIFF
--- a/changes/8067.misc
+++ b/changes/8067.misc
@@ -1,0 +1,2 @@
+The `get_group_or_org_admin_ids` function is old and can be easily replaced by
+the `member_list` action.

--- a/ckan/authz.py
+++ b/ckan/authz.py
@@ -181,22 +181,6 @@ def _get_user(username: Optional[str]) -> Optional['model.User']:
     return model.User.get(username)
 
 
-def get_group_or_org_admin_ids(group_id: Optional[str]) -> list[str]:
-    if not group_id:
-        return []
-    group = model.Group.get(group_id)
-    if not group:
-        return []
-    q = model.Session.query(model.Member.table_id) \
-        .filter(model.Member.group_id == group.id) \
-        .filter(model.Member.table_name == 'user') \
-        .filter(model.Member.state == 'active') \
-        .filter(model.Member.capacity == 'admin')
-
-    # type_ignore_reason: all stored memerships have table_id
-    return [a.table_id for a in q]
-
-
 def is_authorized_boolean(action: str, context: Context, data_dict: Optional[DataDict]=None) -> bool:
     ''' runs the auth function but just returns True if allowed else False
     '''

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -790,13 +790,17 @@ def admins(id: str, group_type: str, is_organization: bool) -> str:
     extra_vars = {}
     set_org(is_organization)
     group_dict = _get_group_dict(id, group_type)
-    admins = authz.get_group_or_org_admin_ids(id)
+    admins = get_action('member_list')(
+        {'ignore_auth': True},
+        {'id': id, 'object_type': 'user', 'capacity': 'admin'}
+    )
+    admin_ids = [admin[0] for admin in admins]
 
     # TODO: Remove
     # ckan 2.9: Adding variables that were removed from c object for
     # compatibility with templates in existing extensions
     g.group_dict = group_dict
-    g.admins = admins
+    g.admins = admin_ids
 
     extra_vars: dict[str, Any] = {
         u"group_dict": group_dict,


### PR DESCRIPTION
The function `get_group_or_org_admin_ids` could be easy replaced with the `member_list` action

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
