### PR TITLE
ckan db create-from-model: update alembic too

### DIFF
--- a/changes/8336.bugfix
+++ b/changes/8336.bugfix
@@ -1,0 +1,1 @@
+`ckan db upgrade` can now be used after `ckan db create-from-model`

--- a/ckan/cli/db.py
+++ b/ckan/cli/db.py
@@ -47,8 +47,17 @@ def create_from_model():
     """
     try:
         model.repo.create_db()
+        model.repo.stamp_alembic_head()
+
+        # also mark plugins as migrated
+        # FIXME: move to model.repo?
+        pending = _get_pending_plugins()
+        for plugin, n in sorted(pending.items()):
+            with _repo_for_plugin(plugin) as repo:
+                print(plugin, repo)
+                repo.stamp_alembic_head()
     except Exception as e:
-        error_shout(e)
+        raise
     else:
         click.secho('Create DB from model: SUCCESS', fg='green', bold=True)
 

--- a/ckan/cli/db.py
+++ b/ckan/cli/db.py
@@ -52,11 +52,11 @@ def create_from_model():
         # also mark plugins as migrated
         # FIXME: move to model.repo?
         pending = _get_pending_plugins()
-        for plugin, n in sorted(pending.items()):
+        for plugin in sorted(pending):
             with _repo_for_plugin(plugin) as repo:
                 print(plugin, repo)
                 repo.stamp_alembic_head()
-    except Exception as e:
+    except Exception:
         raise
     else:
         click.secho('Create DB from model: SUCCESS', fg='green', bold=True)

--- a/ckan/model/__init__.py
+++ b/ckan/model/__init__.py
@@ -14,7 +14,8 @@ from sqlalchemy import MetaData, Table, inspect
 from alembic.command import (
     upgrade as alembic_upgrade,
     downgrade as alembic_downgrade,
-    current as alembic_current
+    current as alembic_current,
+    stamp as alembic_stamp,
 )
 from alembic.config import Config as AlembicConfig
 
@@ -241,7 +242,16 @@ class Repository():
         '''
         with ensure_engine().begin() as conn:
             self.metadata.create_all(conn)
+
         log.info('Database tables created')
+
+    def stamp_alembic_head(self):
+        '''mark database as up to date for alembic'''
+        alembic_config = AlembicConfig(self._alembic_ini)
+        alembic_config.set_main_option(
+            "sqlalchemy.url", config.get("sqlalchemy.url")
+        )
+        alembic_stamp(alembic_config, 'head')
 
     def rebuild_db(self) -> None:
         '''Clean and init the db'''


### PR DESCRIPTION
Fixes issue with `ckan db upgrade` after using `ckan db create-from-model`

### Proposed fixes:
Stamp alembic migrations as completed for core and plugins on `ckan db create-from-model`

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport