### PR TITLE
Add logger configuration inheritance

### DIFF
--- a/ckan/cli/__init__.py
+++ b/ckan/cli/__init__.py
@@ -101,10 +101,28 @@ class CKANConfigLoader(object):
                 )
 
     def _create_config_object(self):
+
+        logging_sections = ["loggers", "handlers", "formatters"]
+        logging_prefixes = tuple(f"{s[:-1]}_" for s in logging_sections)
+
         chain = self._unwrap_config_chain(self.config_file)
         for filename in reversed(chain):
             self._read_config_file(filename)
             self._update_config()
+
+            if all([self.parser.has_section(s) for s in logging_sections]):
+                loggingFileConfig(filename)
+
+                # We use the same parser instance for all chained files, so we
+                # can interpolate variables in the lower level config files, but
+                # we need to reset the logging sections otherwise they will come up
+                # when parsing the next files even if they are not present
+                for section in self.parser.sections():
+                    if section in logging_sections or section.startswith(
+                        logging_prefixes
+                    ):
+                        self.parser.remove_section(section)
+
         log.debug(
             u'Loaded configuration from the following files: %s',
             chain
@@ -155,7 +173,7 @@ or have one of {} in the current directory.'''
         raise CkanConfigurationException(msg)
 
     config_loader = CKANConfigLoader(filename)
-    loggingFileConfig(filename)
+
     log.info('Using configuration file %s', filename)
 
     return config_loader.get_config()

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -151,6 +151,13 @@ groups:
     options:
       - key: use
         placeholder: egg:ckan
+        description: |
+          Allows to define chained configuration files. The base ini file should use the ``egg:ckan``
+          value. Files extending the base ini files must use the ``config:<path to parent ini file>`` form.
+          For instance, if you need to tweak the test settings in a ``test-core-custom.ini`` file, you
+          would use ``use=config:test-core.ini`` as value. Configuration options defined in the higher level
+          files (e.g. ``test-core-custom.ini``) will override the existing ones defined in the base on
+          (e.g. ``test-core.ini``).
 
       - key: SECRET_KEY
         legacy_key: beaker.session.secret
@@ -1185,7 +1192,7 @@ groups:
       - key: ckan.site_custom_css
         description: Custom CSS directives to include on all CKAN pages.
         editable: true
-      
+
       - key: ckan.default_collapse_facets
         type: bool
         default: False

--- a/ckan/tests/cli/data/test-log-1.ini
+++ b/ckan/tests/cli/data/test-log-1.ini
@@ -1,0 +1,30 @@
+[app:main]
+use = egg:ckan
+
+
+[loggers]
+keys = root, ckan
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_ckan]
+qualname = ckan
+handlers = console
+level = WARN
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s

--- a/ckan/tests/cli/data/test-log-2.ini
+++ b/ckan/tests/cli/data/test-log-2.ini
@@ -1,0 +1,30 @@
+[app:main]
+use = config:test-log-1.ini
+
+
+[loggers]
+keys = root, ckan
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_ckan]
+qualname = ckan
+handlers = console
+level = CRITICAL
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s - CUSTOM

--- a/ckan/tests/cli/data/test-log-3.ini
+++ b/ckan/tests/cli/data/test-log-3.ini
@@ -1,0 +1,2 @@
+[app:main]
+use = config:test-log-2.ini

--- a/ckan/tests/cli/test_cli.py
+++ b/ckan/tests/cli/test_cli.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
 
 from configparser import InterpolationMissingOptionError
-import pytest
+import io
+import logging
 import os
 
+import pytest
+
+from ckan.common import config
 from ckan.cli.cli import ckan
 from ckan.cli import CKANConfigLoader
 from ckan.exceptions import CkanConfigurationException
@@ -195,3 +199,64 @@ def test_reference_to_non_existing_config():
         os.path.dirname(__file__), u'data', u'test-non-existing-path.ini')
     with pytest.raises(CkanConfigurationException):
         CKANConfigLoader(filename).get_config()
+
+
+@pytest.fixture
+def clean_logging():
+    yield
+
+    # Restore original logging state by reparsing the test ini file
+    CKANConfigLoader(config["__file__"]).get_config()
+
+
+def test_chained_logging_config_is_overriden(clean_logging):
+    filename = os.path.join(
+        os.path.dirname(__file__), "data", "test-log-2.ini")
+
+    CKANConfigLoader(filename).get_config()
+
+    captured_output = io.StringIO()
+    test_handler = logging.StreamHandler(captured_output)
+    test_handler.formatter = logging.getLogger().handlers[0].formatter
+
+    log = logging.getLogger(__name__)
+    log.addHandler(test_handler)
+
+    try:
+        log.info("Some info message")
+        log.critical("Some critical message")
+
+        assert "Some info message" not in captured_output.getvalue()
+        assert "Some critical message" in captured_output.getvalue()
+        assert "CUSTOM" in captured_output.getvalue()
+    finally:
+        log.removeHandler(test_handler)
+
+
+def test_chained_logging_last_file_does_not_require_logging_conf(clean_logging):
+    filename = os.path.join(
+        os.path.dirname(__file__), "data", "test-log-3.ini")
+
+    CKANConfigLoader(filename).get_config()
+
+
+def test_logging_is_restored():
+    filename = os.path.join(
+        os.path.dirname(__file__), "data", "test-one.ini")
+
+    CKANConfigLoader(filename).get_config()
+
+    captured_output = io.StringIO()
+    test_handler = logging.StreamHandler(captured_output)
+    test_handler.formatter = logging.getLogger().handlers[0].formatter
+
+    log = logging.getLogger(__name__)
+    log.addHandler(test_handler)
+
+    try:
+        log.critical("Some critical message")
+
+        assert "Some critical message" in captured_output.getvalue()
+        assert "CUSTOM" not in captured_output.getvalue()
+    finally:
+        log.removeHandler(test_handler)

--- a/doc/maintaining/configuration.rst
+++ b/doc/maintaining/configuration.rst
@@ -408,13 +408,6 @@ file settings, for reference.
 
         [DEFAULT]
 
-        ...
-
-        [server:main]
-        use = egg:Paste#http
-        host = 0.0.0.0
-        port = 5000
-
         # This setting will not work, because it's outside of [app:main].
         ckan.site_logo = /images/masaq.png
 
@@ -425,6 +418,32 @@ file settings, for reference.
    If the same option is set more than once in your config file, exeption will
    be raised and CKAN application will not start
 
+.. _logging-settings:
+
+Logging settings
+----------------
+
+The logging settings control how CKAN outputs the log messages to the application logs, e.g.::
+
+  ckan run
+
+  2025-06-20 12:46:01,879 INFO  [ckan.cli] Using configuration file /home/adria/dev/projects/ckan-py310/ckan/ckan.ini
+  2025-06-20 12:46:01,880 INFO  [ckan.config.environment] Loading static files from public
+  2025-06-20 12:46:02,565 INFO  [ckan.config.environment] Loading templates from /home/adria/dev/projects/ckan-py310/ckan/ckan/templates
+  2025-06-20 12:46:02,874 INFO  [ckan.cli.server] Running CKAN on http://localhost:5310
+
+CKAN uses Python's standard `Configuration file format <https://docs.python.org/3/library/logging.config.html#configuration-file-format>`_ for the logging sections.
+You can refer to the Python documentation for all details but essentially there are
+three mandatory sections (``loggers``, ``handlers`` and ``formatters``) that contain the keys of
+the actual elements configured. Loggers allow you to define different debugging levels for
+different modules and libraries. By default CKAN only configures a console handler that
+outputs log message to *stderr* but you can configure any of the
+ones `included <https://docs.python.org/3/library/logging.handlers.html#module-logging.handlers>`_ in Python.
+
+If you are chaining configuration files using :ref:`use` you don't need to include the
+logging configuration in all the ini files contained in the chain. As with any regular
+configuration options base logging settings will take effect unless overriden by a higher
+level ini file.
 
 
 .. include:: ../_config_options.inc


### PR DESCRIPTION
The way we currently parse our ini files means the last ini file in a chain (i.e. the one that you pass with the `-c` param to the CKAN CLI or to pytest with `--ckan-ini`) must contain the whole logging configuration, otherwise you get an exception:

```
  File "/home/adria/dev/projects/ckan-py310/ckan/ckan/cli/__init__.py", line 158, in load_config
    loggingFileConfig(filename)
  File "/home/adria/.pyenv/versions/3.10.16/lib/python3.10/logging/config.py", line 72, in fileConfig
    formatters = _create_formatters(cp)
  File "/home/adria/.pyenv/versions/3.10.16/lib/python3.10/logging/config.py", line 105, in _create_formatters
    flist = cp["formatters"]["keys"]
  File "/home/adria/.pyenv/versions/3.10.16/lib/python3.10/configparser.py", line 965, in __getitem__
    raise KeyError(key)
KeyError: 'formatters'
```

This is annoying because when extending ini files you probably just want to override a couple of settings from the base ini file but you need to duplicate the logging configuration. These changes align the logging settings with the rest of CKAN config options: base logging settings will be used unless they are overriden in a higher level ini file.

Added a few docs regarding the logging settings and the `use` config option which were missing.