### PR TITLE
Ignore Fields for DataStore Dump View

### DIFF
--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -54,6 +54,7 @@ def dump_schema() -> Schema:
         u'plain': [ignore_missing, boolean_validator],
         u'language': [ignore_missing, unicode_only],
         u'fields': [ignore_missing, list_of_strings_or_string],
+        u'ignore_fields': [default(u'_id'), list_of_strings_or_string],
         u'sort': [default(u'_id'), list_of_strings_or_string],
     }
 
@@ -78,6 +79,34 @@ def dump(resource_id: str):
     limit = data.get('limit')
     options = {'bom': data['bom']}
     sort = data['sort']
+    fields = data.get('fields', [])
+    ignore_fields = data.get('ignore_fields', [])
+
+    if not fields:
+        ds_info = get_action('datastore_info')({'user': g.user},
+                                               {'id': resource_id})
+        # _id is never returned from datastore_info
+        fields = [field['id'] for field in ds_info.get('fields', [])]
+
+    # fields accepts string or list of strings
+    if isinstance(fields, str):
+        fields = fields.split(',')
+
+    # ignore_fields accepts string or list of strings
+    if isinstance(ignore_fields, str):
+        ignore_fields = ignore_fields.split(',')
+
+    for ignore_field in ignore_fields:
+        if ignore_field in fields:
+            fields.remove(ignore_field)
+
+    if '_id' not in ignore_fields and not data.get('fields'):
+        # _id is never returned from datastore_info,
+        # so we may need to add it back in here
+        fields.insert(0 ,'_id')
+
+    data['fields'] = fields
+
     search_params = {
         k: v
         for k, v in data.items()


### PR DESCRIPTION
feat(views): ignore fields datastore dump;

- Added `ignore_fields` schema and usage for datastore dump blueprint method.

### Changes:

The DataStore Dump view will always dump the `_id` column by default. Now, never dump it by default from the blueprint method.

Users are also able to easily exclude fields. Rather than having to supply a long list of fields to just exclude one field, they could now do that with `ignore_fields`

Test coverage updated and added to.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
