### PR TITLE
Allow using `.` in Solr's local parser parameters

### DIFF
--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -103,7 +103,7 @@ def _parse_local_params(local_params: str) -> list[Union[str, list[str]]]:
     {!type=dismax qf=myfield v='some value'} -> [['type', 'dismax'], ['qf', 'myfield'], ['v', 'some value']]
 
     """
-    key = Word(alphanums + "_")
+    key = Word(alphanums + "_.")
     value = QuotedString('"') | QuotedString("'") | Word(alphanums + "_$")
     pair = Group(key + Suppress("=") + value)
     expression = Suppress("{!") + OneOrMore(pair | key) + Suppress("}")

--- a/ckan/tests/lib/search/test_search.py
+++ b/ckan/tests/lib/search/test_search.py
@@ -196,10 +196,9 @@ def test_allowed_local_params_via_config_not_defined():
     assert str(e.value) == "Local parameters are not supported in param 'q'."
 
 
-@pytest.mark.ckan_config("ckan.search.solr_allowed_query_parsers", "bool knn")
+@pytest.mark.ckan_config("ckan.search.solr_allowed_query_parsers", "bool knn lucene")
 @pytest.mark.usefixtures("clean_index")
 def test_allowed_local_params_via_config():
-
     factories.Dataset(title="A dataset about bees")
     factories.Dataset(title="A dataset about butterflies")
     query = search.query_for(model.Package)
@@ -212,3 +211,7 @@ def test_allowed_local_params_via_config():
     assert query.run({"q": "{!type=bool must=beetles}", "defType": "lucene"})["count"] == 0
 
     assert query.run({"q": "{!must=bees type=bool}", "defType": "lucene"})["count"] == 1
+
+    # Support dot symbol in keys
+    assert query.run({"fq": "{!lucene q.op=AND}bees butterflies"})["count"] == 0
+    assert query.run({"fq": "{!lucene q.op=OR}bees butterflies"})["count"] == 2


### PR DESCRIPTION
Addition to #8053

This PR adds `.` to the list of allowed characters for the parameter name of local parsers. For example, the `q.op` parameter in the following snippet does not pass validation now:
```python
query.run({"fq": "{!lucene q.op=OR}a b"})
```

With this PR applied, `q.op` is accepted by validator