### PR TITLE
Max Idle Time for Jobs Worker Command

### DIFF
--- a/changes/8240.feature
+++ b/changes/8240.feature
@@ -1,0 +1,1 @@
+Add `--max-idle-time` to the `ckan jobs worker` command.

--- a/ckan/cli/jobs.py
+++ b/ckan/cli/jobs.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import click
+import sys
 
 import ckan.lib.jobs as bg_jobs
 import ckan.logic as logic
@@ -15,8 +16,10 @@ def jobs():
 
 @jobs.command(short_help=u"Start a worker.",)
 @click.option(u"--burst", is_flag=True, help=u"Start worker in burst mode.")
+@click.option(u"--max-idle-time", default=None, type=click.INT,
+              help=u"Max seconds for worker to be idle. Defaults to None.")
 @click.argument(u"queues", nargs=-1)
-def worker(burst: bool, queues: list[str]):
+def worker(burst: bool, max_idle_time: int, queues: list[str]):
     """Start a worker that fetches jobs from queues and executes them. If
     no queue names are given then the worker listens to the default
     queue, this is equivalent to
@@ -35,8 +38,11 @@ def worker(burst: bool, queues: list[str]):
 
     If the `--burst` option is given then the worker will exit as soon
     as all its queues are empty.
+
+    If the `--max-idle-time` option is given then the worker will exit
+    after it has been idle for the number of seconds specified.
     """
-    bg_jobs.Worker(queues).work(burst=burst)
+    bg_jobs.Worker(queues).work(burst=burst, max_idle_time=max_idle_time)
 
 
 @jobs.command(name=u"list", short_help=u"List jobs.")

--- a/ckan/cli/jobs.py
+++ b/ckan/cli/jobs.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import click
-import sys
 
 import ckan.lib.jobs as bg_jobs
 import ckan.logic as logic

--- a/ckan/cli/jobs.py
+++ b/ckan/cli/jobs.py
@@ -16,7 +16,8 @@ def jobs():
 @jobs.command(short_help=u"Start a worker.",)
 @click.option(u"--burst", is_flag=True, help=u"Start worker in burst mode.")
 @click.option(u"--max-idle-time", default=None, type=click.INT,
-              help=u"Max seconds for worker to be idle. Defaults to None.")
+              help=u"Max seconds for worker to be idle. "
+              "Defaults to None (never stops idling).")
 @click.argument(u"queues", nargs=-1)
 def worker(burst: bool, max_idle_time: int, queues: list[str]):
     """Start a worker that fetches jobs from queues and executes them. If


### PR DESCRIPTION
feat(cli): jobs max time;

- Added option for max worker timeout.

### Changes:

Adds a `--max-idle-time` option to the `ckan jobs worker` command. 

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
