### PR TITLE
Fix translation issue for new field in resource extra information

### DIFF
--- a/changes/8532.bugfix
+++ b/changes/8532.bugfix
@@ -1,0 +1,1 @@
+Modified the extension so that the key of the new field added to the resource's additional information is translated according to the selected language.

--- a/ckan/templates/package/resource_read.html
+++ b/ckan/templates/package/resource_read.html
@@ -169,7 +169,7 @@
               </tr>
               {% for key, value in h.format_resource_items(res.items()) %}
                 {% if key not in ('created', 'metadata modified', 'last modified', 'format') %}
-                  <tr class="toggle-more"><th scope="row">{{ key | capitalize }}</th><td>{{ value }}</td></tr>
+                  <tr class="toggle-more"><th scope="row">{{ _(key | capitalize) }}</th><td>{{ value }}</td></tr>
                 {% endif %}
               {% endfor %}
             </tbody>


### PR DESCRIPTION
Fixes #8532

### Proposed fixes:

I will modify the template to ensure that the keys in the additional information on the resource screen are translated.
`ckan/templates/package/resource_read.html`

### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
