### PR TITLE
Backport #8530 to 2.11, fix for #5847

### DIFF
--- a/changes/5847.feature
+++ b/changes/5847.feature
@@ -1,9 +1,12 @@
 Allow configuring datastore full text field indexes with new
 ckan.datastore.default_fts_index_field_types config option.
 
-The default is an empty list, avoiding automatically creating
-separate full text indexes for any individual columns. The
-whole-row full text index still exists for all tables.
+The default is "text tsvector" but this can be changed to
+"" to avoiding automatically creating separate full text indexes
+for any individual columns. The whole-row full text index still
+exists for all tables.
+
+After upgrading to ckan 2.12 the default changes to "".
 
 Use the `ckan datastore fts-index` command to remove existing
 column indexes to reclaim database space.

--- a/changes/5847.feature
+++ b/changes/5847.feature
@@ -1,2 +1,6 @@
 Allow configuring datastore full text field indexes with new
-ckan.datastore.default_fts_index_field_types config option
+ckan.datastore.default_fts_index_field_types config option.
+
+The default is an empty list, avoiding automatically creating
+separate full text indexes for any individual columns. The
+whole-row full text index still exists for all tables.

--- a/changes/5847.feature
+++ b/changes/5847.feature
@@ -1,0 +1,2 @@
+Allow configuring datastore full text field indexes with new
+ckan.datastore.default_fts_index_field_types config option

--- a/changes/5847.feature
+++ b/changes/5847.feature
@@ -4,3 +4,6 @@ ckan.datastore.default_fts_index_field_types config option.
 The default is an empty list, avoiding automatically creating
 separate full text indexes for any individual columns. The
 whole-row full text index still exists for all tables.
+
+Use the `ckan datastore fts-index` command to remove existing
+column indexes to reclaim database space.

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -722,7 +722,8 @@ def _build_fts_indexes(
 
     full_text_field = {'type': 'tsvector', 'id': '_full_text'}
     for field in [full_text_field] + fields:
-        if not datastore_helpers.should_fts_index_field_type(field['type']):
+        if field['id'] != '_full_text' and not (
+                datastore_helpers.should_fts_index_field_type(field['type'])):
             continue
 
         field_str = field['id']

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -461,7 +461,6 @@ def _where_clauses(
                 if not datastore_helpers.should_fts_index_field_type(ftyp):
                     clause_str = u'_full_text @@ {0}'.format(query_field)
                     clauses.append((clause_str,))
-                    continue
 
                 clause_str = (
                     u'to_tsvector({0}, cast({1} as text)) @@ {2}').format(

--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -13,12 +13,14 @@ from ckan.common import config
 import ckan.logic as logic
 
 import ckanext.datastore as datastore_module
+from ckanext.datastore.backend import get_all_resources_ids_in_datastore
 from ckanext.datastore.backend.postgres import (
     identifier,
     literal_string,
     get_read_engine,
     get_write_engine,
     _get_raw_field_info,
+    _TIMEOUT,
 )
 from ckanext.datastore.blueprint import DUMP_FORMATS, dump_to
 
@@ -137,27 +139,17 @@ def purge():
 
     site_user = logic.get_action('get_site_user')({'ignore_auth': True}, {})
 
-    result = logic.get_action('datastore_search')(
-        {'user': site_user['name']},
-        {'resource_id': '_table_metadata'}
-    )
-
     resource_id_list = []
-    for record in result['records']:
+    for resid in get_all_resources_ids_in_datastore():
         try:
-            # ignore 'alias' records (views) as they are automatically
-            # deleted when the parent resource table is dropped
-            if record['alias_of']:
-                continue
-
             logic.get_action('resource_show')(
                 {'user': site_user['name']},
-                {'id': record['name']}
+                {'id': resid}
             )
         except logic.NotFound:
-            resource_id_list.append(record['name'])
+            resource_id_list.append(resid)
             click.echo("Resource '%s' orphaned - queued for drop" %
-                       record[u'name'])
+                       resid)
         except KeyError:
             continue
 
@@ -191,22 +183,12 @@ def upgrade():
     '''Move field info to _info so that plugins may add private information
     to each field for their own purposes.'''
 
-    site_user = logic.get_action('get_site_user')({'ignore_auth': True}, {})
-
-    result = logic.get_action('datastore_search')(
-        {'user': site_user['name']},
-        {'resource_id': '_table_metadata'}
-    )
-
     count = 0
     skipped = 0
     noinfo = 0
     read_connection = get_read_engine()
-    for record in result['records']:
-        if record['alias_of']:
-            continue
-
-        raw_fields, old = _get_raw_field_info(read_connection, record['name'])
+    for resid in get_all_resources_ids_in_datastore():
+        raw_fields, old = _get_raw_field_info(read_connection, resid)
         if not old:
             if not raw_fields:
                 noinfo += 1
@@ -222,7 +204,7 @@ def upgrade():
                 raw_sql = literal_string(' ' + json.dumps(
                     raw, ensure_ascii=False, separators=(',', ':')))
                 alter_sql.append(u'COMMENT ON COLUMN {0}.{1} is {2}'.format(
-                    identifier(record['name']),
+                    identifier(resid),
                     identifier(fid),
                     raw_sql))
 
@@ -234,6 +216,34 @@ def upgrade():
 
     click.echo('Upgraded %d tables (%d already upgraded, %d no info)' % (
         count, skipped, noinfo))
+
+
+@datastore.command(
+    'fts-index',
+    short_help='create or remove full-text search indexes after changing '
+    'the ckan.datastore.default_fts_index_field_types setting'
+)
+@click.option(
+    '--timeout', metavar='SECONDS',
+    type=click.FloatRange(0, 2147483.647),  # because postgres max int
+    default=_TIMEOUT / 1000, show_default=True,
+    help='maximum index creation time in seconds',
+)
+def fts_index(timeout: float):
+    '''Use to create or remove full-text search indexes after changing
+    the ckan.datastore.default_fts_index_field_types setting.
+    '''
+    site_user = logic.get_action('get_site_user')({'ignore_auth': True}, {})
+    resource_ids = get_all_resources_ids_in_datastore()
+
+    for i, resid in enumerate(get_all_resources_ids_in_datastore(), 1):
+        print(f'\r{resid} [{i}/{len(resource_ids)}] ...', end='')
+        logic.get_action('datastore_create')(
+            {'user': site_user['name'],
+             'query_timeout': int(timeout * 1000)},  # type: ignore
+            {'resource_id': resid, 'force': True}
+        )
+    print('\x08\x08\x08done')
 
 
 def get_commands():

--- a/ckanext/datastore/config_declaration.yaml
+++ b/ckanext/datastore/config_declaration.yaml
@@ -102,8 +102,8 @@ groups:
 
   - key: ckan.datastore.default_fts_index_field_types
     type: list
-    default: ''
-    example: text tsvector
+    default: text tsvector
+    example: ''
     description: >
       A separate full-text search index will be created by default for fields
       with these types, and used when searching on fields by passing a

--- a/ckanext/datastore/config_declaration.yaml
+++ b/ckanext/datastore/config_declaration.yaml
@@ -99,3 +99,14 @@ groups:
       The default method used when creating full-text search indexes. Currently it
       can be "gin" or "gist". Refer to PostgreSQL's documentation to understand the
       characteristics of each one and pick the best for your instance.
+
+  - key: ckan.datastore.default_fts_index_field_types
+    type: list
+    default: text tsvector
+    description: >
+      A separate full-text search index will be created by default for fields
+      with these types, and used when searching on fields by passing a
+      dictionary to the datastore_search q parameter.
+
+      Indexes increase the time and disk space required to load data
+      into the DataStore.

--- a/ckanext/datastore/config_declaration.yaml
+++ b/ckanext/datastore/config_declaration.yaml
@@ -102,7 +102,8 @@ groups:
 
   - key: ckan.datastore.default_fts_index_field_types
     type: list
-    default: text tsvector
+    default: ''
+    example: text tsvector
     description: >
       A separate full-text search index will be created by default for fields
       with these types, and used when searching on fields by passing a

--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -83,7 +83,7 @@ def _strip(s: Any):
 
 def should_fts_index_field_type(field_type: str):
     return field_type in tk.config.get(
-        'ckan.datastore.default_fts_index_field_types', ['text', 'tsvector'])
+        'ckan.datastore.default_fts_index_field_types', [])
 
 
 def get_table_and_function_names_from_sql(context: Context, sql: str):

--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -82,7 +82,8 @@ def _strip(s: Any):
 
 
 def should_fts_index_field_type(field_type: str):
-    return field_type.lower() in ['tsvector', 'text', 'number']
+    return field_type in tk.config.get(
+        'ckan.datastore.default_fts_index_field_types', ['text', 'tsvector'])
 
 
 def get_table_and_function_names_from_sql(context: Context, sql: str):

--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -159,6 +159,8 @@ class TestDatastoreCreateNewTests(object):
         resource_id = result["resource_id"]
         assert self._has_index_on_field(resource_id, '"_full_text"')
 
+    @pytest.mark.ckan_config(
+        "ckan.datastore.default_fts_index_field_types", "text")
     def test_create_add_full_text_search_indexes_on_every_text_field(self):
         package = factories.Dataset()
         data = {

--- a/ckanext/datastore/tests/test_db.py
+++ b/ckanext/datastore/tests/test_db.py
@@ -67,6 +67,8 @@ class TestCreateIndexes(object):
             "tsvector", connection, resource_id,
         )
 
+    @pytest.mark.ckan_config(
+        "ckan.datastore.default_fts_index_field_types", "")
     @mock.patch("ckanext.datastore.backend.postgres._get_fields")
     def test_creates_no_fts_indexes_by_default(
         self, _get_fields

--- a/ckanext/datastore/tests/test_db.py
+++ b/ckanext/datastore/tests/test_db.py
@@ -45,7 +45,7 @@ class TestCreateIndexes(object):
     ):
         _get_fields.return_value = [
             {"id": "text", "type": "text"},
-            {"id": "number", "type": "number"},
+            {"id": "tsvector", "type": "tsvector"},
             {"id": "nested", "type": "nested"},
             {"id": "date", "type": "date"},
             {"id": "text array", "type": "text[]"},
@@ -62,7 +62,7 @@ class TestCreateIndexes(object):
             "text", connection, resource_id, "english"
         )
         self._assert_created_index_on(
-            "number", connection, resource_id, "english", cast=True
+            "tsvector", connection, resource_id,
         )
 
     @pytest.mark.ckan_config("ckan.datastore.default_fts_lang", "simple")

--- a/ckanext/datastore/tests/test_db.py
+++ b/ckanext/datastore/tests/test_db.py
@@ -67,6 +67,32 @@ class TestCreateIndexes(object):
             "tsvector", connection, resource_id,
         )
 
+    @mock.patch("ckanext.datastore.backend.postgres._get_fields")
+    def test_creates_no_fts_indexes_by_default(
+        self, _get_fields
+    ):
+        _get_fields.return_value = [
+            {"id": "text", "type": "text"},
+            {"id": "tsvector", "type": "tsvector"},
+            {"id": "nested", "type": "nested"},
+            {"id": "date", "type": "date"},
+            {"id": "text array", "type": "text[]"},
+            {"id": "timestamp", "type": "timestamp"},
+        ]
+        connection = mock.MagicMock()
+        context = {"connection": connection}
+        resource_id = "resource_id"
+        data_dict = {"resource_id": resource_id}
+
+        db.create_indexes(context, data_dict)
+
+        self._assert_no_index_created_on(
+            "text", connection, resource_id, "english"
+        )
+        self._assert_no_index_created_on(
+            "tsvector", connection, resource_id,
+        )
+
     @pytest.mark.ckan_config(
         "ckan.datastore.default_fts_index_field_types", "text tsvector")
     @pytest.mark.ckan_config("ckan.datastore.default_fts_lang", "simple")
@@ -130,6 +156,38 @@ class TestCreateIndexes(object):
 
         assert was_called, (
             "Expected 'connection.execute' to have been "
+            "called with a string containing '%s'" % sql_str
+        )
+
+    def _assert_no_index_created_on(
+        self,
+        field,
+        connection,
+        resource_id,
+        lang=None,
+        cast=False,
+        method="gist",
+    ):
+        field = u'"{0}"'.format(field)
+        if cast:
+            field = u"cast({0} AS text)".format(field)
+        if lang is not None:
+            sql_str = (
+                u'ON "resource_id" '
+                u"USING {method}(to_tsvector('{lang}', {field}))"
+            )
+            sql_str = sql_str.format(method=method, lang=lang, field=field)
+        else:
+            sql_str = u"USING {method}({field})".format(
+                method=method, field=field
+            )
+
+        calls = connection.execute.call_args_list
+
+        was_called = any(sql_str in str(call.args[0]) for call in calls)
+
+        assert not was_called, (
+            "Expected 'connection.execute' to not have been "
             "called with a string containing '%s'" % sql_str
         )
 

--- a/ckanext/datastore/tests/test_db.py
+++ b/ckanext/datastore/tests/test_db.py
@@ -39,6 +39,8 @@ class TestCreateIndexes(object):
             "_full_text", connection, resource_id, method="gin"
         )
 
+    @pytest.mark.ckan_config(
+        "ckan.datastore.default_fts_index_field_types", "text tsvector")
     @mock.patch("ckanext.datastore.backend.postgres._get_fields")
     def test_creates_fts_index_on_all_fields_except_dates_nested_and_arrays_with_english_as_default(
         self, _get_fields
@@ -65,6 +67,8 @@ class TestCreateIndexes(object):
             "tsvector", connection, resource_id,
         )
 
+    @pytest.mark.ckan_config(
+        "ckan.datastore.default_fts_index_field_types", "text tsvector")
     @pytest.mark.ckan_config("ckan.datastore.default_fts_lang", "simple")
     @mock.patch("ckanext.datastore.backend.postgres._get_fields")
     def test_creates_fts_index_on_textual_fields_can_overwrite_lang_with_config_var(
@@ -80,6 +84,8 @@ class TestCreateIndexes(object):
 
         self._assert_created_index_on("foo", connection, resource_id, "simple")
 
+    @pytest.mark.ckan_config(
+        "ckan.datastore.default_fts_index_field_types", "text tsvector")
     @pytest.mark.ckan_config("ckan.datastore.default_fts_lang", "simple")
     @mock.patch("ckanext.datastore.backend.postgres._get_fields")
     def test_creates_fts_index_on_textual_fields_can_overwrite_lang_using_lang_param(

--- a/ckanext/datastore/tests/test_helpers.py
+++ b/ckanext/datastore/tests/test_helpers.py
@@ -47,6 +47,8 @@ class TestTypeGetters(object):
         for multiple in multiples:
             assert postgres_backend.is_single_statement(multiple) is False
 
+    @pytest.mark.ckan_config(
+        "ckan.datastore.default_fts_index_field_types", "text tsvector")
     def test_should_fts_index_field_type(self):
         indexable_field_types = ["tsvector", "text"]
 

--- a/ckanext/datastore/tests/test_helpers.py
+++ b/ckanext/datastore/tests/test_helpers.py
@@ -48,7 +48,7 @@ class TestTypeGetters(object):
             assert postgres_backend.is_single_statement(multiple) is False
 
     def test_should_fts_index_field_type(self):
-        indexable_field_types = ["tsvector", "text", "number"]
+        indexable_field_types = ["tsvector", "text"]
 
         non_indexable_field_types = [
             "nested",

--- a/ckanext/datastore/tests/test_plugin.py
+++ b/ckanext/datastore/tests/test_plugin.py
@@ -113,6 +113,8 @@ class TestPluginDatastoreSearch(object):
 
         assert result["where"] == []
 
+    @pytest.mark.ckan_config(
+        "ckan.datastore.default_fts_index_field_types", "text")
     def test_fts_where_clause_lang_uses_english_by_default(self):
         expected_where = [
             (
@@ -129,6 +131,8 @@ class TestPluginDatastoreSearch(object):
 
         assert result["where"] == expected_where
 
+    @pytest.mark.ckan_config(
+        "ckan.datastore.default_fts_index_field_types", "text")
     @pytest.mark.ckan_config("ckan.datastore.default_fts_lang", "simple")
     def test_fts_where_clause_lang_can_be_overwritten_by_config(self):
         expected_where = [
@@ -146,6 +150,8 @@ class TestPluginDatastoreSearch(object):
 
         assert result["where"] == expected_where
 
+    @pytest.mark.ckan_config(
+        "ckan.datastore.default_fts_index_field_types", "text")
     @pytest.mark.ckan_config("ckan.datastore.default_fts_lang", "simple")
     def test_fts_where_clause_lang_can_be_overwritten_using_lang_param(self):
         expected_where = [

--- a/ckanext/datastore/tests/test_plugin.py
+++ b/ckanext/datastore/tests/test_plugin.py
@@ -176,6 +176,10 @@ class TestPluginDatastoreSearch(object):
         should_fts_index_field_type.return_value = False
         expected_where = [
             ('_full_text @@ "query country"',),
+            (
+                u"to_tsvector('english', cast(\"country\" as text))"
+                u' @@ "query country"',
+            ),
         ]
         data_dict = {"q": {"country": "Brazil"}, "language": "english"}
         fields_types = {"country": "non-indexed field type"}

--- a/ckanext/datastore/tests/test_plugin.py
+++ b/ckanext/datastore/tests/test_plugin.py
@@ -131,6 +131,21 @@ class TestPluginDatastoreSearch(object):
 
         assert result["where"] == expected_where
 
+    def test_q_field_with_no_fts_uses_general_full_text(self):
+        expected_where = [
+            (
+                '_full_text @@ "query country"',
+            )
+        ]
+        data_dict = {"q": {"country": "Brazil"}}
+        fields_types = {"country": "text"}
+
+        result = self._datastore_search(
+            data_dict=data_dict, fields_types=fields_types
+        )
+
+        assert result["where"] == expected_where
+
     @pytest.mark.ckan_config(
         "ckan.datastore.default_fts_index_field_types", "text")
     @pytest.mark.ckan_config("ckan.datastore.default_fts_lang", "simple")
@@ -162,27 +177,6 @@ class TestPluginDatastoreSearch(object):
         ]
         data_dict = {"q": {"country": "Brazil"}, "language": "french"}
         fields_types = {"country": "text"}
-
-        result = self._datastore_search(
-            data_dict=data_dict, fields_types=fields_types
-        )
-
-        assert result["where"] == expected_where
-
-    @mock.patch("ckanext.datastore.helpers.should_fts_index_field_type")
-    def test_fts_adds_where_clause_on_full_text_when_querying_non_indexed_fields(
-        self, should_fts_index_field_type
-    ):
-        should_fts_index_field_type.return_value = False
-        expected_where = [
-            ('_full_text @@ "query country"',),
-            (
-                u"to_tsvector('english', cast(\"country\" as text))"
-                u' @@ "query country"',
-            ),
-        ]
-        data_dict = {"q": {"country": "Brazil"}, "language": "english"}
-        fields_types = {"country": "non-indexed field type"}
 
         result = self._datastore_search(
             data_dict=data_dict, fields_types=fields_types


### PR DESCRIPTION
### Proposed fixes:

Same as #8530 but default to the original setting of applying FTS index to `text` and `tsvector` columns.

### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
