### PR TITLE
[Backport dev-v2.10] App returns 500 error instead of 405

### DIFF
--- a/changes/7616.bugfix
+++ b/changes/7616.bugfix
@@ -1,0 +1,1 @@
+POST request to GET-only endpoint causes 500 error

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -416,8 +416,9 @@ def ckan_before_request() -> Optional[Response]:
         # eg "organization.edit" -> "group.edit", or custom dataset types
         endpoint = request.endpoint or ""
         view = current_app.view_functions.get(endpoint)
-        dest = f"{view.__module__}.{view.__name__}"     # type: ignore
-        csrf.exempt(dest)
+        if view:
+            dest = f"{view.__module__}.{view.__name__}"
+            csrf.exempt(dest)
 
     # Set the csrf_field_name so we can use it in our templates
     g.csrf_field_name = config.get("WTF_CSRF_FIELD_NAME")

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -283,10 +283,11 @@ def requires_ckan_version(min_version: str, max_version: Optional[str] = None):
 
 def get_endpoint() -> Union[tuple[str, str], tuple[None, None]]:
     """Returns tuple in format: (blueprint, view)."""
-    if not request:
+    # skip CLI requests and requests with unallowed method
+    if not request or not request.endpoint:
         return None, None
 
-    blueprint, *rest = cast(str, request.endpoint).split(".", 1)
+    blueprint, *rest = request.endpoint.split(".", 1)
     # service routes, like `static`
     view = rest[0] if rest else "index"
     return blueprint, view

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -11,7 +11,7 @@ has been given.
 """
 from __future__ import annotations
 
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, Union
 import ckan
 import ckan.lib.base as base
 from ckan.lib.base import render, abort


### PR DESCRIPTION
Fixes #7616

This backports an issue where POST requests on non-existing routes will throw 500 error codes instead of a 405.

### Proposed fixes:

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
