### PR TITLE
fix typo in documentation info box

### DIFF
--- a/doc/maintaining/datastore.rst
+++ b/doc/maintaining/datastore.rst
@@ -304,7 +304,7 @@ returns its response in a JSON dictionary. See the :doc:`/api/index` for details
 API reference
 =============
 
-.. note:: Lists can always be expressed in different ways. It is possible to use lists, comma separated strings or single items. These are valid lists: ``['foo', 'bar']``, ``'foo, bar'``, ``"foo", "bar"`` and ``'foo'``. Additionally, there are several ways to define a boolean value. ``True``, ``on`` and ``1`` are all vaid boolean values.
+.. note:: Lists can always be expressed in different ways. It is possible to use lists, comma separated strings or single items. These are valid lists: ``['foo', 'bar']``, ``'foo, bar'``, ``"foo", "bar"`` and ``'foo'``. Additionally, there are several ways to define a boolean value. ``True``, ``on`` and ``1`` are all valid boolean values.
 
 .. note:: The table structure of the DataStore is explained in :ref:`db_internals`.
 


### PR DESCRIPTION
Fixes #

### Proposed fixes:
Corrects a typo in the info box in the API Reference section of the documentation: https://docs.ckan.org/en/2.11/maintaining/datastore.html#api-reference


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
