### PR TITLE
Test for duplicated email for different case

### DIFF
--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -377,6 +377,26 @@ class TestUser(object):
         )
         assert "belongs to a registered user" in response
 
+    def test_email_case_insensitive_change_on_existed_email(self, app, user):
+        """ Ensure we detect email case-insensitive duplicates """
+        factories.User(email="EXISTED@email.com")
+        email_lower = "existed@email.com"
+        env = {"Authorization": user["token"]}
+
+        response = app.post(
+            url=url_for("user.edit"),
+            data={
+                "email": email_lower,
+                "save": "",
+                "old_password": "correct123",
+                "password1": "",
+                "password2": "",
+                "name": user["name"],
+            },
+            extra_environ=env
+        )
+        assert "belongs to a registered user" in response
+
     def test_edit_user_logged_in_username_change(self, app, user):
 
         headers = {"Authorization": user["token"]}


### PR DESCRIPTION
### Proposed fixes:

Adding a test to ensure we are covering duplicated email detection for upper/lower cases

In progress

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
