### PR TITLE
Cancel running tests when pushed on branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }} # workflow limits it to this workflow, ref includes a pushed branch or on pull request merge branch
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
   workflow_dispatch:
   workflow_call:
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 permissions:
   contents: read
 

--- a/changes/8759.misc
+++ b/changes/8759.misc
@@ -1,0 +1,1 @@
+Unit tests are cancelled when commits are pushed to branches.


### PR DESCRIPTION
### Proposed fixes:

Running tests on every commit on branch is not needed, this cancels test workflow when there is a push on a branch. On master tests are run on every commit to catch failures.

Cancel is seen here https://github.com/ckan/ckan/actions/runs/14214481840


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
