### PR TITLE
Psql connections

### DIFF
--- a/changes/8762.misc
+++ b/changes/8762.misc
@@ -1,0 +1,6 @@
+The PSQL pool could be improved in order to avoid unnecessary connections.  
+The default value for `sqlalchemy.pool_recycle` is -1 meaning that the
+connections are never recycled. This can lead to problems with long-lived
+connections. It'll be good to define `sqlalchemy.pool_recycle = 3600` as
+default to recycle connections after 1 hour.  
+Also, there is a commit after a read-only query that looks like an error.  

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -363,6 +363,13 @@ groups:
         type: bool
         default: true
 
+      - key: sqlalchemy.pool_recycle
+        type: int
+        default: 3600
+        description: |
+          The number of seconds after which a connection is recycled. The
+          default is -1 and means that connections are never recycled.
+
       - key: sqlalchemy.<OPTION>
         type: dynamic
         description: |

--- a/ckan/model/system_info.py
+++ b/ckan/model/system_info.py
@@ -57,8 +57,6 @@ def get_system_info(key: str, default: Optional[str]=None) -> Optional[str]:
             return obj.value
     except ProgrammingError:
         meta.Session.rollback()
-    finally:
-        meta.Session.close()  # Always close
     return default
 
 

--- a/ckan/model/system_info.py
+++ b/ckan/model/system_info.py
@@ -53,11 +53,12 @@ def get_system_info(key: str, default: Optional[str]=None) -> Optional[str]:
     ''' get data from system_info table '''
     try:
         obj = meta.Session.query(SystemInfo).filter_by(key=key).first()
-        meta.Session.commit()
         if obj:
             return obj.value
     except ProgrammingError:
         meta.Session.rollback()
+    finally:
+        meta.Session.close()  # Always close
     return default
 
 


### PR DESCRIPTION
I'm seeing multiple unexpected old and idle psql connections.
After a short investigation i realize that CKAN usually do not close close connections with something like `model.Session.close()`.
This is probably OK considering that SQLAlchemy will eventually recycle them but the default value for `sqlalchemy.pool_recycle` is -1 meaning that the connections are never recycled. This can lead to problems with long-lived connections.

The PSQL pool could be improved in order to avoid unnecessary connections.  It'll be good to define `sqlalchemy.pool_recycle = 3600` as default to recycle connections after 1 hour.  

Also, this PR proposes to delete a non-required `Session.commit()` after a read-only query.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
