### PR TITLE
fix email notifications checkbox

### DIFF
--- a/changes/8124.bugfix
+++ b/changes/8124.bugfix
@@ -1,0 +1,1 @@
+Populate email notification checkbox from the profile it's on, not from the logged-in user

--- a/ckanext/activity/templates/user/edit_user_form.html
+++ b/ckanext/activity/templates/user/edit_user_form.html
@@ -2,7 +2,7 @@
 
 {% block extra_fields %}
   {% if h.activity_show_email_notifications() %}
-    {% call form.checkbox('activity_streams_email_notifications', label=_('Subscribe to notification emails'), id='field-activity-streams-email-notifications', value=True, checked=g.userobj.activity_streams_email_notifications) %}
+    {% call form.checkbox('activity_streams_email_notifications', label=_('Subscribe to notification emails'), id='field-activity-streams-email-notifications', value=True, checked=data.activity_streams_email_notifications) %}
       {% set helper_text = _("You will receive notification emails from {site_title}, e.g. when you have new activities on your dashboard."|string) %}
       {{ form.info(helper_text.format(site_title=g.site_title)) }}
     {% endcall %}


### PR DESCRIPTION
Fixes #8124

### Proposed fixes:

Populate the email notification checkbox from the profile it's attached to, not from the logged-in user.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
