### PR TITLE
Add missing "public" folder to extension package

### DIFF
--- a/changes/8565.bugfix
+++ b/changes/8565.bugfix
@@ -1,0 +1,1 @@
+Add missing public files

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/MANIFEST.in
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/MANIFEST.in
@@ -3,3 +3,4 @@ include LICENSE
 include requirements.txt
 recursive-include ckanext/{{ cookiecutter.project_shortname }} *.html *.json *.js *.less *.css *.mo *.yml
 recursive-include ckanext/{{ cookiecutter.project_shortname }}/migration *.ini *.py *.mako
+recursive-include ckanext/{{ cookiecutter.project_shortname }}/public *.*


### PR DESCRIPTION
### Proposed fixes:

We need to ensure we add the `public` folder to the extension package

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
