### PR TITLE
rewrite query to fetch one row instead of whole table

### DIFF
--- a/ckanext/tracking/cli/tracking.py
+++ b/ckanext/tracking/cli/tracking.py
@@ -53,8 +53,7 @@ def update_all(start_date: Optional[str] = None):
         # No date given. See when we last have data for and get data
         # from 2 days before then in case new data is available.
         # If no date here then use 2011-01-01 as the start date
-        stmt = select(ts).order_by(ts.tracking_date.desc())
-        result = session.scalars(stmt).first()
+        result = session.query(ts).order_by(desc(ts.tracking_date)).first()
         if result:
             date = result.tracking_date
             date += datetime.timedelta(-2)


### PR DESCRIPTION
Fixes 
- #8749

### Proposed fixes:

Before the fix, the query fetches the whole table into the result set then gets the first row.
After the fix, the new query added `limit 1` and fetches one row only.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
