### PR TITLE
[#8379] backport 2.10: Store `session["last_active"]` as an iso string instead of a …

### DIFF
--- a/changes/8379.bugfix
+++ b/changes/8379.bugfix
@@ -1,0 +1,2 @@
+Ensure `session["last_active"]` is stored as an iso string instead of a `datetime` so that it can be serialized to JSON (e.g. in cookies).
+

--- a/ckan/model/user.py
+++ b/ckan/model/user.py
@@ -354,9 +354,8 @@ class User(core.StatefulObjectMixin,
 
     def set_user_last_active(self) -> None:
         if self.last_active:
-            session["last_active"] = self.last_active
-
-            if session["last_active"] < last_active_check():
+            if self.last_active < last_active_check():
+                session["last_active"] = self.last_active.isoformat()
                 self.last_active = datetime.datetime.utcnow()
                 meta.Session.commit()
         else:


### PR DESCRIPTION
…`datetime`

Currently in CKAN 2.10, `beaker.session.type=json` with `beaker.session.type=cookie` fails because the `last_active` attribute stored on the cookie is a `datetime` (and can't be serialized to JSON).

This change addresses this by setting `session["last_active"]` as an iso string instead.

(cherry picked from commit 40c1abdbce599457324e0f260b54f25fc344162e)

Fixes #8379 

### Proposed fixes:

See #8721

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
