### PR TITLE
chore: replace deprecated log.warn with log.warning

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -226,7 +226,7 @@ def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:
     csrf.init_app(app)
 
     if config.get("ckan.csrf_protection.ignore_extensions"):
-        log.warn(csrf_warn_extensions)
+        log.warning(csrf_warn_extensions)
         _exempt_plugins_blueprints_from_csrf(csrf)
 
     lib_plugins.register_package_blueprints(app)

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -106,7 +106,7 @@ def index_for(_type: Any) -> SearchIndex:
         _type_n = _normalize_type(_type)
         return _INDICES[_type_n]()
     except KeyError:
-        log.warn("Unknown search type: %s" % _type)
+        log.warning("Unknown search type: %s" % _type)
         return NoopSearchIndex()
 
 
@@ -147,7 +147,7 @@ def dispatch_by_operation(entity_type: str, entity: dict[str, Any],
         elif operation == domain_object.DomainObjectOperation.deleted:
             index.remove_dict(entity)
         else:
-            log.warn("Unknown operation: %s" % operation)
+            log.warning("Unknown operation: %s" % operation)
     except Exception as ex:
         log.exception(ex)
         # we really need to know about any exceptions, so reraise
@@ -175,7 +175,7 @@ class SynchronousSearchPlugin(p.SingletonPlugin):
             dispatch_by_operation(entity.__class__.__name__,
                                   {'id': entity.id}, operation)
         else:
-            log.warn("Discarded Sync. indexing for: %s" % entity)
+            log.warning("Discarded Sync. indexing for: %s" % entity)
 
 
 def rebuild(package_id: Optional[str] = None,
@@ -354,7 +354,7 @@ def check_solr_schema_version(schema_file: Optional[str]=None) -> bool:
 
     if not is_available():
         # Something is wrong with the SOLR server
-        log.warn('Problems were found while connecting to the SOLR server')
+        log.warning('Problems were found while connecting to the SOLR server')
         return False
 
     # Try to get the schema XML file to extract the version

--- a/ckan/lib/webassets_tools.py
+++ b/ckan/lib/webassets_tools.py
@@ -146,7 +146,7 @@ def include_asset(name: str) -> None:
             type_ = "script"
             break
     else:
-        log.warn("Undefined asset type: %s", urls)
+        log.warning("Undefined asset type: %s", urls)
         return
 
     g._webassets[type_].extend(urls)

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -357,7 +357,7 @@ def _group_or_org_list(
     # if it is supplied and sort isn't use order_by and raise a warning
     order_by = data_dict.get('order_by', '')
     if order_by:
-        log.warn('`order_by` deprecated please use `sort`')
+        log.warning('`order_by` deprecated please use `sort`')
         if not data_dict.get('sort'):
             sort = order_by
 


### PR DESCRIPTION
Trivial replacing of deprecated method with the recommended one.