### PR TITLE
fix: Only show count of datasets on dashboard org page

### DIFF
--- a/changes/8082.bugfix
+++ b/changes/8082.bugfix
@@ -1,0 +1,1 @@
+Only show the count of an org's datasets on the dashboard organization list (not harvesters, showcases, etc.).

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -333,7 +333,7 @@ def _get_members(context: Context, group: model.Group,
 def get_group_dataset_counts() -> dict[str, Any]:
     '''For all public groups, return their dataset counts, as a SOLR facet'''
     query = search.PackageSearchQuery()
-    q: dict[str, Any] = {'q': '',
+    q: dict[str, Any] = {'q': '', 'fq': 'dataset_type:dataset',
          'fl': 'groups', 'facet.field': ['groups', 'owner_org'],
          'facet.limit': -1, 'rows': 1}
     query.run(q)

--- a/ckan/tests/lib/dictization/test_model_dictize.py
+++ b/ckan/tests/lib/dictization/test_model_dictize.py
@@ -304,6 +304,8 @@ class TestGroupDictize:
         org_obj = factories.Organization.model()
         other_org_ = factories.Organization()
         factories.Dataset(owner_org=org_obj.id)
+        # only actual datasets should be returned
+        factories.Dataset(owner_org=org_obj.id, dataset_type="not_dataset")
         factories.Dataset(owner_org=other_org_["id"])
         context = {
             "model": model,

--- a/ckan/tests/lib/dictization/test_model_dictize.py
+++ b/ckan/tests/lib/dictization/test_model_dictize.py
@@ -305,7 +305,7 @@ class TestGroupDictize:
         other_org_ = factories.Organization()
         factories.Dataset(owner_org=org_obj.id)
         # only actual datasets should be returned
-        factories.Dataset(owner_org=org_obj.id, dataset_type="not_dataset")
+        factories.Dataset(owner_org=org_obj.id, type="not_dataset")
         factories.Dataset(owner_org=other_org_["id"])
         context = {
             "model": model,


### PR DESCRIPTION
### Proposed fixes:

Without this filter, packages of non-dataset type (e.g. harvesters, showcases) are included in the dataset count for organisations on the user's dashboard. If the user then clicks through to the organization itself, a different count is displayed (datasets only), which is confusing.

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
