### PR TITLE
Bump solr schema version for 2.11

### DIFF
--- a/ckan/config/solr/schema.xml
+++ b/ckan/config/solr/schema.xml
@@ -25,7 +25,7 @@
 schema. We used to use the `version` attribute for this but this is an internal
 attribute that should not be used so starting from CKAN 2.10 we use the `name`
 attribute with the form `ckan-X.Y` -->
-<schema name="ckan-2.10" version="1.6">
+<schema name="ckan-2.11" version="1.6">
 
 <types>
     <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -57,7 +57,7 @@ def text_traceback() -> str:
     return res
 
 
-SUPPORTED_SCHEMA_VERSIONS = ['2.8', '2.9', '2.10']
+SUPPORTED_SCHEMA_VERSIONS = ['2.8', '2.9', '2.10', '2.11']
 
 DEFAULT_OPTIONS = {
     'limit': 20,


### PR DESCRIPTION
Nothing really changed in the Solr schema, but it's good to keep the schema and CKAN versions in sync. 