### PR TITLE
Fix critical error if storage path is missing by adding a new config option

### DIFF
--- a/changes/8977.bugfix
+++ b/changes/8977.bugfix
@@ -1,0 +1,4 @@
+Added a new config option :ref:`ckan.uploads_enabled` to fix critical error logs about missing storage_path.
+
+You must set this to true, if you want to enable file uploads in the UI.
+

--- a/changes/8977.bugfix
+++ b/changes/8977.bugfix
@@ -1,4 +1,4 @@
 Added a new config option :ref:`ckan.uploads_enabled` to fix critical error logs about missing storage_path.
 
-You must set this to true, if you want to enable file uploads in the UI.
+If not enabled, you either must have IUploader plugin configured or have defined storage_path to have uploads in the UI.
 

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -1185,7 +1185,7 @@ groups:
       - key: ckan.site_custom_css
         description: Custom CSS directives to include on all CKAN pages.
         editable: true
-      
+
       - key: ckan.default_collapse_facets
         type: bool
         default: False
@@ -1304,10 +1304,22 @@ groups:
 
   - annotation: Storage Settings
     options:
+      - key: ckan.uploads_enabled
+        type: bool
+        default: false
+        example: false
+        description: |
+          Defines file uploads are enabled or not.
+
+          If enabled also set :ref:`ckan.storage_path` if you want to use internal storage.
+
       - key: ckan.storage_path
         placeholder: /var/lib/ckan/default
         example: /var/lib/ckan/default
-        description: This defines the location of where CKAN will store all uploaded data.
+        description: |
+          This defines the location of where CKAN will store all uploaded data.
+
+          If set to some directory, also set :ref:`ckan.uploads_enabled` to true to enable uploads in the UI.
 
       - key: ckan.max_resource_size
         type: int

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -1305,8 +1305,7 @@ groups:
   - annotation: Storage Settings
     options:
       - key: ckan.uploads_enabled
-        type: bool
-        default: false
+        validators: ignore_missing boolean_validator
         example: false
         description: |
           Defines file uploads are enabled or not.

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -35,7 +35,6 @@ import ckan.model as model
 from ckan.lib import base
 from ckan.lib import helpers as h
 from ckan.lib import jinja_extensions
-from ckan.lib import uploader
 from ckan.lib import i18n
 from ckan.lib.flask_multistatic import MultiStaticFlask
 from ckan.common import config, g, request, ungettext
@@ -139,7 +138,7 @@ def make_flask_stack(conf: Union[Config, CKANConfig]) -> CKANApp:
 
     # Register storage for accessing group images, site logo, etc.
     storage_folder = []
-    storage = uploader.get_storage_path()
+    storage = config.get('ckan.storage_path')
     if storage:
         storage_folder = [os.path.join(storage, 'storage')]
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2483,7 +2483,14 @@ localised_filesize = formatters.localised_filesize
 
 @core_helper
 def uploads_enabled() -> bool:
-    if config.get('ckan.uploads_enabled'):
+    upload_config = config.get('ckan.uploads_enabled')
+    if upload_config is not None:
+        return upload_config
+
+    if config['ckan.storage_path'] is not None:
+        return True
+
+    if len([plugin for plugin in p.PluginImplementations(p.IUploader)]) != 0:
         return True
     return False
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -51,7 +51,6 @@ import ckan.lib.formatters as formatters
 import ckan.lib.maintain as maintain
 import ckan.lib.datapreview as datapreview
 import ckan.logic as logic
-import ckan.lib.uploader as uploader
 import ckan.authz as authz
 import ckan.plugins as p
 import ckan
@@ -2484,7 +2483,7 @@ localised_filesize = formatters.localised_filesize
 
 @core_helper
 def uploads_enabled() -> bool:
-    if uploader.get_storage_path():
+    if config.get('ckan.uploads_enabled'):
         return True
     return False
 

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -908,3 +908,26 @@ def test_decode_view_request_filters(test_request_context):
 def test_get_translated(data_dict, locale, result, monkeypatch):
     monkeypatch.setattr(flask_app, "get_locale", lambda: locale)
     assert h.get_translated(data_dict, 'notes') == result
+
+
+class TestUploadsEnabled:
+
+    @pytest.mark.ckan_config("ckan.uploads_enabled", True)
+    def test_uploads_enabled(self):
+        assert h.uploads_enabled() is True
+
+    @pytest.mark.ckan_config("ckan.uploads_enabled", False)
+    def test_uploads_disabled(self):
+        assert h.uploads_enabled() is False
+
+    def test_uploads_disabled_on_default_configuration(self):
+        assert h.uploads_enabled() is False
+
+    @pytest.mark.ckan_config("ckan.storage_path", "/some/path")
+    def test_uploads_enabled_with_only_storage_path(self):
+        assert h.uploads_enabled() is True
+
+    @pytest.mark.usefixtures("with_plugins")
+    @pytest.mark.ckan_config(u"ckan.plugins", "example_iuploader")
+    def test_uploads_enabled_when_iuploader_plugin_exists(self):
+        assert h.uploads_enabled() is True

--- a/ckan/tests/lib/test_uploader.py
+++ b/ckan/tests/lib/test_uploader.py
@@ -7,7 +7,7 @@ from werkzeug.datastructures import FileStorage
 from ckan.logic import ValidationError
 from ckan.lib.uploader import ResourceUpload, Upload
 
-
+@pytest.mark.ckan_config('ckan.uploads_enabled', True)
 class TestInitResourceUpload(object):
     def test_resource_without_upload_with_old_werkzeug(
             self, ckan_config, monkeypatch, tmpdir):
@@ -78,7 +78,7 @@ class TestInitResourceUpload(object):
         with pytest.raises(ValidationError):
             res_upload.upload(resource_id)
 
-
+@pytest.mark.ckan_config('ckan.uploads_enabled', True)
 class TestUpload(object):
     def test_group_upload(self, monkeypatch, tmpdir, make_app, ckan_config, faker):
         """Reproduce group's logo upload and check that file available through

--- a/doc/maintaining/filestore.rst
+++ b/doc/maintaining/filestore.rst
@@ -37,11 +37,12 @@ To setup CKAN's FileStore with local file storage:
 
      sudo mkdir -p |storage_path|
 
-2. Add the following line to your CKAN config file, after the ``[app:main]``
+2. Add the following lines to your CKAN config file, after the ``[app:main]``
    line:
 
    .. parsed-literal::
 
+      ckan.uploads_enabled = true
       ckan.storage_path = |storage_path|
 
 3. Set the permissions of your :ref:`ckan.storage_path` directory.


### PR DESCRIPTION
Fixes #8966 

### Proposed fixes:

Adds a new config option `ckan.uploads_enabled` which only affects `uploads_enabled` helper.  If uploader instances call `get_storage_path` they still get the error.

Does not affect translations or webassets directories as they use the config directly as seen on below:

https://github.com/ckan/ckan/blob/f2cc28e8b71608d70361cf2488ea536447e102a5/ckan/lib/i18n.py#L79

https://github.com/ckan/ckan/blob/f2cc28e8b71608d70361cf2488ea536447e102a5/ckan/lib/webassets_tools.py#L209-L212  


### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
