### PR TITLE
Enable Jinja2 Autoescape

### DIFF
--- a/ckanext/activity/email_notifications.py
+++ b/ckanext/activity/email_notifications.py
@@ -89,7 +89,7 @@ def render_activity_email(activities: list[dict[str, Any]]) -> str:
     globals = {"site_title": config.get("ckan.site_title")}
     template_name = "activity_streams/activity_stream_email_notifications.text"
 
-    env = Environment(**jinja_extensions.get_jinja_env_options())
+    env = Environment(**jinja_extensions.get_jinja_env_options(), autoescape=True)
     # Install the given gettext, ngettext callables into the environment
     env.install_gettext_callables(ugettext, ungettext)  # type: ignore
 


### PR DESCRIPTION
### Proposed fixes:
This codemod enables autoescaping of HTML content in `jinja2`. Unfortunately, the jinja2 default behavior is to not autoescape when rendering templates, which makes your applications potentially vulnerable to Cross-Site Scripting (XSS) attacks.

Our codemod checks if you forgot to enable autoescape or if you explicitly disabled it. The change looks as follows:

```diff
  from jinja2 import Environment

- env = Environment()
- env = Environment(autoescape=False, loader=some_loader)
+ env = Environment(autoescape=True)
+ env = Environment(autoescape=True, loader=some_loader)
  ...
```

<details>
  <summary>More reading</summary>

  * [https://owasp.org/www-community/attacks/xss/](https://owasp.org/www-community/attacks/xss/)
  * [https://jinja.palletsprojects.com/en/3.1.x/api/#autoescaping](https://jinja.palletsprojects.com/en/3.1.x/api/#autoescaping)
</details>


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x ] includes bugfix for possible backport

Please [X] all the boxes above that apply
