### PR TITLE
use the default datatables responsive view

### DIFF
--- a/changes/8754.feature
+++ b/changes/8754.feature
@@ -1,0 +1,3 @@
+datatablesview: use the default datatables responsive view instead of
+a custom modal dialog. For the old responsive modal behaviour set:
+`ckan.datatables.responsive_modal = true`

--- a/ckanext/datatablesview/assets/datatablesview.js
+++ b/ckanext/datatablesview/assets/datatablesview.js
@@ -263,6 +263,41 @@ const esc = function (t) {
     .replace(/"/g, '&quot;')
 }
 
+function responsiveModalSettings (that, packagename, resourcename) {
+  return {
+    details: {
+      display: $.fn.dataTable.Responsive.display.modal({
+        header: function (row) {
+          // add clipboard and print buttons to modal record display
+          var data = row.data();
+          return '<span style="font-size:150%;font-weight:bold;">Details:</span>&nbsp;&nbsp;<div class=" dt-buttons btn-group">' +
+            '<button id="modalcopy-button" class="btn btn-secondary" title="' + that._('Copy to clipboard') + '" onclick="copyModal(\'' +
+            packagename + '&mdash;' + resourcename + '\')"><i class="fa fa-copy"></i></button>' +
+            '<button id="modalprint-button" class="btn btn-secondary" title="' + that._('Print') + '" onclick="printModal(\'' +
+            packagename + '&mdash;' + resourcename + '\')"><i class="fa fa-print"></i></button>' +
+            '</div>&nbsp;'
+        }
+      }),
+      // render the Record Details in a modal dialog box
+      // do not render the _colspacer column, which has the 'none' class
+      // the none class in responsive mode forces the _colspacer column to be hidden
+      // guaranteeing the blue record details button is always displayed, even for narrow tables
+      // also, when a column's content has been truncated with an ellipsis, show the untruncated content
+      renderer: function (api, rowIdx, columns) {
+        const data = $.map(columns, function (col, i) {
+          return col.className !== ' none'
+            ? '<tr class="dt-body-right" data-dt-row="' + col.rowIndex + '" data-dt-column="' + col.columnIndex + '">' +
+              '<td>' + col.title + ':' + '</td><td>' +
+              (col.data.startsWith('<span class="ellipsis"') ? col.data.substr(30, col.data.indexOf('">') - 30) : col.data) +
+              '</td></tr>'
+            : ''
+        }).join('')
+        return data ? $('<table class="dtr-details" width="100%"/>').append(data) : false
+      }
+    }
+  }
+}
+
 // MAIN
 this.ckan.module('datatables_view', function (jQuery) {
 
@@ -413,38 +448,7 @@ this.ckan.module('datatables_view', function (jQuery) {
             className: 'none',
             defaultContent: ''
           })
-          responsiveSettings = {
-            details: {
-              display: $.fn.dataTable.Responsive.display.modal({
-                header: function (row) {
-                  // add clipboard and print buttons to modal record display
-                  var data = row.data();
-                  return '<span style="font-size:150%;font-weight:bold;">Details:</span>&nbsp;&nbsp;<div class=" dt-buttons btn-group">' +
-                    '<button id="modalcopy-button" class="btn btn-secondary" title="' + that._('Copy to clipboard') + '" onclick="copyModal(\'' +
-                    packagename + '&mdash;' + resourcename + '\')"><i class="fa fa-copy"></i></button>' +
-                    '<button id="modalprint-button" class="btn btn-secondary" title="' + that._('Print') + '" onclick="printModal(\'' +
-                    packagename + '&mdash;' + resourcename + '\')"><i class="fa fa-print"></i></button>' +
-                    '</div>&nbsp;'
-                }
-              }),
-              // render the Record Details in a modal dialog box
-              // do not render the _colspacer column, which has the 'none' class
-              // the none class in responsive mode forces the _colspacer column to be hidden
-              // guaranteeing the blue record details button is always displayed, even for narrow tables
-              // also, when a column's content has been truncated with an ellipsis, show the untruncated content
-              renderer: function (api, rowIdx, columns) {
-                const data = $.map(columns, function (col, i) {
-                  return col.className !== ' none'
-                    ? '<tr class="dt-body-right" data-dt-row="' + col.rowIndex + '" data-dt-column="' + col.columnIndex + '">' +
-                      '<td>' + col.title + ':' + '</td><td>' +
-                      (col.data.startsWith('<span class="ellipsis"') ? col.data.substr(30, col.data.indexOf('">') - 30) : col.data) +
-                      '</td></tr>'
-                    : ''
-                }).join('')
-                return data ? $('<table class="dtr-details" width="100%"/>').append(data) : false
-              }
-            }
-          }
+          responsiveSettings = responsiveModalSettings(that, packagename, resourcename)
         } else {
           responsiveSettings = {}
           $('#_colspacer').remove()

--- a/ckanext/datatablesview/assets/datatablesview.js
+++ b/ckanext/datatablesview/assets/datatablesview.js
@@ -265,6 +265,7 @@ const esc = function (t) {
 
 // MAIN
 this.ckan.module('datatables_view', function (jQuery) {
+
   return {
     initialize: function () {
       const that = this
@@ -286,6 +287,7 @@ this.ckan.module('datatables_view', function (jQuery) {
       const ckanfilters = dtprv.data('ckanfilters')
       const resourceurl = dtprv.data('resource-url')
       const defaultview = dtprv.data('default-view')
+      const responsivemodal = dtprv.data('responsive-modal')
 
       // get view mode setting from localstorage (table or list/responsive])
       const lastView = getWithExpiry('lastView-' + gresviewId)
@@ -403,46 +405,50 @@ this.ckan.module('datatables_view', function (jQuery) {
         fixedColumnSetting = false
         scrollXflag = false
 
-        // create _colspacer column to ensure display of green record detail button
-        dynamicCols.push({
-          data: '',
-          searchable: false,
-          className: 'none',
-          defaultContent: ''
-        })
-
-        // initialize settings for responsive mode (list view)
-        responsiveSettings = {
-          details: {
-            display: $.fn.dataTable.Responsive.display.modal({
-              header: function (row) {
-                // add clipboard and print buttons to modal record display
-                var data = row.data();
-                return '<span style="font-size:150%;font-weight:bold;">Details:</span>&nbsp;&nbsp;<div class=" dt-buttons btn-group">' +
-                  '<button id="modalcopy-button" class="btn btn-secondary" title="' + that._('Copy to clipboard') + '" onclick="copyModal(\'' +
-                  packagename + '&mdash;' + resourcename + '\')"><i class="fa fa-copy"></i></button>' +
-                  '<button id="modalprint-button" class="btn btn-secondary" title="' + that._('Print') + '" onclick="printModal(\'' +
-                  packagename + '&mdash;' + resourcename + '\')"><i class="fa fa-print"></i></button>' +
-                  '</div>&nbsp;'
+        if (responsivemodal) {
+          // create _colspacer column to ensure display of green record detail button
+          dynamicCols.push({
+            data: '',
+            searchable: false,
+            className: 'none',
+            defaultContent: ''
+          })
+          responsiveSettings = {
+            details: {
+              display: $.fn.dataTable.Responsive.display.modal({
+                header: function (row) {
+                  // add clipboard and print buttons to modal record display
+                  var data = row.data();
+                  return '<span style="font-size:150%;font-weight:bold;">Details:</span>&nbsp;&nbsp;<div class=" dt-buttons btn-group">' +
+                    '<button id="modalcopy-button" class="btn btn-secondary" title="' + that._('Copy to clipboard') + '" onclick="copyModal(\'' +
+                    packagename + '&mdash;' + resourcename + '\')"><i class="fa fa-copy"></i></button>' +
+                    '<button id="modalprint-button" class="btn btn-secondary" title="' + that._('Print') + '" onclick="printModal(\'' +
+                    packagename + '&mdash;' + resourcename + '\')"><i class="fa fa-print"></i></button>' +
+                    '</div>&nbsp;'
+                }
+              }),
+              // render the Record Details in a modal dialog box
+              // do not render the _colspacer column, which has the 'none' class
+              // the none class in responsive mode forces the _colspacer column to be hidden
+              // guaranteeing the blue record details button is always displayed, even for narrow tables
+              // also, when a column's content has been truncated with an ellipsis, show the untruncated content
+              renderer: function (api, rowIdx, columns) {
+                const data = $.map(columns, function (col, i) {
+                  return col.className !== ' none'
+                    ? '<tr class="dt-body-right" data-dt-row="' + col.rowIndex + '" data-dt-column="' + col.columnIndex + '">' +
+                      '<td>' + col.title + ':' + '</td><td>' +
+                      (col.data.startsWith('<span class="ellipsis"') ? col.data.substr(30, col.data.indexOf('">') - 30) : col.data) +
+                      '</td></tr>'
+                    : ''
+                }).join('')
+                return data ? $('<table class="dtr-details" width="100%"/>').append(data) : false
               }
-            }),
-            // render the Record Details in a modal dialog box
-            // do not render the _colspacer column, which has the 'none' class
-            // the none class in responsive mode forces the _colspacer column to be hidden
-            // guaranteeing the blue record details button is always displayed, even for narrow tables
-            // also, when a column's content has been truncated with an ellipsis, show the untruncated content
-            renderer: function (api, rowIdx, columns) {
-              const data = $.map(columns, function (col, i) {
-                return col.className !== ' none'
-                  ? '<tr class="dt-body-right" data-dt-row="' + col.rowIndex + '" data-dt-column="' + col.columnIndex + '">' +
-                    '<td>' + col.title + ':' + '</td><td>' +
-                    (col.data.startsWith('<span class="ellipsis"') ? col.data.substr(30, col.data.indexOf('">') - 30) : col.data) +
-                    '</td></tr>'
-                  : ''
-              }).join('')
-              return data ? $('<table class="dtr-details" width="100%"/>').append(data) : false
             }
           }
+        } else {
+          responsiveSettings = {}
+          $('#_colspacer').remove()
+          $('#_colspacerfilter').remove()
         }
       } else {
         // we're in table view mode

--- a/ckanext/datatablesview/config_declaration.yaml
+++ b/ckanext/datatablesview/config_declaration.yaml
@@ -90,8 +90,10 @@ groups:
       or ``list``). Table view is the typical grid layout, with horizontal
       scrolling.  List view is a responsive table, automatically hiding columns
       as required to fit the browser viewport. In addition, list view allows
-      the user to view, copy and print the details of a specific row. This
-      value can be overridden at the resource level when configuring a
+      the user to expand the remaining columns by clicking on the first cell,
+      or view all valued for a row in a dialog box depending on the
+      ``ckan.datatables.responsive_modal`` setting.
+      This value can be overridden at the resource level when configuring a
       DataTables resource view.
 
   - key: ckan.datatables.null_label
@@ -100,3 +102,13 @@ groups:
     description: |
       The option defines the label used to display NoneType values for the front-end.
       This should be a string and can be translated via po files.
+
+  - key: ckan.datatables.responsive_modal
+    default: false
+    type: bool
+    example: 'true'
+    description: |
+      When a table is in list (responsive) view mode with some columns hidden
+      and the user clicks on the first cell, use a modal dialog to  display the
+      complete row contents instead of expanding the missing columns
+      in the table itself. Prior to CKAN 2.12 the default setting was "true".

--- a/ckanext/datatablesview/plugin.py
+++ b/ckanext/datatablesview/plugin.py
@@ -53,6 +53,7 @@ class DataTablesView(p.SingletonPlugin):
             u"ckan.datatables.ellipsis_length")
         self.date_format = config.get(u"ckan.datatables.date_format")
         self.default_view = config.get(u"ckan.datatables.default_view")
+        self.responsive_modal = config.get("ckan.datatables.responsive_modal")
 
         toolkit.add_template_directory(config, u'templates')
         toolkit.add_resource(u'assets', u'ckanext-datatablesview')
@@ -65,13 +66,16 @@ class DataTablesView(p.SingletonPlugin):
 
     def setup_template_variables(self, context: Context,
                                  data_dict: dict[str, Any]) -> dict[str, Any]:
-        return {u'page_length_choices': self.page_length_choices,
-                u'state_saving': self.state_saving,
-                u'state_duration': self.state_duration,
-                u'data_dictionary_labels': self.data_dictionary_labels,
-                u'ellipsis_length': self.ellipsis_length,
-                u'date_format': self.date_format,
-                u'default_view': self.default_view}
+        return {
+            'page_length_choices': self.page_length_choices,
+            'state_saving': self.state_saving,
+            'state_duration': self.state_duration,
+            'data_dictionary_labels': self.data_dictionary_labels,
+            'ellipsis_length': self.ellipsis_length,
+            'date_format': self.date_format,
+            'default_view': self.default_view,
+            'responsive_modal': self.responsive_modal,
+        }
 
     def view_template(self, context: Context, data_dict: dict[str, Any]):
         return u'datatables/datatables_view.html'

--- a/ckanext/datatablesview/templates/datatables/datatables_view.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_view.html
@@ -31,6 +31,7 @@
       data-ckanfilters="{{ request.args.get('filters', '')|e }}"
       data-responsive-flag="{{ resource_view.get('responsive')|lower }}"
       data-page-length-choices="{{ page_length_choices }}"
+      data-responsive-modal="{{ responsive_modal|lower }}"
       data-resource-url="{{ h.url_for(package.type ~ '_resource.read', id=package.name, resource_id=resource.id ) }}">
     <thead>
       <tr>


### PR DESCRIPTION
Fixes #8754 

### Proposed fixes:
The default datatables responsive view is compact and allows multiple rows to be expanded at the same time:
![Screenshot from 2025-04-08 21-57-03](https://github.com/user-attachments/assets/930931d3-0911-4c89-8b21-895700d62df0)

Our customized datatablesview.js replaces this behaviour with a custom modal that only shows one row at a time:
![Screenshot from 2025-04-08 22-04-24](https://github.com/user-attachments/assets/1dbf1469-17ec-4571-beab-79e3c36d4d2a)

This PR restores the datatables default responsive view, unless a site sets
```
ckan.datatables.responsive_modal = true
```

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport