### PR TITLE
Updated datastore_info input to resource_id matching documentation

### DIFF
--- a/changes/8770.misc
+++ b/changes/8770.misc
@@ -1,0 +1,1 @@
+Switch 'datastore_info' to use 'resource_id' as input argument

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -383,7 +383,7 @@ def datastore_info(context: Context, data_dict: dict[str, Any]
     if errors:
         raise p.toolkit.ValidationError(errors)
 
-    resource_id = data_dict['id']
+    resource_id = data_dict['resource_id']
     res_exists = backend.resource_exists(resource_id)
     if not res_exists:
         alias_exists, real_id = backend.resource_id_from_alias(resource_id)

--- a/ckanext/datastore/logic/schema.py
+++ b/ckanext/datastore/logic/schema.py
@@ -244,9 +244,9 @@ def datastore_analyze_schema() -> Schema:
 
 
 def datastore_info_schema() -> Schema:
-    return {       
+    return {
         'resource_id': [not_missing, not_empty, unicode_safe],
-        'id': [ignore_missing],       
+        'id': [ignore_missing],
         'include_meta': [default(True), boolean_validator],
         'include_fields_schema': [default(True), boolean_validator],
         '__before': [rename('id', 'resource_id')]

--- a/ckanext/datastore/logic/schema.py
+++ b/ckanext/datastore/logic/schema.py
@@ -244,8 +244,10 @@ def datastore_analyze_schema() -> Schema:
 
 
 def datastore_info_schema() -> Schema:
-    return {
-        'id': [unicode_only, not_empty],
+    return {       
+        'resource_id': [not_missing, not_empty, unicode_safe],
+        'id': [ignore_missing],       
         'include_meta': [default(True), boolean_validator],
         'include_fields_schema': [default(True), boolean_validator],
+        '__before': [rename('id', 'resource_id')]
     }

--- a/ckanext/datastore/tests/test_info.py
+++ b/ckanext/datastore/tests/test_info.py
@@ -29,7 +29,7 @@ def test_info_success():
     }
     helpers.call_action("datastore_create", **data)
 
-    info = helpers.call_action("datastore_info", id=resource["id"])
+    info = helpers.call_action("datastore_info", resource_id=resource["id"])
 
     assert len(info["meta"]) == 7, info["meta"]
     assert info["meta"]["count"] == 2
@@ -52,7 +52,7 @@ def test_info_success():
     assert info["meta"]["id"] == resource["id"]
 
     info = helpers.call_action(
-        "datastore_info", id=resource["id"],
+        "datastore_info", resource_id=resource["id"],
         include_meta=False, include_fields_schema=False)
 
     assert 'meta' not in info


### PR DESCRIPTION

Fixes #8770 

### Proposed fixes:

Updates datastore_info to use resource_id as input parameter name. Preserves backwards compatibility, accepting id instead.

The fix was implemented using a __before rename like the other datastore methods

The tests were updated to use resource_id, there are not tests of backwards compatibility

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport


