### PR TITLE
Docs: remove Python 2.7 URL links

### DIFF
--- a/doc/contributing/python.rst
+++ b/doc/contributing/python.rst
@@ -74,7 +74,7 @@ Imports
 Logging
 -------
 
-We use `the Python standard library's logging module <https://docs.python.org/2.7/library/logging.html>`_
+We use `the Python standard library's logging module <https://docs.python.org/3/library/logging.html>`_
 to log messages in CKAN, e.g.::
 
     import logging
@@ -106,7 +106,7 @@ replacement field, for example::
 
   _(' ... {foo} ... {bar} ...').format(foo='foo-value', bar='bar-value')
 
-.. _new .format() method: http://docs.python.org/2/library/stdtypes.html#str.format
+.. _new .format() method: https://docs.python.org/3/library/stdtypes.html#str.format
 
 
 Unicode handling

--- a/doc/contributing/unicode.rst
+++ b/doc/contributing/unicode.rst
@@ -87,7 +87,7 @@ prefix. Simply use ``ur`` instead::
 For more information on string prefixes please refer to the
 `Python documentation`_.
 
-.. _Python documentation: https://docs.python.org/2.7/reference/lexical_analysis.html#string-literals
+.. _Python documentation: https://docs.python.org/3/reference/lexical_analysis.html
 
 .. note::
 

--- a/doc/maintaining/background-tasks.rst
+++ b/doc/maintaining/background-tasks.rst
@@ -381,10 +381,7 @@ job ID, that will be done automatically for you.
 
 Supporting both systems at once
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Not all CKAN installations will immediately update to CKAN 2.7. It might
-therefore make sense for you to support both the new and the old job system.
-That way you are ready when the old system is removed but can continue to
-support older CKAN installations.
+It might make sense to support both the RQ and the old Celery-based job system.
 
 The easiest way to do that is to use `ckanext-rq
 <https://github.com/davidread/ckanext-rq>`_, which provides a back-port of the


### PR DESCRIPTION


Fixes https://github.com/ckan/ckan/issues/8060

### Proposed fixes:
There are a number of Python **2.7** URL links in 2 documentation pages. These have been replaced with links to Python **3** pages


### Features:

- [ ] includes tests covering changes
- [x ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
