### PR TITLE
Set orgs_available in user read_base template

### DIFF
--- a/ckan/templates/user/read_base.html
+++ b/ckan/templates/user/read_base.html
@@ -1,6 +1,16 @@
 {% extends "page.html" %}
 
 {% set user = user_dict %}
+{% set orgs_available = h.organizations_available(permission='manage_group',
+  include_dataset_count=True,
+  include_member_count=True,
+  user=user['name'])
+%}
+{% set groups_available = h.groups_available(am_member=True,
+  include_dataset_count=True,
+  include_member_count=True,
+  user=user['name'])
+%}
 {% set dataset_type = h.default_package_type() %}
 {% set org_type = h.default_group_type('organization') %}
 {% set group_type = h.default_group_type('group') %}

--- a/ckan/templates/user/read_base.html
+++ b/ckan/templates/user/read_base.html
@@ -1,16 +1,6 @@
 {% extends "page.html" %}
 
 {% set user = user_dict %}
-{% set orgs_available = h.organizations_available(permission='manage_group',
-  include_dataset_count=True,
-  include_member_count=True,
-  user=user['name'])
-%}
-{% set groups_available = h.groups_available(am_member=True,
-  include_dataset_count=True,
-  include_member_count=True,
-  user=user['name'])
-%}
 {% set dataset_type = h.default_package_type() %}
 {% set org_type = h.default_group_type('organization') %}
 {% set group_type = h.default_group_type('group') %}

--- a/ckan/templates/user/read_groups.html
+++ b/ckan/templates/user/read_groups.html
@@ -1,6 +1,12 @@
 {% extends "user/read_base.html" %}
 
+{% set user = user_dict %}
 {% set group_type = h.default_group_type('group') %}
+{% set groups_available = h.groups_available(am_member=True,
+  include_dataset_count=True,
+  include_member_count=True,
+  user=user['name'])
+%}
 
 {% block primary_content_inner %}
   <h2 class="hide-heading">{{ h.humanize_entity_type('group', group_type, 'facet label') or _('Groups') }}</h2>

--- a/ckan/templates/user/read_organizations.html
+++ b/ckan/templates/user/read_organizations.html
@@ -1,6 +1,12 @@
 {% extends "user/read_base.html" %}
 
+{% set user = user_dict %}
 {% set group_type = h.default_group_type('organization') %}
+{% set orgs_available = h.organizations_available(permission='manage_group',
+  include_dataset_count=True,
+  include_member_count=True,
+  user=user['name'])
+%}
 
 {% block primary_content_inner %}
   <h2 class="hide-heading">{{ h.humanize_entity_type('organization', group_type, 'facet label') or _('Organizations') }}</h2>


### PR DESCRIPTION
Fixes #
Fixes the no organization or group listed in user organization/group tab [issue](https://github.com/ckan/ckan/issues/8275)
### Proposed fixes:
Proposed fix for the following [issue](https://github.com/ckan/ckan/issues/8275)
The orgs_available variable is not passed to read_organizations.html or read group.html template 

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
