### PR TITLE
Fix form error message styling

### DIFF
--- a/ckan/templates/macros/form/errors.html
+++ b/ckan/templates/macros/form/errors.html
@@ -12,7 +12,7 @@ Example:
 
 #}
 
-{% macro errors(errors={}, type="error", classes=[]) %}
+{% macro errors(errors={}, type="danger", classes=[]) %}
 {% if errors %}
 <div class="error-explanation alert alert-{{ type }}{{ " " ~ classes | join(' ') }}">
 <p>{{ _('The form contains invalid entries:') }}</p>


### PR DESCRIPTION
The error messages generated by the `form.errors()` macro still used the legacy `alert-error` class instead of the new `alert-danger` one.

Before:
<img width="1396" height="390" alt="Screenshot 2025-08-26 at 14-51-49 Create Dataset - CKAN" src="https://github.com/user-attachments/assets/ad5fe33a-6d42-4356-b15e-176b52586006" />


After:
<img width="1432" height="458" alt="Screenshot 2025-08-26 at 10-54-44 Create Dataset - CKAN" src="https://github.com/user-attachments/assets/c2f861c3-ac75-499d-8fb9-fa9fffb757c8" />

This is fine in the new theme