### PR TITLE
Add an error notification when rebuilding the search index for a package that can't be found

### DIFF
--- a/changes/8148.bugfix
+++ b/changes/8148.bugfix
@@ -1,0 +1,1 @@
+Add error notification when rebuilding the search index via the cli when the requested package can't be found.

--- a/ckan/cli/search_index.py
+++ b/ckan/cli/search_index.py
@@ -48,7 +48,7 @@ def rebuild(
                 defer_commit=(not commit_each),
                 quiet=quiet and not verbose,
                 clear=clear)
-    except logic.NotFound as e:
+    except logic.NotFound:
         error_shout("Couldn't find package %s" % package_id)
     except Exception as e:
         error_shout(e)

--- a/ckan/cli/search_index.py
+++ b/ckan/cli/search_index.py
@@ -48,6 +48,8 @@ def rebuild(
                 defer_commit=(not commit_each),
                 quiet=quiet and not verbose,
                 clear=clear)
+    except logic.NotFound as e:
+        error_shout("Couldn't find package %s" % package_id)
     except Exception as e:
         error_shout(e)
     if not commit_each:

--- a/ckan/tests/cli/test_search_index.py
+++ b/ckan/tests/cli/test_search_index.py
@@ -172,3 +172,9 @@ class TestSearchIndex(object):
         assert not result.exit_code, result.output
         search_result = helpers.call_action(u'package_search', q=u"package")
         assert search_result[u'count'] == 2
+
+    def test_rebuild_invalid_dataset(self, cli):
+        # attempt to index package that doesn't exist
+        result = cli.invoke(ckan, [u'search-index', u'rebuild', u'invalid-dataset'])
+        assert not result.exit_code, result.output
+        assert "Couldn't find" in result.output


### PR DESCRIPTION
Add an error notification when rebuilding the search index for a package that can't be found

Fixes 45 minutes of my life that I can't get back

### Proposed fixes:

Adds a notification that the dataset couldn't be found when running search-index rebuild in the cli.

before:
```
$ ckan search-index rebuild invalid
...
2024-04-03 14:29:24,259 INFO  [ckan.lib.search] Rebuilding search index...

2024-04-03 14:29:24,272 INFO  [ckan.lib.search] Commited pending changes on the search index
```
after:
```
$ ckan search-index rebuild invalid
...
2024-04-03 14:31:10,571 INFO  [ckan.lib.search] Rebuilding search index...
Couldn't find package invalid
2024-04-03 14:31:10,580 INFO  [ckan.lib.search] Committed pending changes on the search index
```

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
