### PR TITLE
Avoid 500 error on deleted resources for the `package_history` view

### DIFF
--- a/changes/8508.misc
+++ b/changes/8508.misc
@@ -1,0 +1,1 @@
+Avoid 500 error on deleted resources for thr package_history view

--- a/ckanext/activity/views.py
+++ b/ckanext/activity/views.py
@@ -270,9 +270,14 @@ def package_history(id: str, activity_id: str) -> Union[Response, str]:
 
     # can the resources be previewed?
     for resource in pkg_dict["resources"]:
-        resource_views = tk.get_action("resource_view_list")(
-            context, {"id": resource["id"]}
-        )
+        # Avoid 500 error on deleted resources
+        try:
+            resource_views = tk.get_action("resource_view_list")(
+                context, {"id": resource["id"]}
+            )
+        except tk.ObjectNotFound:
+            resource_views = []
+
         resource["has_views"] = len(resource_views) > 0
 
     package_type = pkg_dict["type"] or "dataset"


### PR DESCRIPTION
### Proposed fixes:

If a resource is deleted from the database, the `package_history` fails with a 500 error
We should avoid this error

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
