### PR TITLE
8483 fix display of user organizations page if there are no organizations

### DIFF
--- a/changes/8483.bugfix
+++ b/changes/8483.bugfix
@@ -1,0 +1,1 @@
+Fix display of user organizations page if user belongs to no organizations.

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1062,6 +1062,7 @@ def humanize_entity_type(entity_type: str, object_type: str,
         u'save label': _(u"Save {object_type}"),
         u'search placeholder': _(u'Search {object_type}s...'),
         u'you not member': _(u'You are not a member of any {object_type}s.'),
+        u'user not member': _(u'User isn\'t a member of any {object_type}s.'),
         u'update label': _(u"Update {object_type}"),
     }
 

--- a/ckan/templates/user/read_organizations.html
+++ b/ckan/templates/user/read_organizations.html
@@ -1,7 +1,6 @@
 {% extends "user/read_base.html" %}
 
 {% set user = user_dict %}
-{% set org_type = h.default_group_type('organization') %}
 {% set orgs_available = h.organizations_available(permission='manage_group',
   include_dataset_count=True,
   include_member_count=True,

--- a/ckan/templates/user/read_organizations.html
+++ b/ckan/templates/user/read_organizations.html
@@ -8,7 +8,7 @@
 %}
 
 {% block primary_content_inner %}
-  <h2 class="hide-heading">{{ h.humanize_entity_type('organization', group_type, 'facet label') or _('Organizations') }}</h2>
+  <h2 class="hide-heading">{{ h.humanize_entity_type('organization', org_type, 'facet label') or _('Organizations') }}</h2>
   {% if orgs_available %}
     <div class="wide">
       {% snippet "organization/snippets/organization_list.html", organizations=orgs_available, show_capacity=True %}

--- a/ckan/templates/user/read_organizations.html
+++ b/ckan/templates/user/read_organizations.html
@@ -1,7 +1,7 @@
 {% extends "user/read_base.html" %}
 
 {% set user = user_dict %}
-{% set group_type = h.default_group_type('organization') %}
+{% set org_type = h.default_group_type('organization') %}
 {% set orgs_available = h.organizations_available(permission='manage_group',
   include_dataset_count=True,
   include_member_count=True,
@@ -17,9 +17,9 @@
   {% else %}
     <p class="empty">
       {% if is_myself %}
-        {{ h.humanize_entity_type('organization', group_type, 'you not member') or _('You are not a member of any organizations.') }}
+        {{ h.humanize_entity_type('organization', org_type, 'you not member') or _('You are not a member of any organizations.') }}
       {% else %}
-        {{ h.humanize_entity_type('organization', group_type, 'user not member') or _('User isn\'t a member of any organizations.') }}
+        {{ h.humanize_entity_type('organization', org_type, 'user not member') or _('User isn\'t a member of any organizations.') }}
       {% endif %}
     </p>
   {% endif %}


### PR DESCRIPTION
Fixes #8483

### Proposed fixes:

- Add a `humanize_entity_type` template for the message `'user not member'` used in the `ckan/templates/user/read_organizations.html` and `ckan/templates/user/read_groups.html` templates.
- Fix the name of the variable `group_type` in `ckan/templates/user/read_organizations.html`, which should be `org_type`. (Both these variables are set in the parent `read_base.html` template.)

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
