### PR TITLE
Tabledesigner -- Allow user to delete last field

### DIFF
--- a/ckanext/tabledesigner/views.py
+++ b/ckanext/tabledesigner/views.py
@@ -45,6 +45,9 @@ class _TableDesignerDictionary(MethodView):
         if not isinstance(info, list):
             info = []
         custom = data.get('fields')
+        if custom is None:
+            # user has deleted all of the fields.
+            custom = []
         if not isinstance(custom, list):
             return base.abort(400, _('Required fields missing'))
         info = info[:len(custom)]


### PR DESCRIPTION
The tabledesigner view for the data dictionary enforces that fields is a list, however when deleting the last field, this is empty, and therefore null. This results in a confusing 400 validation error to the user. 

This traps it to prevent the 400. 

@wardi  I'm not sure if this is breaking a validation, because now a bare post to this endpoint will delete all the fields in the table. It might be a better approach in the long term to have tombstones for deleted fields. 


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
