### PR TITLE
8719 - When displaying a resource with a large numeric ID (MD5SUM), a 500 error is produced

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2270,17 +2270,21 @@ def format_resource_items(
                 pass
         elif isinstance(value, str):
             # check if strings are actually datetime/number etc
-            if re.search(reg_ex_datetime, value):
-                datetime_ = date_str_to_datetime(value)
-                value = formatters.localised_nice_date(datetime_)
-            elif re.search(reg_ex_float, value):
-                value = formatters.localised_number(float(value))
-            elif re.search(reg_ex_int, value):
-                value = formatters.localised_number(int(value))
-        elif isinstance(value, bool):
-            value = str(value)
-        elif isinstance(value, (int, float)):
-            value = formatters.localised_number(float(value))
+            try:
+                if re.search(reg_ex_datetime, value):
+                    datetime_ = date_str_to_datetime(value)
+                    value = formatters.localised_nice_date(datetime_)
+                elif re.search(reg_ex_float, value):
+                    value = formatters.localised_number(float(value))
+                elif re.search(reg_ex_int, value):
+                    int_value = int(value)
+                    value = formatters.localised_number(int(value))
+            except Exception:
+                # something happened when we tried to format, just return what we were given.
+                pass
+        elif ((isinstance(value, int) or isinstance(value, float))
+                and value not in (True, False)):
+            value = formatters.localised_number(value)
         key = key.replace('_', ' ')
         output.append((key, value))
     return sorted(output, key=lambda x: x[0])

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2246,7 +2246,7 @@ def render_markdown(data: str,
 def format_resource_items(
         items: list[tuple[str, Any]]) -> list[tuple[str, Any]]:
     ''' Take a resource item list and format nicely with blacklisting etc. '''
-    blacklist = ['name', 'description', 'url']
+    blacklist = ['name', 'description', 'url', 'tracking_summary', 'id']
     output = []
     # regular expressions for detecting types in strings
     reg_ex_datetime = r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{6})?$'


### PR DESCRIPTION
Fixes #8719

### Proposed fixes:

Added ID field to blacklist
Put Try/Except around formatting
For Resource display

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X ] includes bugfix for possible backport
We patched 2.9, pull request submitted against HEAD.

