### PR TITLE
Bump minimum Python version supported for CKAN 2.12 to py 3.10

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 env:
   NODE_VERSION: '16'
-  PYTHON_VERSION: '3.9'
+  PYTHON_VERSION: '3.10'
 
 permissions:
   contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
   workflow_dispatch:
 env:
-  PYTHON_VERSION: '3.9'
+  PYTHON_VERSION: '3.10'
 
 permissions:
   contents: read

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Install pypa/build
       run: >-
         python3 -m

--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Add timestamp to version number
       run: |
         TIMESTAMP=$(date +"%Y%m%d%H%M")

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 env:
   NODE_VERSION: '18'
-  PYTHON_VERSION: '3.9'
+  PYTHON_VERSION: '3.10'
 
 permissions:
   contents: read

--- a/.github/workflows/towncrier.yml
+++ b/.github/workflows/towncrier.yml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           cache: 'pip'
       - name: Install python deps
         run: pip install -r requirements.txt -r dev-requirements.txt -e.

--- a/changes/8998.migration
+++ b/changes/8998.migration
@@ -1,0 +1,1 @@
+Starting from CKAN 2.12.0, the minimum Python version supported is Python 3.10

--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/pyproject.toml
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/pyproject.toml
@@ -14,9 +14,9 @@ license = {text = "AGPL"}
 classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 {% set keywords = cookiecutter.keywords.split() %}
 keywords = [ {% for keyword in keywords %}"{{ keyword }}", {% endfor %}]

--- a/doc/maintaining/installing/install-from-package.rst
+++ b/doc/maintaining/installing/install-from-package.rst
@@ -13,7 +13,7 @@ At the end of the installation process you will end up with two running web
 applications, CKAN itself and the DataPusher, a separate service for automatically
 importing data to CKAN's :doc:`/maintaining/datastore`. Additionally, there will be a process running the worker for running :doc:`/maintaining/background-tasks`. All these processes will be managed by `Supervisor <https://supervisord.org/>`_.
 
-For Python 3 installations, the minimum Python version required is 3.9.
+For Python 3 installations, the minimum Python version required is 3.10.
 
 Host ports requirements:
 

--- a/doc/maintaining/installing/install-from-source.rst
+++ b/doc/maintaining/installing/install-from-source.rst
@@ -14,7 +14,7 @@ If you install CKAN from source on your own operating system, please share your
 experiences on our `How to Install CKAN <https://github.com/ckan/ckan/wiki/How-to-Install-CKAN>`_
 wiki page.
 
-**The minimum Python version required is 3.9**
+**The minimum Python version required is 3.10**
 
 From source is also the right installation method for developers who want to
 work on CKAN.
@@ -36,15 +36,13 @@ wiki page for help):
 =====================  ===============================================
 Package                Description
 =====================  ===============================================
-Python                 `The Python programming language, v3.9 or newer <https://www.python.org/getit/>`_
+Python                 `The Python programming language, v3.10 or newer <https://www.python.org/getit/>`_
 |postgres|             `The PostgreSQL database system, v12 or newer <https://www.postgresql.org/docs/10/libpq.html>`_
 libpq                  `The C programmer's interface to PostgreSQL <http://www.postgresql.org/docs/8.1/static/libpq.html>`_
 pip                    `A tool for installing and managing Python packages <https://pip.pypa.io/en/stable/>`_
 python3-venv           `The Python3 virtual environment builder (or for Python 2 use 'virtualenv' instead) <https://virtualenv.pypa.io/en/latest/>`_
 Git                    `A distributed version control system <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`_
 Apache Solr            `A search platform <https://lucene.apache.org/solr/>`_
-Jetty                  `An HTTP server <https://www.eclipse.org/jetty/>`_ (used for Solr).
-OpenJDK JDK            `The Java Development Kit <https://openjdk.java.net/install/>`_ (used by Jetty)
 Redis                  `An in-memory data structure store <https://redis.io/>`_
 =====================  ===============================================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ testpaths = ["ckan", "ckanext"]
 addopts = "--strict-markers --pdbcls=IPython.terminal.debugger:TerminalPdb --ckan-ini=test-core.ini"
 
 [tool.pyright]
-pythonVersion = "3.9"
+pythonVersion = "3.10"
 include = ["ckan", "ckanext"]
 exclude = [
     "**/test*",

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,12 +18,12 @@ classifiers =
             Development Status :: 5 - Production/Stable
             License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)
             Programming Language :: Python
-            Programming Language :: Python :: 3.9
             Programming Language :: Python :: 3.10
             Programming Language :: Python :: 3.11
+            Programming Language :: Python :: 3.12
 
 [options]
-python_requires = >= 3.9
+python_requires = >= 3.10
 install_requires =
                  setuptools >= 44.1.0
 packages = find:


### PR DESCRIPTION
Just updating package metadata, docs and the versions the workflows run on.