### PR TITLE
disable flaky cypress test

### DIFF
--- a/cypress/e2e/modules/autocomplete.cy.js
+++ b/cypress/e2e/modules/autocomplete.cy.js
@@ -1,4 +1,14 @@
 /*globals describe beforeEach afterEach it assert sinon ckan jQuery */
+
+/*
+FIXME: flaky test failing with:
+  1) ckan.modules.AutocompleteModule()
+       .formatInitialValue(element, callback)
+         should return the value if no callback is provided (to support select2 v2.1):
+     TypeError: Cannot read properties of undefined (reading 'jQuery')
+      at Context.eval (webpack://ckan/./cypress/e2e/modules/autocomplete.cy.js:14:14)
+
+
 describe('ckan.modules.AutocompleteModule()', {testIsolation: false}, function () {
   before(() => {
     cy.visit('/');
@@ -365,3 +375,4 @@ describe('ckan.modules.AutocompleteModule()', {testIsolation: false}, function (
     });
   });
 });
+*/


### PR DESCRIPTION
Fixes #

### Proposed fixes:

Disable flaky cypress autocomplete test

- not sure the what the best fix is but we can test the autocomplete endpoint without relying on the browser

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport