### PR TITLE
Use 'os.replace' instead of 'os.rename'

### DIFF
--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -190,7 +190,7 @@ class Upload(object):
                     raise
                 finally:
                     self.upload_file.close()
-            os.rename(self.tmp_filepath, self.filepath)
+            os.replace(self.tmp_filepath, self.filepath)
             self.clear = True
 
         if (self.clear and self.old_filename
@@ -347,7 +347,7 @@ class ResourceUpload(object):
                     raise
                 finally:
                     self.upload_file.close()
-            os.rename(tmp_filepath, filepath)
+            os.replace(tmp_filepath, filepath)
             return
 
         # The resource form only sets self.clear (via the input clear_upload)


### PR DESCRIPTION
A small sanitizing change. In Python 3.3 os.replace was added because os.rename behaves differently on different platforms.

This PR changes uploader.py to use os.replace instead of os.rename. The intention of the code in these locations are indeed a replace of the file and not only a rename.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
