### PR TITLE
Attributtes in assets

### DIFF
--- a/ckan/lib/webassets_tools.py
+++ b/ckan/lib/webassets_tools.py
@@ -163,7 +163,7 @@ def _to_tag(asset_info: Tuple[str, dict[str, str]], type_: AssetType) -> str:
 
     if type_ == "style" and "rel" not in attrs:
         attrs["rel"] = "stylesheet"
-    elif type_ == "script" and "type" not in attrs:
+    elif type_ == "script" and "type" not in attrs and not is_preload:
         attrs["type"] = "text/javascript"
 
     attr_items = []

--- a/ckan/tests/lib/assets/test.css
+++ b/ckan/tests/lib/assets/test.css
@@ -1,0 +1,1 @@
+/* Nothing to see here */

--- a/ckan/tests/lib/assets/test.js
+++ b/ckan/tests/lib/assets/test.js
@@ -1,0 +1,1 @@
+// Nothing to see here

--- a/ckan/tests/lib/assets/webassets.yml
+++ b/ckan/tests/lib/assets/webassets.yml
@@ -1,0 +1,51 @@
+test_js_basic:
+  output: test/rendered_test.js
+  contents:
+    - test.js
+
+test_css_basic:
+  output: test/rendered_test.css
+  contents:
+    - test.css
+
+test_js_attr_key:
+  output: test/rendered_test.js
+  extra:
+    attrs:
+      defer:
+  contents:
+    - test.js
+
+test_js_attr_key_value:
+  output: test/rendered_test.js
+  extra:
+    attrs:
+      crossorigin: anonymous
+  contents:
+    - test.js
+
+test_js_attr_both:
+  output: test/rendered_test.js
+  extra:
+    attrs:
+      async:
+      crossorigin: anonymous
+  contents:
+    - test.js
+
+test_css_attr_key_value:
+  output: test/rendered_test.css
+  extra:
+    attrs:
+      fetchpriority: high
+  contents:
+    - test.css
+
+test_js_attr_preload:
+  output: test/rendered_test.js
+  extra:
+    attrs:
+      rel: preload
+      as: script
+  contents:
+    - test.js

--- a/ckan/tests/lib/test_webassets_tools.py
+++ b/ckan/tests/lib/test_webassets_tools.py
@@ -1,0 +1,77 @@
+import os
+import re
+
+import pytest
+
+from ckan.common import g
+
+from ckan.lib.webassets_tools import render_assets, create_library, include_asset
+
+
+def _remove_cache_busting(tag: str) -> str:
+
+    return re.sub(r'\?[^"]*', "", tag)
+
+
+@pytest.fixture
+def test_assets(app):
+
+    with app.flask_app.app_context():
+        current_assets = getattr(g, "_webassets", None)
+        assets_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "assets"))
+
+        create_library("tests", assets_path)
+
+        yield
+        g._webassets = current_assets
+
+
+# def test_render_assets(test_assets, name, rendered_tag)
+
+
+@pytest.mark.parametrize(
+    "type_,name,expected",
+    [
+        (
+            "script",
+            "tests/test_js_basic",
+            '<script src="/webassets/test/rendered_test.js" type="text/javascript"></script>',
+        ),
+        (
+            "style",
+            "tests/test_css_basic",
+            '<link href="/webassets/test/rendered_test.css" rel="stylesheet"/>',
+        ),
+        (
+            "script",
+            "tests/test_js_attr_key",
+            '<script src="/webassets/test/rendered_test.js" defer type="text/javascript"></script>',
+        ),
+        (
+            "script",
+            "tests/test_js_attr_key_value",
+            '<script src="/webassets/test/rendered_test.js" crossorigin="anonymous" type="text/javascript"></script>',
+        ),
+        (
+            "script",
+            "tests/test_js_attr_both",
+            '<script src="/webassets/test/rendered_test.js" async crossorigin="anonymous" type="text/javascript"></script>',
+        ),
+        (
+            "style",
+            "tests/test_css_attr_key_value",
+            '<link href="/webassets/test/rendered_test.css" fetchpriority="high" rel="stylesheet"/>',
+        ),
+        (
+            "script",
+            "tests/test_js_attr_preload",
+            '<link href="/webassets/test/rendered_test.js" rel="preload" as="script"/>',
+        ),
+
+    ],
+)
+def test_render_assets(test_assets, type_, name, expected):
+
+    include_asset(name)
+
+    assert _remove_cache_busting(render_assets(type_)) == expected

--- a/doc/contributing/frontend/assets.rst
+++ b/doc/contributing/frontend/assets.rst
@@ -28,7 +28,7 @@ Duplicate assets will not be added and any dependencies will be included as
 well as the assets, all in the correct order (see below for details).
 
 Extensions can add new libraries to CKAN using a helper function defined in 
-the :doc:` plugins-toolkit <plugins-toolkit>`. See below.
+the :doc:`plugins toolkit </extensions/plugins-toolkit>`. See below.
 
 In debug mode assets are served un-minified and un-bundled (ie each asset is
 served separately). In non-debug mode the files are served minified and bundled
@@ -139,10 +139,59 @@ documentation
 [extra] (optional)
 ~~~~~~~~~~~~~~~~~~
 
-Additional configuration details. Currently, only one option is
-supported: ``preload``.
+Additional configuration details. The following options are currently
+supported:
 
 **preload**
 
 Defines list of assets in format ``asset_library/asset_name``, that
 must be included into HTML output *before* the current asset.
+
+
+**attrs**
+
+Defines attributes that should be added to the generated HTML tag (``<script>`` or ``<link>``).
+Attributes must have a key, but the value is optional.
+
+For instance::
+
+    my_asset:
+      output: base/%(version)s_my_asset.js
+      extra:
+        attrs:
+          async:
+      contents:
+        - ...
+
+::
+
+    <script src="{url}" async></script>
+
+Another example::
+
+    my_asset:
+      output: base/%(version)s_my_asset.js
+      extra:
+        attrs:
+          type: module
+      contents:
+        - ...
+
+::
+
+    <script src="{url}" type="module"></script>
+
+Scripts loaded using ``preload`` will be correctly rendered as ``<link>`` tags::
+
+    my_asset:
+      output: base/%(version)s_my_asset.js
+      extra:
+        attrs:
+          rel: "preload"
+          as: "script"
+      contents:
+        - ...
+
+::
+
+    <link href="{url}" rel="preload" as="script"/>


### PR DESCRIPTION
Attributes for [`link`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#attributes) and [`script`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#attributes) are really useful to control a wide range of features. For instance attributes like `defer` or `async` can have important performance implications, `type="module` can enable the use of [JS modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules), `crossorigin` might be useful when dealing with CORS, etc

Sadly our webassets rendering code didn't allow any of these but the good news is that with a relatively simple change we can allow arbitrary attributes on the generated HTML tags.

For instance:

```
my_asset:
  output: base/%(version)s_my_asset.js
  extra:
    attrs:
      async:
  contents:
    - ...
```

Will generate:

```
<script src="{url}" async type="text/javascript"></script>
```

Another example:
```
my_asset:
  output: base/%(version)s_my_asset.js
  extra:
    attrs:
      type: module
  contents:
    - ...
```

Will generate:

```
<script src="{url}" type="module"></script>
```

Scripts loaded using `preload` will be correctly renders as `<link>` tags.

```
my_asset:
  output: base/%(version)s_my_asset.js
  extra:
    attrs:
      rel: "preload"
      as: "script"
  contents:
    - ...
```

Will generate:

```
<link href="{url}" rel="preload" as="script"/>
```
The same functionality is available for CSS styles (`<link rel="stylesheet">` tags). 
Includes docs and tests