### PR TITLE
.btn-xs doesn't exist in BS5, replace it with .btn-sm

### DIFF
--- a/changes/8835.bugfix
+++ b/changes/8835.bugfix
@@ -1,0 +1,1 @@
+Fixed slightly too large slug edit button, as .btn-xs was dropped from Bootstrap.

--- a/ckan/public/base/javascript/plugins/jquery.slug-preview.js
+++ b/ckan/public/base/javascript/plugins/jquery.slug-preview.js
@@ -70,7 +70,7 @@
       '<div class="slug-preview">',
       '<strong></strong>',
       '<span class="slug-preview-prefix"></span><span class="slug-preview-value"></span>',
-      '<button class="btn btn-secondary btn-xs"></button>',
+      '<button class="btn btn-secondary btn-sm"></button>',
       '</div>'
     ].join('\n')
   };

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -269,7 +269,7 @@ class ApiTokenView(MethodView):
             u'class': u'fa fa-copy'
         }), {
             u'type': u'button',
-            u'class': u'btn btn-secondary btn-xs',
+            u'class': u'btn btn-secondary btn-sm',
             u'data-module': u'copy-into-buffer',
             u'data-module-copy-value': ensure_str(token)
         })


### PR DESCRIPTION
### Proposed fixes:
`.btn-xs` [was dropped in BS4](https://getbootstrap.com/docs/4.6/migration/#buttons), this replaces it with `.btn-sm`, makes slug preview edit button slightly smaller as it was on BS3 templates.

Before:
![image](https://github.com/user-attachments/assets/d2060973-9842-45b0-92e6-30190be4a11a)

After:
![image](https://github.com/user-attachments/assets/7fa44ff1-f677-42d3-bd60-653db1365cd4)

Should be backported to 2.11 and 2.10.



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
