### PR TITLE
[#8506] Register pytest plugins as entrypoints

### DIFF
--- a/changes/8507.misc
+++ b/changes/8507.misc
@@ -1,0 +1,1 @@
+Register pytest plugins as entrypoints to make them available to all extensions

--- a/ckan/tests/pytest_ckan/fixtures.py
+++ b/ckan/tests/pytest_ckan/fixtures.py
@@ -1,10 +1,8 @@
 """This is a collection of pytest fixtures for use in tests.
 
-All fixtures below available anywhere under the root of CKAN
-repository. Any external CKAN extension should be able to include them
-by adding next lines under root `conftest.py`
-
-.. literalinclude:: /../conftest.py
+All fixtures below are available wherever CKAN is installed.
+Any external CKAN extension should be able to include them directly into
+their tests.
 
 There are three type of fixtures available in CKAN:
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,0 @@
-# -*- coding: utf-8 -*-
-
-pytest_plugins = [
-    u'ckan.tests.pytest_ckan.ckan_setup',
-    u'ckan.tests.pytest_ckan.fixtures',
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,11 +48,10 @@ filterwarnings = [
 ]
 markers = [
     "ckan_config: patch configuration used by other fixtures via (key, value) pair.",
-    "ckan_pytest: test case that is explicitely was rewriten from `nose` style"
 ]
 
 testpaths = ["ckan", "ckanext"]
-addopts = "--strict-markers --pdbcls=IPython.terminal.debugger:TerminalPdb -p no:ckan --ckan-ini=test-core.ini"
+addopts = "--strict-markers --pdbcls=IPython.terminal.debugger:TerminalPdb --ckan-ini=test-core.ini"
 
 [tool.pyright]
 pythonVersion = "3.9"

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,11 @@ include = ckan, ckanext
 [options.extras_require]
 
 [options.entry_points]
+
+pytest11 =
+    ckan = ckan.tests.pytest_ckan.ckan_setup
+    ckan_fixtures = ckan.tests.pytest_ckan.fixtures
+
 console_scripts =
     ckan = ckan.cli.cli:ckan
 


### PR DESCRIPTION
Fixes #8506

As opposed to in a conftest.py file, which will only have effect if tests are run in the ckan folder. This will allow extensions use the `--ckan-ini` option and all ckan fixtures without adding a conftest.py file or installing the old pytest-ckan package.

See #8506 for all details

