### PR TITLE
Prevent exception in Datatables view when the `size` field is missing

### DIFF
--- a/changes/8284.bugfix
+++ b/changes/8284.bugfix
@@ -1,0 +1,1 @@
+Prevent exception in Datatables view when the size field is missing

--- a/ckanext/datatablesview/templates/datatables/datatables_view.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_view.html
@@ -86,8 +86,8 @@
   {{- _('Metadata last updated') }}: {{ local_friendly_datetime(res.metadata_modified) }}&#10;
   {{- _('Created') }}: {{ local_friendly_datetime(res.created) }}&#10;
   {{- res.format or res.mimetype_inner or res.mimetype or _('unknown') -}}&nbsp;
-  {%- if res.size|int != 0 -%}
-   ( {{ h.SI_number_span(res.size)|striptags }} )
+  {%- if res.size && res.size|int != 0 -%}
+   ( {{ h.localize_filesize(res.size)}} )
   {%- endif -%}
 </div>
 {%- endblock -%}


### PR DESCRIPTION
For instance when using a custom schema without this field.

Also use the `h.localise_filesize()` helper instead of the more convoluted `h.SI_number_span(res.size)|striptags`

- [x] includes bugfix for possible backport


