### PR TITLE
Fix activity failure on resource_view_delete

### DIFF
--- a/changes/8760.bugfix
+++ b/changes/8760.bugfix
@@ -1,0 +1,2 @@
+Return resource_id from resource_view_delete so that the activity plugin
+does not fail when recording the deleted view.

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -225,6 +225,10 @@ def resource_view_delete(context: Context, data_dict: DataDict) -> ActionResult.
     resource_view.delete()
     model.repo.commit()
 
+    # resource_view_changed in ckanext/activity/subscriptions.py
+    # needs the resource id
+    return {'resource_id': resource_view.resource_id}
+
 
 def resource_view_clear(context: Context, data_dict: DataDict) -> ActionResult.ResourceViewClear:
     '''Delete all resource views, or all of a particular type.

--- a/ckanext/activity/subscriptions.py
+++ b/ckanext/activity/subscriptions.py
@@ -197,7 +197,7 @@ def resource_view_changed(sender: str, **kwargs: Any):
     elif isinstance(result, str):
         id_ = result
     else:
-        id_ = result["id"]
+        id_ = result.get("id", data_dict.get("id"))
 
     if sender == "resource_view_create":
         activity_type = "new resource view"
@@ -211,7 +211,7 @@ def resource_view_changed(sender: str, **kwargs: Any):
         assert view
         view_dict = dictization.table_dictize(view, context)
     else:
-        view_dict = data_dict
+        view_dict = {"id": id_, "resource_id": result.get("resource_id")}
 
     assert view_dict.get('id')
     assert view_dict.get('resource_id')


### PR DESCRIPTION
Fixes #8760 

### Proposed fixes:
- return the resource_id from resource_view_delete
- update activity plugin to capture the resource_id from return value instead of expecting it to be passed to resource_view_delete (it is not a required parameter)

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X] includes API changes
- [X] includes bugfix for possible backport