### PR TITLE
DataStore Info Side Effect Free

### DIFF
--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -344,6 +344,7 @@ def datastore_upsert(context: Context, data_dict: dict[str, Any]):
     return result
 
 
+@logic.side_effect_free
 def datastore_info(context: Context, data_dict: dict[str, Any]
         ) -> dict[str, Any]:
     '''


### PR DESCRIPTION
feat(logic): ds info action side effect;

- Side effect free datastore info.

### Proposed fixes:

Make `datastore_info` available to GET requests from the API.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
