### PR TITLE
[2.10][#9237] Include lxml as a main requirement to support Python 3.12+

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -17,6 +17,7 @@ Flask-WTF==1.0.1
 flask-multistatic==1.0
 greenlet==2.0.2
 Jinja2==3.1.6
+lxml==6.0.2
 Markdown==3.4.1
 packaging==24.1
 passlib==1.7.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,8 +74,10 @@ jinja2==3.1.6
     #   -r requirements.in
     #   flask
     #   flask-babel
-lxml==4.9.1
-    # via feedgen
+lxml==6.0.2
+    # via
+    #   -r requirements.in
+    #   feedgen
 mako==1.2.2
     # via alembic
 markdown==3.4.1


### PR DESCRIPTION
For CKAN 2.10

The version pinned in requirements.txt (introduced via feedgen) is too old to support Python 3.12+, so we need to include it in our main requirements to bump it to a modern version.

Ref #9327
