### PR TITLE
Fix font of datatables sort indicator

### DIFF
--- a/changes/9078.bugfix
+++ b/changes/9078.bugfix
@@ -1,0 +1,1 @@
+Fixes the font of the sort indicator in datatablesview by properly closing the opening <i tag

--- a/ckanext/datatablesview/assets/datatablesview.js
+++ b/ckanext/datatablesview/assets/datatablesview.js
@@ -906,7 +906,7 @@ this.ckan.module('datatables_view', function (jQuery) {
           return
         }
         gsortInfo = '<b> ' + that._('Sort') + '</b> <i id="sortinfoicon" class="fa fa-info-circle" title="' +
-            that._('Press SHIFT key while clicking on\nsort control for multi-column sort') + '"</i> : '
+            that._('Press SHIFT key while clicking on\nsort control for multi-column sort') + '"></i> : '
         sortOrder.forEach((sortcol, idx) => {
           const colText = datatable.column(sortcol[0]).name()
           gsortInfo = gsortInfo + colText +


### PR DESCRIPTION
### Proposed fixes:

Fixes the font of the sort indicator in datatablesview by properly closing the opening <i tag

Prepatch:
<img width="124" height="31" alt="image" src="https://github.com/user-attachments/assets/c26c4125-af4e-4fa4-9129-98f6f6471931" />


With Patch:
<img width="137" height="28" alt="image" src="https://github.com/user-attachments/assets/da744213-5631-43e2-8db2-abe710bfffa9" />

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
