### PR TITLE
fix for IClick users and #8221

### DIFF
--- a/ckan/cli/cli.py
+++ b/ckan/cli/cli.py
@@ -76,8 +76,7 @@ class ExtendableGroup(click.Group):
         # provided, except for `--help`. In this case it has to be done
         # manually.
         if not ctx.obj:
-            if '-h' not in sys.argv[1:] and '--help' not in sys.argv[1:]:
-                _add_ctx_object(ctx)
+            _add_ctx_object(ctx)
             _add_external_commands(ctx)
 
         commands = []
@@ -128,8 +127,7 @@ class ExtendableGroup(click.Group):
 def _init_ckan_config(ctx: click.Context, param: str, value: str):
     if any(sys.argv[1:len(cmd) + 1] == cmd for cmd in _no_config_commands):
         return
-    if '-h' not in sys.argv[1:] and '--help' not in sys.argv[1:]:
-        _add_ctx_object(ctx, value)
+    _add_ctx_object(ctx, value)
     _add_external_commands(ctx)
 
 


### PR DESCRIPTION
### Proposed fixes:

part of #8221 breaks `--help` use with plugins that use the IClick interface. Revert the change that disables plugin initialization when `-h` or `--help` is present.

This does lose the 2x performance increase, we'll need a different more invasive change to get that back where possible.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
