### PR TITLE
Datastore Records Delete Action Fix

### DIFF
--- a/changes/8101.feature
+++ b/changes/8101.feature
@@ -1,0 +1,2 @@
+`datastore_records_delete` action now calls the `datastore_delete` action
+via the toolkit for better frameworking.

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -524,7 +524,7 @@ def datastore_records_delete(context: Context, data_dict: dict[str, Any]):
     data_dict, errors = _validate(data_dict, schema, context)
     if errors:
         raise p.toolkit.ValidationError(errors)
-    return datastore_delete(context, data_dict)
+    return p.toolkit.get_action('datastore_delete')(context, data_dict)
 
 
 @logic.side_effect_free


### PR DESCRIPTION
fix(logic): ds delete;

- Call `datastore_delete` action via toolkit in `datastore_records_delete`.

### Proposed fixes:

Call the `datastore_delete` action via the toolkit in `datastore_records_delete` so that `datastore_records_delete` is frameworked.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
