### PR TITLE
[#8316] Fix exception in `ckan generate extension` command

### DIFF
--- a/changes/8437.bugfix
+++ b/changes/8437.bugfix
@@ -1,0 +1,1 @@
+Fix exception in `ckan generate extension` command

--- a/contrib/cookiecutter/ckan_extension/hooks/post_gen_project.py
+++ b/contrib/cookiecutter/ckan_extension/hooks/post_gen_project.py
@@ -36,7 +36,15 @@ def recut():
     setup_template = 'setup.py'
 
     # get context
-    context = {{ cookiecutter | jsonify }}
+    context = {}
+
+    {%- for key, value in cookiecutter.items() -%}
+    {% if value is not none %}
+    context[{{key}}] = '{{value}}'
+    {% else %}
+    context[{{key}}] = None
+    {% endif %}
+    {%- endfor -%}
 
     # Process keywords
     keywords = context['keywords'].strip().split()
@@ -68,6 +76,5 @@ def recut():
 
 
 if __name__ == '__main__':
-    context = {{ cookiecutter | jsonify }}
-    if context['_source'] == 'local':
+    if '{{ cookiecutter._source }}' == 'local':
         recut()

--- a/contrib/cookiecutter/ckan_extension/hooks/post_gen_project.py
+++ b/contrib/cookiecutter/ckan_extension/hooks/post_gen_project.py
@@ -38,13 +38,13 @@ def recut():
     # get context
     context = {}
 
-    {%- for key, value in cookiecutter.items() -%}
-    {% if value is not none %}
-    context[{{key}}] = '{{value}}'
-    {% else %}
-    context[{{key}}] = None
-    {% endif %}
-    {%- endfor -%}
+{%- for key, value in cookiecutter.items() -%}
+{% if value is not none %}
+    context["{{key}}"] = {{ value|tojson }}
+{% else %}
+    context["{{key}}"] = None
+{% endif %}
+{%- endfor -%}
 
     # Process keywords
     keywords = context['keywords'].strip().split()


### PR DESCRIPTION
Fixes #8316

In our post_gen_project hook, we were dumping the cookiecutter object as a Python object but using the `jsonify` filter. Cookicutter 2.6 introduced a new item in the context which is None by default, and this got translated as `null` when dumping it, which is not valid Python syntax.

I've refactored the hook a bit so it dumps the context in a bit more safely manner.

- [x] includes bugfix for possible backport


