### PR TITLE
Tracking: Fix error when assigning datetime to Row object

### DIFF
--- a/ckanext/tracking/cli/tracking.py
+++ b/ckanext/tracking/cli/tracking.py
@@ -53,13 +53,10 @@ def update_all(start_date: Optional[str] = None):
         # No date given. See when we last have data for and get data
         # from 2 days before then in case new data is available.
         # If no date here then use 2011-01-01 as the start date
-        result = (
-            session.query(ts.tracking_date)
-            .order_by(desc(ts.tracking_date))
-            .first()
-        )
+        stmt = select(ts).order_by(desc(ts.tracking_date))
+        result = session.scalars(stmt).first()
         if result:
-            date = result
+            date = result.tracking_date
             date += datetime.timedelta(-2)
             # convert date to datetime
             combine = datetime.datetime.combine


### PR DESCRIPTION
Fixes an error when executing: `ckan tracking update` command.

```
~/Repos/ckan  (master) [10:31] $ ckan tracking update
Traceback (most recent call last):
  File "/home/pdelboca/Repos/ckan/.venv/bin/ckan", line 8, in <module>
    sys.exit(ckan())
             ^^^^^^
  File "/home/pdelboca/Repos/ckan/.venv/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pdelboca/Repos/ckan/.venv/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/pdelboca/Repos/ckan/.venv/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pdelboca/Repos/ckan/.venv/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pdelboca/Repos/ckan/.venv/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pdelboca/Repos/ckan/.venv/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pdelboca/Repos/ckan/ckanext/tracking/cli/tracking.py", line 38, in update
    update_all(start_date)
  File "/home/pdelboca/Repos/ckan/ckanext/tracking/cli/tracking.py", line 63, in update_all
    date += datetime.timedelta(-2)
TypeError: unsupported operand type(s) for +=: 'Row' and 'datetime.timedelta'
```

The problem is that SQLALchemy 2.0 return `Row` objects when calling `session.query(...)`. To return the Object we should use `select.scalars(...).first()`

Link to documentation: https://docs.sqlalchemy.org/en/20/tutorial/data_select.html#selecting-orm-entities-and-columns

### Proposed fixes:

Migrate the `session.query(...)` syntax to a more conventional SQLAlchemy 2.0 syntax.
