### PR TITLE
chore: handle UnicodeDecodeErrors on session, expand test coverage

### DIFF
--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -79,7 +79,10 @@ class CKANJsonSessionSerializer(TaggedJSONSerializer, FlaskSessionSerializer):
 
     def decode(self, serialized_data: bytes) -> Any:
         """Deserialize the session data."""
-        return self.loads(serialized_data.decode())
+        try:
+            return self.loads(serialized_data.decode())
+        except UnicodeDecodeError:
+            log.error("unable to decode session data, dropping: %s", serialized_data)
 
 
 class CKANSession(Session):


### PR DESCRIPTION
Fixes: https://github.com/ckan/ckan/issues/8935
Improves: https://github.com/ckan/ckan/pull/8704
### Proposed fixes:

UnicodeDecodeError was not caught if session data was not improperly decoded, i.e. swapping from Flask Serializer to CKANJsonSessionSerializer caused issue.


### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
