### PR TITLE
IRender interface 

### DIFF
--- a/ckan/lib/base.py
+++ b/ckan/lib/base.py
@@ -85,22 +85,23 @@ def render_snippet(*template_names: str, **kw: Any) -> str:
         raise last_exc or TemplatesNotFound(template_names)
 
 
-def render(template_name: str,
-           extra_vars: Optional[dict[str, Any]] = None) -> str:
-    '''Render a template and return the output.
+def render(template_name: str, extra_vars: Optional[dict[str, Any]] = None) -> str:
+    """Render a template and return the output.
 
     This is CKAN's main template rendering function.
 
-    :params template_name: relative path to template inside registered tpl_dir
-    :type template_name: str
-    :params extra_vars: additional variables available in template
-    :type extra_vars: dict
+    :param template_name: relative path to template inside registered tpl_dir
+    :param extra_vars: additional variables available in template
 
-    '''
+    """
     if extra_vars is None:
         extra_vars = {}
 
     _allow_caching()
+
+    for plugin in p.PluginImplementations(p.IRender):
+        template_name, extra_vars = plugin.prepare_render(template_name, extra_vars)
+
     return flask_render_template(template_name, **extra_vars)
 
 

--- a/ckan/plugins/interfaces.py
+++ b/ckan/plugins/interfaces.py
@@ -32,37 +32,38 @@ if TYPE_CHECKING:
 
 
 __all__ = [
-    u'Interface',
-    u'IMiddleware',
-    u'IAuthFunctions',
-    u'IDomainObjectModification',
-    u'IFeed',
-    u'IGroupController',
-    u'IOrganizationController',
-    u'IPackageController',
-    u'IPluginObserver',
-    u'IConfigurable',
-    u'IConfigDeclaration',
-    u'IConfigurer',
-    u'IActions',
-    u'IResourceUrlChange',
-    u'IDatasetForm',
-    u'IValidators',
-    u'IResourceView',
-    u'IResourceController',
-    u'IGroupForm',
-    u'ITagController',
-    u'ITemplateHelpers',
-    u'IFacets',
-    u'IAuthenticator',
-    u'ITranslation',
-    u'IUploader',
-    u'IBlueprint',
-    u'IPermissionLabels',
-    u'IForkObserver',
-    u'IApiToken',
-    u'IClick',
-    u'ISignal',
+    "Interface",
+    "IMiddleware",
+    "IAuthFunctions",
+    "IDomainObjectModification",
+    "IFeed",
+    "IGroupController",
+    "IOrganizationController",
+    "IPackageController",
+    "IPluginObserver",
+    "IConfigurable",
+    "IConfigDeclaration",
+    "IConfigurer",
+    "IActions",
+    "IResourceUrlChange",
+    "IDatasetForm",
+    "IValidators",
+    "IResourceView",
+    "IResourceController",
+    "IGroupForm",
+    "ITagController",
+    "ITemplateHelpers",
+    "IFacets",
+    "IAuthenticator",
+    "ITranslation",
+    "IUploader",
+    "IBlueprint",
+    "IPermissionLabels",
+    "IForkObserver",
+    "IApiToken",
+    "IClick",
+    "ISignal",
+    "IRender",
 ]
 
 
@@ -2265,3 +2266,33 @@ class ISignal(Interface):
 
         """
         return {}
+
+
+class IRender(Interface):
+    """Control template rendering."""
+
+    def prepare_render(
+        self, template: str, extra_vars: dict[str, Any]
+    ) -> tuple[str, dict[str, Any]]:
+        """Modify rendering parameters.
+
+        This method receives and returns the name of the rendered template and
+        all the variables passed to it. Replace the name of the template to
+        render a different page, and patch variables when page requires more
+        data than view provides by default.
+
+        Example::
+
+            def prepare_render(self, template, extra_vars):
+                if tk.get_endpoint() == ("home", "about"):
+                    template = "home/better_about.html"
+                    extra_vars["additional_content"] = ...
+
+                return template, extra_vars
+
+        :param template: name of the rendered template
+        :param extra_vars: variables used in the template
+        :returns: name of the template and its additional variables
+
+        """
+        return template, extra_vars


### PR DESCRIPTION
New interface with a method that can

* Change the name of the rendered template
* Modify data passed into the template

Use cases:

1. Add data to the template. Without the interface, developers are required to use non-idiomatic calls to data-producing helpers inside the template.
2. Change the template. Without the interface, developers are required to register a custom view on an existing endpoint and copy the code from the original view, replacing only the last line, where the name of the template is specified. There are alternatives, but they are also not entirely correct, so I won't mention them.
3. Conditionally render different template. Imagine that I want to implement HTMX shortcut for sorting on the organizations page. Without interface I have to override the whole endpoint. With the interface I can do something like
   ```py
   def prepare_render(name, data):
       if is_htmx():
            return name + ".htmx", data
       return name, data
   ```
   and register the corresponding HTMX template.

