### PR TITLE
Hide invite user form if can't create users

### DIFF
--- a/changes/8141.bugfix
+++ b/changes/8141.bugfix
@@ -1,0 +1,1 @@
+Hide invite user form if the user can't create users

--- a/ckan/templates/group/member_new.html
+++ b/ckan/templates/group/member_new.html
@@ -36,7 +36,7 @@
           </div>
         </div>
       </div>
-      {% if not user %}
+      {% if not user and h.check_access('user_create') %}
       <div class="col-md-2">
         <div class="add-member-or">
           {{ _('or') }}

--- a/ckan/templates/organization/member_new.html
+++ b/ckan/templates/organization/member_new.html
@@ -38,7 +38,7 @@
           </div>
         </div>
       </div>
-      {% if not user %}
+      {% if not user and h.check_access('user_create') %}
       <div class="col-md-2">
         <div class="add-member-or">
           {{ _('or') }}

--- a/ckan/tests/controllers/test_organization.py
+++ b/ckan/tests/controllers/test_organization.py
@@ -515,6 +515,23 @@ class TestOrganizationInnerSearch(object):
 
 @pytest.mark.usefixtures("non_clean_db")
 class TestOrganizationMembership(object):
+
+    @pytest.mark.ckan_config("ckan.auth.create_user_via_web", False)
+    def test_admin_users_cannot_invite_members(self, app, user):
+        """ Org admin users can't invite users if they can't create users """
+        headers = {"Authorization": user["token"]}
+        organization = factories.Organization(
+            users=[{"name": user["name"], "capacity": "admin"}]
+        )
+
+        with app.flask_app.test_request_context():
+            response = app.get(
+                url_for("organization.member_new", id=organization["id"]),
+                headers=headers,
+            )
+            assert response.status_code == 200
+            assert "invite a new user" not in response
+
     def test_editor_users_cannot_add_members(self, app, user):
         headers = {"Authorization": user["token"]}
         organization = factories.Organization(


### PR DESCRIPTION
Fixes and error inviting new user with CKAN 2.10.4

If we can't create new users, then the invite form will generate an error
If `create_user_via_web` is disabled this error will be raised.

<pre>
File "/code/venv/lib/python3.11/site-packages/ckan/config/middleware/../../views/group.py", line 1114, in post
  user_dict = _action(u'user_invite')(context, user_data_dict)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/code/venv/lib/python3.11/site-packages/ckan/logic/__init__.py", line 580, in wrapped
  result = _action(context, data_dict, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/code/venv/lib/python3.11/site-packages/ckan/logic/action/create.py", line 1104, in user_invite
  user_dict = _get_action('user_create')(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/code/venv/lib/python3.11/site-packages/ckan/logic/__init__.py", line 580, in wrapped
  result = _action(context, data_dict, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/code/venv/lib/python3.11/site-packages/ckan/logic/action/create.py", line 1001, in user_create
  _check_access('user_create', context, data_dict)
File "/code/venv/lib/python3.11/site-packages/ckan/logic/__init__.py", line 391, in check_access
  raise NotAuthorized(msg)
</pre>

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
