### PR TITLE
[#8273] deprecation note for package/group extras

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Changelog
 
 .. towncrier release notes start
 
+Deprecations:
+ * PackageExtra and GroupExtra models will be removed in the next release
+   and replaced by Package.extras and Group.extras JSONB fields.
+
 v.2.10.4 2024-03-13
 ===================
 


### PR DESCRIPTION
### Proposed fixes:

Note about PackageExtra, GroupExtra model removal in next release (dev-v2.11 only)


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport