### PR TITLE
Upgrade SQLAlchemy to v2

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -214,7 +214,7 @@ def update_config() -> None:
     # to eliminate database errors due to stale pooled connections
     config.setdefault('sqlalchemy.pool_pre_ping', True)
     # Initialize SQLAlchemy
-    engine = engine_from_config(config)
+    engine = engine_from_config(dict(config))
     model.init_model(engine)
 
     for plugin in p.PluginImplementations(p.IConfigurable):

--- a/ckan/lib/dictization/__init__.py
+++ b/ckan/lib/dictization/__init__.py
@@ -130,7 +130,7 @@ def table_dict_save(table_dict: dict[str, Any],
     if id:
         obj = session.query(ModelClass).get(id)
 
-    if not obj:
+    if not obj and isinstance(table, Table):
         unique_constraints = get_unique_constraints(table, context)
         for constraint in unique_constraints:
             params = dict((key, table_dict.get(key)) for key in constraint)

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -21,10 +21,11 @@ from typing import (
 from typing_extensions import Literal
 
 from urllib.parse import urlsplit
+
 from sqlalchemy.sql.schema import Table
 from sqlalchemy.sql.selectable import Select
 
-from sqlalchemy.sql import select
+from sqlalchemy.sql import select, false
 
 import ckan.logic as logic
 import ckan.plugins as plugins
@@ -146,7 +147,7 @@ def resource_dictize(res: model.Resource, context: Context) -> dict[str, Any]:
     return resource
 
 
-def _execute(q: Select, table: Table, context: Context) -> Any:
+def _execute(q: Select[Any], table: Table, context: Context) -> Any:
     '''
     Takes an SqlAlchemy query (q) that is (at its base) a Select on an
     object table (table), and it returns the object.
@@ -223,7 +224,7 @@ def package_dictize(
     ).where(
         member.c["table_id"] == pkg.id,
         member.c["state"] == 'active',
-        group.c["is_organization"] == False
+        group.c["is_organization"] == false()
     )
 
     result = execute(q, member, context)
@@ -325,7 +326,7 @@ def _get_members(context: Context, group: model.Group,
         filter(model.Member.state == 'active').\
         filter(model.Member.table_name == member_type[:-1])
     if member_type == 'packages':
-        q = q.filter(Entity.private==False)
+        q = q.filter(Entity.private == false())
     if 'limits' in context and member_type in context['limits']:
         limit: int = context['limits'][member_type]
         return q.limit(limit).all()

--- a/ckan/logic/__init__.py
+++ b/ckan/logic/__init__.py
@@ -894,7 +894,7 @@ def guard_against_duplicated_email(email: str):
     try:
         yield
     except exc.IntegrityError as e:
-        if e.orig.pgcode == _PG_ERR_CODE["unique_violation"]:
+        if cast(Any, e.orig).pgcode == _PG_ERR_CODE["unique_violation"]:
             model.Session.rollback()
             raise ValidationError({
                 "email": [

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -692,7 +692,7 @@ def organization_list_for_user(context: Context,
         if not user_id:
             return []
 
-        q: Query[tuple[model.Member, model.Group]] = model.Session.query(model.Member, model.Group) \
+        q = model.Session.query(model.Member, model.Group) \
             .filter(model.Member.table_name == 'user') \
             .filter(
                 model.Member.capacity.in_(roles)
@@ -1947,7 +1947,10 @@ def package_search(context: Context, data_dict: DataDict) -> ActionResult.Packag
               .filter(model.Group.name.in_(group_names))
               .all()
               if group_names else [])
-    group_titles_by_name = dict(groups)
+    group_titles_by_name = {
+        row[0]: row[1]
+        for row in groups
+    }
 
     # Transform facets into a more useful data structure.
     restructured_facets: dict[str, Any] = {}

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -1106,7 +1106,7 @@ def package_owner_org_update(context: Context, data_dict: DataDict) -> ActionRes
 
 
 def _bulk_update_dataset(
-        context: Context, data_dict: DataDict, update_dict: dict[str, Any]):
+        context: Context, data_dict: DataDict, update_dict: dict[Any, Any]):
     ''' Bulk update shared code for organizations'''
 
     datasets = data_dict.get('datasets', [])

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -12,7 +12,7 @@ import uuid
 from typing import Any, Container, Optional, Union
 from urllib.parse import urlparse
 
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import NoResultFound
 
 import ckan.lib.navl.dictization_functions as df
 from ckan import authz, logic
@@ -719,7 +719,7 @@ def user_password_not_empty(key: FlattenKey, data: FlattenDataDict,
             authz.is_sysadmin(context.get('user'))):
         return
 
-    if not ('password1',) in data and not ('password2',) in data:
+    if ('password1',) not in data and ('password2',) not in data:
         password = data.get(('password',),None)
         if not password:
             errors[key].append(_('Missing value'))
@@ -939,7 +939,7 @@ def no_loops_in_hierarchy(key: FlattenKey, data: FlattenDataDict,
     a loop in the group hierarchy, and therefore cause the recursion up/down
     the hierarchy to get into an infinite loop.
     '''
-    if not ('id',) in data:
+    if ('id',) not in data:
         # Must be a new group - has no children, so no chance of loops
         return
     group = context['model'].Group.get(data[('id',)])

--- a/ckan/model/__init__.py
+++ b/ckan/model/__init__.py
@@ -384,6 +384,9 @@ class Repository():
 
     def are_tables_created(self) -> bool:
         meta.metadata = MetaData()
+        if not meta.engine:
+            return False
+
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', '.*(reflection|geometry).*')
             meta.metadata.reflect(meta.engine)

--- a/ckan/model/api_token.py
+++ b/ckan/model/api_token.py
@@ -32,7 +32,7 @@ api_token_table = Table(
     Column(u"user_id", types.UnicodeText, ForeignKey(u"user.id")),
     Column(u"created_at", types.DateTime, default=datetime.datetime.utcnow),
     Column(u"last_access", types.DateTime, nullable=True),
-    Column(u"plugin_extras", MutableDict.as_mutable(JSONB)),
+    Column(u"plugin_extras", MutableDict.as_mutable(JSONB)),  # type: ignore
 )
 
 

--- a/ckan/model/dashboard.py
+++ b/ckan/model/dashboard.py
@@ -38,7 +38,7 @@ class Dashboard(object):
         one will be created and returned.
 
         '''
-        query = meta.Session.query(Dashboard)
+        query = meta.Session.query(cls)
         query = query.filter(Dashboard.user_id == user_id)
         return query.first()
 

--- a/ckan/model/group.py
+++ b/ckan/model/group.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 import datetime
-from typing import Optional, Union, overload
+from typing import Any, Optional, Union, overload
 from typing_extensions import Literal, Self
 
-from sqlalchemy import (column, orm, types, Column, Table, ForeignKey, or_,
-                        and_, text, Index, CheckConstraint)
+from sqlalchemy import (Row, column, orm, types, Column, Table, ForeignKey, or_,
+                        and_, text, Index, CheckConstraint, false)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableDict
 
@@ -15,7 +15,6 @@ import ckan.model.core as core
 import ckan.model.package as _package
 import ckan.model.types as _types
 import ckan.model.domain_object as domain_object
-import ckan.model.package as _package
 
 from ckan.types import Context, Query
 
@@ -49,7 +48,7 @@ group_table = Table('group', meta.metadata,
     Column('is_organization', types.Boolean, default=False),
     Column('approval_status', types.UnicodeText, default=u"approved"),
     Column('state', types.UnicodeText, default=core.State.ACTIVE),
-    Column('extras', MutableDict.as_mutable(JSONB), CheckConstraint(
+    Column('extras', MutableDict.as_mutable(JSONB), CheckConstraint(  # type: ignore
         """
         jsonb_typeof(extras) = 'object' and
         not jsonb_path_exists(extras, '$.* ? (@.type() <> "string")')
@@ -240,7 +239,8 @@ class Group(core.StatefulObjectMixin,
         return result
 
     def get_children_group_hierarchy(
-            self, type: str='group') -> list[tuple[str, str, str, str]]:
+            self, type: str='group'
+    ) -> list[Row[tuple[str, str, str | None, str]]]:
         '''Returns the groups in all levels underneath this group in the
         hierarchy. The ordering is such that children always come after their
         parent.
@@ -253,9 +253,10 @@ class Group(core.StatefulObjectMixin,
         [(u'8ac0...', u'national-health-service', u'National Health Service', u'e041...'),
          (u'b468...', u'nhs-wirral-ccg', u'NHS Wirral CCG', u'8ac0...')]
         '''
-        results: list[tuple[str, str, str, str]] = meta.Session.query(
+        stmt: Any = text(HIERARCHY_DOWNWARDS_CTE)
+        results = meta.Session.query(
             Group.id, Group.name, Group.title,  column('parent_id')
-        ).from_statement(text(HIERARCHY_DOWNWARDS_CTE)).params(
+        ).from_statement(stmt).params(
             id=self.id, type=type).all()
         return results
 
@@ -278,17 +279,18 @@ class Group(core.StatefulObjectMixin,
     def get_parent_group_hierarchy(self, type: str='group') -> list[Group]:
         '''Returns this group's parent, parent's parent, parent's parent's
         parent etc.. Sorted with the top level parent first.'''
+        stmt: Any = text(HIERARCHY_UPWARDS_CTE)
         result: list[Group] =  meta.Session.query(Group).\
-            from_statement(text(HIERARCHY_UPWARDS_CTE)).\
+            from_statement(stmt).\
             params(id=self.id, type=type).all()
         return result
 
     @classmethod
-    def get_top_level_groups(cls, type: str='group') -> list[Group]:
+    def get_top_level_groups(cls, type: str='group') -> list[Self]:
         '''Returns a list of the groups (of the specified type) which have
         no parent groups. Groups are sorted by title.
         '''
-        result: list[Group] = meta.Session.query(cls).\
+        result = meta.Session.query(cls).\
             outerjoin(Member,
                       and_(Member.group_id == Group.id,
                            Member.table_name == 'group',
@@ -380,10 +382,10 @@ class Group(core.StatefulObjectMixin,
 
         # orgs do not show private datasets unless the user is a member
         if self.is_organization and not user_is_org_member:
-            query = query.filter(_package.Package.private == False)
+            query = query.filter(_package.Package.private == false())
         # groups (not orgs) never show private datasets
         if not self.is_organization:
-            query = query.filter(_package.Package.private == False)
+            query = query.filter(_package.Package.private == false())
 
         query: "Query[_package.Package]" = query.join(
             member_table, member_table.c["table_id"] == _package.Package.id)
@@ -422,7 +424,7 @@ class Group(core.StatefulObjectMixin,
             return
         package = _package.Package.by_name(package_name)
         assert package
-        if not package in self.packages():
+        if package not in self.packages():
             member = Member(group=self, table_id=package.id,
                             table_name='package')
             meta.Session.add(member)

--- a/ckan/model/meta.py
+++ b/ckan/model/meta.py
@@ -78,7 +78,7 @@ def ckan_after_rollback(session: Any):
         del session._object_cache
 
 
-mapper = orm.mapper
+mapper = orm.mapper  # type: ignore
 
 metadata = MetaData()
 registry = orm.registry(metadata=metadata)

--- a/ckan/model/resource_view.py
+++ b/ckan/model/resource_view.py
@@ -10,7 +10,6 @@ from typing_extensions import Self
 import ckan.model.meta as meta
 import ckan.model.types as _types
 import ckan.model.domain_object as domain_object
-from ckan.types import Query
 
 __all__ = ['ResourceView', 'resource_view_table']
 
@@ -55,10 +54,10 @@ class ResourceView(domain_object.DomainObject):
 
     @classmethod
     def get_count_not_in_view_types(
-            cls, view_types: Collection[str]) -> list[tuple[str, int]]:
+            cls, view_types: Collection[str]) -> list[sa.Row[tuple[str, int]]]:
         '''Returns the count of ResourceView not in the view types list'''
         view_type = cls.view_type
-        query: 'Query[tuple[str, int]]' = meta.Session.query(
+        query = meta.Session.query(
             view_type, sa.func.count(cls.id)).group_by(view_type).filter(
                 sa.not_(view_type.in_(view_types)))
 

--- a/ckan/model/tag.py
+++ b/ckan/model/tag.py
@@ -78,7 +78,7 @@ class Tag(domain_object.DomainObject):
         :rtype: ckan.model.tag.Tag
 
         '''
-        query = meta.Session.query(Tag).filter(Tag.id==tag_id)
+        query = meta.Session.query(cls).filter(cls.id==tag_id)
         query = query.autoflush(autoflush)
         tag = query.first()
         return tag
@@ -110,11 +110,11 @@ class Tag(domain_object.DomainObject):
 
         '''
         if vocab:
-            query = meta.Session.query(Tag).filter(Tag.name==name).filter(
-                Tag.vocabulary_id==vocab.id)
+            query = meta.Session.query(cls).filter(cls.name==name).filter(
+                cls.vocabulary_id==vocab.id)
         else:
-            query = meta.Session.query(Tag).filter(Tag.name==name).filter(
-                Tag.vocabulary_id.is_(None))
+            query = meta.Session.query(cls).filter(cls.name==name).filter(
+                cls.vocabulary_id.is_(None))
         query = query.autoflush(autoflush)
         tag = query.first()
         return tag
@@ -185,9 +185,9 @@ class Tag(domain_object.DomainObject):
             if vocab is None:
                 # The user specified an invalid vocab.
                 return None
-            query = meta.Session.query(Tag).filter(Tag.vocabulary_id==vocab.id)
+            query = meta.Session.query(cls).filter(cls.vocabulary_id==vocab.id)
         else:
-            query = meta.Session.query(Tag)
+            query = meta.Session.query(cls)
         search_term = search_term.strip().lower()
         query = query.filter(Tag.name.contains(search_term))
         query: 'Query[Self]' = query.distinct().join(Tag.package_tags)
@@ -215,15 +215,15 @@ class Tag(domain_object.DomainObject):
                 # The user specified an invalid vocab.
                 raise ckan.logic.NotFound("could not find vocabulary '%s'"
                         % vocab_id_or_name)
-            query = meta.Session.query(Tag).filter(Tag.vocabulary_id==vocab.id)
+            query = meta.Session.query(cls).filter(cls.vocabulary_id==vocab.id)
         else:
             subquery = meta.Session.query(PackageTag).\
                 filter(PackageTag.state == 'active').subquery()
 
-            query = meta.Session.query(Tag).\
-                filter(Tag.vocabulary_id.is_(None)).\
+            query = meta.Session.query(cls).\
+                filter(cls.vocabulary_id.is_(None)).\
                 distinct().\
-                join(subquery, Tag.id==subquery.c.tag_id)
+                join(subquery, cls.id==subquery.c.tag_id)
 
         return query
 
@@ -305,14 +305,14 @@ class PackageTag(core.StatefulObjectMixin,
             if vocab is None:
                 # The user specified an invalid vocab.
                 return None
-            query = (meta.Session.query(PackageTag, Tag, ckan.model.Package)
+            query = (meta.Session.query(cls, Tag, ckan.model.Package)
                     .filter(Tag.vocabulary_id == vocab.id)
                     .filter(ckan.model.Package.name==package_name)
                     .filter(Tag.name==tag_name))
             query = query.autoflush(autoflush)
             return query.one()[0]
         else:
-            query = (meta.Session.query(PackageTag)
+            query = (meta.Session.query(cls)
                     .filter(ckan.model.Package.name==package_name)
                     .filter(Tag.name==tag_name))
             query = query.autoflush(autoflush)

--- a/ckan/model/types.py
+++ b/ckan/model/types.py
@@ -2,7 +2,7 @@
 
 import copy
 import uuid
-from typing import Any
+from typing import Any, cast
 
 import simplejson as json
 
@@ -27,7 +27,7 @@ class UuidType(types.TypeDecorator):  # type: ignore
         return value
 
     def copy(self, **kw: Any):
-        return UuidType(self.impl.length)
+        return UuidType(cast(Any, self.impl).length)
 
     @classmethod
     def default(cls):
@@ -60,7 +60,7 @@ class JsonType(types.TypeDecorator):  # type: ignore
         return json.loads(value)
 
     def copy(self, **kw: Any):
-        return JsonType(self.impl.length)
+        return JsonType(cast(Any, self.impl).length)
 
     def is_mutable(self):
         return True
@@ -86,4 +86,4 @@ class JsonDictType(JsonType):
         return str(json.dumps(value, ensure_ascii=False))
 
     def copy(self, **kw: Any):
-        return JsonDictType(self.impl.length)
+        return JsonDictType(cast(Any, self.impl).length)

--- a/ckan/model/user.py
+++ b/ckan/model/user.py
@@ -9,7 +9,7 @@ from hashlib import sha1, md5
 
 import passlib.utils
 from passlib.hash import pbkdf2_sha512
-from sqlalchemy.sql.expression import or_
+from sqlalchemy.sql.expression import or_, and_
 from sqlalchemy.orm import synonym, Mapped
 from sqlalchemy import types, Column, Table, func, Index
 from sqlalchemy.dialects.postgresql import JSONB
@@ -17,7 +17,6 @@ from sqlalchemy.ext.mutable import MutableDict
 from flask_login import AnonymousUserMixin
 from typing_extensions import Self
 
-from ckan.common import config
 from ckan.model import meta
 from ckan.model import core
 from ckan.model import types as _types
@@ -59,7 +58,7 @@ user_table = Table('user', meta.metadata,
         Column('sysadmin', types.Boolean, default=False),
         Column('state', types.UnicodeText, default=core.State.ACTIVE, nullable=False),
         Column('image_url', types.UnicodeText),
-        Column('plugin_extras', MutableDict.as_mutable(JSONB)),
+        Column('plugin_extras', MutableDict.as_mutable(JSONB)),  # type: ignore
         Index('idx_user_id', 'id'),
         Index('idx_user_name', 'name'),
         Index('idx_only_one_active_email', 'email', 'state', unique=True,
@@ -209,7 +208,7 @@ class User(core.StatefulObjectMixin,
 
     @classmethod
     def check_name_available(cls, name: str) -> bool:
-        return cls.by_name(name) == None
+        return cls.by_name(name) is None
 
     def as_dict(self) -> dict[str, Any]:
         _dict = domain_object.DomainObject.as_dict(self)
@@ -276,8 +275,8 @@ class User(core.StatefulObjectMixin,
         import ckan.model as model
 
         q: Query[model.Group] = meta.Session.query(model.Group)\
-            .join(model.Member, model.Member.group_id == model.Group.id and \
-                       model.Member.table_name == 'user').\
+            .join(model.Member, and_(model.Member.group_id == model.Group.id,
+                       model.Member.table_name == 'user')).\
                join(model.User, model.User.id == model.Member.table_id).\
                filter(model.Member.state == 'active').\
                filter(model.Member.table_id == self.id)

--- a/ckan/types/logic/action_result.py
+++ b/ckan/types/logic/action_result.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from typing import (
-    Any, List, Optional, Tuple, Union
+    Any, List, Optional, Sequence, Tuple, Union
 )
 from typing_extensions import TypeAlias
 
@@ -12,7 +12,7 @@ AnyDict: TypeAlias = "dict[str, Any]"
 ###############################################################################
 #                                     get                                     #
 ###############################################################################
-PackageList = List[str]
+PackageList = Sequence[str]
 CurrentPackageListWithResources = List[AnyDict]
 MemberList = List[Tuple[Any, ...]]
 PackageCollaboratorList = List[AnyDict]

--- a/ckan/types/model.py
+++ b/ckan/types/model.py
@@ -15,7 +15,7 @@ __all__ = [
     "Model", "AlchemySession", "Query",
 ]
 
-AlchemySession = ScopedSession
+AlchemySession = ScopedSession[Any]
 
 
 class Meta(Protocol):

--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -243,7 +243,7 @@ def action(logic_function: str, ver: int = API_DEFAULT_VERSION) -> Response:
         u'api_version': ver,
         u'auth_user_obj': current_user
     }
-    model.Session()._context = context  # type: ignore
+    model.Session()._context = context
 
     return_dict: dict[str, Any] = {
         u'help': url_for(u'api.action',

--- a/ckanext/activity/logic/action.py
+++ b/ckanext/activity/logic/action.py
@@ -623,7 +623,7 @@ def activity_diff(context: Context, data_dict: DataDict) -> dict[str, Any]:
         .filter(model_activity.Activity.timestamp < activity.timestamp)
         .order_by(
             # type_ignore_reason: incomplete SQLAlchemy types
-            model_activity.Activity.timestamp.desc()  # type: ignore
+            model_activity.Activity.timestamp.desc()
         )
         .first()
     )

--- a/ckanext/activity/logic/auth.py
+++ b/ckanext/activity/logic/auth.py
@@ -145,7 +145,7 @@ def activity_show(context: Context, data_dict: DataDict) -> AuthResult:
     activity = _get_activity_object(context, data_dict)
     # NB it would be better to have recorded an activity_type against the
     # activity
-    if "package" in activity.activity_type:
+    if activity.activity_type and  "package" in activity.activity_type:
         object_type = "package"
 
         # Check permission labels

--- a/ckanext/activity/model/activity.py
+++ b/ckanext/activity/model/activity.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     select,
     literal,
     Index,
+    Table,
 )
 
 from ckan.common import config
@@ -37,22 +38,34 @@ TActivityDetail = TypeVar("TActivityDetail", bound="ActivityDetail")
 QActivity: TypeAlias = "Query[Activity]"
 
 
-class Activity(domain_object.DomainObject, BaseModel):  # type: ignore
-    __tablename__ = "activity"
+class Activity(domain_object.DomainObject, BaseModel):
+    __table__ = Table(
+        "activity",
+        BaseModel.metadata,
+        Column(
+        "id", types.UnicodeText, primary_key=True, default=_types.make_uuid
+        ),
+        Column("timestamp", types.DateTime),
+        Column("user_id", types.UnicodeText),
+        Column("object_id", types.UnicodeText),
+        Column("activity_type", types.UnicodeText),
+        Column("data", _types.JsonDictType),
+        Column("permission_labels", types.Text),
+    )
+
     # the line below handles cases when activity table was already loaded into
     # metadata state(via stats extension). Can be removed if stats stop using
     # Table object.
     __table_args__ = {"extend_existing": True}
 
-    id = Column(
-        "id", types.UnicodeText, primary_key=True, default=_types.make_uuid
-    )
-    timestamp = Column("timestamp", types.DateTime)
-    user_id = Column("user_id", types.UnicodeText)
-    object_id: Any = Column("object_id", types.UnicodeText)
-    activity_type = Column("activity_type", types.UnicodeText)
-    data = Column("data", _types.JsonDictType)
-    permission_labels = Column("permission_labels", types.Text)
+    id: Mapped[str]
+
+    timestamp: Mapped[datetime.datetime]
+    user_id: Mapped[Optional[str]]
+    object_id: Mapped[Optional[str]]
+    activity_type: Mapped[Optional[str]]
+    data: Mapped[Optional[dict[str, Any]]]
+    permission_labels: Mapped[Optional[list[str]]]
 
     def __init__(
         self,
@@ -170,7 +183,7 @@ def activity_list_dictize(
 
 
 # deprecated
-class ActivityDetail(domain_object.DomainObject, BaseModel):  # type: ignore
+class ActivityDetail(domain_object.DomainObject, BaseModel):
     __tablename__ = "activity_detail"
     id = Column(
         "id", types.UnicodeText, primary_key=True, default=_types.make_uuid
@@ -183,7 +196,7 @@ class ActivityDetail(domain_object.DomainObject, BaseModel):  # type: ignore
     activity_type = Column("activity_type", types.UnicodeText)
     data = Column("data", _types.JsonDictType)
 
-    activity: Mapped[Activity] = relationship(  # type: ignore
+    activity: Mapped[Activity] = relationship(
         Activity,
         backref=backref("activity_detail", cascade="all, delete-orphan"),
     )
@@ -235,7 +248,7 @@ def _activities_limit(
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
-        q = q.order_by(Activity.timestamp.desc())  # type: ignore
+        q = q.order_by(Activity.timestamp.desc())
 
     if offset:
         q = q.offset(offset)
@@ -259,7 +272,7 @@ def _activities_union_all(*qlist: QActivity) -> QActivity:
 def _activities_from_user_query(user_id: Union[str, List[str]]) -> QActivity:
     """Return an SQLAlchemy query for all activities from user_id."""
     q = model.Session.query(Activity)
-    q = q.filter(Activity.user_id.in_(_to_list(user_id)))  # type: ignore
+    q = q.filter(Activity.user_id.in_(_to_list(user_id)))
     return q
 
 
@@ -316,7 +329,7 @@ def user_activity_list(
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
-        q = q.order_by(Activity.timestamp.desc())  # type: ignore
+        q = q.order_by(Activity.timestamp.desc())
 
     if offset:
         q = q.offset(offset)
@@ -393,7 +406,7 @@ def package_activity_list(
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
-        q = q.order_by(Activity.timestamp.desc())  # type: ignore
+        q = q.order_by(Activity.timestamp.desc())
 
     if offset:
         q = q.offset(offset)
@@ -544,7 +557,7 @@ def group_activity_list(
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
-        q = q.order_by(Activity.timestamp.desc())  # type: ignore
+        q = q.order_by(Activity.timestamp.desc())
 
     if offset:
         q = q.offset(offset)
@@ -603,7 +616,7 @@ def organization_activity_list(
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
-        q = q.order_by(Activity.timestamp.desc())  # type: ignore
+        q = q.order_by(Activity.timestamp.desc())
 
     if offset:
         q = q.offset(offset)
@@ -739,7 +752,7 @@ def dashboard_activity_list(
         q = q.order_by(Activity.timestamp)
     else:
         # type_ignore_reason: incomplete SQLAlchemy types
-        q = q.order_by(Activity.timestamp.desc())  # type: ignore
+        q = q.order_by(Activity.timestamp.desc())
 
     if offset:
         q = q.offset(offset)
@@ -795,7 +808,7 @@ def _filter_activitites_from_users(q: QActivity) -> QActivity:
     users_to_avoid = _activity_stream_get_filtered_users()
     if users_to_avoid:
         # type_ignore_reason: incomplete SQLAlchemy types
-        q = q.filter(Activity.user_id.notin_(users_to_avoid))  # type: ignore
+        q = q.filter(Activity.user_id.notin_(users_to_avoid))
 
     return q
 
@@ -808,9 +821,9 @@ def _filter_activitites_from_type(
 
     """
     if include:
-        q = q.filter(Activity.activity_type.in_(types))  # type: ignore
+        q = q.filter(Activity.activity_type.in_(types))
     else:
-        q = q.filter(Activity.activity_type.notin_(types))  # type: ignore
+        q = q.filter(Activity.activity_type.notin_(types))
     return q
 
 
@@ -844,9 +857,9 @@ def _filter_activities_by_permission_labels(
         # User can access non-package activities since they don't have labels
         q = q.filter(
             or_(
-                or_(Activity.activity_type.is_(None),  # type: ignore
+                or_(Activity.activity_type.is_(None),
                     not_(Activity.activity_type.endswith("package"))),
-                Activity.permission_labels.op('&&')(  # type: ignore
+                Activity.permission_labels.op('&&')(
                     user_permission_labels)
             )
         )

--- a/requirements.in
+++ b/requirements.in
@@ -30,7 +30,7 @@ pyyaml==6.0.1
 requests==2.32.3
 rq==1.16.2
 simplejson==3.19.2
-SQLAlchemy[mypy]==1.4.52
+SQLAlchemy==2.0.32
 sqlparse==0.5.0
 typing_extensions==4.12.2
 tzlocal==5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,10 +83,6 @@ msgspec==0.18.6
     # via
     #   -r requirements.in
     #   flask-session
-mypy==1.10.1
-    # via sqlalchemy
-mypy-extensions==1.0.0
-    # via mypy
 packaging==24.1
     # via -r requirements.in
 passlib==1.7.4
@@ -127,23 +123,17 @@ six==1.16.0
     # via
     #   bleach
     #   python-dateutil
-sqlalchemy[mypy]==1.4.52
+sqlalchemy==2.0.32
     # via
     #   -r requirements.in
     #   alembic
-    #   sqlalchemy
-sqlalchemy2-stubs==0.0.2a38
-    # via sqlalchemy
 sqlparse==0.5.0
     # via -r requirements.in
-tomli==2.0.1
-    # via mypy
 typing-extensions==4.12.2
     # via
     #   -r requirements.in
     #   alembic
-    #   mypy
-    #   sqlalchemy2-stubs
+    #   sqlalchemy
 tzlocal==5.2
     # via -r requirements.in
 urllib3==2.2.2
@@ -159,7 +149,6 @@ werkzeug[watchdog]==3.0.3
     #   -r requirements.in
     #   flask
     #   flask-login
-    #   werkzeug
 wtforms==3.1.2
     # via flask-wtf
 zipp==3.19.2


### PR DESCRIPTION
When CKAN v2.11 is out and its code is completely compatible with SQLAlcheny v2, extension maintainers can start upgrading their extensions. I'll add a page to the wiki with upgrade tips.

As for the core, we can now upgrade to SQLAlchemy v2. The main part of this upgrade includes only changes to the version inside the requirements file. It's enough to install the latest SQLAlchemy and nothing will be broken. 



But v2 of SQLAlchemy also includes built-in type-definition, so we no longer need any mypy or sqlalchemy-stubs addons. So the secondary feature of this PR is making our typing compatible with new types definitions. 

:information_source: When upgrading CKAN locally, you have to remove external type definitions, or they will cause incorrect type detection. Run `pip uninstall -y sqlalchemy2-stubs sqlalchemy-stubs`

For anyone who is going to review this PR, here are the most common types of changes:

* instead of `== False` it's better to use `== false()`. The result is the same, but the latter is accepted by linters. I changed this expression only inside files that were changed due to other reasons.
* `model.Session.query` is properly typed now, so we don't need explicit types when assigning its result into a variable. `x: Query[...] = model.Session.query(...)` transformed into `x = model.Session.query(...)`
* `model.Session.query` now always returns a sequence of the `Row` object. `list[tuple[TYPE]]` transformed into `Sequence[Row[tuple[TYPE]]]`. Sometimes `list` is used instead of the `Sequence`, to reduce number of changes. But for new code it's recommended to use `Sequence`.
* `.as_mutable(JSONB)` - this type signature is not yet completed and requires `# type: ignore` comment
* Whenever model's classmethod returns `Self`, `.query(cls)` must be used instead of static form, like `.query(Tag)`, because `Tag` class is not final and can be extended by child class
* `pgcode` property exists in SQLAlchemy exceptions only when working with PostgreSQL. Type checker doesn't know that we are not going to use other DB engines, so any access to `pgcode` must be wrapped into a typecast expression.