### PR TITLE
Explain how to stop authentication process

### DIFF
--- a/ckan/lib/authenticator.py
+++ b/ckan/lib/authenticator.py
@@ -1,8 +1,8 @@
-# encoding: utf-8
+from __future__ import annotations
 
 import logging
-import ckan.plugins as plugins
-from typing import Any, Mapping, Optional
+from ckan import model, plugins
+from typing import Any
 
 from ckan.common import g, request
 from ckan.lib import captcha
@@ -12,7 +12,9 @@ from . import signals
 log = logging.getLogger(__name__)
 
 
-def default_authenticate(identity: 'Mapping[str, Any]') -> Optional["User"]:
+def default_authenticate(
+        identity: dict[str, Any]
+) -> model.User | model.AnonymousUser | None:
     if not ('login' in identity and 'password' in identity):
         return None
 
@@ -47,7 +49,9 @@ def default_authenticate(identity: 'Mapping[str, Any]') -> Optional["User"]:
     return None
 
 
-def ckan_authenticator(identity: 'Mapping[str, Any]') -> Optional["User"]:
+def ckan_authenticator(
+        identity: dict[str, Any]
+) -> model.User | model.AnonymousUser | None:
     """Allows extensions that have implemented
     `IAuthenticator.authenticate()` to hook into the CKAN authentication
     process with a custom implementation.

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -1750,13 +1750,16 @@ class IAuthenticator(Interface):
         return (status_code, detail, headers, comment)
 
     def authenticate(
-        self, identity: 'Mapping[str, Any]'
-    ) -> model.User | None:
+        self, identity: dict[str, Any]
+    ) -> model.User | model.AnonymousUser | None:
         """Called before the authentication starts
         (that is after clicking the login button)
 
-        Plugins should return a user object if the authentication was
-        successful, or ``None``` otherwise.
+        Plugins should return:
+
+        * `model.User` object if the authentication was successful
+        * `model.AnonymousUser` object if the authentication failed
+        * `None` to try authentication with different implementations.
         """
 
 

--- a/ckanext/example_iauthenticator/plugin.py
+++ b/ckanext/example_iauthenticator/plugin.py
@@ -1,8 +1,9 @@
-# encoding: utf-8
+from __future__ import annotations
+from typing import Any
 
 from flask import Blueprint, make_response
 
-from ckan import plugins as p
+from ckan import model, plugins as p
 
 
 toolkit = p.toolkit
@@ -51,6 +52,14 @@ class ExampleIAuthenticatorPlugin(p.SingletonPlugin):
     def logout(self):
 
         return toolkit.redirect_to(u'example_iauthenticator.custom_logout')
+
+    def authenticate(
+        self, identity: dict[str, Any]
+    ) -> model.User | model.AnonymousUser | None:
+        if identity.get("use_fallback"):
+            return None
+
+        return model.AnonymousUser()
 
     # IBlueprint
 


### PR DESCRIPTION
Fixes #8229

To prevent default authentication, a plugin that implements IAuthenticator, must return AnonymousUser. This option is not documented.

This PR mentions the AnonymousUser option inside the interface's docstring, fixes types, and adds a pair of tests.