### PR TITLE
ckanext-activity: performance improvements

### DIFF
--- a/ckanext/activity/model/activity.py
+++ b/ckanext/activity/model/activity.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import Any, Iterable, Optional, Type, TypeVar
+from typing import Any, Iterable, Optional, Type, TypeVar, Union, List, Tuple
 from typing_extensions import TypeAlias
 
 from sqlalchemy.orm import relationship, backref, Mapped, defer, load_only
@@ -12,8 +12,11 @@ from sqlalchemy import (
     ForeignKey,
     or_,
     and_,
+    union_all,
     not_,
     text,
+    select,
+    literal,
 )
 
 from ckan.common import config
@@ -49,7 +52,7 @@ class Activity(domain_object.DomainObject, BaseModel):  # type: ignore
     # legacy revision_id values are used by migrate_package_activity.py
     revision_id = Column("revision_id", types.UnicodeText)
     activity_type = Column("activity_type", types.UnicodeText)
-    data = Column("data", _types.JsonDictType)
+    data = Column("data", _types.JsonDictType)  # Big JSON BLOB
     permission_labels = Column("permission_labels", types.Text)
 
     def __init__(
@@ -253,30 +256,33 @@ def _activities_union_all(*qlist: QActivity) -> QActivity:
     Return union of two or more activity queries sorted by timestamp,
     and remove duplicates
     """
-    q, *rest = qlist
-    for query in rest:
-        q = q.union(query)
-
+    q: QActivity = (
+        model.Session.query(Activity)
+        .options(_activities_load_only_without_data())
+        .select_entity_from(union_all(*[q.subquery().select() for q in qlist]))
+        .distinct(Activity.timestamp)
+    )
     return q
 
 
-def _activities_from_user_query(user_id: str) -> QActivity:
+def _activities_from_user_query(user_id: Union[str, List[str]]) -> QActivity:
     """Return an SQLAlchemy query for all activities from user_id."""
     q = model.Session.query(Activity)
     q = q.options(_activities_load_only_without_data())
-    q = q.filter(Activity.user_id == user_id)
+    q = q.filter(Activity.user_id.in_(_to_list(user_id)))  # type: ignore
     return q
 
 
-def _activities_about_user_query(user_id: str) -> QActivity:
+def _activities_about_user_query(user_id: Union[str, List[str]]) -> QActivity:
     """Return an SQLAlchemy query for all activities about user_id."""
     q = model.Session.query(Activity)
     q = q.options(_activities_load_only_without_data())
-    q = q.filter(Activity.object_id == user_id)
+    q = q.filter(Activity.object_id.in_(_to_list(user_id)))  # type: ignore
     return q
 
 
-def _user_activity_query(user_id: str, limit: int) -> QActivity:
+def _user_activity_query(
+        user_id: Union[str, List[str]], limit: int) -> QActivity:
     """Return an SQLAlchemy query for all activities from or about user_id."""
     q1 = _activities_limit(_activities_from_user_query(user_id), limit)
     q2 = _activities_limit(_activities_about_user_query(user_id), limit)
@@ -337,11 +343,17 @@ def user_activity_list(
     return results
 
 
-def _package_activity_query(package_id: str) -> QActivity:
+def _to_list(vals: Union[List[str], Tuple[str], str]):
+    if isinstance(vals, (list, tuple)):
+        return vals
+    return [vals]
+
+
+def _package_activity_query(package_id: Union[str, List[str]]) -> QActivity:
     """Return an SQLAlchemy query for all activities about package_id."""
     q = model.Session.query(Activity) \
         .options(_activities_defer_data()) \
-        .filter_by(object_id=package_id)
+        .filter(Activity.object_id.in_(_to_list(package_id)))  # type: ignore
     return q
 
 
@@ -409,18 +421,15 @@ def package_activity_list(
     return results
 
 
-def _group_activity_query(group_id: str) -> QActivity:
+def _group_activity_query(group_id: Union[str, List[str]]) -> QActivity:
     """Return an SQLAlchemy query for all activities about group_id.
 
     Returns a query for all activities whose object is either the group itself
     or one of the group's datasets.
 
     """
-    group = model.Group.get(group_id)
-    if not group:
-        # Return a query with no results.
-        return model.Session.query(Activity).filter(text("0=1"))
 
+    groups = _to_list(group_id)
     q: QActivity = (
         model.Session.query(Activity)
         .options(_activities_defer_data())
@@ -441,20 +450,20 @@ def _group_activity_query(group_id: str) -> QActivity:
             or_(
                 # active dataset in the group
                 and_(
-                    model.Member.group_id == group_id,
+                    model.Member.group_id.in_(groups),  # type: ignore
                     model.Member.state == "active",
                     model.Package.state == "active",
                 ),
                 # deleted dataset in the group
                 and_(
-                    model.Member.group_id == group_id,
+                    model.Member.group_id.in_(groups),  # type: ignore
                     model.Member.state == "deleted",
                     model.Package.state == "deleted",
                 ),
                 # (we want to avoid showing changes to an active dataset that
                 # was once in this group)
                 # activity the the group itself
-                Activity.object_id == group_id,
+                Activity.object_id.in_(groups),  # type: ignore
             )
         )
     )
@@ -479,21 +488,27 @@ def _organization_activity_query(org_id: str) -> QActivity:
     q: QActivity = (
         model.Session.query(Activity)
         .options(_activities_defer_data())
-        .outerjoin(
-            model.Package,
-            and_(
-                model.Package.id == Activity.object_id,
-                model.Package.private == False,  # noqa
-            ),
-        )
         .filter(
             # We only care about activity either on the the org itself or on
             # packages within that org.
             # FIXME: This means that activity that occured while a package
             # belonged to a org but was then removed will not show up. This may
             # not be desired but is consistent with legacy behaviour.
-            or_(
-                model.Package.owner_org == org_id, Activity.object_id == org_id
+            #
+            # Use subselect instead of outer join so that it can all
+            # be indexable
+            Activity.object_id.in_(  # type: ignore
+                select([model.Package.id])  # type: ignore
+                .where(
+                    and_(
+                        model.Package.private == False,  # noqa
+                        model.Package.owner_org == org_id
+                    )
+                )
+                .union(
+                    # select the org itself
+                    select([literal(org_id)])
+                )
             )
         )
     )
@@ -632,12 +647,9 @@ def _activities_from_users_followed_by_user_query(
             .options(_activities_load_only_without_data()) \
             .filter(text("0=1"))
 
-    return _activities_union_all(
-        *[
-            _user_activity_query(follower.object_id, limit)
-            for follower in follower_objects
-        ]
-    )
+    return _user_activity_query(
+        [follower.object_id for follower in follower_objects],
+        limit)
 
 
 def _activities_from_datasets_followed_by_user_query(
@@ -652,14 +664,10 @@ def _activities_from_datasets_followed_by_user_query(
             .options(_activities_load_only_without_data()) \
             .filter(text("0=1"))
 
-    return _activities_union_all(
-        *[
-            _activities_limit(
-                _package_activity_query(follower.object_id), limit
-            )
-            for follower in follower_objects
-        ]
-    )
+    return _activities_limit(
+        _package_activity_query(
+            [follower.object_id for follower in follower_objects]),
+        limit)
 
 
 def _activities_from_groups_followed_by_user_query(
@@ -680,12 +688,10 @@ def _activities_from_groups_followed_by_user_query(
             .options(_activities_load_only_without_data()) \
             .filter(text("0=1"))
 
-    return _activities_union_all(
-        *[
-            _activities_limit(_group_activity_query(follower.object_id), limit)
-            for follower in follower_objects
-        ]
-    )
+    return _activities_limit(
+        _group_activity_query(
+            [follower.object_id for follower in follower_objects]),
+        limit)
 
 
 def _activities_from_everything_followed_by_user_query(


### PR DESCRIPTION
Fixes #

#7953 

Problem: Dashboards take over 180seconds to load for a logged in normal user, emailing takes over 60minutes for less than 60 users getting notifications due to: high cpu/disk utilization on postgres on inefficient data heavy queries.

Steps to reproduce: 
Have a couple of datasets which have been updating every 15min for the last 10 years creating 'activity' diff's. Have about 2.1million rows in activity table with ```data``` blob field fully populated.

Create default user and `follow` datasets (or the org). Go and visit dashboard and see how long it takes to load. Go and trigger email notifications on updated dataset/resources. 

example org activity stream: https://www.data.qld.gov.au/organization/environment-science-and-innovation 

### Proposed fixes:

Speed up activity stream loading

ckanext-activity plugin:
- Skip or lazy-load heavy CLOB column
- Use subselect instead of union for more effective indexing/querying

These changes have been deployed and tested in www.data.qld.gov.au under commit https://github.com/qld-gov-au/ckan/commit/88d932e280204c338933f1cb502ab5aa86c7914f which is on top of ckan 2.10.4 . This has allowed us to reenable email notifications hourly as this was too much of a database cpu+disk and batch layer cron overlaps since we moved from 2.9 to 2.10 and the activity table 'data' column started to be fleshed out with json blob data of the point in time history.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply

Co-Author: @ThrawnCA 
