### PR TITLE
Update tag-name-validation to less restrictive tag handling

### DIFF
--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -9,6 +9,7 @@ import mimetypes
 import string
 import json
 import uuid
+import unicodedata
 from typing import Any, Container, Optional, Union
 from urllib.parse import urlparse
 
@@ -512,13 +513,41 @@ def tag_length_validator(value: Any, context: Context) -> Any:
     return value
 
 def tag_name_validator(value: Any, context: Context) -> Any:
-    """Ensures that tag does not contain wrong characters
     """
-    tagname_match = re.compile(r'[\w \-.]*$', re.UNICODE)
-    if not tagname_match.match(value):
-        raise Invalid(_('Tag "%s" can only contain alphanumeric '
-                        'characters, spaces (" "), hyphens ("-"), '
-                        'underscores ("_") or dots (".")') % (value))
+    Accept
+    - unicode graphical (printable) characters
+    - single internal spaces (no double-spaces)
+
+    Reject
+    - commas
+    - tags that are too short or too long
+
+    Strip
+    - spaces at beginning and end
+    """
+    value = value.strip()
+
+    if u',' in value:
+        raise Invalid(_(u'Tag "%s" may not contain commas') % (value,))
+    
+    if u'  ' in value:
+        raise Invalid(
+            _(u'Tag "%s" may not contain consecutive spaces') % (value,))
+
+    caution = re.sub(r'[\w ]*', u'', value)
+
+    for ch in caution:
+        category = unicodedata.category(ch)
+        
+        if category.startswith('C'):
+            raise Invalid(
+                _(u'Tag "%s" may not contain unprintable character U+%04x')
+                % (value, ord(ch)))
+        if category.startswith('Z'):
+            raise Invalid(
+                _(u'Tag "%s" may not contain separator charater U+%04x')
+                % (value, ord(ch)))
+
     return value
 
 def tag_not_uppercase(value: Any, context: Context) -> Any:

--- a/ckan/tests/logic/test_validators.py
+++ b/ckan/tests/logic/test_validators.py
@@ -910,6 +910,12 @@ def test_tag_string_convert():
     assert convert("trailing comma,") == ["trailing comma"]
     assert convert("trailing comma space, ") == ["trailing comma space"]
 
+    # test non alphanumeric character
+    assert convert("1:5000") == ["1:5000"]
+    
+    # expect error when comma in string
+    raises_invalid(validators.tag_name_validator)("1,2", {})
+
 
 def test_url_validator():
     key = ("url",)


### PR DESCRIPTION
Update validation to allow more special chars (e.g. punctuation) Add test cases for valid and invalid tags

As discussed in https://github.com/ckan/ckan/issues/2780#issuecomment-225540769 and suggested in
https://github.com/open-data/ckanext-canada/blob/wet4-scheming/ckanext/canada/validators.py#L52-L92
this commit applies the validation for tag names and extends the tests for the new cases.

This was motivated by the possibility to add scales ("1:5000") of spatial datasets as tags.

Fixes #

### Proposed fixes:



### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
