### PR TITLE
Catch error in datastore

### DIFF
--- a/changes/8149.misc
+++ b/changes/8149.misc
@@ -1,0 +1,2 @@
+Catch an error in datastore to avoid 500 error in POSTs to `datatables/ajax/<resource_view_id>`
+The `datastore_search` action raises this error, it's captured later in this function but not here.

--- a/ckanext/datatablesview/blueprint.py
+++ b/ckanext/datatablesview/blueprint.py
@@ -9,7 +9,7 @@ from flask import Blueprint
 
 from ckan.common import json
 from ckan.lib.helpers import decode_view_request_filters
-from ckan.plugins.toolkit import get_action, request, h
+from ckan.plugins.toolkit import get_action, request, h, ObjectNotFound
 import re
 
 datatablesview = Blueprint(u'datatablesview', __name__)
@@ -59,13 +59,16 @@ def ajax(resource_view_id: str):
     filters = merge_filters(view_filters, user_filters)
 
     datastore_search = get_action(u'datastore_search')
-    unfiltered_response = datastore_search(
-        {}, {
-            u"resource_id": resource_view[u'resource_id'],
-            u"limit": 0,
-            u"filters": view_filters,
-        }
-    )
+    try:
+        unfiltered_response = datastore_search(
+            {}, {
+                u"resource_id": resource_view[u'resource_id'],
+                u"limit": 0,
+                u"filters": view_filters,
+            }
+        )
+    except ObjectNotFound:
+        return json.dumps({'error': 'Object not found'})
 
     cols = [f[u'id'] for f in unfiltered_response[u'fields']]
     if u'show_fields' in resource_view:

--- a/ckanext/datatablesview/blueprint.py
+++ b/ckanext/datatablesview/blueprint.py
@@ -9,7 +9,13 @@ from flask import Blueprint
 
 from ckan.common import json
 from ckan.lib.helpers import decode_view_request_filters
-from ckan.plugins.toolkit import get_action, request, h, ObjectNotFound
+from ckan.plugins.toolkit import (
+    get_action,
+    h,
+    NotAuthorized,
+    ObjectNotFound,
+    request,
+)
 import re
 
 datatablesview = Blueprint(u'datatablesview', __name__)
@@ -69,6 +75,8 @@ def ajax(resource_view_id: str):
         )
     except ObjectNotFound:
         return json.dumps({'error': 'Object not found'}), 404
+    except NotAuthorized:
+        return json.dumps({'error': 'Not Authorized'}), 403
 
     cols = [f[u'id'] for f in unfiltered_response[u'fields']]
     if u'show_fields' in resource_view:

--- a/ckanext/datatablesview/blueprint.py
+++ b/ckanext/datatablesview/blueprint.py
@@ -68,7 +68,7 @@ def ajax(resource_view_id: str):
             }
         )
     except ObjectNotFound:
-        return json.dumps({'error': 'Object not found'})
+        return json.dumps({'error': 'Object not found'}), 404
 
     cols = [f[u'id'] for f in unfiltered_response[u'fields']]
     if u'show_fields' in resource_view:
@@ -123,6 +123,7 @@ def ajax(resource_view_id: str):
     except Exception:
         query_error = u'Invalid search query... ' + search_text
         dtdata = {u'error': query_error}
+        status = 400
     else:
         data = []
         null_label = h.datatablesview_null_label()
@@ -140,8 +141,10 @@ def ajax(resource_view_id: str):
             u'recordsFiltered': response.get(u'total', 0),
             u'data': data
         }
+        status = 200
 
-    return json.dumps(dtdata)
+    # return the response as JSON with status
+    return json.dumps(dtdata), status
 
 
 def filtered_download(resource_view_id: str):


### PR DESCRIPTION
Catch an error in datastore to avoid 500 error in POSTs to `datatables/ajax/<resource_view_id>`
The `datastore_search` action raises this error, it's captured later in this function but not here

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
