### PR TITLE
fix: set resource_id and view_type to create views

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -393,6 +393,8 @@ def resource_view_create(
     else:
         order = last_view.order + 1
     data['order'] = order
+    data['view_type'] = view_type
+    data['resource_id'] = resource_id
 
     resource_view = model_save.resource_view_dict_save(data, context)
     if not context.get('defer_commit'):


### PR DESCRIPTION
Fixes #

When calling `package_create_default_resource_views` in the `after_dataset_update`-function from `IPackageController` we kept getting SQL-Import Errors.

```
2025-03-08 13:04:36,455 DEBUG [ckanext.harvest.model] Error importing dataset bev324od3242: IntegrityError('(psycopg2.errors.NotNullViolation) null value in column "view_type" violates not-null constraint\nDETAIL:  Failing row contains (d3a1c45e-2de7-4bfa-80ef-a1e8ab4ca4bc, null, Data Explorer, null, null, 0, null).\n') / Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1900, in _execute_context
    self.dialect.do_execute(
  File "/usr/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 736, in do_execute
    cursor.execute(statement, parameters)
psycopg2.errors.NotNullViolation: null value in column "view_type" violates not-null constraint
DETAIL:  Failing row contains (d3a1c45e-2de7-4bfa-80ef-a1e8ab4ca4bc, null, Data Explorer, null, null, 0, null).


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/srv/app/src/ckanext-dcat/ckanext/dcat/harvesters/rdf.py", line 353, in import_stage
    p.toolkit.get_action('package_update')(context, dataset)
  File "/srv/app/src/ckan/ckan/logic/__init__.py", line 551, in wrapped
    result = _action(context, data_dict, **kw)
  File "/srv/app/src/ckan/ckan/logic/action/update.py", line 351, in package_update
    item.after_dataset_update(context, data)
  File "/srv/app/src_extensions/ckanext-stadtzh-theme/ckanext/stadtzhtheme/plugin.py", line 700, in after_dataset_update
    return self._package_create_default_resource_views(context, pkg_dict)
  File "/srv/app/src_extensions/ckanext-stadtzh-theme/ckanext/stadtzhtheme/plugin.py", line 470, in _package_create_default_resource_views
    tk.get_action("package_create_default_resource_views")(
  File "/srv/app/src/ckan/ckan/logic/__init__.py", line 551, in wrapped
    result = _action(context, data_dict, **kw)
  File "/srv/app/src/ckan/ckan/logic/action/create.py", line 529, in package_create_default_resource_views
    return ckan.lib.datapreview.add_views_to_dataset_resources(
  File "/srv/app/src/ckan/ckan/lib/datapreview.py", line 253, in add_views_to_dataset_resources
    new_views = add_views_to_resource(context,
  File "/srv/app/src/ckan/ckan/lib/datapreview.py", line 221, in add_views_to_resource
    view_dict = logic.get_action('resource_view_create')(context, view)
  File "/srv/app/src/ckan/ckan/logic/__init__.py", line 551, in wrapped
    result = _action(context, data_dict, **kw)
  File "/srv/app/src/ckan/ckan/logic/action/create.py", line 444, in resource_view_create
    model.repo.commit()
  File "<string>", line 2, in commit
  File "/usr/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 1451, in commit
    self._transaction.commit(_to_root=self.future)
  File "/usr/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 829, in commit
    self._prepare_impl()
  File "/usr/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 797, in _prepare_impl
    self.session.dispatch.before_commit(self.session)
  File "/usr/lib/python3.10/site-packages/sqlalchemy/event/attr.py", line 247, in __call__
    fn(*args, **kw)
  File "/srv/app/src/ckan/ckan/model/meta.py", line 70, in ckan_before_commit
    dome.before_commit(session)
  File "/srv/app/src/ckan/ckan/model/modification.py", line 25, in before_commit
    self.notify_observers(session, self.notify)
  File "/srv/app/src/ckan/ckan/model/modification.py", line 28, in notify_observers
    session.flush()
  File "/usr/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 3386, in flush
    self._flush(objects)
  File "/usr/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 3525, in _flush
    with util.safe_reraise():
  File "/usr/lib/python3.10/site-packages/sqlalchemy/util/langhelpers.py", line 70, in __exit__
    compat.raise_(
  File "/usr/lib/python3.10/site-packages/sqlalchemy/util/compat.py", line 208, in raise_
    raise exception
  File "/usr/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 3486, in _flush
    flush_context.execute()
  File "/usr/lib/python3.10/site-packages/sqlalchemy/orm/unitofwork.py", line 456, in execute
    rec.execute(self)
  File "/usr/lib/python3.10/site-packages/sqlalchemy/orm/unitofwork.py", line 630, in execute
    util.preloaded.orm_persistence.save_obj(
  File "/usr/lib/python3.10/site-packages/sqlalchemy/orm/persistence.py", line 245, in save_obj
    _emit_insert_statements(
  File "/usr/lib/python3.10/site-packages/sqlalchemy/orm/persistence.py", line 1238, in _emit_insert_statements
    result = connection._execute_20(
  File "/usr/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1705, in _execute_20
    return meth(self, args_10style, kwargs_10style, execution_options)
  File "/usr/lib/python3.10/site-packages/sqlalchemy/sql/elements.py", line 333, in _execute_on_connection
    return connection._execute_clauseelement(
  File "/usr/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1572, in _execute_clauseelement
    ret = self._execute_context(
  File "/usr/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1943, in _execute_context
    self._handle_dbapi_exception(
  File "/usr/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 2124, in _handle_dbapi_exception
    util.raise_(
  File "/usr/lib/python3.10/site-packages/sqlalchemy/util/compat.py", line 208, in raise_
    raise exception
  File "/usr/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1900, in _execute_context
    self.dialect.do_execute(
  File "/usr/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 736, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.IntegrityError: (psycopg2.errors.NotNullViolation) null value in column "view_type" violates not-null constraint
DETAIL:  Failing row contains (d3a1c45e-2de7-4bfa-80ef-a1e8ab4ca4bc, null, Data Explorer, null, null, 0, null).

[SQL: INSERT INTO resource_view (id, resource_id, title, description, view_type, "order", config) VALUES (%(id)s, %(resource_id)s, %(title)s, %(description)s, %(view_type)s, %(order)s, %(config)s)]
[parameters: {'id': 'd3a1c45e-2de7-4bfa-80ef-a1e8ab4ca4bc', 'resource_id': None, 'title': 'Data Explorer', 'description': None, 'view_type': None, 'order': 0, 'config': None}]
(Background on this error at: https://sqlalche.me/e/14/gkpj)

```
 When debugging this, trying to explicitly pass the `view_type` like the following snippet, led to the same error:

```
get_action("package_create_default_resource_views")(
   context, {
      "package": pkg_dict,
      "view_type": "recline_view"
   }
 )
```

I noticed that, the `view_type` and `view_plugins` and also `resource_id` were always available (for us, we have `view_types` defined in .env which were correctly read).

But when 
```
resource_view = model_save.resource_view_dict_save(data, context)
```
is called, `data` is still missing `view_type` and (as I later noticed) also the `resource_id`


### Proposed fixes:
Setting the values in `resource_view_create` right before saving everything and committing it to the database, the views are correctly created without any errors.

```
data['view_type'] = view_type                                                                                                                                                  
data['resource_id'] = resource_id  
```

_Note: I tested this with version CKAN 2.10, but haven't seen any changes in the functions that play a part here, that would fix this in 2.11 so I assume the behavior is currently the same, I can hopefully test this as well later._

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
