### PR TITLE
Clean orphans from index on db clean and search-index rebuild

### DIFF
--- a/ckan/cli/db.py
+++ b/ckan/cli/db.py
@@ -14,7 +14,7 @@ import ckan.migration as migration_repo
 import ckan.plugins as p
 import ckan.model as model
 from ckan.common import config
-from . import error_shout
+from . import error_shout, search_index
 
 log = logging.getLogger(__name__)
 
@@ -70,11 +70,13 @@ PROMPT_MSG = u'This will delete all of your data!\nDo you want to continue?'
 
 @db.command()
 @click.confirmation_option(prompt=PROMPT_MSG)
-def clean():
+@click.pass_context
+def clean(ctx: click.Context):
     """Clean the database.
     """
     try:
         model.repo.clean_db()
+        ctx.invoke(search_index.clear)
     except Exception as e:
         error_shout(e)
     else:

--- a/ckan/cli/search_index.py
+++ b/ckan/cli/search_index.py
@@ -31,12 +31,13 @@ def search_index():
                    u'ensures that changes are immediately available on the'
                    u'search, but slows significantly the process. Default'
                    u'is false.')
-@click.option('-c', '--clear', help='Clear the index before reindexing',
-              is_flag=True)
+@click.option(u'-k', u'--keep-orphans', is_flag=True,
+              help=u'Keep orphans in the search index')
 @click.argument(u'package_id', required=False)
+@click.pass_context
 def rebuild(
-        verbose: bool, force: bool, only_missing: bool, quiet: bool,
-        commit_each: bool, package_id: str, clear: bool
+        ctx: click.Context, verbose: bool, force: bool, only_missing: bool,
+        quiet: bool, commit_each: bool, package_id: str, keep_orphans: bool
 ):
     u''' Rebuild search index '''
     from ckan.lib.search import rebuild, commit
@@ -47,7 +48,9 @@ def rebuild(
                 force=force,
                 defer_commit=(not commit_each),
                 quiet=quiet and not verbose,
-                clear=clear)
+                clear=False)
+        if not keep_orphans:
+            ctx.invoke(clear_orphans)
     except logic.NotFound:
         error_shout("Couldn't find package %s" % package_id)
     except Exception as e:

--- a/ckan/tests/cli/test_search_index.py
+++ b/ckan/tests/cli/test_search_index.py
@@ -29,7 +29,7 @@ class TestSearchIndex(object):
         assert search_result[u'count'] == 1
 
         # Clear and defer commit
-        result = cli.invoke(ckan, [u'search-index', u'rebuild', '-e', '-c'])
+        result = cli.invoke(ckan, [u'search-index', u'rebuild', '-e'])
         print(result.output)
         assert not result.exit_code
         search_result = helpers.call_action(u'package_search', q=u"After")


### PR DESCRIPTION
Fixes #8347.

### Proposed fixes:

- `ckan db clean` invokes `ckan search-index clear`
- `ckan search-index rebuild` invokes `ckan search-index clear-orphans` automatically after rebuild, and has a new `keep-ophans` option that when passed disables this behavior
- `-c` option from `ckan search-index rebuild` removed

### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [X] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport

Thank you for reviewing!
