### PR TITLE
[2.11] Bump setuptools to avoid pysolr build errors with setuptools-scm

### DIFF
--- a/test-infrastructure/install_deps.sh
+++ b/test-infrastructure/install_deps.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 # OS Dependencies
 apt update
 apt install -y postgresql-client

--- a/test-infrastructure/install_deps.sh
+++ b/test-infrastructure/install_deps.sh
@@ -6,6 +6,7 @@ apt install -y postgresql-client
 
 #Python Dependencies
 pip install -U pip
+pip install -U setuptools
 pip install -r requirements.txt
 pip install -r dev-requirements.txt
 pip install -e .


### PR DESCRIPTION
The CI tests for [dev-v2.10](https://app.circleci.com/pipelines/github/ckan/ckan/7869/workflows/cd4dec5f-7674-46c2-b86f-e22d68764146/jobs/15896) and [dev-v2.11](https://app.circleci.com/pipelines/github/ckan/ckan/7878/workflows/a9a27017-35ce-4b5e-81ab-c5a3b64d7388/jobs/15902) broke a few days ago with the same error

```
Collecting pysolr==3.9.0 (from -r requirements.txt (line 102))
  Downloading pysolr-3.9.0.tar.gz (55 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [68 lines of output]
      /tmp/pip-install-iyrzysc_/pysolr_1ac89b9533694450b0e9e43d23a237e7/.eggs/setuptools_scm-8.2.0-py3.9.egg/setuptools_scm/_integration/setuptools.py:31: RuntimeWarning:
      ERROR: setuptools==58.1.0 is used in combination with setuptools-scm>=8.x

      Your build configuration is incomplete and previously worked by accident!
      setuptools-scm requires setuptools>=61

      Suggested workaround if applicable:
       - migrating from the deprecated setup_requires mechanism to pep517/518 and using a pyproject.toml to declare build dependencies which are reliably pre-installed before running the build tools
```

Full error: https://gist.github.com/amercader/b047186b9ab6cab0e8e47cd87b1aeebe

Summary of a long and convoluted investigation:

* Both CKAN 2.10 and 2.11 use pysolr==3.9.0 and are tested on the `python:3.9-bullseye` image
* This combination no longer works because pysolr uses setuptools-scm and the latest version (8.2) does not work with the setuptools version the image has (58.*)
* All higher version Python images work, because of higher setuptools versions
* CKAN master works because pysolr 3.10.0 does not have this issue (I guess they changed the way build requirements are defined).
* So we either:
  1. Upgrade pysolr on dev-v2.10 and dev-v2.11
  2. Upgrade setuptools in our particular test environment

I went with option 2 because it's the more straightforward and less likely to break things on existing sites but happy to reconsider.

This PR targets 2.11, on 2.10 we still have the `requirement-setuptools.txt` file so I bumped the requirement there (https://github.com/ckan/ckan/commit/0bf1c7df10067bf6619f7492795de2e311d9647f).

 


Refs:

https://github.com/pypa/setuptools-scm/issues/1112
https://github.com/pypa/setuptools-scm/issues/1111

