### PR TITLE
Refactorings for Python 3.11 and 3.12 support

### DIFF
--- a/changes/8357.feature
+++ b/changes/8357.feature
@@ -1,0 +1,1 @@
+Added support for Python 3.11 and 3.12

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import os
 import sys
 import time
+import importlib
 import inspect
 import pkgutil
 import logging
@@ -461,7 +462,10 @@ def _register_core_blueprints(app: CKANApp):
 
     for loader, name, __ in pkgutil.iter_modules([path], 'ckan.views.'):
         # type_ignore_reason: incorrect external type declarations
-        module = loader.find_module(name).load_module(name)  # type: ignore
+        spec = loader.find_spec(name)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
         for blueprint in inspect.getmembers(module, is_blueprint):
             app.register_blueprint(blueprint[1])
             log.debug(u'Registered core blueprint: {0!r}'.format(blueprint[0]))

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -470,7 +470,11 @@ def _register_core_blueprints(app: CKANApp):
                 spec.loader.exec_module(module)
                 for blueprint in inspect.getmembers(module, is_blueprint):
                     app.register_blueprint(blueprint[1])
-                    log.debug(u'Registered core blueprint: {0!r}'.format(blueprint[0]))
+                    log.debug(
+                        u'Registered core blueprint: {0!r}'.format(
+                            blueprint[0]
+                        )
+                    )
 
 
 def _register_error_handler(app: CKANApp):

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -462,13 +462,15 @@ def _register_core_blueprints(app: CKANApp):
 
     for loader, name, __ in pkgutil.iter_modules([path], 'ckan.views.'):
         # type_ignore_reason: incorrect external type declarations
-        spec = loader.find_spec(name)
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[name] = module
-        spec.loader.exec_module(module)
-        for blueprint in inspect.getmembers(module, is_blueprint):
-            app.register_blueprint(blueprint[1])
-            log.debug(u'Registered core blueprint: {0!r}'.format(blueprint[0]))
+        spec = loader.find_spec(name)   # type: ignore
+        if spec is not None:
+            module = importlib.util.module_from_spec(spec)  # type: ignore
+            sys.modules[name] = module
+            if spec.loader is not None:
+                spec.loader.exec_module(module)
+                for blueprint in inspect.getmembers(module, is_blueprint):
+                    app.register_blueprint(blueprint[1])
+                    log.debug(u'Registered core blueprint: {0!r}'.format(blueprint[0]))
 
 
 def _register_error_handler(app: CKANApp):

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -3,6 +3,7 @@
 import datetime
 import hashlib
 import os
+import sys
 
 import pytz
 import tzlocal
@@ -746,15 +747,22 @@ Notes: this is the classic RDF source but historically has had some problems wit
         datetime.datetime(2008, 4, 13, 20, 40, 20, 123000, datetime.timezone(
             -datetime.timedelta(minutes=90)
         ))),
-
+    pytest.param(
+        "2008-04-13T20:40:20-0130",
+        datetime.datetime(2008, 4, 13, 20, 40, 20, tzinfo=datetime.timezone(
+            datetime.timedelta(days=-1, seconds=81000))),
+        marks=pytest.mark.skipif(sys.version_info < (3, 11), reason="This is invalid in py<3.11")
+    )
 ])
 def test_date_str_to_datetime_valid(string: str, date: datetime.datetime):
     assert h.date_str_to_datetime(string) == date
 
 
 @pytest.mark.parametrize("string", [
-
-    "2008-04-13T20:40:20-0130",  # no `:` in timezone
+    pytest.param(
+        "2008-04-13T20:40:20-0130",  # no `:` in timezone
+        marks=pytest.mark.skipif(sys.version_info >= (3, 11), reason="This is valid in py>=3.11"),
+    ),
     "2008-04-13T20:40:20foobar",  # cannot parse the rest as milliseconds
 ])
 def test_date_str_to_datetime_invalid(string: str):


### PR DESCRIPTION
1. Refactor module loading for Python 3.12 support: `loader.find_module()` was deprecated and has been removed in py3.12,
    refactored the code following the examples on:

    https://docs.python.org/3.9/library/importlib.html#importing-programmatically

2. Refactor dates tests for Python 3.11 support: `datetime.datetime.fromisoformat()` got more lenient in Python 3.11, so
    some of the tested strings result in valid dates:

    https://docs.python.org/3.11/library/datetime.html#datetime.datetime.fromisoformat

Part of getting everything green in our CKAN / Python matrix: https://github.com/ckan/ckan-python-monitor