### PR TITLE
Use `pip install -e .` in CircleCI setup

### DIFF
--- a/test-infrastructure/install_deps.sh
+++ b/test-infrastructure/install_deps.sh
@@ -5,7 +5,8 @@ apt update
 apt install -y postgresql-client
 
 #Python Dependencies
+pip install -U pip
 pip install -r requirements.txt
 pip install -r dev-requirements.txt
-python setup.py develop
+pip install -e .
 pip check


### PR DESCRIPTION
Instead of `python setup.py develop`. We started getting failures after merging https://github.com/ckan/ckan/pull/8375 but that seems completely unrelated. I suspect it must be some low level unpinned dependency (setuptools?) as there are some errors in the `test-infrastructure/install_deps.sh` step. Using `pip install .` seems a much more reliable way of setting up CKAN in that env

https://app.circleci.com/pipelines/github/ckan/ckan/7100/workflows/d61a6ae4-e4d5-4d6a-b5b3-8553fefd2215/jobs/15115

