### PR TITLE
allow sysadmins to edit usernames, #4193

### DIFF
--- a/changes/4193.feature
+++ b/changes/4193.feature
@@ -1,0 +1,1 @@
+Allow sysadmins to change usernames of other accounts

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -774,7 +774,7 @@ def user_update(context: Context, data_dict: DataDict) -> ActionResult.UserUpdat
     '''Update a user account.
 
     Normal users can only update their own user accounts. Sysadmins can update
-    any user account. Can not modify exisiting user's name.
+    any user account and modify existing usernames.
 
     .. note:: Update methods may delete parameters not explicitly provided in the
         data_dict. If you want to edit only a specific attribute use `user_patch`

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -14,7 +14,7 @@ from urllib.parse import urlparse
 from sqlalchemy.orm.exc import NoResultFound
 
 import ckan.lib.navl.dictization_functions as df
-import ckan.logic as logic
+from ckan import authz, logic
 import ckan.logic.converters as converters
 import ckan.lib.helpers as h
 from ckan.model import (MAX_TAG_LENGTH, MIN_TAG_LENGTH,
@@ -22,7 +22,6 @@ from ckan.model import (MAX_TAG_LENGTH, MIN_TAG_LENGTH,
                         PACKAGE_VERSION_MAX_LENGTH,
                         VOCABULARY_NAME_MAX_LENGTH,
                         VOCABULARY_NAME_MIN_LENGTH)
-import ckan.authz as authz
 from ckan.model.core import State
 
 from ckan.common import _
@@ -615,10 +614,13 @@ def user_name_validator(key: FlattenKey, data: FlattenDataDict,
             return
         else:
             # Otherwise return an error: there's already another user with that
-            # name, so you can create a new user with that name or update an
+            # name, so you can't create a new user with that name or update an
             # existing user's name to that name.
             errors[key].append(_('That login name is not available.'))
     elif user_obj_from_context:
+        requester = context.get('auth_user_obj', None)
+        if requester and authz.is_sysadmin(requester.name):
+            return
         old_user = model.User.get(user_obj_from_context.id)
         if old_user is not None and old_user.state != model.State.PENDING:
             errors[key].append(_('That login name can not be modified.'))

--- a/ckan/templates/user/edit_user_form.html
+++ b/ckan/templates/user/edit_user_form.html
@@ -8,7 +8,11 @@
     {% block core_fields %}
       <fieldset>
         <legend>{{ _('Change details') }}</legend>
-        {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], attrs={'readonly': '', 'class': 'form-control'}) }}
+        {% if g.userobj.sysadmin %}
+          {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], is_required=true) }}
+        {% else %}
+          {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], attrs={'readonly': '', 'class': 'form-control'}) }}
+        {% endif %}
 
         {{ form.input('fullname', label=_('Full name'), id='field-fullname', value=data.fullname, error=errors.fullname, placeholder=_('eg. Joe Bloggs'), classes=['control-medium']) }}
 

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -428,6 +428,23 @@ class TestUser(object):
 
         assert "That login name can not be modified" in response
 
+    def test_edit_user_logged_in_username_change_by_sysadmin(
+            self, app, user, sysadmin):
+        env = {"Authorization": sysadmin["token"]}
+
+        response = app.post(
+            url=url_for("user.edit", id=user["id"]),
+            data={
+                "email": user["email"],
+                "save": "",
+                "password1": "",
+                "password2": "",
+                "name": factories.User.stub().name,
+            },
+            extra_environ=env
+        )
+        assert 'Profile updated' in response
+
     def test_perform_reset_for_key_change(self, app):
         password = "TestPassword1"
         params = {"password1": password, "password2": password}

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -430,18 +430,19 @@ class TestUser(object):
 
     def test_edit_user_logged_in_username_change_by_sysadmin(
             self, app, user, sysadmin):
-        env = {"Authorization": sysadmin["token"]}
 
+        headers = {"Authorization": sysadmin["token"]}
         response = app.post(
             url=url_for("user.edit", id=user["id"]),
             data={
                 "email": user["email"],
                 "save": "",
+                "old_password": "correct123",
                 "password1": "",
                 "password2": "",
                 "name": factories.User.stub().name,
             },
-            extra_environ=env
+            headers=headers
         )
         assert 'Profile updated' in response
 


### PR DESCRIPTION
Discussion on #4193 identified editing usernames as a potential security hole, allowing takeover of another account in specific situations. However, sysadmins already have more privileges than this security weakness could grant. Thus, there is no additional risk in permitting sysadmins to edit other accounts.

### Proposed fixes:

Allow sysadmins to edit usernames.

### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
