### PR TITLE
fix: Revert deleted method get_site_statistics()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,11 @@ Migration notes
   the string ``*`` as value in both options (this is dangerous and
   **not** recommended).
 
+Minor changes
+-------------
+
+- Remove helper ``get_site_statistics()`` (#8705)
+
 v.2.11.2 2025-02-05
 ===================
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2548,15 +2548,6 @@ def featured_group_org(items: list[str], get_action: str, list_action: str,
 
     return groups_data
 
-@core_helper
-def get_site_statistics() -> dict[str, int]:
-    stats = {}
-    stats['dataset_count'] = logic.get_action('package_search')(
-        {}, {"rows": 1})['count']
-    stats['group_count'] = len(logic.get_action('group_list')({}, {}))
-    stats['organization_count'] = len(
-        logic.get_action('organization_list')({}, {}))
-    return stats
 
 _RESOURCE_FORMATS: dict[str, Any] = {}
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2548,6 +2548,15 @@ def featured_group_org(items: list[str], get_action: str, list_action: str,
 
     return groups_data
 
+@core_helper
+def get_site_statistics() -> dict[str, int]:
+    stats = {}
+    stats['dataset_count'] = logic.get_action('package_search')(
+        {}, {"rows": 1})['count']
+    stats['group_count'] = len(logic.get_action('group_list')({}, {}))
+    stats['organization_count'] = len(
+        logic.get_action('organization_list')({}, {}))
+    return stats
 
 _RESOURCE_FORMATS: dict[str, Any] = {}
 


### PR DESCRIPTION
Fixes #8522

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
