### PR TITLE
Refactor package ownership handling

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -201,13 +201,6 @@ def package_create(
         for index, resource in enumerate(data['resources']):
             resource['id'] = pkg.resources[index].id
 
-    context_org_update = context.copy()
-    context_org_update['ignore_auth'] = True
-    context_org_update['defer_commit'] = True
-    _get_action('package_owner_org_update')(context_org_update,
-                                            {'id': pkg.id,
-                                             'organization_id': pkg.owner_org})
-
     for item in plugins.PluginImplementations(plugins.IPackageController):
         item.create(pkg)
 

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -372,14 +372,26 @@ def _group_or_org_list(
                                total=1)
 
     if sort_info and sort_info[0][0] == 'package_count':
-        query = model.Session.query(model.Group.id,
-                                    model.Group.name,
-                                    sqlalchemy.func.count(model.Group.id))
+        if is_org:
+            query = model.Session.query(
+                model.Group.id,
+                model.Group.name,
+                sqlalchemy.func.count(model.Package.id).label("package_count"),
+            ).outerjoin(
+                model.Package,
+                (model.Group.id == model.Package.owner_org)
+                & (model.Package.state == "active"),
+            )
 
-        query = query.filter(model.Member.group_id == model.Group.id) \
-                     .filter(model.Member.table_id == model.Package.id) \
-                     .filter(model.Member.table_name == 'package') \
-                     .filter(model.Package.state == 'active')
+        else:
+            query = model.Session.query(model.Group.id,
+                                        model.Group.name,
+                                        sqlalchemy.func.count(model.Group.id))
+
+            query = query.filter(model.Member.group_id == model.Group.id) \
+                        .filter(model.Member.table_id == model.Package.id) \
+                        .filter(model.Member.table_name == 'package') \
+                        .filter(model.Package.state == 'active')
     else:
         query = model.Session.query(model.Group.id,
                                     model.Group.name)
@@ -402,7 +414,11 @@ def _group_or_org_list(
     if sort_info:
         sort_field = sort_info[0][0]
         sort_direction = sort_info[0][1]
-        sort_model_field: Any = sqlalchemy.func.count(model.Group.id)
+        sort_model_field: Any = (
+            sqlalchemy.func.count(model.Package.id)
+            if is_org
+            else sqlalchemy.func.count(model.Group.id)
+        )
         if sort_field == 'package_count':
             query = query.group_by(model.Group.id, model.Group.name)
         elif sort_field == 'name':
@@ -987,7 +1003,7 @@ def package_show(context: Context, data_dict: DataDict) -> ActionResult.PackageS
     include_plugin_data = asbool(data_dict.get('include_plugin_data', False))
     if user_obj and user_obj.is_authenticated:
         include_plugin_data = (
-            user_obj.sysadmin  # type: ignore
+            user_obj.sysadmin
             and include_plugin_data
         )
 

--- a/ckan/model/group.py
+++ b/ckan/model/group.py
@@ -63,8 +63,6 @@ class Member(core.StatefulObjectMixin,
     Meanings:
     * Package - the Group is a collection of Packages
                  - capacity is 'public', 'private'
-                   or 'organization' if the Group is an Organization
-                   (see ckan.logic.action.package_owner_org_update)
     * User - the User is granted permissions for the Group
                  - capacity is 'admin', 'editor' or 'member'
     * Group - the Group (Member.group_id) is a parent of the Group (Member.id)
@@ -369,22 +367,29 @@ class Group(core.StatefulObjectMixin,
                     .filter(Member.table_id == user_id)
             user_is_org_member = len(member_query.all()) != 0
 
-        query = meta.Session.query(_package.Package).\
-            filter(_package.Package.state == core.State.ACTIVE).\
-            filter(group_table.c["id"] == self.id).\
-            filter(member_table.c["state"] == 'active')
+        if self.is_organization:
+            query = meta.Session.query(_package.Package).filter(
+                _package.Package.owner_org == self.id,
+                _package.Package.state == 'active',
+            )
+            # orgs do not show private datasets unless the user is a member
+            if not user_is_org_member:
+                 query = query.filter(_package.Package.private == False)
 
-        # orgs do not show private datasets unless the user is a member
-        if self.is_organization and not user_is_org_member:
-            query = query.filter(_package.Package.private == False)
-        # groups (not orgs) never show private datasets
-        if not self.is_organization:
-            query = query.filter(_package.Package.private == False)
+        else:
+            query = meta.Session.query(_package.Package).\
+                filter(_package.Package.state == core.State.ACTIVE).\
+                filter(group_table.c["id"] == self.id).\
+                filter(member_table.c["state"] == 'active')
 
-        query: "Query[_package.Package]" = query.join(
-            member_table, member_table.c["table_id"] == _package.Package.id)
-        query: "Query[_package.Package]" = query.join(
-            group_table, group_table.c["id"] == member_table.c["group_id"])
+            # groups (not orgs) never show private datasets
+            if not self.is_organization:
+                query = query.filter(_package.Package.private == False)
+
+            query: "Query[_package.Package]" = query.join(
+                member_table, member_table.c["table_id"] == _package.Package.id)
+            query: "Query[_package.Package]" = query.join(
+                group_table, group_table.c["id"] == member_table.c["group_id"])
 
         if limit is not None:
             query = query.limit(limit)


### PR DESCRIPTION
Fixes #8249 

### Proposed fixes:

1. Remove usage of `package_owner_org_update` in `package_create` and `package_update`
2. Updated `package_owner_org_update` to use `package_patch` for updating package ownership
3. Modified queries to remove dependency on member table for querying packages for organization

More changes to come...

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
