### PR TITLE
Increase read bytes from file to detect xlsx mimetypes correctly

### DIFF
--- a/changes/8088.bugfix
+++ b/changes/8088.bugfix
@@ -1,0 +1,1 @@
+Detect XLSX mimetypes correctly in uploader

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -211,7 +211,7 @@ class Upload(object):
         if not mimetypes and not types:
             return
 
-        actual = magic.from_buffer(self.upload_file.read(1024), mime=True)
+        actual = magic.from_buffer(self.upload_file.read(2048), mime=True)
         self.upload_file.seek(0, os.SEEK_SET)
         err: ErrorDict = {
             self.file_field: [f"Unsupported upload type: {actual}"]

--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -211,6 +211,7 @@ class Upload(object):
         if not mimetypes and not types:
             return
 
+        # 2KB required for detecting xlsx mimetype
         actual = magic.from_buffer(self.upload_file.read(2048), mime=True)
         self.upload_file.seek(0, os.SEEK_SET)
         err: ErrorDict = {


### PR DESCRIPTION
XLSX files technically are just zipped files and magic detects them as `applcation/zip`, internet sources say that reading about 2000 bytes should be enough to detect them as `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`

We had a custom object type where the files were handled with standard uploader and stumbled upon this.

This should be backported to 2.9 and 2.10 as well.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
