### PR TITLE
[#8692] Escape sqlaclchemy bind params in `ckan datastore upgrade`

### DIFF
--- a/changes/8692.bugfix
+++ b/changes/8692.bugfix
@@ -1,0 +1,2 @@
+`ckan datastore upgrade` no longer fails if datastore column comments contain a 
+substring resmbling a sqlalchemy bind parmeter (e.g `{"key":null}`).

--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -202,7 +202,7 @@ def upgrade():
                 raw = {'_info': fvalue}
                 # ' ' prefix for data version
                 raw_sql = literal_string(' ' + json.dumps(
-                    raw, ensure_ascii=False, separators=(',', ':')))
+                    raw, ensure_ascii=False, separators=(',', ':'))).replace(":", r"\:")
                 alter_sql.append(u'COMMENT ON COLUMN {0}.{1} is {2}'.format(
                     identifier(resid),
                     identifier(fid),


### PR DESCRIPTION
Fixes #8692

### Proposed fixes:

Escape `:`'s in strings passed to `slqalchemy.text` with `\:` so that sqlalchemy doesn't attempt to bind parameters.

The `.replace()` used here feels a bit hacky, but in some minimal testing it has seemed sufficient (and hasn't introduced `\`'s in places accidentally).

### Testing
(apologies this is a bit informal, happy to formalize these in new `pytests` if preferred)

I've tested a few test-cases below. For each test case
- I run `COMMENT ON COLUMN "<table>.<column>" is <test_case>;`
- `ckan datastore upgrade` (confirm it doesn't fail)
- `\d+ <table>` and inspect the comment to ensure it looks correct

Test cases:
- `{"key":null}` -> make sure `:null` doesn't break things and the json `null` persists in the comment
- `{"key":"text with :params"}` -> make sure `:params` doesn't break things and that we don't end up with `{"key":"text with \:params"}`
- `":non json"` -> test a non-json case

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
