### PR TITLE
Fix multithreaded JSON decoding issue by adding json_deserializer at engine level

### DIFF
--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -125,26 +125,25 @@ def get_write_engine():
 
 
 def _get_engine_from_url(connection_url: str, **kwargs: Any) -> Engine:
-    '''Get either read or write engine.'''
+    """Get either read or write engine."""
     engine = _engines.get(connection_url)
-    if not engine:
-        extras = {'url': connection_url}
-        config.setdefault('ckan.datastore.sqlalchemy.pool_pre_ping', True)
-        for key, value in kwargs.items():
-            config.setdefault(key, value)
-        engine = sa.engine_from_config(dict(config),
-                                       'ckan.datastore.sqlalchemy.',
-                                       **extras)
-        _engines[connection_url] = engine
 
-    # don't automatically convert to python objects
-    # when using native json types in 9.2+
-    # http://initd.org/psycopg/docs/extras.html#adapt-json
-    _loads: Callable[[Any], Any] = lambda x: x
-    register_default_json(
-        conn_or_curs=engine.raw_connection().connection,  # type: ignore
-        globally=False,
-        loads=_loads)
+    if engine:
+        return engine
+
+    config.setdefault("ckan.datastore.sqlalchemy.pool_pre_ping", True)
+
+    for key, value in kwargs.items():
+        config.setdefault(key, value)
+
+    engine = sa.engine_from_config(
+        config,
+        "ckan.datastore.sqlalchemy.",
+        json_deserializer=lambda x: x, # do not convert to python objects
+        **{"url": connection_url},
+    )
+
+    _engines[connection_url] = engine
 
     return engine
 


### PR DESCRIPTION

# Problem Description:

In a multithreaded environment, when executing SQL queries such as:

```python
scalar(sa.text(f"EXPLAIN (VERBOSE, FORMAT JSON) {sql}"))
```
the results sometimes return as already decoded Python objects (e.g., lists), rather than as raw JSON strings. This inconsistency led to issues where the query results were not being processed in a consistent manner, especially when the data needed to be handled as JSON.

Previously, the `register_default_json` function was used to apply a JSON patch at the connection level, but this only affected a single psycopg2 connection instance, not the connections from the pool. As a result, other threads using different connections did not receive the correct JSON deserialization, leading to inconsistent results when querying the database in a multithreaded context.

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
