### PR TITLE
Remove ckan.static_max_age from config docs

### DIFF
--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -435,12 +435,6 @@ groups:
 
           ``None`` will not store the mimetype for the resource.
 
-      - key: ckan.static_max_age
-        default: 3600
-        type: int
-        example: 2592000
-        description: Controls CKAN static files' cache max age, if we're serving and caching them.
-
       - key: ckan.valid_url_schemes
         type: list
         default:


### PR DESCRIPTION
This options hasn't been used since CKAN 2.9

