### PR TITLE
chore: Update old HTTP documentations links

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -753,7 +753,7 @@ Minor changes
   <https://github.com/ckan/ckan/pull/8586>`_)
 - Support 2.11 version of the Solr schema in CKAN 2.10 (``5acfeda6e``)
 
-  
+
 Bugfixes
 --------
 - `CVE-2025-24372 <https://github.com/ckan/ckan/security/advisories/GHSA-7pq5-qcp6-mcww>`_: Fix potential
@@ -1000,13 +1000,13 @@ v.2.10.2
 ========
 
 Unreleased
- 
+
 v.2.10.1 2023-05-24
 ===================
 
 Bug fixes
 ---------
-- `CVE-2023-32321 <https://github.com/ckan/ckan/security/advisories/GHSA-446m-hmmm-hm8m>`_: fix 
+- `CVE-2023-32321 <https://github.com/ckan/ckan/security/advisories/GHSA-446m-hmmm-hm8m>`_: fix
   potential path traversal, remote code execution, information disclosure and
   DOS vulnerabilities via crafted resource ids.
 - Redirect on password reset form error now maintains root_path and locale (`#7006 <https://github.com/ckan/ckan/pull/7006>`_)
@@ -1607,7 +1607,7 @@ v.2.9.9 2023-05-24
 Bugfixes
 --------
 
-- `CVE-2023-32321 <https://github.com/ckan/ckan/security/advisories/GHSA-446m-hmmm-hm8m>`_: fix 
+- `CVE-2023-32321 <https://github.com/ckan/ckan/security/advisories/GHSA-446m-hmmm-hm8m>`_: fix
   potential path traversal, remote code execution, information disclosure and
   DOS vulnerabilities via crafted resource ids.
 - Names are now quoted in From and To addresses in emails, meaning that site titles with
@@ -2625,7 +2625,7 @@ Changes and deprecations:
  * The API versions 1 and 2 (also known as the REST API), ie ``/api/rest/*`` have been
    completely removed in favour of the version 3 (action API, ``/api/action/*``).
  * The old Celery based background jobs have been removed in CKAN 2.8 in favour of the new RQ based
-   jobs (http://docs.ckan.org/en/latest/maintaining/background-tasks.html). Extensions can still
+   jobs (https://docs.ckan.org/en/latest/maintaining/background-tasks.html). Extensions can still
    of course use Celery but they will need to handle the management themselves.
  * After introducing dataset blueprint, `h.get_facet_items_dict` takes search_facets as second argument.
    This change is aimed to reduce usage of global variables in context. For a while, it has default value
@@ -2877,7 +2877,7 @@ General notes:
  * Starting from this version, CKAN requires at least Postgres 9.3
  * Starting from this version, CKAN requires a Redis database. Please
    refer to the new `ckan.redis.url
-   <http://docs.ckan.org/en/ckan-2.7.0/maintaining/configuration.html#ckan-redis-url>`_
+   <https://docs.ckan.org/en/ckan-2.7.0/maintaining/configuration.html#ckan-redis-url>`_
    configuration option.
  * This version requires a requirements upgrade on source installations
  * This version requires a database upgrade
@@ -2972,7 +2972,7 @@ Deprecations:
    more efficient alternatives and are now deprecated.
  * The legacy revisions controller (ie ``/revisions/*``) will be completely removed in CKAN 2.8.
  * The old Celery based background jobs will be removed in CKAN 2.8 in favour of the new RQ based
-   jobs (http://docs.ckan.org/en/latest/maintaining/background-tasks.html). Extensions can still
+   jobs (https://docs.ckan.org/en/latest/maintaining/background-tasks.html). Extensions can still
    of course use Celery but they will need to handle the management themselves.
 
 v.2.6.9 2020-04-15
@@ -3663,7 +3663,7 @@ Major:
    to know more, and the "Changes and deprecations" section for migration
    details:
 
-     http://docs.ckan.org/en/latest/maintaining/data-viewer.html
+     https://docs.ckan.org/en/latest/maintaining/data-viewer.html
 
  * Responsive design for the default theme, that allows nicer rendering across
    different devices (#1935)
@@ -3815,7 +3815,7 @@ Changes and deprecations
   a migration command on existing instances. Please refer to the migration
   guide for more details:
 
-    http://docs.ckan.org/en/latest/maintaining/data-viewer.html#migrating-from-previous-ckan-versions
+    https://docs.ckan.org/en/latest/maintaining/data-viewer.html#migrating-from-previous-ckan-versions
 
 * The PDF Viewer extension has been moved to a separate extension:
   https://github.com/ckan/ckanext-pdfview. Please install it separately if
@@ -4136,7 +4136,7 @@ API changes and deprecations:
    the FileStore to hosted files will still work, but there is a command
    available to migrate the files to new Filestore. See this page for more
    details:
-   http://docs.ckan.org/en/latest/filestore.html#filestore-21-to-22-migration
+   https://docs.ckan.org/en/latest/filestore.html#filestore-21-to-22-migration
  * By default, the authorization for any action defined from an extension will
    require a logged in user, otherwise a :py:class:`ckan.logic.NotAuthorized`
    exception will be raised. If an action function allows anonymous access (eg
@@ -4466,10 +4466,10 @@ v2.0 2013-05-10
 ===============
 
 .. note:: Starting on v2.0, issue numbers with four digits refer to the old
- ticketing system at http://trac.ckan.org and the ones with three digits refer
+ ticketing system at https://trac.ckan.org and the ones with three digits refer
  to GitHub issues. For example:
 
- * #3020 is http://trac.ckan.org/ticket/3020
+ * #3020 is https://trac.ckan.org/ticket/3020
  * #271 is https://github.com/ckan/ckan/issues/271
 
  Some GitHub issues URLs will redirect to GitHub pull request pages.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 For contributing CKAN (whether code, bug reports, translations, documentation,
 etc.) see our contributing guidelines:
 
-http://docs.ckan.org/en/latest/contributing
+https://docs.ckan.org/en/latest/contributing/

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ CKAN: The Open Source Data Portal Software
     :alt: License
 
 .. image:: https://img.shields.io/badge/docs-latest-brightgreen.svg?style=flat
-    :target: http://docs.ckan.org
+    :target: https://docs.ckan.org
     :alt: Documentation
 .. image:: https://img.shields.io/badge/support-StackOverflow-yellowgreen.svg?style=flat
     :target: https://stackoverflow.com/questions/tagged/ckan
@@ -28,13 +28,13 @@ CKAN: The Open Source Data Portal Software
 CKAN makes it easy to publish, share and work with data. It's a data management
 system that provides a powerful platform for cataloging, storing and accessing
 datasets with a rich front-end, full API (for both data and catalog), visualization
-tools and more. Read more at `ckan.org <http://ckan.org/>`_.
+tools and more. Read more at `ckan.org <https://ckan.org/>`_.
 
 
 Installation
 ------------
 
-See the `CKAN Documentation <http://docs.ckan.org>`_ for installation instructions.
+See the `CKAN Documentation <https://docs.ckan.org>`_ for installation instructions.
 
 
 Support

--- a/ckan/cli/translation.py
+++ b/ckan/cli/translation.py
@@ -146,7 +146,7 @@ def simple_conv_specs(s: str):
 
     e.g. ['%s', '%i']
 
-    See http://docs.python.org/library/stdtypes.html#string-formatting
+    See https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting
     '''
     simple_conv_specs_re = re.compile(u'\\%\\w')
     return simple_conv_specs_re.findall(s)
@@ -157,7 +157,7 @@ def mapping_keys(s: str):
 
     e.g. ['%(name)s', '%(age)i']
 
-    See http://docs.python.org/library/stdtypes.html#string-formatting
+    See https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting
     '''
     mapping_keys_re = re.compile(u'\\%\\([^\\)]*\\)\\w')
     return sorted(mapping_keys_re.findall(s))
@@ -168,7 +168,7 @@ def replacement_fields(s: str):
 
     e.g. ['{}', '{2}', '{object}', '{target}']
 
-    See http://docs.python.org/library/string.html#formatstrings
+    See https://docs.python.org/3/library/string.html#formatstrings
     '''
     repl_fields_re = re.compile(u'\\{[^\\}]*\\}')
     return sorted(repl_fields_re.findall(s))

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -377,7 +377,7 @@ groups:
 
           To get the list of all the available properties check the `SQLAlchemy documentation`_
 
-          .. _SQLAlchemy documentation: http://docs.sqlalchemy.org/en/rel_0_9/core/engines.html#engine-creation-api
+          .. _SQLAlchemy documentation: https://docs.sqlalchemy.org/en/20/core/engines.html#engine-creation-api
 
   - annotation: Site Settings
     options:

--- a/ckan/config/deployment.ini_tmpl
+++ b/ckan/config/deployment.ini_tmpl
@@ -6,7 +6,7 @@
 # following URL for a description of what they do and the full list of
 # available options:
 #
-# http://docs.ckan.org/en/latest/maintaining/configuration.html
+# https://docs.ckan.org/en/latest/maintaining/configuration.html
 #
 # The %(here)s variable will be replaced with the parent directory of this file
 #

--- a/ckan/public-midnight-blue/base/javascript/client.js
+++ b/ckan/public-midnight-blue/base/javascript/client.js
@@ -232,7 +232,7 @@
 
     /* Requests config options for a file upload.
      *
-     * See: http://docs.ckan.org/en/latest/filestore.html
+     * See: https://docs.ckan.org/en/latest/filestore.html
      *
      * key     - A unique id/filename for the resource.
      * success - A callback to be called on successful response.
@@ -268,7 +268,7 @@
 
     /* Requests metadata for a file upload.
      *
-     * See: http://docs.ckan.org/en/latest/filestore.html
+     * See: https://docs.ckan.org/en/latest/filestore.html
      *
      * key     - A unique id/filename for the resource.
      * success - A callback to be called on successful response.

--- a/ckan/public/base/javascript/client.js
+++ b/ckan/public/base/javascript/client.js
@@ -232,7 +232,7 @@
 
     /* Requests config options for a file upload.
      *
-     * See: http://docs.ckan.org/en/latest/filestore.html
+     * See: https://docs.ckan.org/en/latest/filestore.html
      *
      * key     - A unique id/filename for the resource.
      * success - A callback to be called on successful response.
@@ -268,7 +268,7 @@
 
     /* Requests metadata for a file upload.
      *
-     * See: http://docs.ckan.org/en/latest/filestore.html
+     * See: https://docs.ckan.org/en/latest/filestore.html
      *
      * key     - A unique id/filename for the resource.
      * success - A callback to be called on successful response.

--- a/ckan/templates-midnight-blue/admin/config.html
+++ b/ckan/templates-midnight-blue/admin/config.html
@@ -47,7 +47,7 @@
       {% block admin_form_help %}
         {% set about_url = h.url_for('home.about') %}
         {% set home_url = h.url_for('home.index') %}
-        {% set docs_url = "http://docs.ckan.org/en/{0}/theming".format(g.ckan_doc_version) %}
+        {% set docs_url = "https://docs.ckan.org/en/{0}/theming".format(g.ckan_doc_version) %}
         {% trans %}
           <p><strong>Site Title:</strong> This is the title of this CKAN instance
             It appears in various places throughout CKAN.</p>

--- a/ckan/templates-midnight-blue/admin/index.html
+++ b/ckan/templates-midnight-blue/admin/index.html
@@ -76,7 +76,7 @@
     </h2>
     <div class="module-content">
 
-      {% set docs_url = "http://docs.ckan.org/en/{0}/sysadmin-guide.html".format(g.ckan_doc_version) %}
+      {% set docs_url = "https://docs.ckan.org/en/{0}/sysadmin-guide.html".format(g.ckan_doc_version) %}
       {% trans %}
         <p>As a sysadmin user you have full control over this CKAN instance. Proceed with care!</p>
         <p>For guidance on using sysadmin features, see the CKAN  <a href="{{ docs_url }}" target="_blank" rel="noreferrer">sysadmin guide</a></p>

--- a/ckan/templates-midnight-blue/footer.html
+++ b/ckan/templates-midnight-blue/footer.html
@@ -11,10 +11,10 @@
           </ul>
           <ul class="list-unstyled">
             {% block footer_links_ckan %}
-              {% set api_url = 'http://docs.ckan.org/en/{0}/api/'.format(g.ckan_doc_version) %}
+              {% set api_url = 'https://docs.ckan.org/en/{0}/api/'.format(g.ckan_doc_version) %}
               <li><a href="{{ api_url }}">{{ _('CKAN API') }}</a></li>
-              <li><a href="http://www.ckan.org/">{{ _('CKAN Association') }}</a></li>
-              <li><a href="http://www.opendefinition.org/okd/"><img src="{{ h.url_for_static('/base/images/od_80x15_blue.png') }}" alt="Open Data"></a></li>
+              <li><a href="https://www.ckan.org">{{ _('CKAN Association') }}</a></li>
+              <li><a href="https://www.opendefinition.org/od/"><img src="{{ h.url_for_static('/base/images/od_80x15_blue.png') }}" alt="Open Data"></a></li>
             {% endblock %}
           </ul>
         {% endblock %}

--- a/ckan/templates-midnight-blue/package/search.html
+++ b/ckan/templates-midnight-blue/package/search.html
@@ -50,7 +50,7 @@
         {% block package_search_results_api_inner %}
           <small>
             {% set api_link = h.link_to(_('API'), h.url_for('api.get_api', ver=3)) %}
-            {% set api_doc_link = h.link_to(_('API Docs'), 'http://docs.ckan.org/en/{0}/api/'.format(g.ckan_doc_version)) %}
+            {% set api_doc_link = h.link_to(_('API Docs'), 'https://docs.ckan.org/en/{0}/api/'.format(g.ckan_doc_version)) %}
             {% trans %} You can also access this registry using the {{ api_link }} (see {{ api_doc_link}}). {% endtrans %}
           </small>
         {% endblock %}

--- a/ckan/templates/admin/config.html
+++ b/ckan/templates/admin/config.html
@@ -47,7 +47,7 @@
       {% block admin_form_help %}
         {% set about_url = h.url_for('home.about') %}
         {% set home_url = h.url_for('home.index') %}
-        {% set docs_url = "http://docs.ckan.org/en/{0}/theming".format(g.ckan_doc_version) %}
+        {% set docs_url = "https://docs.ckan.org/en/{0}/theming".format(g.ckan_doc_version) %}
         {% trans %}
           <p><strong>Site Title:</strong> This is the title of this CKAN instance
             It appears in various places throughout CKAN.</p>

--- a/ckan/templates/admin/index.html
+++ b/ckan/templates/admin/index.html
@@ -76,7 +76,7 @@
     </h2>
     <div class="module-content">
 
-      {% set docs_url = "http://docs.ckan.org/en/{0}/sysadmin-guide.html".format(g.ckan_doc_version) %}
+      {% set docs_url = "https://docs.ckan.org/en/{0}/sysadmin-guide.html".format(g.ckan_doc_version) %}
       {% trans %}
         <p>As a sysadmin user you have full control over this CKAN instance. Proceed with care!</p>
         <p>For guidance on using sysadmin features, see the CKAN  <a href="{{ docs_url }}" target="_blank" rel="noreferrer">sysadmin guide</a></p>

--- a/ckan/templates/footer.html
+++ b/ckan/templates/footer.html
@@ -11,10 +11,10 @@
           </ul>
           <ul class="list-unstyled">
             {% block footer_links_ckan %}
-              {% set api_url = 'http://docs.ckan.org/en/{0}/api/'.format(g.ckan_doc_version) %}
+              {% set api_url = 'https://docs.ckan.org/en/{0}/api/'.format(g.ckan_doc_version) %}
               <li><a href="{{ api_url }}">{{ _('CKAN API') }}</a></li>
-              <li><a href="http://www.ckan.org/">{{ _('CKAN Association') }}</a></li>
-              <li><a href="http://www.opendefinition.org/okd/"><img src="{{ h.url_for_static('/base/images/od_80x15_blue.png') }}" alt="Open Data"></a></li>
+              <li><a href="https://www.ckan.org/">{{ _('CKAN Association') }}</a></li>
+              <li><a href="https://www.opendefinition.org/od/"><img src="{{ h.url_for_static('/base/images/od_80x15_blue.png') }}" alt="Open Data"></a></li>
             {% endblock %}
           </ul>
         {% endblock %}

--- a/ckan/templates/package/search.html
+++ b/ckan/templates/package/search.html
@@ -50,7 +50,7 @@
         {% block package_search_results_api_inner %}
           <small>
             {% set api_link = h.link_to(_('API'), h.url_for('api.get_api', ver=3)) %}
-            {% set api_doc_link = h.link_to(_('API Docs'), 'http://docs.ckan.org/en/{0}/api/'.format(g.ckan_doc_version)) %}
+            {% set api_doc_link = h.link_to(_('API Docs'), 'https://docs.ckan.org/en/{0}/api/'.format(g.ckan_doc_version)) %}
             {% trans %} You can also access this registry using the {{ api_link }} (see {{ api_doc_link}}). {% endtrans %}
           </small>
         {% endblock %}

--- a/ckanext/datapusher/config_declaration.yaml
+++ b/ckanext/datapusher/config_declaration.yaml
@@ -26,7 +26,7 @@ groups:
       DataPusher endpoint to use when enabling the ``datapusher`` extension. If you
       installed CKAN via :doc:`/maintaining/installing/install-from-package`, the DataPusher was installed for you
       running on port 8800. If you want to manually install the DataPusher, follow
-      the installation `instructions <http://docs.ckan.org/projects/datapusher>`_.
+      the installation `instructions <https://docs.ckan.org/projects/datapusher>`_.
 
   - key: ckan.datapusher.api_token
     description: >-

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1899,7 +1899,7 @@ class DatastorePostgresqlBackend(DatastoreBackend):
         ''' Returns True if the read engine is a Postgresql Database.
 
         According to
-        http://docs.sqlalchemy.org/en/latest/core/engines.html#postgresql
+        https://docs.sqlalchemy.org/en/20/core/engines.html#postgresql
         all Postgres driver names start with `postgres`.
         '''
         drivername = self._get_read_engine().engine.url.drivername

--- a/ckanext/datastore/config_declaration.yaml
+++ b/ckanext/datastore/config_declaration.yaml
@@ -82,7 +82,7 @@ groups:
 
       To get the list of all the available properties check the `SQLAlchemy documentation`_
 
-      .. _SQLAlchemy documentation: http://docs.sqlalchemy.org/en/rel_0_9/core/engines.html#engine-creation-api
+      .. _SQLAlchemy documentation: https://docs.sqlalchemy.org/en/20/core/engines.html#engine-creation-api
 
   - default: english
     key: ckan.datastore.default_fts_lang

--- a/doc/contributing/documentation.rst
+++ b/doc/contributing/documentation.rst
@@ -2,7 +2,7 @@
 Writing documentation
 =====================
 
-.. _docs.ckan.org: http://docs.ckan.org
+.. _docs.ckan.org: https://docs.ckan.org
 
 This section gives some guidelines to help us to write consistent and good
 quality documentation for CKAN.

--- a/doc/contributing/index.rst
+++ b/doc/contributing/index.rst
@@ -3,7 +3,7 @@ Contributing guide
 ==================
 
 .. _CKAN repo on GitHub: https://github.com/ckan/ckan
-.. _docs.ckan.org: http://docs.ckan.org
+.. _docs.ckan.org: https://docs.ckan.org
 
 CKAN is free open source software and contributions are welcome, whether
 they're bug reports, source code, documentation or translations. The following

--- a/doc/contributing/python.rst
+++ b/doc/contributing/python.rst
@@ -8,7 +8,7 @@ For Python code style follow `PEP 8`_ plus the guidelines below.
 
 Some good links about Python code style:
 
-- `Guide to Python <http://docs.python-guide.org/en/latest/writing/style/>`_ from Hitchhiker's
+- `Guide to Python <https://docs.python-guide.org/writing/style/>`_ from Hitchhiker's
 - `Google Python Style Guide <https://google.github.io/styleguide/pyguide.html>`_
 
 .. seealso::
@@ -93,7 +93,7 @@ When logging:
 - Choose an appropriate log-level (DEBUG, INFO, ERROR, WARNING or CRITICAL,
   see `Python's Logging HOWTO`_).
 
-.. _Python's Logging HOWTO: http://docs.python.org/2/howto/logging.html
+.. _Python's Logging HOWTO: https://docs.python.org/3/howto/logging.html
 
 String formatting
 ------------------

--- a/doc/contributing/release-process.rst
+++ b/doc/contributing/release-process.rst
@@ -69,7 +69,7 @@ Creating a release development branch
 
 
 #. When the Tech Team decides to start a new release branch for a new minor release it's
-   always useful to try to merge any outstanding pull requests that should be included. 
+   always useful to try to merge any outstanding pull requests that should be included.
    This makes it easier to include them as when the release branch
    starts diverging there can appear conflicts when cherry-picking.
 
@@ -421,7 +421,7 @@ stages involved::
 
    This is an issue to track progress on the patch releases (2.X.Y and 2.Z.A)
 
-   [Full docs](http://docs.ckan.org/en/latest/contributing/release-process.html)
+   [Full docs](https://docs.ckan.org/en/latest/contributing/release-process.html)
 
    ### Create a new release branch (remove for patch releases)
 

--- a/doc/contributing/string-i18n.rst
+++ b/doc/contributing/string-i18n.rst
@@ -120,7 +120,7 @@ functions:
 To use variables in strings, use Python `format string syntax`_
 and then call the ``.format()`` method on the string that ``_()`` returns:
 
-.. _format string syntax: https://docs.python.org/2/library/string.html#formatstrings
+.. _format string syntax: https://docs.python.org/3/library/string.html#formatstrings
 
 .. code-block:: jinja
 
@@ -156,16 +156,10 @@ strings in Python code.
 
 .. _Flask-Babel: https://pythonhosted.org/Flask-Babel/
 
-.. note::
-    Code running on Pylons will use the functions provided by
-    the `pylons.i18n.translation`_ module, but their behaviour is the same.
-
-.. _pylons.i18n.translation: http://docs.pylonsproject.org/projects/pylons-webframework/en/latest/modules/i18n_translation.html#module-pylons.i18n.translation
-
 Core CKAN modules should import :py:func:`~ckan.common._` and
 :py:func:`~ckan.common.ungettext` from :py:mod:`ckan.common`,
 i.e. ``from ckan.common import _, ungettext``
-(don't import :py:func:`flask_babel._` or :py:func:`pylons.i18n.translation._` directly, for example).
+(don't import :py:func:`flask_babel._` directly, for example).
 
 CKAN plugins should import :py:mod:`ckan.plugins.toolkit` and use
 :py:func:`ckan.plugins.toolkit._` and
@@ -388,9 +382,9 @@ the quality of CKAN's translations:
          translated_string = _(
              'There are {num_people} people here'.format(num_people=num_people))
 
-* Don't use `old-style %s string formatting <https://docs.python.org/2/library/stdtypes.html#string-formatting>`_
-  in Python, use the new `.format() method`_
-  instead.
+* Don't use `old-style %s string formatting
+  <https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting>`_
+  in Python, use the new `.format() method`_ instead.
 
   Strings formatted with ``.format()`` give translators more context.
   The ``.format()`` method is also more expressive, and is the preferred way
@@ -483,4 +477,4 @@ the quality of CKAN's translations:
    (e.g. different positioning and separators used for decimal points in
    different languages).
 
-.. _.format() method: https://docs.python.org/2/library/stdtypes.html#str.format
+.. _.format() method: https://docs.python.org/3/library/stdtypes.html#str.format

--- a/doc/contributing/testing.rst
+++ b/doc/contributing/testing.rst
@@ -119,8 +119,6 @@ the top-level ``ckan/tests/`` directory. There shouldn't be too many of these.
 Naming test methods
 -------------------
 
-`The name of a test method should clearly explain the intent of the test <http://docs.pylonsproject.org/en/latest/community/testing.html#rule-name-tcms-to-indicate-what-they-test>`_.
-
 Test method names are printed out when tests fail, so the user can often
 see what went wrong without having to look into the test file. When they
 do need to look into the file to debug or update a test, the test name
@@ -174,7 +172,7 @@ Bad test names:
 Recipe for a test method
 ========================
 
-The `Pylons Unit Testing Guidelines <http://docs.pylonsproject.org/en/latest/community/testing.html#tips-for-avoiding-bad-unit-tests>`_
+The `Pylons Unit Testing Guidelines <https://pylonsproject.org/community-unit-testing-guidelines.html#tips-for-avoiding-bad-unit-tests>`_
 give the following recipe for all unit test methods to follow:
 
 1. Set up the preconditions for the method / function being tested.

--- a/doc/extensions/testing-extensions.rst
+++ b/doc/extensions/testing-extensions.rst
@@ -64,7 +64,7 @@ Some notes on how these tests work:
 
 * You might also find it useful to read the
   `Flask testing documentation <https://flask-doc.readthedocs.io/en/latest/testing.html>`_ (or
-  `Pylons testing documentation <http://docs.pylonsproject.org/projects/pylons-webframework/en/latest/testing.html>`_
+  `Pylons testing documentation <https://docs.pylonsproject.org/projects/pylons-webframework/en/latest/testing.html>`_
   for plugins using legacy pylons controllers).
 
 * Avoid importing the plugin modules directly into your test modules

--- a/doc/extensions/translating-extensions.rst
+++ b/doc/extensions/translating-extensions.rst
@@ -118,9 +118,9 @@ Translations with Transifex
 Once you have created your translations, you can manage them using Transifex.
 This is out side of the scope of this tutorial, but the Transifex documentation
 provides tutorials on how to
-`upload translations <http://docs.transifex.com/tutorials/content/#upload-files-and-download-the-translations>`_
+`upload translations <https://help.transifex.com/en/articles/6318456-uploading-translations>`_
 and how to manage them using the
-`command line client <http://docs.transifex.com/tutorials/client/>`_.
+`command line client <https://developers.transifex.com/docs/using-the-client>`_.
 
 
 ---------------------
@@ -166,4 +166,3 @@ implement the ``ITranslation`` interface yourself.
    ~ckan.plugins.interfaces.ITranslation.i18n_directory
    ~ckan.plugins.interfaces.ITranslation.i18n_locales
    ~ckan.plugins.interfaces.ITranslation.i18n_domain
-

--- a/doc/maintaining/filestore.rst
+++ b/doc/maintaining/filestore.rst
@@ -169,4 +169,4 @@ custom types get registered on startup::
 
 
 
-.. _mimetypes: http://docs.python.org/2/library/mimetypes.html
+.. _mimetypes: https://docs.python.org/3/library/mimetypes.html

--- a/doc/theming/variables-and-functions.rst
+++ b/doc/theming/variables-and-functions.rst
@@ -89,7 +89,7 @@ templates in their top-level namespace:
 
 .. py:function:: _()
 
-   The `pylons.i18n.translation.ugettext(value) <http://docs.pylonsproject.org/projects/pylons-webframework/en/latest/modules/i18n_translation.html?highlight=ugettext#pylons.i18n.translation.ugettext>`_ function:
+   The `flask_babel.gettext(value) <https://python-babel.github.io/flask-babel/#flask_babel.gettext>`_ function:
 
     Mark a string for translation. Returns the localized unicode string of
     value.
@@ -98,30 +98,10 @@ templates in their top-level namespace:
 
      _('This should be in lots of languages')
 
-.. py:function:: N_()
-
-   The `pylons.i18n.translation.gettext_noop(value) <http://docs.pylonsproject.org/projects/pylons-webframework/en/latest/modules/i18n_translation.html?highlight=gettext_noop#pylons.i18n.translation.gettext_noop>`_ function:
-
-    Mark a string for translation without translating it. Returns value.
-
-    Used for global strings, e.g.::
-
-        foo = N_('Hello')
-
-        class Bar:
-            def __init__(self):
-                self.local_foo = _(foo)
-
-        h.set_lang('fr')
-        assert Bar().local_foo == 'Bonjour'
-        h.set_lang('es')
-        assert Bar().local_foo == 'Hola'
-        assert foo == 'Hello'
-
 
 .. py:function:: ungettext
 
-   The `pylons.i18n.translation.ungettext(singular, plural, n) <http://docs.pylonsproject.org/projects/pylons-webframework/en/latest/modules/i18n_translation.html?highlight=ungettext#pylons.i18n.translation.ungettext>`_
+   The `flask_babel.ngettext(singular, plural, n) <https://python-babel.github.io/flask-babel/#flask_babel.ngettext>`_
    function:
 
     Mark a string for translation. Returns the localized unicode string of the
@@ -139,7 +119,7 @@ templates in their top-level namespace:
 
 .. py:data:: translator
 
-   An instance of the `gettext.NullTranslations <http://docs.python.org/2/library/gettext.html#the-nulltranslations-class>`_
+   An instance of the `gettext.NullTranslations <https://docs.python.org/3/library/gettext.html#the-nulltranslations-class>`_
    class. This is for internal use only, templates shouldn't need to use this.
 
 


### PR DESCRIPTION
Replace a number of `http://` links with `https://` versions. Certain links are no longer available - I replaced them with the closest alternative