### PR TITLE
Remove deprecated functions and properties

### DIFF
--- a/changes/9050.migration
+++ b/changes/9050.migration
@@ -1,0 +1,1 @@
+The following deprecated functions and properties have been removed: the `truncate()` template helper (use the builtin jinja2 filter instead), `is_flask_request()`, `Request.args`, `set_repoze_user()`, `Tag.search_by_name()`, `PackageTag.by_name()`, `Package.is_private`

--- a/ckan/common.py
+++ b/ckan/common.py
@@ -27,7 +27,6 @@ from flask_babel import (gettext as flask_ugettext,
                          ngettext as flask_ungettext)
 
 import simplejson as json  # type: ignore # noqa
-import ckan.lib.maintain as maintain
 from ckan.config.declaration import Declaration
 from ckan.types import Request
 
@@ -44,14 +43,6 @@ TCurrentUser = Union["model_.User", "model_.AnonymousUser"]
 current_user = cast(TCurrentUser, _cu)
 login_user = _login_user
 logout_user = _logout_user
-
-
-@maintain.deprecated('All web requests are served by Flask', since="2.10.0")
-def is_flask_request():
-    u'''
-    This function is deprecated. All CKAN requests are now served by Flask
-    '''
-    return True
 
 
 def streaming_response(data: Iterable[Any],
@@ -201,19 +192,6 @@ class CKANRequest(LocalProxy[Request]):
     @property
     def htmx(self) -> HtmxDetails:
         return HtmxDetails(self)
-
-    @property
-    @maintain.deprecated('Use `request.args` instead of `request.params`',
-                         since="2.10.0")
-    def params(self):
-        '''This property is deprecated.
-
-        Special case as Pylons' request.params is used all over the place.  All
-        new code meant to be run just in Flask (eg views) should always use
-        request.args
-
-        '''
-        return self.args
 
 
 def _get_c():

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -48,7 +48,6 @@ import ckan.config
 import ckan.exceptions
 import ckan.model as model
 import ckan.lib.formatters as formatters
-import ckan.lib.maintain as maintain
 import ckan.lib.datapreview as datapreview
 import ckan.logic as logic
 import ckan.authz as authz
@@ -1326,54 +1325,6 @@ def group_name_to_title(name: str) -> str:
     if group is not None:
         return group.display_name
     return name
-
-
-@core_helper
-@maintain.deprecated("helpers.truncate() is deprecated and will be removed "
-                     "in a future version of CKAN. Instead, please use the "
-                     "builtin jinja filter instead.",
-                     since="2.10.0")
-def truncate(text: str,
-             length: int = 30,
-             indicator: str = '...',
-             whole_word: bool = False) -> str:
-    """Truncate ``text`` with replacement characters.
-
-    ``length``
-        The maximum length of ``text`` before replacement
-    ``indicator``
-        If ``text`` exceeds the ``length``, this string will replace
-        the end of the string
-    ``whole_word``
-        If true, shorten the string further to avoid breaking a word in the
-        middle.  A word is defined as any string not containing whitespace.
-        If the entire text before the break is a single word, it will have to
-        be broken.
-
-    Example::
-
-        >>> truncate('Once upon a time in a world far far away', 14)
-        'Once upon a...'
-
-    Deprecated: please use jinja filter `truncate` instead
-    """
-    if not text:
-        return ""
-    if len(text) <= length:
-        return text
-    short_length = length - len(indicator)
-    if not whole_word:
-        return text[:short_length] + indicator
-    # Go back to end of previous word.
-    i = short_length
-    while i >= 0 and not text[i].isspace():
-        i -= 1
-    while i >= 0 and text[i].isspace():
-        i -= 1
-    if i <= 0:
-        # Entire text before break is one word, or we miscalculated.
-        return text[:short_length] + indicator
-    return text[:i + 1] + indicator
 
 
 @core_helper

--- a/ckan/model/package.py
+++ b/ckan/model/package.py
@@ -26,7 +26,6 @@ import ckan.model.license as _license
 import ckan.model.types as _types
 import ckan.model.domain_object as domain_object
 
-import ckan.lib.maintain as maintain
 from ckan.types import Query
 
 if TYPE_CHECKING:
@@ -439,20 +438,6 @@ class Package(core.StatefulObjectMixin,
             raise Exception(msg)
 
     license = property(get_license, set_license)
-
-    @maintain.deprecated('`is_private` attriute of model.Package is ' +
-                         'deprecated and should not be used.  Use `private`',
-                         since="2.1.0")
-
-    def _is_private(self):
-        """
-        DEPRECATED in 2.1
-
-        A package is private if belongs to any private groups
-        """
-        return self.private
-
-    is_private = property(_is_private)
 
     def is_in_group(self, group: "Group") -> bool:
         return group in self.get_groups()

--- a/ckan/model/tag.py
+++ b/ckan/model/tag.py
@@ -18,7 +18,6 @@ import ckan.model.domain_object as domain_object
 import ckan.model.vocabulary as vocabulary
 
 import ckan.logic
-import ckan.lib.maintain as maintain
 from ckan.types import Query
 
 __all__ = ['tag_table', 'package_tag_table', 'Tag', 'PackageTag',
@@ -157,42 +156,6 @@ class Tag(domain_object.DomainObject):
         return tag
 
     @classmethod
-    @maintain.deprecated(since="2.9.0")
-    def search_by_name(
-            cls, search_term: str,
-            vocab_id_or_name: Optional[str] = None) -> Optional[Query[Self]]:
-        '''DEPRECATED
-
-        Return all tags whose names contain a given string.
-
-        By default only free tags (tags which do not belong to any vocabulary)
-        are returned. If the optional argument ``vocab_id_or_name`` is given
-        then only tags from that vocabulary are returned.
-
-        :param search_term: the string to search for in the tag names
-        :type search_term: string
-        :param vocab_id_or_name: the id or name of the vocabulary to look in
-            (optional, default: None)
-        :type vocab_id_or_name: string
-
-        :returns: a list of tags that match the search term
-        :rtype: list of ckan.model.tag.Tag objects
-
-        '''
-        if vocab_id_or_name:
-            vocab = vocabulary.Vocabulary.get(vocab_id_or_name)
-            if vocab is None:
-                # The user specified an invalid vocab.
-                return None
-            query = meta.Session.query(cls).filter(cls.vocabulary_id==vocab.id)
-        else:
-            query = meta.Session.query(cls)
-        search_term = search_term.strip().lower()
-        query = query.filter(Tag.name.contains(search_term))
-        query: 'Query[Self]' = query.distinct().join(Tag.package_tags)
-        return query
-
-    @classmethod
     def all(cls, vocab_id_or_name: Optional[str]=None) -> Query[Self]:
         '''Return all tags that are currently applied to any dataset.
 
@@ -269,52 +232,6 @@ class PackageTag(core.StatefulObjectMixin,
         assert self.package
         assert self.tag
         return u'<PackageTag package=%s tag=%s>' % (self.package.name, self.tag.name)
-
-    @classmethod
-    @maintain.deprecated(since="2.9.0")
-    def by_name(
-            cls, package_name: str, tag_name: str,
-            vocab_id_or_name: Optional[str] = None,
-            autoflush: bool = True) -> Optional[Self]:
-        '''DEPRECATED (and broken - missing the join to Tag)
-
-        Return the PackageTag for the given package and tag names, or None.
-
-        By default only PackageTags for free tags (tags which do not belong to
-        any vocabulary) are returned. If the optional argument
-        ``vocab_id_or_name`` is given then only PackageTags for tags from that
-        vocabulary are returned.
-
-        :param package_name: the name of the package to look for
-        :type package_name: string
-        :param tag_name: the name of the tag to look for
-        :type tag_name: string
-        :param vocab_id_or_name: the id or name of the vocabulary to look for
-            the tag in
-        :type vocab_id_or_name: string
-
-        :returns: the PackageTag for the given package and tag names, or None
-            if there is no PackageTag for those package and tag names
-        :rtype: ckan.model.tag.PackageTag
-
-        '''
-        if vocab_id_or_name:
-            vocab = vocabulary.Vocabulary.get(vocab_id_or_name)
-            if vocab is None:
-                # The user specified an invalid vocab.
-                return None
-            query = (meta.Session.query(cls, Tag, ckan.model.Package)
-                    .filter(Tag.vocabulary_id == vocab.id)
-                    .filter(ckan.model.Package.name==package_name)
-                    .filter(Tag.name==tag_name))
-            query = query.autoflush(autoflush)
-            return query.one()[0]
-        else:
-            query = (meta.Session.query(cls)
-                    .filter(ckan.model.Package.name==package_name)
-                    .filter(Tag.name==tag_name))
-            query = query.autoflush(autoflush)
-            return query.one()
 
     def related_packages(self) -> list['ckan.model.Package']:
         if self.package:

--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -15,7 +15,6 @@ from ckan.lib.helpers import helper_functions as h
 from ckan.lib.helpers import Page
 from ckan.lib.dictization import model_dictize
 import ckan.lib.mailer as mailer
-import ckan.lib.maintain as maintain
 import ckan.lib.navl.dictization_functions as dictization_functions
 import ckan.logic as logic
 import ckan.logic.schema as schema
@@ -36,18 +35,6 @@ new_user_form = u'user/new_user_form.html'
 edit_user_form = u'user/edit_user_form.html'
 
 user = Blueprint(u'user', __name__, url_prefix=u'/user')
-
-
-@maintain.deprecated('''set_repoze_user() is deprecated and will be removed.
-                        Use login_user() instead''', since="2.10.0")
-def set_repoze_user(user_id: str, resp: Optional[Response] = None) -> None:
-    """
-    This function is deprecated and will be removed.
-    It exists only to maintain backward compatibility
-    to extensions like saml2auth.
-    """
-    user_obj = model.User.get(user_id)
-    login_user(user_obj)
 
 
 def _edit_form_to_db_schema() -> Schema:


### PR DESCRIPTION
The following deprecated functions and properties have been removed:
* `truncate()` template helper (use the builtin jinja2 filter instead)
* `is_flask_request()`
* `Request.args` (Pylons thing)
* `set_repoze_user()` (repoze.who thing)
* `Tag.search_by_name()`, `PackageTag.by_name()` 
* `Package.is_private` (deprecated since CKAN 2.1 :sauropod: )