### PR TITLE
[2.11][#9237] Include lxml as a main requirement to support Python 3.13+

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -14,6 +14,7 @@ Flask-Login==0.6.3
 Flask-Session==0.8.0
 Flask-WTF==1.2.1
 Jinja2==3.1.6
+lxml==6.0.2
 Markdown==3.6
 msgspec==0.18.6
 packaging==24.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,8 +67,10 @@ jinja2==3.1.6
     #   -r requirements.in
     #   flask
     #   flask-babel
-lxml==5.2.2
-    # via feedgen
+lxml==6.0.2
+    # via
+    #   -r requirements.in
+    #   feedgen
 mako==1.3.5
     # via alembic
 markdown==3.6


### PR DESCRIPTION
For CKAN 2.11

The version pinned in requirements.txt (introduced via feedgen) is too old to support Python 3.13+, so we need to include it in our main requirements to bump it to a modern version.

Ref #9327
