### PR TITLE
CSRF token session improvements

### DIFF
--- a/changes/9049.misc
+++ b/changes/9049.misc
@@ -1,0 +1,1 @@
+Clear CSRF token from session when logging out programmatically.

--- a/ckan/common.py
+++ b/ckan/common.py
@@ -43,7 +43,15 @@ log = logging.getLogger(__name__)
 TCurrentUser = Union["model_.User", "model_.AnonymousUser"]
 current_user = cast(TCurrentUser, _cu)
 login_user = _login_user
-logout_user = _logout_user
+
+
+def logout_user():
+
+    field_name = config.get("WTF_CSRF_FIELD_NAME")
+    if session.get(field_name):
+        session.pop(field_name)
+
+    return _logout_user()
 
 
 @maintain.deprecated('All web requests are served by Flask', since="2.10.0")

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -533,7 +533,8 @@ def rotate_token():
     field_name = config.get("WTF_CSRF_FIELD_NAME")
     if session.get(field_name):
         session.pop(field_name)
-        generate_csrf()
+
+    generate_csrf()
 
 
 def login() -> Union[Response, str]:
@@ -590,13 +591,9 @@ def logout() -> Response:
     if not user:
         return h.redirect_to('user.login')
 
-    came_from = request.args.get('came_from', '')
     logout_user()
 
-    field_name = config.get("WTF_CSRF_FIELD_NAME")
-    if session.get(field_name):
-        session.pop(field_name)
-
+    came_from = request.args.get('came_from', '')
     if h.url_is_local(came_from):
         return h.redirect_to(str(came_from))
 


### PR DESCRIPTION
1. The CSRF token in the session was only cleared in the logout view function (i.e. when hitting the /logout endpoint), but logouts can happen programmatically calling the `logout_user()` function from the toolkit. Moved the logic to a single wrapper in lib/common.py
2. The `rotate_token` function only generated a new CSRF token if one was already present in the session. This was the case for a normal UI request, but not always if calling `rotate_token` directly. Moved back one indentation level to always generate the token.

Added a test to make sure the token is cleared from the session on logout.
