### PR TITLE
Fix datastore data dictionary page access

### DIFF
--- a/changes/8639.bugfix
+++ b/changes/8639.bugfix
@@ -1,0 +1,1 @@
+Fix auth check for datastore data dictionary view

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -139,9 +139,9 @@ class DictionaryView(MethodView):
     def _prepare(self, id: str, resource_id: str) -> dict[str, Any]:
         try:
             check_access(
-                "datastore_upsert",
+                "datastore_create",
                 context={"user": current_user.name, "auth_user_obj": current_user},
-                data_dict={"id": id, "resource_id": resource_id},
+                data_dict={"resource_id": resource_id},
             )
 
             # resource_edit_base template uses these

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -8,7 +8,9 @@ from flask import Blueprint, Response
 from flask.views import MethodView
 
 import ckan.lib.navl.dictization_functions as dict_fns
+from ckan.common import current_user
 from ckan.logic import (
+    check_access,
     tuplize_dict,
     parse_params,
 )
@@ -136,6 +138,12 @@ class DictionaryView(MethodView):
 
     def _prepare(self, id: str, resource_id: str) -> dict[str, Any]:
         try:
+            check_access(
+                "datastore_upsert",
+                context={"user": current_user.name, "auth_user_obj": current_user},
+                data_dict={"id": id, "resource_id": resource_id},
+            )
+
             # resource_edit_base template uses these
             pkg_dict = get_action(u'package_show')({}, {'id': id})
             resource = get_action(u'resource_show')({}, {'id': resource_id})


### PR DESCRIPTION
The datastore data dictionary page doesn't have a proper auth check

This also will fix the table designer views (data dictionary, add, remove, update views), because they call the `DictionaryView` view.

### Proposed fixes:

Check for `datastore_upsert` 

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
