### PR TITLE
Automate publication of ckan package to PyPI

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,72 @@
+name: Publish to PyPI and TestPyPI
+
+on: push
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.9"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: Publish Python distribution on PyPI
+    # Publish to PyPI when pushing a tag
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/ckan
+    permissions:
+      id-token: write
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-to-testpypi:
+    name: Publish Python distribution on TestPyPI
+    # Publish to Test PyPI when a pull request is merged
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://test.pypi.org/p/ckan
+    permissions:
+      id-token: write
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/

--- a/changes/8520.misc
+++ b/changes/8520.misc
@@ -1,0 +1,1 @@
+Automate publishing CKAN package to PyPI

--- a/doc/contributing/maintenance-tools.rst
+++ b/doc/contributing/maintenance-tools.rst
@@ -60,3 +60,29 @@ When creating a new PAT, make sure to select the following settings:
 * Repository permissions: Select *Content* (Read and Write) and *Pull Requests* (Read and Write)
 
 Once generated the token, it will have to be approved by someone with permissions in the *@ckan* organization (by going to Settings > Third-party Access > Personal access tokens > Pending requests).
+
+
+----------------------------
+Automatic publishing to PyPI
+----------------------------
+
+
+.. note:: Automatic publishing to PyPI was added on November 2024
+
+The main CKAN repo has a GitHub workflow that allows to publish to
+    
+* PyPI when a tag is pushed
+* Test PyPI when a PR is merged (Using test.pypi.org allows us to check that
+  the workflow is healthy).
+    
+Besides the workflow file there are two additional configurations needed:
+    
+* `GitHub Actions environmnents`_: This allows us to define additional rules
+  and limit how actions are run.
+* `Trusted Publishers`_ on PyPI: This allows the actions to authenticate
+  without having to share API tokens around
+    
+
+.. _GitHub Actions environmnents:   https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment
+.. _Trusted Publishers: https://docs.pypi.org/trusted-publishers/
+


### PR DESCRIPTION
Part of https://github.com/ckan/ckan/issues/8143

This adds a new GitHub workflow to publish to

* PyPI when a tag is pushed
* Test PyPI when a PR is merged

Using test.pypi.org allows us to check that the workflow is healthy.

Besides the workflow file this has required setting up:

* [GitHub Actions environmnenst][1] (`pypi` and `testpypi`). This allows us to define additional rules and limit how actions are run
* [Trusted Publishers][2] on PyPI: This allows the actions to authenticate without having to share API tokens around

[1]:
https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment
[2]: https://docs.pypi.org/trusted-publishers/