### PR TITLE
Fix resource proxy download proxy setting

### DIFF
--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -1039,7 +1039,6 @@ groups:
               they're implemented in.
 
       - key: ckan.download_proxy
-        default: None
         example: http://proxy:3128
         description: |
           Specifies a HTTP proxy to be used by extensions such as Resource Proxy, XLoader or Archiver

--- a/ckanext/resourceproxy/blueprint.py
+++ b/ckanext/resourceproxy/blueprint.py
@@ -40,7 +40,7 @@ def proxy_resource(context: Context, data_dict: DataDict):
     timeout = config.get('ckan.resource_proxy.timeout')
     max_file_size = config.get(u'ckan.resource_proxy.max_file_size')
     proxy = config.get('ckan.download_proxy')
-    proxies = {'http': proxy, 'https': proxy}
+    proxies = {'http': proxy, 'https': proxy} if proxy else None
     response = make_response()
     try:
         # first we try a HEAD request which may not be supported


### PR DESCRIPTION
Fix after #8354 

Don't pass a dict with None values if not the config option is not set, otherwise we get an error from urllib3

```
Max retries exceeded with url: http://maps.nlsc.gov.tw/S_Maps/wmts
(Caused by ProxyError('Unable to connect to proxy',
 NameResolutionError("<urllib3.connection.HTTPConnection
 object at 0x7f3ea84c73a0>: Failed to resolve
 'none' ([Errno -3] Temporary failure in name
 resolution)")))
```
