### PR TITLE
8537: Only show member_count in a group list item if we have that value

### DIFF
--- a/changes/8537.bugfix
+++ b/changes/8537.bugfix
@@ -1,0 +1,1 @@
+Fix showing '0 members' for all groups on a dataset page.

--- a/ckan/templates/group/snippets/group_item.html
+++ b/ckan/templates/group/snippets/group_item.html
@@ -37,8 +37,9 @@ Example:
   {% block members %}
     {% if 'member_count' in group and group.member_count %}
       <strong class="count">{{ ungettext('{num} Member', '{num} Members', group.member_count).format(num=group.member_count) }}</strong>
-    {% else %}
+    {% elif 'member_count' in group %}
       <span class="count">{{ _('0 Members') }}</span>
+    {% else %}
     {% endif %}
   {% endblock %}
   {% block capacity %}


### PR DESCRIPTION
Fixes #8537 

### Proposed fixes:

When displaying a group list on the group search page, or on a user's page, we have the member_count for each group (as of https://github.com/ckan/ckan/pull/7007). On the groups tab of a dataset page, we don't get the member_count for the groups. In this case, we should rather display nothing than '0 Members'.

Getting the member count for each group and displaying the right number seemed expensive for little utility.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
