### PR TITLE
Fixed typo http://http:// -> http://

### DIFF
--- a/doc/maintaining/installing/deployment.rst
+++ b/doc/maintaining/installing/deployment.rst
@@ -13,7 +13,7 @@ deployment configurations, however the CKAN project has now standardized on one 
 
 .. _uwsgi: https://uwsgi-docs.readthedocs.io/en/latest/
 .. _NGINX: http://nginx.org/
-.. _Supervisor: http://http://supervisord.org/
+.. _Supervisor: http://supervisord.org/
 
 This guide explains how to deploy CKAN using a uwsgi web server and proxied
 with NGINX on an Ubuntu server. These instructions have been tested on Ubuntu


### PR DESCRIPTION
Fixes #

There was a small typo in the documentation that led to a broken URL.

### Proposed fixes:

Fixes a broken URL.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
