### PR TITLE
Catch NotAuthorized exception raised by datastore_search

### DIFF
--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -64,7 +64,7 @@ def dump(resource_id: str):
     try:
         get_action('datastore_search')({}, {'resource_id': resource_id,
                                             'limit': 0})
-    except ObjectNotFound:
+    except (ObjectNotFound, NotAuthorized):
         abort(404, _('DataStore resource not found'))
 
     data, errors = dict_fns.validate(request.args.to_dict(), dump_schema())


### PR DESCRIPTION
The method `datastore_search` can as well raise a NotAuthorized exception. I'm adding it in the except statement to handle it properly and avoid `500`.

```
Traceback (most recent call last):
  File "/app/venv/lib/python3.11/site-packages/flask/app.py", line 880, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib/python3.11/site-packages/flask/app.py", line 865, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib/python3.11/site-packages/ckanext/datastore/blueprint.py", line 65, in dump
    get_action('datastore_search')({}, {'resource_id': resource_id,
  File "/app/venv/lib/python3.11/site-packages/ckan/logic/__init__.py", line 580, in wrapped
    result = _action(context, data_dict, **kw)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib/python3.11/site-packages/ckanext/datastore/logic/action.py", line 656, in datastore_search
    p.toolkit.check_access('datastore_search', context, data_dict)
  File "/app/venv/lib/python3.11/site-packages/ckan/logic/__init__.py", line 388, in check_access
    logic_authorization = authz.is_authorized(action, context, data_dict)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib/python3.11/site-packages/ckan/authz.py", line 242, in is_authorized
    return auth_function(context, data_dict or {})
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib/python3.11/site-packages/ckanext/datastore/logic/auth.py", line 57, in datastore_search
    return datastore_auth(context, data_dict, 'resource_show')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib/python3.11/site-packages/ckanext/datastore/logic/auth.py", line 15, in datastore_auth
    authorized = p.toolkit.check_access(privilege, context, data_dict)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib/python3.11/site-packages/ckan/logic/__init__.py", line 391, in check_access
    raise NotAuthorized(msg)
ckan.logic.NotAuthorized: User  not authorized to read resource 4178c667-dd37-4a2d-9783-de7142a334dd
```
