### PR TITLE
Cast to String for DataStore Text Fields in Where Clauses

### DIFF
--- a/changes/8729.bugfix
+++ b/changes/8729.bugfix
@@ -1,0 +1,1 @@
+You can now use non-string values in `datastore_search` and `datastore_delete` filters for text datatype fields.

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -434,8 +434,18 @@ def _where_clauses(
                 sa.column(field),
                 ','.join(f":{p}" for p in placeholders)
             ))
+            if fields_types[field] == 'text':
+                # pSQL can do int_field = "10"
+                # but cannot do text_field = 10
+                # this fixes parity there.
+                value = [str(v) for v in value]
             clause = (clause_str, dict(zip(placeholders, value)))
         else:
+            if fields_types[field] == 'text':
+                # pSQL can do int_field = "10"
+                # but cannot do text_field = 10
+                # this fixes parity there.
+                value = str(value)
             placeholder = f"value_{next(idx_gen)}"
             clause: tuple[Any, ...] = (
                 f'{sa.column(field)} = :{placeholder}',
@@ -1636,7 +1646,10 @@ def delete_data(context: Context, data_dict: dict[str, Any]):
         where_clause
     )
 
-    _execute_single_statement(context, sql_string, where_values)
+    try:
+        _execute_single_statement(context, sql_string, where_values)
+    except ProgrammingError as pe:
+        raise ValidationError({'filters': [_programming_error_summary(pe)]})
 
 
 def _create_triggers(connection: Any, resource_id: str,

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -438,7 +438,7 @@ def _where_clauses(
                 # pSQL can do int_field = "10"
                 # but cannot do text_field = 10
                 # this fixes parity there.
-                value = [str(v) for v in value]
+                value = (str(v) for v in value)
             clause = (clause_str, dict(zip(placeholders, value)))
         else:
             if fields_types[field] == 'text':

--- a/ckanext/datastore/tests/test_delete.py
+++ b/ckanext/datastore/tests/test_delete.py
@@ -228,8 +228,8 @@ class TestDatastoreRecordsDelete(object):
                 "filters": {"text_field": 25}}
         helpers.call_action("datastore_records_delete", **data)
         result = helpers.call_action("datastore_search",
-                                      resource_id=resource["id"],
-                                      include_total=True)
+                                     resource_id=resource["id"],
+                                     include_total=True)
         assert result["total"] == 1
 
         # can delete by text
@@ -237,8 +237,8 @@ class TestDatastoreRecordsDelete(object):
                 "filters": {"text_field": "37"}}
         helpers.call_action("datastore_records_delete", **data)
         result = helpers.call_action("datastore_search",
-                                      resource_id=resource["id"],
-                                      include_total=True)
+                                     resource_id=resource["id"],
+                                     include_total=True)
         assert result["total"] == 0
 
 

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -835,25 +835,6 @@ class TestDatastoreSearchLegacyTests(object):
 
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
-    def test_search_invalid_filter(self, app):
-        data = {
-            "resource_id": self.data["resource_id"],
-            # invalid because author is not a numeric field
-            "filters": {u"author": 42},
-        }
-
-        headers = {"Authorization": self.sysadmin_token}
-        res = app.post(
-            "/api/action/datastore_search",
-            json=data,
-            headers=headers,
-            status=409,
-        )
-        res_dict = json.loads(res.data)
-        assert res_dict["success"] is False
-
-    @pytest.mark.ckan_config("ckan.plugins", "datastore")
-    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_search_sort(self, app):
         data = {
             "resource_id": self.data["resource_id"],

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -486,6 +486,37 @@ class TestDatastoreSearch(object):
         result = helpers.call_action("datastore_search", **search_data)
         assert result["records"][0]['b'] == 'Z'
 
+    @pytest.mark.ckan_config("ckan.plugins", "datastore")
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    def test_search_records_text_int_filter(self):
+        resource = factories.Resource()
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "fields": [
+                {"id": "text_field", "type": "text"},
+            ],
+            "records": [
+                {"text_field": 25},
+                {"text_field": 37},
+            ],
+        }
+        helpers.call_action("datastore_create", **data)
+
+        # can search by int
+        data = {"resource_id": resource["id"],
+                "include_total": True,
+                "filters": {"text_field": 25}}
+        result = helpers.call_action("datastore_search", **data)
+        assert len(result["records"]) == 1
+
+        # can search by text
+        data = {"resource_id": resource["id"],
+                "include_total": True,
+                "filters": {"text_field": "37"}}
+        result = helpers.call_action("datastore_search", **data)
+        assert len(result["records"]) == 1
+
 
 class TestDatastoreSearchLegacyTests(object):
     sysadmin_user = None


### PR DESCRIPTION
fix(logic): datastore where clause;

- Cast str for text type fields.

Fixes #

### Proposed fixes:

See: https://github.com/ckan/ckan/issues/8725

### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
