### PR TITLE
[#8736] Fix search button styling by removing deprecated wrapper

### DIFF
--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -14580,8 +14580,7 @@ td.diff_header {
 .input-group .form-control {
   z-index: 0;
 }
-
-.input-group-btn:last-child > .btn {
+.input-group > .btn:last-child {
   z-index: 0;
 }
 

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -14580,8 +14580,7 @@ td.diff_header {
 .input-group .form-control {
   z-index: 0;
 }
-
-.input-group-btn:last-child > .btn {
+.input-group > .btn:last-child {
   z-index: 0;
 }
 

--- a/ckan/public/base/scss/_input-groups.scss
+++ b/ckan/public/base/scss/_input-groups.scss
@@ -2,12 +2,7 @@
   .form-control {
     z-index: 0;
   }
-}
-
-.input-group-btn {
-  &:last-child {
-    > .btn {
-      z-index: 0;
-    }
+  > .btn:last-child {
+    z-index: 0;
   }
 }

--- a/ckan/templates/development/primer.html
+++ b/ckan/templates/development/primer.html
@@ -30,12 +30,10 @@
 <div class="module-content">
   <div class="input-group input-group-lg search-giant">
     <input type="text" class="search form-control" name="q" value="" autocomplete="off" placeholder="Search something...">
-    <span class="input-group-btn">
-        <button class="btn btn-secondary" type="submit">
-          <i class="fa fa-search"></i>
-          <span class="sr-only">Search</span>
-        </button>
-      </span>
+      <button class="btn btn-secondary" type="submit">
+        <i class="fa fa-search"></i>
+        <span class="sr-only">Search</span>
+      </button>
   </div>
 </div>
 

--- a/ckan/templates/snippets/search_form.html
+++ b/ckan/templates/snippets/search_form.html
@@ -12,11 +12,9 @@
     <div class="input-group search-input-group">
       <input aria-label="{% block header_site_search_label %}{{ placeholder }}{% endblock %}" id="field-giant-search" type="text" class="form-control input-lg" name="q" value="{{ query }}" autocomplete="off" placeholder="{{ placeholder }}">
       {% block search_input_button %}
-      <span class="input-group-btn">
-        <button class="btn btn-secondary btn-lg" type="submit" value="search" aria-label="{{_('Submit')}}">
-          <i class="fa fa-search"></i>
-        </button>
-      </span>
+      <button class="btn btn-secondary btn-lg" type="submit" value="search" aria-label="{{_('Submit')}}">
+        <i class="fa fa-search"></i>
+      </button>
       {% endblock %}
     </div>
   {% endblock %}


### PR DESCRIPTION
Fixes #8736 

### Proposed fixes:

Remove the `.input-group-btn` wrapper and update related styles

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
