### PR TITLE
Default Licenses to "Not Open"

### DIFF
--- a/changes/8268.bugfix
+++ b/changes/8268.bugfix
@@ -1,0 +1,1 @@
+Set license model `od_conformance` and `osd_conformance` attributes' default values to `False` to prevent errors.

--- a/ckan/model/license.py
+++ b/ckan/model/license.py
@@ -18,6 +18,11 @@ log = logging.getLogger(__name__)
 class License():
     """Domain object for a license."""
 
+    default_values = {
+        'od_conformance': False,
+        'osd_conformance': False,
+    }
+
     def __init__(self, data: dict[str, Any]) -> None:
         self._data = data
         for (key, value) in self._data.items():
@@ -30,6 +35,9 @@ class License():
                 ))
                 self._data[key] = value
             elif isinstance(value, str):
+                self._data[key] = value
+        for (key, value) in self.default_values.items():
+            if key not in self._data:
                 self._data[key] = value
 
     def __getattr__(self, name: str) -> Any:


### PR DESCRIPTION
fix(models): license attributes;

- Give default values to `od_conformance` and `osd_conformance`.

### Proposed fixes:

Give licenses a default value for `od_conformance` and `osd_conformance`, preventing attribute errors when the model's `is_open` method is called.

Thus, by default, a license will be considered "not open" if neither `od_conformance` or `osd_conformance` are defined.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
