### PR TITLE
[Midnight blue] Activity Stream

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1306,11 +1306,7 @@ def linked_user(user: Union[str, model.User],
         if maxlength and len(user.display_name) > maxlength:
             displayname = displayname[:maxlength] + '...'
 
-        return literal(u'{icon} {link}'.format(
-            icon=user_image(
-                user.id,
-                size=avatar
-            ),
+        return literal(u'{link}'.format(
             link=link_to(
                 displayname,
                 url_for('user.read', id=name)

--- a/ckan/public-midnight-blue/base/scss/_bootstrap-variables.scss
+++ b/ckan/public-midnight-blue/base/scss/_bootstrap-variables.scss
@@ -38,13 +38,13 @@ $grays: (
 // fusv-enable
 
 // scss-docs-start color-variables
-$blue:    #206b82 !default;
-$indigo:  #6610f2 !default;
+$blue:    #3395FF !default;
+$indigo:  #6172F3 !default;
 $purple:  #6f42c1 !default;
 $pink:    #d63384 !default;
-$red:     #d9534f !default;
-$orange:  #fd7e14 !default;
-$yellow:  #fd7e14 !default;
+$red:     #DA1E28 !default;
+$orange:  #EF5C03 !default;
+$yellow:  #FCE61E !default;
 $green:   #3A833A !default;
 $teal:    #20c997 !default;
 $cyan:    #0dcaf0 !default;

--- a/ckan/templates-midnight-blue/user/snippets/info.html
+++ b/ckan/templates-midnight-blue/user/snippets/info.html
@@ -12,7 +12,7 @@
 
 
 <div id="user-info" class="module context-info">
-    <section class="module-content">
+    <section class="module-narrow">
       {% block secondary_content_inner %}
         {% block user_image %}
         <div class="image">{{ h.user_image(user.id, size=270) }}</div>

--- a/ckanext/activity/assets-midnight-blue/activity.css
+++ b/ckanext/activity/assets-midnight-blue/activity.css
@@ -1,7 +1,6 @@
 .activity {
   padding: 0;
   list-style-type: none;
-  border-radius: 20px;
 }
 .activity .item {
   position: relative;

--- a/ckanext/activity/assets-midnight-blue/activity.css
+++ b/ckanext/activity/assets-midnight-blue/activity.css
@@ -1,32 +1,118 @@
 .activity {
   padding: 0;
   list-style-type: none;
+  border-radius: 20px;
 }
 .activity .item {
   position: relative;
-  margin: 0 0 15px 0;
-  padding: 0;
+  padding: 1rem 0;
+  border-bottom: 1px solid #e4e7ec;
+  display: flex;
+}
+.activity .item:last-child {
+  border-bottom: none;
+}
+.activity .item .fa-stack {
+  flex: 0 0 auto;
+  margin-right: 5px;
 }
 .activity .item .user-image {
   border-radius: 100px;
 }
 .activity .item .date {
-  color: #999999;
+  color: #3B3B3B;
   font-size: 12px;
 }
 .activity .item.no-avatar p {
   margin-left: 40px;
 }
+.activity .item .icon {
+  color: #3B3B3B;
+}
+.activity .item.failure .icon {
+  color: #DA1E28;
+}
+.activity .item.success .icon {
+  color: #3A833A;
+}
+.activity .item.added-tag .icon {
+  color: #3a8383;
+}
+.activity .item.changed-group .icon {
+  color: #6f42c1;
+}
+.activity .item.changed-package .icon {
+  color: rgb(153.3333333333, 66, 193);
+}
+.activity .item.changed-package_extra .icon {
+  color: rgb(68.6666666667, 66, 193);
+}
+.activity .item.changed-resource .icon {
+  color: rgb(193, 66, 190.3333333333);
+}
+.activity .item.changed-user .icon {
+  color: rgb(66, 105.6666666667, 193);
+}
+.activity .item.changed-organization .icon {
+  color: rgb(58, 131, 118.8333333333);
+}
+.activity .item.deleted-group .icon {
+  color: #DA1E28;
+}
+.activity .item.deleted-package .icon {
+  color: rgb(218, 82.6666666667, 30);
+}
+.activity .item.deleted-package_extra .icon {
+  color: rgb(218, 30, 102.6666666667);
+}
+.activity .item.deleted-resource .icon {
+  color: rgb(218, 145.3333333333, 30);
+}
+.activity .item.deleted-organization .icon {
+  color: rgb(218, 30, 165.3333333333);
+}
+.activity .item.new-group .icon {
+  color: #3A833A;
+}
+.activity .item.new-package .icon {
+  color: rgb(58, 131, 82.3333333333);
+}
+.activity .item.new-package_extra .icon {
+  color: rgb(82.3333333333, 131, 58);
+}
+.activity .item.new-resource .icon {
+  color: rgb(106.6666666667, 131, 58);
+}
+.activity .item.new-user .icon {
+  color: rgb(58, 106.6666666667, 131);
+}
+.activity .item.new-organization .icon {
+  color: rgb(106.6666666667, 131, 58);
+}
+.activity .item.removed-tag .icon {
+  color: rgb(218, 30, 165.3333333333);
+}
+.activity .item.deleted-related-item .icon {
+  color: #dad01e;
+}
+.activity .item.follow-dataset .icon {
+  color: #767DCE;
+}
+.activity .item.follow-user .icon {
+  color: rgb(140.3333333333, 118, 206);
+}
+.activity .item.new-related-item .icon {
+  color: #83833a;
+}
+.activity .item.follow-group .icon {
+  color: rgb(118.8333333333, 131, 58);
+}
 .activity.activity-empty {
   background: none;
 }
-@media (min-width: 768px) {
-  .activity {
-    background: transparent url("/dotted.png") 21px 0 repeat-y;
-  }
-  .activity .item .date {
-    margin: 5px 0 0 80px;
-  }
+.activity .user {
+  font-size: 20px;
+  font-weight: 600;
 }
 
 .activity_buttons {
@@ -57,88 +143,6 @@
   padding: 10px;
   color: #6E6E6E;
   font-style: italic;
-}
-
-.activity .item .icon {
-  color: #999999;
-}
-.activity .item.failure .icon {
-  color: #B95252;
-}
-.activity .item.success .icon {
-  color: #69A67A;
-}
-.activity .item.added-tag .icon {
-  color: #6995a6;
-}
-.activity .item.changed-group .icon {
-  color: #767DCE;
-}
-.activity .item.changed-package .icon {
-  color: #8c76ce;
-}
-.activity .item.changed-package_extra .icon {
-  color: #769ace;
-}
-.activity .item.changed-resource .icon {
-  color: #aa76ce;
-}
-.activity .item.changed-user .icon {
-  color: #76b8ce;
-}
-.activity .item.changed-organization .icon {
-  color: #699fa6;
-}
-.activity .item.deleted-group .icon {
-  color: #B95252;
-}
-.activity .item.deleted-package .icon {
-  color: #b97452;
-}
-.activity .item.deleted-package_extra .icon {
-  color: #b95274;
-}
-.activity .item.deleted-resource .icon {
-  color: #b99752;
-}
-.activity .item.deleted-organization .icon {
-  color: #b95297;
-}
-.activity .item.new-group .icon {
-  color: #69A67A;
-}
-.activity .item.new-package .icon {
-  color: #69a68e;
-}
-.activity .item.new-package_extra .icon {
-  color: #6ca669;
-}
-.activity .item.new-resource .icon {
-  color: #81a669;
-}
-.activity .item.new-user .icon {
-  color: #69a6a3;
-}
-.activity .item.new-organization .icon {
-  color: #81a669;
-}
-.activity .item.removed-tag .icon {
-  color: #b95297;
-}
-.activity .item.deleted-related-item .icon {
-  color: #b9b952;
-}
-.activity .item.follow-dataset .icon {
-  color: #767DCE;
-}
-.activity .item.follow-user .icon {
-  color: #8c76ce;
-}
-.activity .item.new-related-item .icon {
-  color: #95a669;
-}
-.activity .item.follow-group .icon {
-  color: #8ba669;
 }
 
 .select-time {

--- a/ckanext/activity/assets-midnight-blue/activity.scss
+++ b/ckanext/activity/assets-midnight-blue/activity.scss
@@ -1,21 +1,28 @@
 // Activity Stream base colors
 $activityColorText: #FFFFFF;
-$activityColorBlank: #999999;
-$activityColorNew: #69A67A;
+$activityColorBlank: #3B3B3B;
+$activityColorNew: #3A833A;
 $activityColorNeutral: #767DCE;
-$activityColorModify: #767DCE;
-$activityColorDelete: #B95252;
+$activityColorModify: #6f42c1;
+$activityColorDelete: #DA1E28;
 $activityColorEmpty: #6E6E6E;
 
 .activity {
     padding: 0;
     list-style-type: none;
-
+    border-radius: 20px;
     .item {
         position: relative;
-        margin: 0 0 15px 0;
-        padding: 0;
-
+        padding: 1rem 0;
+        border-bottom: 1px solid #e4e7ec;
+        display: flex;
+        &:last-child {
+            border-bottom: none;
+        }
+        .fa-stack {
+            flex: 0 0 auto;
+            margin-right: 5px;
+        }
         .user-image {
             border-radius: 100px;
         }
@@ -29,21 +36,122 @@ $activityColorEmpty: #6E6E6E;
             // Use by datapusher
             margin-left: 40px;
         }
+        .icon {
+            color: $activityColorBlank ;
+        }
+    
+        // Non defined
+        &.failure .icon {
+            color: $activityColorDelete;
+        }
+    
+        &.success .icon {
+            color: $activityColorNew;
+        }
+    
+        &.added-tag .icon {
+            color: adjust-hue($activityColorNew, 60);
+        }
+    
+        &.changed-group .icon {
+            color: $activityColorModify;
+        }
+    
+        &.changed-package .icon {
+            color: adjust-hue($activityColorModify, 20);
+        }
+    
+        &.changed-package_extra .icon {
+            color: adjust-hue($activityColorModify, -20);
+        }
+    
+        &.changed-resource .icon {
+            color: adjust-hue($activityColorModify, 40);
+        }
+    
+        &.changed-user .icon {
+            color: adjust-hue($activityColorModify, -40);
+        }
+    
+        &.changed-organization .icon {
+            color: adjust-hue($activityColorNew, 50);
+        }
+    
+        &.deleted-group .icon {
+            color: $activityColorDelete;
+        }
+    
+        &.deleted-package .icon {
+            color: adjust-hue($activityColorDelete, 20);
+        }
+    
+        &.deleted-package_extra .icon {
+            color: adjust-hue($activityColorDelete, -20);
+        }
+    
+        &.deleted-resource .icon {
+            color: adjust-hue($activityColorDelete, 40);
+        }
+    
+        &.deleted-organization .icon {
+            color: adjust-hue($activityColorDelete, -40);
+        }
+    
+        &.new-group .icon {
+            color: $activityColorNew;
+        }
+    
+        &.new-package .icon {
+            color: adjust-hue($activityColorNew, 20);
+        }
+    
+        &.new-package_extra .icon {
+            color: adjust-hue($activityColorNew, -20);
+        }
+    
+        &.new-resource .icon {
+            color: adjust-hue($activityColorNew, -40);
+        }
+    
+        &.new-user .icon {
+            color: adjust-hue($activityColorNew, 80);
+        }
+    
+        &.new-organization .icon {
+            color: adjust-hue($activityColorNew, -40);
+        }
+    
+        &.removed-tag .icon {
+            color: adjust-hue($activityColorDelete, -40);
+        }
+    
+        &.deleted-related-item .icon {
+            color: adjust-hue($activityColorDelete, 60);
+        }
+    
+        &.follow-dataset .icon {
+            color: $activityColorNeutral;
+        }
+    
+        &.follow-user .icon {
+            color: adjust-hue($activityColorNeutral, 20);
+        }
+    
+        &.new-related-item .icon {
+            color: adjust-hue($activityColorNew, -60);
+        }
+    
+        &.follow-group .icon {
+            color: adjust-hue($activityColorNew, -50);
+        }
     }
 
     &.activity-empty {
         background: none;
     }
-
-    @media (min-width: 768px) {
-        background: transparent url('/dotted.png') 21px 0 repeat-y;
-
-        .item {
-            .date {
-                margin: 5px 0 0 80px;
-            }
-        }
-
+    .user {
+        font-size: 20px;
+        font-weight: 600;
     }
 }
 
@@ -78,119 +186,6 @@ $activityColorEmpty: #6E6E6E;
         padding: 10px;
         color: $activityColorEmpty;
         font-style: italic;
-    }
-}
-
-
-
-.activity .item {
-    .icon {
-        color: $activityColorBlank ;
-    }
-
-    // Non defined
-    &.failure .icon {
-        color: $activityColorDelete;
-    }
-
-    &.success .icon {
-        color: $activityColorNew;
-    }
-
-    &.added-tag .icon {
-        color: adjust-hue($activityColorNew, 60);
-    }
-
-    &.changed-group .icon {
-        color: $activityColorModify;
-    }
-
-    &.changed-package .icon {
-        color: adjust-hue($activityColorModify, 20);
-    }
-
-    &.changed-package_extra .icon {
-        color: adjust-hue($activityColorModify, -20);
-    }
-
-    &.changed-resource .icon {
-        color: adjust-hue($activityColorModify, 40);
-    }
-
-    &.changed-user .icon {
-        color: adjust-hue($activityColorModify, -40);
-    }
-
-    &.changed-organization .icon {
-        color: adjust-hue($activityColorNew, 50);
-    }
-
-    &.deleted-group .icon {
-        color: $activityColorDelete;
-    }
-
-    &.deleted-package .icon {
-        color: adjust-hue($activityColorDelete, 20);
-    }
-
-    &.deleted-package_extra .icon {
-        color: adjust-hue($activityColorDelete, -20);
-    }
-
-    &.deleted-resource .icon {
-        color: adjust-hue($activityColorDelete, 40);
-    }
-
-    &.deleted-organization .icon {
-        color: adjust-hue($activityColorDelete, -40);
-    }
-
-    &.new-group .icon {
-        color: $activityColorNew;
-    }
-
-    &.new-package .icon {
-        color: adjust-hue($activityColorNew, 20);
-    }
-
-    &.new-package_extra .icon {
-        color: adjust-hue($activityColorNew, -20);
-    }
-
-    &.new-resource .icon {
-        color: adjust-hue($activityColorNew, -40);
-    }
-
-    &.new-user .icon {
-        color: adjust-hue($activityColorNew, 40);
-    }
-
-    &.new-organization .icon {
-        color: adjust-hue($activityColorNew, -40);
-    }
-
-    &.removed-tag .icon {
-        color: adjust-hue($activityColorDelete, -40);
-    }
-
-    &.deleted-related-item .icon {
-        color: adjust-hue($activityColorDelete, 60);
-    }
-
-    &.follow-dataset .icon {
-        color: $activityColorNeutral;
-    }
-
-    &.follow-user .icon {
-        color: adjust-hue($activityColorNeutral, 20);
-    }
-
-    &.new-related-item .icon {
-        color: adjust-hue($activityColorNew, -60);
-    }
-
-    &.follow-group .icon {
-        color: adjust-hue($activityColorNew, -50);
     }
 }
 

--- a/ckanext/activity/assets-midnight-blue/activity.scss
+++ b/ckanext/activity/assets-midnight-blue/activity.scss
@@ -10,7 +10,6 @@ $activityColorEmpty: #6E6E6E;
 .activity {
     padding: 0;
     list-style-type: none;
-    border-radius: 20px;
     .item {
         position: relative;
         padding: 1rem 0;

--- a/ckanext/activity/templates-midnight-blue/package/changes.html
+++ b/ckanext/activity/templates-midnight-blue/package/changes.html
@@ -23,12 +23,14 @@
         <input type="hidden" name="current_old_id" value="{{ activity_diffs[-1].activities[0].id }}">
         <input type="hidden" name="current_new_id" value="{{ activity_diffs[0].activities[1].id }}">
       View changes from
-        <select class="form-control select-time" form="range_form" name="old_id">
+        <label for="start_date" class="sr-only">{{ _("Start date") }}</label>
+        <select class="form-control select-time" form="range_form" id="start_date" name="old_id">
           <pre>
             {{ select_list1[1:]|join }}
           </pre>
         </select> to
-        <select class="form-control select-time" form="range_form" name="new_id">
+        <label for="end_date" class="sr-only">{{ _("End date") }}</label>
+        <select class="form-control select-time" form="range_form" id="end_date" name="new_id">
           <pre>
             {{ select_list2|join }}
           </pre>
@@ -45,7 +47,7 @@
         {# TODO: display metadata for more than most recent change #}
         {% if i == 0 %}
           {# button to show JSON metadata diff for the most recent change - not shown by default #}
-          <input type="button" data-module="metadata-button" data-module-target="" class="btn" value="Show metadata diff" id="metadata_button"></input>
+          <input type="button" data-module="metadata-button" data-module-target="" class="btn btn-primary-outline" value="Show metadata diff" id="metadata_button"></input>
           <div id="metadata_diff" style="display:none;">
           {% block package_changes_diff %}
             <pre>

--- a/ckanext/activity/templates-midnight-blue/package/snippets/change_item.html
+++ b/ckanext/activity/templates-midnight-blue/package/snippets/change_item.html
@@ -5,6 +5,5 @@
   {% for change in changes %}
     {% snippet "snippets/changes/{}.html".format(
       change.type), change=change, pkg_dict=pkg_dict, dataset_type=activity_diff.activities[1].data.package.type %}
-    <br>
   {% endfor %}
 </ul>

--- a/ckanext/activity/templates-midnight-blue/snippets/activities/added_tag.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activities/added_tag.html
@@ -3,13 +3,15 @@
     <i class="fa fa-circle fa-stack-2x icon"></i>
     <i class="fa fa-tag fa-stack-1x fa-inverse"></i>
   </span>
-  {{ _('{actor} added the tag {tag} to the dataset {dataset}').format(
-      actor=ah.actor(activity),
-      dataset=ah.dataset(activity),
-      tag=ah.tag(activity)
-    )|safe }}
-    <br />
-  <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
-    {{ h.time_ago_from_timestamp(activity.timestamp) }}
+  <span>
+    {{ _('{actor} added the tag {tag} to the dataset {dataset}').format(
+        actor=ah.actor(activity),
+        dataset=ah.dataset(activity),
+        tag=ah.tag(activity)
+      )|safe }}
+      <br />
+    <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
+      {{ h.time_ago_from_timestamp(activity.timestamp) }}
+    </span>
   </span>
 </li>

--- a/ckanext/activity/templates-midnight-blue/snippets/activities/changed_group.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activities/changed_group.html
@@ -3,18 +3,20 @@
     <i class="fa fa-circle fa-stack-2x icon"></i>
     <i class="fa fa-users fa-stack-1x fa-inverse"></i>
   </span>
-  {{ _('{actor} updated the group {group}').format(
-    actor=ah.actor(activity),
-    group=ah.group(activity)
-  )|safe }}
-  <br />
-  <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
-    {{ h.time_ago_from_timestamp(activity.timestamp) }}
-    {% if can_show_activity_detail %}
-      &nbsp;|&nbsp;
-      <a href="{{ h.url_for('activity.group_changes', id=activity.id) }}">
-        {{ _('Changes') }}
-      </a>
-    {% endif %}
+  <span>
+    {{ _('{actor} updated the group {group}').format(
+      actor=ah.actor(activity),
+      group=ah.group(activity)
+    )|safe }}
+    <br />
+    <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
+      {{ h.time_ago_from_timestamp(activity.timestamp) }}
+      {% if can_show_activity_detail %}
+        &nbsp;|&nbsp;
+        <a href="{{ h.url_for('activity.group_changes', id=activity.id) }}">
+          {{ _('Changes') }}
+        </a>
+      {% endif %}
+    </span>
   </span>
 </li>

--- a/ckanext/activity/templates-midnight-blue/snippets/activities/changed_organization.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activities/changed_organization.html
@@ -3,18 +3,20 @@
     <i class="fa fa-circle fa-stack-2x icon"></i>
     <i class="fa fa-briefcase fa-stack-1x fa-inverse"></i>
   </span>
-  {{ _('{actor} updated the organization {organization}').format(
-    actor=ah.actor(activity),
-    organization=ah.organization(activity)
-  )|safe }}
-  <br />
-  <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
-    {{ h.time_ago_from_timestamp(activity.timestamp) }}
-    {% if can_show_activity_detail %}
-      &nbsp;|&nbsp;
-      <a href="{{ h.url_for('activity.organization_changes', id=activity.id) }}">
-        {{ _('Changes') }}
-      </a>
-    {% endif %}
+  <span>
+    {{ _('{actor} updated the organization {organization}').format(
+      actor=ah.actor(activity),
+      organization=ah.organization(activity)
+    )|safe }}
+    <br />
+    <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
+      {{ h.time_ago_from_timestamp(activity.timestamp) }}
+      {% if can_show_activity_detail %}
+        &nbsp;|&nbsp;
+        <a href="{{ h.url_for('activity.organization_changes', id=activity.id) }}">
+          {{ _('Changes') }}
+        </a>
+      {% endif %}
+    </span>
   </span>
 </li>

--- a/ckanext/activity/templates-midnight-blue/snippets/activities/changed_package.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activities/changed_package.html
@@ -4,23 +4,25 @@
     <i class="fa fa-circle fa-stack-2x icon"></i>
     <i class="fa fa-sitemap fa-stack-1x fa-inverse"></i>
   </span>
-  {{ _('{actor} updated the {dataset_type} {dataset}').format(
-    actor=ah.actor(activity),
-    dataset_type=h.humanize_entity_type('package', dataset_type, 'activity_record') or _('dataset'),
-    dataset=ah.dataset(activity)
-  )|safe }}
-  <br />
-  <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
-    {{ h.time_ago_from_timestamp(activity.timestamp) }}
-    {% if can_show_activity_detail %}
-      &nbsp;|&nbsp;
-      <a href="{{ h.url_for('activity.package_history', id=activity.object_id, activity_id=activity.id) }}">
-        {{ _('View this version') }}
-      </a>
-      &nbsp;|&nbsp;
-      <a href="{{ h.url_for('activity.package_changes', id=activity.id) }}">
-        {{ _('Changes') }}
-      </a>
-    {% endif %}
+  <span>
+    {{ _('{actor} updated the {dataset_type} {dataset}').format(
+      actor=ah.actor(activity),
+      dataset_type=h.humanize_entity_type('package', dataset_type, 'activity_record') or _('dataset'),
+      dataset=ah.dataset(activity)
+    )|safe }}
+    <br />
+    <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
+      {{ h.time_ago_from_timestamp(activity.timestamp) }}
+      {% if can_show_activity_detail %}
+        &nbsp;|&nbsp;
+        <a href="{{ h.url_for('activity.package_history', id=activity.object_id, activity_id=activity.id) }}">
+          {{ _('View this version') }}
+        </a>
+        &nbsp;|&nbsp;
+        <a href="{{ h.url_for('activity.package_changes', id=activity.id) }}">
+          {{ _('Changes') }}
+        </a>
+      {% endif %}
+    </span>
   </span>
 </li>

--- a/ckanext/activity/templates-midnight-blue/snippets/activities/changed_resource.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activities/changed_resource.html
@@ -3,13 +3,15 @@
     <i class="fa fa-circle fa-stack-2x icon"></i>
     <i class="fa fa-icon fa-stack-1x fa-inverse"></i>
   </span>
-  {{ _('{actor} updated the resource {resource} in the dataset {dataset}').format(
-    actor=ah.actor(activity),
-    resource=ah.resource(activity),
-    dataset=ah.datset(activity)
-  )|safe }}
-  <br />
-  <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
-    {{ h.time_ago_from_timestamp(activity.timestamp) }}
+  <span>
+    {{ _('{actor} updated the resource {resource} in the dataset {dataset}').format(
+      actor=ah.actor(activity),
+      resource=ah.resource(activity),
+      dataset=ah.datset(activity)
+    )|safe }}
+    <br />
+    <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
+      {{ h.time_ago_from_timestamp(activity.timestamp) }}
+    </span>
   </span>
 </li>

--- a/ckanext/activity/templates-midnight-blue/snippets/activities/changed_resource_view.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activities/changed_resource_view.html
@@ -3,15 +3,17 @@
     <i class="fa fa-circle fa-stack-2x icon"></i>
     <i class="fa fa-chart-bar fa-stack-1x fa-inverse"></i>
   </span>
-  {% set view_link = h.link_to(label=h.get_translated(activity.data, 'title'),
-                               url=h.url_for('resource.read', id=activity.data.package_id,
-                                resource_id=activity.data.resource_id, view_id=activity.data.id)) %}
-  {{ _('{actor} updated resource view {view_link}').format(
-    actor=ah.actor(activity),
-    view_link=view_link
-  )|safe }}
-  <br />
-  <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
-    {{ h.time_ago_from_timestamp(activity.timestamp) }}
+  <span>
+    {% set view_link = h.link_to(label=h.get_translated(activity.data, 'title'),
+                                url=h.url_for('resource.read', id=activity.data.package_id,
+                                  resource_id=activity.data.resource_id, view_id=activity.data.id)) %}
+    {{ _('{actor} updated resource view {view_link}').format(
+      actor=ah.actor(activity),
+      view_link=view_link
+    )|safe }}
+    <br />
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
+      {{ h.time_ago_from_timestamp(activity.timestamp) }}
+    </span>
   </span>
 </li>

--- a/ckanext/activity/templates-midnight-blue/snippets/activities/changed_user.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activities/changed_user.html
@@ -3,11 +3,13 @@
     <i class="fa fa-circle fa-stack-2x icon"></i>
     <i class="fa fa-users fa-stack-1x fa-inverse"></i>
   </span>
-  {{ _('{actor} updated their profile').format(
-    actor=ah.actor(activity)
-  )|safe }}
-  <br />
-  <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
-    {{ h.time_ago_from_timestamp(activity.timestamp) }}
+  <span>
+    {{ _('{actor} updated their profile').format(
+      actor=ah.actor(activity)
+    )|safe }}
+    <br />
+    <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
+      {{ h.time_ago_from_timestamp(activity.timestamp) }}
+    </span>
   </span>
 </li>

--- a/ckanext/activity/templates-midnight-blue/snippets/activities/deleted_group.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activities/deleted_group.html
@@ -3,6 +3,7 @@
     <i class="fa fa-circle fa-stack-2x icon"></i>
     <i class="fa fa-users fa-stack-1x fa-inverse"></i>
   </span>
+  <span>
     {{ _('{actor} deleted the group {group}').format(
       actor=ah.actor(activity),
       group=ah.group(activity)
@@ -11,4 +12,5 @@
     <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
     </span>
+  </span>
 </li>

--- a/ckanext/activity/templates-midnight-blue/snippets/activities/deleted_organization.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activities/deleted_organization.html
@@ -3,6 +3,7 @@
     <i class="fa fa-circle fa-stack-2x icon"></i>
     <i class="fa fa-briefcase fa-stack-1x fa-inverse"></i>
   </span>
+  <span>
     {{ _('{actor} deleted the organization {organization}').format(
       actor=ah.actor(activity),
       organization=ah.organization(activity)
@@ -11,4 +12,5 @@
     <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
     </span>
+  </span>
 </li>

--- a/ckanext/activity/templates-midnight-blue/snippets/activities/deleted_package.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activities/deleted_package.html
@@ -5,13 +5,15 @@
     <i class="fa fa-circle fa-stack-2x icon"></i>
     <i class="fa fa-sitemap fa-stack-1x fa-inverse"></i>
   </span>
-  {{ _('{actor} deleted the {dataset_type} {dataset}').format(
-    actor=ah.actor(activity),
-    dataset_type=h.humanize_entity_type('package', dataset_type, 'activity_record') or _('dataset'),
-    dataset=ah.dataset(activity)
-  )|safe }}
-  <br />
-  <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
-    {{ h.time_ago_from_timestamp(activity.timestamp) }}
+  <span>
+    {{ _('{actor} deleted the {dataset_type} {dataset}').format(
+      actor=ah.actor(activity),
+      dataset_type=h.humanize_entity_type('package', dataset_type, 'activity_record') or _('dataset'),
+      dataset=ah.dataset(activity)
+    )|safe }}
+    <br />
+    <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
+      {{ h.time_ago_from_timestamp(activity.timestamp) }}
+    </span>
   </span>
 </li>

--- a/ckanext/activity/templates-midnight-blue/snippets/activities/deleted_resource.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activities/deleted_resource.html
@@ -3,13 +3,15 @@
     <i class="fa fa-circle fa-stack-2x icon"></i>
     <i class="fa fa-file fa-stack-1x fa-inverse"></i>
   </span>
-  {{ _('{actor} deleted the resource {resource} from the dataset {dataset}').format(
-    actor=ah.actor(activity),
-    resource=ah.resource(activity),
-    dataset=ah.dataset(activity)
-  )|safe }}
-  <br />
-  <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
-    {{ h.time_ago_from_timestamp(activity.timestamp) }}
+  <span>
+    {{ _('{actor} deleted the resource {resource} from the dataset {dataset}').format(
+      actor=ah.actor(activity),
+      resource=ah.resource(activity),
+      dataset=ah.dataset(activity)
+    )|safe }}
+    <br />
+    <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
+      {{ h.time_ago_from_timestamp(activity.timestamp) }}
+    </span>
   </span>
 </li>

--- a/ckanext/activity/templates-midnight-blue/snippets/activities/deleted_resource_view.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activities/deleted_resource_view.html
@@ -6,13 +6,15 @@
   {% set resource_link = h.link_to(label=activity.data.resource_id,
                                    url=h.url_for('resource.read', id=activity.data.package_id,
                                     resource_id=activity.data.resource_id)) %}
-  {{ _('{actor} deleted resource view "{view_title}" for resource {resource_link}').format(
-    actor=ah.actor(activity),
-    view_title=h.get_translated(activity.data, 'title'),
-    resource_link=resource_link
-  )|safe }}
-  <br />
-  <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
-    {{ h.time_ago_from_timestamp(activity.timestamp) }}
+  <span>
+    {{ _('{actor} deleted resource view "{view_title}" for resource {resource_link}').format(
+      actor=ah.actor(activity),
+      view_title=h.get_translated(activity.data, 'title'),
+      resource_link=resource_link
+    )|safe }}
+    <br />
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
+      {{ h.time_ago_from_timestamp(activity.timestamp) }}
+    </span>
   </span>
 </li>

--- a/ckanext/activity/templates-midnight-blue/snippets/activities/fallback.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activities/fallback.html
@@ -13,6 +13,7 @@
     <i class="fa fa-circle fa-stack-2x icon"></i>
     <i class="fa fa-users fa-stack-1x fa-inverse"></i>
   </span>
+  <span>
     {{ _('{actor} {activity_type}').format(
       actor=ah.actor(activity),
       activity_type=activity.activity_type
@@ -35,4 +36,5 @@
     <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
       {{ h.time_ago_from_timestamp(activity.timestamp) }}
     </span>
-  </li>
+  </span>
+</li>

--- a/ckanext/activity/templates-midnight-blue/snippets/activities/follow_dataset.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activities/follow_dataset.html
@@ -3,12 +3,14 @@
     <i class="fa fa-circle fa-stack-2x icon"></i>
     <i class="fa fa-sitemap fa-stack-1x fa-inverse"></i>
   </span>
-  {{ _('{actor} started following {dataset}').format(
-    actor=ah.actor(activity),
-    dataset=ah.dataset(activity)
-  )|safe }}
-  <br />
-  <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
-    {{ h.time_ago_from_timestamp(activity.timestamp) }}
+  <span>
+    {{ _('{actor} started following {dataset}').format(
+      actor=ah.actor(activity),
+      dataset=ah.dataset(activity)
+    )|safe }}
+    <br />
+    <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
+      {{ h.time_ago_from_timestamp(activity.timestamp) }}
+    </span>
   </span>
 </li>

--- a/ckanext/activity/templates-midnight-blue/snippets/activities/follow_group.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activities/follow_group.html
@@ -3,12 +3,14 @@
     <i class="fa fa-circle fa-stack-2x icon"></i>
     <i class="fa fa-users fa-stack-1x fa-inverse"></i>
   </span>
-  {{ _('{actor} started following {group}').format(
-    actor=ah.actor(activity),
-    group=ah.group(activity)
-  )|safe }}
-  <br />
-  <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
-    {{ h.time_ago_from_timestamp(activity.timestamp) }}
+  <span>
+    {{ _('{actor} started following {group}').format(
+      actor=ah.actor(activity),
+      group=ah.group(activity)
+    )|safe }}
+    <br />
+    <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
+      {{ h.time_ago_from_timestamp(activity.timestamp) }}
+    </span>
   </span>
 </li>

--- a/ckanext/activity/templates-midnight-blue/snippets/activities/follow_user.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activities/follow_user.html
@@ -3,12 +3,14 @@
     <i class="fa fa-circle fa-stack-2x icon"></i>
     <i class="fa fa-users fa-stack-1x fa-inverse"></i>
   </span>
-  {{ _('{actor} started following {user}').format(
-    actor=ah.actor(activity),
-    user=ah.user(activity)
-  )|safe }}
-  <br />
-  <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
-    {{ h.time_ago_from_timestamp(activity.timestamp) }}
+  <span>
+    {{ _('{actor} started following {user}').format(
+      actor=ah.actor(activity),
+      user=ah.user(activity)
+    )|safe }}
+    <br />
+    <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
+      {{ h.time_ago_from_timestamp(activity.timestamp) }}
+    </span>
   </span>
 </li>

--- a/ckanext/activity/templates-midnight-blue/snippets/activities/new_group.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activities/new_group.html
@@ -3,12 +3,14 @@
     <i class="fa fa-circle fa-stack-2x icon"></i>
     <i class="fa fa-users fa-stack-1x fa-inverse"></i>
   </span>
-  {{ _('{actor} created the group {group}').format(
-      actor=ah.actor(activity),
-      group=ah.group(activity)
-    )|safe }}
-  <br />
-  <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
-    {{ h.time_ago_from_timestamp(activity.timestamp) }}
+  <span>
+    {{ _('{actor} created the group {group}').format(
+        actor=ah.actor(activity),
+        group=ah.group(activity)
+      )|safe }}
+    <br />
+    <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
+      {{ h.time_ago_from_timestamp(activity.timestamp) }}
+    </span>
   </span>
 </li>

--- a/ckanext/activity/templates-midnight-blue/snippets/activities/new_organization.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activities/new_organization.html
@@ -3,12 +3,14 @@
     <i class="fa fa-circle fa-stack-2x icon"></i>
     <i class="fa fa-briefcase fa-stack-1x fa-inverse"></i>
   </span>
-  {{ _('{actor} created the organization {organization}').format(
-    actor=ah.actor(activity),
-    organization=ah.organization(activity)
-  )|safe }}
-  <br />
-  <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
-    {{ h.time_ago_from_timestamp(activity.timestamp) }}
+  <span>
+    {{ _('{actor} created the organization {organization}').format(
+      actor=ah.actor(activity),
+      organization=ah.organization(activity)
+    )|safe }}
+    <br />
+    <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
+      {{ h.time_ago_from_timestamp(activity.timestamp) }}
+    </span>
   </span>
 </li>

--- a/ckanext/activity/templates-midnight-blue/snippets/activities/new_package.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activities/new_package.html
@@ -4,19 +4,21 @@
     <i class="fa fa-circle fa-stack-2x icon"></i>
     <i class="fa fa-sitemap fa-stack-1x fa-inverse"></i>
   </span>
-  {{ _('{actor} created the {dataset_type} {dataset}').format(
-    actor=ah.actor(activity),
-    dataset_type=h.humanize_entity_type('package', dataset_type,'activity_record') or _('dataset'),
-    dataset=ah.dataset(activity)
-  )|safe }}
-  <br />
-  <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
-    {{ h.time_ago_from_timestamp(activity.timestamp) }}
-    {% if can_show_activity_detail %}
-      &nbsp;|&nbsp;
-      <a href="{{ h.url_for('activity.package_history', id=activity.object_id, activity_id=activity.id) }}">
-        {{ _('View this version') }}
-      </a>
-    {% endif %}
+  <span>
+    {{ _('{actor} created the {dataset_type} {dataset}').format(
+      actor=ah.actor(activity),
+      dataset_type=h.humanize_entity_type('package', dataset_type,'activity_record') or _('dataset'),
+      dataset=ah.dataset(activity)
+    )|safe }}
+    <br />
+    <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
+      {{ h.time_ago_from_timestamp(activity.timestamp) }}
+      {% if can_show_activity_detail %}
+        &nbsp;|&nbsp;
+        <a href="{{ h.url_for('activity.package_history', id=activity.object_id, activity_id=activity.id) }}">
+          {{ _('View this version') }}
+        </a>
+      {% endif %}
+    </span>
   </span>
 </li>

--- a/ckanext/activity/templates-midnight-blue/snippets/activities/new_resource.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activities/new_resource.html
@@ -3,13 +3,15 @@
     <i class="fa fa-circle fa-stack-2x icon"></i>
     <i class="fa fa-file fa-stack-1x fa-inverse"></i>
   </span>
-  {{ _('{actor} added the resource {resource} to the dataset {dataset}').format(
-    actor=ah.actor(activity),
-    resource=ah.resource(activity),
-    dataset=ah.dataset(activity)
-  )|safe }}
-  <br />
-  <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
-    {{ h.time_ago_from_timestamp(activity.timestamp) }}
+  <span>
+    {{ _('{actor} added the resource {resource} to the dataset {dataset}').format(
+      actor=ah.actor(activity),
+      resource=ah.resource(activity),
+      dataset=ah.dataset(activity)
+    )|safe }}
+    <br />
+    <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
+      {{ h.time_ago_from_timestamp(activity.timestamp) }}
+    </span>
   </span>
 </li>

--- a/ckanext/activity/templates-midnight-blue/snippets/activities/new_resource_view.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activities/new_resource_view.html
@@ -6,12 +6,14 @@
   {% set view_link = h.link_to(label=h.get_translated(activity.data, 'title'),
                                url=h.url_for('resource.read', id=activity.data.package_id,
                                 resource_id=activity.data.resource_id, view_id=activity.data.id)) %}
-  {{ _('{actor} created resource view {view_link}').format(
-    actor=ah.actor(activity),
-    view_link=view_link
-  )|safe }}
-  <br />
-  <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
-    {{ h.time_ago_from_timestamp(activity.timestamp) }}
+  <span>
+    {{ _('{actor} created resource view {view_link}').format(
+      actor=ah.actor(activity),
+      view_link=view_link
+    )|safe }}
+    <br />
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
+      {{ h.time_ago_from_timestamp(activity.timestamp) }}
+    </span>
   </span>
 </li>

--- a/ckanext/activity/templates-midnight-blue/snippets/activities/new_user.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activities/new_user.html
@@ -3,11 +3,13 @@
     <i class="fa fa-circle fa-stack-2x icon"></i>
     <i class="fa fa-user fa-stack-1x fa-inverse"></i>
   </span>
-  {{ _('{actor} signed up').format(
-    actor=ah.actor(activity)
-  )|safe }}
-  <br />
-  <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
-    {{ h.time_ago_from_timestamp(activity.timestamp) }}
+  <span>
+    {{ _('{actor} signed up').format(
+      actor=ah.actor(activity)
+    )|safe }}
+    <br />
+    <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
+      {{ h.time_ago_from_timestamp(activity.timestamp) }}
+    </span>
   </span>
 </li>

--- a/ckanext/activity/templates-midnight-blue/snippets/activities/removed_tag.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activities/removed_tag.html
@@ -3,13 +3,15 @@
     <i class="fa fa-circle fa-stack-2x icon"></i>
     <i class="fa fa-tag fa-stack-1x fa-inverse"></i>
   </span>
-  {{ _('{actor} removed the tag {tag} from the dataset {dataset}').format(
-    actor=ah.actor(activity),
-    tag=ah.tag(activity),
-    dataset=ah.dataset(dataset)
-  )|safe }}
-  <br />
-  <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
-    {{ h.time_ago_from_timestamp(activity.timestamp) }}
+  <span>
+    {{ _('{actor} removed the tag {tag} from the dataset {dataset}').format(
+      actor=ah.actor(activity),
+      tag=ah.tag(activity),
+      dataset=ah.dataset(dataset)
+    )|safe }}
+    <br />
+    <span class="date" aria-label="{{ _('Activity occurred on: {time}').format(time=h.render_datetime(activity.timestamp, with_hours=True)) }}">
+      {{ h.time_ago_from_timestamp(activity.timestamp) }}
+    </span>
   </span>
 </li>

--- a/ckanext/activity/templates-midnight-blue/snippets/stream.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/stream.html
@@ -1,5 +1,5 @@
 {% macro actor(activity) %}
-  <span>
+  <span class="user">
     {{ h.linked_user(activity.user_id, 0, 30) }}
   </span>
 {% endmacro %}
@@ -21,7 +21,7 @@
 {% endmacro %}
 
 {% macro user(activity) %}
-<span>
+<span class="user">
   {{ h.linked_user(activity.object_id, 0, 20) }}
 </span>
 {% endmacro %}


### PR DESCRIPTION
Fixes #

### Proposed fixes:
- Changes layout of activity stream items to use flexbox instead of margins (wrapping the right side activity content in a span)
- Changes colours of activity stream bubbles to match theme colours
- Removes user icon in activity stream and changes page
- Adds button class and select labels to changes page

## Figma:
[Figma screen](https://www.figma.com/design/oI3wDSdZ0cHZLh6CrfYMnb/CKAN-3.0-Design-System?node-id=1578-18128&t=r5F1AyYKbrTQBUXJ-4)

## Screenshots: 
<img width="1642" height="2008" alt="image" src="https://github.com/user-attachments/assets/d950beb4-1fd9-4b23-9b0e-8f0e540c0442" />


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
