### PR TITLE
faster datastore_info: include_meta, include_fields_schema parameters

### DIFF
--- a/changes/8589.feature
+++ b/changes/8589.feature
@@ -1,0 +1,3 @@
+datastore_info: new include_meta and include_fields_schema parameters that
+may be set to False to avoid computing table size, index size, row count,
+aliases or per-field index, unique, notnull status

--- a/ckanext/datastore/backend/__init__.py
+++ b/ckanext/datastore/backend/__init__.py
@@ -189,7 +189,9 @@ class DatastoreBackend:
         """
         raise NotImplementedError()
 
-    def resource_fields(self, id: str) -> Any:
+    def resource_fields(
+            self, id: str, include_meta: bool = True,
+            include_fields_schema: bool = True) -> Any:
         """Return dictonary with resource description.
 
         Called by `datastore_info`.

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -2227,15 +2227,16 @@ class DatastorePostgresqlBackend(DatastoreBackend):
             plugin_data, _old = _get_raw_field_info(conn, id)
             return plugin_data
 
-    def resource_fields(self, id: str) -> dict[str, Any]:
+    def resource_fields(
+            self, id: str, include_meta: bool = True,
+            include_fields_schema: bool = True) -> dict[str, Any]:
 
-        info: dict[str, Any] = {'meta': {}, 'fields': []}
+        info: dict[str, Any] = {'fields': []}
+        engine = self._get_read_engine()
 
-        try:
-            engine = self._get_read_engine()
-
+        if include_meta:
             # resource id for deferencing aliases
-            info['meta']['id'] = id
+            info['meta'] = {'id': id}
 
             # count of rows in table
             meta_sql = sa.text(
@@ -2292,19 +2293,23 @@ class DatastorePostgresqlBackend(DatastoreBackend):
             ''')
             with engine.connect() as conn:
                 alias_results = conn.execute(alias_sql)
-            aliases = []
+            aliases: list[str] = []
             for alias in alias_results.fetchall():
                 aliases.append(alias[0])
             info['meta']['aliases'] = aliases
 
-            # get the data dictionary for the resource
-            with engine.connect() as conn:
-                data_dictionary = _result_fields(
-                    _get_fields_types(conn, id),
-                    _get_field_info(conn, id),
-                    None
-                )
+        # get the data dictionary for the resource
+        with engine.connect() as conn:
+            data_dictionary = _result_fields(
+                _get_fields_types(conn, id),
+                _get_field_info(conn, id),
+                None
+            )
+        info['fields'] = [
+            f for f in data_dictionary if not f['id'].startswith('_')
+        ]
 
+        if include_fields_schema:
             schema_sql = sa.text(f'''
                 SELECT
                 f.attname AS column_name,
@@ -2352,10 +2357,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
                 if field['id'].startswith('_'):
                     continue
                 field.update({'schema': schemainfo[field['id']]})
-                info['fields'].append(field)
 
-        except Exception:
-            pass
         return info
 
     def get_all_ids(self) -> list[str]:

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -2236,7 +2236,8 @@ class DatastorePostgresqlBackend(DatastoreBackend):
 
         if include_meta:
             # resource id for deferencing aliases
-            info['meta'] = {'id': id}
+            meta: dict[str, Any] = {'id': id}
+            info['meta'] = meta
 
             # count of rows in table
             meta_sql = sa.text(

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -139,7 +139,11 @@ class DictionaryView(MethodView):
             # resource_edit_base template uses these
             pkg_dict = get_action(u'package_show')({}, {'id': id})
             resource = get_action(u'resource_show')({}, {'id': resource_id})
-            rec = get_action(u'datastore_info')({}, {'id': resource_id})
+            rec = get_action(u'datastore_info')({}, {
+                'id': resource_id,
+                'include_meta': False,
+                'include_fields_schema': False,
+            })
             return {
                 u'pkg_dict': pkg_dict,
                 u'resource': resource,

--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -217,8 +217,11 @@ def datastore_dictionary(
     """
     try:
         return [
-            f for f in tk.get_action('datastore_info')(
-                {}, {'id': resource_id})['fields']
+            f for f in tk.get_action('datastore_info')({}, {
+                'id': resource_id,
+                'include_meta': False,
+                'include_fields_schema': False,
+            })['fields']
             if not f['id'].startswith(u'_') and (
                 include_columns is None or f['id'] in include_columns)
             ]

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -385,6 +385,8 @@ def datastore_info(context: Context, data_dict: dict[str, Any]
     backend = DatastoreBackend.get_active_backend()
     schema = dsschema.datastore_info_schema()
     data_dict, errors = _validate(data_dict, schema, context)
+    if errors:
+        raise p.toolkit.ValidationError(errors)
 
     resource_id = data_dict['id']
     res_exists = backend.resource_exists(resource_id)

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -352,6 +352,10 @@ def datastore_info(context: Context, data_dict: dict[str, Any]
 
     :param resource_id: id or alias of the resource we want info about.
     :type resource_id: string
+    :param include_meta: return table size, index size, row count and aliases
+    :type include_meta: bool (optional, default: True)
+    :param include_fields_schema: return fields' index, unique, notnull status
+    :type include_fields_schema: bool (optional, default: True)
 
     **Results:**
 
@@ -379,8 +383,10 @@ def datastore_info(context: Context, data_dict: dict[str, Any]
 
     '''
     backend = DatastoreBackend.get_active_backend()
+    schema = dsschema.datastore_info_schema()
+    data_dict, errors = _validate(data_dict, schema, context)
 
-    resource_id = _get_or_bust(data_dict, 'id')
+    resource_id = data_dict['id']
     res_exists = backend.resource_exists(resource_id)
     if not res_exists:
         alias_exists, real_id = backend.resource_id_from_alias(resource_id)
@@ -398,7 +404,8 @@ def datastore_info(context: Context, data_dict: dict[str, Any]
 
     p.toolkit.get_action('resource_show')(context, {'id': id})
 
-    info = backend.resource_fields(id)
+    info = backend.resource_fields(
+        id, data_dict['include_meta'], data_dict['include_fields_schema'])
 
     try:
         plugin_data = backend.resource_plugin_data(id)

--- a/ckanext/datastore/logic/schema.py
+++ b/ckanext/datastore/logic/schema.py
@@ -241,3 +241,11 @@ def datastore_analyze_schema() -> Schema:
     return {
         'resource_id': [unicode_safe, resource_id_exists],
     }
+
+
+def datastore_info_schema() -> Schema:
+    return {
+        'id': [unicode_only, not_empty],
+        'include_meta': [default(True), boolean_validator],
+        'include_fields_schema': [default(True), boolean_validator],
+    }

--- a/ckanext/datastore/tests/test_info.py
+++ b/ckanext/datastore/tests/test_info.py
@@ -51,6 +51,13 @@ def test_info_success():
     assert info["meta"]["count"] == 2
     assert info["meta"]["id"] == resource["id"]
 
+    info = helpers.call_action(
+        "datastore_info", id=resource["id"],
+        include_meta=False, include_fields_schema=False)
+
+    assert 'meta' not in info
+    assert not any('schema' in f for f in info['fields'])
+
 
 @pytest.mark.ckan_config("ckan.plugins", "datastore")
 @pytest.mark.usefixtures("clean_datastore", "with_plugins")

--- a/ckanext/tabledesigner/views.py
+++ b/ckanext/tabledesigner/views.py
@@ -135,7 +135,11 @@ class _TableDesignerAddRow(MethodView):
         except ValidationError as err:
             rec_err = cast(List[str], err.error_dict.get('records', ['']))[0]
             if rec_err.startswith('duplicate key'):
-                info = get_action('datastore_info')({}, {'id': resource_id})
+                info = get_action('datastore_info')({}, {
+                    'id': resource_id,
+                    'include_meta': False,
+                    'include_fields_schema': False,
+                })
                 pk_fields = [
                     f['id'] for f in info['fields']
                     if f.get('tdpkreq') == 'pk'
@@ -217,7 +221,11 @@ class _TableDesignerEditRow(MethodView):
         except ValidationError as err:
             rec_err = cast(List[str], err.error_dict.get('records', ['']))[0]
             if rec_err.startswith('duplicate key'):
-                info = get_action('datastore_info')({}, {'id': resource_id})
+                info = get_action('datastore_info')({}, {
+                    'id': resource_id,
+                    'include_meta': False,
+                    'include_fields_schema': False,
+                })
                 pk_fields = [
                     f['id'] for f in info['fields']
                     if f.get('tdpkreq') == 'pk'


### PR DESCRIPTION
Fixes #8589 

### Proposed fixes:
Add new datastore_info parameters:
- include_meta
- include_fields_schema

both default to True for backwards compatibility, but when set to False those sections of the datastore_info response will be left out. For a datastore table with ~11M rows this drops run time from 1.71s to 0.07s, and can be applied everywhere the API is used internally to improve page render times.

### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport