### PR TITLE
Add extensions migration directory to Manifest.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,6 +15,7 @@ recursive-include ckanext *.py
 recursive-include ckanext/*/i18n *
 recursive-include ckanext/*/public *
 recursive-include ckanext/*/assets *
+recursive-include ckanext/*/migration *
 recursive-include ckanext/*/templates *
 recursive-include ckanext/*/theme/public *
 recursive-include ckanext/*/theme/templates *


### PR DESCRIPTION
Adding ckanext extensions migration directory to the Manifest 

When using `pip install -e git+https://github.com/ckan/ckan.git@ckan-2.10.5#egg=ckan` in docker environment we are missing the   migrations script

