### PR TITLE
fix: correct typos 'occured', 'seperately', and 'recieve'

### DIFF
--- a/ckanext/activity/model/activity.py
+++ b/ckanext/activity/model/activity.py
@@ -442,7 +442,7 @@ def _group_activity_query(group_id: Union[str, List[str]]) -> QActivity:
         .filter(
             # We only care about activity either on the group itself or on
             # packages within that group.  FIXME: This means that activity that
-            # occured while a package belonged to a group but was then removed
+            # occurred while a package belonged to a group but was then removed
             # will not show up. This may not be desired but is consistent with
             # legacy behaviour.
             or_(
@@ -487,7 +487,7 @@ def _organization_activity_query(org_id: str) -> QActivity:
         .filter(
             # We only care about activity either on the the org itself or on
             # packages within that org.
-            # FIXME: This means that activity that occured while a package
+            # FIXME: This means that activity that occurred while a package
             # belonged to a org but was then removed will not show up. This may
             # not be desired but is consistent with legacy behaviour.
             #

--- a/ckanext/multilingual/plugin.py
+++ b/ckanext/multilingual/plugin.py
@@ -196,7 +196,7 @@ def translate_resource_data_dict(data_dict: dict[str, Any]):
             .unflatten(translated_flattened))
     return translated_data_dict
 
-KEYS_TO_IGNORE = ['state', 'revision_id', 'id', #title done seperately
+KEYS_TO_IGNORE = ['state', 'revision_id', 'id', #title done separately
                   'metadata_created', 'metadata_modified', 'site_id']
 
 

--- a/ckanext/tracking/helpers.py
+++ b/ckanext/tracking/helpers.py
@@ -15,7 +15,7 @@ def popular(type_: str,
             '{number} recent view', '{number} recent views', number
             )
     elif not title:
-        raise Exception('popular() did not recieve a valid type_ or title')
+        raise Exception('popular() did not receive a valid type_ or title')
     data_dict = {'title': title, 'number': number, 'min': min}
 
     return toolkit.render_snippet('snippets/popular.html', data_dict)


### PR DESCRIPTION
Fixes typos across 3 files:
- `occured` → `occurred` (2 instances in activity.py)
- `seperately` → `separately` (plugin.py)
- `recieve` → `receive` (helpers.py)