### PR TITLE
Removes all empty or None values from template_paths

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -208,6 +208,9 @@ def update_config() -> None:
     if extra_template_paths:
         # must be first for them to override defaults
         template_paths = extra_template_paths.split(',') + template_paths
+        
+    # Removes all empty or None values from template_paths
+    template_paths = list(filter(None, template_paths))
     config['computed_template_paths'] = template_paths
 
     # Enable pessimistic disconnect handling (added in SQLAlchemy 1.2)

--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -208,7 +208,7 @@ def update_config() -> None:
     if extra_template_paths:
         # must be first for them to override defaults
         template_paths = extra_template_paths.split(',') + template_paths
-        
+
     # Removes all empty or None values from template_paths
     template_paths = list(filter(None, template_paths))
     config['computed_template_paths'] = template_paths


### PR DESCRIPTION
# bugfix:


## AssertionError
After adding the basicgrid extension, the following error occurred when the system started up:
…….
  _File "/home/chuangma/ckan/lib/default/src/ckan/ckan/lib/jinja_extensions.py", line 129, in parse
    assert searchpath and current_path
AssertionError_

## After analysis, we discovered the following:
### 1. Issue location:
In the file ckan/ckan/lib/jinja_extensions.py, line 120, there's an assertion:
assert searchpath and current_path
### 2.Problem:
Sometimes both variables (searchpath and current_path) are simultaneously empty. These variables originate from config['computed_template_paths'].
### 3.Root cause:
The issue stems from ckanext-basiccharts/ckanext/basiccharts/plugin.py, where the configuration item 'extra_template_paths' was modified. The value of this item ends with an extraneous comma.
### 4.Contributing factor:
In ckan/ckan/config/environment.py, lines 205-210, the obtained 'extra_template_paths' value is directly converted to a list using split(). This ultimately results in an empty value within config['computed_template_paths'].

## Solution:
 Insert the following line before the line 'config['computed_template_paths'] = template_paths' in ckan/ckan/config/environment.py:
template_paths = list(filter(None, template_paths))
