### PR TITLE
fix: document js translations generation

### DIFF
--- a/changes/8927.bugfix
+++ b/changes/8927.bugfix
@@ -1,0 +1,1 @@
+fix: document js translations generation

--- a/doc/maintaining/cli.rst
+++ b/doc/maintaining/cli.rst
@@ -698,9 +698,13 @@ Usage
 
 .. note::
 
-    Since version 2.7 the JavaScript translation files are automatically
-    regenerated if necessary when CKAN is started. Hence you usually do not
-    need to run ``ckan translation js`` manually.
+    Since version 2.11 on production intalls the JavaScript translation
+    files from extensions must be combined and generated with the
+    ``ckan translation js`` command after any new plugins are enabled or
+    when new versions of ckan or its extensions are installed.
+
+    In development mode ``ckan run`` will combine and generate these
+    files automatically.
 
 
 .. _cli-user:

--- a/doc/maintaining/cli.rst
+++ b/doc/maintaining/cli.rst
@@ -698,7 +698,7 @@ Usage
 
 .. note::
 
-    Since version 2.11 on production intalls the JavaScript translation
+    Since version 2.11 on production installs the JavaScript translation
     files from extensions must be combined and generated with the
     ``ckan translation js`` command after any new plugins are enabled or
     when new versions of ckan or its extensions are installed.


### PR DESCRIPTION
Fixes #8927 

### Proposed fixes:
correct docs for `ckan translation js`


### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport
