### PR TITLE
[#8424] Fix Chinese locales in DataTables View

### DIFF
--- a/changes/8432.bugfix
+++ b/changes/8432.bugfix
@@ -1,0 +1,1 @@
+Load the right i18n files for Chinese locales in DataTables View.

--- a/ckanext/datatablesview/assets/datatablesview.js
+++ b/ckanext/datatablesview/assets/datatablesview.js
@@ -385,6 +385,11 @@ this.ckan.module('datatables_view', function (jQuery) {
       // en is the default language, no need to load i18n file
       if (languagefile === '/vendor/DataTables/i18n/en.json') {
         activelanguage = ''
+      // load i18n files for zh_Hant_TW and zh_Hans_CN language
+      } else if (languagefile === '/vendor/DataTables/i18n/zh_Hant_TW.json') {
+        activelanguage = '/vendor/DataTables/i18n/zh_Hant.json'
+      } else if (languagefile === '/vendor/DataTables/i18n/zh_Hans_CN.json') {
+        activelanguage = '/vendor/DataTables/i18n/zh_CN.json'
       }
 
       // settings if gcurrentView === table


### PR DESCRIPTION
Fixes #8424

### Proposed fixes:

Load the right i18n files for Chinese locales in DataTables View.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
