### PR TITLE
Fix Password Reset Keys w/ Multiple Accounts

### DIFF
--- a/changes/8077.bugfix
+++ b/changes/8077.bugfix
@@ -1,0 +1,2 @@
+Fixed an issue when resetting password with
+an email address belonging to multiple user accounts.

--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -283,7 +283,7 @@ def send_invite(
 
 def create_reset_key(user: model.User):
     user.reset_key = make_key()
-    model.repo.commit_and_remove()
+    model.repo.commit()
 
 
 def make_key():

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -698,22 +698,18 @@ class RequestResetView(MethodView):
                 # user, as that would reveal the existence of accounts with
                 # this email address)
                 for user_dict in user_list:
-                    # This is ugly, but we need the user object for the mailer,
-                    # and user_list does not return them
-                    logic.get_action(u'user_show')(
-                        context, {u'id': user_dict[u'id']})
-                    user_objs.append(context[u'user_obj'])
+                    # `user_list` returned the users,
+                    # so we know they exist here.
+                    user_objs.append(model.User.get(user_dict['id']))
 
         else:
             # Search by user name
             # (this is helpful as an option for a user who has multiple
             # accounts with the same email address and they want to be
             # specific)
-            try:
-                logic.get_action(u'user_show')(context, {u'id': id})
-                user_objs.append(context[u'user_obj'])
-            except logic.NotFound:
-                pass
+            user_obj = model.User.get(id)
+            if user_obj:
+                user_objs.append(user_obj)
 
         if not user_objs:
             log.info(u'User requested reset link for unknown user: {}'
@@ -736,6 +732,9 @@ class RequestResetView(MethodView):
                 log.exception(e)
                 return h.redirect_to(config.get(
                     u'ckan.user_reset_landing_page'))
+
+        # commit any final changes and remove session
+        model.repo.commit_and_remove()
 
         # always tell the user it succeeded, because otherwise we reveal
         # which accounts exist or not

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -698,9 +698,10 @@ class RequestResetView(MethodView):
                 # user, as that would reveal the existence of accounts with
                 # this email address)
                 for user_dict in user_list:
-                    # `user_list` returned the users,
-                    # so we know they exist here.
-                    user_objs.append(model.User.get(user_dict['id']))
+                    # type_ignore_reason: `user_list` returned the users,
+                    #                     so we know they exist here.
+                    user_objs.append(
+                        model.User.get(user_dict['id']))  # type: ignore
 
         else:
             # Search by user name


### PR DESCRIPTION
fix(user): fix reset keys multiple;

- Fix multiple user account reset keys not getting committed to DB.

### Proposed fixes:

The password reset gen method used `commit_and_remove` which prevented any other DB things from happening. So when in the loop to send multiple reset emails, only the first user object would get the reset key inserted into the DB.

This is only an issue with resetting password with an email that is used on multiple accounts. So will for sure need backporting.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
