### PR TITLE
[8202]Change timestamp format for 'timestamp' field type

### DIFF
--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -2078,7 +2078,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
             if typ == 'nested':
                 fmt = "coalesce(({0}).json,'null')"
             elif typ == 'timestamp':
-                fmt = "to_char({0}, 'YYYY-MM-DD\"T\"HH24:MI:SS')"
+                fmt = "to_char({0}, 'YYYY-MM-DD\"T\"HH24:MI:SS.MS')"
                 if records_format == 'lists':
                     fmt = f"coalesce(to_json({fmt}), 'null')"
             elif typ.startswith('_') or typ.endswith('[]'):


### PR DESCRIPTION
Ad milliseconds into timestamp field

Fixes #8202 

### Features: add ms value into filed with 'timestamp' type.

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
