### PR TITLE
cli profile improvements

### DIFF
--- a/changes/8223.feature
+++ b/changes/8223.feature
@@ -1,0 +1,5 @@
+fix profile cli, add --cold and --best-of options.
+
+By default cli profile will now run the request once (cold), then give the
+best of the next 3 (hot) runs. Use --cold --best-of=1 for the old cli profile
+behavior.

--- a/ckan/cli/profile.py
+++ b/ckan/cli/profile.py
@@ -8,12 +8,14 @@ from . import error_shout
 
 
 @click.command(short_help="Code speed profiler.")
-@click.argument(u"url")
-@click.argument(u"user", required=False, default=u"visitor")
-def profile(url: str, user: str):
+@click.argument("url")
+@click.argument("user", required=False, default="visitor")
+@click.option('--cold', is_flag=True, default=False, help='measure first call')
+@click.option('-b', '--best-of', type=int, default=3, help='best of N calls')
+def profile(url: str, user: str, cold: bool, best_of: int):
     """Provide a ckan url and it will make the request and record how
     long each function call took in a file that can be read by
-    pstats.Stats (command-line) or runsnakerun (gui).
+    pstats.Stats (command-line) or SnakeViz (web).
 
     Usage:
        profile URL [username]
@@ -27,28 +29,37 @@ def profile(url: str, user: str):
     You may need to install python module: cProfile
 
     """
-    import cProfile
+    from cProfile import Profile
     from ckan.tests.helpers import _get_test_app
 
     app = _get_test_app()
 
-    def profile_url(url: str):  # type: ignore # noqa
+    def profile_url(url: str):
         try:
             app.get(
-                url, status=[200], environ_overrides={"REMOTE_USER": str(user)}
+                url, status=200, environ_overrides={"REMOTE_USER": str(user)}
             )
         except KeyboardInterrupt:
             raise
         except Exception:
             error_shout(traceback.format_exc())
 
-    output_filename = u"ckan%s.profile" % re.sub(
-        u"[/?]", u".", url.replace(u"/", u".")
-    )
-    profile_command = u"profile_url('%s')" % url
-    cProfile.runctx(
-        profile_command, globals(), locals(), filename=output_filename
-    )
+    if not cold:
+        profile_url(url)
+
+    best = None
+    for _n in range(best_of):
+        with Profile() as pr:
+            profile_url(url)
+        if best is None or (best.getstats()[0].totaltime
+                            > pr.getstats()[0].totaltime):
+            best = pr
+
+    if best is None:
+        return
+
+    output_filename = "ckan%s.profile" % re.sub(r"[\W]", ".", url)
+    best.dump_stats(output_filename)
     import pstats
 
     stats = pstats.Stats(output_filename)

--- a/ckan/cli/profile.py
+++ b/ckan/cli/profile.py
@@ -7,11 +7,10 @@ import click
 from . import error_shout
 
 
-@click.group(
-    short_help=u"Code speed profiler.", invoke_without_command=True,
-)
-@click.pass_context
-def profile(ctx: click.Context):
+@click.command(short_help="Code speed profiler.")
+@click.argument(u"url")
+@click.argument(u"user", required=False, default=u"visitor")
+def profile(url: str, user: str):
     """Provide a ckan url and it will make the request and record how
     long each function call took in a file that can be read by
     pstats.Stats (command-line) or runsnakerun (gui).
@@ -28,14 +27,6 @@ def profile(ctx: click.Context):
     You may need to install python module: cProfile
 
     """
-    if ctx.invoked_subcommand is None:
-        ctx.invoke(main)
-
-
-@profile.command('profile', short_help=u"Code speed profiler.",)
-@click.argument(u"url")
-@click.argument(u"user", required=False, default=u"visitor")
-def main(url: str, user: str):
     import cProfile
     from ckan.tests.helpers import _get_test_app
 

--- a/ckan/cli/profile.py
+++ b/ckan/cli/profile.py
@@ -51,8 +51,8 @@ def profile(url: str, user: str, cold: bool, best_of: int):
     for _n in range(best_of):
         with Profile() as pr:
             profile_url(url)
-        if best is None or (best.getstats()[0].totaltime
-                            > pr.getstats()[0].totaltime):
+        if best is None or (best.getstats()[0].totaltime  # type: ignore
+                            > pr.getstats()[0].totaltime):  # type: ignore
             best = pr
 
     if best is None:


### PR DESCRIPTION
Fixes #

### Proposed fixes:

- `ckan profile profile /url` should be spelled `ckan profile /url`
- don't profile first run by default
- take profile from best-of-n runs (3 by default)

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport (first commit)