### PR TITLE
[#8668] Add auth function for `recently_changed_packages_activity_list`

### DIFF
--- a/changes/8677.bugfix
+++ b/changes/8677.bugfix
@@ -1,0 +1,1 @@
+Fix exception in `recently_changed_packages_activity_list` action

--- a/ckanext/activity/logic/auth.py
+++ b/ckanext/activity/logic/auth.py
@@ -196,3 +196,13 @@ def dashboard_mark_activities_old(
     context: Context, data_dict: DataDict
 ) -> AuthResult:
     return authz.is_authorized("dashboard_activity_list", context, data_dict)
+
+
+@tk.auth_allow_anonymous_access
+def recently_changed_packages_activity_list(
+    context: Context, data_dict: DataDict
+) -> AuthResult:
+    """Check if the activity stream of all recently added or changed packages is
+    visible. Visible to all by default.
+    Note that the actual datasets shown will be filtered by permission labels"""
+    return {"success": True}

--- a/ckanext/activity/tests/logic/test_auth.py
+++ b/ckanext/activity/tests/logic/test_auth.py
@@ -44,3 +44,10 @@ class TestAuth:
 
         with pytest.raises(tk.NotAuthorized):
             helpers.call_auth("activity_create", context=context)
+
+    def test_recently_changed_packages_activity_list_has_auth_function(self):
+
+        helpers.call_action(
+            "recently_changed_packages_activity_list",
+            context={"ignore_auth": False}
+        )


### PR DESCRIPTION
Fixes #8668

The `recently_changed_packages_activity_list` originally had an [auth function](https://github.com/ckan/ckan/blob/f2d47c8f87bc5f224ebff93b23d0f6fda8fb81b4/ckan/logic/auth/get.py#L577) back in CKAN 2.9 when activities were in core. When they were migrated to a core extension in 2.10 the auth function was lost but it didn't break the action because it didn't check access. In #7885 (private activities) a `check_access` call was added but not the auth function. This made the action fail.
This wasn't raised in the tests because all use `call_action` that uses `ignore_auth: True` by default and so the auth function is never reached.
This change adds the auth function with the original value (all allowed). Note that the actual datasets shown will be filtered by permission labels.

