### PR TITLE
Refactor method check to conform to type checking

### DIFF
--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -547,8 +547,9 @@ def login() -> Union[Response, str]:
         user_obj = authenticator.ckan_authenticator(identity)
         if user_obj:
             next = request.args.get('next', request.args.get('came_from'))
-            if hasattr(current_app.session_interface, 'regenerate'):
-                current_app.session_interface.regenerate(session)
+            regenerate = getattr(current_app.session_interface, 'regenerate', None)
+            if regenerate is not None:
+                regenerate(session)
             if _remember:
                 from datetime import timedelta
                 duration_time = timedelta(milliseconds=int(_remember))


### PR DESCRIPTION
The type checker was complaining that we were trying to access the `regenerate()` method even after checking with `hasattr`. Refactored the check to use `getattr` to be explicit about calling the method.
