### PR TITLE
Fix Password Reset Keys w/ Multiple Accounts (2.9 Patch)

### DIFF
--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -204,7 +204,7 @@ def send_invite(user, group_dict=None, role=None):
 
 def create_reset_key(user):
     user.reset_key = text_type(make_key())
-    model.repo.commit_and_remove()
+    model.repo.commit()
 
 
 def make_key():


### PR DESCRIPTION
fix(user): fix reset keys multiple;

- Fix multiple user account reset keys not getting committed to DB.

### Proposed fixes:

The password reset gen method used `commit_and_remove` which prevented any other DB things from happening. So when in the loop to send multiple reset emails, only the first user object would get the reset key inserted into the DB.

This is only an issue with resetting password with an email that is used on multiple accounts. So will for sure need backporting.

See: https://github.com/ckan/ckan/pull/8077 for master PR

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
