### PR TITLE
Fix cookiecutter typo that breaks minification in new extensions

### DIFF
--- a/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/ckanext/{{cookiecutter.project_shortname}}/assets/webassets.yml
+++ b/contrib/cookiecutter/ckan_extension/{{cookiecutter.project}}/ckanext/{{cookiecutter.project_shortname}}/assets/webassets.yml
@@ -1,5 +1,5 @@
 # {{ cookiecutter.project_shortname }}-js:
-#   filter: rjsmin
+#   filters: rjsmin
 #   output: ckanext-{{ cookiecutter.project_shortname }}/%(version)s-{{ cookiecutter.project_shortname }}.js
 #   contents:
 #     - js/{{ cookiecutter.project_shortname }}.js
@@ -8,7 +8,7 @@
 #       - base/main
 
 # {{ cookiecutter.project_shortname }}-css:
-#   filter: cssrewrite
+#   filters: cssrewrite
 #   output: ckanext-{{ cookiecutter.project_shortname }}/%(version)s-{{ cookiecutter.project_shortname }}.css
 #   contents:
 #     - css/{{ cookiecutter.project_shortname }}.css


### PR DESCRIPTION
In the cookiecutter templates for creating new extensions, the webassets.yml template uses attribute name `filter` where it should be `filters`, breaking out-of-box minification of assets in new extensions.

[Webassets docs with an example
webassets.yml](https://webassets.readthedocs.io/en/latest/loaders.html#webassets.loaders.YAMLLoader)


### Proposed fixes:

Change `filter` to `filters`


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
