### PR TITLE
Fix Preview work on View created

### DIFF
--- a/ckan/templates/package/edit_view.html
+++ b/ckan/templates/package/edit_view.html
@@ -18,7 +18,7 @@
     {% include 'package/snippets/view_form.html' %}
     <div class="form-actions">
       <button class="btn btn-danger pull-left" name="delete" value="Delete"> {{ _('Delete') }} </button>
-      <button class="btn btn-default {% if not h.resource_view_display_preview(data) %}hide{%endif%}" name="preview" value="True" type="submit">{{ _('Preview') }}</button>
+      <button class="btn btn-default {% if not h.resource_view_display_preview(data) %}d-none{%endif%}" name="preview" value="True" type="submit">{{ _('Preview') }}</button>
       <button class="btn btn-primary" name="save" value="Save" type="submit">{{ _('Update') }}</button>
     </div>
   </form>

--- a/ckan/templates/package/new_view.html
+++ b/ckan/templates/package/new_view.html
@@ -26,7 +26,7 @@
     {{ h.csrf_input() }} 
     {% include 'package/snippets/view_form.html' %}
     <div class="form-actions">
-        <button class="btn btn-default {% if not h.resource_view_display_preview(data) %}hide{%endif%}" name="preview" value="True" type="submit">{{ _('Preview') }}</button>
+        <button class="btn btn-default {% if not h.resource_view_display_preview(data) %}d-none{%endif%}" name="preview" value="True" type="submit">{{ _('Preview') }}</button>
         <button class="btn btn-primary" name="save" value="Save" type="submit">{% block save_button_text %}{{ _('Add') }}{% endblock %}</button>
     </div>
   </form>

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -729,9 +729,9 @@ class EditResourceViewView(MethodView):
             view_id: Optional[str] = None,
             post_extra: Optional[dict[str, Any]] = None) -> str:
         context, extra_vars = self._prepare(id, resource_id)
-        to_preview = extra_vars[u'to_preview']
         if post_extra:
             extra_vars.update(post_extra)
+        to_preview = extra_vars[u'to_preview']
 
         package_type = _get_package_type(id)
         data = extra_vars[u'data'] if u'data' in extra_vars else None


### PR DESCRIPTION
Fix generating the preview on new View created. And fix hide the "Preview" button on BootStrap5 with plugin without preview.

### Proposed fixes:
In Preview blueprint initialize a flag to_preview after update extra_vars from call options. And use class d-none to hide the "Preview" button on BS5.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ x] includes bugfix for possible backport

Please [X] all the boxes above that apply
