### PR TITLE
Test fix: restore configuration state after environment patches

### DIFF
--- a/ckan/tests/config/test_environment.py
+++ b/ckan/tests/config/test_environment.py
@@ -32,7 +32,7 @@ def reset_env():
     for env_var, _ in ENV_VAR_LIST:
         if os.environ.get(env_var, None):
             del os.environ[env_var]
-    p.load()
+    p.plugins_update()
 
 
 @pytest.mark.usefixtures(u"reset_env")


### PR DESCRIPTION
Fix for CircleCI errors from [this run](https://app.circleci.com/pipelines/github/ckan/ckan/6788/workflows/dda704aa-3a6a-423e-bee4-b692643e5632/jobs/14885/parallel-runs/3)

If you see 
```
ERROR ckan/tests/controllers/test_admin.py::TestAdminConfigUpdate::test_admin_config_update - sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) could not translate host name "mynewsqlurl" to address: Name or service not known
```
it means [this test](https://github.com/ckan/ckan/blob/master/ckan/tests/config/test_environment.py#L39-L46) was executed before another DB test. The first test does not properly clear environment modifications and the DB connection in the second test is initialized with the wrong parameters.

To fix the problem, instead of `p.load()` which does not reset the DB connection without arguments, we need to call `p.plugins_update()` which restores the DB connection with the original configuration.