### PR TITLE
FIXBUG  RuntimeError: Working outside of request context

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -231,7 +231,7 @@ def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:
     csrf.init_app(app)
 
     if config.get("ckan.csrf_protection.ignore_extensions"):
-        log.warn(csrf_warn_extensions)
+        log.warning(csrf_warn_extensions)
         _exempt_plugins_blueprints_from_csrf(csrf)
 
     lib_plugins.register_package_blueprints(app)
@@ -528,10 +528,11 @@ def _setup_error_mail_handler(app: CKANApp):
 
     class ContextualFilter(logging.Filter):
         def filter(self, log_record: Any) -> bool:
-            log_record.url = request.path
-            log_record.method = request.method
-            log_record.ip = request.environ.get("REMOTE_ADDR")
-            log_record.headers = request.headers
+            if request:
+                log_record.url = request.path
+                log_record.method = request.method
+                log_record.ip = request.environ.get("REMOTE_ADDR")
+                log_record.headers = request.headers
             return True
 
     smtp_server = config.get('smtp.server')


### PR DESCRIPTION

Fixes #

### Proposed fixes: RuntimeError: Working outside of request context when run app
Error occurred in case:  config in ckan.ini:
 - email_to contains value (Ex: email_to= example@example.com)
 - ckan.csrf_protection.ignore_extensions = true
 - debug = false


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
