### PR TITLE
fix for uploads regression

### DIFF
--- a/changes/8496.bugfix
+++ b/changes/8496.bugfix
@@ -1,0 +1,1 @@
+fix for upload regression from #8360

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -423,9 +423,14 @@ def package_update(
 
         # Needed to let extensions know the new resources ids
         model.Session.flush()
-        for index, (resource, upload) in enumerate(
-                zip(data.get('resources', []), resource_uploads)):
-            resource['id'] = pkg.resources[index].id
+        resiter = iter(changed_resources)
+        uploaditer = iter(resource_uploads)
+        for i in range(len(pkg.resources)):
+            if i in copy_resources:
+                continue
+            resource = next(resiter)
+            upload = next(uploaditer)
+            resource['id'] = pkg.resources[i].id
 
             upload.upload(resource['id'], uploader.get_max_resource_size())
 

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -423,17 +423,17 @@ def package_update(
 
         # Needed to let extensions know the new resources ids
         model.Session.flush()
-        assert changed_resources  # pyright
-        resiter = iter(changed_resources)
-        uploaditer = iter(resource_uploads)
-        for i in range(len(pkg.resources)):
-            if i in copy_resources:
-                continue
-            resource = next(resiter)
-            upload = next(uploaditer)
-            resource['id'] = pkg.resources[i].id
+        if changed_resources:
+            resiter = iter(changed_resources)
+            uploaditer = iter(resource_uploads)
+            for i in range(len(pkg.resources)):
+                if i in copy_resources:
+                    continue
+                resource = next(resiter)
+                upload = next(uploaditer)
+                resource['id'] = pkg.resources[i].id
 
-            upload.upload(resource['id'], uploader.get_max_resource_size())
+                upload.upload(resource['id'], uploader.get_max_resource_size())
 
         for item in plugins.PluginImplementations(plugins.IPackageController):
             item.edit(pkg)

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -423,6 +423,7 @@ def package_update(
 
         # Needed to let extensions know the new resources ids
         model.Session.flush()
+        assert changed_resources  # pyright
         resiter = iter(changed_resources)
         uploaditer = iter(resource_uploads)
         for i in range(len(pkg.resources)):

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -777,6 +777,29 @@ class TestResourceCreate:
             helpers.call_action("resource_create", **params)
             assert m.call_args.args[3] == {0: 0}, 'copy existing resource 0'
 
+    def test_upload_file_paths(self, create_with_upload):
+        from ckan.common import config
+        import os
+
+        storage_path = config["ckan.storage_path"]
+
+        dataset = factories.Dataset()
+        resource1 = create_with_upload(
+            "hello world", "file1.txt", url="http://data1",
+            package_id=dataset["id"])
+
+        assert os.path.exists(
+            os.path.join(storage_path, "resources", resource1["id"][:3])
+        )
+
+        resource2 = create_with_upload(
+            "bye bye world", "file2.txt", url="http://data2",
+            package_id=dataset["id"])
+
+        assert os.path.exists(
+            os.path.join(storage_path, "resources", resource2["id"][:3])
+        )
+
 
 @pytest.mark.usefixtures("non_clean_db")
 class TestMemberCreate(object):


### PR DESCRIPTION
Fixes #8496

### Proposed fixes:
grab correct resource ids for uploader with existing unchanged resources

### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
