### PR TITLE
[#8379] Store `session["last_active"]` as an iso string instead of a datetime

### DIFF
--- a/changes/8379.bugfix
+++ b/changes/8379.bugfix
@@ -1,0 +1,2 @@
+Ensure `session["last_active"]` is stored as an iso string instead of a `datetime` so that it can be serialized to JSON (e.g. in cookies).
+

--- a/ckan/model/user.py
+++ b/ckan/model/user.py
@@ -355,7 +355,7 @@ class User(core.StatefulObjectMixin,
     def set_user_last_active(self) -> None:
         if self.last_active:
             if self.last_active < last_active_check():
-                session["last_active"] = self.last_active
+                session["last_active"] = self.last_active.isoformat()
                 self.last_active = datetime.datetime.utcnow()
                 meta.Session.commit()
         else:


### PR DESCRIPTION
Fixes #8379 

CKAN: 2.10.x

### Proposed fixes:

Ensure `session["last_active"]` is stored as an iso-format string instead of a `datetime` so that `beaker` can serialize cookies to JSON.

This is only relevant/needed for CKAN 2.10.x as all other versions use a different library for session management.

Its possible that this would break plugins that are expecting `session["last_active"]` to be a `datetime` object. If that is the case this change may be more trouble than it is worth. A workaround is to use a server-side session (e.g. `beaker.session.type=file`) which is also noted in #8379 

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
