### PR TITLE
fix datastore upgrade with % columns

### DIFF
--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -6,6 +6,7 @@ import os
 import json
 
 import click
+import sqlalchemy as sa
 
 from ckan.model import parse_db_config
 from ckan.common import config
@@ -208,7 +209,9 @@ def upgrade():
                     raw_sql))
 
             if alter_sql:
-                connection.exec_driver_sql(';'.join(alter_sql))
+                connection.execute(sa.text(
+                    ';'.join(alter_sql).replace(':', r'\:')  # no bind params
+                ))
                 count += 1
             else:
                 noinfo += 1


### PR DESCRIPTION
Fixes #9114

### Proposed fixes:

- `exec_driver_sql` doesn't avoid string processing so use `execute`, `sa.text` and `replace` like the other postgres backend code for updating the column comments

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport