### PR TITLE
Make sure JS module system loads before the actual modules

### DIFF
--- a/ckan/public-midnight-blue/base/javascript/init_tooltips.js
+++ b/ckan/public-midnight-blue/base/javascript/init_tooltips.js
@@ -1,0 +1,6 @@
+// Initialize tooltips using Bootstrap
+$(function() {
+  $('[data-bs-toggle="tooltip"]').each(function (index, element) {
+    bootstrap.Tooltip.getOrCreateInstance(element)
+  })
+})

--- a/ckan/public-midnight-blue/base/javascript/main.js
+++ b/ckan/public-midnight-blue/base/javascript/main.js
@@ -101,10 +101,3 @@ $(function() {
     $("body").removeClass("filters-modal");
   });
 });
-
-// Initialize tooltips using Bootstrap
-$(function() {
-  $('[data-bs-toggle="tooltip"]').each(function (index, element) {
-    bootstrap.Tooltip.getOrCreateInstance(element)
-  })
-})

--- a/ckan/public-midnight-blue/base/javascript/webassets.yml
+++ b/ckan/public-midnight-blue/base/javascript/webassets.yml
@@ -4,25 +4,24 @@ main:
   extra:
     preload:
       - vendor/vendor
-      - vendor/bootstrap
       - vendor/htmx
   contents:
     - apply-html-class.js
-    - plugins/jquery.inherit.js
-    - plugins/jquery.proxy-all.js
-    - plugins/jquery.url-helpers.js
-    - plugins/jquery.date-helpers.js
-    - plugins/jquery.slug.js
-    - plugins/jquery.slug-preview.js
-    - plugins/jquery.form-warning.js
+    - plugins/jquery.inherit.js # used in ckan.module() method
+    - plugins/jquery.proxy-all.js # recommended way to bind this to `_on*` methods of the module
+    - plugins/jquery.url-helpers.js # used in jquery.slug and jquery.slug-preview plugins
+    - plugins/jquery.date-helpers.js # used by client.js
+    - plugins/jquery.slug.js # used by jquery.slug-preview plugin and slug-preview module
+    - plugins/jquery.slug-preview.js # used by slug-preview module
+    - plugins/jquery.form-warning.js # used by basic-form module
     - sandbox.js
     - module.js
     - pubsub.js
     - client.js
     - i18n.js
-    - notify.js
-    - toast.js
-    - confirm.js
+    - notify.js # produces UI elements
+    - toast.js # produces UI elements
+    - confirm.js # produces UI elements
     - main.js
     - htmx-ckan.js
 
@@ -32,7 +31,9 @@ ckan:
   extra:
     preload:
       - vendor/bootstrap
+      - base/main
   contents:
+    - init_tooltips.js
     - modules/select-switch.js
     - modules/slug-preview.js
     - modules/basic-form.js

--- a/ckan/public/base/javascript/apply-html-class.js
+++ b/ckan/public/base/javascript/apply-html-class.js
@@ -1,1 +1,0 @@
-document.getElementsByTagName('html')[0].className += ' js';

--- a/ckan/public/base/javascript/init_tooltips.js
+++ b/ckan/public/base/javascript/init_tooltips.js
@@ -1,0 +1,6 @@
+// Initialize tooltips using Bootstrap
+$(function() {
+  $('[data-bs-toggle="tooltip"]').each(function (index, element) {
+    bootstrap.Tooltip.getOrCreateInstance(element)
+  })
+})

--- a/ckan/public/base/javascript/main.js
+++ b/ckan/public/base/javascript/main.js
@@ -101,10 +101,3 @@ $(function() {
     $("body").removeClass("filters-modal");
   });
 });
-
-// Initialize tooltips using Bootstrap
-$(function() {
-  $('[data-bs-toggle="tooltip"]').each(function (index, element) {
-    bootstrap.Tooltip.getOrCreateInstance(element)
-  })
-})

--- a/ckan/public/base/javascript/webassets.yml
+++ b/ckan/public/base/javascript/webassets.yml
@@ -4,27 +4,25 @@ main:
   extra:
     preload:
       - vendor/vendor
-      - vendor/bootstrap
       - vendor/htmx
   contents:
-    - apply-html-class.js
-    - plugins/jquery.inherit.js
-    - plugins/jquery.proxy-all.js
-    - plugins/jquery.url-helpers.js
-    - plugins/jquery.date-helpers.js
-    - plugins/jquery.slug.js
-    - plugins/jquery.slug-preview.js
-    - plugins/jquery.masonry.js
-    - plugins/jquery.form-warning.js
-    - plugins/jquery.images-loaded.js
+    - plugins/jquery.inherit.js # used in ckan.module() method
+    - plugins/jquery.proxy-all.js # recommended way to bind this to `_on*` methods of the module
+    - plugins/jquery.url-helpers.js # used in jquery.slug and jquery.slug-preview plugins
+    - plugins/jquery.date-helpers.js # used by client.js
+    - plugins/jquery.slug.js # used by jquery.slug-preview plugin and slug-preview module
+    - plugins/jquery.slug-preview.js # used by slug-preview module
+    - plugins/jquery.form-warning.js # used by basic-form module
+    - plugins/jquery.images-loaded.js # used by media-grid module
+    - plugins/jquery.masonry.js  # used by media-grid module
     - sandbox.js
     - module.js
     - pubsub.js
     - client.js
     - i18n.js
-    - notify.js
-    - toast.js
-    - confirm.js
+    - notify.js # produces UI elements
+    - toast.js # produces UI elements
+    - confirm.js # produces UI elements
     - main.js
     - htmx-ckan.js
 
@@ -34,7 +32,9 @@ ckan:
   extra:
     preload:
       - vendor/bootstrap
+      - base/ckan
   contents:
+    - init_tooltips.js # uses bootstrap
     - modules/select-switch.js
     - modules/slug-preview.js
     - modules/basic-form.js


### PR DESCRIPTION
Webassets with all JS modules have no dependency on webassets that define the module system. It means it's possible to break JS with a heavily customized script block that affects asset order.

By providing this dependency, we can guarantee that whenever any of the JS modules loads, the module system will be there already.

Additionally, the initialization logic of Bootstrap tooltips was moved to the section that depends on Bootstrap, to avoid a similar problem.