### PR TITLE
fix resource form publish error handling

### DIFF
--- a/changes/9202.bugfix
+++ b/changes/9202.bugfix
@@ -1,0 +1,2 @@
+display correct errors and leave resource form empty when dataset validation errors
+are triggered by publishing a dataset (setting state=active)

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -228,10 +228,9 @@ class CreateView(MethodView):
                     _(u'The dataset {id} could not be found.').format(id=id)
                 )
             except ValidationError as e:
-                errors = cast(
-                    "list[ErrorDict]", e.error_dict.get('resources', [{}]))[-1]
+                errors = cast("list[ErrorDict]", e.error_dict)
                 error_summary = e.error_summary
-                return self.get(package_type, id, data, errors, error_summary)
+                return self.get(package_type, id, {}, errors, error_summary)
             return h.redirect_to(u'{}.read'.format(package_type), id=id)
 
         data[u'package_id'] = id

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -228,9 +228,8 @@ class CreateView(MethodView):
                     _(u'The dataset {id} could not be found.').format(id=id)
                 )
             except ValidationError as e:
-                errors = cast("list[ErrorDict]", e.error_dict)
                 error_summary = e.error_summary
-                return self.get(package_type, id, {}, errors, error_summary)
+                return self.get(package_type, id, {}, e.error_dict, error_summary)
             return h.redirect_to(u'{}.read'.format(package_type), id=id)
 
         data[u'package_id'] = id

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import cgi
 import json
 import logging
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, Union
 
 from werkzeug.wrappers.response import Response as WerkzeugResponse
 import flask
@@ -25,7 +25,7 @@ from ckan.views.dataset import (
     _get_pkg_template, _get_package_type, _setup_template_variables
 )
 
-from ckan.types import Context, Response, ErrorDict
+from ckan.types import Context, Response
 
 Blueprint = flask.Blueprint
 NotFound = logic.NotFound

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -260,10 +260,8 @@ class CreateView(MethodView):
                     {'id': id, 'state': 'active'}
                 )
             except ValidationError as e:
-                errors = cast(
-                    "list[ErrorDict]", e.error_dict.get('resources', [{}]))[-1]
                 error_summary = e.error_summary
-                return self.get(package_type, id, data, errors, error_summary)
+                return self.get(package_type, id, {}, e.error_dict, error_summary)
             return h.redirect_to(u'{}.read'.format(package_type), id=id)
         elif save_action == u'go-metadata-preview':
             data_dict = get_action(u'package_show')(context, {u'id': id})


### PR DESCRIPTION
Fixes #9202

### Proposed fixes:

On validation errors in the resource form triggered by setting state=active
- pass all dataset errors to form (not only errors from the last resource)
- leave resource form blank since the resource was created successfully

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
