### PR TITLE
Hide users from stats

### DIFF
--- a/changes/9030.bugfix
+++ b/changes/9030.bugfix
@@ -1,0 +1,4 @@
+Hide users data from `stats` if the `ckan.auth.public_user_details`
+setting is set to `False`.
+This ensures that user details are not exposed in the statistics when
+public user details are disabled.

--- a/ckanext/stats/blueprint.py
+++ b/ckanext/stats/blueprint.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any
 from flask import Blueprint
 
-from ckan.common import config
 from ckan.plugins.toolkit import render, h
 import ckanext.stats.stats as stats_lib
 

--- a/ckanext/stats/blueprint.py
+++ b/ckanext/stats/blueprint.py
@@ -1,9 +1,9 @@
 # encoding: utf-8
 from __future__ import annotations
 from typing import Any
-
 from flask import Blueprint
 
+from ckan.common import _, config
 from ckan.plugins.toolkit import render, h
 import ckanext.stats.stats as stats_lib
 
@@ -14,16 +14,22 @@ stats = Blueprint(u'stats', __name__)
 @stats.route(u'/stats')
 def index():
     stats = stats_lib.Stats()
+    # Public stats
     extra_vars: dict[str, Any] = {
         'largest_groups': stats.largest_groups(),
         'top_tags': stats.top_tags(),
-        'top_package_creators': stats.top_package_creators(),
         'most_edited_packages': stats.most_edited_packages(),
         'new_packages_by_week': stats.get_by_week('new_packages'),
         'deleted_packages_by_week': stats.get_by_week('deleted_packages'),
         'num_packages_by_week': stats.get_num_packages_by_week(),
-        'package_revisions_by_week': stats.get_by_week('package_revisions')
+        'package_revisions_by_week': stats.get_by_week('package_revisions'),
+        # Stats with users info
+        'top_package_creators': None,
     }
+
+    if config.get('ckan.auth.public_user_details'):
+        # Stats including users
+        extra_vars['top_package_creators'] = stats.top_package_creators()
 
     extra_vars['raw_packages_by_week'] = []
     for week_date, num_packages, cumulative_num_packages\

--- a/ckanext/stats/blueprint.py
+++ b/ckanext/stats/blueprint.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 from flask import Blueprint
 
-from ckan.common import _, config
+from ckan.common import config
 from ckan.plugins.toolkit import render, h
 import ckanext.stats.stats as stats_lib
 

--- a/ckanext/stats/blueprint.py
+++ b/ckanext/stats/blueprint.py
@@ -23,13 +23,8 @@ def index():
         'deleted_packages_by_week': stats.get_by_week('deleted_packages'),
         'num_packages_by_week': stats.get_num_packages_by_week(),
         'package_revisions_by_week': stats.get_by_week('package_revisions'),
-        # Stats with users info
-        'top_package_creators': None,
+        'top_package_creators': stats.top_package_creators(),
     }
-
-    if config.get('ckan.auth.public_user_details'):
-        # Stats including users
-        extra_vars['top_package_creators'] = stats.top_package_creators()
 
     extra_vars['raw_packages_by_week'] = []
     for week_date, num_packages, cumulative_num_packages\

--- a/ckanext/stats/stats.py
+++ b/ckanext/stats/stats.py
@@ -118,7 +118,7 @@ class Stats(object):
     @classmethod
     def top_package_creators(cls, limit: int = 10) -> list[tuple[Optional[model.User], int]]:
         if not config.get('ckan.auth.public_user_details'):
-            log.warning(
+            log.debug(
                 "Top package creators stats are not available because "
                 "ckan.auth.public_user_details is not set to True."
             )

--- a/ckanext/stats/stats.py
+++ b/ckanext/stats/stats.py
@@ -7,6 +7,7 @@ from typing import Any, ClassVar, Optional, Sequence, Union
 
 from sqlalchemy import Table, select, join, func, and_, false
 
+from ckan.common import config
 import ckan.model as model
 
 log = logging.getLogger(__name__)
@@ -116,6 +117,13 @@ class Stats(object):
 
     @classmethod
     def top_package_creators(cls, limit: int = 10) -> list[tuple[Optional[model.User], int]]:
+        if not config.get('ckan.auth.public_user_details'):
+            log.warning(
+                "Top package creators stats are not available because "
+                "ckan.auth.public_user_details is not set to True."
+            )
+            return []
+
         userid_count = (
             model.Session.query(
                 model.Package.creator_user_id,

--- a/ckanext/stats/templates/ckanext/stats/index.html
+++ b/ckanext/stats/templates/ckanext/stats/index.html
@@ -134,6 +134,7 @@
       </table>
     </section>
 
+    {% if top_package_creators %}
     <section id="stats-most-create" class="module-content tab-content">
       <h2>{{ _('Users Creating Most Datasets') }}</h2>
       <table class="table table-chunky table-bordered table-striped">
@@ -153,6 +154,7 @@
         </tbody>
       </table>
     </section>
+    {% endif %}
   </article>
 {% endblock %}
 
@@ -166,7 +168,9 @@
         <li class="nav-item"><a href="#stats-most-edited" data-toggle="tab" data-bs-toggle="tab">{{ _('Most Edited Datasets') }}</a></li>
         <li class="nav-item"><a href="#stats-largest-groups" data-toggle="tab" data-bs-toggle="tab">{{ _('Largest Groups') }}</a></li>
         <li class="nav-item"><a href="#stats-top-tags" data-toggle="tab" data-bs-toggle="tab">{{ _('Top Tags') }}</a></li>
-        <li class="nav-item"><a href="#stats-most-create" data-toggle="tab" data-bs-toggle="tab">{{ _('Users Creating Most Datasets') }}</a></li>
+        {% if top_package_creators %}
+          <li class="nav-item"><a href="#stats-most-create" data-toggle="tab" data-bs-toggle="tab">{{ _('Users Creating Most Datasets') }}</a></li>
+        {% endif %}
       </ul>
     </nav>
   </section>

--- a/ckanext/stats/tests/test_stats_lib.py
+++ b/ckanext/stats/tests/test_stats_lib.py
@@ -116,12 +116,19 @@ class TestStatsPlugin(object):
         tags = [(tag.name, count) for tag, count in tags]
         assert tags == [("tag1", 1)]
 
-    def test_top_package_creators(self):
+    @pytest.mark.ckan_config("ckan.auth.public_user_details", True)
+    def test_top_package_creators_public_user(self):
         creators = Stats.top_package_creators()
         creators = [(creator.name, count) for creator, count in creators]
         # Only 2 shown because one of them was deleted and the other one is
         # private
         assert creators == [("bob", 2)]
+
+    @pytest.mark.ckan_config("ckan.auth.public_user_details", False)
+    def test_top_package_creators_non_public_user(self):
+        creators = Stats.top_package_creators()
+        # The data is not available since ckan.auth.public_user_details is False
+        assert creators == []
 
     def test_new_packages_by_week(self):
         new_packages_by_week = Stats.get_by_week('new_packages')


### PR DESCRIPTION
### Proposed fixes:

Hide users data from `stats` if the `ckan.auth.public_user_details` setting is set to `False`.
This ensures that user details are not exposed in the statistics when public user details are disabled.


### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
