### PR TITLE
Fix extension generation command (again)

### DIFF
--- a/contrib/cookiecutter/ckan_extension/hooks/post_gen_project.py
+++ b/contrib/cookiecutter/ckan_extension/hooks/post_gen_project.py
@@ -38,9 +38,9 @@ def recut():
     # get context
     context = {}
 
-{%- for key, value in cookiecutter.items() -%}
+{% for key, value in cookiecutter.items() %}
     context["{{key}}"] = {{ value.__repr__() | safe }}
-{%- endfor -%}
+{% endfor %}
 
     # Process keywords
     keywords = context['keywords'].strip().split()


### PR DESCRIPTION
Introduced in #8437 trying to fix the `ckan generate extension` command
The "strip whitespace" `-` characters in the jinja2 tags made that the output was not valid python:

```
    # get context
    context = {}context["project"] = 'ckanext-mysite'context["keywords"] = 'CKAN'context["description"] = ''context["author"] = ''context["author_email"] = ''context["github_user_name"] = ''context["project_shortname"] = 'mysite'context["plugin_class_name"] = 'MysitePlugin'context["include_examples"] = '0'context["ckan_version"] = '2.11'context["_source"] = 'cli'context["_template"] = '/home/adria/dev/pyenvs/ckan-211/ckan/contrib/cookiecutter/ckan_extension'context["_output_dir"] = '/home/adria/dev/pyenvs/ckan-211'context["_repo_dir"] = '/home/adria/dev/pyenvs/ckan-211/ckan/contrib/cookiecutter/ckan_extension'context["_checkout"] = None# Process keywords
    keywords = context['keywords'].strip().split()

```

Removing the characters produces valid Python again:

```
context = {}

context["project"] = 'ckanext-mysite'

context["keywords"] = 'CKAN'

context["description"] = ''

```
