### PR TITLE
fix: cookiecutter extension generator

### DIFF
--- a/contrib/cookiecutter/ckan_extension/hooks/pre_prompt.py
+++ b/contrib/cookiecutter/ckan_extension/hooks/pre_prompt.py
@@ -1,0 +1,3 @@
+# For some reason running this empty script results in proper setup
+# of _repo_dir in cookiecutter's context. This is the weirdest behaviour
+# I have ever encountered.


### PR DESCRIPTION
# Fixes

[#9240] Cookiecutter template generation broken

Currently, cookiecutter template generator throws an exception of missing required argument environment. And, if the user calls from cookiecutter from different directory, the cookiecutter will look in default location for templates

After things change, cookiecutter works from any directory

### Proposed fixes:

1. Introduced environment variable at the beginning of recut function.
2. Sourcing cookiecutter's template directory from global context.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
