### PR TITLE
Remove hard requirement on password fields

### DIFF
--- a/changes/8208.changes
+++ b/changes/8208.changes
@@ -1,0 +1,2 @@
+Allow blocking users to change their passwords by hidding the `password1` and
+`password2` fields in the user edit form.

--- a/changes/8208.changes
+++ b/changes/8208.changes
@@ -1,2 +1,0 @@
-Allow blocking users to change their passwords by hidding the `password1` and
-`password2` fields in the user edit form.

--- a/changes/8208.misc
+++ b/changes/8208.misc
@@ -1,3 +1,5 @@
+Allow blocking users to change their passwords by hidding the `password1` and
+`password2` fields in the user edit form.
 This PR just changes the hard requirement on password1 and password2 fields.
 If we need to drop the {% block change_password %} block for the user.edit
 view to do not allow users to change their password (for ckanext-saml2 users

--- a/changes/8208.misc
+++ b/changes/8208.misc
@@ -1,0 +1,4 @@
+This PR just changes the hard requirement on password1 and password2 fields.
+If we need to drop the {% block change_password %} block for the user.edit
+view to do not allow users to change their password (for ckanext-saml2 users
+this is important) we will get an KeyError.

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -356,9 +356,10 @@ class EditView(MethodView):
         # We are recognizing sysadmin user
         # by email_changed variable.. this returns True
         # and we are entering the validation.
-        if (data_dict[u'password1']
-                and data_dict[u'password2']) or email_changed:
-
+        password_changed = (
+            data_dict.get('password1') and data_dict.get('password2')
+        )
+        if password_changed or email_changed:
             # getting the identity for current logged user
             identity = {
                 u'login': current_user.name,


### PR DESCRIPTION
### Proposed fixes:

If we need to drop the `{% block change_password %}` block for the `user.edit` view to do not allow users to change their password (for `ckanext-saml2` users this is important) we will get an `KeyError` 

This PR just changes the hard requirement on `password1` and `password2` fields.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
