### PR TITLE
Datatables form UI Improvements

### DIFF
--- a/changes/8341.feature
+++ b/changes/8341.feature
@@ -1,0 +1,1 @@
+Adds `Show All` and `Hide All` to the Datatables form for column visibility. Fixes responsive issues with the Datatables column visibility modal.

--- a/ckanext/datatablesview/assets/datatables_view.css
+++ b/ckanext/datatablesview/assets/datatables_view.css
@@ -231,3 +231,74 @@ z-index:100;
 .animated-shake {
   animation: shake .4s;
 }
+
+.buttons-collection.buttons-colvis ~ .dt-button-collection.fixed {
+  width: 75%;
+  top: 10% !important;
+  margin-top: 0 !important;
+  transform: translateX(-50%);
+  margin-left: 0;
+  padding: 18px !important;
+  max-height: 80% !important;
+  overflow-y: scroll !important;
+}
+
+.buttons-collection.buttons-colvis ~ .dt-button-collection.fixed .dropdown-menu {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  width: 100%;
+  max-height: 100% !important;
+  min-height: 100% !important;
+  height: 100% !important;
+}
+
+.buttons-collection.buttons-colvis ~ .dt-button-collection.fixed a {
+  word-break: break-all;
+}
+
+.buttons-collection.buttons-colvis ~ .dt-button-collection.fixed a.buttons-columnVisibility {
+  max-width: 50%;
+  min-width: 50%;
+  width: 50%;
+  margin-bottom: 5px;
+  padding-left: 24px;
+  padding-right: 10px;
+  position: relative;
+}
+
+.buttons-collection.buttons-colvis ~ .dt-button-collection.fixed a.buttons-columnVisibility::before {
+  content: '\f096';
+  font: normal normal normal 14px/1 FontAwesome;
+  position: absolute;
+  left: 6px;
+  top: 6px;
+}
+
+.buttons-collection.buttons-colvis ~ .dt-button-collection.fixed a.buttons-columnVisibility.active::before {
+  content: '\f046';
+}
+
+.buttons-collection.buttons-colvis ~ .dt-button-collection.fixed a:not(.buttons-columnVisibility) {
+  flex-basis: 100%;
+  margin-top: 8px;
+}
+
+.buttons-collection.buttons-colvis ~ .dt-button-collection.fixed a:not(.buttons-columnVisibility).buttons-colvisRestore {
+  max-width: 51%;
+  min-width: 51%;
+  width: 51%;
+}
+
+.buttons-collection.buttons-colvis ~ .dt-button-collection.fixed a:not(.buttons-columnVisibility).buttons-colvisGroup {
+  max-width: 50%;
+  min-width: 50%;
+  width: 50%;
+}
+
+.buttons-collection.buttons-colvis ~ .dt-button-collection.fixed a:not(.buttons-columnVisibility).buttons-colvisGroup:nth-last-of-type(3) {
+  max-width: 49%;
+  min-width: 49%;
+  width: 49%;
+  margin-left: -1%;
+}

--- a/ckanext/datatablesview/assets/datatablesview_form.js
+++ b/ckanext/datatablesview/assets/datatablesview_form.js
@@ -1,0 +1,13 @@
+window.addEventListener('load', function(){
+  $(document).ready(function(){
+    let dtShowAll = $('a.dt-show-all');
+    let dtHideAll = $('a.dt-hide-all');
+    let dtColSelects = $('.dt-select-columns').find('input[type="checkbox"]').not('input[value="_id"]');
+    $(dtShowAll).on('click', function(_event){
+      $(dtColSelects).prop('checked', true).change().blur();
+    });
+    $(dtHideAll).on('click', function(_event){
+      $(dtColSelects).prop('checked', false).change().blur();
+    });
+  });
+});

--- a/ckanext/datatablesview/assets/webassets.yml
+++ b/ckanext/datatablesview/assets/webassets.yml
@@ -16,3 +16,10 @@ main-js:
     - vendor/DataTables/dataTables.scrollResize.js
     - vendor/DataTables/datetime.js
     - datatablesview.js
+form-js:
+  output: ckanext-datatablesview/%(version)s_datatablesview_form.js
+  extra:
+    preload:
+      - base/main
+  contents:
+    - datatablesview_form.js

--- a/ckanext/datatablesview/templates/datatables/datatables_form.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_form.html
@@ -27,7 +27,10 @@
 
 <div class="control-group">
   <label class="form-label">{{ _('Show Columns') }}</label>
-  <div class="controls">
+  <br/>
+  <a class="dt-show-all" href="javascript:void(0);"><span class="me-3"><i class="fa fa-eye"></i>&nbsp;{{ _('Show All') }}</span></a>
+  <a class="dt-hide-all" href="javascript:void(0);"><span><i class="fa fa-eye-slash"></i>&nbsp;{{ _('Hide All') }}</span></a>
+  <div class="controls dt-select-columns mt-3">
     <table class="table table-striped table-bordered">
       <thead>
         <tr>
@@ -66,3 +69,5 @@
     </table>
   </div>
 </div>
+
+{% asset 'ckanext-datatablesview/form-js' %}


### PR DESCRIPTION
feat(templates): qol for datatables;

- Added `Show All` and `Hide All` to datatable view form for column selecting.
- Added CSS for better responsiveness of the datatables column visibility.

Fixes #

### Proposed fixes:

- Adds `Show All` button above the datatables column select are to select all the checkboxes.
- Adds `Hide All` button above the datatables column select are to deselect all the checkboxes.
- Adds CSS for the datatables column visibility modal, which fixes a lot of responsive issues and overflow issues.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
