### PR TITLE
8254-fix-markdown formatting is not translated

### DIFF
--- a/changes/8254.bugfix
+++ b/changes/8254.bugfix
@@ -1,0 +1,1 @@
+Markdown formatting is not translated into the selected locale other than English

--- a/ckan/templates/macros/form/markdown.html
+++ b/ckan/templates/macros/form/markdown.html
@@ -28,6 +28,6 @@ Examples:
 {%- set extra_html = caller() if caller -%}
 {% call input_block(id or name, label or name, error, classes, control_classes=["editor"], extra_html=extra_html, is_required=is_required) %}
 <textarea id="{{ id or name }}" name="{{ name }}" cols="20" rows="5" placeholder="{{ placeholder }}" {{ attributes(attrs) }}>{{ value | empty_and_escape }}</textarea>
-<span class="editor-info-block">{% trans %}You can use <a href="#markdown" title="Markdown quick reference" data-bs-toggle="popover" data-bs-content="{{ markdown_tooltip }}" data-bs-html="true">Markdown formatting</a> here{% endtrans %}</span>
+<span class="editor-info-block">{% trans %}You can use <a href="#markdown" title="Markdown quick reference" data-target="popover" data-content="{{ markdown_tooltip }}" data-html="true">Markdown formatting</a> here{% endtrans %}</span> 
 {% endcall %}
 {% endmacro %}


### PR DESCRIPTION
Fixes #8254 

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
