### PR TITLE
User details break group display

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2018,7 +2018,10 @@ def member_count(group: str) -> int:
         u'id': group,
         u'object_type': u'user'
     }
-    return len(logic.get_action(u'member_list')(context, data_dict))
+    try:
+        return len(logic.get_action(u'member_list')(context, data_dict))
+    except logic.NotAuthorized:
+        return 0
 
 
 @core_helper


### PR DESCRIPTION
Put the member_list method in try block and return 0 when not Authorized

Fixes #8438 

