### PR TITLE
Remove CSRF check exemption for form plugins

### DIFF
--- a/changes/8918.migration
+++ b/changes/8918.migration
@@ -1,0 +1,4 @@
+All forms implemented in plugins must now incorporate the :ref:`CSRF protection <csrf_best_practices>` snippet if
+they are still not doing it so. All forms submitted to CKAN are now checked for the CSRF token.
+The ``ckan.csrf_protection.ignore_extensions`` config option has no longer any effect.
+

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -716,14 +716,6 @@ groups:
           Set to False to disable Flask-Babel I18N support.
           Also set to False if you want to use WTForms’s built-in messages directly, see more info here.
 
-      - key: ckan.csrf_protection.ignore_extensions
-        type: bool
-        default: true
-        description: |
-          Exempt plugins blueprints from CSRF protection.
-
-          .. warning:: This feature will be deprecated in future versions.
-
   - annotation: Flask-Login Remember me cookie settings
     options:
       - key: REMEMBER_COOKIE_NAME

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -63,14 +63,6 @@ log = logging.getLogger(__name__)
 
 csrf = CSRFProtect()
 
-csrf_warn_extensions = (
-        "Extensions are excluded from CSRF protection! "
-        "We allow extensions to run without CSRF protection "
-        "but it will be forced future releases. "
-        "Read the documentation for more information on how to add "
-        "CSRF protection to your extension."
-    )
-
 
 class CKANSession(Session):
     def _get_interface(self, app: CKANApp):
@@ -224,10 +216,6 @@ def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:
         config[wtf_key] = app.config[wtf_key] = app.config["SECRET_KEY"]
     app.config["WTF_CSRF_FIELD_NAME"] = config.get('WTF_CSRF_FIELD_NAME')
     csrf.init_app(app)
-
-    if config.get("ckan.csrf_protection.ignore_extensions"):
-        log.warning(csrf_warn_extensions)
-        _exempt_plugins_blueprints_from_csrf(csrf)
 
     lib_plugins.register_package_blueprints(app)
     lib_plugins.register_group_blueprints(app)
@@ -436,20 +424,6 @@ def _register_plugins_blueprints(app: CKANApp):
                 app.register_blueprint(blueprint)
         else:
             app.register_blueprint(plugin_blueprints)
-
-
-def _exempt_plugins_blueprints_from_csrf(csrf: CSRFProtect):
-    """Exempt plugins blueprints from CSRF protection.
-
-    This feature will be deprecated in future versions.
-    """
-    for plugin in PluginImplementations(IBlueprint):
-        plugin_blueprints = plugin.get_blueprint()
-        if isinstance(plugin_blueprints, list):
-            for blueprint in plugin_blueprints:
-                csrf.exempt(blueprint)
-        else:
-            csrf.exempt(plugin_blueprints)
 
 
 def _register_core_blueprints(app: CKANApp):

--- a/ckanext/datapusher/tests/test_views.py
+++ b/ckanext/datapusher/tests/test_views.py
@@ -1,38 +1,31 @@
-# encoding: utf-8
-
 from unittest import mock
 import pytest
 
 import ckan.tests.factories as factories
-import ckan.model as model
 from ckan.logic import _actions
 from ckanext.datapusher.tests import get_api_token
 
 
-@mock.patch("flask_login.utils._get_user")
-@pytest.mark.ckan_config(u"ckan.plugins", u"datapusher datastore")
+@pytest.mark.ckan_config("ckan.plugins", "datapusher datastore")
 @pytest.mark.ckan_config("ckan.datapusher.api_token", get_api_token())
-@pytest.mark.usefixtures(u"non_clean_db", u"with_plugins")
-def test_resource_data(current_user, app, monkeypatch):
-    user = factories.User()
-    user_obj = model.User.get(user["name"])
-    # mock current_user
-    current_user.return_value = user_obj
+@pytest.mark.usefixtures("non_clean_db", "with_plugins")
+def test_resource_data(app, monkeypatch):
+    user = factories.UserWithToken()
+    org = factories.Organization(users=[{"name": user["name"], "capacity": "admin"}])
 
-    dataset = factories.Dataset(creator_user_id=user["id"])
-    resource = factories.Resource(
-        package_id=dataset["id"], creator_user_id=user["id"]
-    )
+    dataset = factories.Dataset(owner_org=org["id"])
+    resource = factories.Resource(package_id=dataset["id"])
 
-    url = u"/dataset/{id}/resource_data/{resource_id}".format(
+    url = "/dataset/{id}/resource_data/{resource_id}".format(
         id=str(dataset["name"]), resource_id=str(resource["id"])
     )
 
+    headers = {"Authorization": user["token"]}
     func = mock.Mock()
-    monkeypatch.setitem(_actions, 'datapusher_submit', func)
-    app.post(url=url, status=200)
+    monkeypatch.setitem(_actions, "datapusher_submit", func)
+    app.post(url=url, headers=headers, status=200)
     func.assert_called()
     func.reset_mock()
 
-    app.get(url=url, status=200)
+    app.get(url=url, headers=headers, status=200)
     func.assert_not_called()


### PR DESCRIPTION
CSRF protection was introduced in 2.10.0 (February 2023). At the time we allowed blueprints from plugins to skip the CSRF checks to allow time to migrate their forms (basically adding the `{{ h.csrf_input() }}` snippet).
 A config option `ckan.csrf_protection.ignore_extensions` allowed to turn this exemption on and off, but now it feels like a good time to enforce this security practice across all extensions.

Refactored an old datapusher test that started failing after this change.