### PR TITLE
Fix tabledesigner integration with datatables, fix datatables localisation issues

### DIFF
--- a/changes/8782.bugfix
+++ b/changes/8782.bugfix
@@ -1,0 +1,1 @@
+Fix tabledesigner integration with datatables and the way datatables work with the i18n files

--- a/ckanext/datatablesview/assets/datatablesview.js
+++ b/ckanext/datatablesview/assets/datatablesview.js
@@ -381,17 +381,6 @@ this.ckan.module('datatables_view', function (jQuery) {
       gtableSearchText = that._('TABLE FILTER')
       gcolFilterText = that._('COLUMN FILTER/S')
 
-      let activelanguage = languagefile
-      // en is the default language, no need to load i18n file
-      if (languagefile === '/vendor/DataTables/i18n/en.json') {
-        activelanguage = ''
-      // load i18n files for zh_Hant_TW and zh_Hans_CN language
-      } else if (languagefile === '/vendor/DataTables/i18n/zh_Hant_TW.json') {
-        activelanguage = '/vendor/DataTables/i18n/zh_Hant.json'
-      } else if (languagefile === '/vendor/DataTables/i18n/zh_Hans_CN.json') {
-        activelanguage = '/vendor/DataTables/i18n/zh_CN.json'
-      }
-
       // settings if gcurrentView === table
       let fixedColumnSetting = true
       let scrollXflag = true
@@ -508,7 +497,7 @@ this.ckan.module('datatables_view', function (jQuery) {
           blurable: true
         },
         language: {
-          url: activelanguage,
+          url: languagefile,
           paginate: {
             previous: '&lt;',
             next: '&gt;'
@@ -703,6 +692,9 @@ this.ckan.module('datatables_view', function (jQuery) {
               }
             }
           }
+
+          // publish the event for other modules that are subscribed to it
+          that.sandbox.publish("datatablesview:init-complete", settings, json);
         }, // end InitComplete
         buttons: [{
           name: 'viewToggleButton',

--- a/ckanext/datatablesview/helpers.py
+++ b/ckanext/datatablesview/helpers.py
@@ -24,7 +24,8 @@ def datatablesview_get_language_file_path(lang: str) -> str:
     Get the language file path for the given language.
 
     If the language is not in the LANGUAGE_MAP, use the language as is.
-    If the language is "en", return an empty string, cause we don't need to load the i18n file.
+    If the language is "en", return an empty string, cause we don't need
+    to load the i18n file.
 
     :param lang: The language to get the language file path for.
     :type lang: str

--- a/ckanext/datatablesview/helpers.py
+++ b/ckanext/datatablesview/helpers.py
@@ -1,7 +1,40 @@
 # encoding: utf-8
-from ckan.plugins.toolkit import _, config
+import ckan.plugins.toolkit as toolkit
+
+LANGUAGE_MAP = {
+    "zh_Hant_TW": "zh_Hant",
+    "zh_Hans_CN": "zh_CN",
+    "nb_NO": "no",
+}
 
 
-def datatablesview_null_label():
-    label = config.get('ckan.datatables.null_label')
-    return _(label) if label else ''
+def datatablesview_null_label() -> str:
+    """
+    Get the label used to display NoneType values for the front-end
+
+    :returns: The label.
+    :rtype: str
+    """
+    label = toolkit.config.get("ckan.datatables.null_label")
+    return toolkit._(label) if label else ""
+
+
+def datatablesview_get_language_file_path(lang: str) -> str:
+    """
+    Get the language file path for the given language.
+
+    If the language is not in the LANGUAGE_MAP, use the language as is.
+    If the language is "en", return an empty string, cause we don't need to load the i18n file.
+
+    :param lang: The language to get the language file path for.
+    :type lang: str
+
+    :returns: The language file path.
+    :rtype: str
+    """
+    if lang == "en":
+        return ""
+
+    return toolkit.h.url_for_static(
+        f"datatablesview/i18n/{LANGUAGE_MAP.get(lang, lang)}.json"
+    )

--- a/ckanext/datatablesview/plugin.py
+++ b/ckanext/datatablesview/plugin.py
@@ -56,6 +56,7 @@ class DataTablesView(p.SingletonPlugin):
 
         toolkit.add_template_directory(config, u'templates')
         toolkit.add_resource(u'assets', u'ckanext-datatablesview')
+        toolkit.add_public_directory(config, u'public')
 
     # IResourceView
 

--- a/ckanext/datatablesview/public/datatablesview/i18n
+++ b/ckanext/datatablesview/public/datatablesview/i18n
@@ -1,0 +1,1 @@
+../../assets/vendor/DataTables/i18n

--- a/ckanext/datatablesview/templates/datatables/datatables_view.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_view.html
@@ -10,6 +10,8 @@
 {#- pass the datadictionary to javascript, so we can init columns there -#}
 {%- set datadictionary = h.datastore_dictionary(resource.id, resource_view.get('show_fields')) -%}
 {%- set nbspval = "&nbsp;"|safe -%}
+{%- set current_language = h.lang() -%}
+
 <script type=text/javascript>
     const gdataDict = {{ datadictionary|tojson }}
     const gresviewId = '{{ resource_view.id }}'
@@ -25,8 +27,8 @@
       data-date-format="{{ resource_view.date_format  if resource_view.date_format is defined else date_format }}"
       data-package-name="{{ package.name }}"
       data-resource-name="{{ h.resource_display_name(resource) }}"
-      data-languagecode="{{ h.lang() }}"
-      data-languagefile="{{ h.url_for_static('vendor/DataTables/i18n/' + h.lang() + '.json') }}"
+      data-languagecode="{{ current_language }}"
+      data-languagefile="{{ h.datatablesview_get_language_file_path(current_language) }}"
       data-ajaxurl="{{ h.url_for('datatablesview.ajax', resource_view_id=resource_view.id) }}"
       data-ckanfilters="{{ request.args.get('filters', '')|e }}"
       data-responsive-flag="{{ resource_view.get('responsive')|lower }}"

--- a/ckanext/tabledesigner/assets/js/tabledesigner-fields.js
+++ b/ckanext/tabledesigner/assets/js/tabledesigner-fields.js
@@ -1,7 +1,6 @@
 this.ckan.module('tabledesigner-fields', function($, _) {
   return {
     initialize: function() {
-      var container = this;
       var $this = $(this.el);
       var $templates = $this.children('div[name="tabledesigner-template"]');
       var templates = Object.fromEntries(

--- a/ckanext/tabledesigner/templates/datatables/datatables_view.html
+++ b/ckanext/tabledesigner/templates/datatables/datatables_view.html
@@ -1,4 +1,5 @@
 {% ckan_extends %}
+
 {% block page %}
   {{ super() }}
   {% if
@@ -8,19 +9,24 @@
     {% asset "ckanext-tabledesigner/datatables_buttons" %}
 
     <div
-      data-module="tabledesigner_datatables_delete"
-      data-edit-text="{{ _('Delete rows') }}"
-      data-edit-url="{{ h.url_for('tabledesigner.delete_rows', id=package.name, resource_id=resource.id) }}"
+      data-module="tabledesigner_datatables_buttons"
+      data-module-type="delete"
+      data-module-text="{{ _('Delete rows') }}"
+      data-module-url="{{ h.url_for('tabledesigner.delete_rows', id=package.name, resource_id=resource.id) }}"
     ></div>
+
     <div
-      data-module="tabledesigner_datatables_edit"
-      data-edit-text="{{ _('Edit row') }}"
-      data-edit-url="{{ h.url_for('tabledesigner.edit_row', id=package.name, resource_id=resource.id) }}"
+      data-module="tabledesigner_datatables_buttons"
+      data-module-type="edit"
+      data-module-text="{{ _('Edit row') }}"
+      data-module-url="{{ h.url_for('tabledesigner.edit_row', id=package.name, resource_id=resource.id) }}"
     ></div>
+
     <div
-      data-module="tabledesigner_datatables_add"
-      data-edit-text="{{ _('Add row') }}"
-      data-edit-url="{{ h.url_for('tabledesigner.add_row', id=package.name, resource_id=resource.id) }}"
+      data-module="tabledesigner_datatables_buttons"
+      data-module-type="add"
+      data-module-text="{{ _('Add row') }}"
+      data-module-url="{{ h.url_for('tabledesigner.add_row', id=package.name, resource_id=resource.id) }}"
     ></div>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
I've encountered few issues with the table designer and data tables. I understand, that those are multiple issues, but they are tightly connected.

1. Previous approach with the comparing strings doesn't include the `ckan.root_path`. This leads to a language file load error. 
2. Moving everything from `public` to `assets` seems erroneous, because we still want to expose data tables language files. 
3. Comparing string for traditional and simplified Chinese is a flawed approach as well, so the language file path determination was moved to the helper. Also, as I can see, the same error may happen with the Norwegian Bokmål locale, altough no one has reported it yet.
4. Move table designer button initialization to the end of the `InitComplete` hook as per the data tables documentation https://datatables.net/reference/option/language.url. Otherwise, the buttons won't appear if the translation is applied.
5. Add a default button class for table designer buttons, Because previously these buttons had different classes - `btn-secondary` and `btn-default`. Bow they all the same and `btn-secondary` looks bad for table designer (no highlight, bad looking disabled). The classes `btn btn-secondary` are hardcoded in the datatable.js, so I can't fully rewrite it (if I can't change the `datatable.js`). I'll leave it for someone, who wants to restyle these buttons in their projects.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
