### PR TITLE
Invoke CKAN's CLI with -m

### DIFF
--- a/ckan/__main__.py
+++ b/ckan/__main__.py
@@ -1,0 +1,3 @@
+if __name__ == '__main__':
+    from ckan.cli import cli
+    cli.ckan()


### PR DESCRIPTION
Small stub to run the CLI with `python -m ckan -c ckan.ini...` for tools that can generate run stubs from __main__ but not script shims.