### PR TITLE
Fix create views without datapusher

### DIFF
--- a/ckan/cli/views.py
+++ b/ckan/cli/views.py
@@ -48,7 +48,7 @@ def create(ctx: click.Context, types: list[str], dataset: list[str],
     `ckan.plugins`), otherwise the command will stop.
 
     """
-    breakpoint()
+
     flask_app = ctx.meta['flask_app']
     datastore_active = plugin_loaded("datastore")
     with flask_app.test_request_context():
@@ -246,7 +246,7 @@ def _search_datasets(
         u"rows": n,
         u"start": n * (page - 1),
     }
-    breakpoint()
+
     if dataset:
 
         search_data_dict[u"q"] = u" OR ".join(


### PR DESCRIPTION
Fixes #9142

### Proposed fixes:

The problem is when the datapusher plugin is not loaded — the line `config.get("ckan.datapusher.formats") `returns None, and later the code attempts to access its first element. I’ve fixed the logic, but there’s still a limitation: users are required to define ckan.datapusher.formats even when using XLoader. I’m happy to submit an update if the CKAN team decides to extend the logic further.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
