### PR TITLE
fix: Revert deleted method get_site_statistics() [Dev-2.11]

### DIFF
--- a/changes/8522.misc
+++ b/changes/8522.misc
@@ -1,1 +1,1 @@
-Re-add the `get _site_statistics()` helper that was removed without mention in the changelog
+Re-add `get _site_statistics()` helper that was removed without mention in the changelog

--- a/changes/8522.misc
+++ b/changes/8522.misc
@@ -1,0 +1,1 @@
+Re-add the `get _site_statistics()` helper that was removed without mention in the changelog

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2491,6 +2491,17 @@ def featured_group_org(items: list[str], get_action: str, list_action: str,
     return groups_data
 
 
+@core_helper
+def get_site_statistics() -> dict[str, int]:
+    stats = {}
+    stats['dataset_count'] = logic.get_action('package_search')(
+        {}, {"rows": 1})['count']
+    stats['group_count'] = len(logic.get_action('group_list')({}, {}))
+    stats['organization_count'] = len(
+        logic.get_action('organization_list')({}, {}))
+    return stats
+
+
 _RESOURCE_FORMATS: dict[str, Any] = {}
 
 


### PR DESCRIPTION
Fixes #8522

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
