### PR TITLE
Fix wrongly migrated .btn-light on 2.11

### DIFF
--- a/changes/8826.bugfix
+++ b/changes/8826.bugfix
@@ -1,0 +1,1 @@
+Some .btn-default classes was mistakenly changed to .btn-light.

--- a/ckan/templates/package/read_base.html
+++ b/ckan/templates/package/read_base.html
@@ -14,7 +14,7 @@
 
 {% block content_action %}
   {% if h.check_access('package_update', {'id':pkg.id }) %}
-    {% link_for _('Manage'), named_route=pkg.type ~ '.edit', id=pkg.name, class_='btn btn-light', icon='wrench' %}
+    {% link_for _('Manage'), named_route=pkg.type ~ '.edit', id=pkg.name, class_='btn btn-default', icon='wrench' %}
   {% endif %}
 {% endblock %}
 

--- a/ckan/templates/package/snippets/resources.html
+++ b/ckan/templates/package/snippets/resources.html
@@ -32,7 +32,7 @@ Example:
                 <li class="nav-item d-flex justify-content-between position-relative">
                   <a class="flex-fill" href="{{ url }}" title="{{ h.resource_display_name(resource) }}">{{ h.resource_display_name(resource)|truncate(25) }}</a>
                   <div class="dropdown position-absolute end-0 me-2">
-                    <button class="btn btn-light btn-sm dropdown-toggle" type="button" id="dropdownRes{{ loop.index }}" data-bs-toggle="dropdown" aria-expanded="false"><i class="fa fa-wrench"></i></button>
+                    <button class="btn btn-default btn-sm dropdown-toggle" type="button" id="dropdownRes{{ loop.index }}" data-bs-toggle="dropdown" aria-expanded="false"><i class="fa fa-wrench"></i></button>
                     <ul class="dropdown-menu" aria-labelledby="dropdownRes{{ loop.index }}">
                       <li>{% link_for _('Edit resource'), named_route=pkg.type ~ '_resource.edit', id=pkg.name, resource_id=resource.id, class_='dropdown-item', icon='pencil' %}</li>
                       {% block resources_list_edit_dropdown_inner scoped %}{% endblock %}
@@ -55,6 +55,6 @@ Example:
 
 {% if can_edit and not is_activity_archive %}
   <div class="module-content">
-    {% link_for _('Add new resource'), named_route=pkg.type ~ '_resource.new', id=pkg.name, class_='btn btn-light btn-sm', icon='plus' %}
+    {% link_for _('Add new resource'), named_route=pkg.type ~ '_resource.new', id=pkg.name, class_='btn btn-default btn-sm', icon='plus' %}
   </div>
 {% endif %}


### PR DESCRIPTION
### Proposed fixes:
Bootstrap migration had couple .btn-default changed to .btn-light, this changes them back.

As a reference, this is what they where in BS3 tempates:

https://github.com/ckan/ckan/blob/9f2094b26721b28918d45d58fea16176df7a1ce1/ckan/templates-bs3/package/read_base.html#L16


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
