### PR TITLE
feat: allow plugins to patch user name

### DIFF
--- a/changes/8622.feature
+++ b/changes/8622.feature
@@ -1,0 +1,1 @@
+Allows plugins to change the user name during ``user_patch`` or ``user_update`` by passing ``ignore_auth: True`` in the context. ``user_show`` also returns restricted properties like ``email`` or ``apikey`` when passing ``ignore_auth: True`` in the context.

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -605,7 +605,7 @@ def user_dictize(
         result_dict['apikey'] = apikey
         result_dict['email'] = email
 
-    if authz.is_sysadmin(requester):
+    if authz.is_sysadmin(requester) or context.get("ignore_auth") is True:
         result_dict['apikey'] = apikey
         result_dict['email'] = email
 

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -702,7 +702,8 @@ def user_name_validator(key: FlattenKey, data: FlattenDataDict,
             errors[key].append(_('The username is already associated with another account. Please use a different username.'))
     elif user_obj_from_context:
         requester = context.get('auth_user_obj', None)
-        if requester and authz.is_sysadmin(requester.name):
+        ignore_auth = context.get('ignore_auth', None)
+        if ignore_auth or (requester and authz.is_sysadmin(requester.name)):
             return
         old_user = model.User.get(user_obj_from_context.id)
         if old_user is not None and old_user.state != model.State.PENDING:

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -872,7 +872,12 @@ class TestUserList(object):
     def test_user_list_default_values(self):
         user = factories.User()
 
-        got_users = helpers.call_action("user_list")
+        got_users = helpers.call_action(
+            "user_list",
+            # call_action will set ignore_auth: True by default, which will
+            # include restricted fields like apikey
+            context={"ignore_auth": False}
+        )
 
         assert len(got_users) == 1
         got_user = got_users[0]
@@ -1049,7 +1054,13 @@ class TestUserShow(object):
 
         user = factories.User()
 
-        got_user = helpers.call_action("user_show", id=user["id"])
+        got_user = helpers.call_action(
+            "user_show",
+            id=user["id"],
+            # call_action will set ignore_auth: True by default, which will
+            # include restricted fields like apikey
+            context={"ignore_auth": False}
+        )
 
         assert got_user["id"] == user["id"]
         assert got_user["name"] == user["name"]
@@ -1071,7 +1082,14 @@ class TestUserShow(object):
         user = factories.User()
 
         got_user = helpers.call_action(
-            "user_show", context={"keep_email": True}, id=user["id"]
+            "user_show",
+            id=user["id"],
+            # call_action will set ignore_auth: True by default, which will
+            # include restricted fields like apikey
+            context={
+                "keep_email": True,
+                "ignore_auth": False
+            }
         )
 
         assert got_user["email"] == user["email"]
@@ -1084,7 +1102,14 @@ class TestUserShow(object):
         user = factories.User()
 
         got_user = helpers.call_action(
-            "user_show", context={"keep_apikey": True}, id=user["id"]
+            "user_show",
+            id=user["id"],
+            # call_action will set ignore_auth: True by default, which will
+            # include restricted fields like apikey
+            context={
+                "keep_apikey": True,
+                "ignore_auth": False
+            }
         )
 
         assert "email" not in got_user

--- a/ckan/tests/logic/action/test_patch.py
+++ b/ckan/tests/logic/action/test_patch.py
@@ -214,6 +214,33 @@ class TestPatch(object):
         assert user2["fullname"] == "Mr. Test User"
         assert user2["about"] == "somethingnew"
 
+    def test_extensions_successful_patch_updating_user_name(self):
+        user = factories.User()
+
+        updated_user = helpers.call_action(
+            "user_patch",
+            context={"user": user["name"], "ignore_auth": True},
+            id=user["id"],
+            name="somethingnew"
+        )
+
+        assert updated_user["name"] == "somethingnew"
+
+        user2 = helpers.call_action("user_show", id=user["id"])
+
+        assert user2["name"] == "somethingnew"
+
+    def test_extensions_failed_patch_updating_user_name(self):
+        user = factories.User()
+
+        with pytest.raises(ValidationError):
+            helpers.call_action(
+                "user_patch",
+                context={"user": user["name"], "ignore_auth": False},
+                id=user["id"],
+                name="somethingnew2"
+            )
+
     def test_package_patch_for_update(self):
 
         dataset = factories.Dataset()

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -41,11 +41,12 @@ class TestUpdate(object):
 
         # 1. Setup.
         user = factories.User()
+        context = {"user": user["name"], "ignore_auth": False}
         user["name"] = "updated"
 
         # 2. Make assertions about the return value and/or side-effects.
         with pytest.raises(logic.ValidationError):
-            helpers.call_action("user_update", **user)
+            helpers.call_action("user_update", context=context, **user)
 
     # END-BEFORE
 
@@ -264,22 +265,6 @@ class TestUpdate(object):
 
         updated_user = helpers.call_action("user_update", **params)
         assert "password" not in updated_user
-
-    def test_user_update_does_not_return_apikey(self):
-        """The user dict that user_update returns should not include the user's
-        API key."""
-
-        user = factories.User()
-        params = {
-            "id": user["id"],
-            "fullname": "updated full name",
-            "about": "updated about",
-            "email": user["email"],
-            "password": factories.User.stub().password,
-        }
-
-        updated_user = helpers.call_action("user_update", **params)
-        assert "apikey" not in updated_user
 
     def test_user_update_does_not_return_reset_key(self):
         """The user dict that user_update returns should not include the user's


### PR DESCRIPTION
This pull request introduces changes that allow plugins to patch the username and email address using external authentication providers. Previously, only system administrators could update the username, but it was not possible to modify it via plugins. This functionality now enables plugins to update both the username and email, allowing for better integration with external authentication systems and more flexible user management.