### PR TITLE
[MANIFEST.in] `include CHANGELOG.rst`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -24,7 +24,7 @@ include ckanext/datastore/set_permissions.sql
 include ckanext/datastore/allowed_functions.txt
 
 prune .git
-include CHANGELOG.txt
+include CHANGELOG.rst
 include ckan/migration/README
 include requirements.txt
 include dev-requirements.txt


### PR DESCRIPTION
`CHANGELOG.txt` had been renamed as `CHANGELOG.rst` since 2013-05-22, but our `MANIFEST.in` still pointing to the old name (across the last 12 years !?).

See https://github.com/ckan/ckan/commit/172563b084c79aba3ddf96549dc572b11216b7dd

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
