### PR TITLE
[5497]Fix cannot create draft datasets via API

### DIFF
--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -132,11 +132,12 @@ def default_create_package_schema(
         package_name_validator: Validator, strip_value: Validator,
         if_empty_same_as: ValidatorFactory,
         email_validator: Validator, package_version_validator: Validator,
-        ignore_not_package_admin: Validator, boolean_validator: Validator,
+        boolean_validator: Validator,
         datasets_with_no_organization_cannot_be_private: Validator,
         empty: Validator, tag_string_convert: Validator,
         owner_org_validator: Validator, json_object: Validator,
         ignore_not_sysadmin: Validator, uuid_validator: Validator) -> Schema:
+    
     return {
         '__before': [duplicate_extras_key, ignore],
         'id': [ignore_missing, empty_if_not_sysadmin, uuid_validator,
@@ -154,7 +155,7 @@ def default_create_package_schema(
         'notes': [ignore_missing, unicode_safe],
         'url': [ignore_missing, unicode_safe],
         'version': [ignore_missing, unicode_safe, package_version_validator],
-        'state': [ignore_not_package_admin, ignore_missing],
+        'state': [ignore_missing],
         'type': [ignore_missing, unicode_safe],
         'owner_org': [owner_org_validator, unicode_safe],
         'private': [ignore_missing, boolean_validator,

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -1128,6 +1128,22 @@ class TestDatasetCreate(object):
 
         assert isinstance(dataset, str)
 
+    def test_create_draft_dataset_via_api(self):
+        user = factories.User()
+
+        org_users = [{"name": user["name"], "capacity": "editor"}]
+        _ = factories.Organization(users=org_users)
+
+        data_dict = {
+            'title': 'A test dataset',
+            'name': 'test_name',
+            'state': 'draft',
+            'author': 'Test User'
+        }
+
+        dataset = logic.get_action("package_create")({"user": user["name"]}, data_dict)
+        assert dataset["state"] == "draft"
+
 
 @pytest.mark.usefixtures("non_clean_db")
 class TestGroupCreate(object):


### PR DESCRIPTION
Fixes #5497 

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
