### PR TITLE
Remove deprecated --no-site-packages from virtualenv instructions

### DIFF
--- a/doc/contributing/documentation.rst
+++ b/doc/contributing/documentation.rst
@@ -69,7 +69,7 @@ terminal:
 
 ::
 
-    virtualenv --no-site-packages pyenv
+    virtualenv pyenv
     . pyenv/bin/activate
     pip install -e 'git+https://github.com/ckan/ckan.git#egg=ckan'
     cd pyenv/src/ckan/


### PR DESCRIPTION
The old `--no-site-packages` option is no longer valid. This change helps new contributors set up their environments more easily.

### Proposed fixes:

Remove `--no-site-packages` from the virtualenv instructions in the contribution docs, as this flag is no longer supported in recent versions of virtualenv.


### Features:

- [ ] includes tests covering changes
- [X] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
