### PR TITLE
Evaluate use_default_schema as boolean

### DIFF
--- a/changes/8130.bugfix
+++ b/changes/8130.bugfix
@@ -1,0 +1,1 @@
+``use_default_schema`` in ``package_show`` is now evaluated as boolean.

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1004,7 +1004,7 @@ def package_show(context: Context, data_dict: DataDict) -> ActionResult.PackageS
     context['package'] = pkg
     _check_access('package_show', context, data_dict)
 
-    if data_dict.get('use_default_schema', False):
+    if asbool(data_dict.get('use_default_schema', False)):
         context['schema'] = ckan.logic.schema.default_show_package_schema()
 
     package_dict = None


### PR DESCRIPTION
### Proposed fixes:

`use_default_schema` is not evaluated as boolean, so if the parameter exists in HTTP api call it's always true. this handles the case it is actually set to false.

Should be backported to 2.9 and 2.10

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
