### PR TITLE
[#8770][2.11] Support resource_id as input in datastore_info 

### DIFF
--- a/changes/8907.misc
+++ b/changes/8907.misc
@@ -1,0 +1,1 @@
+Switch 'datastore_info' to use 'resource_id' as input argument

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -27,6 +27,7 @@ from ckanext.datastore import interfaces
 log = logging.getLogger(__name__)
 _get_or_bust = logic.get_or_bust
 _validate = ckan.lib.navl.dictization_functions.validate
+ValidationError = logic.ValidationError
 
 WHITELISTED_RESOURCES = ['_table_metadata']
 
@@ -380,7 +381,10 @@ def datastore_info(context: Context, data_dict: dict[str, Any]
     '''
     backend = DatastoreBackend.get_active_backend()
 
-    resource_id = _get_or_bust(data_dict, 'id')
+    resource_id = data_dict.get("resource_id", data_dict.get("id"))
+    if not resource_id:
+        raise ValidationError({"resource_id": ["Missing value"]})
+
     res_exists = backend.resource_exists(resource_id)
     if not res_exists:
         alias_exists, real_id = backend.resource_id_from_alias(resource_id)

--- a/ckanext/datastore/tests/test_info.py
+++ b/ckanext/datastore/tests/test_info.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 import pytest
+from ckan.plugins.toolkit import ValidationError
 import ckan.tests.factories as factories
 import ckan.tests.helpers as helpers
 from ckan.lib import helpers as template_helpers
@@ -29,7 +30,7 @@ def test_info_success():
     }
     helpers.call_action("datastore_create", **data)
 
-    info = helpers.call_action("datastore_info", id=resource["id"])
+    info = helpers.call_action("datastore_info", resource_id=resource["id"])
 
     assert len(info["meta"]) == 7, info["meta"]
     assert info["meta"]["count"] == 2
@@ -50,6 +51,13 @@ def test_info_success():
     assert len(info["meta"]) == 7, info["meta"]
     assert info["meta"]["count"] == 2
     assert info["meta"]["id"] == resource["id"]
+
+
+@pytest.mark.ckan_config("ckan.plugins", "datastore")
+@pytest.mark.usefixtures("with_plugins")
+def test_info_missing_id():
+    with pytest.raises(ValidationError):
+        helpers.call_action("datastore_info")
 
 
 @pytest.mark.ckan_config("ckan.plugins", "datastore")


### PR DESCRIPTION
2.11 version of https://github.com/ckan/ckan/pull/8907 with a non-schema validation approach