### PR TITLE
flaky test fix: leave tables in db for other tests

### DIFF
--- a/ckan/tests/cli/test_db.py
+++ b/ckan/tests/cli/test_db.py
@@ -164,6 +164,9 @@ class TestDBCleanSearchIndex:
         # Clean database (with confirmation bypassed in test)
         result = cli.invoke(ckan, ['db', 'clean'], input='y\n')
 
+        # recreate tables for other tests
+        model.repo.init_db()
+
         # Check command executed successfully
         assert result.exit_code == 0
         assert 'Cleaning DB: SUCCESS' in result.output


### PR DESCRIPTION
Fixes occasionally failing tests in other PRs

### Proposed fixes:

recreate tables in cli db clean test so that other tests that haven't been marked with `non_clean_db` fixture can run successfully afterwards. To reproduce failure run:

```bash
pytest -vv --ckan-ini=test-core-ci.ini \
ckan/tests/cli/test_db.py::TestDBCleanSearchIndex::test_db_clean_clears_search_index \
ckan/tests/config/test_sessions.py::TestSessionTypes::test_redis_session_fixation
```

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
