### PR TITLE
datastore: fix for edge case found by xloader test

### DIFF
--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -292,7 +292,7 @@ def _get_field_info(
     )
     try:
         return dict(
-            (n, json.loads(v)) for (n, v) in
+            (n, json.loads(v) if v else {}) for (n, v) in
             connection.execute(qtext, {"res_id": resource_id}).fetchall())
     except (TypeError, ValueError):  # don't die on non-json comments
         return {}


### PR DESCRIPTION
Fixes failure in https://github.com/ckan/ckanext-xloader/pull/220

### Proposed fixes:

Handle case where datastore info is provided for some fields but not others by returning empty dicts for fields missing info instead of no info for any field

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport