### PR TITLE
default_user_schema: add missing boolean_validator

### DIFF
--- a/changes/8674.bugfix
+++ b/changes/8674.bugfix
@@ -1,0 +1,1 @@
+Add missing boolean_validator to sysadmin field in user schema

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -474,7 +474,7 @@ def default_user_schema(
         'about': [ignore_missing, user_about_validator, unicode_safe],
         'created': [ignore],
         'sysadmin': [ignore_missing, ignore_not_sysadmin,
-                     limit_sysadmin_update],
+                     limit_sysadmin_update, boolean_validator],
         'reset_key': [ignore],
         'activity_streams_email_notifications': [ignore_missing,
                                                  boolean_validator],


### PR DESCRIPTION
### Proposed fixes:

Add missing `boolean_validator` to user sysadmin flag.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport