### PR TITLE
New `ckan config docs` command, Markdown serialiazer

### DIFF
--- a/changes/8397.misc
+++ b/changes/8397.misc
@@ -1,0 +1,1 @@
+New `ckan config docs` command, support for config options Markdown documentation

--- a/ckan/cli/config.py
+++ b/ckan/cli/config.py
@@ -105,10 +105,14 @@ def declaration(
     help="Output the documentation in this format",
 )
 def docs(plugins: tuple[str, ...], core: bool, enabled: bool, fmt: str):
-    """Print out documentation for the config declarations for the given plugins."""
+    """
+    Print out documentation for the config declarations for the given
+    plugins.
+    """
     decl = _declaration(plugins, core, enabled)
     if decl:
         click.echo(decl.into_docs(fmt))
+
 
 @config.command()
 @click.argument("pattern", default="*")

--- a/ckan/cli/config.py
+++ b/ckan/cli/config.py
@@ -85,6 +85,32 @@ def declaration(
 
 
 @config.command()
+@click.argument("plugins", nargs=-1)
+@click.option(
+    "--core",
+    is_flag=True,
+    help="Include declarations of CKAN core config options",
+)
+@click.option(
+    "--enabled",
+    is_flag=True,
+    help="Include declarations of plugins enabled in the CKAN config file",
+)
+@click.option(
+    "-f",
+    "--format",
+    "fmt",
+    type=click.Choice(["rst", "md"]),
+    default="rst",
+    help="Output the documentation in this format",
+)
+def docs(plugins: tuple[str, ...], core: bool, enabled: bool, fmt: str):
+    """Print out documentation for the config declarations for the given plugins."""
+    decl = _declaration(plugins, core, enabled)
+    if decl:
+        click.echo(decl.into_docs(fmt))
+
+@config.command()
 @click.argument("pattern", default="*")
 @click.option(
     "-i",

--- a/ckan/config/declaration/__init__.py
+++ b/ckan/config/declaration/__init__.py
@@ -235,7 +235,8 @@ class Declaration:
         return serializer(self, "validation_schema")
 
     def into_docs(self, fmt: str = "rst") -> str:
-        """Serialize declaration into one of the supported documentation formats.
+        """
+        Serialize declaration into one of the supported documentation formats.
         """
         return serializer(self, fmt)
 

--- a/ckan/config/declaration/__init__.py
+++ b/ckan/config/declaration/__init__.py
@@ -234,10 +234,10 @@ class Declaration:
         """
         return serializer(self, "validation_schema")
 
-    def into_docs(self) -> str:
-        """Serialize declaration into reST documentation.
+    def into_docs(self, fmt: str = "rst") -> str:
+        """Serialize declaration into one of the supported documentation formats.
         """
-        return serializer(self, "rst")
+        return serializer(self, fmt)
 
     def describe(self, fmt: str) -> str:
         """Describe definition of options in the given format.

--- a/ckan/config/declaration/serialize.py
+++ b/ckan/config/declaration/serialize.py
@@ -205,7 +205,9 @@ def serialize_md(declaration: "Declaration"):
             result += f"#### {item}\n\n"
 
             if option.example:
-                result += f"Example:\n\n```\n{item} = {option.example}\n```\n\n"
+                result += (
+                    f"Example:\n\n```\n{item} = {option.example}\n```\n\n"
+                )
 
             default = option.str_value()
 

--- a/ckan/config/declaration/serialize.py
+++ b/ckan/config/declaration/serialize.py
@@ -173,3 +173,50 @@ def serialize_rst(declaration: "Declaration"):
             result += option.description + "\n\n"
 
     return result
+
+
+@handler.register("md")
+def serialize_md(declaration: "Declaration"):
+    """Serialize declaration into Markdown documentation.
+    """
+    result = ""
+
+    # Config option may refer to the absolute filepath in their default
+    # values. One of such options is `ckan.resource_formats`. Just to avoid
+    # misunderstanding, we'll update these options, replacing the path till
+    # CKAN root with `/<CKAN_ROOT>` segment.
+    ckan_root = os.path.dirname(
+        os.path.dirname(os.path.realpath(ckan.__file__)))
+
+    for item in declaration._members:
+        if isinstance(item, Annotation):
+            result += f"### {item}\n\n"
+        elif isinstance(item, Key):
+            option = declaration._options[item]
+            if option.has_flag(Flag.non_iterable()):
+                continue
+            if not option.description:
+                log.warning(
+                    "Skip %s option because it has no description",
+                    item
+                )
+                continue
+
+            result += f"#### {item}\n\n"
+
+            if option.example:
+                result += f"Example:\n\n```\n{item} = {option.example}\n```\n\n"
+
+            default = option.str_value()
+
+            if default != '':
+                if default.startswith(ckan_root):
+                    default = default.replace(ckan_root, '/<CKAN_ROOT>')
+                default = f"`{default}`"
+            else:
+                default = "none"
+
+            result += f"Default value: {default}\n\n"
+            result += option.description + "\n\n"
+
+    return result

--- a/ckan/tests/cli/test_config.py
+++ b/ckan/tests/cli/test_config.py
@@ -146,6 +146,45 @@ class TestDeclaration(object):
 
 
 @pytest.mark.usefixtures("with_extended_cli")
+class TestDocs(object):
+    def test_basic_invocation(self, command):
+        result = command("docs")
+        assert not result.output
+        assert not result.exit_code, result.output
+
+    def test_core(self, command):
+        result = command("docs", "--core")
+        assert result.output.startswith(".. _default-settings:")
+        assert not result.exit_code, result.output
+
+    def test_core_format(self, command):
+        result = command("docs", "--core", "--format", "md")
+        assert result.output.startswith("### Default settings")
+        assert not result.exit_code, result.output
+
+    @pytest.mark.ckan_config("ckan.plugins", "datastore")
+    @pytest.mark.usefixtures("with_plugins")
+    def test_enabled(self, command):
+        result = command("docs", "--enabled", "--format", "md")
+        assert "### Datastore settings" in result.output
+        assert (
+            "Default value: `postgresql://ckan_default:pass@localhost/datastore_default`"
+            in result.output
+        )
+        assert not result.exit_code, result.output
+
+    def test_explicit(self, command):
+        result = command("docs", "datastore", "--format", "md")
+        assert "### Datastore settings" in result.output
+        assert "Datastore settings" in result.output
+        assert (
+            "Default value: `postgresql://ckan_default:pass@localhost/datastore_default`"
+            in result.output
+        )
+        assert not result.exit_code, result.output
+
+
+@pytest.mark.usefixtures("with_extended_cli")
 class TestSearch(object):
     def test_wrong_non_pattern(self, command):
         result = command("search", "ckan")


### PR DESCRIPTION
`ckan config docs` generates human-readable documentation that can be inserted in the docs or a README. Accepts a `-f` / `--format` flag to output rst (default) or markdown. Also accepts the same params as `ckan config declaration`. 

This will be useful for extensions to generate their config documentation, as they generally use Markdown READMEs.

![Screenshot 2024-08-15 at 12-35-52 ckanext-dcat_README md at a2e9600504f2df2dc291178698d7dd6b16fe1084 · ckan_ckanext-dcat](https://github.com/user-attachments/assets/34f9945f-0587-43a1-b2a1-b92bd73a86a7)

Running `ckan config docs -f md dcat` will output the snippets, so it should be easy to create a small bash script that inserts the conf docs in the README with some sed magic or even automate it via a Github action if people is feeling adventurous.
