### PR TITLE
Add step to apply activity plugin migrations to install docs

### DIFF
--- a/doc/maintaining/database-management.rst
+++ b/doc/maintaining/database-management.rst
@@ -22,6 +22,12 @@ initialize your database:
 
     ckan -c |ckan.ini| db init
 
+Additionally, some of the loaded plugins might require additional database setup:
+
+.. parsed-literal::
+
+    ckan -c |ckan.ini| db pending-migrations
+
 If you forget to do this you'll see this error message in your web browser:
 
     503 Service Unavailable:  This site is currently off-line. Database is not

--- a/doc/maintaining/installing/install-from-package.rst
+++ b/doc/maintaining/installing/install-from-package.rst
@@ -158,6 +158,7 @@ set the :ref:`ckan.storage_path` configuration option in the next section).
 #. Initialize your CKAN database by running this command in a terminal::
 
     sudo ckan db init
+    sudo ckan db pending-migrations
 
 #. Optionally, setup the DataStore and DataPusher by following the
    instructions in :doc:`/maintaining/datastore`.

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -232,6 +232,7 @@ database, you can :ref:`create the database tables <db init>`:
 
     cd |virtualenv|/src/ckan
     ckan -c |ckan.ini| db init
+    ckan -c |ckan.ini| db pending-migrations
 
 You should see ``Initialising DB: SUCCESS``.
 


### PR DESCRIPTION
If you do a fresh CKAN install, the `activity` plugin gets added by default to the generated ini file. Following the instructions you will run `ckan db init` but as soon as you try to run some command that creates an activity:

```
ckan sysadmin add amercader

[...]
  File "/home/adria/.pyenv/versions/3.9.16/envs/ckan-211/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1910, in _execute_context
    self.dialect.do_execute(
  File "/home/adria/.pyenv/versions/3.9.16/envs/ckan-211/lib/python3.9/site-packages/sqlalchemy/engine/default.py", line 736, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.UndefinedColumn) column "permission_labels" of relation "activity" does not exist
LINE 1: ..._id, object_id, revision_id, activity_type, data, permission...
                                                             ^

[SQL: INSERT INTO activity (id, timestamp, user_id, object_id, revision_id, activity_type, data, permission_labels) VALUES (%(id)s, %(timestamp)s, %(user_id)s, %(object_id)s, %(revision_id)s, %(activity_type)s, %(data)s, %(permission_labels)s)]
[parameters: {'id': '19e533a3-8bc3-4ac1-b687-88c40d1d1229', 'timestamp': datetime.datetime(2024, 7, 8, 14, 6, 37, 545699), 'user_id': 'a8b3031f-babd-44e5-a0dc-712269300a86', 'object_id': 'a8b3031f-babd-44e5-a0dc-712269300a86', 'revision_id': None, 'activity_type': 'new user', 'data': None, 'permission_labels': None}]

```

To fix this you need to run `ckan db upgrade -p activity` or `ckan db pending-migrations`. 

Activity migrations are a bit awkward because half of them exist in the core migrations (and get applied by `ckan db init`) but the other half were introduced after moving the functionality to its own extension, so the model gets half set up.

I'm not sure of the best way to improve this. Calling `ckan db pending-migrations` as part of the install instructions seems like a good stop gap measure but it would be good to improve the experience. Some ideas:
*  Migrate the core activity migrations to the extension and then explicitly call `db init -p activity`
* Make `db init` call all migrations of the loaded plugins
* ??

I'm not sure how feasible any of these are btw, @smotornyuk you are probably the best placed to say.
