### PR TITLE
[#8775] Add migration to populate empty permission labels

### DIFF
--- a/changes/8784.bugfix
+++ b/changes/8784.bugfix
@@ -1,0 +1,4 @@
+Add activity migration to fix existing activities created before a 2.11 migration not showing up in `package_activity_list` calls.
+It requires a database migration: 
+
+    ckan db upgrade -p activity

--- a/ckanext/activity/migration/activity/versions/fab3bfdcf830_populate_permission_labels_column.py
+++ b/ckanext/activity/migration/activity/versions/fab3bfdcf830_populate_permission_labels_column.py
@@ -1,0 +1,37 @@
+"""Populate permission_labels column
+
+Revision ID: fab3bfdcf830
+Revises: 71713a055d5c
+Create Date: 2025-04-10 12:55:05.336000
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "fab3bfdcf830"
+down_revision = "71713a055d5c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Set up the default "public" permission_label for dataset related activity
+    # records where the permission labels are null.
+    # See https://github.com/ckan/ckan/issues/8775
+    op.execute(
+        """
+        UPDATE activity
+        SET permission_labels = '{"public"}'
+        WHERE (
+            activity_type LIKE '% package' AND
+            permission_labels IS NULL
+        )
+        """
+    )
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Fixes #8775

Add the default "public" permission_label on dataset related activity records where the permission labels are null.

This will make existing activities created before a 2.11 migration to show up again in `package_activity_list` calls.

