### PR TITLE
apply 'humanize_entity_type' to the submit button on dataset group lists

### DIFF
--- a/changes/8682.bugfix
+++ b/changes/8682.bugfix
@@ -1,0 +1,1 @@
+Apply 'humanize_entity_type' helper consistently across the group listing page

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1037,7 +1037,8 @@ def humanize_entity_type(entity_type: str, object_type: str,
     Possible purposes(depends on `entity_type` and change over time)::
 
         `add link`: "Add [object]" button on search pages
-        `breadcrumb`: "Home / [object]s / New" section in breadcrums
+        `add association link`: "Add to [object]" button on dataset pages
+        `breadcrumb`: "Home / [object]s / New" section in breadcrumbs
         `content tab`: "[object]s | Groups | Activity" tab on details page
         `create label`: "Home / ... / Create [object]" part of breadcrumb
         `create title`: "Create [object] - CKAN" section of page title
@@ -1051,10 +1052,10 @@ def humanize_entity_type(entity_type: str, object_type: str,
         `my label`: "My [object]s" tab in dashboard
         `name placeholder`: "<[object]>" section of URL preview on object form
         `no any objects`: No objects created yet
-        `no associated label`: no gorups for dataset
+        `no associated label`: no groups for dataset
         `no description`: object has no description
         `no label`: package with no organization
-        `page title`: "Title - [objec]s - CKAN" section of page title
+        `page title`: "Title - [object]s - CKAN" section of page title
         `save label`: "Save [object]" button
         `search placeholder`: "Search [object]s..." placeholder
         `update label`: "Update [object]" button
@@ -1075,6 +1076,7 @@ def humanize_entity_type(entity_type: str, object_type: str,
         u'Humanize %s of type %s for %s', entity_type, object_type, purpose)
     templates = {
         u'add link': _(u"Add {object_type}"),
+        u'add association link': _(u"Add to {object_type}"),
         u'breadcrumb': _(u"{object_type}s"),
         u'content tab': _(u"{object_type}s"),
         u'create label': _(u"Create {object_type}"),

--- a/ckan/templates/package/group_list.html
+++ b/ckan/templates/package/group_list.html
@@ -14,7 +14,7 @@
           <option value="{{ option[0] }}"> {{ option[1] }}</option>
         {% endfor %}
       </select>
-      <button type="submit" class="btn btn-primary" aria-label="{{ _('Associate this group with this dataset') }}">{{ _('Add to group') }}</button>
+      <button type="submit" class="btn btn-primary" aria-label="{{ _('Associate this group with this dataset') }}">{{ h.humanize_entity_type('group', default_group_type, 'add association link') or _('Add to group') }}</button>
     </form>
   {% endif %}
 


### PR DESCRIPTION
Fixes #8682

### Proposed fixes:

- Add a humanize category for adding a dataset-group association, apply it to the submit button in `package/group_list.html`

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
