### PR TITLE
[Midnight Blue] Dashboard pages

### DIFF
--- a/ckan/public-midnight-blue/base/css/main-rtl.css
+++ b/ckan/public-midnight-blue/base/css/main-rtl.css
@@ -12476,6 +12476,7 @@ a.tag:hover {
 @media (max-width: 767.98px) {
   .secondary .nav-items {
     background-color: transparent;
+    border-bottom: none;
     flex-wrap: nowrap;
     overflow-x: auto;
     overflow-y: scroll;

--- a/ckan/public-midnight-blue/base/css/main-rtl.css
+++ b/ckan/public-midnight-blue/base/css/main-rtl.css
@@ -12439,6 +12439,56 @@ a.tag:hover {
   color: #2f4b91;
 }
 
+.secondary .nav-tabs {
+  background-color: #f2f4f7;
+  border-radius: 8px;
+}
+.secondary .nav-tabs .active {
+  background-color: #153084;
+}
+.secondary .nav-tabs .active a {
+  color: #fff;
+}
+.secondary .nav-tabs .active:hover {
+  background-color: #153084;
+}
+.secondary .nav-tabs li {
+  border-radius: 8px;
+  padding: 10px 16px;
+  width: 100%;
+}
+.secondary .nav-tabs li a {
+  display: flex;
+  justify-content: space-between;
+  flex-direction: row-reverse;
+}
+.secondary .nav-tabs li a i {
+  display: flex;
+  align-items: center;
+}
+.secondary .nav-tabs li a:hover {
+  text-decoration: none;
+}
+.secondary .nav-tabs li:hover {
+  background-color: #e4e7ec;
+}
+@media (max-width: 767.98px) {
+  .secondary .nav-tabs {
+    background-color: transparent;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: scroll;
+    white-space: nowrap;
+  }
+  .secondary .nav-tabs li {
+    margin-left: 8px;
+    background-color: #f2f4f7;
+  }
+  .secondary .nav-tabs li i {
+    margin-left: 1rem;
+  }
+}
+
 .nav-stacked > li {
   float: none;
 }
@@ -13950,11 +14000,7 @@ td.diff_header {
 
 @media (max-width: 767.98px) {
   .main .secondary {
-    -webkit-box-ordinal-group: 2;
-    -moz-box-ordinal-group: 2;
-    -webkit-order: 2;
-    order: 2;
-    margin-top: 1rem;
+    margin: 1rem 0;
   }
   .js .main .secondary .filters {
     display: none;
@@ -14524,22 +14570,47 @@ td.diff_header {
   margin-bottom: 20px;
 }
 
-#followee-filter .btn {
-  display: inline-block;
+#followee-filter {
+  position: relative;
+  z-index: 1;
 }
-#followee-filter .btn span,
-#followee-filter .btn strong {
-  line-height: 1.5;
+
+#followee-popover {
+  color: #000;
+  width: 100%;
+  border-radius: 6px;
+  margin-bottom: 10px;
+  padding: 2px 16px 5px 5px;
+  background-color: #fff;
+  display: flex;
+  justify-content: space-between;
 }
-#followee-filter .btn span {
-  font-weight: normal;
+#followee-popover:focus {
+  box-shadow: 0 0 0 0.25rem rgba(21, 48, 132, 0.25);
 }
-#followee-filter .btn strong {
-  margin: 0 5px;
-  white-space: nowrap;
-  max-width: 90px;
-  overflow: hidden;
-  text-overflow: ellipsis;
+#followee-popover:hover {
+  text-decoration: none;
+}
+@media (min-width: 768px) {
+  #followee-popover {
+    float: right;
+    margin-left: 15px;
+    width: max-content;
+  }
+}
+#followee-popover .label {
+  font-size: 12px;
+  font-weight: 500;
+  color: #667085;
+}
+#followee-popover .dropdown-content {
+  padding: 2px 3rem 0.5rem 0.5rem;
+  display: flex;
+  flex-direction: column;
+}
+#followee-popover .caret {
+  display: flex;
+  align-items: center;
 }
 
 .dashboard-context {
@@ -14564,7 +14635,6 @@ td.diff_header {
 }
 
 .followee-container {
-  padding: 0;
   padding: 0;
   margin: 0;
   max-height: 205px;
@@ -14612,6 +14682,22 @@ td.diff_header {
   display: block;
   font-size: 16px;
   margin: 3px 0;
+}
+
+.dashboard-container {
+  display: flex;
+  flex-direction: column-reverse;
+}
+@media (min-width: 576px) {
+  .dashboard-container {
+    flex-direction: row;
+  }
+  .dashboard-container .page_primary_action {
+    display: block;
+  }
+  .dashboard-container .page_primary_action a {
+    float: right;
+  }
 }
 
 .resource-view .actions {

--- a/ckan/public-midnight-blue/base/css/main-rtl.css
+++ b/ckan/public-midnight-blue/base/css/main-rtl.css
@@ -12439,52 +12439,53 @@ a.tag:hover {
   color: #2f4b91;
 }
 
-.secondary .nav-tabs {
+.secondary .nav-items {
   background-color: #f2f4f7;
   border-radius: 8px;
+  border-bottom: 2px solid #d0d5dd;
 }
-.secondary .nav-tabs .active {
+.secondary .nav-items .active {
   background-color: #153084;
 }
-.secondary .nav-tabs .active a {
+.secondary .nav-items .active a {
   color: #fff;
 }
-.secondary .nav-tabs .active:hover {
+.secondary .nav-items .active:hover {
   background-color: #153084;
 }
-.secondary .nav-tabs li {
+.secondary .nav-items li {
   border-radius: 8px;
   padding: 10px 16px;
   width: 100%;
 }
-.secondary .nav-tabs li a {
+.secondary .nav-items li a {
   display: flex;
   justify-content: space-between;
   flex-direction: row-reverse;
 }
-.secondary .nav-tabs li a i {
+.secondary .nav-items li a i {
   display: flex;
   align-items: center;
 }
-.secondary .nav-tabs li a:hover {
+.secondary .nav-items li a:hover {
   text-decoration: none;
 }
-.secondary .nav-tabs li:hover {
+.secondary .nav-items li:hover {
   background-color: #e4e7ec;
 }
 @media (max-width: 767.98px) {
-  .secondary .nav-tabs {
+  .secondary .nav-items {
     background-color: transparent;
     flex-wrap: nowrap;
     overflow-x: auto;
     overflow-y: scroll;
     white-space: nowrap;
   }
-  .secondary .nav-tabs li {
+  .secondary .nav-items li {
     margin-left: 8px;
     background-color: #f2f4f7;
   }
-  .secondary .nav-tabs li i {
+  .secondary .nav-items li i {
     margin-left: 1rem;
   }
 }

--- a/ckan/public-midnight-blue/base/css/main.css
+++ b/ckan/public-midnight-blue/base/css/main.css
@@ -12476,6 +12476,7 @@ a.tag:hover {
 @media (max-width: 767.98px) {
   .secondary .nav-items {
     background-color: transparent;
+    border-bottom: none;
     flex-wrap: nowrap;
     overflow-x: auto;
     overflow-y: scroll;

--- a/ckan/public-midnight-blue/base/css/main.css
+++ b/ckan/public-midnight-blue/base/css/main.css
@@ -12439,6 +12439,56 @@ a.tag:hover {
   color: #2f4b91;
 }
 
+.secondary .nav-tabs {
+  background-color: #f2f4f7;
+  border-radius: 8px;
+}
+.secondary .nav-tabs .active {
+  background-color: #153084;
+}
+.secondary .nav-tabs .active a {
+  color: #fff;
+}
+.secondary .nav-tabs .active:hover {
+  background-color: #153084;
+}
+.secondary .nav-tabs li {
+  border-radius: 8px;
+  padding: 10px 16px;
+  width: 100%;
+}
+.secondary .nav-tabs li a {
+  display: flex;
+  justify-content: space-between;
+  flex-direction: row-reverse;
+}
+.secondary .nav-tabs li a i {
+  display: flex;
+  align-items: center;
+}
+.secondary .nav-tabs li a:hover {
+  text-decoration: none;
+}
+.secondary .nav-tabs li:hover {
+  background-color: #e4e7ec;
+}
+@media (max-width: 767.98px) {
+  .secondary .nav-tabs {
+    background-color: transparent;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: scroll;
+    white-space: nowrap;
+  }
+  .secondary .nav-tabs li {
+    margin-left: 8px;
+    background-color: #f2f4f7;
+  }
+  .secondary .nav-tabs li i {
+    margin-left: 1rem;
+  }
+}
+
 .nav-stacked > li {
   float: none;
 }
@@ -13950,11 +14000,7 @@ td.diff_header {
 
 @media (max-width: 767.98px) {
   .main .secondary {
-    -webkit-box-ordinal-group: 2;
-    -moz-box-ordinal-group: 2;
-    -webkit-order: 2;
-    order: 2;
-    margin-top: 1rem;
+    margin: 1rem 0;
   }
   .js .main .secondary .filters {
     display: none;
@@ -14524,22 +14570,47 @@ td.diff_header {
   margin-bottom: 20px;
 }
 
-#followee-filter .btn {
-  display: inline-block;
+#followee-filter {
+  position: relative;
+  z-index: 1;
 }
-#followee-filter .btn span,
-#followee-filter .btn strong {
-  line-height: 1.5;
+
+#followee-popover {
+  color: #000;
+  width: 100%;
+  border-radius: 6px;
+  margin-bottom: 10px;
+  padding: 2px 16px 5px 5px;
+  background-color: #fff;
+  display: flex;
+  justify-content: space-between;
 }
-#followee-filter .btn span {
-  font-weight: normal;
+#followee-popover:focus {
+  box-shadow: 0 0 0 0.25rem rgba(21, 48, 132, 0.25);
 }
-#followee-filter .btn strong {
-  margin: 0 5px;
-  white-space: nowrap;
-  max-width: 90px;
-  overflow: hidden;
-  text-overflow: ellipsis;
+#followee-popover:hover {
+  text-decoration: none;
+}
+@media (min-width: 768px) {
+  #followee-popover {
+    float: right;
+    margin-left: 15px;
+    width: max-content;
+  }
+}
+#followee-popover .label {
+  font-size: 12px;
+  font-weight: 500;
+  color: #667085;
+}
+#followee-popover .dropdown-content {
+  padding: 2px 3rem 0.5rem 0.5rem;
+  display: flex;
+  flex-direction: column;
+}
+#followee-popover .caret {
+  display: flex;
+  align-items: center;
 }
 
 .dashboard-context {
@@ -14564,7 +14635,6 @@ td.diff_header {
 }
 
 .followee-container {
-  padding: 0;
   padding: 0;
   margin: 0;
   max-height: 205px;
@@ -14612,6 +14682,22 @@ td.diff_header {
   display: block;
   font-size: 16px;
   margin: 3px 0;
+}
+
+.dashboard-container {
+  display: flex;
+  flex-direction: column-reverse;
+}
+@media (min-width: 576px) {
+  .dashboard-container {
+    flex-direction: row;
+  }
+  .dashboard-container .page_primary_action {
+    display: block;
+  }
+  .dashboard-container .page_primary_action a {
+    float: right;
+  }
 }
 
 .resource-view .actions {

--- a/ckan/public-midnight-blue/base/css/main.css
+++ b/ckan/public-midnight-blue/base/css/main.css
@@ -12439,52 +12439,53 @@ a.tag:hover {
   color: #2f4b91;
 }
 
-.secondary .nav-tabs {
+.secondary .nav-items {
   background-color: #f2f4f7;
   border-radius: 8px;
+  border-bottom: 2px solid #d0d5dd;
 }
-.secondary .nav-tabs .active {
+.secondary .nav-items .active {
   background-color: #153084;
 }
-.secondary .nav-tabs .active a {
+.secondary .nav-items .active a {
   color: #fff;
 }
-.secondary .nav-tabs .active:hover {
+.secondary .nav-items .active:hover {
   background-color: #153084;
 }
-.secondary .nav-tabs li {
+.secondary .nav-items li {
   border-radius: 8px;
   padding: 10px 16px;
   width: 100%;
 }
-.secondary .nav-tabs li a {
+.secondary .nav-items li a {
   display: flex;
   justify-content: space-between;
   flex-direction: row-reverse;
 }
-.secondary .nav-tabs li a i {
+.secondary .nav-items li a i {
   display: flex;
   align-items: center;
 }
-.secondary .nav-tabs li a:hover {
+.secondary .nav-items li a:hover {
   text-decoration: none;
 }
-.secondary .nav-tabs li:hover {
+.secondary .nav-items li:hover {
   background-color: #e4e7ec;
 }
 @media (max-width: 767.98px) {
-  .secondary .nav-tabs {
+  .secondary .nav-items {
     background-color: transparent;
     flex-wrap: nowrap;
     overflow-x: auto;
     overflow-y: scroll;
     white-space: nowrap;
   }
-  .secondary .nav-tabs li {
+  .secondary .nav-items li {
     margin-left: 8px;
     background-color: #f2f4f7;
   }
-  .secondary .nav-tabs li i {
+  .secondary .nav-items li i {
     margin-left: 1rem;
   }
 }

--- a/ckan/public-midnight-blue/base/javascript/modules/active-nav-item-scroll.js
+++ b/ckan/public-midnight-blue/base/javascript/modules/active-nav-item-scroll.js
@@ -1,3 +1,7 @@
+/*
+ * Module to horizontally scroll to active nav item.
+ * Specifically when item is not initially in view.
+ */
 this.ckan.module('active-nav-item-scroll', function ($) {
     return {
       initialize: function () {

--- a/ckan/public-midnight-blue/base/javascript/modules/active-nav-item-scroll.js
+++ b/ckan/public-midnight-blue/base/javascript/modules/active-nav-item-scroll.js
@@ -1,4 +1,4 @@
-this.ckan.module('active-nav-tabs-scroll', function ($) {
+this.ckan.module('active-nav-item-scroll', function ($) {
     return {
       initialize: function () {
         console.log("hello")

--- a/ckan/public-midnight-blue/base/javascript/modules/active-nav-tabs-scroll.js
+++ b/ckan/public-midnight-blue/base/javascript/modules/active-nav-tabs-scroll.js
@@ -1,0 +1,15 @@
+this.ckan.module('active-nav-tabs-scroll', function ($) {
+    return {
+      initialize: function () {
+        console.log("hello")
+        var activeTab = this.el.find('li.active');
+
+        if (window.innerWidth <= 768) {
+            this.el.animate({
+                scrollLeft: activeTab.position().left - this.el.width() / 2 + activeTab.outerWidth() / 2
+            }, 500);
+        }
+      },
+    };
+  });
+  

--- a/ckan/public-midnight-blue/base/javascript/webassets.yml
+++ b/ckan/public-midnight-blue/base/javascript/webassets.yml
@@ -54,7 +54,7 @@ ckan:
     - modules/image-upload.js
     - modules/metadata-button.js
     - modules/copy-into-buffer.js
-    - modules/active-nav-tabs-scroll.js
+    - modules/active-nav-item-scroll.js
 
 view-filters:
   output: base/%(version)s_view-filters.js

--- a/ckan/public-midnight-blue/base/javascript/webassets.yml
+++ b/ckan/public-midnight-blue/base/javascript/webassets.yml
@@ -54,6 +54,7 @@ ckan:
     - modules/image-upload.js
     - modules/metadata-button.js
     - modules/copy-into-buffer.js
+    - modules/active-nav-tabs-scroll.js
 
 view-filters:
   output: base/%(version)s_view-filters.js

--- a/ckan/public-midnight-blue/base/scss/_dashboard.scss
+++ b/ckan/public-midnight-blue/base/scss/_dashboard.scss
@@ -1,20 +1,40 @@
 #followee-filter {
-    .btn {
-        display: inline-block;
-        span,
-        strong {
-            line-height: 1.5;
-        }
-        span {
-            font-weight: normal;
-        }
-        strong {
-            margin: 0 5px;
-            white-space: nowrap;
-            max-width: 90px;
-            overflow: hidden;
-            text-overflow: ellipsis;
-        }
+    position: relative;
+    z-index: 1;
+}
+#followee-popover {
+    &:focus {
+        box-shadow: 0 0 0 0.25rem rgba(21, 48, 132, 0.25);
+    }
+    &:hover {
+        text-decoration: none;
+    }
+    color: $black;
+    width: 100%;
+    border-radius: 6px;
+    margin-bottom: 10px;
+    padding: 2px 16px 5px 5px;
+    background-color: #fff;
+    display: flex;
+    justify-content: space-between;
+    @include media-breakpoint-up(md) {
+        float: right;
+        margin-left: 15px;
+        width: max-content;
+    }
+    .label {
+        font-size: 12px;
+        font-weight: 500;
+        color: #667085;
+    }
+    .dropdown-content {
+        padding: 2px 3rem 0.5rem 0.5rem;
+        display: flex;
+        flex-direction: column;
+    }
+    .caret {
+        display: flex;
+        align-items: center;
     }
 }
 
@@ -40,39 +60,34 @@
 }
 
 .followee-container {
-    padding:0;
     .popover-title {
         display: none;
     }
-
     .empty {
         padding: 10px;
     }
-
-        padding: 0;
-        margin: 0;
-        max-height: 205px;
-        overflow: auto;
-        @include border-radius(0 0 3px 3px);
-        li {
+    padding: 0;
+    margin: 0;
+    max-height: 205px;
+    overflow: auto;
+    @include border-radius(0 0 3px 3px);
+    li {
+        i {
+            margin-right: 11px;
+            padding: 3px 5px;
+            line-height: 1;
+        }
+        &:hover,  &.active {
+            background: $primary;
+            a  { color: $white;}
             i {
-                margin-right: 11px;
-                padding: 3px 5px;
-                line-height: 1;
+                background-color: $layoutLinkColor;
+                color: $inputBackground;
+
+                @include border-radius(100px);
+                @include box-shadow(inset 0 1px 2x rgba(0, 0, 0, 0.2));
             }
-            &:hover,  &.active {
-                background: $primary;
-                a  { color: $white;}
-                i {
-                    background-color: $layoutLinkColor;
-                    color: $inputBackground;
-
-                    @include border-radius(100px);
-                    @include box-shadow(inset 0 1px 2x rgba(0, 0, 0, 0.2));
-                }
-
-            }
-
+        }
     }
 }
 
@@ -88,5 +103,19 @@
         display: block;
         font-size: 16px;
         margin: 3px 0;
+    }
+}
+
+.dashboard-container {
+    display: flex;
+    flex-direction: column-reverse;
+    @include media-breakpoint-up(sm) {
+        flex-direction: row;
+        .page_primary_action {
+            display: block;
+            a {
+                float: right;
+            }
+        }
     }
 }

--- a/ckan/public-midnight-blue/base/scss/_layout.scss
+++ b/ckan/public-midnight-blue/base/scss/_layout.scss
@@ -43,12 +43,8 @@
 }
 
 @include media-breakpoint-down(md) {
-    .main .secondary {
-        -webkit-box-ordinal-group: 2;
-        -moz-box-ordinal-group: 2;
-        -webkit-order: 2;
-        order: 2;
-        margin-top: 1rem;
+.main .secondary {
+        margin: 1rem 0;
     }
     .js .main .secondary .filters {
         display: none;

--- a/ckan/public-midnight-blue/base/scss/_nav.scss
+++ b/ckan/public-midnight-blue/base/scss/_nav.scss
@@ -202,6 +202,7 @@
     }
     @include media-breakpoint-down(md) {
         background-color: transparent;
+        border-bottom: none;
         flex-wrap: nowrap;
         overflow-x: auto;
         overflow-y: scroll;

--- a/ckan/public-midnight-blue/base/scss/_nav.scss
+++ b/ckan/public-midnight-blue/base/scss/_nav.scss
@@ -166,7 +166,7 @@
     }
 }
 
-// Nav tabs in secondary
+// Nav items in secondary
 .secondary .nav-items {
     background-color: $gray-100;
     border-radius: 8px;

--- a/ckan/public-midnight-blue/base/scss/_nav.scss
+++ b/ckan/public-midnight-blue/base/scss/_nav.scss
@@ -167,9 +167,10 @@
 }
 
 // Nav tabs in secondary
-.secondary .nav-tabs {
+.secondary .nav-items {
     background-color: $gray-100;
     border-radius: 8px;
+    border-bottom: 2px solid $gray-300;
     .active {
         background-color: $brand-600;
         a {

--- a/ckan/public-midnight-blue/base/scss/_nav.scss
+++ b/ckan/public-midnight-blue/base/scss/_nav.scss
@@ -166,6 +166,55 @@
     }
 }
 
+// Nav tabs in secondary
+.secondary .nav-tabs {
+    background-color: $gray-100;
+    border-radius: 8px;
+    .active {
+        background-color: $brand-600;
+        a {
+            color: $white;
+        }
+        &:hover {
+            background-color: $brand-600;
+        }
+    }
+    li {
+        border-radius: 8px;
+        padding: 10px 16px;
+        width: 100%;
+        a {
+            display: flex;
+            justify-content: space-between;
+            flex-direction: row-reverse;
+            i {
+                display: flex;
+                align-items: center;
+            }
+            &:hover {
+                text-decoration: none;
+            }
+        }
+        &:hover {
+            background-color: $gray-200;
+        }
+    }
+    @include media-breakpoint-down(md) {
+        background-color: transparent;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        overflow-y: scroll;
+        white-space: nowrap;
+        li {
+            margin-left: 8px;
+            background-color: $gray-100;
+            i {
+                margin-left: 1rem;
+            }
+        }
+    }
+}
+
 // STACKED NAV
 // -----------
 

--- a/ckan/templates-midnight-blue/user/dashboard.html
+++ b/ckan/templates-midnight-blue/user/dashboard.html
@@ -1,43 +1,46 @@
 {% extends "user/edit_base.html" %}
+{% import 'macros/nav_link.html' as nav %}
 
 {% set user = current_user %}
 {% set org_type = h.default_group_type('organization') %}
 {% set group_type = h.default_group_type('group') %}
 {% set dataset_type = h.default_package_type() %}
 
+{% block content_action %}
+  {% link_for _('Profile settings'), named_route='user.edit', id=user.name, class_='btn btn-secondary', icon='cog' %}
+{% endblock %}
 
 {% block breadcrumb_content %}
   <li class="active"><a href="{{ h.url_for('dashboard.datasets') }}">{{ _('Dashboard') }}</a></li>
 {% endblock %}
 
-{% block secondary %}{% endblock %}
+{% block secondary_content %}
+  <ul class="nav nav-tabs" data-module="active-nav-tabs-scroll">
+    {% block dashboard_nav_links %}
+      {{ nav.link(h.url_for('dashboard.datasets'), h.humanize_entity_type('package', dataset_type, 'my label') or _('My Datasets'), icon='sitemap') }}
+      {{ nav.link(h.url_for('dashboard.organizations'), h.humanize_entity_type('organization', org_type, 'my label') or _('My Organizations'), icon='briefcase') }}
+      {{ nav.link(h.url_for('dashboard.groups'), h.humanize_entity_type('group', group_type, 'my label') or _('My Groups'), icon='users') }}
+    {% endblock dashboard_nav_links %}
+  </ul>
+{% endblock secondary_content %}
 
 {% block primary %}
+<div class="primary col-md-8 col-lg-9 col-xs-12" role="main">
   <article class="module">
-    {% block page_header %}
-      <header class="module-content page-header hug">
-        <div class="content_action">
-          {% link_for _('Profile settings'), named_route='user.edit', id=user.name, class_='btn btn-secondary', icon='cog' %}
-        </div>
-      {% block content_primary_nav %}
-        <ul class="nav nav-tabs">
-          {% block dashboard_nav_links %}
-            {{ h.build_nav_icon('dashboard.datasets', h.humanize_entity_type('package', dataset_type, 'my label') or _('My Datasets'), icon='sitemap') }}
-            {{ h.build_nav_icon('dashboard.organizations', h.humanize_entity_type('organization', org_type, 'my label') or _('My Organizations'), icon='building') }}
-            {{ h.build_nav_icon('dashboard.groups', h.humanize_entity_type('group', group_type, 'my label') or _('My Groups'), icon='users') }}
-          {% endblock dashboard_nav_links %}
-        </ul>
-     {% endblock %}
-      </header>
-    {% endblock %}
     <div class="module-content">
-      {% if self.page_primary_action() | trim %}
-        <div class="page_primary_action">
-          {% block page_primary_action %}{% endblock %}
+      <div class="dashboard-container row">
+        <div class="col-md-6">
+          {% block page_heading %}{% endblock %}
         </div>
-      {% endif %}
+        {% if self.page_primary_action() | trim %}
+          <div class="page_primary_action col-md-6">
+            {% block page_primary_action %}{% endblock %}
+          </div>
+        {% endif %}
+      </div>
       {% block primary_content_inner %}
       {% endblock %}
     </div>
   </article>
+</div>
 {% endblock %}

--- a/ckan/templates-midnight-blue/user/dashboard.html
+++ b/ckan/templates-midnight-blue/user/dashboard.html
@@ -15,7 +15,7 @@
 {% endblock %}
 
 {% block secondary_content %}
-  <ul class="nav nav-tabs" data-module="active-nav-tabs-scroll">
+  <ul class="nav nav-items" data-module="active-nav-item-scroll">
     {% block dashboard_nav_links %}
       {{ nav.link(h.url_for('dashboard.datasets'), h.humanize_entity_type('package', dataset_type, 'my label') or _('My Datasets'), icon='sitemap') }}
       {{ nav.link(h.url_for('dashboard.organizations'), h.humanize_entity_type('organization', org_type, 'my label') or _('My Organizations'), icon='briefcase') }}

--- a/ckan/templates-midnight-blue/user/dashboard_datasets.html
+++ b/ckan/templates-midnight-blue/user/dashboard_datasets.html
@@ -7,8 +7,11 @@
   {% endif %}
 {% endblock %}
 
+{% block page_heading %}
+  <h1>{{ h.humanize_entity_type('package', dataset_type, 'my label') or _('My Datasets') }}</h1>
+{% endblock %}
+
 {% block primary_content_inner %}
-  <h2 class="hide-heading">{{ h.humanize_entity_type('package', dataset_type, 'my label') or _('My Datasets') }}</h2>
   {% if user_dict.datasets %}
     {% snippet 'snippets/package_list.html', packages=user_dict.datasets %}
   {% else %}

--- a/ckan/templates-midnight-blue/user/dashboard_groups.html
+++ b/ckan/templates-midnight-blue/user/dashboard_groups.html
@@ -8,8 +8,11 @@
   {% endif %}
 {% endblock %}
 
+{% block page_heading %}
+  <h1>{{ h.humanize_entity_type('group', group_type, 'my label') or _('My Groups') }}</h1>
+{% endblock %}
+
 {% block primary_content_inner %}
-  <h2 class="hide-heading">{{ h.humanize_entity_type('group', group_type, 'my label') or _('My Groups') }}</h2>
   {% set groups = h.groups_available(am_member=True,
     include_dataset_count=True,
     include_member_count=True) %}

--- a/ckan/templates-midnight-blue/user/dashboard_organizations.html
+++ b/ckan/templates-midnight-blue/user/dashboard_organizations.html
@@ -8,8 +8,11 @@
   {% endif %}
 {% endblock %}
 
+{% block page_heading %}
+  <h1>{{ h.humanize_entity_type('organization', org_type, 'my label') or _('My Organizations') }}</h1>
+{% endblock %}
+
 {% block primary_content_inner %}
-  <h2 class="hide-heading">{{ h.humanize_entity_type('organization', org_type, 'my label') or _('My Organizations') }}</h2>
   {% set organizations = h.organizations_available(permission='manage_group',
     include_dataset_count=True,
     include_member_count=True) %}

--- a/ckanext/activity/assets/activity.css
+++ b/ckanext/activity/assets/activity.css
@@ -33,9 +33,10 @@
   display: flex;
   gap: 0.5rem;
 }
-.activity_buttons > a.btn.disabled {
-  color: inherit;
-  opacity: 0.7;
+@media (max-width: 768px) {
+  .activity_buttons {
+    flex-direction: column;
+  }
 }
 
 .popover {
@@ -79,9 +80,6 @@
 .activity .item.changed-package_extra .icon {
   color: #769ace;
 }
-.activity .item.changed-resource-view .icon{
-  color: #9c89d5;
-}
 .activity .item.changed-resource .icon {
   color: #aa76ce;
 }
@@ -100,9 +98,6 @@
 .activity .item.deleted-package_extra .icon {
   color: #b95274;
 }
-.activity .item.deleted-resource-view .icon{
-  color: #c06483;
-}
 .activity .item.deleted-resource .icon {
   color: #b99752;
 }
@@ -117,9 +112,6 @@
 }
 .activity .item.new-package_extra .icon {
   color: #6ca669;
-}
-.activity .item.new-resource-view .icon{
-  color: #7caf79;
 }
 .activity .item.new-resource .icon {
   color: #81a669;
@@ -161,5 +153,3 @@ br.line-height2 {
 .pull-right {
   float: right;
 }
-
-/*# sourceMappingURL=activity.css.map */

--- a/ckanext/activity/assets/activity.scss
+++ b/ckanext/activity/assets/activity.scss
@@ -50,10 +50,9 @@ $activityColorEmpty: #6E6E6E;
 .activity_buttons {
     display: flex;
     gap: .5rem;
+    @media (max-width: 768px) {
+        flex-direction: column;
 
-    &>a.btn.disabled {
-        color: inherit;
-        opacity: 0.70;
     }
 }
 

--- a/ckanext/activity/assets/dashboard.js
+++ b/ckanext/activity/assets/dashboard.js
@@ -19,11 +19,10 @@ this.ckan.module('dashboard', function ($) {
      */
     initialize: function () {
       $.proxyAll(this, /_on/);
-      this.button = $('#followee-filter .btn').
+      this.button = $('#followee-filter .followee-toggle').
         on('click', this._onShowFolloweeDropdown);
       var title = this.button.prop('title');
-
-      this.button.popover = new bootstrap.Popover(document.querySelector('#followee-filter .btn'), {
+      this.button.popover = new bootstrap.Popover(document.querySelector('#followee-filter .followee-toggle'), {
           placement: 'bottom',
           html: true,
           template: '<div class="popover" role="tooltip"><div class="popover-arrow"></div><h3 class="popover-header"></h3><div class="popover-body followee-container"></div></div>',
@@ -32,7 +31,6 @@ this.ckan.module('dashboard', function ($) {
             return DOMPurify.sanitize(content, { ALLOWED_TAGS: [
               "form", "div", "input", "footer", "header", "h1", "h2", "h3", "h4",
               "small", "span", "strong", "i", 'a', 'li', 'ul','p'
-
             ]});
           },
           content: $('#followee-content').html()

--- a/ckanext/activity/templates/snippets/pagination.html
+++ b/ckanext/activity/templates/snippets/pagination.html
@@ -1,5 +1,5 @@
-{% set class_prev = "btn btn-secondary" if newer_activities_url else "btn disabled" %}
-{% set class_next = "btn btn-secondary" if older_activities_url else "btn disabled" %}
+{% set class_prev = "btn btn-secondary" if newer_activities_url else "btn btn-secondary disabled" %}
+{% set class_next = "btn btn-secondary" if older_activities_url else "btn btn-secondary disabled" %}
 
 {% if newer_activities_url or older_activities_url %}
     <div hx-boost="true" hx-target="closest .module-content" id="activity_page_buttons" class="activity_buttons" style="margin-top: 25px;">

--- a/ckanext/activity/templates/user/dashboard.html
+++ b/ckanext/activity/templates/user/dashboard.html
@@ -9,19 +9,12 @@
   {{ super() }}
 {% endblock %}
 
-
 {% block primary_content_inner %}
-  <div data-module="dashboard">
-    {% snippet 'user/snippets/followee_dropdown.html', context=dashboard_activity_stream_context, followees=followee_list %}
-    <h2 class="page-heading mb-4">
-      {% block page_heading %}
-        {{ _('News feed') }}
-      {% endblock %}
-      <small class="text-muted fs-5">{{ _("Activity from items that I'm following") }}</small>
-    </h2>
-    {% snippet 'snippets/stream.html', activity_stream=dashboard_activity_stream %}
-  </div>
-
-  {% snippet 'snippets/pagination.html', newer_activities_url=newer_activities_url, older_activities_url=older_activities_url %}
-
+  {% snippet 'user/snippets/news_feed.html',
+  dashboard_activity_stream=dashboard_activity_stream,
+  dashboard_activity_stream_context=dashboard_activity_stream_context,
+  id=id,
+  followees=followee_list,
+  newer_activities_url=newer_activities_url,
+  older_activities_url=older_activities_url %}
 {% endblock %}

--- a/ckanext/activity/templates/user/snippets/followee_dropdown.html
+++ b/ckanext/activity/templates/user/snippets/followee_dropdown.html
@@ -10,11 +10,14 @@
   {% endif %}
 {%- endmacro %}
 
-<div id="followee-filter" class="pull-right">
+<div id="followee-filter">
   <div class="dropdown">
-    <a href="#" id="followee-popover" class="btn btn-secondary dropdown-toggle"
+    <a href="#" id="followee-popover" class="followee-toggle"
       aria-label="{{ _('Activity from:') }} {{ context.context }}">
-      <span>{{ _('Activity from:') }}</span> <strong>{{ context.context }}</strong> <span class="caret"></span>
+      <span class="dropdown-content">
+        <span class="label">{{ _('Activity from:') }}</span> {{ context.context }}
+      </span>
+      <span class="caret"><i class="fa-solid fa-angle-down"></i></span>
     </a>
   </div>
 

--- a/ckanext/activity/templates/user/snippets/news_feed.html
+++ b/ckanext/activity/templates/user/snippets/news_feed.html
@@ -1,0 +1,11 @@
+{% block page_heading %}
+  <h1>{{ _('News feed') }}</h1>
+  <p>{{ _("Activity from items that I'm following") }}</p>
+{% endblock %}
+
+<div class="row" data-module="dashboard">
+    {% snippet 'user/snippets/followee_dropdown.html', context=dashboard_activity_stream_context, followees=followee_list %}
+    {% snippet 'snippets/stream.html', activity_stream=dashboard_activity_stream %}
+</div>
+
+{% snippet 'snippets/pagination.html', newer_activities_url=newer_activities_url, older_activities_url=older_activities_url %}

--- a/ckanext/activity/views.py
+++ b/ckanext/activity/views.py
@@ -904,7 +904,14 @@ def dashboard() -> str:
     # dashboard page.
     tk.get_action("dashboard_mark_activities_old")(context, {})
 
-    return tk.render("user/dashboard.html", extra_vars)
+    if ckan_request.htmx:
+        return tk.render(
+            "user/snippets/news_feed.html", extra_vars
+        )
+    else:
+        return tk.render(
+            "user/dashboard.html", extra_vars
+        )
 
 
 def _get_dashboard_context(


### PR DESCRIPTION
### Proposed fixes:
- Simple js module for scrolling to active nav item in mobile
- Dashboard secondary nav items
- Followee filter dropdown
- Add HTMX to dashboard news feed page. There is currently a bug when you press the newer or older activities button, it duplicates the page in the body instead of replacing the body content with the newer/older activities.
- Layout for dashboard pages

[Figma designs](https://www.figma.com/design/oI3wDSdZ0cHZLh6CrfYMnb/CKAN-3.0-Design-System?node-id=1037-8316)

### Screenshots

Desktop:
![image](https://github.com/user-attachments/assets/dc98ebb3-3ab0-466b-94dc-5f639a55f4c9)

Mobile:
![image](https://github.com/user-attachments/assets/e81543c9-406c-4f41-9a6a-4f64e9115a88)

Screenshots taken from [preview site](https://ckan-design-preview.galv1.links.com.au/dashboard/), have to be logged in to see dashboard.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
