### PR TITLE
TableDesigner shows incorrect data-dictionary link for new resource

### DIFF
--- a/ckanext/tabledesigner/templates/package/snippets/resource_upload_field.html
+++ b/ckanext/tabledesigner/templates/package/snippets/resource_upload_field.html
@@ -16,7 +16,7 @@
   <div class="select-type">
     {{ remove_button() }}
     <label>{{ _('Table Designer') }}</label>
-    {% if not data %}
+    {% if not data.id %}
       <p>{{ _('Save this resource, then customize the table from the Data Dictionary tab') }}</p>
     {% else %}
       <p>{% trans url=h.url_for('datastore.dictionary', id=data.package_id, resource_id=data.id) -%}


### PR DESCRIPTION
For new(not created) resource, the table designer shows the following message:
![image](https://github.com/ckan/ckan/assets/11091199/6d6125ce-067f-456e-ac71-a54149ab88ab)

But when the resource is saved with a validation error, the table designer, thinks that resource created and shows a broken link to the resource's data dictionary
![image](https://github.com/ckan/ckan/assets/11091199/369a2789-c666-42b7-8c42-2287d335b894)


Checking presence of resource's ID solves the problem
