### PR TITLE
datatables: skip extra draw calls on load

### DIFF
--- a/ckanext/datatablesview/assets/datatablesview.js
+++ b/ckanext/datatablesview/assets/datatablesview.js
@@ -114,7 +114,6 @@ function fitColText () {
   if (gcurrentView === 'list') {
     dt.responsive.recalc()
   }
-  dt.columns.adjust().draw(false)
 }
 
 // ensure element id is valid
@@ -576,7 +575,6 @@ this.ckan.module('datatables_view', function (jQuery) {
               }
             }
           })
-          api.draw(false)
         }, // end stateLoadParams
         stateSaveParams: function (settings, data) {
           // this callback is invoked when saving state info


### PR DESCRIPTION
Fixes #8595

### Proposed fixes:
Skip extra second and third draw call on page load to cut time waiting for duplicated ajax responses.

Was ~17s for view of 11M row table, now ~9s

![less-slow-datatables](https://github.com/user-attachments/assets/4a813e88-24fa-4bee-bffa-d40b83ce97aa)

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport
