### PR TITLE
Fix .btn-light on 2.10

### DIFF
--- a/changes/8828.bugfix
+++ b/changes/8828.bugfix
@@ -1,0 +1,1 @@
+Some .btn-default classes was mistakenly changed to .btn-light.

--- a/ckan/templates/package/read_base.html
+++ b/ckan/templates/package/read_base.html
@@ -13,7 +13,7 @@
 
 {% block content_action %}
   {% if h.check_access('package_update', {'id':pkg.id }) %}
-    {% link_for _('Manage'), named_route=pkg.type ~ '.edit', id=pkg.name, class_='btn btn-light', icon='wrench' %}
+    {% link_for _('Manage'), named_route=pkg.type ~ '.edit', id=pkg.name, class_='btn btn-default', icon='wrench' %}
   {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
### Proposed fixes:

Same as #8826, but for 2.10

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
