### PR TITLE
Less details in Solr connection error message

### DIFF
--- a/ckan/lib/search/common.py
+++ b/ckan/lib/search/common.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import datetime
 import logging
 import re
-from urllib3.exceptions import NewConnectionError
 from typing import Any, Optional
 
 import pysolr
@@ -30,7 +29,7 @@ class SearchQueryError(SearchError):
     pass
 
 
-class SolrConnectionError(NewConnectionError):
+class SolrConnectionError(Exception):
     pass
 
 

--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -470,7 +470,7 @@ class PackageSearchQuery(SearchQuery):
                     raise SearchQueryError('Invalid "sort" parameter')
 
                 if "Failed to connect to server" in e.args[0]:
-                    raise SolrConnectionError("Connection Error", message=e.args[0])
+                    raise SolrConnectionError("Connection Error", message="Failed to connect to Solr server")
 
             raise SearchError('SOLR returned an error running query: %r Error: %r' %
                               (query, e))

--- a/ckan/lib/search/query.py
+++ b/ckan/lib/search/query.py
@@ -470,7 +470,8 @@ class PackageSearchQuery(SearchQuery):
                     raise SearchQueryError('Invalid "sort" parameter')
 
                 if "Failed to connect to server" in e.args[0]:
-                    raise SolrConnectionError("Connection Error", message="Failed to connect to Solr server")
+                    log.warning("Connection Error: Failed to connect to Solr server.")
+                    raise SolrConnectionError("Solr returned an error while searching.")
 
             raise SearchError('SOLR returned an error running query: %r Error: %r' %
                               (query, e))


### PR DESCRIPTION
Fixes #
Use a generic error message, not connection details in Solr error message. 

### Proposed fixes:

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
