### PR TITLE
fix: remove unnecessary BOM_UTF8 in group members CSV export

### DIFF
--- a/changes/8635.bugfix
+++ b/changes/8635.bugfix
@@ -1,1 +1,1 @@
-Fix CSV export error caused by writing BOM_UTF8 to output stream.
+Fix CSV export error by ensuring BOM is written correctly as a string for Excel compatibility.

--- a/changes/8635.bugfix
+++ b/changes/8635.bugfix
@@ -1,0 +1,1 @@
+Fix CSV export error caused by writing BOM_UTF8 to output stream.

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -8,7 +8,6 @@ from typing import Any, Optional, Union
 from urllib.parse import urlencode
 import csv
 from io import StringIO
-from codecs import BOM_UTF8
 
 import ckan.lib.base as base
 from ckan.lib.helpers import helper_functions as h
@@ -604,7 +603,6 @@ def member_dump(id: str, group_type: str, is_organization: bool):
         ])
 
     output_stream = StringIO()
-    output_stream.write(BOM_UTF8)  # type: ignore
     csv.writer(output_stream).writerows(results)
 
     file_name = u'{org_id}-{members}'.format(

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -603,6 +603,7 @@ def member_dump(id: str, group_type: str, is_organization: bool):
         ])
 
     output_stream = StringIO()
+    output_stream.write('\N{BOM}')  # for Excel handling of non-ASCII
     csv.writer(output_stream).writerows(results)
 
     file_name = u'{org_id}-{members}'.format(


### PR DESCRIPTION
### Proposed fixes:
This PR removes the unnecessary BOM_UTF8 from the CSV export of group members. The current code writes BOM_UTF8 to output_stream, which expects a string but receives bytes, causing an error. Since the BOM is not required for UTF-8 encoding, removing it prevents this issue while keeping the CSV export behavior unchanged.