### PR TITLE
Move location-root and site-root from body to head>meta

### DIFF
--- a/changes/9284.misc
+++ b/changes/9284.misc
@@ -1,0 +1,5 @@
+``data-site-root`` and ``data-locale-root`` moved to
+``site-root``/``locale-root`` meta elements inside ``head``. It means that code
+like ``$('body').data('site-root');`` must be replaced with
+``$('meta[name=site-root]').attr('content');`` or
+``document.head.querySelector(['meta[name=site-root]'])?.content``

--- a/ckan/public-midnight-blue/base/javascript/modules/data-viewer.js
+++ b/ckan/public-midnight-blue/base/javascript/modules/data-viewer.js
@@ -24,7 +24,7 @@ this.ckan.module('data-viewer', function (jQuery) {
 
     _onLoad: function() {
       var self = this;
-      var loc = $('body').data('site-root');
+      var loc = document.head.querySelector(['meta[name=site-root]'])?.content;
       // see if page is in part of the same domain
       if (this.el.attr('src').substring(0, loc.length) === loc) {
         this._recalibrate();

--- a/ckan/public/base/javascript/modules/data-viewer.js
+++ b/ckan/public/base/javascript/modules/data-viewer.js
@@ -24,7 +24,7 @@ this.ckan.module('data-viewer', function (jQuery) {
 
     _onLoad: function() {
       var self = this;
-      var loc = $('body').data('site-root');
+      var loc = document.head.querySelector(['meta[name=site-root]'])?.content;
       // see if page is in part of the same domain
       if (this.el.attr('src').substring(0, loc.length) === loc) {
         this._recalibrate();

--- a/ckan/templates-midnight-blue/base.html
+++ b/ckan/templates-midnight-blue/base.html
@@ -4,8 +4,7 @@
 {# Allows custom attributes to be added to the <html> tag #}
 {%- block htmltag -%}
 {% set lang = h.lang() %}
-<!--[if IE 9]> <html lang="{{ lang }}" class="ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html lang="{{ lang }}" {% if h.is_rtl_language()  %} dir="rtl" {% endif %} > <!--<![endif]-->
+  <html lang="{{ lang }}" {% if h.is_rtl_language()  %} dir="rtl" {% endif %} class="js">
 {%- endblock -%}
 
   {# Allows custom attributes to be added to the <head> tag #}
@@ -26,6 +25,8 @@
       <meta charset="utf-8" />
       <meta name="csrf_field_name" content="{{ g.csrf_field_name }}" />
       <meta name="{{ g.csrf_field_name }}" content="{{ csrf_token() }}" />
+      <meta name="site-root" content="{{ h.url_for('home.index', locale='default', _external=true) }}" />
+      <meta name="locale-root" content="{{ h.url_for('home.index', _external=true) }}" />
 
       {% block meta_generator %}<meta name="generator" content="ckan {{ h.ckan_version() }}" />{% endblock %}
       {% block meta_viewport %}<meta name="viewport" content="width=device-width, initial-scale=1.0">{% endblock %}
@@ -90,7 +91,7 @@
   </head>
 
   {# Allows custom attributes to be added to the <body> tag #}
-  <body{% block bodytag %} data-site-root="{{ h.url_for('home.index', locale='default', qualified=true) }}" data-locale-root="{{ h.url_for('home.index', qualified=true) }}" {% endblock %}>
+  <body{% block bodytag %}{% endblock %}>
 
     {#
     The page block allows you to add content to the page. Most of the time it is

--- a/ckan/templates/base.html
+++ b/ckan/templates/base.html
@@ -4,8 +4,7 @@
 {# Allows custom attributes to be added to the <html> tag #}
 {%- block htmltag -%}
 {% set lang = h.lang() %}
-<!--[if IE 9]> <html lang="{{ lang }}" class="ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html lang="{{ lang }}" {% if h.is_rtl_language()  %} dir="rtl" {% endif %} > <!--<![endif]-->
+  <html lang="{{ lang }}" {% if h.is_rtl_language()  %} dir="rtl" {% endif %} class="js">
 {%- endblock -%}
 
   {# Allows custom attributes to be added to the <head> tag #}
@@ -26,6 +25,8 @@
       <meta charset="utf-8" />
       <meta name="csrf_field_name" content="{{ g.csrf_field_name }}" />
       <meta name="{{ g.csrf_field_name }}" content="{{ csrf_token() }}" />
+      <meta name="site-root" content="{{ h.url_for('home.index', locale='default', _external=true) }}" />
+      <meta name="locale-root" content="{{ h.url_for('home.index', _external=true) }}" />
 
       {% block meta_generator %}<meta name="generator" content="ckan {{ h.ckan_version() }}" />{% endblock %}
       {% block meta_viewport %}<meta name="viewport" content="width=device-width, initial-scale=1.0">{% endblock %}
@@ -90,7 +91,7 @@
   </head>
 
   {# Allows custom attributes to be added to the <body> tag #}
-  <body{% block bodytag %} data-site-root="{{ h.url_for('home.index', locale='default', qualified=true) }}" data-locale-root="{{ h.url_for('home.index', qualified=true) }}" {% endblock %}>
+  <body{% block bodytag %}{% endblock %}>
 
     {#
     The page block allows you to add content to the page. Most of the time it is

--- a/ckanext/tracking/assets/tracking.js
+++ b/ckanext/tracking/assets/tracking.js
@@ -15,11 +15,12 @@
 $(function (){
     // remove any site root from url and trim any trailing /
     var url = location.pathname;
-    url = url.substring($('body').data('locale-root'), url.length);
+
+    url = url.substring(document.head.querySelector(['meta[name=locale-root]'])?.content, url.length);
     url = url.replace(/\/*$/, '');
 
     // POST request for each visited page
-    $.ajax({url : $('body').data('site-root') + '_tracking',
+    $.ajax({url : $('meta[name=site-root]').attr('content') + '_tracking',
             type : 'POST',
             data : {url:url, type:'page'},
             timeout : 300 });
@@ -27,7 +28,7 @@ $(function (){
     // POST request when clicking links with class 'resource-url-analytics'
     $('a.resource-url-analytics').on('click', function (e){
       var url = $(e.target).closest('a').attr('href');
-      $.ajax({url : $('body').data('site-root') + '_tracking',
+      $.ajax({url : document.head.querySelector(['meta[name=site-root]'])?.content + '_tracking',
               data : {url:url, type:'resource'},
               type : 'POST',
               timeout : 30});


### PR DESCRIPTION
These attributes, just like CSRF token, are required for internal logic and it's better to keep them inside page's meta, instead of body attributes.