### PR TITLE
feature: Enable etag and improved cache control options

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -390,3 +390,8 @@ jobs:
         with:
           name: combined-test-coverage-reports
           path: results
+
+      - name: Test Summary Combined (if Failure)
+        uses: test-summary/action@v2
+        with:
+          paths: "./merged.xml"

--- a/changes/8781.feature
+++ b/changes/8781.feature
@@ -1,0 +1,44 @@
+feature/performance: Improved caching and ETag handling
+
+- Webassets (static files) now support configurable ETag and Cache-Control headers.
+  See `ckan.cache.*` and `ckan.etag.enabled` for included configuration options.
+  By default, assets will use strong ETags and try to not include vary on cookie unless session was modified prior to render.
+
+- **Config changes:**
+  - Renamed:
+    - `ckan.cache_expires` → `ckan.cache.expires` (default: 3600)
+    - `ckan.cache_enabled` → `ckan.cache.public.enabled` (boolean, default: True)
+  - New config keys:
+    - `ckan.cache.private.enabled` (default: True)
+    - `ckan.cache.shared.expires` (default: 7200)
+    - `ckan.cache.private.expires` (default: 60)
+    - `ckan.cache.stale_while_revalidates` (default: 3600)
+    - `ckan.cache.stale_if_error` (default: 86400)
+    - `ckan.cache.no_transform` (default: False)
+    - `ckan.etags.enabled` (default: True)
+
+- **Cache-Control Header Behavior:**
+  - If `ckan.cache.public.enabled` is `False`, all responses include `Cache-Control: private`.
+  - If `ckan.cache.public.enabled` is `True` and the user is not logged in, `Cache-Control: public` is set.
+  - If `ckan.cache.private.enabled` is `False`, private responses use at least `Cache-Control: no-cache`.
+  - When the session is modified or a `Set-Cookie` is present, `Cache-Control: no-store` prevents caching.
+  - Incoming `Cache-Control` headers are respected in responses.
+
+- **New core helpers:**
+  - `cache_level`, `set_cache_level`: Get/set cache type (in Flask's `g` context).
+  - `limit_cache_for_page`, `set_limit_cache_for_page`: Control per-page cache limits.
+  - `etag_append`, `set_etag_replace`, `set_etag_modified_time`: Advanced ETag customization.
+
+- **Plugin Example:**
+  - Added `example_etags` plugin demonstrating MD5 content hashing with the new interface.
+
+- **Interface Updates (`IMiddleware`):**
+  - New methods for plugins to override response headers:
+    - `set_cors_headers_for_response(self, response)`
+    - `set_cache_control_headers_for_response(self, response)`
+    - `set_etag_for_response(self, response)`
+
+---
+
+**Summary:**
+These changes improve caching flexibility, allow for fine-grained ETag and Cache-Control behavior, and introduce new helpers and plugin interfaces for advanced cache/header control.

--- a/changes/8951.feature
+++ b/changes/8951.feature
@@ -1,0 +1,7 @@
+feature: Performance improvements by allowing CSRF head meta data to only be activated when CSRF session token is available
+
+* Dynamically include CSRF HEAD Meta when CSRF token is available in user session.
+  Allows pages to stay PUBLIC cached for as long as possible.
+* A new util JSON interface for CSRF token retrieval for XHR/Fetch calls (protected by CORS)
+* A new JS util library for CSRF token retrieval for client side usage
+* Allow CSRF subsystem to be fully disabled for true read-only CKAN sites.

--- a/ckan/common.py
+++ b/ckan/common.py
@@ -11,10 +11,13 @@ from __future__ import annotations
 
 import logging
 from collections.abc import MutableMapping, Iterable
+from enum import Enum
 
 from typing import (
     Any, Optional, TYPE_CHECKING,
     TypeVar, cast, overload, Union)
+
+from flask.sessions import SessionMixin
 from typing_extensions import Literal
 
 import flask
@@ -30,7 +33,6 @@ import simplejson as json  # type: ignore # noqa
 import ckan.lib.maintain as maintain
 from ckan.config.declaration import Declaration
 from ckan.types import Request
-
 
 if TYPE_CHECKING:
     MutableMapping = MutableMapping[str, Any]
@@ -216,11 +218,16 @@ class CKANRequest(LocalProxy[Request]):
         return self.args
 
 
-def _get_c():
+def _get_g():
     return flask.g
 
 
-def _get_session():
+# Deprecated, use _get_g()
+def _get_c():  # pyright: ignore[reportUnusedFunction]
+    return _get_g()
+
+
+def _get_session() -> SessionMixin:
     return flask.session
 
 
@@ -330,9 +337,46 @@ config_declaration = local.config_declaration = Declaration()
 # Proxies to already thread-local safe objects
 request = CKANRequest(_get_request)
 # Provide a `c`  alias for `g` for backwards compatibility
-g: Any = LocalProxy(_get_c)
+g = LocalProxy(_get_g)  # flask.ctx._AppCtxGlobals
 c = g
-session: Any = LocalProxy(_get_session)
+session = LocalProxy(_get_session)
 
 truthy = frozenset([u'true', u'yes', u'on', u'y', u't', u'1'])
 falsy = frozenset([u'false', u'no', u'off', u'n', u'f', u'0'])
+
+
+class CacheType(Enum):
+    """ This enum is to simplify cache controls since you can only have one type set
+    If response cache_controls are manually configured, use context OVERRIDDEN to
+    not allow default behaviour to alter your settings"""
+
+    priority: int
+
+    def __new__(cls, value: str, priority: int):
+        obj = object.__new__(cls)
+        obj._value_ = value
+        obj.priority = priority
+        return obj
+
+    PUBLIC = ('public', 1)
+    PRIVATE = ('private', 2)
+    NO_CACHE = ('no-cache', 3)
+    SENSITIVE = ('no-store', 4)
+    OVERRIDDEN = ('overridden', 99)
+
+    @classmethod
+    def can_override(cls, current_in: 'str|CacheType', new_in: 'str|CacheType') -> bool:
+        """Returns True if `new` can override `current`"""
+        if isinstance(current_in, str):
+            current: CacheType = cls(current_in)
+        else:
+            current = current_in
+        if isinstance(new_in, str):
+            new: CacheType = cls(new_in)
+        else:
+            new = new_in
+        return new.priority >= current.priority
+
+
+# This is what can be passed into the query args that is removed from dicts
+CACHE_PARAMETERS = frozenset([u'__cache', u'__no_cache__'])

--- a/ckan/common.py
+++ b/ckan/common.py
@@ -5,7 +5,7 @@
 # but at the same time making it easy to change for example the json lib
 # used.
 #
-# NOTE:  This file is specificaly created for
+# NOTE:  This file is specifically created for
 # from ckan.common import x, y, z to be allowed
 from __future__ import annotations
 

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -1075,7 +1075,7 @@ groups:
 
       - key: ckan.site_logo
         default: /base/images/ckan-logo.png
-        example: /images/ckan_logo_fullname_long.png
+        example: /base/images/ckan-logo.png
         description: This sets the logo used in the title bar.
         editable: true
 
@@ -1185,7 +1185,7 @@ groups:
       - key: ckan.site_custom_css
         description: Custom CSS directives to include on all CKAN pages.
         editable: true
-      
+
       - key: ckan.default_collapse_facets
         type: bool
         default: False

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -408,20 +408,88 @@ groups:
           token. This is useful in some scenarios where using the default ``Authorization`` one
           causes problems.
 
-      - key: ckan.cache_expires
-        default: 0
+      - key: ckan.cache.expires
+        default: 3600
+        legacy_key: ckan.cache_expires  # since v.2.12.0
         type: int
         example: 2592000
-        description: This sets ``Cache-Control`` header's max-age value.
+        description: |
+          This sets ``Cache-Control`` header's max-age value on public cache.
+          3600 = 1 hour before revalidate with shared cache
 
-      - key: ckan.cache_enabled
+      - key: ckan.cache.shared.expires
+        default: 7200
+        type: int
+        example: 7200
+        description: |
+          This sets ``Cache-Control`` header's s-maxage value on public cache.
+          7200 = 2 hour before shared cache revalidates
+
+      - key: ckan.cache.private.expires
+        type: int
+        default: 60
+        example: 3600
+        description: |
+          This sets ``Cache-Control`` header's max-age value on private cache.
+
+      - key: ckan.cache.public.enabled
+        legacy_key: ckan.cache_enabled  # since v.2.12.0
+        default: True
         type: bool
         example: "true"
         description: |
           This enables cache control headers on all requests. If the user is
           not logged in and there is no session data a ``Cache-Control:
-          public`` header will be added. For all other requests the
-          ``Cache-control: private`` header will be added.
+          public`` header will be added. For all other requests see `
+          `ckan.cache.private.enabled`` config option.
+
+      - key: ckan.cache.private.enabled
+        default: true
+        type: bool
+        example: "true"
+        description: |
+          When this is set to true and cache type requested is private,
+          then ``Cache-control: private`` header will be added,
+          else ``Cache-Control: no-cache max-age=0`` will be set on all
+          requests except for sensitive responses where no-store
+          will also be set.
+
+      - key: ckan.cache.stale_while_revalidates
+        default: 3600
+        type: int
+        example: 3600
+        description: |
+          This sets ``Cache-Control`` header's stale-while-revalidate value on public/private cache.
+          In Seconds, config used to serve stale content while being background revalidated
+          users will continue to receive stale data until refresh call is returned
+          limiting requests to one per edge cache instead of all users when shared
+          cache is stale/expired - dependant on cache keys.
+          Set to 0 to disallow stale cache server on requests.
+
+      - key: ckan.cache.stale_if_error
+        default: 86400
+        type: int
+        example: 7200
+        description: |
+          This sets ``Cache-Control`` header's stale-if-error value on public/private cache.
+          86400 = 1 day if origin server throws 5xx error.
+          Set to 0 to disallow stale cache server on 5xx errors.
+          Note: When both ``stale_while_revalidates`` and ``stale_if_error`` are set to 0, ``must-revalidate`` is used instead.
+
+      - key: ckan.cache.no_transform
+        type: bool
+        default: false
+        example: "true"
+        description: |
+          If the HTTP response is not to be manipulated, Default: False
+          Adds to ``Cache-control`` ``no-transform``.
+
+      - key: ckan.etags.enabled
+        type: bool
+        default: true
+        example: "true"
+        description: |
+          Add etag response header on all payloads
 
       - key: ckan.mimetype_guess
         default: file_ext
@@ -700,6 +768,7 @@ groups:
         default: 31536000
         description: |
           Max age in seconds for CSRF tokens.
+          Must be longer than shared/max cache age + standard session length
           This value is capped by the lifetime of the session.
 
       - key: WTF_CSRF_SSL_STRICT
@@ -1248,7 +1317,7 @@ groups:
         example: public
         description: |
           This config option is used to configure the base folder for static files used
-          by CKAN core. Starting CKAN 2.11 it only accepts: ``public`` as a value.
+          by CKAN core. Starting CKAN 2.11 it only accepts: ``public`` or ``public-midenight-blue`` as a value.
           (This variable is kept for backwards compatibility when updating Bootstrap
           versions.)
 

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -389,6 +389,7 @@ def ckan_before_request() -> Optional[Response]:
 
     # Set the csrf_field_name so we can use it in our templates
     g.csrf_field_name = config.get("WTF_CSRF_FIELD_NAME")
+    g.csrf_enabled = config.get('WTF_CSRF_ENABLED')
 
     # Provide g.controller and g.action for backward compatibility
     # with extensions

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -242,6 +242,7 @@ def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:
     if not app.config.get(wtf_key):
         config[wtf_key] = app.config[wtf_key] = app.config["SECRET_KEY"]
     app.config["WTF_CSRF_FIELD_NAME"] = config.get('WTF_CSRF_FIELD_NAME')
+    app.config["WTF_CSRF_HEADERS"] = config.get('WTF_CSRF_HEADERS')
     app.config["WTF_CSRF_ENABLED"] = config.get("WTF_CSRF_ENABLED")
     app.config["WTF_CSRF_TIME_LIMIT"] = config.get("WTF_CSRF_TIME_LIMIT")
     csrf.init_app(app)
@@ -387,8 +388,11 @@ def ckan_before_request() -> Optional[Response]:
             dest = f"{view.__module__}.{view.__name__}"
             csrf.exempt(dest)
 
-    # Set the csrf_field_name so we can use it in our templates
+    # Set the csrf_field_name, so we can use it in our templates
     g.csrf_field_name = config.get("WTF_CSRF_FIELD_NAME")
+    g.csrf_header_name = config.get("WTF_CSRF_HEADERS")[0] \
+        if isinstance(config.get("WTF_CSRF_HEADERS"), list) \
+        else config.get("WTF_CSRF_HEADERS")
     g.csrf_enabled = config.get('WTF_CSRF_ENABLED')
 
     # Provide g.controller and g.action for backward compatibility

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -44,6 +44,8 @@ from ckan.config.middleware.common_middleware import (
     RootPathMiddleware,
     CKANSecureCookieSessionInterface,
     CKANRedisSessionInterface,
+    static_or_webasset_pre_configuration,
+    static_or_webasset_post_configuration
 )
 import ckan.lib.app_globals as app_globals
 import ckan.lib.plugins as lib_plugins
@@ -55,6 +57,7 @@ from ckan.views import (identify_user,
                         set_cors_headers_for_response,
                         set_controller_and_action,
                         set_cache_control_headers_for_response,
+                        set_etag_for_response,
                         handle_i18n,
                         set_ckan_current_url,
                         _get_user_for_apitoken,
@@ -364,6 +367,11 @@ def ckan_before_request() -> Optional[Response]:
 
     g.__timer = time.time()
 
+    session_access = session.accessed
+    # used to mimic session.new since flask_session.new can lie
+    g.__session_was_empty = len(session.keys()) == 0
+    session.accessed = session_access  # reset session accessed state
+
     # Update app_globals
     app_globals.app_globals._check_uptodate()
 
@@ -414,7 +422,37 @@ def ckan_after_request(response: Response) -> Response:
     response = set_cors_headers_for_response(response)
 
     # Set Cache Control headers
-    response = set_cache_control_headers_for_response(response)
+    default_cors_enabled = True
+    for plugin in PluginImplementations(IMiddleware):
+        if hasattr(plugin, 'set_cors_headers_for_response'):
+            response_returned = plugin.set_cors_headers_for_response(response)
+            if response_returned:
+                response = response_returned
+                default_cors_enabled = False
+    if default_cors_enabled:
+        response = set_cors_headers_for_response(response)
+
+    # Set Cache Control headers
+    default_cache_control_enabled = True
+    for plugin in PluginImplementations(IMiddleware):
+        if hasattr(plugin, 'set_cache_control_headers_for_response'):
+            response_returned = plugin.set_cache_control_headers_for_response(response)
+            if response_returned:
+                response = response_returned
+                default_cache_control_enabled = False
+    if default_cache_control_enabled:
+        response = set_cache_control_headers_for_response(response)
+
+    # Set ETag response headers
+    default_etag_enabled = True
+    for plugin in PluginImplementations(IMiddleware):
+        if hasattr(plugin, 'set_etag_for_response'):
+            response_returned = plugin.set_etag_for_response(response)
+            if response_returned:
+                response = response_returned
+                default_etag_enabled = False
+    if default_etag_enabled:
+        response = set_etag_for_response(response)
 
     r_time = time.time() - g.__timer
     url = request.environ['PATH_INFO']
@@ -569,8 +607,12 @@ def _setup_webassets(app: CKANApp):
 
     webassets_folder = get_webassets_path()
 
-    def webassets(path: str):
-        return send_from_directory(webassets_folder, path)
+    def webassets(path: str) -> Response:
+        cache_expire, shared_cache_expire = static_or_webasset_pre_configuration(None)
+        response = send_from_directory(webassets_folder, path,
+                                       etag=True, max_age=cache_expire)
+        static_or_webasset_post_configuration(response, shared_cache_expire)
+        return response
 
     path = config["ckan.webassets.url"].rstrip("/")
     app.add_url_rule(f'{path}/<path:path>', 'webassets.index', webassets)

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -31,7 +31,7 @@ import dominate.tags as dom_tags
 from dominate.util import raw as raw_dom_tags
 from markdown import markdown
 from bleach import clean as bleach_clean, ALLOWED_TAGS, ALLOWED_ATTRIBUTES
-from ckan.common import asbool, config, current_user
+from ckan.common import asbool, config, current_user, session
 from flask import flash, has_request_context, current_app
 from flask import get_flashed_messages as _flask_get_flashed_messages
 from flask import redirect as _flask_redirect
@@ -2908,3 +2908,16 @@ def csrf_input():
     '''
     import ckan.lib.base as base
     return literal(base.render('snippets/csrf_input.html'))
+
+
+@core_helper
+def csrf_session_enabled() -> bool:
+    """ Returns true if the session is enabled for CSRF protection """
+    log.debug("WTF_CSRF_FIELD_NAME: %r", config.get('WTF_CSRF_FIELD_NAME'))
+    log.debug("session: %r", session)
+
+    session_accessed = session.accessed
+    is_enabled = config.get('WTF_CSRF_FIELD_NAME') in session
+    # Reset session accessed state, so we don't introduce vary cookie accidentally
+    session.accessed = session_accessed
+    return is_enabled

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -31,7 +31,7 @@ import dominate.tags as dom_tags
 from dominate.util import raw as raw_dom_tags
 from markdown import markdown
 from bleach import clean as bleach_clean, ALLOWED_TAGS, ALLOWED_ATTRIBUTES
-from ckan.common import asbool, config, current_user, session
+from ckan.common import asbool, config, current_user, CacheType, session
 from flask import flash, has_request_context, current_app
 from flask import get_flashed_messages as _flask_get_flashed_messages
 from flask import redirect as _flask_redirect
@@ -2921,3 +2921,65 @@ def csrf_session_enabled() -> bool:
     # Reset session accessed state, so we don't introduce vary cookie accidentally
     session.accessed = session_accessed
     return is_enabled
+
+
+@core_helper
+def cache_level():
+    return getattr(g, 'cache_type', None)
+
+
+@core_helper
+def limit_cache_for_page() -> Optional[bool]:
+    return getattr(g, 'limit_cache_for_page', None)
+
+
+@core_helper
+def set_limit_cache_for_page(limit: bool) -> None:
+    g.limit_cache_for_page = limit
+
+
+@core_helper
+def set_cache_level(cache_type: 'CacheType|str',
+                    force: bool = False) -> Optional[CacheType]:
+    """Allow setting the cache without downgrading cache unless forced
+    force: Use with caution for example, downgrading cache to public
+    when logged in can have major side effects"""
+    if isinstance(cache_type, str):
+        try:
+            cache_type = CacheType(cache_type)
+        except ValueError:
+            log.warning("Invalid Cache Type passed in, received %r. Ignoring",
+                        cache_type)
+            return None
+
+    currentCacheType = cache_level()
+
+    if currentCacheType and cache_type:
+        if CacheType.can_override(currentCacheType, cache_type) or force:
+            g.cache_type = cache_type
+    else:
+        g.cache_type = cache_type
+    # log.debug('cacheType set to %r', cache_type)
+    return g.cache_type
+
+
+@core_helper
+def etag_append(append_value: str) -> None:
+    """ Adds additional etag uniqueness, can be called multiple times"""
+    current_value = getattr(g, 'etag_append', "")
+    g.etag_append = current_value + append_value
+
+
+@core_helper
+def set_etag_replace(etag_replace: str) -> None:
+    """ Replace etag with this value, disable etag generation
+    will not append set suffix's or prefix's"""
+    g.etag_replace = etag_replace
+
+
+@core_helper
+def set_etag_modified_time(etag_modified_time: str) -> None:
+    """ Set modified time value on etag instead of current datetime of request.
+    Very useful if you want to key a page to db last modified where
+    other plugins provide their uniqueness constraint via etag_append(str)"""
+    g.etag_modified_time = etag_modified_time

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -105,6 +105,22 @@ class IMiddleware(Interface):
         '''
         return app
 
+    def set_cors_headers_for_response(self, response: Response) -> Optional[Response]:
+        u'''Plugins can return an updated response object to prevent the default CKAN
+            ckan_after_request.set_cors_headers_for_response()
+        '''
+
+    def set_cache_control_headers_for_response(self, response: Response) \
+            -> Optional[Response]:
+        u'''Plugins can return an updated response object to prevent the default CKAN
+            ckan_after_request.set_cache_control_headers_for_response()
+        '''
+
+    def set_etag_for_response(self, response: Response) -> Optional[Response]:
+        u'''Plugins can return an updated response object to prevent the default CKAN
+            ckan_after_request.set_etag_for_response()
+        '''
+
 
 class IDomainObjectModification(Interface):
     u'''

--- a/ckan/public-midnight-blue/base/javascript/client.js
+++ b/ckan/public-midnight-blue/base/javascript/client.js
@@ -38,32 +38,40 @@
      *
      */
     call: function(type, path, data, fn, error) {
-      var url = this.url('/api/action/' + path);
-      var error = ( error == 'undefined' ) ? function() {} : error;
-      var options = {
-        contentType: 'application/json',
-        url: url,
-        dataType: 'json',
-        processData: false,
-        success: fn,
-        error: error
-      };
+      let url = this.url('/api/action/' + path);
+      error = error || function () {};
+
       if (type === 'POST') {
-        ckan.fetchCsrfToken().then(csrf => {
-          options.type = 'POST';
-          options.data = JSON.stringify(data);
-          options.headers = {
-            'X-CSRFToken': csrf.token
-          }
+        return ckan.fetchCsrfToken().then(csrf => {
+          let headers = {};
+          headers[csrf.header] = csrf.token
+          return jQuery.ajax({
+            type: 'POST',
+            contentType: 'application/json',
+            url: url,
+            data: JSON.stringify(data),
+            dataType: 'json',
+            processData: false,
+            success: fn,
+            error: error,
+            headers: headers
+          });
         }).catch((err) => {
           console.error('CSRF token fetch failed:', err);
           if (typeof error === 'function') error(err);
-        })
+          return Promise.reject(err);
+        });
       } else {
-        options.type = 'GET';
-        options.url += data;
+        return jQuery.ajax({
+          type: 'GET',
+          contentType: 'application/json',
+          url: url + data,
+          dataType: 'json',
+          processData: false,
+          success: fn,
+          error: error
+        });
       }
-      jQuery.ajax(options);
     },
 
     /* Fetches the current locale translation from the API.

--- a/ckan/public-midnight-blue/base/javascript/client.js
+++ b/ckan/public-midnight-blue/base/javascript/client.js
@@ -48,14 +48,17 @@
         success: fn,
         error: error
       };
-      if (type == 'POST') {
-        options.type = 'POST';
-        options.data = JSON.stringify(data);
-        var csrf_field = $('meta[name=csrf_field_name]').attr('content');
-        var csrf_token = $('meta[name='+ csrf_field +']').attr('content');
-        options.headers = {
-          'X-CSRFToken': csrf_token
-        }
+      if (type === 'POST') {
+        ckan.fetchCsrfToken().then(csrf => {
+          options.type = 'POST';
+          options.data = JSON.stringify(data);
+          options.headers = {
+            'X-CSRFToken': csrf.token
+          }
+        }).catch((err) => {
+          console.error('CSRF token fetch failed:', err);
+          if (typeof error === 'function') error(err);
+        })
       } else {
         options.type = 'GET';
         options.url += data;

--- a/ckan/public-midnight-blue/base/javascript/csrf-token.js
+++ b/ckan/public-midnight-blue/base/javascript/csrf-token.js
@@ -1,0 +1,54 @@
+(function (ckan) {
+  /* This script collects csrf token for xhr requests, also set meta tags if not found */
+  function getCsrfMetaToken() {
+    var csrfFieldMeta = document.querySelector('meta[name="csrf_field_name"]');
+    if (!csrfFieldMeta) return null;
+
+    var csrfField = csrfFieldMeta.getAttribute('content');
+    var csrfTokenMeta = document.querySelector('meta[name="' + csrfField + '"]');
+    if (!csrfTokenMeta) return null;
+
+    return {name: csrfField, token: csrfTokenMeta.getAttribute('content')};
+  }
+
+  function fetchAndSetCsrfMetaTag() {
+    return new Promise(function (resolve, reject) {
+      var existing = getCsrfMetaToken();
+      if (existing) return resolve(existing);
+
+      var xhr = new XMLHttpRequest();
+      xhr.open('GET', '/csrf-input');
+      xhr.setRequestHeader('Accept', 'application/json');
+      xhr.onreadystatechange = function () {
+        if (xhr.readyState === 4) {
+          if (xhr.status === 200) {
+            var data = JSON.parse(xhr.responseText);
+
+            var head = document.head;
+
+            var csrfFieldMeta = document.querySelector('meta[name="csrf_field_name"]');
+            if (!csrfFieldMeta) {
+              var metaField = document.createElement('meta');
+              metaField.name = 'csrf_field_name';
+              metaField.content = data.name;
+              head.appendChild(metaField);
+            }
+
+            var metaToken = document.createElement('meta');
+            metaToken.name = data.name;
+            metaToken.content = data.value;
+            head.appendChild(metaToken);
+
+            resolve({name: data.name, token: data.value});
+          } else {
+            reject(new Error('Failed to fetch CSRF data: ' + xhr.status));
+          }
+        }
+      };
+      xhr.send();
+    });
+  }
+
+  ckan.fetchCsrfToken = fetchAndSetCsrfMetaTag;
+
+})(this.ckan);

--- a/ckan/public-midnight-blue/base/javascript/csrf-token.js
+++ b/ckan/public-midnight-blue/base/javascript/csrf-token.js
@@ -1,45 +1,50 @@
 (function (ckan) {
-  /* This script collects csrf token for xhr requests, also set meta tags if not found */
+  /* This script collects csrf token for xhr requests, also set meta tags if not found
+   */
+
+  let csrfPromise = null;
+
   function getCsrfMetaToken() {
-    var csrfFieldMeta = document.querySelector('meta[name="csrf_field_name"]');
-    if (!csrfFieldMeta) return null;
+    let csrfFieldMeta = document.querySelector('meta[name="csrf_field_name"]');
+    let csrfHeaderMeta = document.querySelector('meta[name="csrf_header_name"]');
+    if (!csrfFieldMeta || !csrfHeaderMeta) return null;
 
-    var csrfField = csrfFieldMeta.getAttribute('content');
-    var csrfTokenMeta = document.querySelector('meta[name="' + csrfField + '"]');
-    if (!csrfTokenMeta) return null;
+    let csrfField = csrfFieldMeta.getAttribute('content');
+    let csrfHeader = csrfHeaderMeta.getAttribute('content');
 
-    return {name: csrfField, token: csrfTokenMeta.getAttribute('content')};
+    let csrfTokenMeta = document.querySelector('meta[name="' + csrfField + '"]');
+    if (!csrfTokenMeta) {
+      return null;
+    }
+    let token = csrfTokenMeta.getAttribute('content');
+    return {name: csrfField, header: csrfHeader, token: token};
   }
 
   function fetchAndSetCsrfMetaTag() {
-    return new Promise(function (resolve, reject) {
-      var existing = getCsrfMetaToken();
-      if (existing) return resolve(existing);
+    if (csrfPromise) return csrfPromise;
 
+    csrfPromise = new Promise(function (resolve, reject) {
+      var existing = getCsrfMetaToken();
+      if (existing)  {
+        return resolve(existing);
+      }
+
+      // If the meta tag is not found, we need to fetch it from the server
       var xhr = new XMLHttpRequest();
       xhr.open('GET', '/csrf-input');
       xhr.setRequestHeader('Accept', 'application/json');
       xhr.onreadystatechange = function () {
         if (xhr.readyState === 4) {
           if (xhr.status === 200) {
-            var data = JSON.parse(xhr.responseText);
+            let data = JSON.parse(xhr.responseText);
+            let head = document.head;
 
-            var head = document.head;
-
-            var csrfFieldMeta = document.querySelector('meta[name="csrf_field_name"]');
-            if (!csrfFieldMeta) {
-              var metaField = document.createElement('meta');
-              metaField.name = 'csrf_field_name';
-              metaField.content = data.name;
-              head.appendChild(metaField);
-            }
-
-            var metaToken = document.createElement('meta');
+            let metaToken = document.createElement('meta');
             metaToken.name = data.name;
-            metaToken.content = data.value;
+            metaToken.content = data.token;
             head.appendChild(metaToken);
 
-            resolve({name: data.name, token: data.value});
+            resolve({name: data.name,  header: data.header, token: data.token});
           } else {
             reject(new Error('Failed to fetch CSRF data: ' + xhr.status));
           }
@@ -47,8 +52,16 @@
       };
       xhr.send();
     });
+
+    return csrfPromise;
+  }
+
+  function csrfSafeMethod(method) {
+    // these HTTP methods do not require CSRF protection
+    return (/^(GET|HEAD|OPTIONS)$/.test(method));
   }
 
   ckan.fetchCsrfToken = fetchAndSetCsrfMetaTag;
+  ckan.csrfSafeMethod = csrfSafeMethod;
 
 })(this.ckan);

--- a/ckan/public-midnight-blue/base/javascript/webassets.yml
+++ b/ckan/public-midnight-blue/base/javascript/webassets.yml
@@ -20,6 +20,7 @@ main:
     - sandbox.js
     - module.js
     - pubsub.js
+    - csrf-token.js
     - client.js
     - i18n.js
     - notify.js

--- a/ckan/public/base/javascript/client.js
+++ b/ckan/public/base/javascript/client.js
@@ -38,32 +38,40 @@
      *
      */
     call: function(type, path, data, fn, error) {
-      var url = this.url('/api/action/' + path);
-      var error = ( error == 'undefined' ) ? function() {} : error;
-      var options = {
-        contentType: 'application/json',
-        url: url,
-        dataType: 'json',
-        processData: false,
-        success: fn,
-        error: error
-      };
+      let url = this.url('/api/action/' + path);
+      error = error || function () {};
+
       if (type === 'POST') {
-        ckan.fetchCsrfToken().then(csrf => {
-          options.type = 'POST';
-          options.data = JSON.stringify(data);
-          options.headers = {
-            'X-CSRFToken': csrf.token
-          }
+        return ckan.fetchCsrfToken().then(csrf => {
+          let headers = {};
+          headers[csrf.header] = csrf.token
+          return jQuery.ajax({
+            type: 'POST',
+            contentType: 'application/json',
+            url: url,
+            data: JSON.stringify(data),
+            dataType: 'json',
+            processData: false,
+            success: fn,
+            error: error,
+            headers: headers
+          });
         }).catch((err) => {
           console.error('CSRF token fetch failed:', err);
           if (typeof error === 'function') error(err);
-        })
+          return Promise.reject(err);
+        });
       } else {
-        options.type = 'GET';
-        options.url += data;
+        return jQuery.ajax({
+          type: 'GET',
+          contentType: 'application/json',
+          url: url + data,
+          dataType: 'json',
+          processData: false,
+          success: fn,
+          error: error
+        });
       }
-      jQuery.ajax(options);
     },
 
     /* Fetches the current locale translation from the API.

--- a/ckan/public/base/javascript/client.js
+++ b/ckan/public/base/javascript/client.js
@@ -48,14 +48,17 @@
         success: fn,
         error: error
       };
-      if (type == 'POST') {
-        options.type = 'POST';
-        options.data = JSON.stringify(data);
-        var csrf_field = $('meta[name=csrf_field_name]').attr('content');
-        var csrf_token = $('meta[name='+ csrf_field +']').attr('content');
-        options.headers = {
-          'X-CSRFToken': csrf_token
-        }
+      if (type === 'POST') {
+        ckan.fetchCsrfToken().then(csrf => {
+          options.type = 'POST';
+          options.data = JSON.stringify(data);
+          options.headers = {
+            'X-CSRFToken': csrf.token
+          }
+        }).catch((err) => {
+          console.error('CSRF token fetch failed:', err);
+          if (typeof error === 'function') error(err);
+        })
       } else {
         options.type = 'GET';
         options.url += data;

--- a/ckan/public/base/javascript/csrf-token.js
+++ b/ckan/public/base/javascript/csrf-token.js
@@ -1,43 +1,50 @@
 (function (ckan) {
   /* This script collects csrf token for xhr requests, also set meta tags if not found
    */
+
+  let csrfPromise = null;
+
   function getCsrfMetaToken() {
-    var csrfFieldMeta = document.querySelector('meta[name="csrf_field_name"]');
-    if (!csrfFieldMeta) return null;
+    let csrfFieldMeta = document.querySelector('meta[name="csrf_field_name"]');
+    let csrfHeaderMeta = document.querySelector('meta[name="csrf_header_name"]');
+    if (!csrfFieldMeta || !csrfHeaderMeta) return null;
 
-    var csrfField = csrfFieldMeta.getAttribute('content');
-    var csrfTokenMeta = document.querySelector('meta[name="' + csrfField + '"]');
-    if (!csrfTokenMeta) return null;
+    let csrfField = csrfFieldMeta.getAttribute('content');
+    let csrfHeader = csrfHeaderMeta.getAttribute('content');
 
-    return {name: csrfField, token: csrfTokenMeta.getAttribute('content')};
+    let csrfTokenMeta = document.querySelector('meta[name="' + csrfField + '"]');
+    if (!csrfTokenMeta) {
+      return null;
+    }
+    let token = csrfTokenMeta.getAttribute('content');
+    return {name: csrfField, header: csrfHeader, token: token};
   }
 
   function fetchAndSetCsrfMetaTag() {
-    return new Promise(function (resolve, reject) {
-      var existing = getCsrfMetaToken();
-      if (existing) return resolve(existing);
+    if (csrfPromise) return csrfPromise;
 
+    csrfPromise = new Promise(function (resolve, reject) {
+      var existing = getCsrfMetaToken();
+      if (existing)  {
+        return resolve(existing);
+      }
+
+      // If the meta tag is not found, we need to fetch it from the server
       var xhr = new XMLHttpRequest();
       xhr.open('GET', '/csrf-input');
       xhr.setRequestHeader('Accept', 'application/json');
       xhr.onreadystatechange = function () {
         if (xhr.readyState === 4) {
           if (xhr.status === 200) {
-            var data = JSON.parse(xhr.responseText);
+            let data = JSON.parse(xhr.responseText);
+            let head = document.head;
 
-            var head = document.head;
-
-            var metaField = document.createElement('meta');
-            metaField.name = 'csrf_field_name';
-            metaField.content = data.name;
-            head.appendChild(metaField);
-
-            var metaToken = document.createElement('meta');
+            let metaToken = document.createElement('meta');
             metaToken.name = data.name;
-            metaToken.content = data.value;
+            metaToken.content = data.token;
             head.appendChild(metaToken);
 
-            resolve({name: data.name, token: data.value});
+            resolve({name: data.name,  header: data.header, token: data.token});
           } else {
             reject(new Error('Failed to fetch CSRF data: ' + xhr.status));
           }
@@ -45,8 +52,16 @@
       };
       xhr.send();
     });
+
+    return csrfPromise;
+  }
+
+  function csrfSafeMethod(method) {
+    // these HTTP methods do not require CSRF protection
+    return (/^(GET|HEAD|OPTIONS)$/.test(method));
   }
 
   ckan.fetchCsrfToken = fetchAndSetCsrfMetaTag;
+  ckan.csrfSafeMethod = csrfSafeMethod;
 
 })(this.ckan);

--- a/ckan/public/base/javascript/csrf-token.js
+++ b/ckan/public/base/javascript/csrf-token.js
@@ -1,0 +1,52 @@
+(function (ckan) {
+  /* This script collects csrf token for xhr requests, also set meta tags if not found
+   */
+  function getCsrfMetaToken() {
+    var csrfFieldMeta = document.querySelector('meta[name="csrf_field_name"]');
+    if (!csrfFieldMeta) return null;
+
+    var csrfField = csrfFieldMeta.getAttribute('content');
+    var csrfTokenMeta = document.querySelector('meta[name="' + csrfField + '"]');
+    if (!csrfTokenMeta) return null;
+
+    return {name: csrfField, token: csrfTokenMeta.getAttribute('content')};
+  }
+
+  function fetchAndSetCsrfMetaTag() {
+    return new Promise(function (resolve, reject) {
+      var existing = getCsrfMetaToken();
+      if (existing) return resolve(existing);
+
+      var xhr = new XMLHttpRequest();
+      xhr.open('GET', '/csrf-input');
+      xhr.setRequestHeader('Accept', 'application/json');
+      xhr.onreadystatechange = function () {
+        if (xhr.readyState === 4) {
+          if (xhr.status === 200) {
+            var data = JSON.parse(xhr.responseText);
+
+            var head = document.head;
+
+            var metaField = document.createElement('meta');
+            metaField.name = 'csrf_field_name';
+            metaField.content = data.name;
+            head.appendChild(metaField);
+
+            var metaToken = document.createElement('meta');
+            metaToken.name = data.name;
+            metaToken.content = data.value;
+            head.appendChild(metaToken);
+
+            resolve({name: data.name, token: data.value});
+          } else {
+            reject(new Error('Failed to fetch CSRF data: ' + xhr.status));
+          }
+        }
+      };
+      xhr.send();
+    });
+  }
+
+  ckan.fetchCsrfToken = fetchAndSetCsrfMetaTag;
+
+})(this.ckan);

--- a/ckan/public/base/javascript/webassets.yml
+++ b/ckan/public/base/javascript/webassets.yml
@@ -20,6 +20,7 @@ main:
     - sandbox.js
     - module.js
     - pubsub.js
+    - csrf-token.js
     - client.js
     - i18n.js
     - notify.js

--- a/ckan/templates-midnight-blue/base.html
+++ b/ckan/templates-midnight-blue/base.html
@@ -24,9 +24,7 @@
     #}
     {%- block meta -%}
       <meta charset="utf-8" />
-      <meta name="csrf_field_name" content="{{ g.csrf_field_name }}" />
-      <meta name="{{ g.csrf_field_name }}" content="{{ csrf_token() }}" />
-
+      {% include 'snippets/csrf_meta.html' %}
       {% block meta_generator %}<meta name="generator" content="ckan {{ h.ckan_version() }}" />{% endblock %}
       {% block meta_viewport %}<meta name="viewport" content="width=device-width, initial-scale=1.0">{% endblock %}
     {%- endblock -%}

--- a/ckan/templates-midnight-blue/snippets/csrf_input.html
+++ b/ckan/templates-midnight-blue/snippets/csrf_input.html
@@ -1,2 +1,4 @@
 {# Adds a csrf_token to the forms as a hidden input. #}
+{% if g.csrf_enabled %}
 <input type="hidden" name="{{ g.csrf_field_name }}" value="{{ csrf_token() }}"/>
+{% endif %}

--- a/ckan/templates-midnight-blue/snippets/csrf_meta.html
+++ b/ckan/templates-midnight-blue/snippets/csrf_meta.html
@@ -1,6 +1,7 @@
 {#- Adds a csrf_token to meta for javascript usage. -#}
 {%- block csrf_meta -%}
       <meta name="csrf_field_name" content="{{ g.csrf_field_name }}" />
+      <meta name="csrf_header_name" content="{{ g.csrf_header_name }}" />
 {%- if g.csrf_enabled and h.csrf_session_enabled() %}
 {#- only add when session is in use, if not found xhr will need to lookup /csrf-input for csrf token #}
       <meta name="{{ g.csrf_field_name }}" content="{{ csrf_token() }}" />

--- a/ckan/templates-midnight-blue/snippets/csrf_meta.html
+++ b/ckan/templates-midnight-blue/snippets/csrf_meta.html
@@ -1,0 +1,12 @@
+{#- Adds a csrf_token to meta for javascript usage. -#}
+{%- block csrf_meta -%}
+      <meta name="csrf_field_name" content="{{ g.csrf_field_name }}" />
+{%- if g.csrf_enabled and h.csrf_session_enabled() %}
+{#- only add when session is in use, if not found xhr will need to lookup /csrf-input for csrf token #}
+      <meta name="{{ g.csrf_field_name }}" content="{{ csrf_token() }}" />
+{%- else -%}
+  {%- if g.debug -%}
+        <!-- csrf session not available at render -->
+  {%- endif -%}
+{%- endif -%}
+{%- endblock -%}

--- a/ckan/templates-midnight-blue/snippets/language_selector.html
+++ b/ckan/templates-midnight-blue/snippets/language_selector.html
@@ -1,6 +1,5 @@
 {% set current_lang = request.environ.CKAN_LANG %}
-<form class="lang-select" action="{% url_for 'util.internal_redirect' %}" data-module="select-switch" method="POST">
-  {{ h.csrf_input() }}
+<form class="lang-select" action="{% url_for 'util.internal_redirect' %}" data-module="select-switch" method="GET">
   <div class="form-group">
     <label for="field-lang-select">{{ _('Language') }}</label>
     <select id="field-lang-select" name="url" data-module="autocomplete" data-module-dropdown-class="lang-dropdown" data-module-container-class="lang-container">

--- a/ckan/templates/base.html
+++ b/ckan/templates/base.html
@@ -24,9 +24,7 @@
     #}
     {%- block meta -%}
       <meta charset="utf-8" />
-      <meta name="csrf_field_name" content="{{ g.csrf_field_name }}" />
-      <meta name="{{ g.csrf_field_name }}" content="{{ csrf_token() }}" />
-
+      {% include 'snippets/csrf_meta.html' %}
       {% block meta_generator %}<meta name="generator" content="ckan {{ h.ckan_version() }}" />{% endblock %}
       {% block meta_viewport %}<meta name="viewport" content="width=device-width, initial-scale=1.0">{% endblock %}
     {%- endblock -%}

--- a/ckan/templates/snippets/csrf_input.html
+++ b/ckan/templates/snippets/csrf_input.html
@@ -1,2 +1,4 @@
 {# Adds a csrf_token to the forms as a hidden input. #}
+{% if g.csrf_enabled %}
 <input type="hidden" name="{{ g.csrf_field_name }}" value="{{ csrf_token() }}"/>
+{% endif %}

--- a/ckan/templates/snippets/csrf_meta.html
+++ b/ckan/templates/snippets/csrf_meta.html
@@ -1,6 +1,7 @@
 {#- Adds a csrf_token to meta for javascript usage. -#}
 {%- block csrf_meta -%}
       <meta name="csrf_field_name" content="{{ g.csrf_field_name }}" />
+      <meta name="csrf_header_name" content="{{ g.csrf_header_name }}" />
 {%- if g.csrf_enabled and h.csrf_session_enabled() %}
 {#- only add when session is in use, if not found xhr will need to lookup /csrf-input for csrf token #}
       <meta name="{{ g.csrf_field_name }}" content="{{ csrf_token() }}" />

--- a/ckan/templates/snippets/csrf_meta.html
+++ b/ckan/templates/snippets/csrf_meta.html
@@ -1,0 +1,12 @@
+{#- Adds a csrf_token to meta for javascript usage. -#}
+{%- block csrf_meta -%}
+      <meta name="csrf_field_name" content="{{ g.csrf_field_name }}" />
+{%- if g.csrf_enabled and h.csrf_session_enabled() %}
+{#- only add when session is in use, if not found xhr will need to lookup /csrf-input for csrf token #}
+      <meta name="{{ g.csrf_field_name }}" content="{{ csrf_token() }}" />
+{%- else -%}
+  {%- if g.debug -%}
+        <!-- csrf session not available at render -->
+  {%- endif -%}
+{%- endif -%}
+{%- endblock -%}

--- a/ckan/templates/snippets/language_selector.html
+++ b/ckan/templates/snippets/language_selector.html
@@ -1,6 +1,5 @@
 {% set current_lang = request.environ.CKAN_LANG %}
-<form class="lang-select" action="{% url_for 'util.internal_redirect' %}" data-module="select-switch" method="POST">
-  {{ h.csrf_input() }}
+<form class="lang-select" action="{% url_for 'util.internal_redirect' %}" data-module="select-switch" method="GET">
   <div class="form-group">
     <label for="field-lang-select">{{ _('Language') }}</label>
     <select id="field-lang-select" name="url" data-module="autocomplete" data-module-dropdown-class="lang-dropdown" data-module-container-class="lang-container">

--- a/ckan/tests/config/test_sessions.py
+++ b/ckan/tests/config/test_sessions.py
@@ -103,12 +103,26 @@ class TestSessionTypes:
         redis = connect_to_redis()
 
         assert not redis.keys("*")
-        response = app.get("/")
+        # A page that sets session
+        response = app.get("/user/login")
 
         cookie = re.match(r'ckan=([^;]+)', response.headers['set-cookie'])
         assert cookie
 
         assert redis.keys("*") == [f"session:{cookie.group(1)}".encode()]
+
+    @pytest.mark.usefixtures("clean_redis")
+    @pytest.mark.ckan_config("SESSION_TYPE", "redis")
+    def test_redis_storage_no_session(self, app, monkeypatch):
+        """Redis session interface creates a record in redis upon request.
+        """
+        redis = connect_to_redis()
+
+        assert not redis.keys("*")
+        # A request that has no session
+        response = app.get("/")
+        assert 'Set-Cookie' not in response.headers
+        assert not redis.keys("*")
 
     @pytest.mark.usefixtures("test_request_context")
     def test_cookie_storage(self, app, user_factory, faker):

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -883,9 +883,11 @@ class TestCSRFToken:
         response = app.get(url_for("util.csrf_input"))
         csrf_object = json.loads(response.get_data(as_text=True))
         assert 'name' in csrf_object
-        assert 'value' in csrf_object
+        assert 'token' in csrf_object
+        assert 'header' in csrf_object
         assert csrf_object["name"] == '_csrf_token'
-        assert csrf_object["value"] is not None
+        assert csrf_object["header"] == 'X-CSRFToken'
+        assert csrf_object["token"] is not None
 
     def test_csrf_token_tags_get_render(self, app: helpers.CKANTestApp):
         # init single client so cookies persist between calls

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -1,4 +1,5 @@
 # encoding: utf-8
+import json
 import unittest.mock as mock
 import pytest
 from bs4 import BeautifulSoup
@@ -111,7 +112,7 @@ def sysadmin():
 class TestUser(object):
 
     @pytest.mark.ckan_config("ckan.auth.create_user_via_web", True)
-    def test_register_a_user(self, app):
+    def test_register_a_user(self, app: helpers.CKANTestApp):
         url = url_for("user.register")
         stub = factories.User.stub()
         response = app.post(
@@ -878,29 +879,62 @@ class TestUserImage(object):
 
 @pytest.mark.usefixtures("clean_db")
 class TestCSRFToken:
-    def test_csrf_token_tags_get_render(self, app):
-        response = app.get(url_for("home.index"))
+    def test_csrf_token_get_rest_endpoint(self, app: helpers.CKANTestApp):
+        response = app.get(url_for("util.csrf_input"))
+        csrf_object = json.loads(response.get_data(as_text=True))
+        assert 'name' in csrf_object
+        assert 'value' in csrf_object
+        assert csrf_object["name"] == '_csrf_token'
+        assert csrf_object["value"] is not None
+
+    def test_csrf_token_tags_get_render(self, app: helpers.CKANTestApp):
+        # init single client so cookies persist between calls
+        client = app.test_client()
+        response = client.get(url_for("user.login"))
+
         assert '<meta name="csrf_field_name"' in response.body
+        assert '<meta name="_csrf_token"' not in response.body
+
+        response = client.get(url_for("user.login"))
+        response = client.get(url_for("user.login"))
+        assert '<meta name="csrf_field_name" content="_csrf_token" />' in response.body
         assert '<meta name="_csrf_token"' in response.body
 
-    def test_csrf_tags_contains_values(self, app):
-        response = app.get(url_for("home.index"))
+    def test_csrf_tags_contains_values(self, app: helpers.CKANTestApp):
+        # init single client so cookies persist between calls
+        client = app.test_client()
+        response = client.get(url_for("user.login"))
+        res_html = BeautifulSoup(response.data)
+        csrf_input_token = res_html.select_one("input[type='hidden'][name='_csrf_token']")
+        assert csrf_input_token.attrs["value"] is not None
+        csrf_value = csrf_input_token.attrs["value"]
+
+        response = client.get(url_for("user.login"))
         res_html = BeautifulSoup(response.data)
         # Using the same selector as CKAN client.js
         csrf_field_name = res_html.select_one("meta[name=csrf_field_name]")
         assert csrf_field_name.attrs["content"] == "_csrf_token"
         csrf_token = res_html.select_one("meta[name=_csrf_token]")
-        assert csrf_token.attrs["content"] is not None
+        assert csrf_token.attrs["content"] == csrf_value
 
     @pytest.mark.ckan_config("WTF_CSRF_FIELD_NAME", "new_name")
-    def test_csrf_config_option_contains_values(self, app):
-        response = app.get(url_for("home.index"))
+    def test_csrf_config_option_contains_values(self, app: helpers.CKANTestApp):
+        # init single client so cookies persist between calls
+        client = app.test_client()
+        response = client.get(url_for("user.login"))
+
+        res_html = BeautifulSoup(response.data)
+        csrf_input_token = res_html.select_one("input[type='hidden'][name='new_name']")
+        assert csrf_input_token.attrs["value"] is not None
+        csrf_value = csrf_input_token.attrs["value"]
+
+        response = client.get(url_for("user.login"))
         res_html = BeautifulSoup(response.data)
 
         csrf_field_name = res_html.select_one("meta[name=csrf_field_name]")
         assert csrf_field_name.attrs["content"] == "new_name"
         csrf_token = res_html.select_one("meta[name=new_name]")
-        assert csrf_token.attrs["content"] is not None
+        assert csrf_token.attrs["content"] == csrf_value
 
     def test_csrf_token_in_g_object(self, app):
         password = "RandomPassword123"

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -128,6 +128,8 @@ class TestUser(object):
         )
 
         assert 200 == response.status_code
+        assert response.get_etag(), response
+        assert response.cache_control.to_header() == 'must-understand, no-cache, max-age=0, no-store'
 
         user = helpers.call_action("user_show", id=stub.name)
         assert user["name"] == stub.name

--- a/ckan/tests/lib/test_base.py
+++ b/ckan/tests/lib/test_base.py
@@ -1,9 +1,11 @@
 # encoding: utf-8
+import json
 
 import pytest
 
 import ckan.tests.factories as factories
 import ckan.lib.helpers as h
+from ckan.tests.helpers import CKANTestApp
 
 
 def test_apitoken_missing(app):
@@ -440,59 +442,100 @@ def test_cors_config_origin_allow_all_false_with_whitelist_not_containing_origin
     assert "Access-Control-Allow-Headers" not in response_headers
 
 
-@pytest.mark.ckan_config('ckan.cache_enabled', 'false')
-def test_cache_control_in_when_cache_is_not_enabled(app):
+# Disable CSRF so we have a known session state
+@pytest.mark.ckan_config("WTF_CSRF_ENABLED", False)
+@pytest.mark.ckan_config('ckan.cache.public.enabled', False)
+@pytest.mark.ckan_config('ckan.cache.private.enabled', True)
+def test_cache_control_in_when_public_cache_is_not_enabled(app: CKANTestApp):
     request_headers = {}
     response = app.get('/', headers=request_headers)
-    response_headers = dict(response.headers)
 
-    assert 'Cache-Control' in response_headers
-    assert response_headers['Cache-Control'] == 'private'
+    assert 'Cache-Control' in response.headers
+    assert 'Set-Cookie' not in response.headers
+    assert response.headers['Cache-Control'] == 'must-understand, private, max-age=60, stale-while-revalidate=3600, stale-if-error=86400'
 
 
-@pytest.mark.ckan_config('ckan.cache_enabled', 'true')
-def test_cache_control_when_cache_enabled(app):
+# Disable CSRF so we have a known session state
+@pytest.mark.ckan_config("WTF_CSRF_ENABLED", False)
+@pytest.mark.ckan_config('ckan.cache.public.enabled', True)
+def test_cache_control_when_cache_enabled(app: CKANTestApp):
     request_headers = {}
     response = app.get('/', headers=request_headers)
-    response_headers = dict(response.headers)
 
-    assert 'Cache-Control' in response_headers
-    assert 'public' in response_headers['Cache-Control']
+    assert 'Cache-Control' in response.headers
+    assert 'Set-Cookie' not in response.headers
+    assert ('must-understand, public, max-age=3600, s-maxage=7200, stale-while-revalidate=3600, stale-if-error=86400'
+            == response.headers['Cache-Control'])
 
 
-@pytest.mark.ckan_config('ckan.cache_enabled', 'true')
-@pytest.mark.ckan_config('ckan.cache_expires', 300)
-def test_cache_control_max_age_when_cache_enabled(app):
+# Disable CSRF so we have a known session state
+@pytest.mark.ckan_config("WTF_CSRF_ENABLED", False)
+@pytest.mark.ckan_config('ckan.cache.public.enabled', True)
+@pytest.mark.ckan_config('ckan.cache.expires', 300)
+def test_cache_control_max_age_when_cache_enabled(app: CKANTestApp):
     request_headers = {}
     response = app.get('/', headers=request_headers)
-    response_headers = dict(response.headers)
+
+    response_headers = response.headers
 
     assert 'Cache-Control' in response_headers
     assert 'public' in response_headers['Cache-Control']
     assert 'max-age=300' in response_headers['Cache-Control']
 
 
-@pytest.mark.ckan_config('ckan.cache_enabled', None)
-def test_cache_control_when_cache_is_not_set_in_config(app):
+@pytest.mark.ckan_config('ckan.cache.public.enabled', 'true')
+@pytest.mark.ckan_config('ckan.cache.private.enabled', 'true')
+def test_cache_control_while_logged_in(app: CKANTestApp):
+    # Collect client, so cookies persist for session
+    client = app.test_client()
+    user = factories.User(fullname="Logged-In-User", password="correct123")
+
+    # get csrf input token via rest endpoint (also sets session cookie)
+    csrf_object = json.loads(
+        client.get(h.url_for("util.csrf_input"),
+                   headers={"Origin": "http://test.ckan.net",
+                            "Accept": "application/json"})
+        .get_data(as_text=True))
+
+    identity = {"login": user["name"], "password": "correct123", csrf_object["name"]: csrf_object["token"]}
+    response = client.post(h.url_for("user.login"), data=identity)
+
+    # Verify we did log in
+    assert "Logged-In-User" in response.get_data(as_text=True)
+
+    # test client is too helpful and will automatically follow redirects for us,
+    # need to look up response history for 302 header checks
+    assert len(response.history) == 1
+    assert 'Cache-Control' in response.history[0].headers
+    assert response.history[0].headers['Cache-Control'] == 'must-understand, no-cache, max-age=0, no-store'
+    assert 'Set-Cookie' in response.history[0].headers.keys()
+
+    # Now test the page we were redirected to
+    assert 'Set-Cookie' not in response.headers.keys()
+    assert 'Cache-Control' in response.headers
+    assert response.headers['Cache-Control'] == 'must-understand, private, max-age=60, stale-while-revalidate=3600, stale-if-error=86400'
+
+
+# Disable CSRF so we have a known session state
+@pytest.mark.ckan_config("WTF_CSRF_ENABLED", False)
+@pytest.mark.ckan_config('ckan.cache.public.enabled', True)
+@pytest.mark.ckan_config('ckan.cache.private.enabled', False)
+def test_cache_control_while_logged_in_private_cache_disable(app: CKANTestApp):
     request_headers = {}
     response = app.get('/', headers=request_headers)
-    response_headers = dict(response.headers)
 
-    assert 'Cache-Control' in response_headers
-    assert response_headers['Cache-Control'] == 'private'
+    assert 'Cache-Control' in response.headers
+    assert ('must-understand, public, max-age=3600, s-maxage=7200, stale-while-revalidate=3600, stale-if-error=86400'
+            == response.headers['Cache-Control'])
 
-
-@pytest.mark.ckan_config('ckan.cache_enabled', 'true')
-def test_cache_control_while_logged_in(app):
-    from ckan.lib.helpers import url_for
     user = factories.User(password="correct123")
     identity = {"login": user["name"], "password": "correct123"}
     request_headers = {}
 
     response = app.post(
-        url_for("user.login"), data=identity, headers=request_headers
+        h.url_for("user.login"), data=identity, headers=request_headers
     )
     response_headers = dict(response.headers)
 
     assert 'Cache-Control' in response_headers
-    assert response_headers['Cache-Control'] == 'private'
+    assert response_headers['Cache-Control'] == 'must-understand, no-cache, max-age=0, no-store'

--- a/ckan/tests/pytest_ckan/fixtures.py
+++ b/ckan/tests/pytest_ckan/fixtures.py
@@ -440,7 +440,7 @@ def with_plugins(ckan_config):
 
 
 @pytest.fixture
-def test_request_context(app):
+def test_request_context(app: test_helpers.CKANTestApp):
     """Provide function for creating Flask request context.
     """
     return app.flask_app.test_request_context

--- a/ckan/tests/views/test_cache.py
+++ b/ckan/tests/views/test_cache.py
@@ -1,0 +1,312 @@
+import pytest
+import re
+
+from flask import Request, Response
+from werkzeug.test import EnvironBuilder
+from ckan.common import request, CacheType, session, g
+from ckan.lib import helpers as h, base
+
+from ckan.tests.helpers import CKANTestApp
+from werkzeug.test import TestResponse
+
+import ckan.views as views
+
+field_name = '_csrf_token'  # emulate WTF_CSRF_FIELD_NAME for regex verification check
+pattern = fr'(?i)((?:_csrf_token|{field_name})[^>]*?\b(?:content|value)=|\bnonce=)["\'][^"\']+(["\'])'  # noqa: E501
+
+
+def clean_dynamic_values(text):
+    return re.sub(pattern, lambda m: m.group(1) + '="etag_removed"', text)
+
+
+@pytest.mark.ckan_config("WTF_CSRF_ENABLED", False)
+def test_sets_cache_control_headers_default(app: CKANTestApp):
+    """Test that cache control headers are set correctly when caching is allowed."""
+
+    builder = EnvironBuilder(path='/', method='GET', headers={}, environ_overrides={})
+    env = builder.get_environ()
+    Request(env)
+    response = Response()  # dummy response
+
+    with app.flask_app.request_context(env):  # only works if you have app.flask_app
+        g.__session_was_empty = True
+        h.set_cache_level(CacheType.PUBLIC)
+        updated_response = views.set_cache_control_headers_for_response(response)
+    assert ('must-understand, public, max-age=3600, s-maxage=7200, stale-while-revalidate=3600, stale-if-error=86400' ==
+            updated_response.headers['Cache-Control'])
+
+
+@pytest.mark.ckan_config("WTF_CSRF_ENABLED", False)
+@pytest.mark.ckan_config("ckan.cache.expires", 3600)
+def test_sets_cache_control_headers_cache_expires(app: CKANTestApp):
+    """Test that cache control headers are set correctly when caching is allowed with override on max-age."""
+
+    builder = EnvironBuilder(path='/', method='GET', headers={})
+    env = builder.get_environ()
+    Request(env)
+    response = Response()  # dummy response
+
+    with app.flask_app.request_context(env):  # only works if you have app.flask_app
+        g.__session_was_empty = True
+        h.set_cache_level(CacheType.PUBLIC, True)
+        updated_response = views.set_cache_control_headers_for_response(response)
+    assert ('must-understand, public, max-age=3600, s-maxage=7200, stale-while-revalidate=3600, stale-if-error=86400'
+            == updated_response.headers['Cache-Control'])
+
+
+@pytest.mark.ckan_config("WTF_CSRF_ENABLED", False)
+@pytest.mark.ckan_config("ckan.cache.shared.expires", 1)
+def test_sets_cache_control_headers_shared_cache_expires(app: CKANTestApp):
+    """Test that cache control headers are set correctly when caching is allowed with override on max-age."""
+
+    builder = EnvironBuilder(path='/', method='GET', headers={})
+    env = builder.get_environ()
+    Request(env)
+    response = Response()  # dummy response
+
+    with app.flask_app.request_context(env):  # only works if you have app.flask_app
+        g.__session_was_empty = True
+        assert h.set_cache_level(CacheType.PUBLIC, True) is CacheType.PUBLIC
+        updated_response = views.set_cache_control_headers_for_response(response)
+    assert ('must-understand, public, max-age=3600, s-maxage=1, stale-while-revalidate=3600, stale-if-error=86400'
+            == updated_response.headers['Cache-Control'])
+
+
+@pytest.mark.ckan_config("WTF_CSRF_ENABLED", False)
+@pytest.mark.ckan_config("ckan.cache.stale_while_revalidates", 1)
+@pytest.mark.ckan_config("ckan.cache.stale_if_error", 2)
+def test_sets_cache_control_headers_stale_config_settings(app: CKANTestApp):
+    """Test that cache control headers are set correctly when caching is allowed with override on max-age."""
+
+    builder = EnvironBuilder(path='/', method='GET', headers={})
+    env = builder.get_environ()
+    Request(env)
+    response = Response()  # dummy response
+
+    with app.flask_app.request_context(env):  # only works if you have app.flask_app
+        g.__session_was_empty = True
+        assert h.set_cache_level(CacheType.PUBLIC, True)
+        updated_response = views.set_cache_control_headers_for_response(response)
+    assert ('must-understand, public, max-age=3600, s-maxage=7200, stale-while-revalidate=1, stale-if-error=2'
+            == updated_response.headers['Cache-Control'])
+
+
+@pytest.mark.ckan_config("WTF_CSRF_ENABLED", False)
+@pytest.mark.ckan_config("ckan.cache.stale_while_revalidates", 0)
+@pytest.mark.ckan_config("ckan.cache.stale_if_error", 0)
+def test_sets_cache_control_headers_stale_config_settings_disable(app: CKANTestApp):
+    """Test that cache control headers are set correctly when caching is allowed with override on max-age."""
+
+    builder = EnvironBuilder(path='/', method='GET', headers={})
+    env = builder.get_environ()
+    Request(env)
+    response = Response()  # dummy response
+
+    with app.flask_app.request_context(env):  # only works if you have app.flask_app
+        g.__session_was_empty = True
+        assert h.set_cache_level(CacheType.PUBLIC, True)
+        updated_response = views.set_cache_control_headers_for_response(response)
+    assert 'must-understand, public, max-age=3600, s-maxage=7200, must-revalidate' == updated_response.headers['Cache-Control']
+
+
+@pytest.mark.ckan_config("ckan.cache.private.expires", 1234)
+def test_sets_cache_control_headers_private_cache_expires(app: CKANTestApp):
+    """Test that cache control headers are set correctly when caching is allowed with override on max-age."""
+
+    builder = EnvironBuilder(path='/', method='GET', headers={})
+    env = builder.get_environ()
+    Request(env)
+    response = Response()  # dummy response
+
+    with app.flask_app.request_context(env):  # only works if you have app.flask_app
+        g.__session_was_empty = False
+        assert h.set_cache_level(CacheType.PRIVATE, True)
+        updated_response = views.set_cache_control_headers_for_response(response)
+    assert 'must-understand, private, max-age=1234, stale-while-revalidate=3600, stale-if-error=86400' == updated_response.headers['Cache-Control']
+
+
+@pytest.mark.ckan_config("WTF_CSRF_ENABLED", False)
+@pytest.mark.ckan_config("ckan.cache.public.enabled", False)
+def test_cache_enabled_false_defaults_to_private(app: CKANTestApp):
+    """Test that cache control headers are set correctly when caching is allowed with override on max-age."""
+    builder = EnvironBuilder(path='/', method='GET')
+    env = builder.get_environ()
+    Request(env)
+    response = Response()  # dummy response
+
+    with app.flask_app.request_context(env):  # only works if you have app.flask_app
+        g.__session_was_empty = True
+        session.accessed = False
+        session.modified = False  # CSRF is getting in the way of testing public overrides, disable session for now
+        base._allow_caching()
+        assert h.cache_level() == CacheType.PRIVATE
+        updated_response = views.set_cache_control_headers_for_response(response)
+    assert 'must-understand, private, max-age=60, stale-while-revalidate=3600, stale-if-error=86400' == updated_response.headers['Cache-Control']
+
+
+@pytest.mark.ckan_config("WTF_CSRF_ENABLED", False)
+@pytest.mark.ckan_config("ckan.cache.public.enabled", False)
+@pytest.mark.ckan_config("ckan.cache.private.enabled", False)
+def test_cache_enabled_false_private_enabled_false_defaults_to_no_cache(app: CKANTestApp):
+    """Test that cache control headers are set correctly when caching is not allowed."""
+    response = app.get(h.url_for("/"))
+    assert 'must-understand, no-cache, max-age=0' == response.headers['Cache-Control']
+
+
+# Vary testing
+
+def test_adds_vary_cookie_when_limit_cache_by_cookie_is_present(app: CKANTestApp):
+    """Test that `Vary: Cookie` is added when `__limit_cache_by_cookie__` is in the environment."""
+    builder = EnvironBuilder(path='/', method='GET', headers={}, environ_overrides={
+        "__limit_cache_by_cookie__": True})
+    env = builder.get_environ()
+    Request(env)
+    response = Response()  # dummy response
+
+    with app.flask_app.request_context(env):  # only works if you have app.flask_app
+        g.__session_was_empty = True
+        assert request.environ.get('__limit_cache_by_cookie__') is True
+        updated_response = views.set_cache_control_headers_for_response(response)
+    assert "Cookie" in updated_response.vary
+    assert "HX-Request" in updated_response.vary
+
+
+def test_adds_vary_cookie_when_g_limit_cache_for_page_is_true(app: CKANTestApp):
+    """Test that `Vary: Cookie` is added when `__limit_cache_by_cookie__` is in the environment."""
+    builder = EnvironBuilder(path='/', method='GET', headers={},)
+    env = builder.get_environ()
+    Request(env)
+    response = Response()  # dummy response
+
+    with app.flask_app.request_context(env):  # only works if you have app.flask_app
+        with app.flask_app.app_context() as ctx:
+            g.__session_was_empty = True
+            assert request.environ.get('__limit_cache_by_cookie__') is None
+            base._allow_caching()
+            assert ctx.g.limit_cache_for_page is True
+            updated_response = views.set_cache_control_headers_for_response(response)
+    assert "Cookie" in updated_response.vary
+    assert "HX-Request" in updated_response.vary
+
+
+def test_removes_pragma_header_if_present(app: CKANTestApp):
+    """Test that the `Pragma` header is removed if present in the response."""
+    builder = EnvironBuilder(path='/', method='GET', headers={}, environ_overrides={
+        "__limit_cache_by_cookie__": True})
+    env = builder.get_environ()
+    Request(env)
+    response = Response()  # dummy response
+
+    with app.flask_app.request_context(env):  # only works if you have app.flask_app
+        g.__session_was_empty = True
+        response.headers["Pragma"] = "no-cache"
+        # recall for under test altered response
+        updated_response = views.set_cache_control_headers_for_response(response)
+
+    assert "Pragma" not in updated_response.headers
+
+
+# Etag testing
+@pytest.mark.ckan_config("ckan.etags.enabled", False)
+def test_etag_not_set_when_config_disables_it(app: CKANTestApp):
+    """Test that ETag is set if missing in the response headers."""
+    request_headers = {}
+    response = app.get('/', headers=request_headers)
+    assert "ETag" not in response.headers, response.headers
+
+
+@pytest.mark.ckan_config("ckan.etags.enabled", True)
+def test_sets_etag_when_missing(app: CKANTestApp):
+    """Test that ETag is set if missing in the response headers."""
+    request_headers = {}
+    response = app.get('/', headers=request_headers)
+    assert response.headers["ETag"] is not None
+
+
+@pytest.mark.ckan_config("ckan.etags.enabled", True)
+def test_does_not_modify_etag_if_already_set(app: CKANTestApp):
+    """Test that an existing ETag is not modified."""
+
+    builder = EnvironBuilder(path='/', method='GET', headers={}, environ_overrides={
+        "__limit_cache_by_cookie__": True})
+    env = builder.get_environ()
+    Request(env)
+    response = Response()  # dummy response
+
+    with app.flask_app.request_context(env):  # only works if you have app.flask_app
+        response.headers["ETag"] = '"existing-etag"'
+        # recall set_etag_and_fast_304_response_if_unchanged again
+        # with different etag to verify that it does not override
+        updated_response = views.set_etag_for_response(response)
+    assert updated_response.headers["ETag"] == '"existing-etag"'
+
+
+@pytest.mark.ckan_config("ckan.etags.enabled", True)
+def test_returns_304_if_etag_matches(app: CKANTestApp):
+    """Test that response is changed to 304 Not Modified if ETag matches request."""
+    request_headers = {}
+    with app.flask_app.app_context() as ctx:
+        ctx.g.etag_modified_time = "fixed"
+        response: TestResponse = app.get('/', headers=request_headers)
+    # use previous response ETag on next call
+    assert response.headers["Etag"] is not None, response.headers
+
+    with app.flask_app.app_context() as ctx:
+        ctx.g.etag_modified_time = "fixed"  # expecting fixed-11683-3145776
+        request_headers["if_none_match"] = response.headers["Etag"]
+        updated_response: TestResponse = app.get('/', headers=request_headers)
+
+        assert updated_response.status_code == 304, "original Etag was {}, second call etag was {}".format(response.headers["Etag"], updated_response.headers["Etag"])
+        assert updated_response.get_data() == b""
+        assert "Content-Length" not in updated_response.headers
+
+    with app.flask_app.app_context() as ctx:
+        request_headers["if_none_match"] = response.headers["Etag"]
+        # Due to hash system always different, we fix it for this test
+        ctx.g.etag_replace = response.headers["Etag"].replace('"', '',)
+        updated_response: TestResponse = app.get('/', headers=request_headers)
+
+        assert updated_response.status_code == 304, "original Etag was {}, second call etag was {}".format(response.headers["Etag"], updated_response.headers["Etag"])
+        assert updated_response.get_data() == b""
+        assert "Content-Length" not in updated_response.headers
+
+
+@pytest.mark.ckan_config("ckan.etags.enabled", True)
+def test_does_not_return_304_if_etag_does_not_match(app: CKANTestApp):
+    """Test that response is not modified if request's If-None-Match does not match the ETag."""
+
+    request_headers = {}
+    clean_response: TestResponse = app.get('/', headers=request_headers)
+    clean_response_data = clean_response.get_data(as_text=True)
+    request_headers: dict = {"if_none_match": "some-other-etag"}
+    updated_response: TestResponse = app.get('/', headers=request_headers)
+
+    assert updated_response.status_code == 200
+    under_test_response_data = updated_response.get_data(as_text=True)
+    assert clean_dynamic_values(clean_response_data) == clean_dynamic_values(under_test_response_data)
+    assert updated_response.get_etag() != clean_response.get_etag(), "etag were not the same, got {}, original etag was {}".format(updated_response.get_etag(), clean_response.get_etag())
+
+
+def streaming_generator():
+    yield b"streaming response data"
+
+
+@pytest.mark.ckan_config("ckan.etags.enabled", True)
+def test_does_not_add_etag_if_streaming_response_encountered(app: CKANTestApp):
+    """Test that response is not modified if request's If-None-Match does not match the ETag."""
+    from types import GeneratorType
+    builder = EnvironBuilder(path='/', method='GET', headers={}, environ_overrides={
+        "__limit_cache_by_cookie__": True})
+    env = builder.get_environ()
+    Request(env)
+    response = Response(streaming_generator(), mimetype='text/plain')
+
+    with app.flask_app.request_context(env):  # only works if you have app.flask_app
+        # Ensure it is detected as streamed prior to calling function under test
+        assert response.is_streamed
+        assert isinstance(response.response, GeneratorType)
+
+        # recall set_etag_and_fast_304_response_if_unchanged again with
+        # different etag to verify that it does not override
+        updated_response = views.set_etag_for_response(response)
+    assert "ETag" not in updated_response.headers, updated_response.headers

--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -1,19 +1,28 @@
 # encoding: utf-8
 from __future__ import annotations
 
+import time
+from http import HTTPStatus
 from typing import Any, Optional
+from zlib import adler32
 
 from urllib.parse import quote
 from flask.wrappers import Response
 
 import ckan.model as model
 import ckan.lib.api_token as api_token
-from ckan.common import g, request, config, current_user, logout_user
+from ckan.common import (g, request, config, current_user,
+                         logout_user, session, CacheType)
 from ckan.lib.i18n import get_locales_from_config
 import ckan.plugins as p
 
 import logging
+
 log = logging.getLogger(__name__)
+
+# For more details about caching, please read the spec located at
+# https://datatracker.ietf.org/doc/html/rfc9111
+# as well as RFC 7234 + RFC 5861 + RFC 9111
 
 
 def set_cors_headers_for_response(response: Response) -> Response:
@@ -43,31 +52,202 @@ def set_cors_headers_for_response(response: Response) -> Response:
     return response
 
 
-def set_cache_control_headers_for_response(response: Response) -> Response:
+allowed_status_codes = frozenset({HTTPStatus.OK,  # 200
+                                  HTTPStatus.MOVED_PERMANENTLY,  # 301
+                                  HTTPStatus.FOUND,  # 302
+                                  HTTPStatus.UNAUTHORIZED,  # 401
+                                  HTTPStatus.FORBIDDEN,  # 403
+                                  HTTPStatus.NOT_FOUND  # 404
+                                  })
 
-    # __no_cache__ should not be present when caching is allowed
-    allow_cache = u'__no_cache__' not in request.environ
-    limit_cache_by_cookie = u'__limit_cache_by_cookie__' in request.environ
 
-    if u'Pragma' in response.headers:
-        del response.headers["Pragma"]
+# ETag's are very useful since it allows conditional freshness checks
+# without bandwidth costs by the browser/cdn.
+# Since html pages from ckan are always generated on the fly it
+# can't use last modified and content length our Nginx does it
+# This is a simple etag which changes on each request
+def set_etag_for_response(response: Response) -> Response:
+    """Set ETag and return 304 if content is unchanged."""
 
-    if allow_cache:
-        response.cache_control.public = True
-        try:
-            cache_expire = config.get(u'ckan.cache_expires')
-            response.cache_control.max_age = cache_expire
-            response.cache_control.must_revalidate = True
-        except ValueError:
-            pass
-    else:
-        response.cache_control.private = True
+    # skip streaming content
+    if response.is_streamed:
+        return response
 
-    # Invalidate cached pages upon login/logout
-    if limit_cache_by_cookie:
-        response.vary.add("Cookie")
+    enable_etags = config.get(u'ckan.etags.enabled', True)
+    if enable_etags and response.status_code in allowed_status_codes:
+        if 'etag' not in response.headers:
+            etag_replace = getattr(g, 'etag_replace', None)
+            if etag_replace:
+                response.set_etag(etag_replace)
+            else:
+                # s3 etag uses md5 if you want that, load `etag` plugin, this is fast
+                # hash etag which h.set_etag_modified_time(str) can be used to set
+                # correct modified time as well as extended by plugins via
+                # `h.etag_append(str)` for their uniqueness constraints
+                mtime = getattr(g, 'etag_modified_time', time.time())
+                size = response.content_length
+                etag_append = getattr(g, 'etag_append', "")
+                check = (adler32(request.environ['PATH_INFO'].encode('utf-8'))
+                         & 0xFFFFFFFF)
+                response.set_etag(f"{mtime}-{size}-{check}{etag_append}")
+
+    # Use built-in function for make_conditional
+    response.make_conditional(request.environ)
 
     return response
+
+
+def set_cache_control_headers_for_response(response: Response) -> Response:
+    cache_type: Optional[CacheType] = getattr(g, 'cache_type', None)
+    # log.debug("set_cache_control_headers_for_response %r", cacheType)
+    cache_type = set_cache_control_headers_from_request(cache_type, response)
+
+    if cache_type == CacheType.OVERRIDDEN:
+        # Don't alter notified overridden response
+        return response
+
+    # the must-understand directive is recommended to be used in conjunction
+    # with no-store in the case that said directive is unsupported by a
+    # legacy cache and thus ignored.
+    response.cache_control.must_understand = True
+
+    if u'Pragma' in response.headers:
+        # Pragma has been replaced with Cache-Control
+        del response.headers["Pragma"]
+
+    no_transform = config.get(u'ckan.cache.no_transform')
+    if no_transform:
+        response.cache_control.no_transform = True
+
+    set_vary_cache_settings(response)
+
+    # environ is deprecated and will be removed in 2026/7
+    environ_no_cache = u'__no_cache__' in request.environ
+    if environ_no_cache:
+        log.warning("environ '__no_cache__' is deprecated, "
+                    "use 'h.set_cache_level' function instead")
+        if cache_type is None or cache_type == CacheType.PUBLIC:
+            # Only make private, don't override other levels
+            cache_type = CacheType.PRIVATE
+
+    session_type = config.get(u'SESSION_TYPE')
+    # If cookie's is changing, don't allow it to be cached/stored
+    is_set_cookie_header = u'Set-Cookie' in response.headers
+    if is_set_cookie_header:
+        # If cookie's is changing, don't allow it to be cached/stored
+        cache_type = CacheType.SENSITIVE
+
+    # log.debug("session accessed: %r modified: %r, keys: %r",
+    #           session.accessed, session.modified, session.keys())
+
+    if session_type == 'redis':
+        if not g.__session_was_empty and cache_type != CacheType.SENSITIVE:
+            # Session exists, so can't be public
+            # As session data is in redis, it won't alter its cookie
+            cache_type = CacheType.PRIVATE
+        elif g.__session_was_empty and session.modified:
+            # Redis session created, cookie will be created
+            cache_type = CacheType.SENSITIVE
+
+    else:
+        # Cookie based session handling
+        if not g.__session_was_empty and cache_type != CacheType.SENSITIVE:
+            # If we have session data, it can't be public
+            # Note: due to CSRF protection being 'session' based. All html pages will
+            # now be classified non-public due to needing to vary on at least cookie.
+            # as session stores '_csrf_token', '_fresh', '_permanent'
+            cache_type = CacheType.PRIVATE
+
+        if session.modified:
+            # Note, flask_session occurs after ckan cache controls. So must use
+            # session.modified flag for swap outs
+
+            cache_type = CacheType.SENSITIVE
+
+    # log.error("chacheType = %r", cache_type)
+    # log.error("session keys %r", session.keys())
+    # log.error("session %r", session)
+
+    if cache_type == CacheType.PUBLIC:
+        response.cache_control.public = True
+        response.cache_control.private = None  # Reset
+        response.cache_control.max_age = config.get(u'ckan.cache.expires')
+        response.cache_control.s_maxage = config.get(u'ckan.cache.shared.expires')
+        set_cache_control_while_stale(response)
+
+    elif cache_type == CacheType.PRIVATE:
+        response.cache_control.public = False  # Reset
+        response.cache_control.private = True
+        private_cache_expire = config.get(u'ckan.cache.private.expires')
+        response.cache_control.max_age = private_cache_expire
+        set_cache_control_while_stale(response)
+
+    elif cache_type in (CacheType.NO_CACHE, CacheType.SENSITIVE):
+        # no_cache is like private, max-age=0
+        # no_cache Does not block bfcache — revalidation applies to HTTP cache only
+        response.cache_control.no_cache = True
+        response.cache_control.max_age = 0  # This is fall back for older browsers
+        response.cache_control.public = False  # Reset
+        response.cache_control.private = None  # Reset
+
+    if cache_type == CacheType.SENSITIVE:
+        # https://developer.chrome.com/docs/web-platform/bfcache-ccns
+        # no_store Chrome assumes the page should never be reused, even in memory.
+        response.cache_control.no_store = True
+
+    return response
+
+
+def set_vary_cache_settings(rs: Response):
+    # limit_cache_for_api should vary by api auth header name
+    limit_cache_by_api = getattr(g, 'limit_cache_for_api', False)
+    if limit_cache_by_api:
+        rs.vary.add(config.get("apitoken_header_name"))
+
+    limit_cache_by_cookie = u'__limit_cache_by_cookie__' in request.environ
+    if limit_cache_by_cookie:
+        log.warning("environ: '__limit_cache_by_cookie__' is deprecated, "
+                    "use 'g.limit_cache_for_page = True' instead")
+
+    limit_cache_for_page = getattr(g, 'limit_cache_for_page', False)
+    if limit_cache_for_page or limit_cache_by_cookie:
+        rs.vary.add("Cookie")
+        rs.vary.add("HX-Request")
+
+
+def set_cache_control_while_stale(rs: Response) -> None:
+    """This functions updates cache_control with config settings.
+    If both stale configs are set to 0, then must-validate will be enabled"""
+    stale_while_revalidates = config.get(u'ckan.cache.stale_while_revalidates')
+    stale_if_error = config.get(u'ckan.cache.stale_if_error')
+    if stale_while_revalidates == 0 and stale_if_error == 0:
+        # must_revalidate overrides staleness values.
+        rs.cache_control.must_revalidate = True
+    else:
+        rs.cache_control.stale_while_revalidate = stale_while_revalidates
+        rs.cache_control.stale_if_error = stale_if_error
+        rs.cache_control.must_revalidate = False
+
+
+def set_cache_control_headers_from_request(cache_type: Optional[CacheType],
+                                           rs: Response) -> Optional[CacheType]:
+    """This function returns updated cacheType if request headers wants us
+    to disable cache, also sets no-transform if also found."""
+    # https://http.dev/cache-control
+    # This is very useful for developer tools testing as well as
+    # loopback to break cdn cache is 'Cache-Control' is set as a key
+    if 'Cache-Control' in request.headers:
+        request_cache_control = request.headers.get('Cache-Control', '')
+        directives = {d.strip() for d in request_cache_control.lower().split(',')}
+
+        if 'no-cache' in directives:
+            cache_type = CacheType.NO_CACHE
+        elif 'no-store' in directives:
+            cache_type = CacheType.SENSITIVE
+
+        if 'no-transform' in directives:
+            rs.cache_control.no_transform = True
+    return cache_type
 
 
 def identify_user() -> Optional[Response]:
@@ -124,14 +304,18 @@ def identify_user() -> Optional[Response]:
 
 def _get_user_for_apitoken() -> Optional[model.User]:  # type: ignore
     apitoken_header_name = config.get("apitoken_header_name")
-    apitoken: str = request.headers.get(apitoken_header_name, u'')
+    apitoken_value: str = request.headers.get(apitoken_header_name, u'')
 
-    if not apitoken:
+    if not apitoken_value:
         return None
-    apitoken = str(apitoken)
-    log.debug('Received API Token: %s[...]', apitoken[:10])
 
-    user = api_token.get_user_from_token(apitoken)
+    # If it is set, then Response Vary. This is a catch-all for extensions
+    g.limit_cache_for_api = True
+
+    apitoken_value = str(apitoken_value)
+    log.debug('Received API Token: %s[...]', apitoken_value[:10])
+
+    user = api_token.get_user_from_token(apitoken_value)
 
     return user
 

--- a/ckan/views/admin.py
+++ b/ckan/views/admin.py
@@ -15,8 +15,7 @@ import ckan.lib.navl.dictization_functions as dict_fns
 import ckan.logic as logic
 import ckan.model as model
 import ckan.logic.schema
-from ckan.common import _, config, request, current_user
-from ckan.views.home import CACHE_PARAMETERS
+from ckan.common import _, config, request, current_user, CACHE_PARAMETERS
 
 from ckan.types import Context, Query
 

--- a/ckan/views/api.py
+++ b/ckan/views/api.py
@@ -483,6 +483,15 @@ def i18n_js_translations(
     return _finish_ok(LazyJSONObject(translations))
 
 
+# API Blueprint wrapping
+
+@api.before_request
+def api_pre_hook():
+    # ensure response cache-control `Vary` includes api auth header
+    # (like cookie on template pages)
+    g.limit_cache_for_api = True
+
+
 # Routing
 
 # Root

--- a/ckan/views/dataset.py
+++ b/ckan/views/dataset.py
@@ -13,7 +13,7 @@ from flask import Blueprint
 from flask.views import MethodView
 from jinja2.exceptions import TemplateNotFound
 from werkzeug.datastructures import MultiDict
-from ckan.common import asbool, current_user
+from ckan.common import asbool, current_user, CACHE_PARAMETERS
 
 import ckan.lib.base as base
 from ckan.lib.helpers import helper_functions as h
@@ -24,7 +24,6 @@ import ckan.model as model
 import ckan.plugins as plugins
 import ckan.authz as authz
 from ckan.common import _, config, g, request
-from ckan.views.home import CACHE_PARAMETERS
 from ckan.lib.plugins import lookup_package_plugin
 from ckan.lib.search import (
     SearchError, SearchQueryError, SearchIndexError, SolrConnectionError

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -19,8 +19,7 @@ import ckan.model as model
 import ckan.authz as authz
 import ckan.lib.plugins as lib_plugins
 import ckan.plugins as plugins
-from ckan.common import g, config, request, current_user, _
-from ckan.views.home import CACHE_PARAMETERS
+from ckan.common import g, config, request, current_user, _, CACHE_PARAMETERS
 from ckan.views.dataset import _get_search_details
 
 from flask import Blueprint, make_response

--- a/ckan/views/home.py
+++ b/ckan/views/home.py
@@ -12,14 +12,13 @@ import ckan.lib.base as base
 import ckan.lib.search as search
 from ckan.lib.helpers import helper_functions as h
 
-from ckan.common import g, config, current_user, _
+from ckan.common import g, config, current_user, _, CACHE_PARAMETERS as cache_params
 from ckan.types import Context, Response
 
-
-CACHE_PARAMETERS = [u'__cache', u'__no_cache__']
-
-
 home = Blueprint(u'home', __name__)
+
+# Deprecated use common.CACHE_PARAMETERS
+CACHE_PARAMETERS = cache_params
 
 
 def index() -> str:

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -19,8 +19,7 @@ import ckan.logic as logic
 import ckan.model as model
 import ckan.plugins as plugins
 from ckan.lib import signals
-from ckan.common import _, config, g, request, current_user
-from ckan.views.home import CACHE_PARAMETERS
+from ckan.common import _, config, g, request, current_user, CACHE_PARAMETERS
 from ckan.views.dataset import (
     _get_pkg_template, _get_package_type, _setup_template_variables
 )

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -6,7 +6,7 @@ from typing import Any, Optional, Union
 
 from flask import Blueprint
 from flask.views import MethodView
-from ckan.common import asbool
+from ckan.common import asbool, CacheType
 
 import ckan.lib.authenticator as authenticator
 import ckan.lib.base as base
@@ -210,6 +210,7 @@ def read_groups(id: str) -> Union[Response, str]:
 
 class ApiTokenView(MethodView):
     def get(self, id: str) -> Union[Response, str]:
+        h.set_cache_level(CacheType.SENSITIVE)
         try:
             tokens = logic.get_action('api_token_list')(
                 {}, {'user': id}
@@ -228,6 +229,8 @@ class ApiTokenView(MethodView):
         return base.render('user/api_tokens.html', extra_vars)
 
     def post(self, id: str) -> Union[Response, str]:
+        h.set_cache_level(CacheType.SENSITIVE)
+
         data_dict = logic.clean_dict(
             dictization_functions.unflatten(
                 logic.tuplize_dict(logic.parse_params(request.form))))
@@ -276,6 +279,7 @@ def api_tokens_revoke(id: str) -> Union[Response, str]:
 
 class EditView(MethodView):
     def _prepare(self, id: Optional[str]) -> tuple[Context, str]:
+        h.set_cache_level(CacheType.SENSITIVE)
         context: Context = {
             u'save': u'save' in request.form,
             u'schema': _edit_form_to_db_schema(),
@@ -423,6 +427,7 @@ class EditView(MethodView):
 
 class RegisterView(MethodView):
     def _prepare(self):
+        h.set_cache_level(CacheType.SENSITIVE)
         context: Context = {
             u'user': current_user.name,
             u'auth_user_obj': current_user,
@@ -537,6 +542,7 @@ def rotate_token():
 
 
 def login() -> Union[Response, str]:
+    h.set_cache_level(CacheType.SENSITIVE)
     for item in plugins.PluginImplementations(plugins.IAuthenticator):
         response = item.login()
         if response:
@@ -582,6 +588,7 @@ def login() -> Union[Response, str]:
 
 
 def logout() -> Response:
+    h.set_cache_level(CacheType.SENSITIVE)
     for item in plugins.PluginImplementations(plugins.IAuthenticator):
         response = item.logout()
         if response:
@@ -604,6 +611,7 @@ def logout() -> Response:
 
 
 def logged_out_page() -> str:
+    h.set_cache_level(CacheType.SENSITIVE)
     return base.render(u'user/logout.html', {})
 
 
@@ -650,6 +658,7 @@ def delete(id: str) -> Union[Response, Any]:
 
 class RequestResetView(MethodView):
     def _prepare(self):
+        h.set_cache_level(CacheType.SENSITIVE)
         context: Context = {
             u'user': current_user.name,
             u'auth_user_obj': current_user
@@ -749,6 +758,7 @@ class RequestResetView(MethodView):
 
 class PerformResetView(MethodView):
     def _prepare(self, id: str) -> tuple[Context, dict[str, Any]]:
+        h.set_cache_level(CacheType.SENSITIVE)
         # FIXME 403 error for invalid key is a non helpful page
         context: Context = {
             'user': id,

--- a/ckan/views/util.py
+++ b/ckan/views/util.py
@@ -50,7 +50,7 @@ def csrf_input() -> Response:
     Note: CORS protects this endpoint cross domain in XHR/Fetch context"""
     origin = request.headers.get("Origin")
     if origin is None or origin == '':
-        _abort(400, "Origin header is missing.")
+        return _abort(400, "Origin header is missing.")
 
     domain = config.get('ckan.site_url')
     if g.debug:
@@ -62,7 +62,7 @@ def csrf_input() -> Response:
     if request.method == "OPTIONS":
         response = Response()
         response.headers["Access-Control-Allow-Origin"] = domain
-        response.headers["Access-Control-Allow-Methods"] = "POST, OPTIONS"
+        response.headers["Access-Control-Allow-Methods"] = "GET, OPTIONS"
         response.headers["Access-Control-Allow-Headers"] = "Content-Type"
         response.headers["Access-Control-Allow-Credentials"] = "true"
         return response
@@ -70,10 +70,10 @@ def csrf_input() -> Response:
     # Handle GET request protections
     if 'application/json' not in request.accept_mimetypes:
         # Disallowing simple content types to ensure browser CORS checking
-        _abort(400, "Only application/json content-type accept is allowed.")
+        return _abort(400, "Only application/json content-type accept is allowed.")
 
     if origin != domain:
-        _abort(403, "Origin not allowed.")
+        return _abort(400, "Origin not allowed.")
 
     if g.csrf_enabled:
         csrf_token = generate_csrf()

--- a/ckan/views/util.py
+++ b/ckan/views/util.py
@@ -1,10 +1,11 @@
 # encoding: utf-8
 
-from flask import Blueprint
+from flask import Blueprint, jsonify
+from flask_wtf.csrf import generate_csrf
 
 import ckan.lib.base as base
 from ckan.lib.helpers import helper_functions as h
-from ckan.common import _, request
+from ckan.common import _, request, g
 from ckan.types import Response
 
 util = Blueprint(u'util', __name__)
@@ -39,7 +40,17 @@ def custom_form_fields() -> str:
     )
 
 
+def csrf_input() -> Response:
+    """ Generate a CSRF token and return it in a JSON response for XHR POST requests.
+    Note: CORS protects this endpoint cross domain in XHR/Fetch context"""
+    return jsonify({
+        "name": g.csrf_field_name,
+        "value": generate_csrf()
+    })
+
+
 util.add_url_rule(
     '/util/redirect', view_func=internal_redirect, methods=('GET', 'POST',))
 util.add_url_rule('/testing/primer', view_func=primer)
 util.add_url_rule('/testing/custom_form_fields', view_func=custom_form_fields)
+util.add_url_rule('/csrf-input', view_func=csrf_input, methods=('GET',))

--- a/ckan/views/util.py
+++ b/ckan/views/util.py
@@ -1,11 +1,11 @@
 # encoding: utf-8
 
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, make_response
 from flask_wtf.csrf import generate_csrf
 
 import ckan.lib.base as base
 from ckan.lib.helpers import helper_functions as h
-from ckan.common import _, request, g
+from ckan.common import _, request, g, config
 from ckan.types import Response
 
 util = Blueprint(u'util', __name__)
@@ -40,17 +40,55 @@ def custom_form_fields() -> str:
     )
 
 
+def _abort(status_code: int, detail: str) -> Response:
+    headers = {u'Content-Type': "application/json;charset=utf-8"}
+    return make_response((detail, status_code, headers))
+
+
 def csrf_input() -> Response:
     """ Generate a CSRF token and return it in a JSON response for XHR POST requests.
     Note: CORS protects this endpoint cross domain in XHR/Fetch context"""
+    origin = request.headers.get("Origin")
+    if origin is None or origin == '':
+        _abort(400, "Origin header is missing.")
+
+    domain = config.get('ckan.site_url')
+    if g.debug:
+        # return domain we received on.
+        if "localhost" in origin:
+            domain = origin
+
+    # Handle preflight OPTIONS request
+    if request.method == "OPTIONS":
+        response = Response()
+        response.headers["Access-Control-Allow-Origin"] = domain
+        response.headers["Access-Control-Allow-Methods"] = "POST, OPTIONS"
+        response.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        response.headers["Access-Control-Allow-Credentials"] = "true"
+        return response
+
+    # Handle GET request protections
+    if 'application/json' not in request.accept_mimetypes:
+        # Disallowing simple content types to ensure browser CORS checking
+        _abort(400, "Only application/json content-type accept is allowed.")
+
+    if origin != domain:
+        _abort(403, "Origin not allowed.")
+
+    if g.csrf_enabled:
+        csrf_token = generate_csrf()
+    else:
+        csrf_token = "disabled"
+
     return jsonify({
-        "name": g.csrf_field_name,
-        "value": generate_csrf()
-    })
+            "name": g.csrf_field_name,
+            "header": g.csrf_header_name,
+            "token": csrf_token
+        })
 
 
 util.add_url_rule(
     '/util/redirect', view_func=internal_redirect, methods=('GET', 'POST',))
 util.add_url_rule('/testing/primer', view_func=primer)
 util.add_url_rule('/testing/custom_form_fields', view_func=custom_form_fields)
-util.add_url_rule('/csrf-input', view_func=csrf_input, methods=('GET',))
+util.add_url_rule('/csrf-input', view_func=csrf_input, methods=('GET', 'OPTIONS'))

--- a/ckanext/example_etags/plugin.py
+++ b/ckanext/example_etags/plugin.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+from http import HTTPStatus
+import hashlib
+import re
+from flask.wrappers import Response
+
+from ckan import plugins as p
+
+
+from ckan.plugins.toolkit import request, config, g, current_user
+
+
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class ETagsPlugin(p.SingletonPlugin):
+    """ This plugin is to generate 'Strong' etag hashes """
+
+    p.implements(p.IMiddleware)
+
+    # IMiddleware
+
+    def set_etag_for_response(self, response: Response) -> Optional[Response]:
+        """Set ETag and return 304 if content is unchanged."""
+
+        __timer = time.time()
+        # skip stremaing content
+        if not response.is_streamed:
+            allowed_status_codes = {HTTPStatus.OK,  # 200
+                                    HTTPStatus.MOVED_PERMANENTLY,  # 301
+                                    HTTPStatus.FOUND,  # 302
+                                    HTTPStatus.UNAUTHORIZED,  # 401
+                                    HTTPStatus.FORBIDDEN,  # 403
+                                    HTTPStatus.NOT_FOUND  # 404
+                                    }
+
+            if response.status_code in allowed_status_codes:
+                if 'etag' not in response.headers:
+                    # s3 etag uses md5, so using it here also
+                    content_type = response.mimetype or ''
+                    allowed_types = {'text/plain', 'text/css',
+                                     'text/html', 'application/json'}
+                    etag_super_strong = u'__etag_super_strong__' in request.environ
+
+                    try:
+                        # anon/public get ignored csrf
+                        if (etag_super_strong
+                                or content_type not in allowed_types
+                                or current_user.is_authenticated or g.user):
+                            log.debug("not regex-ing payload")
+                            data_to_hash = response.get_data()
+                        else:
+                            log.debug("regex-ing payload for etag")
+                            # Regex for both _csrf_token content and csp nonce and don't
+                            # care if there is new lines spacing etc attributes which
+                            # are dynamic on pages
+                            # May need to add more when we come across them.
+
+                            field_name = re.escape(config.get("WTF_CSRF_FIELD_NAME", "_csrf_token"))  # noqa: E501
+                            # csrf meta only, if to include value,
+                            #   update (?:content) to (?:content|value)
+                            pattern = fr'(?i)((?:_csrf_token|{field_name})[^>]*?\b(?:content)=|\bnonce=)["\'][^"\']+(["\'])'  # noqa: E501
+
+                            # Replace values with etag_removed
+                            response_data = re.sub(pattern,
+                                                   lambda m: m.group(1) + '="etag_removed"',  # noqa: E501
+                                                   response.get_data(as_text=True))
+                            data_to_hash = response_data.encode()
+
+                        etag = hashlib.md5(data_to_hash).hexdigest()
+
+                        r_time = time.time() - __timer
+                        log.debug(' %s %s hash time %.3f seconds',
+                                  etag, response.content_length, r_time)
+
+                        response.set_etag(etag)
+                    except (AttributeError, IndexError, TypeError,
+                            UnicodeEncodeError, ValueError, re.error) as e:
+                        r_time = time.time() - __timer
+                        logging.info("Failed to compute and set ETag %.3f seconds: %s",
+                                     r_time, e)
+
+                etag_not_conditional = (u'__etag_not_conditional__'
+                                        not in request.environ)
+                if etag_not_conditional:
+                    # Use built-in function now that we have an eTag
+                    response.make_conditional(request.environ)
+
+        return response

--- a/ckanext/example_etags/tests/test_etags.py
+++ b/ckanext/example_etags/tests/test_etags.py
@@ -1,0 +1,166 @@
+import pytest
+import re
+import hashlib
+from flask import Request, Response
+from werkzeug.test import EnvironBuilder
+from ckan.lib.helpers import url_for
+from ckan.tests import factories
+
+from ckan.tests.helpers import CKANTestApp
+from werkzeug.test import TestResponse
+
+import ckan.views as views
+
+field_name = '_csrf_token'  # emulate WTF_CSRF_FIELD_NAME for regex verification check
+pattern = fr'(?i)((?:_csrf_token|{field_name})[^>]*?\b(?:content|value)=|\bnonce=)["\'][^"\']+(["\'])'  # noqa: E501
+
+
+def clean_dynamic_values(text):
+    return re.sub(pattern, lambda m: m.group(1) + '="etag_removed"', text)
+
+
+def streaming_generator():
+    yield b"streaming response data"
+
+
+@pytest.mark.ckan_config(u'ckan.plugins', u'etags')
+@pytest.mark.usefixtures(u'with_plugins', u'etags')
+@pytest.mark.ckan_config("ckan.etags.enabled", True)
+class test_etag_plugins():
+
+    @pytest.mark.ckan_config("ckan.etags.enabled", False)
+    def test_etag_not_set_when_config_disables_it(self, app: CKANTestApp):
+        """Test that ETag is set if missing in the response headers."""
+        request_headers = {}
+        response = app.get('/', headers=request_headers)
+        assert "ETag" not in response.headers, response.headers
+
+    def test_sets_etag_when_missing(self, app: CKANTestApp):
+        """Test that ETag is set if missing in the response headers."""
+        request_headers = {}
+        response = app.get('/', headers=request_headers)
+        expected_etag = hashlib.md5(clean_dynamic_values(response.get_data(as_text=True)).encode()).hexdigest()
+        assert response.headers["ETag"] == f'"{expected_etag}"'
+
+    def test_does_not_modify_etag_if_already_set(self, app: CKANTestApp):
+        """Test that an existing ETag is not modified."""
+
+        builder = EnvironBuilder(path='/', method='GET', headers={}, environ_overrides={
+            "__limit_cache_by_cookie__": True})
+        env = builder.get_environ()
+        Request(env)
+        response = Response()  # dummy response
+
+        with app.flask_app.request_context(env):  # only works if you have app.flask_app
+            response.headers["ETag"] = '"existing-etag"'
+            # recall set_etag_and_fast_304_response_if_unchanged again
+            # with different etag to verify that it does not override
+            updated_response = views.set_etag_for_response(response)
+        assert updated_response.headers["ETag"] == '"existing-etag"'
+
+    def test_returns_304_if_etag_matches(self, app: CKANTestApp):
+        """Test that response is changed to 304 Not Modified if ETag matches request."""
+        request_headers = {}
+        response: TestResponse = app.get('/', headers=request_headers)
+        # use previous response ETag on next call
+        assert response.headers["Etag"] is not None, response.headers
+
+        request_headers["if_none_match"] = response.headers["Etag"]
+        updated_response: TestResponse = app.get('/', headers=request_headers)
+
+        assert updated_response.status_code == 304, "original Etag was {}, second call etag was {}".format(
+            response.headers["Etag"], updated_response.headers["Etag"])
+        assert updated_response.get_data() == b""
+        assert "Content-Length" not in updated_response.headers
+
+    def test_does_not_return_304_if_etag_does_not_match(self, app: CKANTestApp):
+        """Test that response is not modified if request's If-None-Match does not match the ETag."""
+
+        request_headers = {}
+        clean_response: TestResponse = app.get('/', headers=request_headers)
+        clean_response_data = clean_response.get_data(as_text=True)
+        request_headers: dict = {"if_none_match": "some-other-etag"}
+        updated_response: TestResponse = app.get('/', headers=request_headers)
+
+        assert updated_response.status_code == 200, "should have received payload, not 304 as invalid etag was passed in"
+        under_test_response_data = updated_response.get_data(as_text=True)
+        assert clean_dynamic_values(clean_response_data) == clean_dynamic_values(under_test_response_data)
+        assert updated_response.get_etag() == clean_response.get_etag(), "etag were not the same, got {}, original etag was {}".format(
+            updated_response.get_etag(), clean_response.get_etag())
+
+    def test_does_not_add_etag_if_streaming_response_encountered(self, app: CKANTestApp):
+        """Test that response is not modified if request's If-None-Match does not match the ETag."""
+        from types import GeneratorType
+        builder = EnvironBuilder(path='/', method='GET', headers={}, environ_overrides={
+            "__limit_cache_by_cookie__": True})
+        env = builder.get_environ()
+        Request(env)
+        response = Response(streaming_generator(), mimetype='text/plain')
+
+        with app.flask_app.request_context(env):  # only works if you have app.flask_app
+            # Ensure it is detected as streamed prior to calling function under test
+            assert response.is_streamed
+            assert isinstance(response.response, GeneratorType)
+
+            # recall set_etag_and_fast_304_response_if_unchanged again
+            # with different etag to verify that it does not override
+            updated_response = views.set_etag_for_response(response)
+        assert "ETag" not in updated_response.headers, updated_response.headers
+
+    def test_returns_200_if_etag_super_strong_set_in_g(self, app: CKANTestApp):
+        with app.flask_app.app_context() as ctx:
+            ctx.g.etag_super_strong = True
+            response: TestResponse = app.get(
+                url_for("index")
+            )
+
+        with app.flask_app.app_context() as ctx:
+            ctx.g.etag_super_strong = True
+
+            # use previous response ETag on next call
+            assert response.headers["Etag"] is not None, response.headers
+            request_headers = {"if_none_match": response.headers["Etag"]}
+            updated_response: TestResponse = app.get('/', headers=request_headers)
+
+        assert updated_response.headers["ETag"] != response.headers["ETag"]
+        assert updated_response.status_code == 200, "original Etag was {}, second call etag was {}".format(
+            response.headers["Etag"], updated_response.headers["Etag"])
+        assert updated_response.get_data() != response.get_data()
+
+    def test_returns_200_if_etag_super_strong_when_logged_in(self, app: CKANTestApp):
+        password = "RandomPassword123"
+        user = factories.User(password=password)
+
+        login_response: TestResponse = app.post(
+            url_for("user.login"),
+            data={
+                "login": user["name"],
+                "password": password
+            },
+        )
+
+        assert login_response.headers["set-cookie"] is not None, login_response.headers
+
+        match = re.search(r'ckan=([^;]+)', login_response.headers['set-cookie'])
+        if match:
+            cookie_value = match.group(0)  # Includes 'ckan=...' part
+            headers = {"Cookie": cookie_value}
+        else:
+            pytest.fail("Not CKAN cookie found in Set-Cookie header")
+
+        response: TestResponse = app.get(
+            url_for("dashboard.index"),
+            headers=headers
+        )
+
+        # use previous response ETag on next call
+        assert response.headers["Etag"] is not None, response.headers
+
+        headers["if_none_match"] = response.headers["Etag"]
+        request_headers = {}
+        updated_response: TestResponse = app.get('/', headers=request_headers)
+
+        assert updated_response.headers["ETag"] != response.headers["ETag"]
+        assert updated_response.status_code == 200, "original Etag was {}, second call etag was {}".format(
+            response.headers["Etag"], updated_response.headers["Etag"])
+        assert updated_response.get_data() != response.get_data()

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,7 @@ ckan.plugins =
     video_view = ckanext.videoview.plugin:VideoView
     webpage_view = ckanext.webpageview.plugin:WebPageView
     tabledesigner = ckanext.tabledesigner.plugin:TableDesignerPlugin
+    example_etags = ckanext.example_etags.plugin:ETagsPlugin
     example_itemplatehelpers = ckanext.example_itemplatehelpers.plugin:ExampleITemplateHelpersPlugin
     example_idatasetform = ckanext.example_idatasetform.plugin:ExampleIDatasetFormPlugin
     example_idatasetform_inherit = ckanext.example_idatasetform.plugin:ExampleIDatasetFormInheritPlugin

--- a/test-core.ini
+++ b/test-core.ini
@@ -46,11 +46,11 @@ ckan.auth.user_delete_organizations=true
 ckan.auth.create_unowned_dataset=true
 ckan.auth.create_default_api_keys =true
 
-ckan.cache_enabled = False
-
 ckan.site_id = test.ckan.net
 ckan.site_title = CKAN
-ckan.site_logo = /images/ckan_logo_fullname_long.png
+;ckan.base_public_folder = public-midnight-blue
+;ckan.base_templates_folder = templates-midnight-blue
+;ckan.site_logo = /base/images/ckan-logo.png
 ckan.site_description =
 licenses_group_url =
 ckan.site_url = http://test.ckan.net


### PR DESCRIPTION
Fixes #8778

Depends-on #8952  (CSRF session creation when required)

### Proposed fixes:

For more details about caching, please read the spec located at https://datatracker.ietf.org/doc/html/rfc9111 as well as RFC 7234 + RFC 5861 + RFC 9111

Public pages will stay public until session is configured for the user, swapping to private. `Cache-Controls` request headers now honoured on response allowing 'cache busting' (dependant on other modules/cdn's being correctly configured)

Any page request which set cookies or the session is modified (cookie based session) will be forced to 'not cache' to ensure we do not pollute cache's with invalid cookies.

This also allows browser ``If-None-Match`` ability to query the server if it is still valid reducing bandwidth transfers and when in combinations with cdn/varnish cache's in the picture will also reduce cpu.

Web assets now configured with etags and set to not include 'vary: cookie' and is public cached and this is 100% fine since python web assets already include hash sum in its filenames.

new config:
```
      - key: ckan.cache.expires
        default: 3600
        legacy_key: ckan.cache_expires  # since v.2.12.0
        type: int
        example: 2592000
        description: |
          This sets ``Cache-Control`` header's max-age value on public cache.
          3600 = 1 hour before revalidate with shared cache

      - key: ckan.cache.shared.expires
        default: 7200
        type: int
        example: 7200
        description: |
          This sets ``Cache-Control`` header's s-maxage value on public cache.
          7200 = 2 hour before shared cache revalidates

      - key: ckan.cache.private.expires
        type: int
        default: 60
        example: 3600
        description: |
          This sets ``Cache-Control`` header's max-age value on private cache.

      - key: ckan.cache.public.enabled
        legacy_key: ckan.cache_enabled  # since v.2.12.0
        default: True
        type: bool
        example: "true"
        description: |
          This enables cache control headers on all requests. If the user is
          not logged in and there is no session data a ``Cache-Control:
          public`` header will be added. For all other requests see `
          `ckan.cache.private.enabled`` config option.

      - key: ckan.cache.private.enabled
        default: true
        type: bool
        example: "true"
        description: |
          When this is set to true and cache type requested is private,
          then ``Cache-control: private`` header will be added,
          else ``Cache-Control: no-cache max-age=0`` will be set on all
          requests except for sensitive responses where no-store
          will also be set.

      - key: ckan.cache.stale_while_revalidates
        default: 3600
        type: int
        example: 3600
        description: |
          This sets ``Cache-Control`` header's stale-while-revalidate value on public/private cache.
          In Seconds, config used to serve stale content while being background revalidated
          users will continue to receive stale data until refresh call is returned
          limiting requests to one per edge cache instead of all users when shared
          cache is stale/expired - dependant on cache keys.
          Set to 0 to disallow stale cache server on requests.

      - key: ckan.cache.stale_if_error
        default: 86400
        type: int
        example: 7200
        description: |
          This sets ``Cache-Control`` header's stale-if-error value on public/private cache.
          86400 = 1 day if origin server throws 5xx error.
          Set to 0 to disallow stale cache server on 5xx errors.
          Note: When both ``stale_while_revalidates`` and ``stale_if_error`` are set to 0, ``must-revalidate`` is used instead.

      - key: ckan.cache.no_transform
        type: bool
        default: false
        example: "true"
        description: |
          If the HTTP response is not to be manipulated, Default: False
          Adds to ``Cache-control`` ``no-transform``.

      - key: ckan.etags.enabled
        type: bool
        default: true
        example: "true"
        description: |
          Add etag response header on all payloads
```

new core helpers:
* cache_level
   get ``g.cache_type``
* limit_cache_for_page
  get ``g.limit_cache_for_page``
* set_limit_cache_for_page
  set ``g.limit_cache_for_page
* set_cache_level
  set ``g.cache_type`` if it can be overridden (or bool override flag), takes string or enum
* etag_append
  adds to ``g.etag_append`` additional strings
* set_etag_replace
  sets ``g.etag_replace``, default ckan behaviour, if set it will override any etag generation with set value
* set_etag_modified_time
  sets ``g.etag_modified_time`` if set will stop 'now()' time being used, useful for future extension to use db time once plugins start adding appending etag data.


Updates:
* webassets, enable etags and public cache control (plus disable session access flag)
* MultiStaticFlask (also known as public assets), enable etags and public cache control (plus disable session access flag)
* Vary now set on api as well as on pages, surface flask global ``g`` flag for extensions to use
* Update interface ``IMiddleware``
  now surfaces: ``set_cors_headers_for_response``, ``set_cache_control_headers_for_response``, ``set_etag_for_response`` for overrides

Tests:
Over 1000 lines of test's added covering all new features and then some.

### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
