### PR TITLE
Replace btn default

### DIFF
--- a/ckan/public-midnight-blue/base/css/main-rtl.css
+++ b/ckan/public-midnight-blue/base/css/main-rtl.css
@@ -3077,7 +3077,7 @@ textarea.form-control-lg {
   --bs-btn-disabled-border-color: #d43f3a;
 }
 
-.btn-light, .btn-default {
+.btn-light, .btn-secondary {
   --bs-btn-color: #000;
   --bs-btn-bg: #fff;
   --bs-btn-border-color: #fff;
@@ -11843,10 +11843,10 @@ h6, .h6, h5, .h5, h4, .h4, h3, .h3, h2, .h2, h1, .h1 {
   font-weight: 600;
 }
 
-.btn-light, .btn-default {
+.btn-light, .btn-secondary {
   border: #d0d5dd solid 1px;
 }
-.btn-light:hover, .btn-default:hover {
+.btn-light:hover, .btn-secondary:hover {
   background-color: #d0d5dd !important;
   border-color: #d0d5dd;
 }
@@ -14870,7 +14870,7 @@ td.diff_header {
   }
 }
 @media (max-width: 767.98px) {
-  .login-main .btn-light, .login-main .btn-default {
+  .login-main .btn-light, .login-main .btn-secondary {
     width: 100%;
     display: block !important;
   }

--- a/ckan/public-midnight-blue/base/css/main.css
+++ b/ckan/public-midnight-blue/base/css/main.css
@@ -3077,7 +3077,7 @@ textarea.form-control-lg {
   --bs-btn-disabled-border-color: #d43f3a;
 }
 
-.btn-light, .btn-default {
+.btn-light, .btn-secondary {
   --bs-btn-color: #000;
   --bs-btn-bg: #fff;
   --bs-btn-border-color: #fff;
@@ -11843,10 +11843,10 @@ h6, .h6, h5, .h5, h4, .h4, h3, .h3, h2, .h2, h1, .h1 {
   font-weight: 600;
 }
 
-.btn-light, .btn-default {
+.btn-light, .btn-secondary {
   border: #d0d5dd solid 1px;
 }
-.btn-light:hover, .btn-default:hover {
+.btn-light:hover, .btn-secondary:hover {
   background-color: #d0d5dd !important;
   border-color: #d0d5dd;
 }
@@ -14870,7 +14870,7 @@ td.diff_header {
   }
 }
 @media (max-width: 767.98px) {
-  .login-main .btn-light, .login-main .btn-default {
+  .login-main .btn-light, .login-main .btn-secondary {
     width: 100%;
     display: block !important;
   }

--- a/ckan/public-midnight-blue/base/javascript/modules/confirm-action.js
+++ b/ckan/public-midnight-blue/base/javascript/modules/confirm-action.js
@@ -43,7 +43,7 @@ this.ckan.module('confirm-action', function (jQuery) {
         '</div>',
         '<div class="modal-body"></div>',
         '<div class="modal-footer">',
-        '<button class="btn btn-default btn-cancel"></button>',
+        '<button class="btn btn-secondary btn-cancel"></button>',
         '<button class="btn btn-primary"></button>',
         '</div>',
         '</div>',

--- a/ckan/public-midnight-blue/base/javascript/modules/image-upload.js
+++ b/ckan/public-midnight-blue/base/javascript/modules/image-upload.js
@@ -57,7 +57,7 @@ this.ckan.module('image-upload', function($) {
         .appendTo(this.el);
 
       // Button to set the field to be a URL
-      this.button_url = $('<a href="javascript:;" class="btn btn-default">' +
+      this.button_url = $('<a href="javascript:;" class="btn btn-secondary">' +
                           '<i class="fa fa-globe"></i>' +
                           this._('Link') + '</a>')
         .prop('title', this._('Link to a URL on the internet (you can also link to an API)'))
@@ -65,7 +65,7 @@ this.ckan.module('image-upload', function($) {
         .insertAfter(this.input);
 
       // Button to attach local file to the form
-      this.button_upload = $('<a href="javascript:;" class="btn btn-default">' +
+      this.button_upload = $('<a href="javascript:;" class="btn btn-secondary">' +
                              '<i class="fa fa-cloud-upload"></i>' +
                              this._('Upload') + '</a>')
         .insertAfter(this.input);

--- a/ckan/public-midnight-blue/base/javascript/modules/resource-reorder.js
+++ b/ckan/public-midnight-blue/base/javascript/modules/resource-reorder.js
@@ -10,7 +10,7 @@ this.ckan.module('resource-reorder', function($) {
       title: '<h1></h1>',
       help_text: '<p></p>',
       button: [
-        '<a href="javascript:;" class="btn btn-default">',
+        '<a href="javascript:;" class="btn btn-secondary">',
         '<i class="fa fa-bars"></i>',
         '<span></span>',
         '</a>'

--- a/ckan/public-midnight-blue/base/javascript/modules/resource-view-reorder.js
+++ b/ckan/public-midnight-blue/base/javascript/modules/resource-view-reorder.js
@@ -8,7 +8,7 @@ this.ckan.module('resource-view-reorder', function($) {
     template: {
       title: '<h1></h1>',
       button: [
-        '<a href="javascript:;" class="btn btn-default">',
+        '<a href="javascript:;" class="btn btn-secondary">',
         '<i class="fa fa-bars"></i>',
         '<span></span>',
         '</a>'

--- a/ckan/public-midnight-blue/base/javascript/plugins/jquery.slug-preview.js
+++ b/ckan/public-midnight-blue/base/javascript/plugins/jquery.slug-preview.js
@@ -70,7 +70,7 @@
       '<div class="slug-preview">',
       '<strong></strong>',
       '<span class="slug-preview-prefix"></span><span class="slug-preview-value"></span>',
-      '<button class="btn btn-default btn-xs"></button>',
+      '<button class="btn btn-secondary btn-xs"></button>',
       '</div>'
     ].join('\n')
   };

--- a/ckan/public-midnight-blue/base/scss/_custom.scss
+++ b/ckan/public-midnight-blue/base/scss/_custom.scss
@@ -4,7 +4,7 @@ h6, .h6, h5, .h5, h4, .h4, h3, .h3, h2, .h2, h1, .h1 {
     font-weight: $font-weight-semibold;
 }
 
-.btn-light, .btn-default {
+.btn-light, .btn-secondary {
     @extend .btn-light;
     border: $table-border-color solid 1px;
     &:hover {

--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -3076,7 +3076,7 @@ textarea.form-control-lg {
   --bs-btn-disabled-border-color: #d43f3a;
 }
 
-.btn-light, .btn-default {
+.btn-light, .btn-secondary {
   --bs-btn-color: #000;
   --bs-btn-bg: #fff;
   --bs-btn-border-color: #fff;
@@ -11842,10 +11842,10 @@ h6, .h6, h5, .h5, h4, .h4, h3, .h3, h2, .h2, h1, .h1 {
   font-weight: 600;
 }
 
-.btn-light, .btn-default {
+.btn-light, .btn-secondary {
   border: #dee2e6 solid 1px;
 }
-.btn-light:hover, .btn-default:hover {
+.btn-light:hover, .btn-secondary:hover {
   background-color: #dee2e6 !important;
   border-color: #dee2e6;
 }

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -3076,7 +3076,7 @@ textarea.form-control-lg {
   --bs-btn-disabled-border-color: #d43f3a;
 }
 
-.btn-light, .btn-default {
+.btn-light, .btn-secondary {
   --bs-btn-color: #000;
   --bs-btn-bg: #fff;
   --bs-btn-border-color: #fff;
@@ -11842,10 +11842,10 @@ h6, .h6, h5, .h5, h4, .h4, h3, .h3, h2, .h2, h1, .h1 {
   font-weight: 600;
 }
 
-.btn-light, .btn-default {
+.btn-light, .btn-secondary {
   border: #dee2e6 solid 1px;
 }
-.btn-light:hover, .btn-default:hover {
+.btn-light:hover, .btn-secondary:hover {
   background-color: #dee2e6 !important;
   border-color: #dee2e6;
 }

--- a/ckan/public/base/javascript/modules/confirm-action.js
+++ b/ckan/public/base/javascript/modules/confirm-action.js
@@ -43,7 +43,7 @@ this.ckan.module('confirm-action', function (jQuery) {
         '</div>',
         '<div class="modal-body"></div>',
         '<div class="modal-footer">',
-        '<button class="btn btn-default btn-cancel"></button>',
+        '<button class="btn btn-secondary btn-cancel"></button>',
         '<button class="btn btn-primary"></button>',
         '</div>',
         '</div>',

--- a/ckan/public/base/javascript/modules/image-upload.js
+++ b/ckan/public/base/javascript/modules/image-upload.js
@@ -57,7 +57,7 @@ this.ckan.module('image-upload', function($) {
         .appendTo(this.el);
 
       // Button to set the field to be a URL
-      this.button_url = $('<a href="javascript:;" class="btn btn-default">' +
+      this.button_url = $('<a href="javascript:;" class="btn btn-secondary">' +
                           '<i class="fa fa-globe"></i>' +
                           this._('Link') + '</a>')
         .prop('title', this._('Link to a URL on the internet (you can also link to an API)'))
@@ -65,7 +65,7 @@ this.ckan.module('image-upload', function($) {
         .insertAfter(this.input);
 
       // Button to attach local file to the form
-      this.button_upload = $('<a href="javascript:;" class="btn btn-default">' +
+      this.button_upload = $('<a href="javascript:;" class="btn btn-secondary">' +
                              '<i class="fa fa-cloud-upload"></i>' +
                              this._('Upload') + '</a>')
         .insertAfter(this.input);

--- a/ckan/public/base/javascript/modules/resource-reorder.js
+++ b/ckan/public/base/javascript/modules/resource-reorder.js
@@ -10,7 +10,7 @@ this.ckan.module('resource-reorder', function($) {
       title: '<h1></h1>',
       help_text: '<p></p>',
       button: [
-        '<a href="javascript:;" class="btn btn-default">',
+        '<a href="javascript:;" class="btn btn-secondary">',
         '<i class="fa fa-bars"></i>',
         '<span></span>',
         '</a>'

--- a/ckan/public/base/javascript/modules/resource-view-reorder.js
+++ b/ckan/public/base/javascript/modules/resource-view-reorder.js
@@ -8,7 +8,7 @@ this.ckan.module('resource-view-reorder', function($) {
     template: {
       title: '<h1></h1>',
       button: [
-        '<a href="javascript:;" class="btn btn-default">',
+        '<a href="javascript:;" class="btn btn-secondary">',
         '<i class="fa fa-bars"></i>',
         '<span></span>',
         '</a>'

--- a/ckan/public/base/javascript/plugins/jquery.slug-preview.js
+++ b/ckan/public/base/javascript/plugins/jquery.slug-preview.js
@@ -70,7 +70,7 @@
       '<div class="slug-preview">',
       '<strong></strong>',
       '<span class="slug-preview-prefix"></span><span class="slug-preview-value"></span>',
-      '<button class="btn btn-default btn-xs"></button>',
+      '<button class="btn btn-secondary btn-xs"></button>',
       '</div>'
     ].join('\n')
   };

--- a/ckan/public/base/scss/_custom.scss
+++ b/ckan/public/base/scss/_custom.scss
@@ -4,7 +4,7 @@ h6, .h6, h5, .h5, h4, .h4, h3, .h3, h2, .h2, h1, .h1 {
     font-weight: 600;
 }
 
-.btn-light, .btn-default {
+.btn-light, .btn-secondary {
     @extend .btn-light;
     border: $table-border-color solid 1px;
     &:hover {

--- a/ckan/templates-midnight-blue/development/primer.html
+++ b/ckan/templates-midnight-blue/development/primer.html
@@ -31,7 +31,7 @@
   <div class="input-group input-group-lg search-giant">
     <input type="text" class="search form-control" name="q" value="" autocomplete="off" placeholder="Search something...">
     <span class="input-group-btn">
-        <button class="btn btn-default" type="submit">
+        <button class="btn btn-secondary" type="submit">
           <i class="fa fa-search"></i>
           <span class="sr-only">Search</span>
         </button>

--- a/ckan/templates-midnight-blue/development/snippets/actions.html
+++ b/ckan/templates-midnight-blue/development/snippets/actions.html
@@ -1,2 +1,2 @@
-<li><a class="btn btn-default" href="#"><i class="fa fa-wrench"></i> Button</a></li>
+<li><a class="btn btn-secondary" href="#"><i class="fa fa-wrench"></i> Button</a></li>
 <li><a class="btn btn-primary" href="#"><i class="fa fa-wrench"></i> Primary Button</a></li>

--- a/ckan/templates-midnight-blue/group/edit_base.html
+++ b/ckan/templates-midnight-blue/group/edit_base.html
@@ -6,7 +6,7 @@
 {% set group = group_dict %}
 
 {% block content_action %}
-  {% link_for _('View'), named_route=group_type+'.read', id=group_dict.name, class_='btn btn-default', icon='eye' %}
+  {% link_for _('View'), named_route=group_type+'.read', id=group_dict.name, class_='btn btn-secondary', icon='eye' %}
 {% endblock %}
 
 {% block content_primary_nav %}

--- a/ckan/templates-midnight-blue/group/manage_members.html
+++ b/ckan/templates-midnight-blue/group/manage_members.html
@@ -26,7 +26,7 @@
         <td>{{ role }}</td>
         <td>
           <div class="btn-group pull-right">
-            <a class="btn btn-default btn-sm" href="{{ h.url_for(group_type + '.member_new', id=group_dict.id, user=user_id) }}" aria-label="{{ _('Edit role') }}" aria-description="{{ _('Edit the role of the user within the group') }}" data-bs-title="{{ _('Edit role') }}" data-bs-toggle="tooltip">
+            <a class="btn btn-secondary btn-sm" href="{{ h.url_for(group_type + '.member_new', id=group_dict.id, user=user_id) }}" aria-label="{{ _('Edit role') }}" aria-description="{{ _('Edit the role of the user within the group') }}" data-bs-title="{{ _('Edit role') }}" data-bs-toggle="tooltip">
               <i class="fa fa-wrench"></i>
             </a>
             <a class="btn btn-danger btn-sm" href="{{ h.url_for(group_type + '.member_delete', id=group_dict.id, user=user_id) }}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?') }}" aria-label="{{ _('Delete member') }}" aria-description="{{ _('Delete this member from the group') }}" data-bs-title="{{ _('Delete member') }}" data-bs-toggle="tooltip">{% block delete_button_text %}<i class="fa fa-times"></i>{% endblock %}</a>

--- a/ckan/templates-midnight-blue/group/member_new.html
+++ b/ckan/templates-midnight-blue/group/member_new.html
@@ -5,7 +5,7 @@
 {% set user = user_dict %}
 
 {% block primary_content_inner %}
-  {% link_for _('Back to all members'), named_route=group_type+'.manage_members', id=group.name, class_='btn btn-default pull-right', icon='arrow-left' %}
+  {% link_for _('Back to all members'), named_route=group_type+'.manage_members', id=group.name, class_='btn btn-secondary pull-right', icon='arrow-left' %}
   <h1 class="page-heading">
     {% block page_heading %}{{ _('Edit Member') if user else _('Add Member') }}{% endblock %}
   </h1>

--- a/ckan/templates-midnight-blue/group/read_base.html
+++ b/ckan/templates-midnight-blue/group/read_base.html
@@ -10,7 +10,7 @@
 
 {% block content_action %}
   {% if h.check_access('group_update', {'id': group_dict.id}) %}
-    {% link_for _('Manage'), named_route=group_type+'.edit', id=group_dict.name, class_='btn btn-default', icon='wrench' %}
+    {% link_for _('Manage'), named_route=group_type+'.edit', id=group_dict.name, class_='btn btn-secondary', icon='wrench' %}
   {% endif %}
 {% endblock %}
 

--- a/ckan/templates-midnight-blue/organization/bulk_process.html
+++ b/ckan/templates-midnight-blue/organization/bulk_process.html
@@ -45,11 +45,11 @@
                   <th></th>
                   <th class="table-actions">
                     <div class="btn-group">
-                      <button name="bulk_action.public" value="public" class="btn btn-default" type="submit">
+                      <button name="bulk_action.public" value="public" class="btn btn-secondary" type="submit">
                         <i class="fa fa-eye"></i>
                         {{ _('Make public') }}
                       </button>
-                      <button name="bulk_action.private" value="private" class="btn btn-default" type="submit">
+                      <button name="bulk_action.private" value="private" class="btn btn-secondary" type="submit">
                         <i class="fa fa-eye-slash"></i>
                         {{ _('Make private') }}
                       </button>

--- a/ckan/templates-midnight-blue/organization/edit_base.html
+++ b/ckan/templates-midnight-blue/organization/edit_base.html
@@ -6,7 +6,7 @@
 
 {% block content_action %}
   {% if organization and h.check_access('organization_update', {'id': organization.id}) %}
-    {% link_for _('View'), named_route=group_type+'.read', id=organization.name, class_='btn btn-default', icon='eye'%}
+    {% link_for _('View'), named_route=group_type+'.read', id=organization.name, class_='btn btn-secondary', icon='eye'%}
   {% endif %}
 {% endblock %}
 

--- a/ckan/templates-midnight-blue/organization/manage_members.html
+++ b/ckan/templates-midnight-blue/organization/manage_members.html
@@ -37,7 +37,7 @@
             <td>
               <div class="btn-group pull-right">
                 {% if can_create_members %}
-                  <a class="btn btn-default btn-sm" href="{{ h.url_for(group_type + '.member_new', id=group_dict.id, user=user_id) }}" aria-label="{{ _('Edit role') }}" aria-description="{{ _('Edit the role of the user within the organization') }}" data-bs-title="{{ _('Edit role') }}" data-bs-toggle="tooltip">
+                  <a class="btn btn-secondary btn-sm" href="{{ h.url_for(group_type + '.member_new', id=group_dict.id, user=user_id) }}" aria-label="{{ _('Edit role') }}" aria-description="{{ _('Edit the role of the user within the organization') }}" data-bs-title="{{ _('Edit role') }}" data-bs-toggle="tooltip">
                     <i class="fa fa-wrench"></i>
                   </a>
                 {% endif %}

--- a/ckan/templates-midnight-blue/organization/member_new.html
+++ b/ckan/templates-midnight-blue/organization/member_new.html
@@ -7,7 +7,7 @@
 {% block subtitle %}{{ _('Edit Member') if user else _('Add Member') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
-  {% link_for _('Back to all members'), named_route=group_type+'.manage_members', id=organization.name, class_='btn btn-default pull-right', icon='arrow-left' %}
+  {% link_for _('Back to all members'), named_route=group_type+'.manage_members', id=organization.name, class_='btn btn-secondary pull-right', icon='arrow-left' %}
   <h1 class="page-heading">
     {% block page_heading %}{{ _('Edit Member') if user else _('Add Member') }}{% endblock %}
   </h1>

--- a/ckan/templates-midnight-blue/organization/read_base.html
+++ b/ckan/templates-midnight-blue/organization/read_base.html
@@ -11,7 +11,7 @@
 
 {% block content_action %}
   {% if h.check_access('organization_update', {'id': group_dict.id}) %}
-    {% link_for _('Manage'), named_route=group_type+'.edit', id=group_dict.name, class_='btn btn-default', icon='wrench' %}
+    {% link_for _('Manage'), named_route=group_type+'.edit', id=group_dict.name, class_='btn btn-secondary', icon='wrench' %}
   {% endif %}
 {% endblock %}
 

--- a/ckan/templates-midnight-blue/package/collaborators/collaborator_new.html
+++ b/ckan/templates-midnight-blue/package/collaborators/collaborator_new.html
@@ -5,7 +5,7 @@
 {% block subtitle %}{{ _('Edit Collaborator') if user else _('Add Collaborator') }} - {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
-  {% link_for _('Back to all collaborators'), named_route='dataset.collaborators_read', id=pkg_dict.name, class_='btn btn-default pull-right', icon='arrow-left' %}
+  {% link_for _('Back to all collaborators'), named_route='dataset.collaborators_read', id=pkg_dict.name, class_='btn btn-secondary pull-right', icon='arrow-left' %}
   <h1 class="page-heading">
     {% block page_heading %}{{ _('Edit Collaborator') if user else _('Add Collaborator') }}{% endblock %}
   </h1>

--- a/ckan/templates-midnight-blue/package/collaborators/collaborators.html
+++ b/ckan/templates-midnight-blue/package/collaborators/collaborators.html
@@ -30,7 +30,7 @@
           <td>{{ capacity }}</td>
           <td>
             <div class="btn-group pull-right">
-                <a class="btn btn-default btn-sm" href="{{ h.url_for('dataset.new_collaborator', id=pkg_dict.name, user_id=user_id) }}" aria-label="{{ _('Edit role') }}" data-bs-title="{{ _('Edit role') }}" data-bs-toggle="tooltip">
+                <a class="btn btn-secondary btn-sm" href="{{ h.url_for('dataset.new_collaborator', id=pkg_dict.name, user_id=user_id) }}" aria-label="{{ _('Edit role') }}" data-bs-title="{{ _('Edit role') }}" data-bs-toggle="tooltip">
                 <i class="fa fa-wrench"></i>
               </a>
               <a class="btn btn-danger btn-sm" href="{{ h.url_for('dataset.collaborator_delete', id=pkg_dict.name, user_id=user_id) }}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this collaborator?') }}" aria-label="{{ _('Delete collaborator') }}" aria-description="{{ _('Delete this collaborator from the dataset') }}" data-bs-title="{{ _('Delete collaborator') }}" data-bs-toggle="tooltip">{% block delete_button_text %}<i class="fa fa-times"></i>{% endblock %}</a>

--- a/ckan/templates-midnight-blue/package/edit_base.html
+++ b/ckan/templates-midnight-blue/package/edit_base.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block content_action %}
-    {% link_for h.humanize_entity_type('package', pkg.type, 'view label') or _('View dataset'), named_route=pkg.type ~ '.read', id=pkg.name, class_='btn btn-default', icon='eye' %}
+    {% link_for h.humanize_entity_type('package', pkg.type, 'view label') or _('View dataset'), named_route=pkg.type ~ '.read', id=pkg.name, class_='btn btn-secondary', icon='eye' %}
 {% endblock %}
 
 {% block content_primary_nav %}

--- a/ckan/templates-midnight-blue/package/edit_view.html
+++ b/ckan/templates-midnight-blue/package/edit_view.html
@@ -18,7 +18,7 @@
     {% include 'package/snippets/view_form.html' %}
     <div class="form-actions">
       <button class="btn btn-danger pull-left" name="delete" value="Delete"> {{ _('Delete') }} </button>
-      <button class="btn btn-default {% if not h.resource_view_display_preview(data) %}hide{%endif%}" name="preview" value="True" type="submit">{{ _('Preview') }}</button>
+      <button class="btn btn-secondary {% if not h.resource_view_display_preview(data) %}hide{%endif%}" name="preview" value="True" type="submit">{{ _('Preview') }}</button>
       <button class="btn btn-primary" name="save" value="Save" type="submit">{{ _('Update') }}</button>
     </div>
   </form>

--- a/ckan/templates-midnight-blue/package/new_view.html
+++ b/ckan/templates-midnight-blue/package/new_view.html
@@ -17,7 +17,7 @@
     {{ h.csrf_input() }}
     {% include 'package/snippets/view_form.html' %}
     <div class="form-actions">
-        <button class="btn btn-default {% if not h.resource_view_display_preview(data) %}hide{%endif%}" name="preview" value="True" type="submit">{{ _('Preview') }}</button>
+        <button class="btn btn-secondary {% if not h.resource_view_display_preview(data) %}hide{%endif%}" name="preview" value="True" type="submit">{{ _('Preview') }}</button>
         <button class="btn btn-primary" name="save" value="Save" type="submit">{% block save_button_text %}{{ _('Add') }}{% endblock %}</button>
     </div>
   </form>

--- a/ckan/templates-midnight-blue/package/resource_edit_base.html
+++ b/ckan/templates-midnight-blue/package/resource_edit_base.html
@@ -15,7 +15,7 @@
 
 {% block content_action %}
     {% if res %}
-	{% link_for _('View resource'), named_route=pkg.type ~ '_resource.read', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='eye' %}
+	{% link_for _('View resource'), named_route=pkg.type ~ '_resource.read', id=pkg.name, resource_id=res.id, class_='btn btn-secondary', icon='eye' %}
   {% endif %}
 {% endblock %}
 

--- a/ckan/templates-midnight-blue/package/resource_read.html
+++ b/ckan/templates-midnight-blue/package/resource_read.html
@@ -29,9 +29,9 @@
               {% block resource_actions_inner %}
                 {% block action_manage %}
                   {% if h.check_access('package_update', {'id':pkg.id }) %}
-                    <li>{% link_for _('Edit resource'), named_route=pkg.type ~ '_resource.edit', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='pencil' %}</li>
+                    <li>{% link_for _('Edit resource'), named_route=pkg.type ~ '_resource.edit', id=pkg.name, resource_id=res.id, class_='btn btn-secondary', icon='pencil' %}</li>
                     {% block action_manage_inner %}{% endblock %}
-                    <li>{% link_for _('Views'), named_route=pkg.type ~ '_resource.views', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='chart-bar' %}</li>
+                    <li>{% link_for _('Views'), named_route=pkg.type ~ '_resource.views', id=pkg.name, resource_id=res.id, class_='btn btn-secondary', icon='chart-bar' %}</li>
                   {% endif %}
                 {% endblock action_manage %}
             {% if res.url and h.is_url(res.url) %}

--- a/ckan/templates-midnight-blue/package/snippets/resource_form.html
+++ b/ckan/templates-midnight-blue/package/snippets/resource_form.html
@@ -76,11 +76,11 @@
     {% endblock %}
     {% if stage %}
       {% block previous_button %}
-        <button class="btn btn-default" name="save" value="go-dataset" type="submit">{{ _('Previous') }}</button>
+        <button class="btn btn-secondary" name="save" value="go-dataset" type="submit">{{ _('Previous') }}</button>
       {% endblock %}
     {% endif %}
     {% block again_button %}
-      <button class="btn btn-default" name="save" value="again" type="submit">{{ _('Save & add another') }}</button>
+      <button class="btn btn-secondary" name="save" value="again" type="submit">{{ _('Save & add another') }}</button>
     {% endblock %}
     {% if stage %}
       {% block save_button %}

--- a/ckan/templates-midnight-blue/package/snippets/resource_upload_field.html
+++ b/ckan/templates-midnight-blue/package/snippets/resource_upload_field.html
@@ -43,14 +43,14 @@ placeholder - placeholder text for url field
     <div role="group" aria-labelledby="resource-menu-label">
       {% block url_type_select %}
         {% if is_upload_enabled %}
-          <button type="button" class="btn btn-default" id="resource-upload-button"
+          <button type="button" class="btn btn-secondary" id="resource-upload-button"
             aria-label="{{ _('Upload a file on your computer') }}" data-bs-title="{{ _('Upload a file on your computer') }}" data-bs-toggle="tooltip"
             onclick="
               document.getElementById('resource-url-upload').checked = true;
               document.getElementById('field-resource-upload').click();
             "autofocus="true"><i class="fa fa-cloud-upload"></i>{{ _("Upload") }}</button>
         {% endif %}
-        <button type="button" class="btn btn-default" id="resource-link-button"
+        <button type="button" class="btn btn-secondary" id="resource-link-button"
           aria-label="{{ _('Link to a URL on the internet (you can also link to an API)') }}" data-bs-title="{{ _('Link to a URL on the internet (you can also link to an API)') }}" data-bs-toggle="tooltip"
             onclick="
               document.getElementById('resource-url-link').checked = true;

--- a/ckan/templates-midnight-blue/package/snippets/resource_view.html
+++ b/ckan/templates-midnight-blue/package/snippets/resource_view.html
@@ -3,14 +3,14 @@
 {% block resource_view %}
   <div id="view-{{ resource_view['id'] }}" class="resource-view" data-id="{{ resource_view['id'] }}" data-title="{{ resource_view['title'] }}" data-description="{{ resource_view['descripion'] }}">
   <div class="actions">
-    <a class="btn btn-default"
+    <a class="btn btn-secondary"
        target="_blank"
        rel="noreferrer"
        href="{{ h.url_for(package['type'] ~ '_resource.view', id=package['name'], resource_id=resource['id'], view_id=resource_view['id'], qualified=True) }}">
       <i class="fa fa-arrows-alt"></i>
       {{ _("Fullscreen") }}
     </a>
-    <a class="btn btn-default"
+    <a class="btn btn-secondary"
        href="#embed-{{ resource_view['id'] }}"
        data-module="resource-view-embed"
        data-module-id="{{ resource_view['id'] }}"
@@ -37,7 +37,7 @@
           </p>
           <p id="data-view-error" class="collapse"></p>
           <p>
-            <a href="{{ resource.url }}" class="btn btn-default btn-lg resource-url-analytics" target="_blank" rel="noreferrer">
+            <a href="{{ resource.url }}" class="btn btn-secondary btn-lg resource-url-analytics" target="_blank" rel="noreferrer">
               <i class="fa fa-lg fa-arrow-circle-down"></i>
               {{ _('Download resource') }}
             </a>

--- a/ckan/templates-midnight-blue/package/view_edit_base.html
+++ b/ckan/templates-midnight-blue/package/view_edit_base.html
@@ -6,10 +6,10 @@
 {% block breadcrumb_edit_selected %}{% endblock %}
 
 {% block content_action %}
-  {% link_for _('All views'), named_route=pkg.type ~ '_resource.views', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='arrow-left' %}
+  {% link_for _('All views'), named_route=pkg.type ~ '_resource.views', id=pkg.name, resource_id=res.id, class_='btn btn-secondary', icon='arrow-left' %}
   {% if res %}
     {% set url = h.url_for(pkg.type ~ '_resource.read', id=pkg.name, resource_id=res.id) ~ '?view_id=' ~ resource_view.id %}
-    <a href="{{ url }}" class="btn btn-default"><i class="fa fa-eye"></i> {{ _('View view') }}</a>
+    <a href="{{ url }}" class="btn btn-secondary"><i class="fa fa-eye"></i> {{ _('View view') }}</a>
   {% endif %}
 {% endblock %}
 

--- a/ckan/templates-midnight-blue/snippets/language_selector.html
+++ b/ckan/templates-midnight-blue/snippets/language_selector.html
@@ -1,6 +1,6 @@
 {% set current_lang = request.environ.CKAN_LANG %}
 <form class="lang-select" action="{% url_for 'util.internal_redirect' %}" data-module="select-switch" method="POST">
-  {{ h.csrf_input() }} 
+  {{ h.csrf_input() }}
   <div class="form-group">
     <label for="field-lang-select">{{ _('Language') }}</label>
     <select id="field-lang-select" name="url" data-module="autocomplete" data-module-dropdown-class="lang-dropdown" data-module-container-class="lang-container">
@@ -11,7 +11,7 @@
       {% endfor %}
     </select>
   </div>
-  <button class="btn btn-default d-none " type="submit">{{ _('Go') }}</button>
+  <button class="btn btn-secondary d-none " type="submit">{{ _('Go') }}</button>
 </form>
 
 

--- a/ckan/templates-midnight-blue/snippets/search_form.html
+++ b/ckan/templates-midnight-blue/snippets/search_form.html
@@ -13,7 +13,7 @@
       <input aria-label="{% block header_site_search_label %}{{ placeholder }}{% endblock %}" id="field-giant-search" type="text" class="form-control input-lg" name="q" value="{{ query }}" autocomplete="off" placeholder="{{ placeholder }}">
       {% block search_input_button %}
       <span class="input-group-btn">
-        <button class="btn btn-default btn-lg" type="submit" value="search" aria-label="{{_('Submit')}}">
+        <button class="btn btn-secondary btn-lg" type="submit" value="search" aria-label="{{_('Submit')}}">
           <i class="fa fa-search"></i>
         </button>
       </span>
@@ -39,7 +39,7 @@
           {% endfor %}
         </select>
         {% block search_sortby_button %}
-        <button class="btn btn-default js-hide" type="submit">{{ _('Go') }}</button>
+        <button class="btn btn-secondary js-hide" type="submit">{{ _('Go') }}</button>
         {% endblock %}
       </div>
     {% endif %}
@@ -73,7 +73,7 @@
           {% endfor %}
         {% endfor %}
       </p>
-      <a class="show-filters btn btn-default">{{ _('Filter Results') }}</a>
+      <a class="show-filters btn btn-secondary">{{ _('Filter Results') }}</a>
     {% endif %}
   {% endblock %}
 

--- a/ckan/templates-midnight-blue/snippets/simple_search.html
+++ b/ckan/templates-midnight-blue/snippets/simple_search.html
@@ -12,6 +12,6 @@
         <option value="{{ item[1] }}"{% if sort==item[1] %} selected="selected"{% endif %}>{{ item[0] }}</option>
       {% endfor %}
     </select>
-    <button class="btn btn-default js-hide" type="submit">{{ _('Go') }}</button>
+    <button class="btn btn-secondary js-hide" type="submit">{{ _('Go') }}</button>
   </span>
 </form>

--- a/ckan/templates-midnight-blue/user/dashboard.html
+++ b/ckan/templates-midnight-blue/user/dashboard.html
@@ -17,7 +17,7 @@
     {% block page_header %}
       <header class="module-content page-header hug">
         <div class="content_action">
-          {% link_for _('Profile settings'), named_route='user.edit', id=user.name, class_='btn btn-default', icon='cog' %}
+          {% link_for _('Profile settings'), named_route='user.edit', id=user.name, class_='btn btn-secondary', icon='cog' %}
         </div>
       {% block content_primary_nav %}
         <ul class="nav nav-tabs">

--- a/ckan/templates-midnight-blue/user/logout_first.html
+++ b/ckan/templates-midnight-blue/user/logout_first.html
@@ -17,5 +17,5 @@
 
 {% block primary_content_inner %}
   <p>{{ _("You need to log out before you can log in with another account.") }}</p>
-  <a class="btn btn-default" href="{{ logout_url }}">{{ _("Log out now") }}</a>
+  <a class="btn btn-secondary" href="{{ logout_url }}">{{ _("Log out now") }}</a>
 {% endblock %}

--- a/ckan/templates-midnight-blue/user/read_base.html
+++ b/ckan/templates-midnight-blue/user/read_base.html
@@ -14,7 +14,7 @@
 
 {% block content_action %}
   {% if h.check_access('user_update', user) %}
-    {% link_for _('Manage'), named_route='user.edit', id=user.name, class_='btn btn-default', icon='wrench' %}
+    {% link_for _('Manage'), named_route='user.edit', id=user.name, class_='btn btn-secondary', icon='wrench' %}
   {% endif %}
 {% endblock %}
 

--- a/ckan/templates/development/primer.html
+++ b/ckan/templates/development/primer.html
@@ -31,7 +31,7 @@
   <div class="input-group input-group-lg search-giant">
     <input type="text" class="search form-control" name="q" value="" autocomplete="off" placeholder="Search something...">
     <span class="input-group-btn">
-        <button class="btn btn-default" type="submit">
+        <button class="btn btn-secondary" type="submit">
           <i class="fa fa-search"></i>
           <span class="sr-only">Search</span>
         </button>

--- a/ckan/templates/development/snippets/actions.html
+++ b/ckan/templates/development/snippets/actions.html
@@ -1,2 +1,2 @@
-<li><a class="btn btn-default" href="#"><i class="fa fa-wrench"></i> Button</a></li>
+<li><a class="btn btn-secondary" href="#"><i class="fa fa-wrench"></i> Button</a></li>
 <li><a class="btn btn-primary" href="#"><i class="fa fa-wrench"></i> Primary Button</a></li>

--- a/ckan/templates/group/edit_base.html
+++ b/ckan/templates/group/edit_base.html
@@ -6,7 +6,7 @@
 {% set group = group_dict %}
 
 {% block content_action %}
-  {% link_for _('View'), named_route=group_type+'.read', id=group_dict.name, class_='btn btn-default', icon='eye' %}
+  {% link_for _('View'), named_route=group_type+'.read', id=group_dict.name, class_='btn btn-secondary', icon='eye' %}
 {% endblock %}
 
 {% block content_primary_nav %}

--- a/ckan/templates/group/manage_members.html
+++ b/ckan/templates/group/manage_members.html
@@ -26,7 +26,7 @@
         <td>{{ role }}</td>
         <td>
           <div class="btn-group pull-right">
-            <a class="btn btn-default btn-sm" href="{{ h.url_for(group_type + '.member_new', id=group_dict.id, user=user_id) }}" aria-label="{{ _('Edit role') }}" aria-description="{{ _('Edit the role of the user within the group') }}" data-bs-title="{{ _('Edit role') }}" data-bs-toggle="tooltip">
+            <a class="btn btn-secondary btn-sm" href="{{ h.url_for(group_type + '.member_new', id=group_dict.id, user=user_id) }}" aria-label="{{ _('Edit role') }}" aria-description="{{ _('Edit the role of the user within the group') }}" data-bs-title="{{ _('Edit role') }}" data-bs-toggle="tooltip">
               <i class="fa fa-wrench"></i>
             </a>
             <a class="btn btn-danger btn-sm" href="{{ h.url_for(group_type + '.member_delete', id=group_dict.id, user=user_id) }}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?') }}" aria-label="{{ _('Delete member') }}" aria-description="{{ _('Delete this member from the group') }}" data-bs-title="{{ _('Delete member') }}" data-bs-toggle="tooltip">{% block delete_button_text %}<i class="fa fa-times"></i>{% endblock %}</a>

--- a/ckan/templates/group/member_new.html
+++ b/ckan/templates/group/member_new.html
@@ -5,7 +5,7 @@
 {% set user = user_dict %}
 
 {% block primary_content_inner %}
-  {% link_for _('Back to all members'), named_route=group_type+'.manage_members', id=group.name, class_='btn btn-default pull-right', icon='arrow-left' %}
+  {% link_for _('Back to all members'), named_route=group_type+'.manage_members', id=group.name, class_='btn btn-secondary pull-right', icon='arrow-left' %}
   <h1 class="page-heading">
     {% block page_heading %}{{ _('Edit Member') if user else _('Add Member') }}{% endblock %}
   </h1>

--- a/ckan/templates/group/read_base.html
+++ b/ckan/templates/group/read_base.html
@@ -10,7 +10,7 @@
 
 {% block content_action %}
   {% if h.check_access('group_update', {'id': group_dict.id}) %}
-    {% link_for _('Manage'), named_route=group_type+'.edit', id=group_dict.name, class_='btn btn-default', icon='wrench' %}
+    {% link_for _('Manage'), named_route=group_type+'.edit', id=group_dict.name, class_='btn btn-secondary', icon='wrench' %}
   {% endif %}
 {% endblock %}
 

--- a/ckan/templates/organization/bulk_process.html
+++ b/ckan/templates/organization/bulk_process.html
@@ -45,11 +45,11 @@
                   <th></th>
                   <th class="table-actions">
                     <div class="btn-group">
-                      <button name="bulk_action.public" value="public" class="btn btn-default" type="submit">
+                      <button name="bulk_action.public" value="public" class="btn btn-secondary" type="submit">
                         <i class="fa fa-eye"></i>
                         {{ _('Make public') }}
                       </button>
-                      <button name="bulk_action.private" value="private" class="btn btn-default" type="submit">
+                      <button name="bulk_action.private" value="private" class="btn btn-secondary" type="submit">
                         <i class="fa fa-eye-slash"></i>
                         {{ _('Make private') }}
                       </button>

--- a/ckan/templates/organization/edit_base.html
+++ b/ckan/templates/organization/edit_base.html
@@ -6,7 +6,7 @@
 
 {% block content_action %}
   {% if organization and h.check_access('organization_update', {'id': organization.id}) %}
-    {% link_for _('View'), named_route=group_type+'.read', id=organization.name, class_='btn btn-default', icon='eye'%}
+    {% link_for _('View'), named_route=group_type+'.read', id=organization.name, class_='btn btn-secondary', icon='eye'%}
   {% endif %}
 {% endblock %}
 

--- a/ckan/templates/organization/manage_members.html
+++ b/ckan/templates/organization/manage_members.html
@@ -37,7 +37,7 @@
             <td>
               <div class="btn-group pull-right">
                 {% if can_create_members %}
-                  <a class="btn btn-default btn-sm" href="{{ h.url_for(group_type + '.member_new', id=group_dict.id, user=user_id) }}" aria-label="{{ _('Edit role') }}" aria-description="{{ _('Edit the role of the user within the organization') }}" data-bs-title="{{ _('Edit role') }}" data-bs-toggle="tooltip">
+                  <a class="btn btn-secondary btn-sm" href="{{ h.url_for(group_type + '.member_new', id=group_dict.id, user=user_id) }}" aria-label="{{ _('Edit role') }}" aria-description="{{ _('Edit the role of the user within the organization') }}" data-bs-title="{{ _('Edit role') }}" data-bs-toggle="tooltip">
                     <i class="fa fa-wrench"></i>
                   </a>
                 {% endif %}

--- a/ckan/templates/organization/member_new.html
+++ b/ckan/templates/organization/member_new.html
@@ -7,7 +7,7 @@
 {% block subtitle %}{{ _('Edit Member') if user else _('Add Member') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
-  {% link_for _('Back to all members'), named_route=group_type+'.manage_members', id=organization.name, class_='btn btn-default pull-right', icon='arrow-left' %}
+  {% link_for _('Back to all members'), named_route=group_type+'.manage_members', id=organization.name, class_='btn btn-secondary pull-right', icon='arrow-left' %}
   <h1 class="page-heading">
     {% block page_heading %}{{ _('Edit Member') if user else _('Add Member') }}{% endblock %}
   </h1>

--- a/ckan/templates/organization/read_base.html
+++ b/ckan/templates/organization/read_base.html
@@ -11,7 +11,7 @@
 
 {% block content_action %}
   {% if h.check_access('organization_update', {'id': group_dict.id}) %}
-    {% link_for _('Manage'), named_route=group_type+'.edit', id=group_dict.name, class_='btn btn-default', icon='wrench' %}
+    {% link_for _('Manage'), named_route=group_type+'.edit', id=group_dict.name, class_='btn btn-secondary', icon='wrench' %}
   {% endif %}
 {% endblock %}
 

--- a/ckan/templates/package/collaborators/collaborator_new.html
+++ b/ckan/templates/package/collaborators/collaborator_new.html
@@ -5,7 +5,7 @@
 {% block subtitle %}{{ _('Edit Collaborator') if user else _('Add Collaborator') }} - {{ super() }}{% endblock %}
 
 {% block primary_content_inner %}
-  {% link_for _('Back to all collaborators'), named_route='dataset.collaborators_read', id=pkg_dict.name, class_='btn btn-default pull-right', icon='arrow-left' %}
+  {% link_for _('Back to all collaborators'), named_route='dataset.collaborators_read', id=pkg_dict.name, class_='btn btn-secondary pull-right', icon='arrow-left' %}
   <h1 class="page-heading">
     {% block page_heading %}{{ _('Edit Collaborator') if user else _('Add Collaborator') }}{% endblock %}
   </h1>

--- a/ckan/templates/package/collaborators/collaborators.html
+++ b/ckan/templates/package/collaborators/collaborators.html
@@ -30,7 +30,7 @@
           <td>{{ capacity }}</td>
           <td>
             <div class="btn-group pull-right">
-                <a class="btn btn-default btn-sm" href="{{ h.url_for('dataset.new_collaborator', id=pkg_dict.name, user_id=user_id) }}" aria-label="{{ _('Edit role') }}" data-bs-title="{{ _('Edit role') }}" data-bs-toggle="tooltip">
+                <a class="btn btn-secondary btn-sm" href="{{ h.url_for('dataset.new_collaborator', id=pkg_dict.name, user_id=user_id) }}" aria-label="{{ _('Edit role') }}" data-bs-title="{{ _('Edit role') }}" data-bs-toggle="tooltip">
                 <i class="fa fa-wrench"></i>
               </a>
               <a class="btn btn-danger btn-sm" href="{{ h.url_for('dataset.collaborator_delete', id=pkg_dict.name, user_id=user_id) }}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this collaborator?') }}" aria-label="{{ _('Delete collaborator') }}" aria-description="{{ _('Delete this collaborator from the dataset') }}" data-bs-title="{{ _('Delete collaborator') }}" data-bs-toggle="tooltip">{% block delete_button_text %}<i class="fa fa-times"></i>{% endblock %}</a>

--- a/ckan/templates/package/edit_base.html
+++ b/ckan/templates/package/edit_base.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block content_action %}
-    {% link_for h.humanize_entity_type('package', pkg.type, 'view label') or _('View dataset'), named_route=pkg.type ~ '.read', id=pkg.name, class_='btn btn-default', icon='eye' %}
+    {% link_for h.humanize_entity_type('package', pkg.type, 'view label') or _('View dataset'), named_route=pkg.type ~ '.read', id=pkg.name, class_='btn btn-secondary', icon='eye' %}
 {% endblock %}
 
 {% block content_primary_nav %}

--- a/ckan/templates/package/edit_view.html
+++ b/ckan/templates/package/edit_view.html
@@ -18,7 +18,7 @@
     {% include 'package/snippets/view_form.html' %}
     <div class="form-actions">
       <button class="btn btn-danger pull-left" name="delete" value="Delete"> {{ _('Delete') }} </button>
-      <button class="btn btn-default {% if not h.resource_view_display_preview(data) %}hide{%endif%}" name="preview" value="True" type="submit">{{ _('Preview') }}</button>
+      <button class="btn btn-secondary {% if not h.resource_view_display_preview(data) %}hide{%endif%}" name="preview" value="True" type="submit">{{ _('Preview') }}</button>
       <button class="btn btn-primary" name="save" value="Save" type="submit">{{ _('Update') }}</button>
     </div>
   </form>

--- a/ckan/templates/package/new_view.html
+++ b/ckan/templates/package/new_view.html
@@ -17,7 +17,7 @@
     {{ h.csrf_input() }}
     {% include 'package/snippets/view_form.html' %}
     <div class="form-actions">
-        <button class="btn btn-default {% if not h.resource_view_display_preview(data) %}hide{%endif%}" name="preview" value="True" type="submit">{{ _('Preview') }}</button>
+        <button class="btn btn-secondary {% if not h.resource_view_display_preview(data) %}hide{%endif%}" name="preview" value="True" type="submit">{{ _('Preview') }}</button>
         <button class="btn btn-primary" name="save" value="Save" type="submit">{% block save_button_text %}{{ _('Add') }}{% endblock %}</button>
     </div>
   </form>

--- a/ckan/templates/package/resource_edit_base.html
+++ b/ckan/templates/package/resource_edit_base.html
@@ -15,7 +15,7 @@
 
 {% block content_action %}
     {% if res %}
-	{% link_for _('View resource'), named_route=pkg.type ~ '_resource.read', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='eye' %}
+	{% link_for _('View resource'), named_route=pkg.type ~ '_resource.read', id=pkg.name, resource_id=res.id, class_='btn btn-secondary', icon='eye' %}
   {% endif %}
 {% endblock %}
 

--- a/ckan/templates/package/resource_read.html
+++ b/ckan/templates/package/resource_read.html
@@ -29,9 +29,9 @@
               {% block resource_actions_inner %}
                 {% block action_manage %}
                   {% if h.check_access('package_update', {'id':pkg.id }) %}
-                    <li>{% link_for _('Edit resource'), named_route=pkg.type ~ '_resource.edit', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='pencil' %}</li>
+                    <li>{% link_for _('Edit resource'), named_route=pkg.type ~ '_resource.edit', id=pkg.name, resource_id=res.id, class_='btn btn-secondary', icon='pencil' %}</li>
                     {% block action_manage_inner %}{% endblock %}
-                    <li>{% link_for _('Views'), named_route=pkg.type ~ '_resource.views', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='chart-bar' %}</li>
+                    <li>{% link_for _('Views'), named_route=pkg.type ~ '_resource.views', id=pkg.name, resource_id=res.id, class_='btn btn-secondary', icon='chart-bar' %}</li>
                   {% endif %}
                 {% endblock action_manage %}
             {% if res.url and h.is_url(res.url) %}

--- a/ckan/templates/package/snippets/resource_form.html
+++ b/ckan/templates/package/snippets/resource_form.html
@@ -76,11 +76,11 @@
     {% endblock %}
     {% if stage %}
       {% block previous_button %}
-        <button class="btn btn-default" name="save" value="go-dataset" type="submit">{{ _('Previous') }}</button>
+        <button class="btn btn-secondary" name="save" value="go-dataset" type="submit">{{ _('Previous') }}</button>
       {% endblock %}
     {% endif %}
     {% block again_button %}
-      <button class="btn btn-default" name="save" value="again" type="submit">{{ _('Save & add another') }}</button>
+      <button class="btn btn-secondary" name="save" value="again" type="submit">{{ _('Save & add another') }}</button>
     {% endblock %}
     {% if stage %}
       {% block save_button %}

--- a/ckan/templates/package/snippets/resource_upload_field.html
+++ b/ckan/templates/package/snippets/resource_upload_field.html
@@ -43,14 +43,14 @@ placeholder - placeholder text for url field
     <div role="group" aria-labelledby="resource-menu-label">
       {% block url_type_select %}
         {% if is_upload_enabled %}
-          <button type="button" class="btn btn-default" id="resource-upload-button"
+          <button type="button" class="btn btn-secondary" id="resource-upload-button"
             aria-label="{{ _('Upload a file on your computer') }}" data-bs-title="{{ _('Upload a file on your computer') }}" data-bs-toggle="tooltip"
             onclick="
               document.getElementById('resource-url-upload').checked = true;
               document.getElementById('field-resource-upload').click();
             "autofocus="true"><i class="fa fa-cloud-upload"></i>{{ _("Upload") }}</button>
         {% endif %}
-        <button type="button" class="btn btn-default" id="resource-link-button"
+        <button type="button" class="btn btn-secondary" id="resource-link-button"
           aria-label="{{ _('Link to a URL on the internet (you can also link to an API)') }}" data-bs-title="{{ _('Link to a URL on the internet (you can also link to an API)') }}" data-bs-toggle="tooltip"
             onclick="
               document.getElementById('resource-url-link').checked = true;

--- a/ckan/templates/package/snippets/resource_view.html
+++ b/ckan/templates/package/snippets/resource_view.html
@@ -3,14 +3,14 @@
 {% block resource_view %}
   <div id="view-{{ resource_view['id'] }}" class="resource-view" data-id="{{ resource_view['id'] }}" data-title="{{ resource_view['title'] }}" data-description="{{ resource_view['descripion'] }}">
   <div class="actions">
-    <a class="btn btn-default"
+    <a class="btn btn-secondary"
        target="_blank"
        rel="noreferrer"
        href="{{ h.url_for(package['type'] ~ '_resource.view', id=package['name'], resource_id=resource['id'], view_id=resource_view['id'], qualified=True) }}">
       <i class="fa fa-arrows-alt"></i>
       {{ _("Fullscreen") }}
     </a>
-    <a class="btn btn-default"
+    <a class="btn btn-secondary"
        href="#embed-{{ resource_view['id'] }}"
        data-module="resource-view-embed"
        data-module-id="{{ resource_view['id'] }}"
@@ -37,7 +37,7 @@
           </p>
           <p id="data-view-error" class="collapse"></p>
           <p>
-            <a href="{{ resource.url }}" class="btn btn-default btn-lg resource-url-analytics" target="_blank" rel="noreferrer">
+            <a href="{{ resource.url }}" class="btn btn-secondary btn-lg resource-url-analytics" target="_blank" rel="noreferrer">
               <i class="fa fa-lg fa-arrow-circle-down"></i>
               {{ _('Download resource') }}
             </a>

--- a/ckan/templates/package/view_edit_base.html
+++ b/ckan/templates/package/view_edit_base.html
@@ -6,10 +6,10 @@
 {% block breadcrumb_edit_selected %}{% endblock %}
 
 {% block content_action %}
-  {% link_for _('All views'), named_route=pkg.type ~ '_resource.views', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='arrow-left' %}
+  {% link_for _('All views'), named_route=pkg.type ~ '_resource.views', id=pkg.name, resource_id=res.id, class_='btn btn-secondary', icon='arrow-left' %}
   {% if res %}
     {% set url = h.url_for(pkg.type ~ '_resource.read', id=pkg.name, resource_id=res.id) ~ '?view_id=' ~ resource_view.id %}
-    <a href="{{ url }}" class="btn btn-default"><i class="fa fa-eye"></i> {{ _('View view') }}</a>
+    <a href="{{ url }}" class="btn btn-secondary"><i class="fa fa-eye"></i> {{ _('View view') }}</a>
   {% endif %}
 {% endblock %}
 

--- a/ckan/templates/snippets/language_selector.html
+++ b/ckan/templates/snippets/language_selector.html
@@ -1,6 +1,6 @@
 {% set current_lang = request.environ.CKAN_LANG %}
 <form class="lang-select" action="{% url_for 'util.internal_redirect' %}" data-module="select-switch" method="POST">
-  {{ h.csrf_input() }} 
+  {{ h.csrf_input() }}
   <div class="form-group">
     <label for="field-lang-select">{{ _('Language') }}</label>
     <select id="field-lang-select" name="url" data-module="autocomplete" data-module-dropdown-class="lang-dropdown" data-module-container-class="lang-container">
@@ -11,7 +11,7 @@
       {% endfor %}
     </select>
   </div>
-  <button class="btn btn-default d-none " type="submit">{{ _('Go') }}</button>
+  <button class="btn btn-secondary d-none " type="submit">{{ _('Go') }}</button>
 </form>
 
 

--- a/ckan/templates/snippets/search_form.html
+++ b/ckan/templates/snippets/search_form.html
@@ -13,7 +13,7 @@
       <input aria-label="{% block header_site_search_label %}{{ placeholder }}{% endblock %}" id="field-giant-search" type="text" class="form-control input-lg" name="q" value="{{ query }}" autocomplete="off" placeholder="{{ placeholder }}">
       {% block search_input_button %}
       <span class="input-group-btn">
-        <button class="btn btn-default btn-lg" type="submit" value="search" aria-label="{{_('Submit')}}">
+        <button class="btn btn-secondary btn-lg" type="submit" value="search" aria-label="{{_('Submit')}}">
           <i class="fa fa-search"></i>
         </button>
       </span>
@@ -39,7 +39,7 @@
           {% endfor %}
         </select>
         {% block search_sortby_button %}
-        <button class="btn btn-default js-hide" type="submit">{{ _('Go') }}</button>
+        <button class="btn btn-secondary js-hide" type="submit">{{ _('Go') }}</button>
         {% endblock %}
       </div>
     {% endif %}
@@ -73,7 +73,7 @@
           {% endfor %}
         {% endfor %}
       </p>
-      <a class="show-filters btn btn-default">{{ _('Filter Results') }}</a>
+      <a class="show-filters btn btn-secondary">{{ _('Filter Results') }}</a>
     {% endif %}
   {% endblock %}
 

--- a/ckan/templates/snippets/simple_search.html
+++ b/ckan/templates/snippets/simple_search.html
@@ -12,6 +12,6 @@
         <option value="{{ item[1] }}"{% if sort==item[1] %} selected="selected"{% endif %}>{{ item[0] }}</option>
       {% endfor %}
     </select>
-    <button class="btn btn-default js-hide" type="submit">{{ _('Go') }}</button>
+    <button class="btn btn-secondary js-hide" type="submit">{{ _('Go') }}</button>
   </span>
 </form>

--- a/ckan/templates/user/dashboard.html
+++ b/ckan/templates/user/dashboard.html
@@ -17,7 +17,7 @@
     {% block page_header %}
       <header class="module-content page-header hug">
         <div class="content_action">
-          {% link_for _('Profile settings'), named_route='user.edit', id=user.name, class_='btn btn-default', icon='cog' %}
+          {% link_for _('Profile settings'), named_route='user.edit', id=user.name, class_='btn btn-secondary', icon='cog' %}
         </div>
       {% block content_primary_nav %}
         <ul class="nav nav-tabs">

--- a/ckan/templates/user/login.html
+++ b/ckan/templates/user/login.html
@@ -27,7 +27,7 @@
         <p>{% trans %}Then sign right up, it only takes a minute.{% endtrans %}</p>
         <p class="action">
         {% block help_register_button %}
-          <a class="btn btn-default" href="{{ h.url_for('user.register') }}">{{ _('Create an Account') }}</a>
+          <a class="btn btn-secondary" href="{{ h.url_for('user.register') }}">{{ _('Create an Account') }}</a>
         {% endblock %}
         </p>
       </div>
@@ -44,7 +44,7 @@
       <p>{% trans %}No problem, use our password recovery form to reset it.{% endtrans %}</p>
       <p class="action">
         {% block help_forgotten_button %}
-        <a class="btn btn-default" href="{{ h.url_for('user.request_reset') }}">{{ _('Forgot your password?') }}</a>
+        <a class="btn btn-secondary" href="{{ h.url_for('user.request_reset') }}">{{ _('Forgot your password?') }}</a>
         {% endblock %}
       </p>
     </div>

--- a/ckan/templates/user/logout_first.html
+++ b/ckan/templates/user/logout_first.html
@@ -20,7 +20,7 @@
     <h2 class="module-heading">{{ _("You're already logged in") }}</h2>
     <div class="module-content">
       <p>{{ _("You need to log out before you can log in with another account.") }}</p>
-      <p class="action"><a class="btn btn-default" href="{{ logout_url }}">{{ _("Log out now") }}</a></p>
+      <p class="action"><a class="btn btn-secondary" href="{{ logout_url }}">{{ _("Log out now") }}</a></p>
     </div>
   </section>
 {% endblock %}

--- a/ckan/templates/user/read_base.html
+++ b/ckan/templates/user/read_base.html
@@ -14,7 +14,7 @@
 
 {% block content_action %}
   {% if h.check_access('user_update', user) %}
-    {% link_for _('Manage'), named_route='user.edit', id=user.name, class_='btn btn-default', icon='wrench' %}
+    {% link_for _('Manage'), named_route='user.edit', id=user.name, class_='btn btn-secondary', icon='wrench' %}
   {% endif %}
 {% endblock %}
 

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -269,7 +269,7 @@ class ApiTokenView(MethodView):
             u'class': u'fa fa-copy'
         }), {
             u'type': u'button',
-            u'class': u'btn btn-default btn-xs',
+            u'class': u'btn btn-secondary btn-xs',
             u'data-module': u'copy-into-buffer',
             u'data-module-copy-value': ensure_str(token)
         })

--- a/ckanext/activity/templates/snippets/pagination.html
+++ b/ckanext/activity/templates/snippets/pagination.html
@@ -1,5 +1,5 @@
-{% set class_prev = "btn btn-default" if newer_activities_url else "btn disabled" %}
-{% set class_next = "btn btn-default" if older_activities_url else "btn disabled" %}
+{% set class_prev = "btn btn-secondary" if newer_activities_url else "btn disabled" %}
+{% set class_next = "btn btn-secondary" if older_activities_url else "btn disabled" %}
 
 {% if newer_activities_url or older_activities_url %}
     <div hx-boost="true" hx-target="closest .module-content" id="activity_page_buttons" class="activity_buttons" style="margin-top: 25px;">

--- a/ckanext/activity/templates/user/snippets/followee_dropdown.html
+++ b/ckanext/activity/templates/user/snippets/followee_dropdown.html
@@ -12,7 +12,7 @@
 
 <div id="followee-filter" class="pull-right">
   <div class="dropdown">
-    <a href="#" id="followee-popover" class="btn btn-default dropdown-toggle"
+    <a href="#" id="followee-popover" class="btn btn-secondary dropdown-toggle"
       aria-label="{{ _('Activity from:') }} {{ context.context }}">
       <span>{{ _('Activity from:') }}</span> <strong>{{ context.context }}</strong> <span class="caret"></span>
     </a>

--- a/ckanext/datastore/templates/package/resource_read.html
+++ b/ckanext/datastore/templates/package/resource_read.html
@@ -46,7 +46,7 @@
 {% block action_manage_inner %}
   {{ super() }}
   {% if res.datastore_active %}
-    <li>{% link_for _('Data Dictionary'), named_route='datastore.dictionary', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='code' %}</li>
+    <li>{% link_for _('Data Dictionary'), named_route='datastore.dictionary', id=pkg.name, resource_id=res.id, class_='btn btn-secondary', icon='code' %}</li>
   {% endif %}
 {% endblock %}
 

--- a/ckanext/datatablesview/assets/datatablesview.js
+++ b/ckanext/datatablesview/assets/datatablesview.js
@@ -419,9 +419,9 @@ this.ckan.module('datatables_view', function (jQuery) {
                 // add clipboard and print buttons to modal record display
                 var data = row.data();
                 return '<span style="font-size:150%;font-weight:bold;">Details:</span>&nbsp;&nbsp;<div class=" dt-buttons btn-group">' +
-                  '<button id="modalcopy-button" class="btn btn-default" title="' + that._('Copy to clipboard') + '" onclick="copyModal(\'' +
+                  '<button id="modalcopy-button" class="btn btn-secondary" title="' + that._('Copy to clipboard') + '" onclick="copyModal(\'' +
                   packagename + '&mdash;' + resourcename + '\')"><i class="fa fa-copy"></i></button>' +
-                  '<button id="modalprint-button" class="btn btn-default" title="' + that._('Print') + '" onclick="printModal(\'' +
+                  '<button id="modalprint-button" class="btn btn-secondary" title="' + that._('Print') + '" onclick="printModal(\'' +
                   packagename + '&mdash;' + resourcename + '\')"><i class="fa fa-print"></i></button>' +
                   '</div>&nbsp;'
               }
@@ -708,7 +708,7 @@ this.ckan.module('datatables_view', function (jQuery) {
           name: 'viewToggleButton',
           text: gcurrentView === 'table' ? '<i class="fa fa-list"></i>' : '<i class="fa fa-table"></i>',
           titleAttr: that._('Table/List toggle'),
-          className: 'btn-default',
+          className: 'btn-secondary',
           action: function (e, dt, node, config) {
             if (gcurrentView === 'list') {
               dt.button('viewToggleButton:name').text('<i class="fa fa-table"></i>')
@@ -728,7 +728,7 @@ this.ckan.module('datatables_view', function (jQuery) {
           extend: 'copy',
           text: '<i class="fa fa-copy"></i>',
           titleAttr: that._('Copy to clipboard'),
-          className: 'btn-default',
+          className: 'btn-secondary',
           title: function () {
             // remove html tags from filterInfo msg
             const filternohtml = filterInfo(datatable, true)
@@ -742,7 +742,7 @@ this.ckan.module('datatables_view', function (jQuery) {
           extend: 'colvis',
           text: '<i class="fa fa-eye-slash"></i>',
           titleAttr: that._('Toggle column visibility'),
-          className: 'btn-default',
+          className: 'btn-secondary',
           columns: 'th:gt(0):not(:contains("colspacer"))',
           collectionLayout: 'fixed',
           postfixButtons: [{
@@ -780,7 +780,7 @@ this.ckan.module('datatables_view', function (jQuery) {
         }, {
           text: '<i class="fa fa-download"></i>',
           titleAttr: that._('Filtered download'),
-          className: 'btn-default',
+          className: 'btn-secondary',
           autoClose: true,
           extend: 'collection',
           buttons: [{
@@ -816,7 +816,7 @@ this.ckan.module('datatables_view', function (jQuery) {
           name: 'resetButton',
           text: '<i class="fa fa-repeat"></i>',
           titleAttr: that._('Reset'),
-          className: 'btn-default resetButton',
+          className: 'btn-secondary resetButton',
           action: function (e, dt, node, config) {
             dt.state.clear()
             $('.resetButton').css('color', 'black')
@@ -827,7 +827,7 @@ this.ckan.module('datatables_view', function (jQuery) {
           extend: 'print',
           text: '<i class="fa fa-print"></i>',
           titleAttr: that._('Print'),
-          className: 'btn-default',
+          className: 'btn-secondary',
           title: packagename + ' — ' + resourcename,
           messageTop: function () {
             return filterInfo(datatable)
@@ -843,7 +843,7 @@ this.ckan.module('datatables_view', function (jQuery) {
           name: 'shareButton',
           text: '<i class="fa fa-share"></i>',
           titleAttr: that._('Share current view'),
-          className: 'btn-default',
+          className: 'btn-secondary',
           action: function (e, dt, node, config) {
             dt.state.save()
             const sharelink = window.location.href + '?state=' + window.btoa(JSON.stringify(dt.state()))

--- a/ckanext/datatablesview/templates/datatables/datatables_view.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_view.html
@@ -51,7 +51,7 @@
        <th id="_colspacer">colspacer</th>
       </tr>
       <tr>
-        <th><button id="refit-button" class="btn btn-default" title="{{- _('Refit') -}}" onclick="fitColText()"><i class="fa fa-text-width"></i></button></th>
+        <th><button id="refit-button" class="btn btn-secondary" title="{{- _('Refit') -}}" onclick="fitColText()"><i class="fa fa-text-width"></i></button></th>
         {% for field in datadictionary -%}
           <th id="cdx{{ loop.index }}" class="fhead" data-type="{{ field.type }}">
               {{- field.id -}}

--- a/ckanext/tabledesigner/templates/package/snippets/resource_upload_field.html
+++ b/ckanext/tabledesigner/templates/package/snippets/resource_upload_field.html
@@ -2,7 +2,7 @@
 
 {% block url_type_select %}
   {{ super() }}
-  <button type="button" class="btn btn-default" id="resource-table-designer-button"
+  <button type="button" class="btn btn-secondary" id="resource-table-designer-button"
     aria-label="{{ _('Create a custom table for your data') }}"
       onclick="
         document.getElementById('resource-url-table-designer').checked = true;


### PR DESCRIPTION
### Proposed fixes:
Bootstrap 4 renamed `.btn-default` to `.btn-secondary`  https://getbootstrap.com/docs/4.6/migration/#buttons

This just renames all of them as it wasn't done when migrating to bs5 as bs4 was skipped.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
