### PR TITLE
Fix typo in changelog example

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -722,7 +722,7 @@ Removals and deprecations
       class FirstPlugin(p.SingletonPlugin, BasePlugin):
           p.implements(ISomething)
 
-      class SecondPlugin(p.SingletonPlugin, BasePlutin):
+      class SecondPlugin(p.SingletonPlugin, BasePlugin):
           p.implements(IAnything)
 
 


### PR DESCRIPTION
Fixes a typo in changelog example, it doesn't seem to be generated no longer from any changelog entry.
