### PR TITLE
Replace usage of pkg_resources.iter_entry_points [2.11 version]

### DIFF
--- a/changes/8992.misc
+++ b/changes/8992.misc
@@ -1,0 +1,1 @@
+Replace usage of pkg_resources.iter_entry_points, update exception message

--- a/ckan/cli/cli.py
+++ b/ckan/cli/cli.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from typing import Optional
-from pkg_resources import iter_entry_points
+from importlib.metadata import entry_points
 
 import click
 import sys
@@ -186,7 +186,12 @@ def _get_commands_from_entry_point(entry_point: str = 'ckan.click_command'):
 
     """
     registered_entries = {}
-    for entry in iter_entry_points(entry_point):
+    try:
+        eps = entry_points(group=entry_point)
+    except TypeError:
+        # Python 3.9
+        eps = entry_points().get(entry_point)
+    for entry in eps:
         if entry.name in registered_entries:
             error_shout((
                 u'Attempt to override entry_point `{name}`.\n'

--- a/ckan/cli/cli.py
+++ b/ckan/cli/cli.py
@@ -187,11 +187,11 @@ def _get_commands_from_entry_point(entry_point: str = 'ckan.click_command'):
     """
     registered_entries = {}
     try:
-        eps = entry_points(group=entry_point)
+        eps = entry_points(group=entry_point)   # type: ignore
     except TypeError:
         # Python 3.9
         eps = entry_points().get(entry_point)
-    for entry in eps:
+    for entry in eps:   # type: ignore
         if entry.name in registered_entries:
             error_shout((
                 u'Attempt to override entry_point `{name}`.\n'
@@ -202,7 +202,7 @@ def _get_commands_from_entry_point(entry_point: str = 'ckan.click_command'):
             ).format(
                 name=entry.name,
                 first=registered_entries[entry.name].dist,
-                second=entry.dist))
+                second=entry.dist))     # type: ignore
             raise click.Abort()
         registered_entries[entry.name] = entry
 

--- a/ckan/plugins/base.py
+++ b/ckan/plugins/base.py
@@ -36,7 +36,10 @@ class PluginNotFoundException(PluginException):
         self.name = name
 
     def __str__(self):
-        return f"Interface {self.name} does not exist"
+        return (
+            f"Plugin '{self.name}' not found.\n\n"
+            "Did you install the 'ckanext-*' Python package that contains the plugin?"
+        )
 
 
 class Interface:

--- a/ckan/plugins/core.py
+++ b/ckan/plugins/core.py
@@ -243,12 +243,12 @@ def find_system_plugins() -> list[str]:
 
     eps = []
     try:
-        for ep in entry_points(group=SYSTEM_PLUGINS_ENTRY_POINT_GROUP):
+        for ep in entry_points(group=SYSTEM_PLUGINS_ENTRY_POINT_GROUP):     # type: ignore
             ep.load()
             eps.append(ep.name)
     except TypeError:
         # Python 3.9
-        for ep in entry_points().get(SYSTEM_PLUGINS_ENTRY_POINT_GROUP):
+        for ep in entry_points().get(SYSTEM_PLUGINS_ENTRY_POINT_GROUP):     # type: ignore
             ep.load()
             eps.append(ep.name)
 
@@ -283,7 +283,7 @@ def _get_service(plugin_name: str) -> Plugin:
     """
     for group in GROUPS:
         try:
-            eps = list(entry_points(group=group, name=plugin_name))
+            eps = list(entry_points(group=group, name=plugin_name))     # type: ignore
             ep = eps[0] if eps else None
             if ep:
                 return ep[plugin_name].load()(name=plugin_name)


### PR DESCRIPTION
2.11 version of #8992 
Slightly more complex as the entry_point functions have different signatures on Python 3.9