### PR TITLE
Add timezone support to date helpers

### DIFF
--- a/changes/8305.feature
+++ b/changes/8305.feature
@@ -1,0 +1,1 @@
+`date_str_to_datetime` helper accept values with timezone information.

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -755,7 +755,7 @@ def test_date_str_to_datetime_valid(string: str, date: datetime.datetime):
 @pytest.mark.parametrize("string", [
 
     "2008-04-13T20:40:20-0130",  # no `:` in timezone
-    "2008-04-13T20:40:20foobar", # cannot parse the rest as milliseconds
+    "2008-04-13T20:40:20foobar",  # cannot parse the rest as milliseconds
 ])
 def test_date_str_to_datetime_invalid(string: str):
     with pytest.raises(ValueError):

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -741,17 +741,23 @@ Notes: this is the classic RDF source but historically has had some problems wit
     ("2008-04-13T20:40:20.123456", datetime.datetime(2008, 4, 13, 20, 40, 20, 123456)),
     ("2008-04-13T20:40:20", datetime.datetime(2008, 4, 13, 20, 40, 20)),
     ("2008-04-13T20:40:20.1234", datetime.datetime(2008, 4, 13, 20, 40, 20, 123400)),
+    (
+        "2008-04-13T20:40:20.123-01:30",
+        datetime.datetime(2008, 4, 13, 20, 40, 20, 123000, datetime.timezone(
+            -datetime.timedelta(minutes=90)
+        ))),
+
 ])
-def test_date_str_to_datetime_valid(string, date):
+def test_date_str_to_datetime_valid(string: str, date: datetime.datetime):
     assert h.date_str_to_datetime(string) == date
 
 
 @pytest.mark.parametrize("string", [
-    "2008-04-13T20:40:20-01:30",
-    "2008-04-13T20:40:20-0130",
-    "2008-04-13T20:40:20foobar",
+
+    "2008-04-13T20:40:20-0130",  # no `:` in timezone
+    "2008-04-13T20:40:20foobar", # cannot parse the rest as milliseconds
 ])
-def test_date_str_to_datetime_invalid(string):
+def test_date_str_to_datetime_invalid(string: str):
     with pytest.raises(ValueError):
         h.date_str_to_datetime(string)
 


### PR DESCRIPTION
Because of naive `datetime` deprecation(#8139), we'll face more dates with timezone in the future.

`date_str_to_datetime` helper does not support timezones. But this can be easily fixed, as since python 3.7, `datetime` has `fromisoformat` helper that parses some of ISO 8601 representations, including the one, with timezone specification.

I left the original implementation unchanged, so all previously parsed values are still supported. 

As a bonus, parsing any ISO 8601 value(`YYYY-MM-DD HH:MM:SS` with or without timezone) is 20 times faster than before.

