### PR TITLE
Investigate failing tests in github actions only

### DIFF
--- a/ckanext/activity/tests/test_views.py
+++ b/ckanext/activity/tests/test_views.py
@@ -2,7 +2,6 @@
 
 import unittest.mock as mock
 from datetime import datetime
-from time import sleep
 
 import pytest
 from bs4 import BeautifulSoup


### PR DESCRIPTION
Remove sleep retries and show the response on flaky tests that seem to only fail on github actions.

I've tried running the same tests in the same order that they were run here https://github.com/ckan/ckan/actions/runs/19266158937/job/55082472015 locally but they don't trigger failures in the flaky tests.

If this change is merged we should at least have more information to resolve the flaky test issue the next time they fail on an unrelated PR.