### PR TITLE
Redefine `by_email`

### DIFF
--- a/changes/8491.misc
+++ b/changes/8491.misc
@@ -1,0 +1,10 @@
+After [#7934](https://github.com/ckan/ckan/pull/7934),
+[#6916](https://github.com/ckan/ckan/pull/6916)
+[#5100](https://github.com/ckan/ckan/pull/5100) and many other we can't never
+be sure about duplicated email users. Saml2 and other extensions trust in the
+`User.by_email` function to get the user by email. Usually we expect that
+function to return `None` or a unique user, but if there are duplicated emails,
+We can expect an error.
+Migration `102_ff13667243ed_create_conditinal_index_on_user` mark as unique
+a combination of `email` and `state` but not takes into consideration upper
+and lower case.

--- a/ckan/model/user.py
+++ b/ckan/model/user.py
@@ -99,7 +99,7 @@ class User(core.StatefulObjectMixin,
             Also, older CKAN instances can have duplicated emails
         """
         all_users = meta.Session.query(
-            cls.name, cls.email, cls.state
+            cls
         ).filter(
             func.lower(cls.email) == func.lower(email)
         ).all()

--- a/ckan/model/user.py
+++ b/ckan/model/user.py
@@ -1,6 +1,5 @@
 # encoding: utf-8
 from __future__ import annotations
-import logging
 from typing import Any, Iterable, Optional, TYPE_CHECKING
 
 import datetime
@@ -27,9 +26,6 @@ from ckan.types import Query
 
 if TYPE_CHECKING:
     from ckan.model import Group, ApiToken
-
-
-log = logging.getLogger(__name__)
 
 
 def last_active_check():
@@ -114,8 +110,6 @@ class User(core.StatefulObjectMixin,
             ]
             if len(active_users) == 1:
                 return active_users[0]
-            user_names = [user.name for user in all_users]
-            log.error(f"Multiple users found for email {email}: {user_names}")
             if raise_on_duplicated:
                 raise Exception(f"Multiple users found for email {email}")
 

--- a/ckan/model/user.py
+++ b/ckan/model/user.py
@@ -98,26 +98,28 @@ class User(core.StatefulObjectMixin,
             Even if we try to avoid duplicated emails, extensions may allow it
             Also, older CKAN instances can have duplicated emails
         """
-        all_insensitive_users = meta.Session.query(cls).filter(
+        all_users = meta.Session.query(
+            cls.name, cls.email, cls.state
+        ).filter(
             func.lower(cls.email) == func.lower(email)
         ).all()
-        if len(all_insensitive_users) == 0:
+        if len(all_users) == 0:
             return None
 
-        if len(all_insensitive_users) > 1:
+        if len(all_users) > 1:
             # Try to get only active users
             active_users = [
-                u for u in all_insensitive_users
+                u for u in all_users
                 if u.state == core.State.ACTIVE
             ]
             if len(active_users) == 1:
                 return active_users[0]
-            user_names = [user.name for user in all_insensitive_users]
+            user_names = [user.name for user in all_users]
             log.error(f"Multiple users found for email {email}: {user_names}")
             if raise_on_duplicated:
                 raise Exception(f"Multiple users found for email {email}")
 
-        return all_insensitive_users[0]
+        return all_users[0]
 
 
     @classmethod


### PR DESCRIPTION
Even after #7934, #6916, #5100 and probably others we can't never be sure about duplicated email.
Saml2 and other extensions trust in the `User.by_email` function to get the user by email. Usually we expect that function to return `None` or a unique user, but if there are duplicated emails, we can expect an error.

Migration `102_ff13667243ed_create_conditinal_index_on_user` mark as unique a combination of `email` and `state` but not takes into consideration upper and lower case for the email.

I think is required to redefine the `User.by_email` function or add another one.

If you have an active and an inactive user with the same email, this function can return the inactive one.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
