### PR TITLE
Unify secondary buttons

### DIFF
--- a/ckan/templates-midnight-blue/package/base_form_page.html
+++ b/ckan/templates-midnight-blue/package/base_form_page.html
@@ -95,7 +95,7 @@
                     <li class="list-group-item d-flex justify-content-between position-relative">
                       <a class="flex-fill" href="{{ url }}" aria-label="{{ _('Navigate to resource: {name_or_id}').format(name_or_id=res.name or res.id) }}"> {{ res.name | truncate(25) }}</a>
                       <div class="dropdown position-absolute end-0 me-2">
-                        <button class="btn btn-light btn-sm dropdown-toggle" type="button" id="dropdownRes{{ loop.index }}" data-bs-toggle="dropdown" aria-expanded="false"><i class="fa fa-wrench"></i></button>
+                        <button class="btn btn-secondary btn-sm dropdown-toggle" type="button" id="dropdownRes{{ loop.index }}" data-bs-toggle="dropdown" aria-expanded="false"><i class="fa fa-wrench"></i></button>
                         <ul class="dropdown-menu" aria-labelledby="dropdownRes{{ loop.index }}">
                           <li>{% link_for _('Edit resource'), named_route=pkg_dict.type ~ '_resource.edit', id=pkg_dict.name, resource_id=res.id, class_='dropdown-item', icon='pencil' %}</li>
                           {% block resources_list_edit_dropdown_inner scoped %}{% endblock %}

--- a/ckan/templates-midnight-blue/package/preview_draft.html
+++ b/ckan/templates-midnight-blue/package/preview_draft.html
@@ -83,7 +83,7 @@
           {% endblock %}
         {% endif %}
         {% block again_button %}
-          <button class="btn btn-default" name="save" value="save-draft" type="submit">{{ _('Save to drafts') }}</button>
+          <button class="btn btn-secondary" name="save" value="save-draft" type="submit">{{ _('Save to drafts') }}</button>
         {% endblock %}
         {% if stage %}
           {% block save_button %}

--- a/ckan/templates-midnight-blue/package/read_base.html
+++ b/ckan/templates-midnight-blue/package/read_base.html
@@ -14,7 +14,7 @@
 
 {% block content_action %}
   {% if h.check_access('package_update', {'id':pkg.id }) %}
-    {% link_for _('Manage'), named_route=pkg.type ~ '.edit', id=pkg.name, class_='btn btn-light', icon='wrench' %}
+    {% link_for _('Manage'), named_route=pkg.type ~ '.edit', id=pkg.name, class_='btn btn-secondary', icon='wrench' %}
   {% endif %}
 {% endblock %}
 

--- a/ckan/templates-midnight-blue/package/snippets/package_wrench.html
+++ b/ckan/templates-midnight-blue/package/snippets/package_wrench.html
@@ -15,7 +15,7 @@
                     <li class="list-group-item d-flex justify-content-between position-relative">
                         <a class="flex-fill" href="{{ url }}" aria-label="{{ _('Navigate to package: {name}').format(name=pkg.title or pkg.name) }}">{{ pkg.title | truncate(25)  }}</a>
                         <div class="dropdown position-absolute end-0 me-2">
-                          <button class="btn btn-light btn-sm dropdown-toggle" type="button" id="dropdownRes{{ pkg.id }}" data-bs-toggle="dropdown" aria-expanded="false"><i class="fa fa-wrench"></i></button>
+                          <button class="btn btn-secondary btn-sm dropdown-toggle" type="button" id="dropdownRes{{ pkg.id }}" data-bs-toggle="dropdown" aria-expanded="false"><i class="fa fa-wrench"></i></button>
                           <ul class="dropdown-menu" aria-labelledby="dropdownRes{{ pkg.id }}">
                             {% set can_edit = h.check_access('package_update', {'id':pkg.id }) %}
                             {% if can_edit %}

--- a/ckan/templates-midnight-blue/package/snippets/resources.html
+++ b/ckan/templates-midnight-blue/package/snippets/resources.html
@@ -40,7 +40,7 @@ Example:
                     <li class="list-group-item d-flex justify-content-between position-relative">
                       <a class="flex-fill" href="{{ url }}" aria-label="{{ _('Navigate to resource: {name}').format(name=h.resource_display_name(resource)) }}">{{ h.resource_display_name(resource)|truncate(25) }}</a>
                       <div class="dropdown position-absolute end-0 me-2">
-                        <button class="btn btn-light btn-sm dropdown-toggle" type="button" id="dropdownRes{{ loop.index }}" data-bs-toggle="dropdown" aria-expanded="false"><i class="fa fa-wrench"></i></button>
+                        <button class="btn btn-secondary btn-sm dropdown-toggle" type="button" id="dropdownRes{{ loop.index }}" data-bs-toggle="dropdown" aria-expanded="false"><i class="fa fa-wrench"></i></button>
                         <ul class="dropdown-menu" aria-labelledby="dropdownRes{{ loop.index }}">
                           <li>{% link_for _('Edit resource'), named_route=pkg.type ~ '_resource.edit', id=pkg.name, resource_id=resource.id, class_='dropdown-item', icon='pencil' %}</li>
                           {% block resources_list_edit_dropdown_inner scoped %}{% endblock %}
@@ -58,7 +58,7 @@ Example:
             {% endblock %}
             {% if can_edit and not is_activity_archive %}
               <div class="module-content">
-                {% link_for _('Add new resource'), named_route=pkg.type ~ '_resource.new', id=pkg.name, class_='btn btn-light btn-sm', icon='plus' %}
+                {% link_for _('Add new resource'), named_route=pkg.type ~ '_resource.new', id=pkg.name, class_='btn btn-secondary btn-sm', icon='plus' %}
               </div>
             {% endif %}
           </div>

--- a/ckan/templates/package/read_base.html
+++ b/ckan/templates/package/read_base.html
@@ -14,7 +14,7 @@
 
 {% block content_action %}
   {% if h.check_access('package_update', {'id':pkg.id }) %}
-    {% link_for _('Manage'), named_route=pkg.type ~ '.edit', id=pkg.name, class_='btn btn-light', icon='wrench' %}
+    {% link_for _('Manage'), named_route=pkg.type ~ '.edit', id=pkg.name, class_='btn btn-secondary', icon='wrench' %}
   {% endif %}
 {% endblock %}
 

--- a/ckan/templates/package/snippets/resources.html
+++ b/ckan/templates/package/snippets/resources.html
@@ -32,7 +32,7 @@ Example:
                 <li class="nav-item d-flex justify-content-between position-relative">
                   <a class="flex-fill" href="{{ url }}" aria-label="{{ _('Navigate to resource: {name}').format(name=h.resource_display_name(resource)) }}">{{ h.resource_display_name(resource)|truncate(25) }}</a>
                   <div class="dropdown position-absolute end-0 me-2">
-                    <button class="btn btn-light btn-sm dropdown-toggle" type="button" id="dropdownRes{{ loop.index }}" data-bs-toggle="dropdown" aria-expanded="false"><i class="fa fa-wrench"></i></button>
+                    <button class="btn btn-secondary btn-sm dropdown-toggle" type="button" id="dropdownRes{{ loop.index }}" data-bs-toggle="dropdown" aria-expanded="false"><i class="fa fa-wrench"></i></button>
                     <ul class="dropdown-menu" aria-labelledby="dropdownRes{{ loop.index }}">
                       <li>{% link_for _('Edit resource'), named_route=pkg.type ~ '_resource.edit', id=pkg.name, resource_id=resource.id, class_='dropdown-item', icon='pencil' %}</li>
                       {% block resources_list_edit_dropdown_inner scoped %}{% endblock %}
@@ -55,6 +55,6 @@ Example:
 
 {% if can_edit and active and not is_activity_archive %}
   <div class="module-content">
-    {% link_for _('Add new resource'), named_route=pkg.type ~ '_resource.new', id=pkg.name, class_='btn btn-light btn-sm', icon='plus' %}
+    {% link_for _('Add new resource'), named_route=pkg.type ~ '_resource.new', id=pkg.name, class_='btn btn-secondary btn-sm', icon='plus' %}
   </div>
 {% endif %}


### PR DESCRIPTION
Probably due search and replace mistake during bootstrap migration, some buttons were changed from btn-default to btn-light, this PR unifies all of them to btn-secondary.

This has the following change on midnight blue templates:


https://github.com/user-attachments/assets/52d72453-db68-41e0-84ec-5c191ea802a5


https://github.com/user-attachments/assets/2dbb8440-3426-45ef-aa97-3c575fd39f54


I didn't find these actually designed in figma templates so it probably doesn't matter.


### Proposed fixes:
Unifies secondary buttons to use btn-secondary class. Makes it easier to customize the theme as the developer can define primary and secondary colors instead of primary, secondary and light colors. I'll make separate PR for 2.10 and 2.11 to change incorrectly migrated btn-light's to btn-default as btn-secondary is used only on master.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
