### PR TITLE
Add sysadmin check to has_user_permission_for_some_org

### DIFF
--- a/changes/8679.bugfix
+++ b/changes/8679.bugfix
@@ -1,0 +1,1 @@
+`authz.has_user_permission_for_some_org` returns True for sysadmins.

--- a/ckan/authz.py
+++ b/ckan/authz.py
@@ -390,6 +390,11 @@ def users_role_for_group_or_org(
 def has_user_permission_for_some_org(
         user_name: Optional[str], permission: str) -> bool:
     ''' Check if the user has the given permission for any organization. '''
+
+    # Sys admins can do anything
+    if is_sysadmin(user_name):
+        return True
+
     user_id = get_user_id_for_username(user_name, allow_none=True)
     if not user_id:
         return False


### PR DESCRIPTION
Fixes #8676 

### Proposed fixes:

Adds is_sysadmin check similar to https://github.com/ckan/ckan/blob/243de661bc9979e57e1afe33a5d47a64fb227c91/ckan/authz.py#L299-L315


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
