### PR TITLE
restore documentation for activity actions

### DIFF
--- a/changes/8780.misc
+++ b/changes/8780.misc
@@ -1,0 +1,1 @@
+Restore activity API documentation.

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -453,3 +453,14 @@ ckan.logic.action.delete
 
 .. automodule:: ckan.logic.action.delete
    :members:
+
+
+ckanext.activity.logic.action
+=============================
+
+.. note::
+
+   These actions are available only when ``activity`` plugin is enabled.
+
+.. automodule:: ckanext.activity.logic.action
+   :members:


### PR DESCRIPTION
After extraction into a separate module, activity actions are not collected automatically by Sphinx. This PR adds autodoc for activity API after the list of core actions with a notice that `activity` plugin must be enabled to use these actions