### PR TITLE
Fix error handling in tabledesigner with new datastore column

### DIFF
--- a/ckanext/tabledesigner/views.py
+++ b/ckanext/tabledesigner/views.py
@@ -88,6 +88,9 @@ class _TableDesignerDictionary(MethodView):
                         error_summary[_('Field %d') % i] = ', '.join(
                             v for vals in f.values()
                             for v in vals)
+            if fields and new_fields:
+                errors['fields'] = [{}]*len(fields) + field_errors
+
             return _datastore_view.get(
                 id, resource_id, data, errors, error_summary)
 


### PR DESCRIPTION
### Proposed fixes:

Table designer's templates assume that there are either no or len(fields) errors, but if there's an error when adding a new column, the error structure is a single element list

```
{'fields': ['"INVALID FIELDNAME " is not a valid field name']}
```

This eventually leads to an attribute error:
```
return { prefix + key: value for (key, value) in dict.items() }
AttributeError: 'str' object has no attribute 'items'
```
Deep in the jinja templating, because we're trying to get an attribute of a jinja.element.Undefined, and it fails.

`design_fields.html` tries to handle this case:
```
          errors=(errors.get('fields', [])[fields | length:] + [{}] * loop.length)[loop.index0]) }}
```
But this is returning an undefined item.

I'm not 100% on the solution here, because this isn't actually getting the error into the right place.  I want to get some tests in, but more eyes make sense.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
