### PR TITLE
add missing head_extras block

### DIFF
--- a/ckan/templates/base.html
+++ b/ckan/templates/base.html
@@ -83,6 +83,10 @@
       </style>
       {%- endif %}
     {% endblock %}
+
+    {%- block head_extras %}
+    {% endblock %}
+
   </head>
 
   {# Allows custom attributes to be added to the <body> tag #}


### PR DESCRIPTION
added missing head_extras block used in default templates ckan/templates/package/read_base.html and ckan/templates/package/resource_read.html

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
