### PR TITLE
Implement `ckan db init` as an alias of `ckan db upgrade`

### DIFF
--- a/changes/8339.misc
+++ b/changes/8339.misc
@@ -1,0 +1,2 @@
+`ckan db init` is now alias of `ckan db upgrade`, which provides better support
+for includuing plugin migrations

--- a/ckan/cli/db.py
+++ b/ckan/cli/db.py
@@ -29,16 +29,19 @@ def db():
 
 
 @db.command()
-def init():
-    """Initialize the database.
+@click.option('-v', '--version', help='Migration version', default='head')
+@click.option('--skip-plugins', is_flag=True, help='Skip plugin migrations')
+@click.option('--skip-core', is_flag=True, help='Skip core migrations')
+@click.pass_context
+@applies_to_plugin
+def init(
+        ctx: click.Context, version: str, plugin: str,
+        skip_core: bool, skip_plugins: bool
+):
+
+    """Initialize the database (alias of `ckan db upgrade`)
     """
-    log.info(u"Initialize the Database")
-    try:
-        model.repo.init_db()
-    except Exception as e:
-        error_shout(e)
-    else:
-        click.secho(u'Initialising DB: SUCCESS', fg=u'green', bold=True)
+    ctx.forward(upgrade)
 
 
 @db.command()
@@ -79,7 +82,7 @@ def upgrade(
         ctx: click.Context, version: str, plugin: str,
         skip_core: bool, skip_plugins: bool
 ):
-    """Upgrade the database.
+    """Upgrade or initialize the database.
     """
     if not skip_core:
         _run_migrations(plugin, version)


### PR DESCRIPTION
As discussed in https://github.com/ckan/ckan/pull/8329

This applies any migrations from plugins loaded in the ini file when setting up the database for the first time  (the issue with `activity` raised in the PR above)
