### PR TITLE
Propose INotifier

### DIFF
--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -190,7 +190,7 @@ def mail_recipient(recipient_name: str,
             attachments=attachments)
 
     # send an email ONLY if we have smtp settings available
-    if config.get('smtp.mail_from'):
+    if config.get('smtp.server'):
         _mail_recipient(
             recipient_name, recipient_email,
             site_title, site_url, subject, body,

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -7,8 +7,8 @@ extend CKAN.
 from __future__ import annotations
 
 from typing import (
-    Any, Callable, ClassVar, Iterable, Mapping, Optional, Sequence,
-    TYPE_CHECKING, Type, Union,
+    Any, Callable, ClassVar, IO, Iterable, Mapping, Optional, Sequence,
+    TYPE_CHECKING, Type, Tuple, Union,
 )
 
 from pyutilib.component.core import Interface as _pca_Interface
@@ -31,6 +31,14 @@ if TYPE_CHECKING:
     from ckan.config.middleware.flask_app import CKANFlask
     from ckan.config.declaration import Declaration, Key
     from .core import SingletonPlugin
+
+
+AttachmentWithType = Union[
+    Tuple[str, IO[str], str],
+    Tuple[str, IO[bytes], str]
+]
+AttachmentWithoutType = Union[Tuple[str, IO[str]], Tuple[str, IO[bytes]]]
+Attachment = Union[AttachmentWithType, AttachmentWithoutType]
 
 
 __all__ = [
@@ -2208,3 +2216,55 @@ class ISignal(Interface):
 
         """
         return {}
+
+
+class INotifier(Interface):
+    """Define notification methods for the plugin."""
+
+    def notify_recipient(
+        self,
+        recipient_name: str,
+        recipient_email: str,
+        subject: str,
+        body: str,
+        body_html: Optional[str] = None,
+        headers: Optional[dict[str, Any]] = None,
+        attachments: Optional[Iterable[Attachment]] = None
+    ) -> None:
+        '''Sends an notification to a an email address.
+
+        .. note:: You need to set up the :ref:`email-settings` to able to send
+            emails.
+
+        :param recipient_name: the name of the recipient
+        :type recipient: string
+        :param recipient_email: the email address of the recipient
+        :type recipient: string
+
+        :param subject: the email subject
+        :type subject: string
+        :param body: the email body, in plain text
+        :type body: string
+        :param body_html: the email body, in html format (optional)
+        :type body_html: string
+        :headers: extra headers to add to email, in the form
+            {'Header name': 'Header value'}
+        :type: dict
+        :attachments: a list of tuples containing file attachments to add to the
+            email. Tuples should contain the file name and a file-like object
+            pointing to the file contents::
+
+                [
+                    ('some_report.csv', file_object),
+                ]
+
+            Optionally, you can add a third element to the tuple containing the
+            media type. If not provided, it will be guessed using
+            the ``mimetypes`` module::
+
+                [
+                    ('some_report.csv', file_object, 'text/csv'),
+                ]
+        :type: list
+        '''
+        pass


### PR DESCRIPTION
### Proposed fixes:

In different CKAN projects I'm using Sendgrid and Slack to notify users. I assume other users have similar requirements.
Sometimes we don't have (and don't need) an SMTP server.

I think it will be nice to allow users to work without SMTP and define custom notification services (or don't notify at all)
I started this PR to:
 - Propose a new `INotifier` interface to allow extension to notify in different ways.
 - Propose to stop trying to send email when there is no available settings to do it

I know this will require more work but I want to be sure that this is a good idea.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
