### PR TITLE
Hide activity stream if the user is not allowed

### DIFF
--- a/changes/8153.bugfix
+++ b/changes/8153.bugfix
@@ -1,0 +1,1 @@
+Hide link if the user does not have permission to view the page.

--- a/ckanext/activity/templates/group/read_base.html
+++ b/ckanext/activity/templates/group/read_base.html
@@ -2,7 +2,7 @@
 
 {% block content_primary_nav %}
   {{ super() }}
-  {% if h.check_access('group_activity_list') %}
+  {% if h.check_access('group_activity_list', {'id': group_dict.id}) %}
   {{ h.build_nav_icon('activity.group_activity', _('Activity Stream'), id=group_dict.name, offset=0, icon='clock') }}
   {% endif %}
 {% endblock content_primary_nav %}

--- a/ckanext/activity/templates/group/read_base.html
+++ b/ckanext/activity/templates/group/read_base.html
@@ -2,5 +2,7 @@
 
 {% block content_primary_nav %}
   {{ super() }}
+  {% if h.check_access('group_activity_list') %}
   {{ h.build_nav_icon('activity.group_activity', _('Activity Stream'), id=group_dict.name, offset=0, icon='clock') }}
+  {% endif %}
 {% endblock content_primary_nav %}

--- a/ckanext/activity/templates/organization/read_base.html
+++ b/ckanext/activity/templates/organization/read_base.html
@@ -2,7 +2,7 @@
 
 {% block content_primary_nav %}
   {{ super() }}
-  {% if h.check_access('organization_activity_list') %}
+  {% if h.check_access('organization_activity_list', {'id': group_dict.id}) %}
   {{ h.build_nav_icon('activity.organization_activity', _('Activity Stream'), id=group_dict.name, offset=0, icon='clock') }}
   {% endif %}
 {% endblock content_primary_nav %}

--- a/ckanext/activity/templates/organization/read_base.html
+++ b/ckanext/activity/templates/organization/read_base.html
@@ -2,5 +2,7 @@
 
 {% block content_primary_nav %}
   {{ super() }}
+  {% if h.check_access('organization_activity_list') %}
   {{ h.build_nav_icon('activity.organization_activity', _('Activity Stream'), id=group_dict.name, offset=0, icon='clock') }}
+  {% endif %}
 {% endblock content_primary_nav %}

--- a/ckanext/activity/templates/package/read_base.html
+++ b/ckanext/activity/templates/package/read_base.html
@@ -2,5 +2,7 @@
 
 {% block content_primary_nav %}
   {{ super() }}
+  {% if h.check_access('package_activity_list') %}
   {{ h.build_nav_icon('activity.package_activity', _('Activity Stream'), id=pkg.id if is_activity_archive else pkg.name, icon='clock') }}
+  {% endif %}
 {% endblock content_primary_nav %}

--- a/ckanext/activity/templates/package/read_base.html
+++ b/ckanext/activity/templates/package/read_base.html
@@ -2,7 +2,7 @@
 
 {% block content_primary_nav %}
   {{ super() }}
-  {% if h.check_access('package_activity_list') %}
+  {% if h.check_access('package_activity_list', {'id': pkg.id}) %}
   {{ h.build_nav_icon('activity.package_activity', _('Activity Stream'), id=pkg.id if is_activity_archive else pkg.name, icon='clock') }}
   {% endif %}
 {% endblock content_primary_nav %}

--- a/ckanext/activity/templates/user/read_base.html
+++ b/ckanext/activity/templates/user/read_base.html
@@ -2,7 +2,7 @@
 
 {% block content_primary_nav %}
   {{ super() }}
-  {% if h.check_access('user_activity_list') %}
+  {% if h.check_access('user_activity_list', {'id': user.id}) %}
   {{ h.build_nav_icon('activity.user_activity', _('Activity Stream'), id=user.name, icon='clock') }}
   {% endif %}
 {% endblock %}

--- a/ckanext/activity/templates/user/read_base.html
+++ b/ckanext/activity/templates/user/read_base.html
@@ -2,5 +2,7 @@
 
 {% block content_primary_nav %}
   {{ super() }}
+  {% if h.check_access('user_activity_list') %}
   {{ h.build_nav_icon('activity.user_activity', _('Activity Stream'), id=user.name, icon='clock') }}
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
Fixes 403 errors for users trying to see activity stream but do not have the permission to do it

### Proposed fixes:

If a user do not have permission for user/package/org/group activity list the link must not be visible

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
