### PR TITLE
fix: search-index clear-orphans does not remove records

### DIFF
--- a/ckan/cli/search_index.py
+++ b/ckan/cli/search_index.py
@@ -128,13 +128,14 @@ def list_orphans_command():
     short_help=u'Clear any non-existant packages in the search index'
 )
 @click.option(u'-v', u'--verbose', is_flag=True)
-def clear_orphans(verbose: bool = False):
+@click.pass_context
+def clear_orphans(ctx: click.Context, verbose: bool = False):
     for orphaned_package_id in get_orphans():
         if verbose:
             click.echo("Clearing search index for dataset {}...".format(
                 orphaned_package_id
             ))
-        clear(orphaned_package_id)
+        ctx.invoke(clear, dataset_name=orphaned_package_id)
 
 
 @search_index.command(


### PR DESCRIPTION
`ckan search-index clear-orphans` (command that removes records from Solr if they are not present in DB) makes incorrect internal call to other click command and as result dataset's ID is not recognized:

```
Error: Got unexpected extra arguments (4 7 0 9 c e 1 - 2 8 2 7 - 4 3 2 6 - a d 6 d - 8 6 a b 2 b 4 d 3 7 1 d)
```

This command calls `ckan search-index clear ID` internally, via direct invocation of corresponding function, `clear(dataset_name)`. But click now requires indirect invocation via context object: `ctx.invoce(clear, dataset_name=dataset_name)`. And that's what I fixed in this PR