### PR TITLE
chore: Switch Cypress GH workflow to upload-artifact@v4

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -60,13 +60,13 @@ jobs:
         with:
           start: ckan -c test-core-cypress.ini run
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-screenshots
           path: cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: cypress-videos


### PR DESCRIPTION
On January 30th, v3 of upload-artifacts action used by cypress workflow was deprecated and cypress tests are disabled([blogpost](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)). This PR updates the version of upload-artifacts to enable cypress workflow back.