### PR TITLE
Argmode for DataStore Create Function

### DIFF
--- a/changes/8279.feature
+++ b/changes/8279.feature
@@ -1,0 +1,1 @@
+Adds `argmode` to the DataStore function create, allowing Database functions to have less than 5 parameters.

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -2422,7 +2422,9 @@ def create_function(name: str, arguments: Iterable[dict[str, Any]],
         or_replace=u'OR REPLACE' if or_replace else u'',
         name=identifier(name),
         args=u', '.join(
-            u'{argname} {argtype}'.format(
+            u'{argmode} {argname} {argtype}'.format(
+                # validator one_of checks for safety of argmode(in, out, inout)
+                argmode=a['argmode'] if 'argmode' in a else '',
                 argname=identifier(a['argname']),
                 argtype=identifier(a['argtype']))
             for a in arguments),

--- a/ckanext/datastore/logic/schema.py
+++ b/ckanext/datastore/logic/schema.py
@@ -222,6 +222,8 @@ def datastore_function_create_schema() -> Schema:
         'arguments': {
             'argname': [unicode_only, not_empty],
             'argtype': [unicode_only, not_empty],
+            'argmode': [ignore_missing, unicode_only, one_of([
+                'in', 'out', 'inout'])],
         },
         'rettype': [default(u'void'), unicode_only],
         'definition': [unicode_only],


### PR DESCRIPTION
feat(dev): datastore argmode;

- Adds `argmode` to DataStore create function.

cc: @wardi (original: https://github.com/open-data/ckan/commit/90cc1852c63849226b52ea4859ba865d8551b035)

### Proposed fixes:

Adds the capability for the DataStore Database to have functions/triggers with less than 5 params.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
