### PR TITLE
compatibility fix for jsonb extras feature

### DIFF
--- a/ckan/logic/converters.py
+++ b/ckan/logic/converters.py
@@ -6,6 +6,7 @@ from typing import Any
 import ckan.model as model
 import ckan.lib.navl.dictization_functions as df
 import ckan.logic.validators as validators
+from ckan.lib.navl.validators import unicode_safe
 
 from ckan.common import _, aslist
 from ckan.types import (
@@ -24,7 +25,7 @@ def convert_to_extras(key: FlattenKey, data: FlattenDataDict,
     new_index = max(current_indexes) + 1 if current_indexes else 0
 
     data[('extras', new_index, 'key')] = key[-1]
-    data[('extras', new_index, 'value')] = data[key]
+    data[('extras', new_index, 'value')] = unicode_safe(data[key])
 
 
 def convert_from_extras(key: FlattenKey, data: FlattenDataDict,

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -385,7 +385,7 @@ def default_extras_schema(ignore: Validator, not_empty: Validator,
     return {
         'id': [ignore_missing, empty_if_not_sysadmin, uuid_validator],
         'key': [not_empty, extra_key_not_in_root_schema, unicode_safe],
-        'value': [not_missing],
+        'value': [not_missing, unicode_safe],
         'state': [ignore],
         'deleted': [ignore_missing],
         'revision_timestamp': [ignore],

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -394,13 +394,13 @@ def default_extras_schema(ignore: Validator, not_empty: Validator,
 
 
 @validator_args
-def default_show_extras_schema(ignore: Validator):
+def default_show_extras_schema(
+        ignore: Validator, not_empty: Validator) -> Schema:
 
-    schema = default_extras_schema()
-
-    schema["id"] = [ignore]
-
-    return schema
+    return {
+        'key': [not_empty],
+        'value': [not_empty],
+    }
 
 
 @validator_args

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -1128,6 +1128,19 @@ class TestDatasetCreate(object):
 
         assert isinstance(dataset, str)
 
+    def test_non_string_extras(self):
+        data_dict = {
+            "name": "test-non-string-extras",
+            "extras": [
+                {
+                    "key": "some_number",
+                    "value": 1.5
+                }
+            ]
+        }
+
+        helpers.call_action("package_create", **data_dict)
+
 
 @pytest.mark.usefixtures("non_clean_db")
 class TestGroupCreate(object):

--- a/ckanext/example_idatasetform/plugin_v5.py
+++ b/ckanext/example_idatasetform/plugin_v5.py
@@ -17,6 +17,12 @@ class ExampleIDatasetFormPlugin(tk.DefaultDatasetForm, p.SingletonPlugin):
             u'custom_text': [tk.get_validator(u'ignore_missing'),
                              tk.get_converter(u'convert_to_extras')]
         })
+        schema.update({
+            u'custom_number': [tk.get_validator(u'ignore_missing'),
+                               tk.get_converter(u'convert_to_extras'),
+                               tk.get_validator('int_validator')]
+        })
+
         return schema
 
     def update_package_schema(self) -> Schema:
@@ -27,6 +33,11 @@ class ExampleIDatasetFormPlugin(tk.DefaultDatasetForm, p.SingletonPlugin):
             u'custom_text': [tk.get_validator(u'ignore_missing'),
                              tk.get_converter(u'convert_to_extras')]
         })
+        schema.update({
+            u'custom_number': [tk.get_validator(u'ignore_missing'),
+                               tk.get_converter(u'convert_to_extras')]
+        })
+
         return schema
 
     def show_package_schema(self) -> Schema:
@@ -37,6 +48,10 @@ class ExampleIDatasetFormPlugin(tk.DefaultDatasetForm, p.SingletonPlugin):
                              tk.get_validator(u'ignore_missing')],
             u'custom_text_2': [tk.get_converter(u'convert_from_extras'),
                                tk.get_validator(u'ignore_missing')],
+            u'custom_number': [tk.get_converter(u'convert_from_extras'),
+                               tk.get_validator(u'ignore_missing'),
+                               tk.get_validator('int_validator')],
+
         })
         return schema
 

--- a/ckanext/example_idatasetform/tests/test_example_idatasetform.py
+++ b/ckanext/example_idatasetform/tests/test_example_idatasetform.py
@@ -113,6 +113,15 @@ class TestVersion5(object):
             {'key': 'key2', 'value': 'value2'},
         ]
 
+    def test_non_string_extras(self):
+        dataset = factories.Dataset(
+            type='fancy_type',
+            name='test-dataset',
+            custom_text='custom-text',
+            custom_number=15
+        )
+        assert dataset["custom_number"] == 15
+
 
 @pytest.fixture
 def user():


### PR DESCRIPTION
Fix for incompatibility introduced by #8288 

@amercader does this resolve the issue you raised in gitter?

### Proposed fixes:

convert extras values to strings for backwards compatibility

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
