### PR TITLE
[8482] Fix permissions for groups_available and organizations_available

### DIFF
--- a/changes/8482.bugfix
+++ b/changes/8482.bugfix
@@ -1,0 +1,1 @@
+Fix internal server error when viewing a deleted user.

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1982,9 +1982,10 @@ def groups_available(am_member: bool = False,
 
     '''
     if user is None:
-        user = current_user.name
-    context: Context = {'user': user}
-    data_dict = {'available_only': True,
+        user = current_user.id
+    context: Context = {'user': current_user.name}
+    data_dict = {'id': user,
+                 'available_only': True,
                  'am_member': am_member,
                  'include_dataset_count': include_dataset_count,
                  'include_member_count': include_member_count}
@@ -1997,13 +1998,14 @@ def organizations_available(permission: str = 'manage_group',
                             include_member_count: bool = False,
                             user: Union[str, None] = None
                             ) -> list[dict[str, Any]]:
-    '''Return a list of organizations that the current user has the specified
-    permission for.
+    '''Return a list of organizations that a user has the specified permission
+    for. If no user is specified, the current user is used.
     '''
     if user is None:
-        user = current_user.name
-    context: Context = {'user': user}
+        user = current_user.id
+    context: Context = {'user': current_user.name}
     data_dict = {
+        'id': user,
         'permission': permission,
         'include_dataset_count': include_dataset_count,
         'include_member_count': include_member_count}

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1982,7 +1982,11 @@ def groups_available(am_member: bool = False,
 
     '''
     if user is None:
-        user = current_user.id
+        try:
+            user = current_user.id
+        except AttributeError:
+            # current_user is anonymous
+            pass
     context: Context = {'user': current_user.name}
     data_dict = {'id': user,
                  'available_only': True,
@@ -2002,7 +2006,11 @@ def organizations_available(permission: str = 'manage_group',
     for. If no user is specified, the current user is used.
     '''
     if user is None:
-        user = current_user.id
+        try:
+            user = current_user.id
+        except AttributeError:
+            # current_user is anonymous
+            pass
     context: Context = {'user': current_user.name}
     data_dict = {
         'id': user,

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1983,7 +1983,7 @@ def groups_available(am_member: bool = False,
     '''
     if user is None:
         try:
-            user = current_user.id
+            user = current_user.id  # type: ignore
         except AttributeError:
             # current_user is anonymous
             pass
@@ -2007,7 +2007,7 @@ def organizations_available(permission: str = 'manage_group',
     '''
     if user is None:
         try:
-            user = current_user.id
+            user = current_user.id  # type: ignore
         except AttributeError:
             # current_user is anonymous
             pass

--- a/ckan/templates/user/read_groups.html
+++ b/ckan/templates/user/read_groups.html
@@ -5,7 +5,7 @@
 {% set groups_available = h.groups_available(am_member=True,
   include_dataset_count=True,
   include_member_count=True,
-  user=user['name'])
+  user=user['id'])
 %}
 
 {% block primary_content_inner %}

--- a/ckan/templates/user/read_organizations.html
+++ b/ckan/templates/user/read_organizations.html
@@ -5,7 +5,7 @@
 {% set orgs_available = h.organizations_available(permission='manage_group',
   include_dataset_count=True,
   include_member_count=True,
-  user=user['name'])
+  user=user['id'])
 %}
 
 {% block primary_content_inner %}

--- a/ckan/templates/user/snippets/info.html
+++ b/ckan/templates/user/snippets/info.html
@@ -2,12 +2,12 @@
 {% set orgs_available = h.organizations_available(permission='manage_group',
   include_dataset_count=True,
   include_member_count=True,
-  user=user['name'])
+  user=user['id'])
 %}
 {% set groups_available = h.groups_available(am_member=True,
   include_dataset_count=True,
   include_member_count=True,
-  user=user['name'])
+  user=user['id'])
 %}
 
 


### PR DESCRIPTION
Fixes #8482

### Proposed fixes:

When checking access to the action organization_list_for_user, we should be checking the current user's access, not the access of the user whose groups or organizations we are enquiring about. The current user's name should be included in the context dict. The id of the user we are enquiring about should be included in the data_dict.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
