### PR TITLE
fix generate extension command

### DIFF
--- a/changes/8475.bugfix
+++ b/changes/8475.bugfix
@@ -1,0 +1,1 @@
+fix error on ckan generate extension command

--- a/contrib/cookiecutter/ckan_extension/hooks/post_gen_project.py
+++ b/contrib/cookiecutter/ckan_extension/hooks/post_gen_project.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 import os
+from collections import OrderedDict  # for context
 import jinja2
 import cookiecutter.find as find
 import cookiecutter.generate as gen
@@ -36,7 +37,7 @@ def recut():
     setup_template = 'setup.py'
 
     # get context
-    context = {{ cookiecutter | jsonify }}
+    context = {{ cookiecutter }}
 
     # Process keywords
     keywords = context['keywords'].strip().split()
@@ -68,6 +69,6 @@ def recut():
 
 
 if __name__ == '__main__':
-    context = {{ cookiecutter | jsonify }}
+    context = {{ cookiecutter }}
     if context['_source'] == 'local':
         recut()


### PR DESCRIPTION
Fixes `cookiecutter.exceptions.FailedHookException: Hook script failed (exit status: 1)` on `ckan generate extension`

### Proposed fixes:
- emit python not json into post_gen_project.py

full traceback:
```python-traceback
Traceback (most recent call last):
  File "/tmp/tmptpov8m3z.py", line 88, in <module>
    "_checkout": null,
NameError: name 'null' is not defined
Stopping generation because post_gen_project hook script didn't exit successfully
Traceback (most recent call last):
  File "/usr/local/bin/ckan", line 8, in <module>
    sys.exit(ckan())
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/srv/app/src_extensions/ckan/ckan/cli/generate.py", line 115, in extension
    cookiecutter(template_loc, no_input=True, extra_context=context,
  File "/usr/local/lib/python3.10/site-packages/cookiecutter/main.py", line 182, in cookiecutter
    result = generate_files(
  File "/usr/local/lib/python3.10/site-packages/cookiecutter/generate.py", line 419, in generate_files
    run_hook_from_repo_dir(
  File "/usr/local/lib/python3.10/site-packages/cookiecutter/hooks.py", line 157, in run_hook_from_repo_dir
    run_hook(hook_name, project_dir, context)
  File "/usr/local/lib/python3.10/site-packages/cookiecutter/hooks.py", line 140, in run_hook
    run_script_with_context(script, project_dir, context)
  File "/usr/local/lib/python3.10/site-packages/cookiecutter/hooks.py", line 123, in run_script_with_context
    run_script(temp.name, cwd)
  File "/usr/local/lib/python3.10/site-packages/cookiecutter/hooks.py", line 94, in run_script
    raise FailedHookException(
cookiecutter.exceptions.FailedHookException: Hook script failed (exit status: 1)
```

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport