### PR TITLE
Fix missing robots.txt template while using bs3 templates

### DIFF
--- a/ckan/templates-bs3/home/robots.txt
+++ b/ckan/templates-bs3/home/robots.txt
@@ -1,0 +1,12 @@
+User-agent: *
+{% block all_user_agents -%}
+Disallow: /dataset/rate/
+Disallow: /revision/
+Disallow: /dataset/*/history
+Disallow: /api/
+Crawl-Delay: 10
+{%- endblock %}
+
+{% block additional_user_agents -%}
+{%- endblock %}
+


### PR DESCRIPTION
### Proposed fixes:

While using bs3 templates on ckan 2.10.5, robots.txt template is missing and it produces server error.  The problem doesn't exist on ckan 2.11 or master as the bs3 templates were already removed.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
