### PR TITLE
More lenient line length setting for linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,5 @@
 [flake8]
+max-line-length=88
 exclude =
         .*
         ./contrib


### PR DESCRIPTION
I don't want to open a can of worms here, but can we push this to at least 88 (what Black uses)?
