### PR TITLE
[#8382] Packaging updates in the extensions template

### DIFF
--- a/changes/8437.bugfix
+++ b/changes/8437.bugfix
@@ -1,0 +1,1 @@
+Fix exception in `ckan generate extension` command

--- a/contrib/cookiecutter/ckan_extension/hooks/post_gen_project.py
+++ b/contrib/cookiecutter/ckan_extension/hooks/post_gen_project.py
@@ -50,9 +50,8 @@ def recut():
     keywords = context['keywords'].strip().split()
     keywords = [keyword for keyword in keywords
                 if keyword not in ('ckan', 'CKAN', 'A', 'space',
-                                   'seperated', 'list', 'of', 'keywords')]
+                                   'separated', 'list', 'of', 'keywords')]
     keywords.insert(0, 'CKAN')
-    keywords = u' '.join(keywords)
     context['keywords'] = keywords
 
     # Double check 'project_shortname' and 'plugin_class_name'

--- a/contrib/cookiecutter/ckan_extension/hooks/post_gen_project.py
+++ b/contrib/cookiecutter/ckan_extension/hooks/post_gen_project.py
@@ -36,7 +36,15 @@ def recut():
     setup_template = 'setup.py'
 
     # get context
-    context = {{ cookiecutter | jsonify }}
+    context = {}
+
+{%- for key, value in cookiecutter.items() -%}
+{% if value is not none %}
+    context["{{key}}"] = {{ value|tojson }}
+{% else %}
+    context["{{key}}"] = None
+{% endif %}
+{%- endfor -%}
 
     # Process keywords
     keywords = context['keywords'].strip().split()
@@ -68,6 +76,5 @@ def recut():
 
 
 if __name__ == '__main__':
-    context = {{ cookiecutter | jsonify }}
-    if context['_source'] == 'local':
+    if '{{ cookiecutter._source }}' == 'local':
         recut()

--- a/contrib/cookiecutter/ckan_extension/hooks/post_gen_project.py
+++ b/contrib/cookiecutter/ckan_extension/hooks/post_gen_project.py
@@ -39,11 +39,7 @@ def recut():
     context = {}
 
 {%- for key, value in cookiecutter.items() -%}
-{% if value is not none %}
-    context["{{key}}"] = {{ value|tojson }}
-{% else %}
-    context["{{key}}"] = None
-{% endif %}
+    context["{{key}}"] = {{ value.__repr__() | safe }}
 {%- endfor -%}
 
     # Process keywords

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/README.md
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/README.md
@@ -90,7 +90,7 @@ To run the tests, do:
 
 If {{ cookiecutter.project }} should be available on PyPI you can follow these steps to publish a new version:
 
-1. Update the version number in the `setup.py` file. See [PEP 440](http://legacy.python.org/dev/peps/pep-0440/#public-version-identifiers) for how to choose version numbers.
+1. Update the version number in the `pyproject.toml` file. See [PEP 440](http://legacy.python.org/dev/peps/pep-0440/#public-version-identifiers) for how to choose version numbers.
 
 2. Make sure you have the latest version of necessary packages:
 

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/README.md
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/README.md
@@ -45,7 +45,7 @@ To install {{ cookiecutter.project }}:
 
     git clone https://github.com/{{ cookiecutter.github_user_name }}/{{ cookiecutter.project }}.git
     cd {{ cookiecutter.project }}
-    pip install .
+    pip install -e .
 	pip install -r requirements.txt
 
 3. Add `{{ cookiecutter.project[8:] }}` to the `ckan.plugins` setting in your CKAN

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/README.md
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/README.md
@@ -45,7 +45,7 @@ To install {{ cookiecutter.project }}:
 
     git clone https://github.com/{{ cookiecutter.github_user_name }}/{{ cookiecutter.project }}.git
     cd {{ cookiecutter.project }}
-    pip install -e .
+    pip install .
 	pip install -r requirements.txt
 
 3. Add `{{ cookiecutter.project[8:] }}` to the `ckan.plugins` setting in your CKAN
@@ -75,7 +75,7 @@ do:
 
     git clone https://github.com/{{ cookiecutter.github_user_name }}/{{ cookiecutter.project }}.git
     cd {{ cookiecutter.project }}
-    python setup.py develop
+    pip install -e .
     pip install -r dev-requirements.txt
 
 
@@ -98,7 +98,7 @@ If {{ cookiecutter.project }} should be available on PyPI you can follow these s
 
 3. Create a source and binary distributions of the new version:
 
-       python setup.py sdist bdist_wheel && twine check dist/*
+       python -m build && twine check dist/*
 
    Fix any errors you get.
 

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/pyproject.toml
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/pyproject.toml
@@ -1,0 +1,38 @@
+[project]
+name = "{{ cookiecutter.project }}"
+version = "0.0.1"
+description = "{{ cookiecutter.description }}"
+readme = "README.md"
+authors = [
+    {name = "{{ cookiecutter.author }}", email = "{{ cookiecutter.author_email }}"}
+]
+license = {text = "AGPL"}
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+]
+{% set keywords = cookiecutter.keywords.split() %}
+keywords = [ {% for keyword in keywords %}"{{ keyword }}", {% endfor %}]
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/{{ cookiecutter.github_user_name }}/{{ cookiecutter.project }}"
+
+[project.entry-points."ckan.plugins"]
+{{ cookiecutter.project_shortname }} = "ckanext.{{ cookiecutter.project_shortname }}.plugin:{{ cookiecutter.plugin_class_name }}"
+
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+        "ignore::sqlalchemy.exc.SADeprecationWarning",
+        "ignore::sqlalchemy.exc.SAWarning",
+        "ignore::DeprecationWarning",
+]
+addopts = "--ckan-ini test.ini"

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/setup.cfg
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/setup.cfg
@@ -1,20 +1,9 @@
-[metadata]
-name = {{ cookiecutter.project }}
-version = 0.0.1
-description = {{ cookiecutter.description }}
-long_description = file: README.md
-long_description_content_type = text/markdown
-url = https://github.com/{{ cookiecutter.github_user_name }}/{{ cookiecutter.project }}
-author = {{ cookiecutter.author }}
-author_email = {{ cookiecutter.author_email }}
-license = AGPL
-classifiers =
-            Development Status :: 4 - Beta
-            License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)
-            Programming Language :: Python :: 3.8
-            Programming Language :: Python :: 3.9
-            Programming Language :: Python :: 3.10
-keywords = {{ cookiecutter.keywords }}
+# This file should only contain setuptools related configuration to build the
+# extension (i.e. arguments to setup() in setup.py). Add any other project
+# information should go to pyproject.toml instead.
+#
+# TODO: migrate Babel options to pyproject.toml when it's better supported
+
 
 [options]
 packages = find:
@@ -23,9 +12,6 @@ install_requires =
 include_package_data = True
 
 [options.entry_points]
-ckan.plugins =
-             {{ cookiecutter.project_shortname }} = ckanext.{{ cookiecutter.project_shortname }}.plugin:{{ cookiecutter.plugin_class_name }}
-
 babel.extractors =
                  ckan = ckan.lib.extract:extract_ckan
 
@@ -52,10 +38,3 @@ previous = true
 domain = ckanext-{{ cookiecutter.project_shortname }}
 directory = ckanext/{{ cookiecutter.project_shortname }}/i18n
 statistics = true
-
-[tool:pytest]
-filterwarnings =
-        ignore::sqlalchemy.exc.SADeprecationWarning
-        ignore::sqlalchemy.exc.SAWarning
-        ignore::DeprecationWarning
-addopts = --ckan-ini test.ini

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/setup.py
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/setup.py
@@ -4,6 +4,7 @@ from setuptools import setup
 # Note: Do not add new arguments to setup(), instead add setuptools
 # configuration options to setup.cfg, or any other project information
 # to pyproject.toml
+# See https://github.com/ckan/ckan/issues/8382 for details
 
 setup(
     # If you are changing from the default layout of your extension, you may

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/setup.py
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/setup.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup
 
+# Note: Do not add new arguments to setup(), instead add setuptools
+# configuration options to setup.cfg, or any other project information
+# to pyproject.toml
+
 setup(
     # If you are changing from the default layout of your extension, you may
     # have to change the message extractors, you can read more about babel

--- a/doc/contributing/release-process.rst
+++ b/doc/contributing/release-process.rst
@@ -395,15 +395,15 @@ a release.
         username: __token__
         password: <token>
 
-   For more info, see:
-   `here <>`_
+   For more info, see
+   `here <https://packaging.python.org/en/latest/specifications/pypirc/>`_
 
    If you upload a bad package, then you can remove it from PyPI however you
    must use a new version number next time.
 
 #. Build new Docker images for the new version in the following repos:
 
-   * `openknowledge/docker-ckan <https://github.com/okfn/docker-ckan>`_ -> ``openknowledge/ckan-base:{Major:minor}`` and ``openknowledge/ckan-dev:{Major:minor}`` (ping @amercader for this one)
+   * `ckan/ckan-docker-base <https://github.com/ckan/ckan-docker-base>`_ -> ``ckan/ckan-base:{Major:minor}`` and ``ckan/ckan-dev:{Major:minor}``
    * `ckan/ckan-solr <https://github.com/ckan/ckan-solr>`_ -> ``ckan/ckan-solr:{Major:minor}-solr{solr-version}``
    * `ckan/ckan-postgres-dev <https://github.com/ckan/ckan-postgres-dev>`_ -> ``ckan/ckan-postgres-dev:{Major:minor}``
 

--- a/doc/contributing/release-process.rst
+++ b/doc/contributing/release-process.rst
@@ -379,32 +379,24 @@ a release.
 
 #. Upload the release to PyPI::
 
-        python setup.py sdist upload
+        python -m build
+        twine check dist/*
+        twine upload dist/*
+
 
    You will need a PyPI account with admin permissions on the ckan package,
    and your credentials should be defined on a ``~/.pypirc`` file such as::
 
         [distutils]
         index-servers =
-            pypi
+          pypi
 
         [pypi]
-        username: <user-name>
-        password: <password>
+        username: __token__
+        password: <token>
 
    For more info, see:
-   `here <http://docs.python.org/distutils/packageindex.html#pypirc>`_
-
-   If running in Vagrant you may get error ``error: Operation not permitted``
-   due to failure to create a hard link. The solution is to add a line at the top
-   of setup.py::
-
-        # Avoid problem releasing to pypi from vagrant
-        import os
-        if os.environ.get('USER', '') == 'vagrant':
-            del os.link
-
-   as described here: https://stackoverflow.com/questions/7719380/python-setup-py-sdist-error-operation-not-permitted
+   `here <>`_
 
    If you upload a bad package, then you can remove it from PyPI however you
    must use a new version number next time.
@@ -513,7 +505,9 @@ Doing the patch releases
 
 #. Upload the release to PyPI::
 
-        python setup.py sdist upload
+        python -m build
+        twine check dist/*
+        twine upload dist/*
 
 #. Make sure the documentation branch (``X.Y``) is up to date with the latest changes in the
    corresponding ``dev-vX.Y`` branch.

--- a/doc/contributing/upgrading-dependencies.rst
+++ b/doc/contributing/upgrading-dependencies.rst
@@ -36,7 +36,7 @@ Steps to upgrade
 These steps will upgrade all of CKAN's dependencies to the latest versions that
 work with CKAN:
 
-#. Create a new virtualenv: ``virtualenv --no-site-packages upgrading``
+#. Create a new virtualenv: ``python -m venv --no-site-packages upgrading``
 
 #. Install the requirements with unpinned versions: ``pip install -r
    requirements.in``
@@ -45,7 +45,7 @@ work with CKAN:
    have to do this before installing the other dependencies so we get only what
    was in ``requirements.in``
 
-#. Install CKAN: ``python setup.py develop``
+#. Install CKAN: ``pip install -e .``
 
 #. Install the development dependencies: ``pip install -r
    dev-requirements.txt``

--- a/doc/maintaining/upgrading/upgrade-package-to-minor-release.rst
+++ b/doc/maintaining/upgrading/upgrade-package-to-minor-release.rst
@@ -50,7 +50,7 @@ respectively.
      enable them again, the installation process will iterate over all folders in
      the ``src`` directory, reinstall the requirements listed in
      ``pip-requirements.txt`` and ``requirements.txt`` files and run
-     ``python setup.py develop`` for each. If you are using a custom extension
+     ``pip install -e .`` for each. If you are using a custom extension
      which does not use this requirements file name or is located elsewhere,
      you will need to manually reinstall it.
 

--- a/doc/maintaining/upgrading/upgrade-package-to-patch-release.rst
+++ b/doc/maintaining/upgrading/upgrade-package-to-patch-release.rst
@@ -63,7 +63,7 @@ minor release they belong to, so for example CKAN ``2.0``, ``2.0.1``,
      enable them again, the installation process will iterate all folders in
      the ``src`` directory, reinstall the requirements listed in
      ``pip-requirements.txt`` and ``requirements.txt`` files and run
-     ``python setup.py develop`` for each. If you are using a custom extension
+     ``pip install -e .`` for each. If you are using a custom extension
      which does not use this requirements file names or is located elsewhere,
      you will need to manually reenable it.
 

--- a/doc/maintaining/upgrading/upgrade-source.rst
+++ b/doc/maintaining/upgrading/upgrade-source.rst
@@ -50,7 +50,11 @@ CKAN release you're upgrading to:
 
    ::
 
-     python setup.py develop
+     pip install .
+
+   .. note:: If you plan on modifying the CKAN source code, do an editable install instead::
+
+      pip install -e .
 
 #. If there have been changes in the Solr schema (check the :doc:`/changelog`
    to find out) you need to restart Jetty for the changes to take effect:

--- a/doc/maintaining/upgrading/upgrade-source.rst
+++ b/doc/maintaining/upgrading/upgrade-source.rst
@@ -52,9 +52,12 @@ CKAN release you're upgrading to:
 
      pip install .
 
-   .. note:: If you plan on modifying the CKAN source code, do an editable install instead::
+   .. note:: 
 
-      pip install -e .
+      If you plan on modifying the CKAN source code, do an editable install instead::
+
+         pip install -e .
+
 
 #. If there have been changes in the Solr schema (check the :doc:`/changelog`
    to find out) you need to restart Jetty for the changes to take effect:

--- a/doc/theming/templates.rst
+++ b/doc/theming/templates.rst
@@ -37,12 +37,12 @@ an extension and plugin. For a detailed explanation of the steps below, see
         example_theme=ckanext.example_theme.plugin:ExampleThemePlugin
     ''',
 
-4. Run ``python setup.py develop``:
+4. Run ``pip install -e .``:
 
    .. parsed-literal::
 
     cd |extension_dir|
-    python setup.py develop
+    pip install -e .
 
 5. Add the plugin to the ``ckan.plugins`` setting in your |ckan.ini|
    file::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+
 [tool.towncrier]
 directory = "changes"
 package = "ckan"


### PR DESCRIPTION
Refers to #8382 (this also includes #8437)

As discussed in #8382, this PR:

* Updates the documentation to remove instances of the deprecated `python setup.py develop` and `python setup.py sdist upload` commands, and to not recommend editable installs unless it's a development install
* Adds a new pyproject.toml file to the extension template which includes all project information, except for:
    * setuptools config options, which go to `setup.cfg`
    * Babel config options, which still hasn't mature pyproject.toml support
* Adds the `[build-system]` section to CKAN core's pyproject.toml

There are no changes with relation to namespace packages or requirements in this PR