### PR TITLE
New config value for query timeout

### DIFF
--- a/changes/8984.misc
+++ b/changes/8984.misc
@@ -1,0 +1,2 @@
+Add a new config value for Datastore query
+timeout ckan.datastore.default_query_timeout

--- a/ckanext/datastore/config_declaration.yaml
+++ b/ckanext/datastore/config_declaration.yaml
@@ -92,6 +92,16 @@ groups:
       them. It can be overwritten by the user by passing the "lang" parameter to
       "datastore_search" and "datastore_create".
 
+  - default: 60_000
+    key: ckan.datastore.default_query_timeout
+    type: int
+    example: 180_000
+    description: >
+      The default query timeout (in milliseconds) for the datastore queries.
+      This is usedwhen executing queries against the datastore.
+      "search"/"search_sql", "upsert", and "create" actions will use this
+      timeout
+
   - default: gist
     key: ckan.datastore.default_fts_index_method
     example: gist


### PR DESCRIPTION
### Proposed fixes:

This is a proposal to allow users to define the default query timeouts for the datastore

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
