### PR TITLE
Correct package_patch docstring re: updating resources

### DIFF
--- a/changes/8179.bugfix
+++ b/changes/8179.bugfix
@@ -1,0 +1,1 @@
+Correct package_patch docstring re: updating resources

--- a/ckan/logic/action/patch.py
+++ b/ckan/logic/action/patch.py
@@ -24,12 +24,10 @@ def package_patch(
     parameters unchanged, whereas the update methods deletes all parameters
     not explicitly provided in the data_dict.
 
-    You are able to partially update and/or create resources with
-    package_patch. If you are updating existing resources be sure to provide
-    the resource id. Existing resources excluded from the package_patch
-    data_dict will be removed. Resources in the package data_dict without
-    an id will be treated as new resources and will be added. New resources
-    added with the patch method do not create the default views.
+    To partially update resources or other metadata not at the top level
+    of a package use
+    :py:func:`~ckan.logic.action.update.package_revise` instead to maintain
+    existing nested values.
 
     You must be authorized to edit the dataset and the groups that it belongs
     to.


### PR DESCRIPTION
Fixes #8179

### Proposed fixes:
package_patch contained misleading documentation about updating resources, update to recommend package_revise for those cases instead


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport