### PR TITLE
[2.11] Fix entrypoints logic to make CKAN 2.11 work on Python 3.12

### DIFF
--- a/ckan/plugins/core.py
+++ b/ckan/plugins/core.py
@@ -285,7 +285,7 @@ def _get_service(plugin_name: str) -> Plugin:
         try:
             eps = list(entry_points(group=group, name=plugin_name))     # type: ignore
 
-            ep = eps[0][plugin_name] if eps else None
+            ep = eps[0] if eps else None
         except TypeError:
             # Python 3.9
             eps = entry_points().get(group, [])


### PR DESCRIPTION
My fix introduced in https://github.com/ckan/ckan/pull/9013 was incorrect, and as @wardi predicted, catching TypeErrors masked other problems. There was a TypeError raised when referencing the entrypoint object, so the fallback logic was used. But this fallback logic stopped working on Python 3.12 so we got an exception instead.

Part of the cross-python version support work tracked [here](https://github.com/ckan/ckan-python-monitor)
