### PR TITLE
definition list for data dictionary view

### DIFF
--- a/changes/8110.feature
+++ b/changes/8110.feature
@@ -1,0 +1,3 @@
+Use a definition list for the Data Dictionary view on resource pages to allow
+extra information for each field. Update example_idatadictionaryform plugin to
+display extra information.

--- a/ckanext/datastore/assets/css/datastore.css
+++ b/ckanext/datastore/assets/css/datastore.css
@@ -1,3 +1,7 @@
+.accordion-button.no-after::after {
+  background-image: none;
+}
+
 input#lang-curl ~ div .example-curl {
   display: none;
 }

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -2315,7 +2315,12 @@ class DatastorePostgresqlBackend(DatastoreBackend):
             info['meta']['aliases'] = aliases
 
             # get the data dictionary for the resource
-            data_dictionary = datastore_helpers.datastore_dictionary(id)
+            with engine.connect() as conn:
+                data_dictionary = _result_fields(
+                    _get_fields_types(conn, id),
+                    _get_field_info(conn, id),
+                    None
+                )
 
             schema_sql = sa.text(f'''
                 SELECT
@@ -2361,6 +2366,8 @@ class DatastorePostgresqlBackend(DatastoreBackend):
                 schemainfo[colname] = colinfo
 
             for field in data_dictionary:
+                if field['id'].startswith('_'):
+                    continue
                 field.update({'schema': schemainfo[field['id']]})
                 info['fields'].append(field)
 

--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -216,11 +216,8 @@ def datastore_dictionary(
     """
     try:
         return [
-            f for f in tk.get_action('datastore_search')(
-                {}, {
-                    u'resource_id': resource_id,
-                    u'limit': 0,
-                    u'include_total': False})['fields']
+            f for f in tk.get_action('datastore_info')(
+                {}, {'id': resource_id})['fields']
             if not f['id'].startswith(u'_') and (
                 include_columns is None or f['id'] in include_columns)
             ]

--- a/ckanext/datastore/templates/datastore/snippets/dictionary_view.html
+++ b/ckanext/datastore/templates/datastore/snippets/dictionary_view.html
@@ -17,20 +17,20 @@
 
       <div class="accordion">
         <div class="accordion-item">
-          <h3 class="accordion-header" id="field-{{ field.id }}"
+          <h3 class="accordion-header" id="field-{{ loop.index }}"
             ><button class="accordion-button collapsed" type="button"
             data-bs-toggle="collapse" aria-expanded="false"
-            data-bs-target="#collapse{{ prefix }}-{{ field.id }}"
-            aria-controls="collapse{{ prefix }}-{{ field.id }}"
+            data-bs-target="#collapse{{ prefix }}-{{ loop.index }}"
+            aria-controls="collapse{{ prefix }}-{{ loop.index }}"
             ><div class="col-sm-1"
             >{{ loop.index }}.</div
             ><div class="col-sm-7">{{
             h.get_translated(field.get('info', {}), 'label') or field.id
             }}</div><div class="col-sm-4"
             >{{ field_type }}</div></h3>
-          <div id="collapse{{ prefix }}-{{ field.id }}"
+          <div id="collapse{{ prefix }}-{{ loop.index }}"
             class="accordion-collapse collapse"
-            aria-labelledby="field-{{ field.id }}">
+            aria-labelledby="field-{{ loop.index }}">
             <dl class="row accordion-body">
               {% block resource_data_dictionary_field scoped %}
                 {% call dictionary_field(_('ID')) %}{{ field.id }}{% endcall %}

--- a/ckanext/datastore/templates/datastore/snippets/dictionary_view.html
+++ b/ckanext/datastore/templates/datastore/snippets/dictionary_view.html
@@ -30,12 +30,12 @@
 
       <div class="accordion">
         <div class="accordion-item">
-          <h3 class="accordion-header" id="field-{{ loop.index }}">
+          <h3 class="accordion-header" id="field{{ prefix }}-{{ loop.index }}">
             {%- if has_extra -%}
               <button class="accordion-button collapsed" type="button"
               data-bs-toggle="collapse" aria-expanded="false"
-              data-bs-target="#collapse-{{ loop.index }}"
-              aria-controls="collapse-{{ loop.index }}">
+              data-bs-target="#collapse{{ prefix }}-{{ loop.index }}"
+              aria-controls="collapse{{ prefix }}-{{ loop.index }}">
             {%- else -%}
               <button class="accordion-button no-after" disabled>
             {%- endif -%}
@@ -47,9 +47,9 @@
             </button>
           </h3>
           {% if has_extra %}
-            <div id="collapse-{{ loop.index }}"
+            <div id="collapse{{ prefix }}-{{ loop.index }}"
               class="accordion-collapse collapse"
-              aria-labelledby="field-{{ loop.index }}">
+              aria-labelledby="field{{ prefix }}-{{ loop.index }}">
               <dl class="row accordion-body">
                 {% block resource_data_dictionary_field scoped %}
                   {% call dictionary_field(_('ID')) %}{{ field.id }}{% endcall %}

--- a/ckanext/datastore/templates/datastore/snippets/dictionary_view.html
+++ b/ckanext/datastore/templates/datastore/snippets/dictionary_view.html
@@ -14,37 +14,51 @@
 
       {% set field_type %}{% block dictionary_field_type scoped
         %}{{ field.type }}{% endblock %}{% endset %}
+      {% set extra_info -%}
+        {% call dictionary_field(_('Label')) %}
+          {{ h.get_translated(field.get('info', {}), 'label') }}
+        {% endcall %}
+        {% call dictionary_field(_('Description')) %}
+          {{ h.render_markdown(h.get_translated(
+            field.get('info', {}), 'notes')) }}
+        {% endcall %}
+        {% block dictionary_field_extras scoped %}
+        {% endblock %}
+      {%- endset %}
+      {# render_markdown to strip snippet comments and whitespace #}
+      {% set has_extra=h.render_markdown(extra_info) %}
 
       <div class="accordion">
         <div class="accordion-item">
-          <h3 class="accordion-header" id="field-{{ loop.index }}"
-            ><button class="accordion-button collapsed" type="button"
-            data-bs-toggle="collapse" aria-expanded="false"
-            data-bs-target="#collapse{{ prefix }}-{{ loop.index }}"
-            aria-controls="collapse{{ prefix }}-{{ loop.index }}"
-            ><div class="col-sm-1"
-            >{{ loop.index }}.</div
-            ><div class="col-sm-7">{{
-            h.get_translated(field.get('info', {}), 'label') or field.id
-            }}</div><div class="col-sm-4"
-            >{{ field_type }}</div></h3>
-          <div id="collapse{{ prefix }}-{{ loop.index }}"
-            class="accordion-collapse collapse"
-            aria-labelledby="field-{{ loop.index }}">
-            <dl class="row accordion-body">
-              {% block resource_data_dictionary_field scoped %}
-                {% call dictionary_field(_('ID')) %}{{ field.id }}{% endcall %}
-                {% call dictionary_field(_('Type')) %}{{ field_type }}{% endcall %}
-                {% call dictionary_field(_('Label')) %}{{
-                  h.get_translated(field.get('info', {}), 'label') }}{% endcall %}
-                {% call dictionary_field(_('Description')) %}{{
-                  h.render_markdown(h.get_translated(
-                  field.get('info', {}), 'notes')) }}{% endcall %}
-                {% block dictionary_field_extras scoped %}
+          <h3 class="accordion-header" id="field-{{ loop.index }}">
+            {%- if has_extra -%}
+              <button class="accordion-button collapsed" type="button"
+              data-bs-toggle="collapse" aria-expanded="false"
+              data-bs-target="#collapse-{{ loop.index }}"
+              aria-controls="collapse-{{ loop.index }}">
+            {%- else -%}
+              <button class="accordion-button no-after" disabled>
+            {%- endif -%}
+              <div class="col-1">{{ loop.index }}.</div><div class="col-7">
+                {{- h.get_translated(field.get('info', {}), 'label')
+                  or field.id -}}
+              </div>
+              <div class="col-4">{{ field_type }}</div>
+            </button>
+          </h3>
+          {% if has_extra %}
+            <div id="collapse-{{ loop.index }}"
+              class="accordion-collapse collapse"
+              aria-labelledby="field-{{ loop.index }}">
+              <dl class="row accordion-body">
+                {% block resource_data_dictionary_field scoped %}
+                  {% call dictionary_field(_('ID')) %}{{ field.id }}{% endcall %}
+                  {% call dictionary_field(_('Type')) %}{{ field_type }}{% endcall %}
+                  {{ extra_info }}
                 {% endblock %}
-              {% endblock %}
-            </dl>
-          </div>
+              </dl>
+            </div>
+          {% endif %}
         </div>
       </div>
 

--- a/ckanext/datastore/templates/datastore/snippets/dictionary_view.html
+++ b/ckanext/datastore/templates/datastore/snippets/dictionary_view.html
@@ -20,15 +20,15 @@
           <h3 class="accordion-header" id="field-{{ field.id }}"
             ><button class="accordion-button collapsed" type="button"
             data-bs-toggle="collapse" aria-expanded="false"
-            data-bs-target="#collapse-{{ field.id }}"
-            aria-controls="collapse-{{ field.id }}"
+            data-bs-target="#collapse{{ prefix }}-{{ field.id }}"
+            aria-controls="collapse{{ prefix }}-{{ field.id }}"
             ><div class="col-sm-1"
             >{{ loop.index }}.</div
             ><div class="col-sm-7">{{
             h.get_translated(field.get('info', {}), 'label') or field.id
             }}</div><div class="col-sm-4"
             >{{ field_type }}</div></h3>
-          <div id="collapse-{{ field.id }}"
+          <div id="collapse{{ prefix }}-{{ field.id }}"
             class="accordion-collapse collapse"
             aria-labelledby="field-{{ field.id }}">
             <dl class="row accordion-body">

--- a/ckanext/datastore/templates/datastore/snippets/dictionary_view.html
+++ b/ckanext/datastore/templates/datastore/snippets/dictionary_view.html
@@ -1,0 +1,53 @@
+{% block dictionary_view %}
+  <div class="module-content">
+    <h2>{{ _('Data Dictionary') }}</h2>
+
+    {% macro dictionary_field(label) %}
+      {% set content = caller().strip() %}
+      {% if content %}
+        <dt class="col-sm-3 text-secondary">{{ label }}</dt>
+        <dd class="col-sm-9">{{ content }}</dd>
+      {% endif %}
+    {% endmacro %}
+
+    {% for field in ddict %}
+
+      {% set field_type %}{% block dictionary_field_type scoped
+        %}{{ field.type }}{% endblock %}{% endset %}
+
+      <div class="accordion">
+        <div class="accordion-item">
+          <h3 class="accordion-header" id="field-{{ field.id }}"
+            ><button class="accordion-button collapsed" type="button"
+            data-bs-toggle="collapse" aria-expanded="false"
+            data-bs-target="#collapse-{{ field.id }}"
+            aria-controls="collapse-{{ field.id }}"
+            ><div class="col-sm-1"
+            >{{ loop.index }}.</div
+            ><div class="col-sm-7">{{
+            h.get_translated(field.get('info', {}), 'label') or field.id
+            }}</div><div class="col-sm-4"
+            >{{ field_type }}</div></h3>
+          <div id="collapse-{{ field.id }}"
+            class="accordion-collapse collapse"
+            aria-labelledby="field-{{ field.id }}">
+            <dl class="row accordion-body">
+              {% block resource_data_dictionary_field scoped %}
+                {% call dictionary_field(_('ID')) %}{{ field.id }}{% endcall %}
+                {% call dictionary_field(_('Type')) %}{{ field_type }}{% endcall %}
+                {% call dictionary_field(_('Label')) %}{{
+                  h.get_translated(field.get('info', {}), 'label') }}{% endcall %}
+                {% call dictionary_field(_('Description')) %}{{
+                  h.render_markdown(h.get_translated(
+                  field.get('info', {}), 'notes')) }}{% endcall %}
+                {% block dictionary_field_extras scoped %}
+                {% endblock %}
+              {% endblock %}
+            </dl>
+          </div>
+        </div>
+      </div>
+
+    {% endfor %}
+  </div>
+{% endblock %}

--- a/ckanext/datastore/templates/package/resource_read.html
+++ b/ckanext/datastore/templates/package/resource_read.html
@@ -52,23 +52,37 @@
           {% set ddict=h.datastore_dictionary(res.id) %}
           {% for field in ddict %}
 
-            <h3 id="field-{{ field.id }}"><a href="#field-{{ field.id }}"
-              >{{ loop.index }}.</a> {{
-              h.get_translated(field.get('info', {}), 'label') or field.id
-              }}</a></h3>
-            <dl class="row">
-              {% block resource_data_dictionary_field scoped %}
-                {% call dictionary_field(_('ID')) %}{{ field.id }}{% endcall %}
-                {% call dictionary_field(_('Type')) %}{{ field.type }}{% endcall %}
-                {% call dictionary_field(_('Label')) %}{{
-                  h.get_translated(field.get('info', {}), 'label') }}{% endcall %}
-                {% call dictionary_field(_('Description')) %}{{
-                  h.render_markdown(h.get_translated(
-                  field.get('info', {}), 'notes')) }}{% endcall %}
-                {% block resource_data_dictionary_field_extras scoped %}
-                {% endblock %}
-              {% endblock %}
-            </dl>
+            <div class="accordion">
+              <div class="accordion-item">
+                <h3 class="accordion-header row" id="field-{{ field.id }}"
+                  ><button class="accordion-button collapsed" type="button"
+                  data-bs-toggle="collapse" aria-expanded="false"
+                  data-bs-target="#collapse-{{ field.id }}"
+                  aria-controls="collapse-{{ field.id }}"
+                  ><div class="col-sm-1"
+                  >{{ loop.index }}.</div
+                  ><div class="col-sm-7">{{
+                  h.get_translated(field.get('info', {}), 'label') or field.id
+                  }}</div><div class="col-sm-4">{{ field.type }}</div></h3>
+                <div id="collapse-{{ field.id }}"
+                  class="accordion-collapse collapse"
+                  aria-labelledby="field-{{ field.id }}">
+                  <dl class="row accordion-body">
+                    {% block resource_data_dictionary_field scoped %}
+                      {% call dictionary_field(_('ID')) %}{{ field.id }}{% endcall %}
+                      {% call dictionary_field(_('Type')) %}{{ field.type }}{% endcall %}
+                      {% call dictionary_field(_('Label')) %}{{
+                        h.get_translated(field.get('info', {}), 'label') }}{% endcall %}
+                      {% call dictionary_field(_('Description')) %}{{
+                        h.render_markdown(h.get_translated(
+                        field.get('info', {}), 'notes')) }}{% endcall %}
+                      {% block resource_data_dictionary_field_extras scoped %}
+                      {% endblock %}
+                    {% endblock %}
+                  </dl>
+                </div>
+              </div>
+            </div>
 
           {% endfor %}
         {% endblock %}

--- a/ckanext/datastore/templates/package/resource_read.html
+++ b/ckanext/datastore/templates/package/resource_read.html
@@ -35,8 +35,10 @@
 
 {% block resource_additional_information_inner %}
   {% if res.datastore_active %}
-    {% snippet 'datastore/snippets/dictionary_view.html',
-      ddict=h.datastore_dictionary(res.id) %}
+    {% block resource_data_dictionary %}
+      {% snippet 'datastore/snippets/dictionary_view.html',
+        ddict=h.datastore_dictionary(res.id) %}
+    {% endblock %}
   {% endif %}
   {{ super() }}
 {% endblock %}

--- a/ckanext/datastore/templates/package/resource_read.html
+++ b/ckanext/datastore/templates/package/resource_read.html
@@ -35,29 +35,43 @@
 
 {% block resource_additional_information_inner %}
   {% if res.datastore_active %}
-  {% block resource_data_dictionary %}
-    <div class="module-content">
-      <h2>{{ _('Data Dictionary') }}</h2>
-      <table class="table table-striped table-bordered table-condensed" data-module="table-toggle-more">
-        <thead>
-          {% block resouce_data_dictionary_headers %}
-          <tr>
-            <th scope="col">{{ _('Column') }}</th>
-            <th scope="col">{{ _('Type') }}</th>
-            <th scope="col">{{ _('Label') }}</th>
-            <th scope="col">{{ _('Description') }}</th>
-          </tr>
-          {% endblock %}
-        </thead>
-        {% block resource_data_dictionary_data %}
-          {% set dict=h.datastore_dictionary(res.id) %}
-          {% for field in dict %}
-            {% snippet "package/snippets/dictionary_table.html", field=field %}
+
+    {% block resource_data_dictionary %}
+      <div class="module-content">
+        <h2>{{ _('Data Dictionary') }}</h2>
+
+        {% macro dictionary_field(label) %}
+          {% set content = caller() %}
+          {% if content %}
+            <dt class="col-sm-3 text-secondary">{{ label }}</dt>
+            <dd class="col-sm-9">{{ caller() }}</dd>
+          {% endif %}
+        {% endmacro %}
+
+        {% block resource_data_dictionary_data scoped %}
+          {% set ddict=h.datastore_dictionary(res.id) %}
+          {% for field in ddict %}
+
+            <h3 id="field-{{ field.id }}"><a href="#field-{{ field.id }}"
+              >{{ loop.index }}.</a> {{
+              h.get_translated(field.get('info', {}), 'label') or field.id
+              }}</a></h3>
+            <dl class="row">
+              {% block resource_data_dictionary_field scoped %}
+                {% call dictionary_field(_('ID')) %}{{ field.id }}{% endcall %}
+                {% call dictionary_field(_('Type')) %}{{ field.type }}{% endcall %}
+                {% call dictionary_field(_('Label')) %}{{
+                  h.get_translated(field.get('info', {}), 'label') }}{% endcall %}
+                {% call dictionary_field(_('Description')) %}{{
+                  h.render_markdown(h.get_translated(
+                  field.get('info', {}), 'notes')) }}{% endcall %}
+              {% endblock %}
+            </dl>
+
           {% endfor %}
         {% endblock %}
-      </table>
-    </div>
-  {% endblock %}
+      </div>
+    {% endblock %}
   {% endif %}
   {{ super() }}
 {% endblock %}

--- a/ckanext/datastore/templates/package/resource_read.html
+++ b/ckanext/datastore/templates/package/resource_read.html
@@ -54,7 +54,7 @@
 
             <div class="accordion">
               <div class="accordion-item">
-                <h3 class="accordion-header row" id="field-{{ field.id }}"
+                <h3 class="accordion-header" id="field-{{ field.id }}"
                   ><button class="accordion-button collapsed" type="button"
                   data-bs-toggle="collapse" aria-expanded="false"
                   data-bs-target="#collapse-{{ field.id }}"

--- a/ckanext/datastore/templates/package/resource_read.html
+++ b/ckanext/datastore/templates/package/resource_read.html
@@ -65,6 +65,8 @@
                 {% call dictionary_field(_('Description')) %}{{
                   h.render_markdown(h.get_translated(
                   field.get('info', {}), 'notes')) }}{% endcall %}
+                {% block resource_data_dictionary_field_extras scoped %}
+                {% endblock %}
               {% endblock %}
             </dl>
 

--- a/ckanext/datastore/templates/package/resource_read.html
+++ b/ckanext/datastore/templates/package/resource_read.html
@@ -41,10 +41,10 @@
         <h2>{{ _('Data Dictionary') }}</h2>
 
         {% macro dictionary_field(label) %}
-          {% set content = caller() %}
+          {% set content = caller().strip() %}
           {% if content %}
             <dt class="col-sm-3 text-secondary">{{ label }}</dt>
-            <dd class="col-sm-9">{{ caller() }}</dd>
+            <dd class="col-sm-9">{{ content }}</dd>
           {% endif %}
         {% endmacro %}
 

--- a/ckanext/datastore/templates/package/resource_read.html
+++ b/ckanext/datastore/templates/package/resource_read.html
@@ -35,59 +35,8 @@
 
 {% block resource_additional_information_inner %}
   {% if res.datastore_active %}
-
-    {% block resource_data_dictionary %}
-      <div class="module-content">
-        <h2>{{ _('Data Dictionary') }}</h2>
-
-        {% macro dictionary_field(label) %}
-          {% set content = caller().strip() %}
-          {% if content %}
-            <dt class="col-sm-3 text-secondary">{{ label }}</dt>
-            <dd class="col-sm-9">{{ content }}</dd>
-          {% endif %}
-        {% endmacro %}
-
-        {% block resource_data_dictionary_data scoped %}
-          {% set ddict=h.datastore_dictionary(res.id) %}
-          {% for field in ddict %}
-
-            <div class="accordion">
-              <div class="accordion-item">
-                <h3 class="accordion-header" id="field-{{ field.id }}"
-                  ><button class="accordion-button collapsed" type="button"
-                  data-bs-toggle="collapse" aria-expanded="false"
-                  data-bs-target="#collapse-{{ field.id }}"
-                  aria-controls="collapse-{{ field.id }}"
-                  ><div class="col-sm-1"
-                  >{{ loop.index }}.</div
-                  ><div class="col-sm-7">{{
-                  h.get_translated(field.get('info', {}), 'label') or field.id
-                  }}</div><div class="col-sm-4">{{ field.type }}</div></h3>
-                <div id="collapse-{{ field.id }}"
-                  class="accordion-collapse collapse"
-                  aria-labelledby="field-{{ field.id }}">
-                  <dl class="row accordion-body">
-                    {% block resource_data_dictionary_field scoped %}
-                      {% call dictionary_field(_('ID')) %}{{ field.id }}{% endcall %}
-                      {% call dictionary_field(_('Type')) %}{{ field.type }}{% endcall %}
-                      {% call dictionary_field(_('Label')) %}{{
-                        h.get_translated(field.get('info', {}), 'label') }}{% endcall %}
-                      {% call dictionary_field(_('Description')) %}{{
-                        h.render_markdown(h.get_translated(
-                        field.get('info', {}), 'notes')) }}{% endcall %}
-                      {% block resource_data_dictionary_field_extras scoped %}
-                      {% endblock %}
-                    {% endblock %}
-                  </dl>
-                </div>
-              </div>
-            </div>
-
-          {% endfor %}
-        {% endblock %}
-      </div>
-    {% endblock %}
+    {% snippet 'datastore/snippets/dictionary_view.html',
+      ddict=h.datastore_dictionary(res.id) %}
   {% endif %}
   {{ super() }}
 {% endblock %}

--- a/ckanext/datastore/templates/package/snippets/dictionary_table.html
+++ b/ckanext/datastore/templates/package/snippets/dictionary_table.html
@@ -1,7 +1,0 @@
-<tr>
-  <td>{{ field.id }}</td>
-  <td>{{ field.type }}</td>
-  <td>{{ h.get_translated(field.get('info', {}), 'label') }}</td>
-  <td>{{ h.render_markdown(
-    h.get_translated(field.get('info', {}), 'notes')) }}</td>
-</tr>

--- a/ckanext/example_idatadictionaryform/templates/datastore/snippets/dictionary_view.html
+++ b/ckanext/example_idatadictionaryform/templates/datastore/snippets/dictionary_view.html
@@ -1,6 +1,6 @@
 {% ckan_extends %}
 
-{% block resource_data_dictionary_field_extras %}
+{% block dictionary_field_extras %}
   {{ super() }}
   {% call dictionary_field(_('An integer')) %}{{ field.an_int }}{% endcall %}
   {% call dictionary_field(_('JSON object')) %}{{ field.json_obj }}{% endcall %}

--- a/ckanext/example_idatadictionaryform/templates/package/resource_read.html
+++ b/ckanext/example_idatadictionaryform/templates/package/resource_read.html
@@ -1,0 +1,9 @@
+{% ckan_extends %}
+
+{% block resource_data_dictionary_field_extras %}
+  {{ super() }}
+  {% call dictionary_field(_('An integer')) %}{{ field.an_int }}{% endcall %}
+  {% call dictionary_field(_('JSON object')) %}{{ field.json_obj }}{% endcall %}
+  {% call dictionary_field(_('Always increasing')) %}{{ field.only_up }}{% endcall %}
+  {% call dictionary_field(_('Sticky input')) %}{{ field.sticky }}{% endcall %}
+{% endblock %}


### PR DESCRIPTION
Fixes #8108 

### Proposed fixes:
Switch data dictionary from a table display to a definition list to allow additional information to be added for each field.

Current:

![data-dictionary-table](https://github.com/ckan/ckan/assets/153258/0c1896f1-695a-4cb8-a580-649e8e08a238)

New:

![data-dictionary-dl](https://github.com/ckan/ckan/assets/153258/cf4d5614-96ba-4ed4-b6c3-ed553fb8db44)

New with additional information per field:

![data-dictionary-extra](https://github.com/ckan/ckan/assets/153258/512223d3-e287-45fc-bf96-6b42dc44099a)


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
