### PR TITLE
Job List Limit

### DIFF
--- a/changes/8070.feature
+++ b/changes/8070.feature
@@ -1,0 +1,2 @@
+job_list action now only returns 200 jobs by default.
+Use `limit` or `ckan.jobs.default_list_limit` config option now.

--- a/ckan/cli/jobs.py
+++ b/ckan/cli/jobs.py
@@ -42,13 +42,13 @@ def worker(burst: bool, queues: list[str]):
 @jobs.command(name=u"list", short_help=u"List jobs.")
 @click.option("-l", "--limit", type=click.INT,
               help="Number of jobs to return. Default: %s" %
-                bg_jobs.DEFAULT_JOB_LIST_LIMIT,
+              bg_jobs.DEFAULT_JOB_LIST_LIMIT,
               default=bg_jobs.DEFAULT_JOB_LIST_LIMIT)
 @click.option("-i", "--ids", is_flag=True, type=click.BOOL,
               help="Only return a list of job ids.", default=False)
 @click.argument(u"queues", nargs=-1)
 def list_jobs(queues: list[str],
-              limit: int=bg_jobs.DEFAULT_JOB_LIST_LIMIT, ids: bool=False):
+              limit: int = bg_jobs.DEFAULT_JOB_LIST_LIMIT, ids: bool = False):
     """List currently enqueued jobs from the given queues. If no queue
     names are given then the jobs from all queues are listed.
     """

--- a/ckan/cli/jobs.py
+++ b/ckan/cli/jobs.py
@@ -40,23 +40,35 @@ def worker(burst: bool, queues: list[str]):
 
 
 @jobs.command(name=u"list", short_help=u"List jobs.")
+@click.option("-l", "--limit", type=click.INT,
+              help="Number of jobs to return. Default: %s" %
+                bg_jobs.DEFAULT_JOB_LIST_LIMIT,
+              default=bg_jobs.DEFAULT_JOB_LIST_LIMIT)
+@click.option("-i", "--ids", is_flag=True, type=click.BOOL,
+              help="Only return a list of job ids.", default=False)
 @click.argument(u"queues", nargs=-1)
-def list_jobs(queues: list[str]):
+def list_jobs(queues: list[str],
+              limit: int=bg_jobs.DEFAULT_JOB_LIST_LIMIT, ids: bool=False):
     """List currently enqueued jobs from the given queues. If no queue
     names are given then the jobs from all queues are listed.
     """
     data_dict = {
         u"queues": list(queues),
+        "limit": limit,
+        "ids_only": ids,
     }
     jobs = logic.get_action(u"job_list")({u"ignore_auth": True}, data_dict)
     if not jobs:
         return click.secho(u"There are no pending jobs.", fg=u"green")
     for job in jobs:
-        if job[u"title"] is None:
-            job[u"title"] = u""
+        if ids:
+            click.secho(job)
         else:
-            job[u"title"] = u'"{}"'.format(job[u"title"])
-        click.secho(u"{created} {id} {queue} {title}".format(**job))
+            if job[u"title"] is None:
+                job[u"title"] = u""
+            else:
+                job[u"title"] = u'"{}"'.format(job[u"title"])
+            click.secho(u"{created} {id} {queue} {title}".format(**job))
 
 
 @jobs.command(short_help=u"Show details about a specific job.")

--- a/ckan/lib/jobs.py
+++ b/ckan/lib/jobs.py
@@ -38,6 +38,7 @@ import ckan.plugins as plugins
 log = logging.getLogger(__name__)
 
 DEFAULT_QUEUE_NAME = u'default'
+DEFAULT_JOB_LIST_LIMIT = 200
 
 # RQ job queues. Do not use this directly, use ``get_queue`` instead.
 _queues: dict[str, rq.Queue] = {}

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -3154,7 +3154,9 @@ def config_option_list(context: Context,
 
 
 @logic.validate(ckan.logic.schema.job_list_schema)
-def job_list(context: Context, data_dict: DataDict) -> ActionResult.JobList:
+def job_list(context: Context, data_dict: DataDict) \
+        -> Union[ActionResult.JobList, list[str]]:
+
     '''List enqueued background jobs.
 
     :param list queues: Queues to list jobs from. If not given then the

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -3190,6 +3190,10 @@ def job_list(context: Context, data_dict: DataDict) -> ActionResult.JobList:
             # type_ignore_reason: pyright does not know return from queue.jobs
             jobs_list += [jobs.dictize_job(j)  # type: ignore
                           for j in queue.jobs[:limit]]
+        if limit > 0 and len(jobs_list) > limit:
+            # we need to return here if there is a limit
+            # and it has been surpassed
+            return jobs_list[:limit]
     return jobs_list
 
 

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -3187,7 +3187,9 @@ def job_list(context: Context, data_dict: DataDict) -> ActionResult.JobList:
         if ids_only:
             jobs_list += queue.job_ids[:limit]
         else:
-            jobs_list += [jobs.dictize_job(j) for j in queue.jobs[:limit]]
+            # type_ignore_reason: pyright does not know return from queue.jobs
+            jobs_list += [jobs.dictize_job(j)  # type: ignore
+                          for j in queue.jobs[:limit]]
     return jobs_list
 
 

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -3154,9 +3154,7 @@ def config_option_list(context: Context,
 
 
 @logic.validate(ckan.logic.schema.job_list_schema)
-def job_list(context: Context, data_dict: DataDict) \
-        -> Union[ActionResult.JobList, list[str]]:
-
+def job_list(context: Context, data_dict: DataDict) -> ActionResult.JobList:
     '''List enqueued background jobs.
 
     :param list queues: Queues to list jobs from. If not given then the
@@ -3176,7 +3174,7 @@ def job_list(context: Context, data_dict: DataDict) \
     .. versionadded:: 2.7
     '''
     _check_access(u'job_list', context, data_dict)
-    jobs_list: Union[ActionResult.JobList, list[str]] = []
+    jobs_list: ActionResult.JobList = []
     queues: Any = data_dict.get(u'queues')
     limit = data_dict.get('limit', config.get('ckan.jobs.default_list_limit',
                                               jobs.DEFAULT_JOB_LIST_LIMIT))

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -783,12 +783,12 @@ def update_configuration_schema():
 @validator_args
 def job_list_schema(
         ignore_missing: Validator, list_of_strings: Validator,
-        int_validator: Validator, bool_validator: Validator
+        int_validator: Validator, boolean_validator: Validator
 ) -> Schema:
     return {
         u'queues': [ignore_missing, list_of_strings],
         'limit': [ignore_missing, int_validator],
-        'ids_only': [ignore_missing, bool_validator],
+        'ids_only': [ignore_missing, boolean_validator],
     }
 
 

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -782,10 +782,13 @@ def update_configuration_schema():
 
 @validator_args
 def job_list_schema(
-        ignore_missing: Validator, list_of_strings: Validator
+        ignore_missing: Validator, list_of_strings: Validator,
+        int_validator: Validator, bool_validator: Validator
 ) -> Schema:
     return {
         u'queues': [ignore_missing, list_of_strings],
+        'limit': [ignore_missing, int_validator],
+        'ids_only': [ignore_missing, bool_validator],
     }
 
 

--- a/ckan/types/logic/action_result.py
+++ b/ckan/types/logic/action_result.py
@@ -75,7 +75,7 @@ MemberRolesList = List[AnyDict]
 HelpShow = Optional[str]
 ConfigOptionShow = Any
 ConfigOptionList = List[str]
-JobList = List[AnyDict]
+JobList = Union[List[AnyDict], List[str]]
 JobShow = AnyDict
 ApiTokenList = List[AnyDict]
 


### PR DESCRIPTION
feat(dev): job list limit;

- Job list limit and ides only options.

### Proposed fixes:

Adds default limit of 200 and config option `ckan.jobs.default_list_limit` to the `job_list` action method.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
