### PR TITLE
use postgres 12 in circleci and test-infrastructure docker-compose

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ defaults:
       SQLALCHEMY_WARN_20: 1
   pg_image: &pg_image
     # Note, this should be in sync with test-infrastructure/docker-compose.yml
-    image: postgres:10
+    image: postgres:12
     environment:
       POSTGRES_USER: ckan
       POSTGRES_PASSWORD: ckan

--- a/changes/8289.misc
+++ b/changes/8289.misc
@@ -1,0 +1,1 @@
+Use postgres 12

--- a/test-infrastructure/docker-compose.yml
+++ b/test-infrastructure/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 networks:
   default:
 volumes:
@@ -8,7 +7,7 @@ services:
   ckan-postgres:
     networks:
       - default
-    image: "postgres:10"
+    image: "postgres:12"
     environment:
       POSTGRES_USER: ckan
       POSTGRES_PASSWORD: ckan


### PR DESCRIPTION
Fixes #8289 

### Proposed fixes:
Use ancient but at least supported version of postgres


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport