### PR TITLE
[#8467] Use legacy_key in SECRET_KEY fallback

### DIFF
--- a/changes/8468.misc
+++ b/changes/8468.misc
@@ -1,0 +1,1 @@
+Remove unnecessary beaker.session.secret warning

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -141,12 +141,12 @@ groups:
         placeholder: egg:ckan
 
       - key: SECRET_KEY
+        legacy_key: beaker.session.secret
         validators: not_empty
         required: true
         placeholder_callable: secrets:token_urlsafe
         callable_args:
           nbytes: 20
-        validators: configured_default("beaker.session.secret",None)
         description: |
           This is the secret token that is used by security related tasks by CKAN and its extensions.
           ``ckan generate config`` generates a unique

--- a/ckan/tests/config/test_environment.py
+++ b/ckan/tests/config/test_environment.py
@@ -123,3 +123,13 @@ def test_all_secrets_default_to_SECRET_KEY(ckan_config):
         assert ckan_config[key] == "super_secret"
 
     # Note: api_token.jwt.*.secret are tested in ckan/tests/lib/test_api_token.py
+
+
+@pytest.mark.ckan_config("beaker.session.secret", "super_secret")
+def test_SECRET_KEY_falls_back_to_beaker_session_secret(ckan_config, monkeypatch):
+
+    monkeypatch.delitem(ckan_config, "SECRET_KEY")
+
+    environment.update_config()
+
+    assert ckan_config["SECRET_KEY"] == "super_secret"


### PR DESCRIPTION
Fixes #8467 

Use `legacy_key` instead of `configured_default` to avoid a non-declared warning.

Note that the fallback to `beaker.session.secret` will only work if `SECRET_KEY` is not present at all. If it is present but empty a non-empty error will be shown.
