### PR TITLE
[#8875] Fix activity + scheming combination

### DIFF
--- a/changes/8875.bugfix
+++ b/changes/8875.bugfix
@@ -1,0 +1,2 @@
+Historical versions of a custom dataset type ignores base template specified by
+the ``IDatasetForm`` interface.

--- a/ckanext/activity/templates/package/history.html
+++ b/ckanext/activity/templates/package/history.html
@@ -1,4 +1,4 @@
-{% extends "package/read.html" %}
+{% extends base_template %}
 
 {% block package_description %}
   {% block package_archive_notice %}

--- a/ckanext/activity/templates/package/resource_history.html
+++ b/ckanext/activity/templates/package/resource_history.html
@@ -1,4 +1,4 @@
-{% extends "package/resource_read.html" %}
+{% extends base_template %}
 
 {% block action_manage %}
 {% endblock action_manage %}

--- a/ckanext/activity/views.py
+++ b/ckanext/activity/views.py
@@ -14,6 +14,7 @@ from ckan.views.group import (
     # TODO: don't use hidden funcitons
     _get_group_template,
 )
+from ckan.views.dataset import _get_pkg_template
 
 from ckan.common import request as ckan_request
 
@@ -185,6 +186,7 @@ def resource_history(id: str, resource_id: str, activity_id: str) -> str:
     tk.g.pkg_dict = package
 
     extra_vars: dict[str, Any] = {
+        "base_template": _get_pkg_template("resource_template", dataset_type),
         "resource_views": resource_views,
         "current_resource_view": current_resource_view,
         "dataset_type": dataset_type,
@@ -287,6 +289,7 @@ def package_history(id: str, activity_id: str) -> Union[Response, str]:
     return tk.render(
         "package/history.html",
         {
+            "base_template": _get_pkg_template("read_template", package_type),
             "dataset_type": package_type,
             "pkg_dict": pkg_dict,
             "pkg": pkg,


### PR DESCRIPTION
Fixes #8875

The historical view of the dataset always uses `package/read.html` as a base template. As a result, custom dataset types, like ones provided by ckanext-scheming, that rely on [a different base template](https://github.com/ckan/ckanext-scheming/blob/master/ckanext/scheming/plugins.py#L219-L220) are not rendered properly.

Solution:
Choose base template for package/resource historical view based on package type