### PR TITLE
Don't add author email to pyproject.toml if empty

### DIFF
--- a/changes/8519.misc
+++ b/changes/8519.misc
@@ -1,0 +1,1 @@
+ Don't add author email to pyproject.toml if empty when creating an extension

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/pyproject.toml
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/pyproject.toml
@@ -4,7 +4,11 @@ version = "0.0.1"
 description = "{{ cookiecutter.description }}"
 readme = "README.md"
 authors = [
-    {name = "{{ cookiecutter.author }}", email = "{{ cookiecutter.author_email }}"}
+    {name = "{{ cookiecutter.author }}"
+        {%- if cookiecutter.author_email -%}
+        , email = "{{ cookiecutter.author_email }}"
+        {%- endif -%}
+    }
 ]
 license = {text = "AGPL"}
 classifiers = [


### PR DESCRIPTION
If you leave the Author's email empty when creating an extension, it will generate the pyproject.toml:

```toml
authors = [
    {name = "", email=""}
]
```

But when trying to install the extension an error will be raised:

```
        File "/tmp/pip-build-env-46vr8mrg/overlay/lib/python3.9/site-packages/setuptools/config/pyprojecttoml.py", line 60, in validate
          raise ValueError(f"{error}\n{summary}") from None
      ValueError: invalid pyproject.toml config: `project.authors[0].email`.
      configuration error: `project.authors[0].email` must be idn-email

```
Now the email bit is only added if provided.