### PR TITLE
Reset Password Template: Translate each line to keep newline breaks.

### DIFF
--- a/ckan/templates/emails/reset_password.txt
+++ b/ckan/templates/emails/reset_password.txt
@@ -1,14 +1,11 @@
-{% trans %}
-Dear {{ user_name }},
+{% trans %}Dear {{ user_name }},{% endtrans %}
 
-You have requested your password on {{ site_title }} to be reset.
-
-Please click the following link to confirm this request:
+{% trans %}You have requested your password on {{ site_title }} to be reset.{% endtrans %}
+{% trans %}Please click the following link to confirm this request:{% endtrans %}
 
    {{ reset_link }}
 
-Have a nice day.
+{% trans %}Have a nice day.{% endtrans %}
 
 --
-Message sent by {{ site_title }} ({{ site_url }})
-{% endtrans %}
+{% trans %}Message sent by {{ site_title }} ({{ site_url }}){% endtrans %}


### PR DESCRIPTION
Fixes #7340 

The current template does not respect the format nor new lines and it will endup in an email with a single line which is difficult to read.

This fixed was proposed in the issue and seems like a simple solution.