### PR TITLE
feat: allow plugins to set user ID

### DIFF
--- a/changes/8609.feature
+++ b/changes/8609.feature
@@ -1,0 +1,1 @@
+Allows plugins to set the user ID during user creation, by passing ``ignore_auth: True`` in the ``user_create()`` context.

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -969,7 +969,8 @@ def user_create(context: Context,
     author_obj = model.User.get(context.get('user'))
     if data_dict.get("id"):
         is_sysadmin = (author_obj and author_obj.sysadmin)
-        if not is_sysadmin or model.User.get(data_dict["id"]):
+        ignore_auth = context.get('ignore_auth')
+        if not (ignore_auth or is_sysadmin) or model.User.get(data_dict["id"]):
             data_dict.pop("id", None)
     context.pop("user_obj", None)
 

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -2114,6 +2114,21 @@ class TestUserPluginExtras(object):
         )
 
         assert user["plugin_extras"] is None
+    
+    def test_extensions_can_provide_custom_id(self):
+        
+        stub = factories.User.stub()
+        context = {"user": None, "ignore_auth": True}
+        _id = str(uuid.uuid4())
+        user_dict = {
+            "id": _id,
+            "name": stub.name,
+            "email": stub.email,
+            "password": "12345678",
+        }
+        created_user = helpers.call_action("user_create", context=context, **user_dict)
+
+        assert created_user["id"] == _id
 
 
 @pytest.mark.usefixtures("non_clean_db")


### PR DESCRIPTION
This pull request introduces changes that allow plugins to access and synchronize the sub (the internal unique user ID of Keycloak) as user id. The sub remains unchanged even if other user attributes, such as the email address, are modified. This functionality was already present in the [validator](https://github.com/ckan/ckan/blob/fd86be7f713947e0c4aeb9f793c14d4bca6aab86/ckan/logic/validators.py#L593C5-L595C15) but was previously inaccessible via plugins or external mechanisms. This change ensures that plugins can now work with and set the sub to maintain stable user identification regardless of email changes.