### PR TITLE
[#8201] Fix misplaced CSRF token in the BS3 collaborator_new.html

### DIFF
--- a/changes/8204.bugfix
+++ b/changes/8204.bugfix
@@ -1,0 +1,1 @@
+Fix misplaced CSRF token in the BS3 collaborator_new.html.

--- a/ckan/templates-bs3/package/collaborators/collaborator_new.html
+++ b/ckan/templates-bs3/package/collaborators/collaborator_new.html
@@ -10,8 +10,8 @@
     {% block page_heading %}{{ _('Edit Collaborator') if user else _('Add Collaborator') }}{% endblock %}
   </h1>
   {% block form %}
-  {{ h.csrf_input() }}
   <form class="dataset-form add-member-form" method='post'>
+    {{ h.csrf_input() }}
     <div class="row">
       <div class="col-md-5">
         <div class="form-group control-medium">


### PR DESCRIPTION
Fixes #8201

### Proposed fixes:

A simple fix which moves the CSRF token inside the `<form>` tag.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
