### PR TITLE
[#9240] Simplify and cleanup cookiecutter generation hooks

### DIFF
--- a/changes/9296.bugfix
+++ b/changes/9296.bugfix
@@ -1,0 +1,1 @@
+Fix error when creating an extension calling cookiecutter directly. Simplify and remove dead code.

--- a/contrib/cookiecutter/ckan_extension/hooks/post_gen_project.py
+++ b/contrib/cookiecutter/ckan_extension/hooks/post_gen_project.py
@@ -1,75 +1,24 @@
 # encoding: utf-8
 
 import os
-import jinja2
-import cookiecutter.find as find
-import cookiecutter.generate as gen
-from cookiecutter.config import DEFAULT_CONFIG as config
-from cookiecutter.environment import StrictEnvironment
-from cookiecutter.exceptions import NonTemplatedInputDirException
 from ckan.common import asbool
 from ckan.cli.generate import remove_code_examples
 
 
 def recut():
     """
-    Recreate setup.py so that we can edit keywords
     Remove unnecessary code examples
     """
-    # template location
-    try:
-        # cutting cookie from directory with template
-        temp_dir = find.find_template('..')
-    except NonTemplatedInputDirException as e:
-        # template coming from Github
-        # Hooks are passed through jinja2. raw will
-        # Make sure `cookiecutter.project` isn't replaced
-        {% raw %}
-        temp_dir = os.path.join(config['cookiecutters_dir'],
-                                'cookiecutter-ckan-extension',
-                                '{{cookiecutter.project}}')
-        {% endraw %}
 
     # Location for resulting file
     destination = os.getcwd()
-    # name of template
-    setup_template = 'setup.py'
 
-    # get context
-    context = {}
-
-{% for key, value in cookiecutter.items() %}
-    context["{{key}}"] = {{ value.__repr__() | safe }}
-{% endfor %}
-
-    # Process keywords
-    keywords = context['keywords'].strip().split()
-    keywords = [keyword for keyword in keywords
-                if keyword not in ('ckan', 'CKAN', 'A', 'space',
-                                   'separated', 'list', 'of', 'keywords')]
-    keywords.insert(0, 'CKAN')
-    context['keywords'] = keywords
-
-    # Double check 'project_shortname' and 'plugin_class_name'
-    short_name = context['project'][8:].replace('-','_')
-    if context['project_shortname'] != short_name:
-        context['project_shortname'] = short_name
-
-    plugin_class_name = '{}Plugin'.format(context['project_shortname']
-                        .title().replace('_', ''))
-    if context['plugin_class_name'] != plugin_class_name:
-        context['plugin_class_name'] = plugin_class_name
-    # Recut cookie
-    env = StrictEnvironment()
-    env.loader = jinja2.FileSystemLoader(temp_dir)
-    gen.generate_file(project_dir=destination,
-                      infile=setup_template,
-                      context={'cookiecutter': context},
-                      env=env)
-    if not asbool(context['include_examples']):
-        remove_code_examples(os.path.join(destination, 'ckanext', short_name))
+    if not asbool("{{ cookiecutter.include_examples }}"):
+        remove_code_examples(
+            os.path.join(destination, "ckanext", "{{ cookiecutter.project_shortname }}")
+        )
 
 
-if __name__ == '__main__':
-    if '{{ cookiecutter._source }}' == 'local':
+if __name__ == "__main__":
+    if "{{ cookiecutter._source }}" == "local":
         recut()


### PR DESCRIPTION
Fixes #9240 

The logic in the `post_gen_project.py` hook is only executed when creating the template using the `cookiecutter` command directly, e.g.:

    cookiecutter ckan/contrib/cookiecutter/ckan_extension -o .

In this case `cookicutter._source == "local"`, as it is defined in [cookiecutter.json](https://github.com/ckan/ckan/blob/ec49c8b0bfaf242453140a6b9b05bc8cdab815a4/contrib/cookiecutter/ckan_extension/cookiecutter.json#L12). When running `ckan generate extension` all the logic is skipped because [`cookicutter._source == "cli"`](https://github.com/ckan/ckan/blob/ec49c8b0bfaf242453140a6b9b05bc8cdab815a4/ckan/cli/generate.py#L107).

Besides that, most of the code in the hook was dead anyway, either broken or non-relevant after newer refactors. The only thing that needed to be kept was the logic to remove the code examples.

