### PR TITLE
use translated notes field in package meta block

### DIFF
--- a/ckan/templates/package/read_base.html
+++ b/ckan/templates/package/read_base.html
@@ -6,7 +6,8 @@
 
 {% block head_extras -%}
   {{ super() }}
-  {% set description = h.markdown_extract(pkg.notes, extract_length=200)|forceescape %}
+  {% set description = h.markdown_extract(
+    h.get_translated(pkg, 'notes'), extract_length=200) %}
   <meta property="og:title" content="{{ h.dataset_display_name(pkg) }} - {{ g.site_title }}">
   <meta property="og:description" content="{{ description|forceescape|trim }}">
 {% endblock -%}


### PR DESCRIPTION
### Proposed fixes:
Use the correct language version of package notes in `<meta property="og:description"…` in the package read page.

Also, avoid double-escaping some characters (`forceescape` is already used below)


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport