### PR TITLE
Fix customize css instructions.

### DIFF
--- a/ckanext/example_theme_docs/v13_custom_css/templates/base.html
+++ b/ckanext/example_theme_docs/v13_custom_css/templates/base.html
@@ -1,6 +1,6 @@
 {% ckan_extends %}
 
-{% block styles %}
+{% block custom_styles %}
   {{ super() }}
   <link rel="stylesheet" href="/example_theme.css" />
 {% endblock %}


### PR DESCRIPTION
'styles' block gets overridden. Use 'custom_styles' instead. Entire 'customizing css' page in docs does not work.

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
