### PR TITLE
Add missing snippet parameter

### DIFF
--- a/ckan/templates/user/read_base.html
+++ b/ckan/templates/user/read_base.html
@@ -28,5 +28,5 @@
 {% endblock %}
 
 {% block secondary_content %}
-  {% snippet "user/snippets/info.html", user=user, is_myself=is_myself, is_sysadmin=is_sysadmin, dataset_type=dataset_type, org_type=org_type, group_type=group_type, am_following=am_following %}
+  {% snippet "user/snippets/info.html", user=user, is_myself=is_myself, is_sysadmin=is_sysadmin, dataset_type=dataset_type, org_type=org_type, group_type=group_type, am_following=am_following, about_formatted=about_formatted %}
 {% endblock %}


### PR DESCRIPTION
The biography was missing from the user page because it was not passed to the snippet

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
