### PR TITLE
Expose NotFound exception as such in toolkit

### DIFF
--- a/changes/8996.misc
+++ b/changes/8996.misc
@@ -1,0 +1,1 @@
+Expose `NotFound` exception in plugins toolkit for consistency with core extensions (it's the same exception as the existing `ObjectNotFound`)

--- a/ckan/plugins/toolkit.py
+++ b/ckan/plugins/toolkit.py
@@ -23,7 +23,7 @@ from ckan.logic import (  # noqa: re-export
     get_validator,
     chained_auth_function,
     chained_action,
-    NotFound as ObjectNotFound,
+    NotFound,
     NotAuthorized,
     ValidationError,
     UnknownValidator,
@@ -87,6 +87,9 @@ from ckan.cli import error_shout
 from ckan.lib.mailer import mail_recipient, mail_user
 from ckan.model.base import BaseModel
 
+ObjectNotFound = NotFound
+
+
 __all__ = [
     "BaseModel",
     "CkanVersionException",
@@ -96,6 +99,7 @@ __all__ = [
     "HelperError",
     "Invalid",
     "NotAuthorized",
+    "NotFound",
     "ObjectNotFound",
     "StopOnError",
     "UnknownValidator",

--- a/ckan/tests/plugins/test_toolkit.py
+++ b/ckan/tests/plugins/test_toolkit.py
@@ -3,6 +3,7 @@
 import pytest
 
 import ckan.plugins.toolkit as tk
+from ckan.logic import NotFound
 
 
 @pytest.mark.parametrize(
@@ -124,3 +125,12 @@ def test_get_endpoint_without_context():
 def test_get_endpoint_with_context():
     """with_request_context fixture mocks request to the homepage."""
     assert tk.get_endpoint() == ("home", "index")
+
+
+@pytest.mark.parametrize("exception_class", [tk.NotFound, tk.ObjectNotFound])
+def test_not_found_exception(exception_class: Exception):
+
+    with pytest.raises(exception_class) as e:
+        tk.get_action("package_show")({"ignore_auth": True}, {"id": "not_found"})
+
+    assert isinstance(e.value, NotFound)


### PR DESCRIPTION
Very minor thing that has always bothered me.

Back in 33fcc1dff773fe355c39d11107727270ab41aacf the exception was "intentionally" renamed as `ObjectNotFound` but sadly the reasoning behind the intention was not captured. I can't think of a good reason why the toolkit exception should be named differently than the core one, and only in this particular case.
I expect we'll keep `ObjectNotFound` around forever for compatibility but at least new code targeting the version where this will be merged can use `NotFound`

