### PR TITLE
review gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,42 +1,29 @@
 syntax: glob
+
 # generic
+__pycache__/
 *.pyc
+
+# other (candidates for removal)
+pip-requirements-local.txt
+tmp/
+solr_runtime/
+sandbox/
+fl_notes.txt
+
+# distribution
+ckan.egg-info/
+dist/
+build/
+.eggs/
+
+# artifacts from text editors and os
 *.swp
 *.swo
-.DS_Store
-ckan.egg-info/*
-sandbox/*
-dist
-.mypy_cache
-.eggs/*
-
-# pylons
-development.ini*
-sstore/*
-data/*
-pylons_data/*
-#ckan/i18n/*/*/*.mo
-
-# other
-pip-requirements-local.txt
-migrate/*
-build/*
-tmp/*
-solr_runtime/*
-fl_notes.txt
-*.ini
-!ckan/migration/alembic.ini
-.noseids
 *~
 .idea
 .vscode
-
-# custom style
-ckan/public/base/less/custom.less
-
-# nosetest coverage output
-.coverage
-htmlcov/*
+.DS_Store
 
 # CKAN
 ckan.log
@@ -46,18 +33,17 @@ ckan_deb/DEBIAN/prerm
 # node.js
 node_modules/
 
-# docker
-contrib/docker/.env
-cypress.env.json
-
 # cypress
+cypress.env.json
 cypress/videos
 
 #testing
 junit
-.coverage*
+htmlcov/
+.coverage
 .cache
 .bash_history
 .gitconfig
 .npm
 .test_durations
+.mypy_cache


### PR DESCRIPTION
Remove old unused records, like folders created by pylons from gitignore.

The only controversial change I see here is removing `*.ini` files from gitignore. If anyone relies on this and creates new INI files _inside CKAN source folder_, these files will be seen from now on. 