### PR TITLE
datastore_search: sort on array column types fix

### DIFF
--- a/changes/8709.bugfix
+++ b/changes/8709.bugfix
@@ -1,0 +1,1 @@
+datastore_search: fix for sort on array column types

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1455,9 +1455,7 @@ def search_data(context: Context, data_dict: dict[str, Any]):
         sort = ['_id']
 
     if sort:
-        sort_clause = 'ORDER BY {}'.format(', '.join(
-            identifier(data_dict['resource_id']) + '.' + s
-            for s in sort))
+        sort_clause = 'ORDER BY {}'.format(', '.join(sort))
     else:
         sort_clause = ''
 
@@ -1466,8 +1464,10 @@ def search_data(context: Context, data_dict: dict[str, Any]):
         sql_fmt = u'''
             SELECT array_to_json(array_agg(j))::text FROM (
                 SELECT {distinct} {select}
-                FROM "{resource}" {ts_query}
-                {where} {sort} LIMIT {limit} OFFSET {offset}
+                FROM (
+                    SELECT * FROM {resource} {ts_query}
+                    {where} {sort} LIMIT {limit} OFFSET {offset}
+                ) as z
             ) AS j'''
     elif records_format == u'lists':
         select_columns = u" || ',' || ".join(
@@ -1477,29 +1477,34 @@ def search_data(context: Context, data_dict: dict[str, Any]):
             SELECT '[' || array_to_string(array_agg(j.v), ',') || ']' FROM (
                 SELECT {distinct} '[' || {select} || ']' v
                 FROM (
-                    SELECT * FROM "{resource}" {ts_query}
-                    {where} {sort} LIMIT {limit} OFFSET {offset}) as z
+                    SELECT * FROM {resource} {ts_query}
+                    {where} {sort} LIMIT {limit} OFFSET {offset}
+                ) as z
             ) AS j'''
     elif records_format == u'csv':
         sql_fmt = u'''
             COPY (
                 SELECT {distinct} {select}
-                FROM "{resource}" {ts_query}
-                {where} {sort} LIMIT {limit} OFFSET {offset}
+                FROM (
+                    SELECT * FROM {resource} {ts_query}
+                    {where} {sort} LIMIT {limit} OFFSET {offset}
+                ) as z
             ) TO STDOUT csv DELIMITER ',' '''
     elif records_format == u'tsv':
         sql_fmt = u'''
             COPY (
                 SELECT {distinct} {select}
-                FROM "{resource}" {ts_query}
-                {where} {sort} LIMIT {limit} OFFSET {offset}
+                FROM (
+                    SELECT * FROM {resource} {ts_query}
+                    {where} {sort} LIMIT {limit} OFFSET {offset}
+                ) as z
             ) TO STDOUT csv DELIMITER '\t' '''
     else:
         sql_fmt = u''
     sql_string = sql_fmt.format(
         distinct=distinct,
         select=select_columns,
-        resource=resource_id,
+        resource=identifier(resource_id),
         ts_query=ts_query,
         where=where_clause,
         sort=sort_clause,

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1455,7 +1455,9 @@ def search_data(context: Context, data_dict: dict[str, Any]):
         sort = ['_id']
 
     if sort:
-        sort_clause = 'ORDER BY {}'.format(', '.join(sort))
+        sort_clause = 'ORDER BY {}'.format(', '.join(
+            identifier(data_dict['resource_id']) + '.' + s
+            for s in sort))
     else:
         sort_clause = ''
 

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -2204,7 +2204,7 @@ class TestDatastoreSearchRecordsFormat(object):
                 {"id": "lst", "type": "_text"},
             ],
             records=[
-                {"num": 10, "dt": "2020-01-01", "txt": "aaab", "lst": ["one", "two"]},
+                {"num": 10, "dt": "2020-01-01", "txt": "aaab", "lst": ["one"]},
                 {"num": 9, "dt": "2020-01-02", "txt": "aaab"},
                 {"num": 9, "txt": "aaac", "lst": ["one", "two"]},
                 {},  # all nulls
@@ -2218,8 +2218,19 @@ class TestDatastoreSearchRecordsFormat(object):
         )["records"] == [
             [2, 9, "2020-01-02T00:00:00", "aaab", None],
             [3, 9, None, "aaac", ["one", "two"]],
-            [1, 10, "2020-01-01T00:00:00", "aaab", ["one", "two"]],
+            [1, 10, "2020-01-01T00:00:00", "aaab", ["one"]],
             [4, None, None, None, None],
+        ]
+        assert helpers.call_action(
+            "datastore_search",
+            resource_id=r["resource_id"],
+            records_format="lists",
+            sort="lst nulls first, num nulls last",
+        )["records"] == [
+            [2, 9, "2020-01-02T00:00:00", "aaab", None],
+            [4, None, None, None, None],
+            [1, 10, "2020-01-01T00:00:00", "aaab", ["one"]],
+            [3, 9, None, "aaac", ["one", "two"]],
         ]
         assert helpers.call_action(
             "datastore_search",
@@ -2229,6 +2240,17 @@ class TestDatastoreSearchRecordsFormat(object):
         )["records"] == [
             {"_id": 2, "num": 9, "dt": "2020-01-02T00:00:00", "txt": "aaab", "lst": None},
             {"_id": 3, "num": 9, "dt": None, "txt": "aaac", "lst": ["one", "two"]},
-            {"_id": 1, "num": 10, "dt": "2020-01-01T00:00:00", "txt": "aaab", "lst": ["one", "two"]},
+            {"_id": 1, "num": 10, "dt": "2020-01-01T00:00:00", "txt": "aaab", "lst": ["one"]},
             {"_id": 4, "num": None, "dt": None, "txt": None, "lst": None},
+        ]
+        assert helpers.call_action(
+            "datastore_search",
+            resource_id=r["resource_id"],
+            records_format="objects",
+            sort="lst nulls first, num nulls last",
+        )["records"] == [
+            {"_id": 2, "num": 9, "dt": "2020-01-02T00:00:00", "txt": "aaab", "lst": None},
+            {"_id": 4, "num": None, "dt": None, "txt": None, "lst": None},
+            {"_id": 1, "num": 10, "dt": "2020-01-01T00:00:00", "txt": "aaab", "lst": ["one"]},
+            {"_id": 3, "num": 9, "dt": None, "txt": "aaac", "lst": ["one", "two"]},
         ]


### PR DESCRIPTION
Fixes #8709

### Proposed fixes:

Apply sort on inner select so that sorting on arrays works properly

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport