### PR TITLE
Fix datastore main auth function

### DIFF
--- a/changes/9021.misc
+++ b/changes/9021.misc
@@ -1,0 +1,2 @@
+Auth functions are expected to return a dictionary with a 'success' key,
+not raise exceptions.

--- a/ckanext/datastore/logic/auth.py
+++ b/ckanext/datastore/logic/auth.py
@@ -12,17 +12,17 @@ def datastore_auth(context: Context,
 
     user = context.get('user')
 
-    authorized = p.toolkit.check_access(privilege, context, data_dict)
-    if not authorized:
+    try:
+        p.toolkit.check_access(privilege, context, data_dict)
+    except p.toolkit.NotAuthorized:
         return {
             'success': False,
             'msg': p.toolkit._(
-                'User {0} not authorized to update resource {1}'
-                    .format(str(user), data_dict['id'])
+                'User {0} not authorized to perform {1} on resource {2}'
+                    .format(str(user), privilege, data_dict['id'])
             )
         }
-    else:
-        return {'success': True}
+    return {'success': True}
 
 
 def datastore_create(context: Context, data_dict: DataDict):


### PR DESCRIPTION
### Proposed fixes:

Auth functions are expected to return a dictionary with a 'success' key, not raising exceptions.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
