### PR TITLE
Simplify url_for

### DIFF
--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -47,7 +47,7 @@ groups:
   - annotation: ~
     options:
       - key: APPLICATION_ROOT
-        internal: true
+        ignored: true
       - key: BABEL_DEFAULT_LOCALE
         internal: true
       - key: BABEL_DEFAULT_TIMEZONE
@@ -93,7 +93,7 @@ groups:
       - key: SEND_FILE_MAX_AGE_DEFAULT
         internal: true
       - key: SERVER_NAME
-        internal: true
+        ignored: true
       - key: SESSION_COOKIE_PARTITIONED
         internal: true
       - key: TEMPLATES_AUTO_RELOAD

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -172,18 +172,6 @@ groups:
           If not provided, for backwards compatibility with earlier configurations the value of
           ``beaker.session.secret`` will be used.
 
-
-      - key: ckan.legacy_route_mappings
-        default: {}
-        example: '{"home": "home.index", "about": "home.about", "search": "dataset.search"}'
-        description: |
-          This can be used when using an extension that is still using old
-          (Pylons-based) route names to maintain compatibility.
-
-          .. warning:: This configuration will be removed when the migration to
-            Flask is completed. Please update the extension code to use the new
-            Flask-based route names.
-
       - key: config.mode
         default: strict
         example: strict

--- a/ckan/config/middleware/common_middleware.py
+++ b/ckan/config/middleware/common_middleware.py
@@ -14,27 +14,24 @@ from ckan.lib.redis import connect_to_redis
 
 
 class RootPathMiddleware(object):
-    '''
-    Prevents the SCRIPT_NAME server variable conflicting with the ckan.root_url
-    config. The routes package uses the SCRIPT_NAME variable and appends to the
-    path and ckan addes the root url causing a duplication of the root path.
-    This is a middleware to ensure that even redirects use this logic.
-    '''
+    """Set SERVER_NAME and SCRIPT_NAME.
+
+    Ideally, these variables must be set by web server, but adding it here is
+    more reliable and works even when server configuration is not synchronized
+    with CKAN configuration.
+    """
     def __init__(self, app: CKANApp):
         self.app = app
 
     def __call__(self, environ: Any, start_response: Any):
-        # Prevents the variable interfering with the root_path logic
-        parsed = urlparse(config["ckan.site_url"])
-        environ["SERVER_NAME"] = parsed.netloc
+        # SERVER_NAME is used for building external URLs.
+        environ["SERVER_NAME"] = config["SERVER_NAME"]
 
-        if not environ.get("SCRIPT_NAME"):
-            application_root = config["ckan.root_path"] or "/"
-            if not application_root.endswith("/"):
-                application_root += "/"
-            application_root = application_root.replace("/{{LANG}}", "")
-            environ["SCRIPT_NAME"] = application_root
-
+        # SCRIPT_NAME defines the prefix of the URL path. It's set to
+        # `ckan.root_path` without locale part. The locale is added manually
+        # inside `url_for` helper, which opens a possibility for building
+        # cross-locale links(mainly used by language selector).
+        environ["SCRIPT_NAME"] = config["APPLICATION_ROOT"]
 
         return self.app(environ, start_response)
 

--- a/ckan/config/middleware/common_middleware.py
+++ b/ckan/config/middleware/common_middleware.py
@@ -25,8 +25,16 @@ class RootPathMiddleware(object):
 
     def __call__(self, environ: Any, start_response: Any):
         # Prevents the variable interfering with the root_path logic
-        if 'SCRIPT_NAME' in environ:
-            environ['SCRIPT_NAME'] = ''
+        parsed = urlparse(config["ckan.site_url"])
+        environ["SERVER_NAME"] = parsed.netloc
+
+        if not environ.get("SCRIPT_NAME"):
+            application_root = config["ckan.root_path"] or "/"
+            if not application_root.endswith("/"):
+                application_root += "/"
+            application_root = application_root.replace("/{{LANG}}", "")
+            environ["SCRIPT_NAME"] = application_root
+
 
         return self.app(environ, start_response)
 

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -11,6 +11,7 @@ import logging
 
 from logging.handlers import SMTPHandler
 from typing import Any, Optional, Union, cast
+from urllib.parse import urlparse
 
 from flask import Blueprint, send_from_directory, current_app
 from flask.ctx import _AppCtxGlobals
@@ -131,6 +132,13 @@ def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:
     app.testing = testing
     app.template_folder = os.path.join(root, 'templates')
     app.app_ctx_globals_class = CKAN_AppCtxGlobals
+
+    application_root = config["ckan.root_path"] or "/"
+    if not application_root.endswith("/"):
+        application_root += "/"
+    application_root = application_root.replace("/{{LANG}}", "")
+    config["APPLICATION_ROOT"] = application_root
+    config["SERVER_NAME"] = urlparse(config["ckan.site_url"]).netloc
 
     # Update Flask config with the CKAN values. We use the common config
     # object as values might have been modified on `load_environment`

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -140,8 +140,6 @@ def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:
         app.config.update(conf)
 
     # Do all the Flask-specific stuff before adding other middlewares
-
-    root_path = config.get('ckan.root_path')
     if debug:
         from flask_debugtoolbar import DebugToolbarExtension
         app.config['DEBUG_TB_INTERCEPT_REDIRECTS'] = False
@@ -151,17 +149,6 @@ def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:
         # initializing debug app. In such a way, our route receives
         # higher precedence.
 
-        # TODO: After removal of Pylons code, switch to
-        # `APPLICATION_ROOT` config value for flask application. Right
-        # now it's a bad option because we are handling both pylons
-        # and flask urls inside helpers and splitting this logic will
-        # bring us tons of headache.
-        if root_path:
-            app.add_url_rule(
-                root_path.replace('{{LANG}}', '').rstrip('/') +
-                '/_debug_toolbar/static/<path:filename>',
-                '_debug_toolbar.static', debug_ext.send_static_file
-            )
         debug_ext.init_app(app)
 
         from werkzeug.debug import DebuggedApplication

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -32,11 +32,11 @@ from dominate.util import raw as raw_dom_tags
 from markdown import markdown
 from bleach import clean as bleach_clean, ALLOWED_TAGS, ALLOWED_ATTRIBUTES
 from ckan.common import asbool, config, current_user
+import flask
 from flask import flash, has_request_context, current_app
 from flask import get_flashed_messages as _flask_get_flashed_messages
 from flask import redirect as _flask_redirect
-from flask import url_for as _flask_default_url_for
-from werkzeug.routing import BuildError as FlaskRouteBuildError
+
 from ckan.lib import i18n
 from ckan.plugins.core import plugin_loaded
 
@@ -78,37 +78,6 @@ MARKDOWN_TAGS = set([
 
 MARKDOWN_ATTRIBUTES = copy.deepcopy(ALLOWED_ATTRIBUTES)
 MARKDOWN_ATTRIBUTES.setdefault('img', []).extend(['src', 'alt', 'title'])
-
-LEGACY_ROUTE_NAMES = {
-    'home': 'home.index',
-    'about': 'home.about',
-    'search': 'dataset.search',
-    'dataset_read': 'dataset.read',
-    'dataset_groups': 'dataset.groups',
-    'group_index': 'group.index',
-    'group_about': 'group.about',
-    'group_read': 'group.read',
-    'organizations_index': 'organization.index',
-    'organization_read': 'organization.read',
-    'organization_about': 'organization.about',
-
-    # Deprecated since v2.10
-    'dataset_activity': 'activity.package_activity',
-    'dataset.activity': 'activity.package_activity',
-    'group_activity': 'activity.group_activity',
-    'group.activity': 'activity.group_activity',
-    'organization_activity': 'activity.organization_activity',
-    'organization.activity': 'activity.organization_activity',
-    "user.activity": "activity.user_activity",
-    "dashboard.index": "activity.dashboard",
-    "dataset.changes_multiple": "activity.package_changes_multiple",
-    "dataset.changes": "activity.package_changes",
-    "group.changes_multiple": "activity.group_changes_multiple",
-    "group.changes": "activity.group_changes",
-    "organization.changes_multiple": "activity.organization_changes_multiple",
-    "organization.changes": "activity.organization_changes",
-
-}
 
 
 class HelperAttributeDict(Dict[str, Callable[..., Any]]):
@@ -330,11 +299,10 @@ def _get_auto_flask_context():
 def url_for(*args: Any, **kw: Any) -> str:
     '''Return the URL for an endpoint given some parameters.
 
-    This is a wrapper for :py:func:`flask.url_for`
-    and :py:func:`routes.url_for` that adds some extra features that CKAN
-    needs.
+    This is a wrapper for :py:func:`flask.url_for` that adds some extra
+    features that CKAN needs.
 
-    To build a URL for a Flask view, pass the name of the blueprint and the
+    To build a URL for a view, pass the name of the blueprint and the
     view function separated by a period ``.``, plus any URL parameters::
 
         url_for('api.action', ver=3, logic_function='status_show')
@@ -346,193 +314,82 @@ def url_for(*args: Any, **kw: Any) -> str:
         url_for('api.action', ver=3, logic_function='status_show',
                 _external=True)
         # Returns http://example.com/api/3/action/status_show
-
-    URLs built by Pylons use the Routes syntax::
-
-        url_for(controller='my_ctrl', action='my_action', id='my_dataset')
-        # Returns '/dataset/my_dataset'
-
-    Or, using a named route::
-
-        url_for('dataset.read', id='changed')
-        # Returns '/dataset/changed'
-
-    Use ``qualified=True`` for a fully qualified URL when targeting a Pylons
-    endpoint.
-
-    For backwards compatibility, an effort is made to support the Pylons syntax
-    when building a Flask URL, but this support might be dropped in the future,
-    so calls should be updated.
     '''
-    # Get the actual string code for the locale
-    locale = kw.pop('locale', None)
-    if locale and isinstance(locale, i18n.Locale):
-        locale = i18n.get_identifier_from_locale_class(locale)
+    blueprint = kw.pop("controller", None)
+    view = kw.pop("action", None)
+    if not args:
+        args = (f"{blueprint}.{view}",)
 
-    # remove __ckan_no_root and add after to not pollute url
-    no_root = kw.pop('__ckan_no_root', False)
+    if kw.pop("qualified", False):
+        kw.setdefault("_external", True)
+
+    locale = kw.pop('locale', None)
 
     _auto_flask_context = _get_auto_flask_context()
     try:
         if _auto_flask_context:
             _auto_flask_context.push()
 
-        # First try to build the URL with the Flask router
-        # Temporary mapping for pylons to flask route names
-        if len(args):
-            args = (map_pylons_to_flask_route_name(args[0]),)
-        my_url = _url_for_flask(*args, **kw)
+        url = flask.url_for(*args, **kw)
 
-    except FlaskRouteBuildError:
-        raise
+        if locale and isinstance(locale, i18n.Locale):
+            locale = i18n.get_identifier_from_locale_class(locale)
+        allowed_locales = ['default'] + i18n.get_locales()
+        if locale and locale not in allowed_locales:
+            locale = None
+
+        default_locale = False
+        if locale:
+            if locale == 'default':
+                default_locale = True
+        else:
+            try:
+                locale = request.environ.get('CKAN_LANG')
+                default_locale = request.environ.get('CKAN_LANG_IS_DEFAULT', True)
+            except TypeError:
+                default_locale = True
+
+        if not default_locale:
+            if root_path := config["ckan.root_path"]:
+                idx = max(root_path.find("/{{LANG}}"), 0)
+            else:
+                idx = 0
+            parsed = urlparse(url)
+            parsed = parsed._replace(
+                path=f"{parsed.path[:idx]}/{locale}{parsed.path[idx:]}",
+            )
+            url = urlunparse(parsed)
+
     finally:
         if _auto_flask_context:
             _auto_flask_context.pop()
 
-    # Add back internal params
-    kw['__ckan_no_root'] = no_root
-
-    # Rewrite the URL to take the locale and root_path into account
-    return _local_url(my_url, locale=locale, **kw)
+    return url
 
 
-def _url_for_flask(*args: Any, **kw: Any) -> str:
-    '''Build a URL using the Flask router
-
-    This function should not be called directly, use ``url_for`` instead
-
-    This function tries to support the Pylons syntax for ``url_for`` and adapt
-    it to the Flask one, eg::
-
-        # Pylons
-        url_for(controller='api', action='action', ver=3, qualified=True)
-
-        # Flask
-        url_for('api.action', ver=3, _external=True)
-
-
-    Raises :py:exception:`werkzeug.routing.BuildError` if it couldn't
-    generate a URL.
-    '''
-    if (len(args) and '_' in args[0]
-            and '.' not in args[0]
-            and not args[0].startswith('/')):
-        # Try to translate Python named routes to Flask endpoints
-        # eg `dataset_new` -> `dataset.new`
-        args = (args[0].replace('_', '.', 1), )
-    elif kw.get('controller') and kw.get('action'):
-        # If `controller` and `action` are passed, build a Flask endpoint
-        # from them
-        # eg controller='user', action='login' -> 'user.login'
-        args = ('{0}.{1}'.format(kw.pop('controller'), kw.pop('action')),)
-
-    # Support Pylons' way of asking for full URLs
-
-    external = kw.pop('_external', False) or kw.pop('qualified', False)
-
-    # The API routes used to require a slash on the version number, make sure
-    # we remove it
-    if (args and args[0].startswith('api.') and
-            isinstance(kw.get('ver'), str) and
-            kw['ver'].startswith('/')):
-        kw['ver'] = kw['ver'].replace('/', '')
-
-    # Try to build the URL with flask.url_for
-    try:
-        my_url = _flask_default_url_for(*args, **kw)
-    except FlaskRouteBuildError:
-        # Check if this a relative path
-        if len(args) and args[0].startswith('/'):
-            my_url = args[0]
-            if request.environ.get('SCRIPT_NAME'):
-                my_url = request.environ['SCRIPT_NAME'] + my_url
-            kw.pop('host', None)
-            kw.pop('protocol', None)
-            if kw:
-                query_args = []
-                for key, val in kw.items():
-                    if isinstance(val, (list, tuple)):
-                        for value in val:
-                            if value is None:
-                                continue
-                            query_args.append(
-                                u'{}={}'.format(
-                                    quote(str(key)),
-                                    quote(str(value))
-                                )
-                            )
-                    else:
-                        if val is None:
-                            continue
-                        query_args.append(
-                            u'{}={}'.format(
-                                quote(str(key)),
-                                quote(str(val))
-                            )
-                        )
-
-                if query_args:
-                    my_url += '?'
-                my_url += '&'.join(query_args)
-        else:
-            raise
-
-    if external:
-        # Don't rely on the host generated by Flask, as SERVER_NAME might not
-        # be set or might be not be up to date (as in tests changing
-        # `ckan.site_url`). Contrary to the Routes mapper, there is no way in
-        # Flask to pass the host explicitly, so we rebuild the URL manually
-        # based on `ckan.site_url`, which is essentially what we did on Pylons
-        protocol, host = get_site_protocol_and_host()
-        # these items cannot be empty because CKAN won't start otherwise
-        assert (protocol, host) != (None, None)
-        parts = urlparse(my_url)
-        my_url = urlunparse((protocol, host, parts.path, parts.params,
-                             parts.query, parts.fragment))
-
-    return my_url
 
 
 @core_helper
-def url_for_static(*args: Any, **kw: Any) -> str:
+def url_for_static(filename: str, **kw: Any) -> str:
     '''Returns the URL for static content that doesn't get translated (eg CSS)
 
-    It'll raise CkanUrlException if called with an external URL
-
-    This is a wrapper for :py:func:`routes.url_for`
     '''
-    if args:
-        url = urlparse(args[0])
-        url_is_external = (url.scheme != '' or url.netloc != '')
-        if url_is_external:
-            raise ckan.exceptions.CkanUrlException(
-                'External URL passed to url_for_static()')
-    return url_for_static_or_external(*args, **kw)
+    kw["filename"] = filename
+    return url_for("static", **kw)
 
 
 @core_helper
-def url_for_static_or_external(*args: Any, **kw: Any) -> str:
+def url_for_static_or_external(url: str, **kw: Any) -> str:
     '''Returns the URL for static content that doesn't get translated (eg CSS),
     or external URLs
     '''
-    def fix_arg(arg: Any):
-        url = urlparse(str(arg))
-        url_is_relative = (url.scheme == '' and url.netloc == '' and
-                           not url.path.startswith('/'))
-        if url_is_relative:
-            return False, '/' + url.geturl()
+    if urlparse(url).scheme:
+        return url
 
-        return bool(url.scheme), url.geturl()
-
-    if args:
-        is_external, fixed_url = fix_arg(args[0])
-        if is_external:
-            return fixed_url
-        args = (fixed_url, ) + args[1:]
-    if kw.get('qualified', False):
-        kw['protocol'], kw['host'] = get_site_protocol_and_host()
+    kw["filename"] = url
     kw['locale'] = 'default'
-    return url_for(*args, **kw)
+
+    return url_for("static", **kw)
 
 
 @core_helper
@@ -552,87 +409,6 @@ def is_url(*args: Any, **kw: Any) -> bool:
     return url.scheme in (valid_schemes)
 
 
-def _local_url(url_to_amend: str, **kw: Any):
-    # If the locale keyword param is provided then the url is rewritten
-    # using that locale .If return_to is provided this is used as the url
-    # (as part of the language changing feature).
-    # A locale of default will not add locale info to the url.
-
-    default_locale = False
-    locale = kw.pop('locale', None)
-    no_root = kw.pop('__ckan_no_root', False)
-    allowed_locales = ['default'] + i18n.get_locales()
-    if locale and locale not in allowed_locales:
-        locale = None
-
-    _auto_flask_context = _get_auto_flask_context()
-
-    if _auto_flask_context:
-        _auto_flask_context.push()
-
-    if locale:
-        if locale == 'default':
-            default_locale = True
-    else:
-        try:
-            locale = request.environ.get('CKAN_LANG')
-            default_locale = request.environ.get('CKAN_LANG_IS_DEFAULT', True)
-        except TypeError:
-            default_locale = True
-
-    root = ''
-    if kw.get('qualified', False) or kw.get('_external', False):
-        # if qualified is given we want the full url ie http://...
-        protocol, host = get_site_protocol_and_host()
-
-        parts = urlparse(
-            _flask_default_url_for('home.index', _external=True)
-        )
-
-        path = parts.path.rstrip('/')
-        root = urlunparse(
-            (protocol, host, path,
-                parts.params, parts.query, parts.fragment))
-
-    if _auto_flask_context:
-        _auto_flask_context.pop()
-
-    # ckan.root_path is defined when we have none standard language
-    # position in the url
-    root_path = config.get('ckan.root_path')
-    if root_path:
-        # FIXME this can be written better once the merge
-        # into the ecportal core is done - Toby
-        # we have a special root specified so use that
-        if default_locale:
-            root_path = re.sub('/{{LANG}}', '', root_path)
-        else:
-            root_path = re.sub('{{LANG}}', str(locale), root_path)
-        # make sure we don't have a trailing / on the root
-        if root_path[-1] == '/':
-            root_path = root_path[:-1]
-    else:
-        if default_locale:
-            root_path = ''
-        else:
-            root_path = '/' + str(locale)
-
-    url_path = url_to_amend[len(root):]
-    url = '%s%s%s' % (root, root_path, url_path)
-
-    # stop the root being added twice in redirects
-    if no_root and url_to_amend.startswith(root):
-        url = url_to_amend[len(root):]
-        if not default_locale:
-            url = '/%s%s' % (locale, url)
-
-    if url == '/packages':
-        error = 'There is a broken url being created %s' % kw
-        raise ckan.exceptions.CkanUrlException(error)
-
-    return url
-
-
 @core_helper
 def url_is_local(url: str) -> bool:
     '''Returns True if url is local'''
@@ -650,13 +426,12 @@ def url_is_local(url: str) -> bool:
 def full_current_url() -> str:
     ''' Returns the fully qualified current url (eg http://...) useful
     for sharing etc '''
-    return (url_for(request.environ['CKAN_CURRENT_URL'], qualified=True))
-
+    return request.url
 
 @core_helper
 def current_url() -> str:
     ''' Returns current url unquoted'''
-    return request.environ['CKAN_CURRENT_URL']
+    return request.full_path
 
 
 @core_helper
@@ -934,23 +709,6 @@ def build_nav(menu_item: str, title: str, **kw: Any) -> Markup:
 
     '''
     return _make_menu_item(menu_item, title, icon=None, **kw)
-
-
-def map_pylons_to_flask_route_name(menu_item: str):
-    '''returns flask routes for old fashioned route names'''
-    # Pylons to Flask legacy route names mappings
-    mappings = config.get('ckan.legacy_route_mappings')
-    if mappings:
-        if isinstance(mappings, str):
-            LEGACY_ROUTE_NAMES.update(json.loads(mappings))
-        elif isinstance(mappings, dict):
-            LEGACY_ROUTE_NAMES.update(mappings)
-
-    if menu_item in LEGACY_ROUTE_NAMES:
-        log.info('Route name "%s" is deprecated and will be removed. '
-                 'Please update calls to use "%s" instead',
-                 menu_item, LEGACY_ROUTE_NAMES[menu_item])
-    return LEGACY_ROUTE_NAMES.get(menu_item, menu_item)
 
 
 def _make_menu_item(menu_item: str, title: str, **kw: Any) -> Markup:

--- a/ckan/lib/webassets_tools.py
+++ b/ckan/lib/webassets_tools.py
@@ -135,10 +135,14 @@ def include_asset(name: str) -> None:
         include_asset(dep)
 
     # Add `site_root` if configured
-    urls = [url_for_static_or_external(url) for url in bundle.urls()]
+    urls: list[str] = []
 
-    for url in urls:
-        link = url.split("?")[0]
+    for url in bundle.urls():
+        parts = url.split("?", 1)
+        link = parts.pop(0)
+        query = parts.pop() if parts else ""
+        link = url_for_static_or_external(link)
+        urls.append("?".join([link, query]))
         if link.endswith(".css"):
             type_ = "style"
             break

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -184,12 +184,9 @@ def add_public_directory(config_: CKANConfig, relative_path: str):
     public urls.
 
     """
-    from ckan.lib.helpers import _local_url
     from ckan.lib.webassets_tools import add_public_path
-
     path = _add_served_directory(config_, relative_path, "plugin_public_paths")
-    url = _local_url("/", locale="default")
-    add_public_path(path, url)
+    add_public_path(path, "/")
 
 
 def _add_served_directory(

--- a/ckan/templates-midnight-blue/snippets/language_selector.html
+++ b/ckan/templates-midnight-blue/snippets/language_selector.html
@@ -5,7 +5,7 @@
     <label for="field-lang-select">{{ _('Language') }}</label>
     <select id="field-lang-select" name="url" data-module="autocomplete" data-module-dropdown-class="lang-dropdown" data-module-container-class="lang-container">
       {% for locale in h.get_available_locales() %}
-        <option value="{% url_for h.current_url(), locale=locale.short_name %}" {% if locale.short_name == current_lang %}selected="selected"{% endif %}>
+        <option value="{{ h.url_for(request.endpoint, locale=locale.short_name, **request.view_args) }}" {% if locale.short_name == current_lang %}selected="selected"{% endif %}>
           {{ locale.display_name or locale.english_name }}
         </option>
       {% endfor %}
@@ -13,5 +13,3 @@
   </div>
   <button class="btn btn-secondary d-none " type="submit">{{ _('Go') }}</button>
 </form>
-
-

--- a/ckan/templates-midnight-blue/snippets/language_selector.html
+++ b/ckan/templates-midnight-blue/snippets/language_selector.html
@@ -1,11 +1,13 @@
 {% set current_lang = request.environ.CKAN_LANG %}
+{% set url_args = request.args.to_dict() %}
+{% do url_args.update(request.view_args) %}
 <form class="lang-select" action="{% url_for 'util.internal_redirect' %}" data-module="select-switch" method="POST">
   {{ h.csrf_input() }}
   <div class="form-group">
     <label for="field-lang-select">{{ _('Language') }}</label>
     <select id="field-lang-select" name="url" data-module="autocomplete" data-module-dropdown-class="lang-dropdown" data-module-container-class="lang-container">
       {% for locale in h.get_available_locales() %}
-        <option value="{{ h.url_for(request.endpoint, locale=locale.short_name, **request.view_args) }}" {% if locale.short_name == current_lang %}selected="selected"{% endif %}>
+        <option value="{{ h.url_for(request.endpoint, locale=locale.short_name, **url_args) }}" {% if locale.short_name == current_lang %}selected="selected"{% endif %}>
           {{ locale.display_name or locale.english_name }}
         </option>
       {% endfor %}

--- a/ckan/templates/snippets/language_selector.html
+++ b/ckan/templates/snippets/language_selector.html
@@ -5,7 +5,7 @@
     <label for="field-lang-select">{{ _('Language') }}</label>
     <select id="field-lang-select" name="url" data-module="autocomplete" data-module-dropdown-class="lang-dropdown" data-module-container-class="lang-container">
       {% for locale in h.get_available_locales() %}
-        <option value="{% url_for h.current_url(), locale=locale.short_name %}" {% if locale.short_name == current_lang %}selected="selected"{% endif %}>
+        <option value="{{ h.url_for(request.endpoint, locale=locale.short_name, **request.view_args) }}" {% if locale.short_name == current_lang %}selected="selected"{% endif %}>
           {{ locale.display_name or locale.english_name }}
         </option>
       {% endfor %}
@@ -13,5 +13,3 @@
   </div>
   <button class="btn btn-secondary d-none " type="submit">{{ _('Go') }}</button>
 </form>
-
-

--- a/ckan/templates/snippets/language_selector.html
+++ b/ckan/templates/snippets/language_selector.html
@@ -1,11 +1,13 @@
 {% set current_lang = request.environ.CKAN_LANG %}
+{% set url_args = request.args.to_dict() %}
+{% do url_args.update(request.view_args) %}
 <form class="lang-select" action="{% url_for 'util.internal_redirect' %}" data-module="select-switch" method="POST">
   {{ h.csrf_input() }}
   <div class="form-group">
     <label for="field-lang-select">{{ _('Language') }}</label>
     <select id="field-lang-select" name="url" data-module="autocomplete" data-module-dropdown-class="lang-dropdown" data-module-container-class="lang-container">
       {% for locale in h.get_available_locales() %}
-        <option value="{{ h.url_for(request.endpoint, locale=locale.short_name, **request.view_args) }}" {% if locale.short_name == current_lang %}selected="selected"{% endif %}>
+        <option value="{{ h.url_for(request.endpoint, locale=locale.short_name, **url_args) }}" {% if locale.short_name == current_lang %}selected="selected"{% endif %}>
           {{ locale.display_name or locale.english_name }}
         </option>
       {% endfor %}

--- a/ckan/tests/controllers/test_home.py
+++ b/ckan/tests/controllers/test_home.py
@@ -41,26 +41,6 @@ class TestHome(object):
 
         assert "add your email address" not in response
 
-    @pytest.mark.ckan_config(
-        "ckan.legacy_route_mappings", '{"my_home_route": "home.index"}'
-    )
-    def test_map_pylons_to_flask_route(self, app):
-        response = app.get(url_for("my_home_route"))
-        assert "Welcome to CKAN" in response.body
-
-        response = app.get(url_for("home"))
-        assert "Welcome to CKAN" in response.body
-
-    @pytest.mark.ckan_config(
-        "ckan.legacy_route_mappings", {"my_home_route": "home.index"}
-    )
-    def test_map_pylons_to_flask_route_using_dict(self, app):
-        response = app.get(url_for("my_home_route"))
-        assert "Welcome to CKAN" in response.body
-
-        response = app.get(url_for("home"))
-        assert "Welcome to CKAN" in response.body
-
 
 class TestI18nURLs(object):
     def test_right_urls_are_rendered_on_language_selector(self, app):

--- a/ckan/tests/controllers/test_pagination.py
+++ b/ckan/tests/controllers/test_pagination.py
@@ -45,7 +45,7 @@ def test_group_datasets_read(app):
         for dataset in factories.Dataset.create_batch(51, groups=[{"name": group["name"]}])
     ]
     resp = app.get(
-        url_for(controller="group", action="read", id=group["name"])
+        url_for("group.read", id=group["name"])
     )
     page = BeautifulSoup(resp.data)
     href = page.select_one(".pagination").find("a", text=2)["href"]
@@ -58,7 +58,7 @@ def test_group_datasets_read(app):
     assert all_names[:-21:-1] == names
 
     resp = app.get(
-        url_for(controller="group", action="read", id=group["name"], page=2)
+        url_for("group.read", id=group["name"], page=2)
     )
     page = BeautifulSoup(resp.data)
     href = page.select_one(".pagination").find("a", text=1)["href"]

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -196,7 +196,7 @@ class TestHelpersUrlForFlaskandPylons(BaseUrlFor):
 
     def test_url_for_flask_route_old_syntax(self):
         url = "/api/3"
-        generated_url = h.url_for(controller="api", action="get_api", ver=3)
+        generated_url = h.url_for("api.get_api", ver=3)
         assert generated_url == url
 
     def test_url_for_flask_route_new_syntax_external(self):
@@ -213,7 +213,7 @@ class TestHelpersUrlForFlaskandPylons(BaseUrlFor):
     def test_url_for_flask_route_old_syntax_external(self):
         url = "http://example.com/api/3"
         generated_url = h.url_for(
-            controller="api", action="get_api", ver=3, _external=True
+            "api.get_api", ver=3, _external=True
         )
         assert generated_url == url
 
@@ -221,14 +221,14 @@ class TestHelpersUrlForFlaskandPylons(BaseUrlFor):
     def test_url_for_flask_route_old_syntax_external_with_root_path(self):
         url = "http://example.com/data/api/3"
         generated_url = h.url_for(
-            controller="api", action="get_api", ver=3, _external=True
+            "api.get_api", ver=3, _external=True
         )
         assert generated_url == url
 
     def test_url_for_flask_route_old_syntax_qualified(self):
         url = "http://example.com/api/3"
         generated_url = h.url_for(
-            controller="api", action="get_api", ver=3, qualified=True
+            "api.get_api", ver=3, qualified=True
         )
         assert generated_url == url
 
@@ -236,7 +236,7 @@ class TestHelpersUrlForFlaskandPylons(BaseUrlFor):
     def test_url_for_flask_route_old_syntax_qualified_with_root_path(self):
         url = "http://example.com/data/api/3"
         generated_url = h.url_for(
-            controller="api", action="get_api", ver=3, qualified=True
+            "api.get_api", ver=3, qualified=True
         )
         assert generated_url == url
 
@@ -247,7 +247,7 @@ class TestHelpersUrlForFlaskandPylons(BaseUrlFor):
 
     def test_url_for_flask_route_old_syntax_site_url(self):
         url = "/api/3"
-        generated_url = h.url_for(controller="api", action="get_api", ver=3)
+        generated_url = h.url_for("api.get_api", ver=3)
         assert generated_url == url
 
     def test_url_for_flask_route_new_syntax_request_context(self, app):

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -28,7 +28,6 @@ class BaseUrlFor(object):
             yield
 
 
-
 class TestHelpersUrlForStatic(BaseUrlFor):
     def test_url_for_static(self):
         url = "/assets/ckan.jpg"

--- a/ckan/views/home.py
+++ b/ckan/views/home.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from urllib.parse import urlencode
 from typing import Any, Optional, List, Tuple
 
 from flask import Blueprint, make_response, redirect, request

--- a/ckan/views/home.py
+++ b/ckan/views/home.py
@@ -91,10 +91,7 @@ def robots_txt() -> Response:
 def redirect_locale(target_locale: str, path: Optional[str] = None) -> Any:
     target = f'/{target_locale}/{path}' if path else f'/{target_locale}'
 
-    if request.args:
-        target += f'?{urlencode(request.args)}'
-
-    url = h.url_for(target, _external=True)
+    url = h.url_for_static(target, _external=True, **request.args.to_dict())
 
     return redirect(url, code=308)
 

--- a/ckanext/activity/tests/logic/test_functional.py
+++ b/ckanext/activity/tests/logic/test_functional.py
@@ -29,7 +29,7 @@ class TestPagination():
             )
 
         # Test initial pagination buttons are rendered correctly
-        url = tk.url_for("dataset.activity", id=dataset["id"])
+        url = tk.url_for("activity.package_activity", id=dataset["id"])
         response = app.get(url)
 
         body = BeautifulSoup(response.body)

--- a/ckanext/stats/templates/ckanext/stats/index.html
+++ b/ckanext/stats/templates/ckanext/stats/index.html
@@ -96,7 +96,7 @@
             {% for group, num_packages in largest_groups %}
               <tr>
                 <td>
-                  <a href="{{ h.url_for(controller=group.type, action='read', id=group.name) }}">
+                  <a href="{{ h.url_for(group.type ~ '.read', id=group.name) }}">
                     {{group.title or group.name}}
                   </a>
                 </td>

--- a/doc/contributing/frontend/templating.rst
+++ b/doc/contributing/frontend/templating.rst
@@ -238,7 +238,7 @@ Works exactly the same as ``h.link_for()``:
 
 ::
 
-    <li>{% link_for _("Home"), controller="home", action="index" %}</li>
+    <li>{% link_for _("Home"), named_route="home.index" %}</li>
 
 url\_for\_static
 ~~~~~~~~~~~~~~~~

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ dominate==2.9.1
     # via -r requirements.in
 feedgen==1.0.0
     # via -r requirements.in
-flask==3.1.0
+flask[async]==3.1.0
     # via
     #   -r requirements.in
     #   flask-babel


### PR DESCRIPTION
Make `url_for` helper less custom.

Flask uses `SERVER_NAME` and `APPLICATION_ROOT` when building URLs. `SERVER_NAME` is used for external URLs and `APPLICATION_ROOT` serves a similar purpose to `ckan.root_path`. These options can be automatically set during initialization, allowing us to remove essential parts of the `url_for` custom logic. 

Breaking changes: 

* `url_for`, `url_for_static`, and `url_for_static_or_external` now accept only one positional parameter - endpoint in case of `url_for` and relative/absolute URL in case of the other two helpers. All other parameters are keyword-only
* `url_for` accepts only endpoint names. Previously it was allowed to pass into it relative or absolute URLs(can be easily replaced with `url_for_static_or_external`).
* Query parameters must be passed into `url_for_static` as named parameters. Previously it was allowed to pass relative URLs with `?...` part.    