### PR TITLE
Fix Datatables Last View

### DIFF
--- a/changes/8209.bugfix
+++ b/changes/8209.bugfix
@@ -1,0 +1,2 @@
+Datatables View's `lastView` local storage key is now suffixed with the view ID,
+allowing each datatable view to respect its given `responsive-flag`.

--- a/ckanext/datatablesview/assets/datatablesview.js
+++ b/ckanext/datatablesview/assets/datatablesview.js
@@ -288,14 +288,14 @@ this.ckan.module('datatables_view', function (jQuery) {
       const defaultview = dtprv.data('default-view')
 
       // get view mode setting from localstorage (table or list/responsive])
-      const lastView = getWithExpiry('lastView')
+      const lastView = getWithExpiry('lastView-' + gresviewId)
       if (!lastView) {
         if (responsiveflag) {
           gcurrentView = 'list' // aka responsive
         } else {
           gcurrentView = defaultview
         }
-        setWithExpiry('lastView', gcurrentView, 0)
+        setWithExpiry('lastView-' + gresviewId, gcurrentView, 0)
       } else {
         gcurrentView = lastView
       }
@@ -558,7 +558,7 @@ this.ckan.module('datatables_view', function (jQuery) {
           // save selected rows settings
           gsavedSelected = data.selected
           // save view mode
-          setWithExpiry('lastView', data.viewmode, 0)
+          setWithExpiry('lastView-' + gresviewId, data.viewmode, 0)
 
           // restore values of column filters
           const api = new $.fn.dataTable.Api(settings)
@@ -714,7 +714,7 @@ this.ckan.module('datatables_view', function (jQuery) {
               gcurrentView = 'list'
               $('#dtprv').addClass('dt-responsive')
             }
-            setWithExpiry('lastView', gcurrentView, 0)
+            setWithExpiry('lastView-' + gresviewId, gcurrentView, 0)
             window.localStorage.removeItem('loadctr-' + gresviewId)
             dt.state.clear()
             window.location.reload()


### PR DESCRIPTION
fix(js): datatables last view;

- Changed local storage key to suffix with view ID.

Fixes #

### Proposed fixes:

The Datatables View plugin uses a local storage key `lastView` to get the last view type (list or table) and will always use that when displaying a table. This breaks the functionality of the `responsive-flag`.

Suffixing the local storage key with the view ID will fix this issue (at least when looking at different datatable views across a site). The JS code here already suffixes some local storage keys with the view ID, so this is really just aligning with that.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
