### PR TITLE
[#9142] More robust handling of config in the views command

### DIFF
--- a/ckan/cli/views.py
+++ b/ckan/cli/views.py
@@ -10,7 +10,7 @@ import json
 import ckan.logic as logic
 import ckan.model as model
 import ckan.plugins as p
-from ckan.common import config
+from ckan.common import config, aslist
 from ckan.cli import error_shout
 from ckan.lib.datapreview import (
     add_views_to_dataset_resources,
@@ -294,33 +294,42 @@ def _add_default_filters(search_data_dict: dict[str, Any],
     modified with extra filters.
     """
 
-    from ckanext.textview.plugin import get_formats as get_text_formats
-    datapusher_formats = config.get("ckan.datapusher.formats")
+    try:
+        from ckanext.textview.plugin import get_formats as get_text_formats
+        text_formats = get_text_formats(config)
+    except ImportError:
+        text_formats = {}
+
+    datastore_formats = []
+    if config.get("ckan.datapusher.formats"):
+        datastore_formats = aslist(config["ckan.datapusher.formats"])
+    elif config.get("ckanext.xloader.formats"):
+        datastore_formats = aslist(config["ckanext.xloader.formats"])
 
     filter_formats = []
 
     for view_type in view_types:
-        if view_type == u"image_view":
-            formats = config.get(
-                "ckan.preview.image_formats").split()
+        if view_type == "image_view":
+            formats = aslist(config.get(
+                "ckan.preview.image_formats"))
             for _format in formats:
                 filter_formats.extend([_format, _format.upper()])
 
-        elif view_type == u"text_view":
-            formats = get_text_formats(config)
+        elif view_type == "text_view":
+            formats = text_formats
             for _format in itertools.chain.from_iterable(formats.values()):
                 filter_formats.extend([_format, _format.upper()])
 
-        elif view_type == u"pdf_view":
-            filter_formats.extend([u"pdf", u"PDF"])
+        elif view_type == "pdf_view":
+            filter_formats.extend(["pdf", "PDF"])
 
         elif view_type == "datatables_view":
 
-            if datapusher_formats[0] in filter_formats:
+            if not datastore_formats:
                 continue
 
-            for _format in datapusher_formats:
-                if u"/" not in _format:
+            for _format in datastore_formats:
+                if "/" not in _format:
                     filter_formats.extend([_format, _format.upper()])
         else:
             # There is another view type provided so we can't add any

--- a/ckanext/textview/plugin.py
+++ b/ckanext/textview/plugin.py
@@ -5,7 +5,7 @@ from ckan.types import Context
 import logging
 from typing import Any
 
-from ckan.common import CKANConfig, json
+from ckan.common import CKANConfig, aslist, json
 import ckan.plugins as p
 import ckanext.resourceproxy.plugin as proxy
 import ckan.lib.datapreview as datapreview
@@ -16,16 +16,16 @@ log = logging.getLogger(__name__)
 def get_formats(config: CKANConfig) -> dict[str, list[str]]:
     out = {}
 
-    out["text_formats"] = config.get(
+    out["text_formats"] = aslist(config.get(
         "ckan.preview.text_formats"
-    ).split()
-    out["xml_formats"] = config.get("ckan.preview.xml_formats").split()
-    out["json_formats"] = config.get(
+    ))
+    out["xml_formats"] = aslist(config.get("ckan.preview.xml_formats"))
+    out["json_formats"] = aslist(config.get(
         "ckan.preview.json_formats"
-    ).split()
-    out["jsonp_formats"] = config.get(
+    ))
+    out["jsonp_formats"] = aslist(config.get(
         "ckan.preview.jsonp_formats"
-    ).split()
+    ))
 
     return out
 


### PR DESCRIPTION
Fixes #9142

### Proposed fixes:

Don't assume config options are there and normalize them to lists (some old config options don't use config declaration)
Use xloader formats config in addition to datapusher ones.

Tried to add tests but the test CKANCliRunner that we use doesn't seem to load plugins defined in `pytest.mark.ckan_config()`


### Features:

- [x] includes bugfix for possible backport


