### PR TITLE
Hide and show simply

### DIFF
--- a/changes/8960.bugfix
+++ b/changes/8960.bugfix
@@ -1,0 +1,1 @@
+Fix loading image for datatbles view.

--- a/ckanext/datatablesview/assets/datatablesview.js
+++ b/ckanext/datatablesview/assets/datatablesview.js
@@ -484,6 +484,7 @@ this.ckan.module('datatables_view', function (jQuery) {
         // show loading indicator when first painting data into the table.
         // useful with very large resources that take long to load
         $('body.dt-view').css('visibility', 'visible');
+        $('#dtprv_processing').addClass('pre-init');
         $('#dtprv_processing').show();
       });
       datatable = $('#dtprv').DataTable({
@@ -606,6 +607,7 @@ this.ckan.module('datatables_view', function (jQuery) {
           }
 
           // hide the pre-loading indicator background so the table is interactive when loading
+          $('#dtprv_processing').removeClass('pre-init');
           $('#dtprv_processing').hide();
 
           // restore selected rows from state

--- a/ckanext/datatablesview/assets/datatablesview.js
+++ b/ckanext/datatablesview/assets/datatablesview.js
@@ -484,7 +484,7 @@ this.ckan.module('datatables_view', function (jQuery) {
         // show loading indicator when first painting data into the table.
         // useful with very large resources that take long to load
         $('body.dt-view').css('visibility', 'visible');
-        $('#dtprv_processing').addClass('pre-init');
+        $('#dtprv_processing').show();
       });
       datatable = $('#dtprv').DataTable({
         paging: true,
@@ -606,7 +606,7 @@ this.ckan.module('datatables_view', function (jQuery) {
           }
 
           // hide the pre-loading indicator background so the table is interactive when loading
-          $('#dtprv_processing').removeClass('pre-init');
+          $('#dtprv_processing').hide();
 
           // restore selected rows from state
           if (typeof gsavedSelected !== 'undefined') {


### PR DESCRIPTION
Related to #7900

### Proposed fixes:

I'm having troubles to hide the loading dots in the datatables view.
This fixed it.
The proposal is to move to the simple way to hide/show in jQuery

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
