### PR TITLE
Fix display of social media links on resource

### DIFF
--- a/ckan/templates/package/resource_read.html
+++ b/ckan/templates/package/resource_read.html
@@ -187,7 +187,7 @@
     {% snippet "package/snippets/resources.html", pkg=pkg, active=res.id, action='read' %}
   {% endblock %}
 
-  {% block resource_license %}
+  {% block resource_social %}
     {% snippet "snippets/social.html" %}
   {% endblock %}
 {% endblock %}


### PR DESCRIPTION
The name of this block did not reflect its contents. What's more, ckanext-scheming's resource_read.html template contains a block called 'resource_license', which contains information on the resource's license. If ckanext-scheming is used in a CKAN project, that block would override this one, showing the license information where social media links should be.

Fixes #8454

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
