### PR TITLE
`ckan.download_proxy` support for the `resourceproxy` plugin

### DIFF
--- a/changes/8354.misc
+++ b/changes/8354.misc
@@ -1,0 +1,1 @@
+Added support for :ref:`ckan.download_proxy` to the `resourceproxy` plugin

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -1038,10 +1038,15 @@ groups:
               they're given in the config file, regardless of which Python modules
               they're implemented in.
 
-      - key: ckan.resource_proxy.timeout
-        type: int
-        default: 5
-        description: Timeout in seconds to use on Resource Proxy requests.
+      - key: ckan.download_proxy
+        default: None
+        example: http://proxy:3128
+        description: |
+          Specifies a HTTP proxy to be used by extensions such as XLoader or Archiver
+          when downloading remote files. This may be useful for enabling access to
+          restricted network locations, or restricting access to privileged ones, eg
+          preventing `Server Side Request Forgery <https://feeding.cloud.geek.nz/posts/restricting-outgoing-webapp-requests-using-squid-proxy/>`_.
+          It will not be used by CKAN core.
 
   - annotation: Front-End Settings
     options:

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -1042,7 +1042,7 @@ groups:
         default: None
         example: http://proxy:3128
         description: |
-          Specifies a HTTP proxy to be used by extensions such as XLoader or Archiver
+          Specifies a HTTP proxy to be used by extensions such as Resource Proxy, XLoader or Archiver
           when downloading remote files. This may be useful for enabling access to
           restricted network locations, or restricting access to privileged ones, eg
           preventing `Server Side Request Forgery <https://feeding.cloud.geek.nz/posts/restricting-outgoing-webapp-requests-using-squid-proxy/>`_.

--- a/ckanext/resourceproxy/blueprint.py
+++ b/ckanext/resourceproxy/blueprint.py
@@ -39,17 +39,24 @@ def proxy_resource(context: Context, data_dict: DataDict):
 
     timeout = config.get('ckan.resource_proxy.timeout')
     max_file_size = config.get(u'ckan.resource_proxy.max_file_size')
+    proxy = config.get('ckan.download_proxy')
+    proxies = {'http': proxy, 'https': proxy}
     response = make_response()
     try:
         # first we try a HEAD request which may not be supported
         did_get = False
-        r = requests.head(url, timeout=timeout)
+        r = requests.head(url, timeout=timeout, proxies=proxies)
         # Servers can refuse HEAD requests. 405 is the appropriate
         # response, but 400 with the invalid method mentioned in the
         # text, or a 403 (forbidden) status is also possible (#2412,
         # #2530)
         if r.status_code in (400, 403, 405):
-            r = requests.get(url, timeout=timeout, stream=True)
+            r = requests.get(
+                url,
+                timeout=timeout,
+                stream=True,
+                proxies=proxies
+            )
             did_get = True
         r.raise_for_status()
 
@@ -64,7 +71,12 @@ def proxy_resource(context: Context, data_dict: DataDict):
             )
 
         if not did_get:
-            r = requests.get(url, timeout=timeout, stream=True)
+            r = requests.get(
+                url,
+                timeout=timeout,
+                stream=True,
+                proxies=proxies,
+            )
 
         response.headers[u'content-type'] = r.headers[u'content-type']
 

--- a/ckanext/resourceproxy/config_declaration.yaml
+++ b/ckanext/resourceproxy/config_declaration.yaml
@@ -20,3 +20,8 @@ groups:
       This sets size of the chunk to read and write when proxying.
       Raising this value might save some CPU cycles. It makes no sense to lower it
       below the page size, which is default.
+
+  - key: ckan.resource_proxy.timeout
+    type: int
+    default: 5
+    description: Timeout in seconds to use on Resource Proxy requests.

--- a/doc/maintaining/data-viewer.rst
+++ b/doc/maintaining/data-viewer.rst
@@ -266,6 +266,10 @@ as CKAN.
 You can modify the maximum allowed size for proxied files using the
 :ref:`ckan.resource_proxy.max_file_size` configuration setting.
 
+.. warning:: To prevent exposing internal network resources via the resource proxy,
+   consider setting up a download proxy and configure CKAN with :ref:`ckan.download_proxy`
+
+
 
 .. _same-origin policy: http://en.wikipedia.org/wiki/Same_origin_policy
 


### PR DESCRIPTION
* Added back the documentation for `ckan.download_proxy` , probably lost during the switch to config declaration. Fixes #7422 
* Added support for `ckan.download_proxy` to `resourceproxy` following the same pattern used in [xloader](https://github.com/ckan/ckanext-xloader/pull/127), [archiver](https://github.com/ckan/ckanext-archiver/pull/78), etc