### PR TITLE
Use empty string alt text on decorative images

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1431,7 +1431,7 @@ def gravatar(email_hash: str,
         default = quote(default, safe='')
 
     return literal('''<img src="//gravatar.com/avatar/%s?s=%d&amp;d=%s"
-        class="user-image" width="%s" height="%s" alt="Gravatar" />'''
+        class="user-image" width="%s" height="%s" alt="" />'''
                    % (email_hash, size, default, size, size)
                    )
 
@@ -1487,10 +1487,9 @@ def user_image(user_id: str, size: int = 100) -> Union[Markup, str]:
     if user_dict['image_display_url']:
         return literal('''<img src="{url}"
                        class="user-image"
-                       width="{size}" height="{size}" alt="{alt}" />'''.format(
+                       width="{size}" height="{size}" alt="" />'''.format(
             url=sanitize_url(user_dict['image_display_url']),
             size=size,
-            alt=user_dict['name']
         ))
     elif gravatar_default == 'disabled':
         return snippet(

--- a/ckan/templates/group/snippets/group_item.html
+++ b/ckan/templates/group/snippets/group_item.html
@@ -17,7 +17,7 @@ Example:
 <li class="media-item">
   {% block item_inner %}
   {% block image %}
-    <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="{{ group.name }}" class="media-image img-fluid">
+    <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="" class="media-image img-fluid">
   {% endblock %}
   {% block title %}
     <h2 class="media-heading">{{ group.display_name }}</h2>

--- a/ckan/templates/group/snippets/info.html
+++ b/ckan/templates/group/snippets/info.html
@@ -8,7 +8,7 @@
     {% block image %}
     <div class="image">
       <a href="{{ group.url }}">
-        <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" width="190" height="118" alt="{{ group.name }}" />
+        <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" width="190" height="118" alt="" />
       </a>
     </div>
     {% endblock %}

--- a/ckan/templates/organization/snippets/info.html
+++ b/ckan/templates/organization/snippets/info.html
@@ -18,7 +18,7 @@
       {% block image %}
         <div class="image">
           <a href="{{ url }}">
-            <img src="{{ organization.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}" width="200" alt="{{ organization.name }}" />
+            <img src="{{ organization.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}" width="200" alt="" />
           </a>
         </div>
       {% endblock %}

--- a/ckan/templates/organization/snippets/organization_item.html
+++ b/ckan/templates/organization/snippets/organization_item.html
@@ -16,7 +16,7 @@ Example:
 <li class="media-item">
   {% block item_inner %}
   {% block image %}
-    <img src="{{ organization.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}" alt="{{ organization.name }}" class="img-fluid media-image">
+    <img src="{{ organization.image_display_url or h.url_for_static('/base/images/placeholder-organization.png') }}" alt="" class="img-fluid media-image">
   {% endblock %}
   {% block title %}
     <h2 class="media-heading">{{ organization.display_name }}</h2>


### PR DESCRIPTION
The ["German centre for accessible reading"](https://www.dzblesen.de/auftraege/digitales) performed an accessibility audit on [our CKAN instance](https://opendata.leipzig.de), and one of the findings was that there are a lot of unnecessary alt-texts on group and organization "profile" pictures. User pages were not checked but they have the same issue imho.

[Images of limited informational value should have an empty string for their alt text](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/alt), to avoid clutter in assistive output.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport
