### PR TITLE
feat: Case-insensitive login by email / Unique emails across all user states

### DIFF
--- a/changes/8626.bugfix
+++ b/changes/8626.bugfix
@@ -1,0 +1,1 @@
+Switch login by email to case-insensitive mode.

--- a/changes/8626.bugfix
+++ b/changes/8626.bugfix
@@ -1,1 +1,3 @@
-Switch login by email to case-insensitive mode.
+Switch login by email to case-insensitive mode. Execute `ckan db
+duplicate_emails` CLI command to verify that there are no identical email with
+different letter-case among registered user.

--- a/changes/8626.feature
+++ b/changes/8626.feature
@@ -1,3 +1,5 @@
 :ref:`ckan.user.unique_email_states` can be used to specify statuses of user
 accounts that are used for checking uniqueness of the email during
-registration.
+registration. After changing the value of the option, run `ckan db
+duplicate_emails` CLI command to verify that all existing emails are still
+unique.

--- a/changes/8626.feature
+++ b/changes/8626.feature
@@ -1,0 +1,3 @@
+:ref:`ckan.user.unique_email_states` can be used to specify statuses of user
+accounts that are used for checking uniqueness of the email during
+registration.

--- a/ckan/cli/db.py
+++ b/ckan/cli/db.py
@@ -10,6 +10,8 @@ from typing import Optional
 import click
 from itertools import groupby
 
+from sqlalchemy.sql.operators import isnot
+
 import ckan.migration as migration_repo
 import ckan.plugins as p
 import ckan.model as model
@@ -195,15 +197,15 @@ def duplicate_emails():
     u'''Check users email for duplicate'''
     log.info(u"Searching for accounts with duplicate emails.")
 
-    q = model.Session.query(model.User.email,
-                            model.User.name) \
-        .filter(model.User.state == u"active") \
-        .filter(model.User.email != u"") \
-        .order_by(model.User.email).all()
+    q = model.Session.query(model.User.email, model.User.name).filter(
+        model.User.state.in_(config["ckan.user.unique_email_states"]),
+        model.User.email != u"",
+        model.User.email.isnot(None),
+    ).order_by(model.User.email).all()
 
     duplicates_found = False
     try:
-        for k, grp in groupby(q, lambda x: x[0]):
+        for k, grp in groupby(q, lambda x: x[0].lower()):
             users = [user[1] for user in grp]
             if len(users) > 1:
                 duplicates_found = True

--- a/ckan/cli/db.py
+++ b/ckan/cli/db.py
@@ -10,8 +10,6 @@ from typing import Optional
 import click
 from itertools import groupby
 
-from sqlalchemy.sql.operators import isnot
-
 import ckan.migration as migration_repo
 import ckan.plugins as p
 import ckan.model as model

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -326,7 +326,7 @@ groups:
         default: 31_536_000 # 1 year
         description: |
           If :ref:`SESSION_PERMANENT` is enabled, the session’s expiration will be
-          set this number of seconds in the future. Note that you can not set a 
+          set this number of seconds in the future. Note that you can not set a
           session that never expires (only very far into the future).
 
       - key: SESSION_USE_SIGNER
@@ -1374,6 +1374,28 @@ groups:
         description: |
           This controls the page where users will be sent after requesting a password reset.
           This is ordinarily the home page, but specific sites may prefer somewhere else.
+
+      - key: ckan.user.unique_email_states
+        type: list
+        default: [active]
+        example: [pending, active]
+        description: |
+          When a new user created, uniqueness of its email is checked among
+          users with specified statuses.
+
+          Using `active` is appropriate if users are created on portal only
+          through original user registration form and always have active
+          status. When user is deleted, his email can be reused by a new
+          account.
+
+          Using `pending active` is suitable for workflows with user approval
+          or invitations. In such scenario, user is created with `pending`
+          status initially and activated at some point in future.
+
+          Adding `deleted` to this option makes sense if email of removed users
+          must not be reused. In other words, when user is deleted, he is not
+          able to create a new account with the same email and is virtually
+          blocked on the portal.
 
   # TODO: move to activity extension
   - annotation: Activity Streams Settings

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -1137,7 +1137,10 @@ def email_is_unique(key: FlattenKey, data: FlattenDataDict,
 
     existing_users = (
         session.query(model.User)
-        .filter(model.User.email.ilike(data[key]), model.User.state == "active")
+        .filter(
+            model.User.email.ilike(data[key]),
+            model.User.state.in_(config["ckan.user.unique_email_states"]),
+        )
         .all()
     )
 

--- a/ckan/model/user.py
+++ b/ckan/model/user.py
@@ -90,7 +90,15 @@ class User(core.StatefulObjectMixin,
 
     @classmethod
     def by_email(cls, email: str) -> Optional[Self]:
-        return meta.Session.query(cls).filter_by(email=email).first()
+        """Case-insensitive search by email.
+
+        Returns first user with the given email. Because default CKAN
+        configuration allows reusing emails of deleted users, this method can
+        return deleted object instead of an active email owner.
+        """
+        return meta.Session.query(cls).filter(
+            func.lower(cls.email) == email.lower()
+        ).first()
 
     @classmethod
     def get(cls, user_reference: Optional[str]) -> Optional[Self]:


### PR DESCRIPTION
This PR changes two places in the user's email-related logic.

The first suggestion: `User.by_email` should use a case-insensitive email search. 
In this way, the user can authenticate using any letter case for an email address, even if it is not the same as one used during registration. It isn't a common problem, but recently I heard a complaint from `Sergey@Gmail.Com` that he cannot log in as `sergey@gmail.com`. It does not look like a security measure and we can allow it.


Second suggestion: make states of users, that are checked for email uniqueness, configurable. Right now only active users are checked when a new email is registered in the system, which is intentional(to allow reusing emails of deleted user accounts). But it causes the problem if:

* you want to delete an account and prevent user from registering a new account with the same email
* you have something similar to the request-an-account feature, where users are created in a pending state initially and must be approved by an authorized person. Ideally, there should be no requests with an existing email.

With this PR the default behavior of email uniqueness check remains unchanged, but now it's possible to configure states of users across which email is checked using `ckan.user.unique_email_states = active pending deleted some-other-status` option.
