### PR TITLE
[#7220] Remove global var and magic methods in group blueprint

### DIFF
--- a/changes/8359.misc
+++ b/changes/8359.misc
@@ -1,0 +1,1 @@
+Remove mutable global state usage in group blueprint

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -2,10 +2,8 @@
 from __future__ import annotations
 
 import logging
-import re
 from collections import OrderedDict
 from typing import Any, Optional, Union
-from typing_extensions import Literal
 
 from urllib.parse import urlencode
 import csv
@@ -29,7 +27,7 @@ from ckan.views.dataset import _get_search_details
 from flask import Blueprint, make_response
 from flask.views import MethodView
 from flask.wrappers import Response
-from ckan.types import Action, Context, DataDict, Schema
+from ckan.types import Context, DataDict, Schema
 
 
 NotFound = logic.NotFound

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -116,7 +116,7 @@ def index(group_type: str, is_organization: bool) -> str:
 
     try:
         action_name = 'organization_list' if is_organization else 'group_list'
-        assert check_access(action_name, context)
+        check_access(action_name, context)
     except NotAuthorized:
         base.abort(403, _(u'Not authorized to see this page'))
 
@@ -485,7 +485,7 @@ def members(id: str, group_type: str, is_organization: bool) -> str:
 
     try:
         data_dict: dict[str, Any] = {u'id': id}
-        assert check_access(u'group_show', context, data_dict)
+        check_access(u'group_show', context, data_dict)
         members = get_action(u'member_list')(context, {
             u'id': id,
             u'object_type': u'user'
@@ -525,7 +525,7 @@ def manage_members(id: str, group_type: str, is_organization: bool) -> str:
 
     try:
         data_dict: dict[str, Any] = {u'id': id}
-        assert check_access(u'group_edit_permissions', context, data_dict)
+        check_access(u'group_edit_permissions', context, data_dict)
         members = get_action(u'member_list')(context, {
             u'id': id,
             u'object_type': u'user'
@@ -575,7 +575,7 @@ def member_dump(id: str, group_type: str, is_organization: bool):
             if is_organization else
             "group_member_create"
         )
-        assert check_access(action_name, context, {'id': id})
+        check_access(action_name, context, {'id': id})
     except NotAuthorized:
         base.abort(404,
                    _(u'Not authorized to access {group} members download'
@@ -637,7 +637,7 @@ def member_delete(id: str, group_type: str,
             if is_organization else
             "group_member_delete"
         )
-        assert check_access(action_name, context, {'id': id})
+        check_access(action_name, context, {'id': id})
     except NotAuthorized:
         base.abort(403, _(u'Unauthorized to delete group %s members') % u'')
 
@@ -957,7 +957,7 @@ class CreateGroupView(MethodView):
             action_name = (
                 'organization_create' if is_organization else 'group_create'
             )
-            assert check_access(action_name, context)
+            check_access(action_name, context)
         except NotAuthorized:
             base.abort(403, _(u'Unauthorized to create a group'))
 
@@ -1058,7 +1058,7 @@ class EditGroupView(MethodView):
             action_name = (
                 'organization_update' if is_organization else 'group_update'
             )
-            assert check_access(action_name, context, data_dict)
+            check_access(action_name, context, data_dict)
         except NotAuthorized:
             base.abort(403, _(u'Unauthorized to create a group'))
         except NotFound:
@@ -1156,7 +1156,7 @@ class DeleteGroupView(MethodView):
             action_name = (
                 'organization_delete' if is_organization else 'group_delete'
             )
-            assert check_access(action_name, context, {'id': id})
+            check_access(action_name, context, {'id': id})
         except NotAuthorized:
             base.abort(403, _(u'Unauthorized to delete group %s') % u'')
         return context
@@ -1227,7 +1227,7 @@ class MembersGroupView(MethodView):
                 if is_organization
                 else 'group_member_create'
             )
-            assert check_access(action_name, context, {u'id': id})
+            check_access(action_name, context, {u'id': id})
         except NotAuthorized:
             base.abort(403,
                        _(u'Unauthorized to create group %s members') % u'')

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -380,7 +380,11 @@ def _get_group_dict(id: str, is_organization: bool) -> dict[str, Any]:
         })
     except (NotFound, NotAuthorized):
 
-        msg = _("Organization not found") if is_organization else _("Group not found")
+        msg = (
+            _("Organization not found")
+            if is_organization
+            else _("Group not found")
+        )
         base.abort(404, msg)
 
 
@@ -511,7 +515,9 @@ def members(id: str, group_type: str, is_organization: bool) -> str:
     }
 
     template_name = (
-        "organization/members.html" if is_organization else "group/members.html"
+        "organization/members.html"
+        if is_organization else
+        "group/members.html"
     )
     return base.render(template_name, extra_vars)
 
@@ -548,7 +554,9 @@ def manage_members(id: str, group_type: str, is_organization: bool) -> str:
         u"group_type": group_type,
     }
     template_name = (
-        "organization/manage_members.html" if is_organization else "group/manage_members.html"
+        "organization/manage_members.html"
+        if is_organization
+        else "group/manage_members.html"
     )
     return base.render(template_name, extra_vars)
 
@@ -565,7 +573,9 @@ def member_dump(id: str, group_type: str, is_organization: bool):
 
     try:
         action_name = (
-            "organization_member_create" if is_organization else "group_member_create"
+            "organization_member_create"
+            if is_organization else
+            "group_member_create"
         )
         assert check_access(action_name, context, {'id': id})
     except NotAuthorized:
@@ -625,7 +635,9 @@ def member_delete(id: str, group_type: str,
 
     try:
         action_name = (
-            "organization_member_delete" if is_organization else "group_member_delete"
+            "organization_member_delete"
+            if is_organization else
+            "group_member_delete"
         )
         assert check_access(action_name, context, {'id': id})
     except NotAuthorized:
@@ -637,7 +649,9 @@ def member_delete(id: str, group_type: str,
             base.abort(404, _(u'User not found'))
         if request.method == u'POST':
             action_name = (
-                "organization_member_delete" if is_organization else "group_member_delete"
+                "organization_member_delete"
+                if is_organization
+                else "group_member_delete"
             )
             get_action(action_name)(context, {
                 u'id': id,
@@ -661,7 +675,9 @@ def member_delete(id: str, group_type: str,
         u"group_type": group_type
     }
     template_name = (
-        'organization/confirm_delete_member.html' if is_organization else 'group/confirm_delete_member.html'
+        'organization/confirm_delete_member.html'
+        if is_organization
+        else 'group/confirm_delete_member.html'
     )
     return base.render(template_name, extra_vars)
 
@@ -816,7 +832,9 @@ class BulkProcessView(MethodView):
         data_dict: dict[str, Any] = {u'id': id, u'type': group_type}
         data_dict['include_datasets'] = False
         try:
-            action_name = "organization_show" if is_organization else "group_show"
+            action_name = (
+                "organization_show" if is_organization else "group_show"
+            )
             group_dict = get_action(action_name)(context, data_dict)
             group = context['group']
         except NotFound:
@@ -850,7 +868,9 @@ class BulkProcessView(MethodView):
             # Do not query for the group datasets when dictizing, as they will
             # be ignored and get requested on the controller anyway
             data_dict['include_datasets'] = False
-            action_name = "organization_show" if is_organization else "group_show"
+            action_name = (
+                "organization_show" if is_organization else "group_show"
+            )
             group_dict = get_action(action_name)(context, data_dict)
         except NotFound:
             group_label = h.humanize_entity_type(
@@ -916,7 +936,10 @@ class BulkProcessView(MethodView):
 class CreateGroupView(MethodView):
     u'''Create group view '''
 
-    def _prepare(self, is_organization: bool, data: Optional[dict[str, Any]] = None) -> Context:
+    def _prepare(
+            self,
+            is_organization: bool,
+            data: Optional[dict[str, Any]] = None) -> Context:
         if data and u'type' in data:
             group_type = data['type']
         else:
@@ -932,7 +955,9 @@ class CreateGroupView(MethodView):
         }
 
         try:
-            action_name = 'organization_create' if is_organization else 'group_create'
+            action_name = (
+                'organization_create' if is_organization else 'group_create'
+            )
             assert check_access(action_name, context)
         except NotAuthorized:
             base.abort(403, _(u'Unauthorized to create a group'))
@@ -955,7 +980,9 @@ class CreateGroupView(MethodView):
         data_dict['type'] = group_type or u'group'
         data_dict['users'] = [{u'name': user, u'capacity': u'admin'}]
         try:
-            action_name = 'organization_create' if is_organization else 'group_create'
+            action_name = (
+                'organization_create' if is_organization else 'group_create'
+            )
             group = get_action(action_name)(context, data_dict)
         except (NotFound, NotAuthorized):
             base.abort(404, _(u'Group not found'))
@@ -1024,10 +1051,14 @@ class EditGroupView(MethodView):
         }
 
         try:
-            action_name = 'organization_show' if is_organization else 'group_show'
+            action_name = (
+                'organization_show' if is_organization else 'group_show'
+            )
             get_action(action_name)(context, data_dict)
 
-            action_name = 'organization_update' if is_organization else 'group_update'
+            action_name = (
+                'organization_update' if is_organization else 'group_update'
+            )
             assert check_access(action_name, context, data_dict)
         except NotAuthorized:
             base.abort(403, _(u'Unauthorized to create a group'))
@@ -1052,8 +1083,9 @@ class EditGroupView(MethodView):
         data_dict['id'] = context['id']
         context['allow_partial_update'] = True
         try:
-
-            action_name = 'organization_update' if is_organization else 'group_update'
+            action_name = (
+                'organization_update' if is_organization else 'group_update'
+            )
             group = get_action(action_name)(context, data_dict)
             if id != group['name']:
                 _force_reindex(group)
@@ -1078,7 +1110,9 @@ class EditGroupView(MethodView):
         context = self._prepare(is_organization, id=id)
         data_dict: dict[str, Any] = {u'id': id, u'include_datasets': False}
         try:
-            action_name = 'organization_show' if is_organization else 'group_show'
+            action_name = (
+                'organization_show' if is_organization else 'group_show'
+            )
             group_dict = get_action(action_name)(context, data_dict)
         except (NotFound, NotAuthorized):
             base.abort(404, _(u'Group not found'))
@@ -1114,10 +1148,15 @@ class EditGroupView(MethodView):
 class DeleteGroupView(MethodView):
     u'''Delete group view '''
 
-    def _prepare(self, is_organization: bool, id: Optional[str] = None) -> Context:
+    def _prepare(
+            self,
+            is_organization: bool,
+            id: Optional[str] = None) -> Context:
         context: Context = {'user': current_user.name}
         try:
-            action_name = 'organization_delete' if is_organization else 'group_delete'
+            action_name = (
+                'organization_delete' if is_organization else 'group_delete'
+            )
             assert check_access(action_name, context, {'id': id})
         except NotAuthorized:
             base.abort(403, _(u'Unauthorized to delete group %s') % u'')
@@ -1129,7 +1168,9 @@ class DeleteGroupView(MethodView):
              id: Optional[str] = None) -> Response:
         context = self._prepare(is_organization, id=id)
         try:
-            action_name = 'organization_delete' if is_organization else 'group_delete'
+            action_name = (
+                'organization_delete' if is_organization else 'group_delete'
+            )
             get_action(action_name)(context, {'id': id})
             group_label = h.humanize_entity_type(
                 u'group',
@@ -1151,7 +1192,9 @@ class DeleteGroupView(MethodView):
             is_organization: bool,
             id: Optional[str] = None) -> Union[str, Response]:
         context = self._prepare(is_organization, id=id)
-        action_name = 'organization_show' if is_organization else 'group_show'
+        action_name = (
+            'organization_show' if is_organization else 'group_show'
+        )
         group_dict = get_action(action_name)(context, {'id': id})
 
         if u'cancel' in request.args:
@@ -1164,7 +1207,9 @@ class DeleteGroupView(MethodView):
             u"group_type": group_type
         }
         template_name = (
-            "organization/confirm_delete.html" if is_organization else "group/confirm_delete.html"
+            "organization/confirm_delete.html"
+            if is_organization
+            else "group/confirm_delete.html"
         )
         return base.render(template_name, extra_vars)
 
@@ -1172,11 +1217,16 @@ class DeleteGroupView(MethodView):
 class MembersGroupView(MethodView):
     u'''New members group view'''
 
-    def _prepare(self, is_organization: bool, id: Optional[str] = None) -> Context:
+    def _prepare(
+            self,
+            is_organization: bool,
+            id: Optional[str] = None) -> Context:
         context: Context = {'user': current_user.name}
         try:
             action_name = (
-                'organization_member_create' if is_organization else 'group_member_create'
+                'organization_member_create'
+                if is_organization
+                else 'group_member_create'
             )
             assert check_access(action_name, context, {u'id': id})
         except NotAuthorized:
@@ -1216,7 +1266,9 @@ class MembersGroupView(MethodView):
 
         try:
             action_name = (
-                'organization_member_create' if is_organization else 'group_member_create'
+                'organization_member_create'
+                if is_organization else
+                'group_member_create'
             )
             group_dict = get_action(action_name)(context, data_dict)
         except NotAuthorized:
@@ -1271,7 +1323,9 @@ class MembersGroupView(MethodView):
             u"user_dict": user_dict
         })
         template_name = (
-            "organization/member_new.html" if is_organization else "group/member_new.html"
+            "organization/member_new.html"
+            if is_organization
+            else "group/member_new.html"
         )
         return base.render(template_name, extra_vars)
 

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -44,8 +44,6 @@ log = logging.getLogger(__name__)
 lookup_group_plugin = lib_plugins.lookup_group_plugin
 lookup_group_controller = lib_plugins.lookup_group_controller
 
-is_org = False
-
 
 def _get_group_template(template_type: str,
                         group_type: Optional[str] = None) -> str:
@@ -756,7 +754,7 @@ def unfollow(id: str, group_type: str, is_organization: bool) -> str:
     extra_vars['error_message'] = error_message
     extra_vars['am_following'] = am_following
 
-    if is_org:
+    if is_organization:
         return base.render('organization/snippets/info.html', extra_vars)
     return base.render('group/snippets/info.html', extra_vars)
 
@@ -840,6 +838,7 @@ class BulkProcessView(MethodView):
         except NotFound:
             base.abort(404, _(u'Group not found'))
 
+        if not group_dict['is_organization']:
             # FIXME: better error
             raise Exception(u'Must be an organization')
 

--- a/ckanext/activity/views.py
+++ b/ckanext/activity/views.py
@@ -10,11 +10,8 @@ from flask import Blueprint
 import ckan.plugins.toolkit as tk
 import ckan.model as model
 from ckan.views.group import (
-    set_org,
     # TODO: don't use hidden funcitons
-    _get_group_dict,
     _get_group_template,
-    _replace_group_org,
 )
 
 from ckan.common import request as ckan_request
@@ -501,53 +498,55 @@ def package_changes_multiple() -> Union[Response, str]:  # noqa
 @bp.route(
     "/group/activity/<id>",
     endpoint="group_activity",
-    defaults={"group_type": "group"},
+    defaults={
+        "group_type": "group",
+        "is_organization": False,
+    },
 )
 @bp.route(
     "/organization/activity/<id>",
     endpoint="organization_activity",
-    defaults={"group_type": "organization"},
+    defaults={
+        "group_type": "organization",
+        "is_organization": True,
+    },
 )
-def group_activity(id: str, group_type: str) -> str:
+def group_activity(id: str, group_type: str, is_organization: bool) -> str:
     """Render this group's public activity stream page."""
     after = tk.request.args.get("after")
     before = tk.request.args.get("before")
 
-    if group_type == 'organization':
-        set_org(True)
-
     context: Context = {"user": tk.g.user, "for_view": True}
 
     try:
-        group_dict = _get_group_dict(id, group_type)
+        action_name = "organization_show" if is_organization else "group_show"
+        group_dict = tk.get_action(action_name)(context, {"id": id})
     except (tk.ObjectNotFound, tk.NotAuthorized):
         tk.abort(404, tk._("Group not found"))
-
-    real_group_type = group_dict["type"]
-    action_name = "organization_activity_list"
-    if not group_dict.get("is_organization"):
-        action_name = "group_activity_list"
 
     activity_type = tk.request.args.get("activity_type")
     activity_types = [activity_type] if activity_type else None
 
     limit = _get_activity_stream_limit()
-
+    action_name = (
+        "organization_activity_list" if is_organization else "group_activity_list"
+    )
     try:
         activity_stream = tk.get_action(action_name)(
-            context, {
+            context,
+            {
                 "id": group_dict["id"],
                 "before": before,
                 "after": after,
                 "limit": limit + 1,
                 "activity_types": activity_types
-                }
-            )
+            }
+        )
     except tk.ValidationError as error:
         tk.abort(400, error.message or "")
 
     filter_types = VALIDATORS_PACKAGE_ACTIVITY_TYPES.copy()
-    if group_type == 'organization':
+    if is_organization:
         filter_types.update(VALIDATORS_ORGANIZATION_ACTIVITY_TYPES)
     else:
         filter_types.update(VALIDATORS_GROUP_ACTIVITY_TYPES)
@@ -579,7 +578,7 @@ def group_activity(id: str, group_type: str) -> str:
     extra_vars = {
         "id": id,
         "activity_stream": activity_stream,
-        "group_type": real_group_type,
+        "group_type": group_dict["type"],
         "group_dict": group_dict,
         "activity_type": activity_type,
         "activity_types": filter_types.keys(),
@@ -613,7 +612,6 @@ def group_changes(id: str, group_type: str, is_organization: bool) -> str:
     Shows the changes to an organization in one particular activity stream
     item.
     """
-    extra_vars = {}
     activity_id = id
     context: Context = {
         "auth_user_obj": tk.g.userobj,
@@ -633,10 +631,15 @@ def group_changes(id: str, group_type: str, is_organization: bool) -> str:
     # Use the current version of the package, in case the name/title have
     # changed, and we need a link to it which works
     group_id = activity_diff["activities"][1]["data"]["group"]["id"]
-    current_group_dict = tk.get_action(group_type + "_show")(
+
+    action_name = "organization_show" if is_organization else "group_show"
+    current_group_dict = tk.get_action(action_name)(
         context, {"id": group_id}
     )
-    group_activity_list = tk.get_action(group_type + "_activity_list")(
+    action_name = (
+        "organization_activity_list" if is_organization else "group_activity_list"
+    )
+    group_activity_list = tk.get_action(action_name)(
         context, {"id": group_id, "limit": 100}
     )
 
@@ -646,8 +649,10 @@ def group_changes(id: str, group_type: str, is_organization: bool) -> str:
         "group_activity_list": group_activity_list,
         "group_type": current_group_dict["type"],
     }
-
-    return tk.render(_replace_group_org("group/changes.html"), extra_vars)
+    template_name = (
+        "organization/changes.html" if is_organization else "group/changes.html"
+    )
+    return tk.render(template_name, extra_vars)
 
 
 @bp.route(
@@ -666,12 +671,11 @@ def group_changes_multiple(is_organization: bool, group_type: str) -> str:
     activity diffs for the changes in the given version range, then
     re-renders changes.html with the list.
     """
-    extra_vars = {}
     new_id = tk.h.get_request_param("new_id")
     old_id = tk.h.get_request_param("old_id")
 
     context: Context = {
-            "auth_user_obj": tk.g.userobj,
+        "auth_user_obj": tk.g.userobj,
     }
 
     # check to ensure that the old activity is actually older than
@@ -730,10 +734,14 @@ def group_changes_multiple(is_organization: bool, group_type: str) -> str:
             current_id = activity_diff["activities"][0]["id"]
 
     group_id: str = diff_list[0]["activities"][1]["data"]["group"]["id"]
-    current_group_dict = tk.get_action(group_type + "_show")(
+    action_name = "organization_show" if is_organization else "group_show"
+    current_group_dict = tk.get_action(action_name)(
         context, {"id": group_id}
     )
-    group_activity_list = tk.get_action(group_type + "_activity_list")(
+    action_name = (
+        "organization_activity_list" if is_organization else "group_activity_list"
+    )
+    group_activity_list = tk.get_action(action_name)(
         context, {"id": group_id, "limit": 100}
     )
 
@@ -743,8 +751,10 @@ def group_changes_multiple(is_organization: bool, group_type: str) -> str:
         "group_activity_list": group_activity_list,
         "group_type": current_group_dict["type"],
     }
-
-    return tk.render(_replace_group_org("group/changes.html"), extra_vars)
+    template_name = (
+        "organization/changes.html" if is_organization else "group/changes.html"
+    )
+    return tk.render(template_name, extra_vars)
 
 
 @bp.route("/user/activity/<id>")

--- a/ckanext/activity/views.py
+++ b/ckanext/activity/views.py
@@ -529,7 +529,9 @@ def group_activity(id: str, group_type: str, is_organization: bool) -> str:
 
     limit = _get_activity_stream_limit()
     action_name = (
-        "organization_activity_list" if is_organization else "group_activity_list"
+        "organization_activity_list"
+        if is_organization
+        else "group_activity_list"
     )
     try:
         activity_stream = tk.get_action(action_name)(
@@ -637,7 +639,8 @@ def group_changes(id: str, group_type: str, is_organization: bool) -> str:
         context, {"id": group_id}
     )
     action_name = (
-        "organization_activity_list" if is_organization else "group_activity_list"
+        "organization_activity_list"
+        if is_organization else "group_activity_list"
     )
     group_activity_list = tk.get_action(action_name)(
         context, {"id": group_id, "limit": 100}
@@ -650,7 +653,8 @@ def group_changes(id: str, group_type: str, is_organization: bool) -> str:
         "group_type": current_group_dict["type"],
     }
     template_name = (
-        "organization/changes.html" if is_organization else "group/changes.html"
+        "organization/changes.html"
+        if is_organization else "group/changes.html"
     )
     return tk.render(template_name, extra_vars)
 
@@ -739,7 +743,8 @@ def group_changes_multiple(is_organization: bool, group_type: str) -> str:
         context, {"id": group_id}
     )
     action_name = (
-        "organization_activity_list" if is_organization else "group_activity_list"
+        "organization_activity_list"
+        if is_organization else "group_activity_list"
     )
     group_activity_list = tk.get_action(action_name)(
         context, {"id": group_id, "limit": 100}
@@ -752,7 +757,8 @@ def group_changes_multiple(is_organization: bool, group_type: str) -> str:
         "group_type": current_group_dict["type"],
     }
     template_name = (
-        "organization/changes.html" if is_organization else "group/changes.html"
+        "organization/changes.html"
+        if is_organization else "group/changes.html"
     )
     return tk.render(template_name, extra_vars)
 


### PR DESCRIPTION
Ref #7720 

This addresses issue number 1 in #7720 (making use of mutable global state). And replaces global vars and magic methods with explicit `is_organization` params and calls to the relevant org / group actions.

Usage of global state started to give consistent test failures after changes in https://github.com/ckan/ckan/pull/8357 to support py 3.11 and 3.12


Looks like a lot of changes but they are very repetitive, it might be even safe to backport to 2.10
