### PR TITLE
Datastore Field Name Validation and Control Characters

### DIFF
--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -14,6 +14,8 @@ import ckan.common as converters
 import ckan.plugins.toolkit as tk
 from ckan.types import Context
 
+import unicodedata
+
 
 log = logging.getLogger(__name__)
 
@@ -30,10 +32,13 @@ def is_valid_field_name(name: str):
     * can't start with underscore
     * can't contain double quote (")
     * can't be empty
+    * can't contain control characters
     '''
     return (name and name == name.strip() and
             not name.startswith('_') and
-            '"' not in name)
+            '"' not in name
+            and not True in [
+                unicodedata.category(char).startswith('C') for char in name])
 
 
 def is_valid_table_name(name: str):

--- a/ckanext/datastore/logic/schema.py
+++ b/ckanext/datastore/logic/schema.py
@@ -110,13 +110,14 @@ def unicode_or_json_validator(value: Any) -> Any:
 
 
 def datastore_create_schema() -> Schema:
+    datastore_field_name = get_validator('datastore_field_name')
     schema = {
         'resource_id': [ignore_missing, unicode_safe, resource_id_exists],
         'force': [ignore_missing, boolean_validator],
         'id': [ignore_missing],
         'aliases': [ignore_missing, list_of_strings_or_string],
         'fields': {
-            'id': [not_empty, unicode_safe],
+            'id': [not_empty, unicode_safe, datastore_field_name],
             'type': [ignore_missing],
             'info': [ignore_missing],
         },

--- a/ckanext/datastore/logic/validators.py
+++ b/ckanext/datastore/logic/validators.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 from ckan.types import (
     Context, FlattenDataDict, FlattenKey, FlattenErrorDict,
 )
-from ckan.plugins.toolkit import missing
+from ckan.plugins.toolkit import missing, Invalid, _
+
+from ckanext.datastore.helpers import is_valid_field_name
 
 
 def to_datastore_plugin_data(plugin_key: str):
@@ -47,3 +49,12 @@ def datastore_default_current(
         field_name)
     if current:
         data[key] = current
+
+
+def datastore_field_name(value, context):
+    """
+    Check if the field name is valid
+    """
+    if not is_valid_field_name(value):
+        raise Invalid(_('"{0}" is not a valid field name').format(value))
+    return value


### PR DESCRIPTION
feat(logic): ds field name validator;

- Added Datastore field name validator to ds create sub-schema.
- Added catch to conrtol characters in ds field names.

Fixes #

### Proposed fixes:

Adds a validator to the datastore create sub-schema for field IDs. And also prevents control characters from being used in datastore field names.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
