### PR TITLE
Include the site_user id in `get_site_user` fn

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -2400,8 +2400,11 @@ def get_site_user(context: Context, data_dict: DataDict) -> ActionResult.GetSite
         if not context.get('defer_commit'):
             model.repo.commit()
 
-    return {'name': user.name,
-            'apikey': user.apikey}
+    return {
+        'name': user.name,
+        'id': user.id,
+        'apikey': user.apikey,
+    }
 
 
 def status_show(context: Context, data_dict: DataDict) -> ActionResult.StatusShow:


### PR DESCRIPTION
It's not the first time I need to check against site user name or id
Is this valid?

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
