### PR TITLE
refactor Follow buttons to use snippet, #8651

### DIFF
--- a/changes/8651.bugfix
+++ b/changes/8651.bugfix
@@ -1,0 +1,1 @@
+Restore usage of 'follow_button' snippet so it can be overridden and customised

--- a/ckan/templates/group/snippets/info.html
+++ b/ckan/templates/group/snippets/info.html
@@ -53,11 +53,7 @@
           {% if error_message %}
             <div class="alert alert-danger">{{ error_message }}</div>
           {% endif %}
-          {% if am_following %}
-            <a class="btn btn-danger" hx-post="{{ h.url_for('group.unfollow', id=group.id) }}" hx-target="#group-info"><i class="fa-solid fa-circle-minus"></i> Unfollow</a>
-          {% else %}
-            <a class="btn btn-success" hx-post="{{ h.url_for('group.follow', id=group.id) }}" hx-target="#group-info"><i class="fa-solid fa-circle-plus"></i> Follow</a>
-          {% endif %}
+          {% snippet 'snippets/follow_button.html', am_following=am_following, obj_type='group', obj_id=group.id %}
         {% endif %}
       {% endblock %}
     {% endif %}

--- a/ckan/templates/organization/snippets/info.html
+++ b/ckan/templates/organization/snippets/info.html
@@ -63,11 +63,8 @@
         {% if current_user.is_authenticated %}
           {% if error_message %}
             <div class="alert alert-danger">{{ error_message }}</div>
-          {% elif am_following %}
-            <a class="btn btn-danger" hx-post="{{ h.url_for('organization.unfollow', id=organization.id) }}" hx-target="#organization-info"><i class="fa-solid fa-circle-minus"></i> Unfollow</a>
-          {% else %}
-            <a class="btn btn-success" hx-post="{{ h.url_for('organization.follow', id=organization.id) }}" hx-target="#organization-info"><i class="fa-solid fa-circle-plus"></i> Follow</a>
           {% endif %}
+          {% snippet 'snippets/follow_button.html', am_following=am_following, obj_type='organization', obj_id=organization.id %}
         {% endif %}
         {% endblock %}
       {% endif %}

--- a/ckan/templates/package/snippets/info.html
+++ b/ckan/templates/package/snippets/info.html
@@ -29,14 +29,10 @@ Example:
             {% endblock %}
             {% block follow_button %}
               {% if current_user.is_authenticated %}
-               {% if error_message %}
+                {% if error_message %}
                   <div class="alert alert-danger">{{ error_message }}</div>
                 {% endif %}
-               {% if am_following %}
-                  <a class="btn btn-danger" hx-post="{{ h.url_for('dataset.unfollow', id=pkg.id) }}" hx-target="#package-info"><i class="fa-solid fa-circle-minus"></i> Unfollow</a>
-                {% else %}
-                <a class="btn btn-success" hx-post="{{ h.url_for('dataset.follow', id=pkg.id) }}" hx-target="#package-info"><i class="fa-solid fa-circle-plus"></i> Follow</a>
-                {% endif %}
+                {% snippet 'snippets/follow_button.html', am_following=am_following, obj_type='dataset', obj_id=pkg.id, anchor_type='package' %}
               {% endif %}
             {% endblock %}
           {% endblock %}

--- a/ckan/templates/snippets/follow_button.html
+++ b/ckan/templates/snippets/follow_button.html
@@ -1,11 +1,8 @@
-{% if following %}
-  <a href="{{ h.url_for(obj_type + '.unfollow', id=obj_id) }}" class="{% block following_class %}btn btn-danger{% endblock %}" data-module="follow" data-module-type="{{ obj_type }}" data-module-id="{{ obj_id }}" data-module-action="unfollow">
-    <i class="fa fa-times-circle"></i>
-    {{ _('Unfollow') }}
-  </a>
+{# By default the anchor_type is the same as the obj_type,
+   eg 'user.unfollow' will anchor to '#user-info' #}
+{% set anchor_type = anchor_type or obj_type %}
+{% if following or am_following %}
+  <a class="btn btn-danger" hx-post="{{ h.url_for(obj_type + '.unfollow', id=obj_id) }}" hx-target="#{{ anchor_type }}-info"><i class="fa-solid fa-circle-minus"></i> Unfollow</a>
 {% else %}
-  <a href="{{ h.url_for(obj_type + '.follow', id=obj_id) }}" class="{% block unfollowing_class %}btn btn-success{% endblock %}" data-module="follow" data-module-type="{{ obj_type }}" data-module-id="{{ obj_id }}" data-module-action="follow">
-    <i class="fa fa-plus-circle"></i>
-    {{ _('Follow') }}
-  </a>
+  <a class="btn btn-success" hx-post="{{ h.url_for(obj_type + '.follow', id=obj_id) }}" hx-target="#{{ anchor_type }}-info"><i class="fa-solid fa-circle-plus"></i> Follow</a>
 {% endif %}


### PR DESCRIPTION
Fixes #8651

### Proposed fixes:

Restore usage of `snippets/follow_button.html` instead of inlining it.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
