### PR TITLE
Enable pytest on GitHub Actions and other CICD improvements

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,5 +1,8 @@
 name: Cypress
-on: [pull_request]
+on:
+#  pull_request:
+  workflow_call:
+  workflow_dispatch:
 env:
   NODE_VERSION: '16'
   PYTHON_VERSION: '3.9'
@@ -11,8 +14,8 @@ jobs:
   cypress:
     runs-on: ubuntu-latest
     services:
-      ckan-postgres:
-        image: postgres:12
+      ckan_postgres:
+        image: postgres:15
         ports:
           - 5432:5432
         options: >-
@@ -25,11 +28,11 @@ jobs:
           POSTGRES_PASSWORD: pass
           POSTGRES_DB: ckan_test
 
-      ckan-redis:
+      ckan_redis:
         image: redis
         ports:
           - 6379:6379
-      ckan-solr:
+      ckan_solr:
         image: ckan/ckan-solr:master
         ports:
           - 8983:8983
@@ -40,25 +43,32 @@ jobs:
       CKAN_REDIS_URL: redis://localhost:6379/1
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - uses: actions/setup-node@v3
+          cache: 'pip'
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
 
       - name: Install python deps
-        run: pip install -r requirements.txt -r dev-requirements.txt -e.
+        run: |
+         pip install -U pip
+         pip install -r requirements.txt -r dev-requirements.txt -e.
+         pip check
 
       - name: Init environment
         run: |
-          ckan -c test-core-cypress.ini db init
+          ckan -c test-core-github-actions.ini db init
+          #cypress testing requires activity plugin to be active
+          ckan config-tool test-core-github-actions.ini "ckan.plugins = activity"
 
       - name: Run Cypress
         uses: cypress-io/github-action@v6
         with:
-          start: ckan -c test-core-cypress.ini run
+          start: ckan -c test-core-github-actions.ini run
 
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,5 +1,8 @@
 name: Lint
-on: [pull_request]
+on:
+#  pull_request:
+  workflow_call:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -1,5 +1,8 @@
 name: Check types
-on: [pull_request]
+on:
+#  pull_request:
+  workflow_call:
+  workflow_dispatch:
 env:
   NODE_VERSION: '18'
   PYTHON_VERSION: '3.9'
@@ -15,9 +18,11 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
       - name: Install python deps
         run: pip install -r requirements.txt -r dev-requirements.txt -e.
       - name: Install node deps

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,313 @@
+name: Pytest
+#pytest split data storage https://github.com/jerry-git/pytest-split/issues/20#issuecomment-2576031836
+on:
+  #pull_request: #disabled as its called via test.yml uses delegation
+  workflow_call:
+  workflow_dispatch:
+    inputs:
+      split:
+        type: choice
+        options:
+          - '["1"]'
+          - '["1", "2", "3", "4"]'
+          - '["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"]'
+          - '["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16"]'
+          - '["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20"]'
+        description: 'Number of test splits (set to ["1"])'
+        required: false
+        default: '["1"]'
+env:
+  NODE_VERSION: '16'
+  PYTHON_VERSION: '3.9'
+
+permissions:
+  contents: read
+
+jobs:
+  define-matrix:
+    runs-on: ubuntu-latest
+
+    outputs:
+      SPLIT_LIST: ${{ steps.splits.outputs.SPLIT_LIST }}
+      SPLIT_COUNT: ${{ steps.splits.outputs.SPLIT_COUNT }}
+      # This output will be used to know if we had a cache hit (exact match or not), or no cache hit at all.
+      # See documentation about the `cache-hit` output:
+      # https://github.com/actions/cache/blob/main/README.md#outputs
+      # > cache-hit - A string value to indicate an exact match was found for the key.
+      # > If there's a cache hit, this will be 'true' or 'false' to indicate if there's an exact match
+      # > for key.
+      # > If there's a cache miss, this will be an empty string.
+      restored: ${{ steps.restore-test-durations.outputs.cache-hit == '' && 'false' || 'true' }}
+    steps:
+      # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#example-using-an-output-to-define-two-matrice
+      - name: Define matrix split
+        id: splits
+        # default maxtrix for splits if we did not get an input
+        run: |
+          export SPLIT_LIST='${{ inputs.split || '["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"]' }}'
+          echo "this is my list: ${SPLIT_LIST}"
+          export SPLIT_COUNT="$(echo ${SPLIT_LIST} | jq 'length')"
+          echo "${SPLIT_COUNT} : ${SPLIT_LIST}"
+          echo "SPLIT_LIST=${SPLIT_LIST}" >> "$GITHUB_OUTPUT"
+          echo "SPLIT_COUNT=${SPLIT_COUNT}" >> "$GITHUB_OUTPUT"
+
+      # It's mandatory to use the exact same path when saving/restoring cache, otherwise it won't work
+      # (the same key is not enough - see documentation:
+      # https://github.com/actions/cache/blob/main/README.md#cache-version).
+      # I went with `/tmp/.test_durations`.
+      - name: Restore test durations
+        id: restore-test-durations
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/.test_durations
+          key: tests-durations-${{ github.sha }}
+          restore-keys: |
+            tests-durations-${{ github.sha }}-
+            tests-durations-
+          fail-on-cache-miss: false
+
+      # Then we upload the restored test durations as an artifact. This way, each matrix job will download
+      # it when it starts. When a matrix job will be manually retried, it will also reuse the artifact (to
+      # retry the exact same tests, even if the cache has been updated in the meantime).
+      - name: Upload test durations
+        if: steps.restore-test-durations.outputs.cache-hit != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-durations-before
+          path: /tmp/.test_durations
+          include-hidden-files: true
+
+
+
+  pytest:
+    needs: define-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        split: ${{ fromJSON(needs.define-matrix.outputs.SPLIT_LIST) }}
+
+    services:
+      ckan_postgres:
+        image: postgres:12 # should be postgres:15
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          POSTGRES_USER: ckan
+          POSTGRES_PASSWORD: ckan
+          POSTGRES_DB: ckan
+          PGDATA: "/data"
+
+      ckan_redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+      ckan_solr:
+        image: ckan/ckan-solr:master
+        ports:
+          - 8983:8983
+
+    env:
+      SPLIT_COUNT: ${{ needs.define-matrix.outputs.SPLIT_COUNT }}
+      CKAN_SQLALCHEMY_URL: postgresql://ckan_default:pass@localhost/ckan_test
+      CKAN_SOLR_URL: http://localhost:8983/solr/ckan
+      CKAN_REDIS_URL: redis://localhost:6379/1
+      POSTGRES_USER: ckan
+      POSTGRES_PASSWORD: ckan
+      CKAN_DB: ckan_test
+      CKAN_DATASTORE_POSTGRES_DB: datastore_test
+      CKAN_DATASTORE_POSTGRES_READ_USER: datastore_read
+      CKAN_DATASTORE_POSTGRES_READ_PWD: pass
+      CKAN_DATASTORE_POSTGRES_WRITE_USER: datastore_write
+      CKAN_DATASTORE_POSTGRES_WRITE_PWD: pass
+      CKAN_POSTGRES_DB: ckan_test
+      CKAN_POSTGRES_USER: ckan_default
+      CKAN_POSTGRES_PWD: pass
+      PGPASSWORD: ckan
+      PGHOST: localhost
+      CKAN_STORAGE_PATH: /tmp/storage
+      PYTEST_COMMON_OPTIONS: -v --ckan-ini=test-core-github-actions.ini --cov=ckan --cov=ckanext --junitxml=./junit/result/junit.xml
+
+
+    steps:
+      - run: |
+          echo "${{ matrix.split }} of $SPLIT_COUNT"
+      - name: Setup Database
+        run: |
+          # Database Creation
+          psql     --host=${PGHOST} --username=${POSTGRES_USER} --command="CREATE USER ${CKAN_POSTGRES_USER} WITH PASSWORD '${CKAN_POSTGRES_PWD}' NOSUPERUSER NOCREATEDB NOCREATEROLE;"
+          createdb --encoding=utf-8 --host=${PGHOST} --username=${POSTGRES_USER} --owner=${CKAN_POSTGRES_USER} ${CKAN_POSTGRES_DB}
+          psql     --host=${PGHOST} --username=${POSTGRES_USER} --command="CREATE USER ${CKAN_DATASTORE_POSTGRES_READ_USER} WITH PASSWORD '${CKAN_DATASTORE_POSTGRES_READ_PWD}' NOSUPERUSER NOCREATEDB NOCREATEROLE;"
+          psql     --host=${PGHOST} --username=${POSTGRES_USER} --command="CREATE USER ${CKAN_DATASTORE_POSTGRES_WRITE_USER} WITH PASSWORD '${CKAN_DATASTORE_POSTGRES_WRITE_PWD}' NOSUPERUSER NOCREATEDB NOCREATEROLE;"
+          createdb --encoding=utf-8 --host=${PGHOST} --username=${POSTGRES_USER} --owner=${CKAN_DATASTORE_POSTGRES_WRITE_USER} ${CKAN_DATASTORE_POSTGRES_DB}
+
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history, including tags
+
+      # These two steps will be executed only when there IS a cache hit (exact match or not). When a matrix
+      # job is retried, it will reuse the same artifact, to execute the exact same split.
+      - name: Download test durations
+        if: needs.define-matrix.outputs.restored == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: test-durations-before
+#      - name: Use cached test durations
+#        if: needs.define-matrix.outputs.restored == 'true'
+#        run: mv .test_durations /path/to/your/app/.test_durations
+
+      # This step will be executed only when there is NO cache hit.
+      # You need to commit file `.test_durations_fallback`.
+      # You can also refresh it manually from time to time to keep an up-to-date fallback
+      # (see step "Upload final test durations" below).
+      - name: Use fallback test durations
+        if: needs.define-matrix.outputs.restored == 'false'
+        run: |
+          # Note: to update this, you must run pytest --store-durations and commit to repo
+          echo "unzip pytest test duration details"
+          gunzip .test_durations.gz
+
+
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Install python deps
+        run: |
+         pip install -U pip
+         pip install -r requirements.txt -r dev-requirements.txt -e .
+         pip check
+
+      - name: Init environment
+        run: |
+          export PGPASSWORD=${POSTGRES_PASSWORD}
+          # Database Initialization
+          ckan -c test-core-github-actions.ini datastore set-permissions | grep -v "Using configuration file" | psql --host=${PGHOST} --username=${POSTGRES_USER}
+          ckan -c test-core-github-actions.ini db init
+
+
+
+      #as pytest runs test_building_the_docs, we might as well have an output
+      - name: Create Docs
+        if: matrix.split == '1'
+        run: |
+           sphinx-build doc build/sphinx
+
+      #as pytest runs test_building_the_docs, we might as well have an output
+      - name: Store docs
+        if: matrix.split == '1'
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-${{ matrix.split }}
+          path: ./build/sphinx
+
+      # When running pytest, we write the new test durations using options
+      # `--store-durations --clean-durations`.
+      # Option `--clean-durations` is undocumented but you can check its implementation here:
+      # https://github.com/jerry-git/pytest-split/blob/fb9af7e0122c18a96a7c01ca734c4ab01027f8d9/src/pytest_split/plugin.py#L68-L76
+      # > Removes the test duration info for tests which are not present while running the suite with
+      # > '--store-durations'.
+      - name: Run pytest
+        run: |
+          echo "::group::prepTest"
+          unset CKAN_SQLALCHEMY_URL CKAN_SOLR_URL CKAN_REDIS_URL POSTGRES_USER POSTGRES_PASSWORD
+          unset CKAN_DB CKAN_DATASTORE_POSTGRES_DB CKAN_DATASTORE_POSTGRES_READ_USER CKAN_DATASTORE_POSTGRES_READ_PWD
+          unset CKAN_DATASTORE_POSTGRES_WRITE_USER CKAN_DATASTORE_POSTGRES_WRITE_PWD CKAN_POSTGRES_DB
+          unset CKAN_POSTGRES_USER CKAN_POSTGRES_PWD PGPASSWORD PGHOST CKAN_STORAGE_PATH
+
+          mkdir -p ./junit/result
+          echo "${{ matrix.split }} of $SPLIT_COUNT"
+          echo "::endgroup::"
+
+          echo "::group::pytest"
+          pytest $PYTEST_COMMON_OPTIONS --splits $SPLIT_COUNT --group ${{ matrix.split }} --splitting-algorithm least_duration --store-durations --clean-durations
+          echo "::endgroup::"
+
+
+      # Each matrix job uploads its freshly updated partial test durations. We regroup them all
+      # within one final file in the "Merge all partial test durations" step below.
+      - name: Upload test durations
+        if: github.run_attempt == 1
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-durations-after-partial-${{ matrix.split }}
+          path: ./.test_durations
+          if-no-files-found: error
+          include-hidden-files: true
+
+      - name: Store test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-results-${{ matrix.split }}
+          path: ./junit
+
+      - name: Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: "./junit/result/*.xml"
+        if: always()
+
+      - name: Test Summary Local copy
+        uses: test-summary/action@v2
+        with:
+          paths: "./junit/result/*.xml"
+          output: "./junit/result/test-summary.md"
+        if: always()
+
+      - name: Store Test Summary results
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-summary-${{ matrix.split }}
+          path: "./junit/result/test-summary.md"
+        if: always()
+
+
+  cache-test-durations:
+    name: Cache test durations
+    needs: pytest
+    if: github.run_attempt == 1 && (success() || failure())
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all partial test durations
+        uses: actions/download-artifact@v4
+        with:
+          pattern: test-durations-after-partial-*
+
+      # This step regroups the 8 partial files and sorts keys alphabetically:
+      - name: Merge all partial test durations
+        run: |
+          jq -s 'add' test-durations-after-partial-*/.test_durations \
+          | jq 'to_entries | sort_by(.key) | from_entries' \
+          > /tmp/.test_durations
+
+      # This step uploads the final file as an artifact. You can then download it from the Github GUI,
+      # and use it to manually commit file `.test_durations_fallback` from time to time,
+      # to keep an up-to-date fallback:
+      - name: Upload final test durations
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-durations-after
+          path: /tmp/.test_durations
+          if-no-files-found: error
+          include-hidden-files: true
+
+      # Finally, we cache the new test durations. This file will be restored in next CI execution
+      # (see step "Restore test durations" above).
+      - name: Cache final test durations
+        uses: actions/cache/save@v4
+        with:
+          path: /tmp/.test_durations
+          key: tests-durations-${{ github.sha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+
+  flake8:
+    name: Lint (Flake8)
+    uses: ./.github/workflows/flake8.yml # Call the reusable workflow
+
+  pyright:
+    name: Lint (PyRight)
+    uses: ./.github/workflows/pyright.yml # Call the reusable workflow
+
+  cypress:
+    name: Test (Cypress)
+    #needs: [flake8]
+    uses: ./.github/workflows/cypress.yml # Call the reusable workflow
+
+  pytest:
+    name: Test (Pytest)
+    #needs: [flake8]
+    uses: ./.github/workflows/pytest.yml # Call the reusable workflow

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,11 @@ tmp/*
 solr_runtime/*
 fl_notes.txt
 *.ini
+!test-core-cypress.ini
+!test-core.ini
+!test-core-circle-ci.ini
+!test-core-docker.ini
+!test-core-github-actions.ini
 !ckan/migration/alembic.ini
 .noseids
 *~

--- a/changes/8731.misc 
+++ b/changes/8731.misc 
@@ -1,0 +1,1 @@
+Update CICD Infrastructure

--- a/ckanext/activity/tests/test_views.py
+++ b/ckanext/activity/tests/test_views.py
@@ -747,6 +747,7 @@ class TestPackage:
         assert helpers.body_contains(response, "Dataset title")
         assert helpers.body_contains(response, resource["name"])
 
+    @pytest.mark.flaky(retries=3, delay=1)
     def test_read_resource_as_it_used_to_be(self, app):
         dataset = factories.Dataset(title="Dataset title")
         resource = factories.Resource(package_id=dataset["id"], name="Original name")

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -22,3 +22,4 @@ pytest-factoryboy==2.7.0
 pytest-freezegun==0.4.2
 pytest-rerunfailures==15.0
 pytest-split==0.10.0
+pytest-retry==1.7.0

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,7 +19,7 @@ import re
 import os
 import subprocess
 
-from packaging.version import parse as version_parse
+from packaging.version import parse as version_parse, VERSION_PATTERN
 
 import ckan
 
@@ -133,12 +133,20 @@ point_releases_ = None
 
 SUPPORTED_CKAN_VERSIONS = 2
 
+def extract_version(tag):
+    """ Ensure we only work with 'valid' ckan tagged releases"""
+    _regex = re.compile(r"^\s*ckan-" + VERSION_PATTERN + r"\s*$", re.VERBOSE | re.IGNORECASE)
+    match = re.search(_regex, tag)
+    if not match:
+        return False
+    else:
+        return True
 
 def get_release_tags():
     git_tags = subprocess.check_output(
         ['git', 'tag', '-l'], stderr=subprocess.STDOUT).decode('utf8')
     git_tags = git_tags.split()
-    release_tags_ = [tag for tag in git_tags if tag.startswith('ckan-')]
+    release_tags_ = [tag for tag in git_tags if extract_version(tag)]
 
     # git tag -l prints out the tags in the right order anyway, but don't rely
     # on that, sort them again here for good measure.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "sass": "^1.74.1"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "cypress run",
     "watch": "gulp watch",
     "build": "gulp build",
     "watch-midnight-blue": "gulp watchMidnightBlue",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ line-length = 79
 preview = true
 
 [tool.pytest.ini_options]
+retries = 1
+retry_delay = 0.5
+cumulative_timing = true
 filterwarnings = [
     "ignore::DeprecationWarning",
     "ignore::bs4.GuessedAtParserWarning",  # using lxml as default parser

--- a/test-core-github-actions.ini
+++ b/test-core-github-actions.ini
@@ -1,7 +1,17 @@
-[app:main]
-use = config:test-core-circle-ci.ini
+[server:main]
+use = config:test-core.ini
 
-ckan.plugins = activity
+[app:main]
+use = config:test-core.ini
+
+ckan.datastore.write_url = postgresql://datastore_write:pass@localhost/datastore_test
+ckan.datastore.read_url = postgresql://datastore_read:pass@localhost/datastore_test
+
+ckan.redis.url = redis://localhost:6379/1
+
+sqlalchemy.url = postgresql://ckan_default:pass@localhost/ckan_test
+
+solr_url = http://localhost:8983/solr/ckan
 
 [loggers]
 keys = root, ckan, sqlalchemy

--- a/test-infrastructure/install_deps.sh
+++ b/test-infrastructure/install_deps.sh
@@ -3,6 +3,7 @@
 # OS Dependencies
 apt update
 apt install -y postgresql-client
+## MaxOS  ``brew install postgresql libmagic``
 
 #Python Dependencies
 pip install -U pip


### PR DESCRIPTION

Fixes #8730

### Proposed fixes:
* Merge all testing under one parent workflow
* Pytest now runs and is split into 16 to run in under 3 mins (vs 10min for only 4 workers)
  * Allow dynamic splits to be passed in
* Allow individual workflows to still be callable (manually)
* Allow pytest to run in single instance mode to generate test duration time data for improved splits



### Features:

- [X] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
