### PR TITLE
datastore upgrade sql fix

### DIFF
--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -209,7 +209,7 @@ def upgrade():
                     raw_sql))
 
             if alter_sql:
-                connection.execute(sa.text(';'.join(alter_sql)))
+                connection.execute(';'.join(alter_sql))
                 count += 1
             else:
                 noinfo += 1


### PR DESCRIPTION
comment text should not be processed for sqlalchemy bind parameters

Fixes #8692

### Proposed fixes:

datastore column comments should not be processed for sqlalchemy bind parameters

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport