### PR TITLE
Reindex Packages UI and After Org/Group Update

### DIFF
--- a/ckan/cli/search_index.py
+++ b/ckan/cli/search_index.py
@@ -41,13 +41,21 @@ def rebuild(
     u''' Rebuild search index '''
     from ckan.lib.search import rebuild, commit
     try:
-
-        rebuild(package_id,
-                only_missing=only_missing,
-                force=force,
-                defer_commit=(not commit_each),
-                quiet=quiet and not verbose,
-                clear=clear)
+        for pkg_id, total, indexed, err in rebuild(package_id,
+                                                   only_missing=only_missing,
+                                                   force=force,
+                                                   defer_commit=(not commit_each),
+                                                   clear=clear):
+            if not verbose:
+                if err:
+                    click.echo('Failed to index dataset %s with error: %s' %
+                               (pkg_id, err))
+                continue
+            if not err:
+                click.echo('[%s/%s] Indexed dataset %s' % (indexed, total, pkg_id))
+            else:
+                click.echo('[%s/%s] Failed to index dataset %s with error: %s' %
+                           (indexed, total, pkg_id, err))
     except logic.NotFound:
         error_shout("Couldn't find package %s" % package_id)
     except Exception as e:

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -326,7 +326,7 @@ groups:
         default: 31_536_000 # 1 year
         description: |
           If :ref:`SESSION_PERMANENT` is enabled, the session’s expiration will be
-          set this number of seconds in the future. Note that you can not set a 
+          set this number of seconds in the future. Note that you can not set a
           session that never expires (only very far into the future).
 
       - key: SESSION_USE_SIGNER
@@ -911,6 +911,20 @@ groups:
         description: >-
           Controls whether the default search page (``/dataset``) should different
           sorting parameter by default when the request does not specify sort.
+
+      - key: ckan.search.reindex_after_group_or_org_update
+        default: False
+        type: bool
+        example: True
+        description: >
+          Controls whether to enqueue a background job after changing a Group's or
+          Organization's title or name.
+
+      - key: ckan.search.rebuild_queue_name
+        type: str
+        default: search_rebuild
+        example: reindex_packages
+        description: Name of the REDIS queue for reindexing jobs.
 
       - key: search.facets
         type: list

--- a/ckan/lib/plugins.py
+++ b/ckan/lib/plugins.py
@@ -488,6 +488,13 @@ class DefaultGroupForm(object):
         """
         return 'group/bulk_process.html'
 
+    def search_rebuild_template(self) -> str:
+        """
+        Returns a string representing the location of the template to be
+        rendered for the search_rebuild page
+        """
+        return 'group/search_rebuild.html'
+
     def group_form(self) -> str:
         return 'group/new_group_form.html'
 
@@ -602,6 +609,13 @@ class DefaultOrganizationForm(DefaultGroupForm):
 
     def activity_template(self) -> str:
         return 'organization/activity_stream.html'
+
+    def search_rebuild_template(self) -> str:
+        """
+        Returns a string representing the location of the template to be
+        rendered for the search_rebuild page
+        """
+        return 'organization/search_rebuild.html'
 
 
 class DefaultTranslation(object):

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -7,6 +7,8 @@ import sys
 import cgitb
 import warnings
 import traceback
+import json
+import datetime
 
 import xml.dom.minidom
 from typing import Collection, Any, Optional, Type, overload
@@ -183,7 +185,6 @@ def rebuild(package_id: Optional[str] = None,
             force: bool = False,
             defer_commit: bool = False,
             package_ids: Optional[Collection[str]] = None,
-            quiet: bool = False,
             clear: bool = False):
     '''
         Rebuilds the search index.
@@ -210,12 +211,15 @@ def rebuild(package_id: Optional[str] = None,
         log.info('Indexing just package %r...', pkg_dict['name'])
         package_index.remove_dict(pkg_dict)
         package_index.insert_dict(pkg_dict)
+        yield package_id, 1, 1, None
     elif package_ids is not None:
-        for package_id in package_ids:
+        total_packages = len(package_ids)
+        for counter, package_id in enumerate(package_ids, 1):
             pkg_dict = logic.get_action('package_show')(context,
                 {'id': package_id})
             log.info('Indexing just package %r...', pkg_dict['name'])
             package_index.update_dict(pkg_dict, True)
+            yield package_id, total_packages, counter, None
     else:
         packages = model.Session.query(model.Package.id)
         if config.get('ckan.search.remove_deleted_packages'):
@@ -241,13 +245,7 @@ def rebuild(package_id: Optional[str] = None,
                 package_index.clear()
 
         total_packages = len(package_ids)
-        for counter, pkg_id in enumerate(package_ids):
-            if not quiet:
-                sys.stdout.write(
-                    "\rIndexing dataset {0}/{1}".format(
-                        counter +1, total_packages)
-                )
-                sys.stdout.flush()
+        for counter, pkg_id in enumerate(package_ids, 1):
             try:
                 package_index.update_dict(
                     logic.get_action('package_show')(context,
@@ -255,9 +253,11 @@ def rebuild(package_id: Optional[str] = None,
                     ),
                     defer_commit
                 )
+                yield pkg_id, total_packages, counter, None
             except Exception as e:
                 log.error(u'Error while indexing dataset %s: %s' %
                           (pkg_id, repr(e)))
+                yield pkg_id, total_packages, counter, str(e)
                 if force:
                     log.error(text_traceback())
                     continue

--- a/ckan/lib/search/jobs.py
+++ b/ckan/lib/search/jobs.py
@@ -1,0 +1,94 @@
+# encoding: utf-8
+import json
+import datetime
+from rq import get_current_job
+
+from typing import Optional, Union
+
+import ckan.logic as logic
+import ckan.lib.search as search
+import ckan.model as model
+
+from ckan.plugins import toolkit
+
+from logging import getLogger
+log = getLogger(__name__)
+
+
+def reindex_packages(package_ids: Optional[Union[list, None]] = None,
+                     group_id: Optional[Union[str, None]] = None):
+    """
+    Callback for a REDIS job
+
+    Uses task_status to track the state of a search.rebuild call.
+
+    This always commits each record in a forceful manner.
+
+    See ckan.lib.search.rebuild for more information.
+
+    :param package_ids: list of package IDs to pass to search.rebuild
+    :type package_ids: list
+
+    :param group_id: organization or group ID to reindex the records
+    :type group_id: string
+    """
+    context = {
+        'model': model,
+        'ignore_auth': True,
+        'validate': False,
+        'use_cache': False
+    }
+
+    _entity_id = group_id if group_id else toolkit.config.get('ckan.site_id')
+    task = {
+        'entity_id': _entity_id,
+        'entity_type': 'group' if group_id else 'site',
+        'task_type': 'reindex_packages',
+        'last_updated': str(datetime.datetime.now(datetime.timezone.utc)),
+        'state': 'running',
+        'key': 'search_rebuild',
+        'value': '{}',
+        'error': '{}',
+    }
+
+    try:
+        task = logic.get_action('task_status_show')(
+                    context, {'entity_id': _entity_id,
+                              'task_type': 'reindex_packages',
+                              'key': 'search_rebuild'})
+        task['state'] = 'running'
+        task['last_updated'] = str(datetime.datetime.now(datetime.timezone.utc))
+        logic.get_action('task_status_update')({
+            'session': model.meta.create_local_session(), 'ignore_auth': True},
+            task)
+    except logic.NotFound:
+        pass
+
+    value = json.loads(task.get('value', '{}'))
+    error = json.loads(task.get('error', '{}'))
+
+    value['job_id'] = get_current_job().id
+
+    for pkg_id, total, indexed, err in \
+        search.rebuild(force=True, package_ids=package_ids):
+
+        if not err:
+            log.info('[%s/%s] Indexed dataset %s' % (indexed, total, pkg_id))
+        else:
+            log.error('[%s/%s] Failed to index dataset %s with error: %s' %
+                      (indexed, total, pkg_id, err))
+        value['indexed'] = indexed
+        value['total'] = total
+        if err:
+            error[pkg_id] = err
+        task['value'] = json.dumps(value)
+        task['last_updated'] = str(datetime.datetime.now(datetime.timezone.utc))
+        logic.get_action('task_status_update')(
+            {'session': model.meta.create_local_session(), 'ignore_auth': True},
+            task)
+
+    task['state'] = 'complete'
+    task['last_updated'] = str(datetime.datetime.now(datetime.timezone.utc))
+    logic.get_action('task_status_update')(
+        {'session': model.meta.create_local_session(), 'ignore_auth': True},
+        task)

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -2295,6 +2295,8 @@ def task_status_show(context: Context, data_dict: DataDict) -> ActionResult.Task
     model = context['model']
     id = data_dict.get('id')
 
+    _check_access('task_status_show', context, data_dict)
+
     if id:
         task_status = model.TaskStatus.get(id)
     else:
@@ -2312,7 +2314,6 @@ def task_status_show(context: Context, data_dict: DataDict) -> ActionResult.Task
     if task_status is None:
         raise NotFound
     context['task_status'] = task_status
-    _check_access('task_status_show', context, data_dict)
 
     task_status_dict = model_dictize.task_status_dictize(task_status, context)
     return task_status_dict

--- a/ckan/logic/auth/update.py
+++ b/ckan/logic/auth/update.py
@@ -152,6 +152,28 @@ def organization_update(context: Context, data_dict: DataDict) -> AuthResult:
         return {'success': True}
 
 
+def reindex_organization_datasets(context: Context,
+                                  data_dict: DataDict) -> AuthResult:
+    """
+    If you have permission to edit the Organization, you can reindex it.
+    """
+    return authz.is_authorized('organization_update', context, data_dict)
+
+
+def reindex_group_datasets(context: Context, data_dict: DataDict) -> AuthResult:
+    """
+    If you have permission to edit the Group, you can reindex it.
+    """
+    return authz.is_authorized('group_update', context, data_dict)
+
+
+def reindex_site(context: Context, data_dict: DataDict) -> AuthResult:
+    """
+    Only sysadmins can perform reindexing
+    """
+    return {'success': False}
+
+
 def group_change_state(context: Context, data_dict: DataDict) -> AuthResult:
     user = context['user']
     group = logic_auth.get_group_object(context, data_dict)

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -14796,3 +14796,15 @@ td.diff_header {
   gap: 0.5rem;
   align-items: center;
 }
+
+div[data-module="progress-bar"] .progress{
+  margin-bottom: 0;
+}
+div[data-module="progress-bar"] .progress-bar{
+  transition: none;
+}
+div[data-module="progress-bar"] .progress-bar-label{
+  display: block;
+  text-align: right;
+  margin-bottom: 23px;
+}

--- a/ckan/public/base/javascript/modules/progress-bar.js
+++ b/ckan/public/base/javascript/modules/progress-bar.js
@@ -1,0 +1,84 @@
+this.ckan.module('progress-bar', function ($) {
+  return {
+    options: {
+      endpoint: '',
+      percentage: false,
+    },
+
+    initialize: function () {
+      let options = this.options;
+      let el = this.el;
+
+      if( options.endpoint.length > 0 ){
+
+        $(el).append('<div class="progress"><div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div></div><small class="progress-bar-label"></small>');
+        let progressBar = $(el).find('.progress-bar');
+        let progressBarLabel = $(el).find('.progress-bar-label');
+
+        function update_bar(_total, _current, _label, _timestamp){
+          let label = '';
+          if( _label.length > 0 ){
+            label = _label;
+            if( _timestamp.length > 0 ){
+              label += ' (' + _timestamp + ')';
+            }
+          }else if( _timestamp.length > 0 ){
+            label = _timestamp;
+          }
+          if( label.length > 0 ){
+            $(progressBarLabel).text(label);
+          }
+          if( ! _total || ! _current ){
+            return
+          }
+          let val = (_total / _current) * 100;
+          if( _total != _current ){
+            $(progressBar).animate({'width': val + '%'}, 635);
+          }else{
+            $(progressBar).css({'width': val + '%'});
+          }
+          if( options.percentage != false ){
+            $(progressBar).text(val + '%');
+            $(progressBar).attr('aria-valuenow', val);
+          }else{
+            $(progressBar).text(_current + '/' + _total);
+            $(progressBar).attr('aria-valuemax', _total);
+            $(progressBar).attr('aria-valuenow', _current);
+          }
+        }
+
+        function heartbeat(){
+          $.ajax({
+            'url': options.endpoint,
+            'type': 'GET',
+            'dataType': 'JSON',
+            'complete': function(_data){
+              if( _data.responseJSON ){  // we have response JSON
+                // label should be optional
+                _label = '';
+                if( typeof _data.responseJSON.label != 'undefined' ){
+                  _label = _data.responseJSON.label
+                }
+                // last updated should be optional
+                _timestamp = '';
+                if( typeof _data.responseJSON.last_updated != 'undefined' ){
+                  _timestamp = _data.responseJSON.last_updated
+                }
+                update_bar(_data.responseJSON.total, _data.responseJSON.current, _label, _timestamp);
+                if( _data.responseJSON.total != _data.responseJSON.current){
+                  setTimeout(heartbeat, 5000);
+                }
+              }else{  // fully flopped ajax request
+                // just try again...
+                setTimeout(heartbeat, 5000);
+              }
+            }
+          });
+        }
+
+        heartbeat();
+
+      }
+    }
+  };
+});

--- a/ckan/public/base/javascript/webassets.yml
+++ b/ckan/public/base/javascript/webassets.yml
@@ -54,6 +54,7 @@ ckan:
     - modules/image-upload.js
     - modules/metadata-button.js
     - modules/copy-into-buffer.js
+    - modules/progress-bar.js
 
 view-filters:
   output: base/%(version)s_view-filters.js

--- a/ckan/templates/admin/base.html
+++ b/ckan/templates/admin/base.html
@@ -8,4 +8,5 @@
   {{ h.build_nav_icon('admin.index', _('Sysadmins'), icon='gavel') }}
   {{ h.build_nav_icon('admin.config', _('Config'), icon='gear') }}
   {{ h.build_nav_icon('admin.trash', _('Trash'), icon='trash') }}
+  {{ h.build_nav_icon('admin.search_rebuild', _('Rebuild Search Index'), icon='database') }}
 {% endblock %}

--- a/ckan/templates/admin/search_rebuild.html
+++ b/ckan/templates/admin/search_rebuild.html
@@ -1,0 +1,37 @@
+{% extends "admin/base.html" %}
+
+{% block subtitle %}{{ _("Rebuild Search Index") }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
+
+{% block primary_content_inner %}
+  {% if job_info %}
+    <div class="row">
+      <div class="col-md-12">
+        <div data-module="progress-bar" data-module-endpoint="{{ h.url_for('util.search_rebuild_progress', entity_id=site_id) }}"></div>
+      </div>
+    </div>
+    <hr />
+  {% endif %}
+  <form method="post">
+    {{ h.csrf_input() }}
+    <button class="btn btn-primary" name="reindex" type="submit" data-module="confirm-action" data-module-with-data="true" data-module-content="{{ _('Are you sure you want to re-index all the records for this site? This can take a long time if the site has a lot of records.') }}">
+      {% block form_submit_text %}{{ _('Re-index Site\'s Records') }}{% endblock %}
+    </button>
+  </form>
+{% endblock %}
+
+{% block secondary_content %}
+  {{ super() }}
+  {% block secondary_help %}
+    <div class="module module-narrow module-shallow">
+      <h2 class="module-heading">
+        <i class="fa fa-lg fa-info-circle"></i>
+        {{ _('Why re-index?') }}
+      </h2>
+      <div class="module-content">
+        {% trans %}
+          <p>The SOLR index is used for searching datasets and search facets. In the case that some datasets are not showing in the search or a search facet is not working, you can try to re-index the site.</p>
+        {% endtrans %}
+      </div>
+    </div>
+  {% endblock %}
+{% endblock %}

--- a/ckan/templates/group/edit_base.html
+++ b/ckan/templates/group/edit_base.html
@@ -12,6 +12,9 @@
 {% block content_primary_nav %}
   {{ h.build_nav_icon(group_type + '.edit', _('Edit'), id=group_dict.name, icon='pencil') }}
   {{ h.build_nav_icon(group_type + '.manage_members', _('Members'), id=group_dict.name, icon='users') }}
+  {% if group_dict and h.check_access('reindex_group_datasets', {'id': group_dict.id}) %}
+    {{ h.build_nav_icon(group_type + '.search_rebuild', _('Rebuild Search Index'), id=group_dict.name, icon='database') }}
+  {% endif %}
 {% endblock %}
 
 {% block secondary_content %}

--- a/ckan/templates/group/search_rebuild.html
+++ b/ckan/templates/group/search_rebuild.html
@@ -1,0 +1,40 @@
+{% extends "group/edit_base.html" %}
+
+{% block subtitle %}{{ _('Rebuild Search Index') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
+
+{% block primary_content_inner %}
+  {% if job_info %}
+    <div class="row">
+      <div class="col-md-12">
+        <div data-module="progress-bar" data-module-endpoint="{{ h.url_for('util.search_rebuild_progress', entity_id=group_dict.get('id')) }}"></div>
+      </div>
+    </div>
+    <hr />
+  {% endif %}
+  <form method="post">
+    {{ h.csrf_input() }}
+    <button class="btn btn-primary" name="reindex" type="submit" data-module="confirm-action" data-module-with-data="true" data-module-content="{{ _('Are you sure you want to re-index all the records for this group? This can take a long time if the group has a lot of records.') }}">
+      {% block form_submit_text %}{{ _('Re-index Group\'s Records') }}{% endblock %}
+    </button>
+  </form>
+{% endblock %}
+
+{% block secondary_content %}
+  {{ super() }}
+  {% if not has_auto_index %}
+    {% block secondary_help %}
+      <div class="module module-narrow module-shallow">
+        <h2 class="module-heading">
+          <i class="fa fa-lg fa-info-circle"></i>
+          {{ _('Why re-index?') }}
+        </h2>
+        <div class="module-content">
+          {% trans %}
+            <p>If you update an Group's <strong>title</strong> or <strong>name,</strong> it's datasets in the SOLR Index will not have the new title or name.</p>
+            <p>To solve this, you can re-index all of the Group's records in a background job.</p>
+          {% endtrans %}
+        </div>
+      </div>
+    {% endblock %}
+  {% endif %}
+{% endblock %}

--- a/ckan/templates/organization/edit_base.html
+++ b/ckan/templates/organization/edit_base.html
@@ -14,6 +14,9 @@
     {{ h.build_nav_icon(group_type + '.edit', _('Edit'), id=group_dict.name, icon='pencil') }}
     {{ h.build_nav_icon(group_type + '.bulk_process', h.humanize_entity_type('package', dataset_type, 'content tab') or _('Datasets'), id=group_dict.name, icon='sitemap') }}
     {{ h.build_nav_icon(group_type + '.manage_members', _('Members'), id=group_dict.name, icon='users') }}
+    {% if organization and h.check_access('reindex_organization_datasets', {'id': organization.id}) %}
+      {{ h.build_nav_icon(group_type + '.search_rebuild', _('Rebuild Search Index'), id=group_dict.name, icon='database') }}
+    {% endif %}
 {% endblock %}
 
 {% block secondary_content %}

--- a/ckan/templates/organization/search_rebuild.html
+++ b/ckan/templates/organization/search_rebuild.html
@@ -1,0 +1,40 @@
+{% extends "organization/edit_base.html" %}
+
+{% block subtitle %}{{ _('Rebuild Search Index') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
+
+{% block primary_content_inner %}
+  {% if job_info %}
+    <div class="row">
+      <div class="col-md-12">
+        <div data-module="progress-bar" data-module-endpoint="{{ h.url_for('util.search_rebuild_progress', entity_id=group_dict.get('id')) }}"></div>
+      </div>
+    </div>
+    <hr />
+  {% endif %}
+  <form method="post">
+    {{ h.csrf_input() }}
+    <button class="btn btn-primary" name="reindex" type="submit" data-module="confirm-action" data-module-with-data="true" data-module-content="{{ _('Are you sure you want to re-index all the records for this organization? This can take a long time if the organization has a lot of records.') }}">
+      {% block form_submit_text %}{{ _('Re-index Organization\'s Records') }}{% endblock %}
+    </button>
+  </form>
+{% endblock %}
+
+{% block secondary_content %}
+  {{ super() }}
+  {% if not has_auto_index %}
+    {% block secondary_help %}
+      <div class="module module-narrow module-shallow">
+        <h2 class="module-heading">
+          <i class="fa fa-lg fa-info-circle"></i>
+          {{ _('Why re-index?') }}
+        </h2>
+        <div class="module-content">
+          {% trans %}
+            <p>If you update an Organization's <strong>title</strong> or <strong>name,</strong> it's datasets in the SOLR Index will not have the new title or name.</p>
+            <p>To solve this, you can re-index all of the Organization's records in a background job.</p>
+          {% endtrans %}
+        </div>
+      </div>
+    {% endblock %}
+  {% endif %}
+{% endblock %}

--- a/ckan/views/admin.py
+++ b/ckan/views/admin.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any, Union, List
+import json
 
 from flask import Blueprint
 from flask.views import MethodView
@@ -14,6 +15,7 @@ from ckan.lib.helpers import helper_functions as h
 import ckan.lib.navl.dictization_functions as dict_fns
 import ckan.logic as logic
 import ckan.model as model
+import ckan.plugins as plugins
 import ckan.logic.schema
 from ckan.common import _, config, request, current_user
 from ckan.views.home import CACHE_PARAMETERS
@@ -244,6 +246,47 @@ class TrashView(MethodView):
         return actions[ent_type]
 
 
+def search_rebuild():
+    context = {
+        'model': model,
+        'session': model.Session,
+        'user': plugins.toolkit.g.user,
+        'for_view': True,
+    }
+
+    try:
+        plugins.toolkit.check_access('reindex_site', context)
+    except logic.NotAuthorized:
+        return base.abort(403, _('Not authorized to see this page'))
+
+    if request.method == 'POST':
+        try:
+            job_dict = plugins.toolkit.get_action(
+                'site_packages_background_reindex')(context, {})
+            if job_dict:
+                h.flash_success(_('Records are in queue to be re-indexed.'))
+            else:
+                h.flash_notice(_('Records already in queue to be re-indexed.'))
+        except logic.NotAuthorized:
+            h.flash_error(_('Unable to re-index records.'))
+
+    task = None
+    try:
+        _entity_id = plugins.toolkit.config.get('ckan.site_id')
+        task = plugins.toolkit.get_action('task_status_show')(
+                    context, {'entity_id': _entity_id,
+                              'task_type': 'reindex_packages',
+                              'key': 'search_rebuild'})
+        task['value'] = json.loads(task.get('value', '{}'))
+    except logic.NotFound:
+        pass
+
+    extra_vars = {'job_info': task,
+                  'site_id': _entity_id}
+
+    return base.render('admin/search_rebuild.html', extra_vars)
+
+
 admin.add_url_rule(
     u'/', view_func=index, methods=['GET'], strict_slashes=False
 )
@@ -251,3 +294,5 @@ admin.add_url_rule(u'/reset_config',
                    view_func=ResetConfigView.as_view(str(u'reset_config')))
 admin.add_url_rule(u'/config', view_func=ConfigView.as_view(str(u'config')))
 admin.add_url_rule(u'/trash', view_func=TrashView.as_view(str(u'trash')))
+admin.add_url_rule('/search_rebuild', view_func=search_rebuild,
+                   methods=['GET', 'POST'])

--- a/ckan/views/util.py
+++ b/ckan/views/util.py
@@ -1,11 +1,16 @@
 # encoding: utf-8
 
 from flask import Blueprint
+import json
 
 import ckan.lib.base as base
 from ckan.lib.helpers import helper_functions as h
 from ckan.common import _, request
 from ckan.types import Response
+from ckan.plugins import toolkit
+from ckan import model
+from ckan.views.api import _finish_ok, _finish
+
 
 util = Blueprint(u'util', __name__)
 
@@ -32,6 +37,47 @@ def primer() -> str:
     return base.render(u'development/primer.html')
 
 
+def search_rebuild_progress(entity_id: str):
+    context = {
+        'model': model,
+        'session': model.Session,
+        'user': toolkit.g.user,
+    }
+
+    try:
+        task_status = toolkit.get_action('task_status_show')(
+                            context, {'entity_id': entity_id,
+                                      'task_type': 'reindex_packages',
+                                      'key': 'search_rebuild'})
+    except toolkit.NotAuthorized:
+        return _finish(403, _('Not authorized to view task status'), 'json')
+    except toolkit.ObjectNotFound:
+        return _finish(404, _('Task not found'), 'json')
+
+    task_status['value'] = json.loads(task_status.get('value', '{}'))
+    task_status['error'] = json.loads(task_status.get('error', '{}'))
+
+    messages = {
+        'pending': _('In queue to re-index records'),
+        'running': _('Currently re-indexing records'),
+        'complete': _('All records indexed'),
+        'unknown': _('Unknown'),
+    }
+
+    return_dict = {
+        'total': task_status.get('value', {}).get('total', 0),
+        'current': task_status.get('value', {}).get('indexed', 0),
+        'label': messages.get(task_status.get('state', 'unknown')),
+        'last_updated': h.render_datetime(
+            task_status.get('last_updated'), '%Y-%m-%d %H:%M:%S %Z')
+            if task_status.get('last_updated') else None,
+    }
+
+    return _finish_ok(return_dict)
+
+
 util.add_url_rule(
     u'/util/redirect', view_func=internal_redirect, methods=(u'GET', u'POST',))
 util.add_url_rule(u'/testing/primer', view_func=primer)
+util.add_url_rule('/util/search_rebuild_progress/<entity_id>',
+                  view_func=search_rebuild_progress, methods=['GET'])


### PR DESCRIPTION
Related issues:

- https://github.com/ckan/ckan/issues/7722
- https://github.com/ckan/ckan/issues/5842

Fixes #

### Proposed fixes:

After updating a group or organization, any datasets that are in the SOLR index will not get the new title or name until a reindex of the package.

This adds in a background job if the org or group title or name change, to reindex all of the records in that org or group. It also adds in some views for admins to enqueue these background jobs, and shows the progress with a new progress bar module.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
