### PR TITLE
Escape entities when generating links in `link_to()` helper

### DIFF
--- a/changes/9297.bugfix
+++ b/changes/9297.bugfix
@@ -1,0 +1,3 @@
+Remove unsafe usage of unescaped HTML entities when generating links which could act as a 
+potential XSS vector. *Note*: This vulnerability was not released in a public CKAN version, it was 
+present only in the master branch. Many thanks to @Shirshaw64p for reporting it.

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -864,24 +864,40 @@ def _link_to(text: str, *args: Any, **kwargs: Any) -> Markup:
             active = ''
         return kwargs.pop('class_', '') + active or None
 
-    def _create_link_text(text: str, **kwargs: Any):
-        ''' Update link text to add a icon or span if specified in the
-        kwargs '''
-        if kwargs.pop('inner_span', None):
-            text = literal('<span>') + text + literal('</span>')
-        if icon:
-            text = literal('<i class="fa fa-%s"></i> ' % icon) + text
-        return text
-
     icon = kwargs.pop('icon', None)
+    inner_span = kwargs.pop('inner_span', None)
     cls = _link_class(kwargs)
     title = kwargs.pop('title', kwargs.pop('title_', None))
-    return link_to(
-        _create_link_text(text, **kwargs),
-        url_for(*args, **kwargs),
-        cls=cls,
-        title=title
-    )
+
+    label = text
+    if inner_span:
+        label = dom_tags.span(text)
+    elif icon:
+        label = " " + label
+
+    if icon:
+
+        icon = dom_tags.i(
+            cls=f"fa fa-{icon}"
+        )
+
+        out = dom_tags.a(
+            href=url_for(*args, **kwargs),
+            cls=cls,
+            title=title
+        )
+
+        out.add(icon, label)    # noqa
+
+    else:
+        out = dom_tags.a(
+            label,
+            href=url_for(*args, **kwargs),
+            cls=cls,
+            title=title
+        )
+
+    return literal(str(out))
 
 
 def _preprocess_dom_attrs(attrs: dict[str, Any]) -> dict[str, Any]:
@@ -904,7 +920,7 @@ def link_to(label: Optional[str], url: str, **attrs: Any) -> Markup:
     attrs['href'] = url
     if label == '' or label is None:
         label = url
-    return literal(str(dom_tags.a(raw_dom_tags(label), **attrs)))
+    return literal(str(dom_tags.a(label, **attrs)))
 
 
 @core_helper

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -28,7 +28,6 @@ from typing import (
 
 
 import dominate.tags as dom_tags
-from dominate.util import raw as raw_dom_tags
 from markdown import markdown
 from bleach import clean as bleach_clean, ALLOWED_TAGS, ALLOWED_ATTRIBUTES
 from ckan.common import asbool, config, current_user
@@ -887,7 +886,7 @@ def _link_to(text: str, *args: Any, **kwargs: Any) -> Markup:
             title=title
         )
 
-        out.add(icon, label)    # noqa
+        out.add(icon, label)  # type: ignore
 
     else:
         out = dom_tags.a(

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -871,9 +871,10 @@ def _link_to(text: str, *args: Any, **kwargs: Any) -> Markup:
     link = dom_tags.a(href=url_for(*args, **kwargs), cls=cls, title=title)
 
     if icon:
-        link.add(dom_tags.i(cls=f"fa fa-{icon}"))
+        link.add(dom_tags.i(cls=f"fa fa-{icon}"))   # type: ignore
 
-    link.add(dom_tags.span(text) if inner_span else f"{text}")
+    link.add(dom_tags.span(text) if inner_span else f"{text}")  # type: ignore
+
     return literal(link)
 
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -868,35 +868,13 @@ def _link_to(text: str, *args: Any, **kwargs: Any) -> Markup:
     cls = _link_class(kwargs)
     title = kwargs.pop('title', kwargs.pop('title_', None))
 
-    label = text
-    if inner_span:
-        label = dom_tags.span(text)
-    elif icon:
-        label = " " + label
+    link = dom_tags.a(href=url_for(*args, **kwargs), cls=cls, title=title)
 
     if icon:
+        link.add(dom_tags.i(cls=f"fa fa-{icon}"))
 
-        icon = dom_tags.i(
-            cls=f"fa fa-{icon}"
-        )
-
-        out = dom_tags.a(
-            href=url_for(*args, **kwargs),
-            cls=cls,
-            title=title
-        )
-
-        out.add(icon, label)  # type: ignore
-
-    else:
-        out = dom_tags.a(
-            label,
-            href=url_for(*args, **kwargs),
-            cls=cls,
-            title=title
-        )
-
-    return literal(str(out))
+    link.add(dom_tags.span(text) if inner_span else f"{text}")
+    return literal(link)
 
 
 def _preprocess_dom_attrs(attrs: dict[str, Any]) -> dict[str, Any]:

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -3,6 +3,7 @@
 import datetime
 import hashlib
 import os
+import re
 import sys
 from typing import Any
 
@@ -19,6 +20,24 @@ import ckan.exceptions
 from ckan.tests import helpers, factories
 
 CkanUrlException = ckan.exceptions.CkanUrlException
+
+
+def _remove_whitespace(text):
+    """
+    Remove new lines and indentation to make it easier to match markup
+    e.g.
+
+    <ul>
+        <li>
+            <span>Test</span>
+        </li>
+    </ul>
+
+    becomes
+
+    <ul><li><span>Test</span></li></ul>
+    """
+    return re.sub(r'\n\s+', '', text)
 
 
 class BaseUrlFor(object):
@@ -653,11 +672,11 @@ class TestBuildNavMain(object):
         assert link == '<a class="css-class" href="https://www.example.com" target="_blank">Example Link</a>'
 
         link2 = h.link_to('display_name', h.url_for('dataset.search', tags='name'), class_='tag')
-        link2 == '<a class="tag" href="/dataset/?tags=name">display_name</a>'
+        assert link2 == '<a class="tag" href="/dataset/?tags=name">display_name</a>'
 
     def test_build_nav_icon(self):
         link = h.build_nav_icon('organization.edit', 'Edit', id='org-id', icon='pencil')
-        assert link == '<li><a href="/organization/edit/org-id"><i class="fa fa-pencil"></i> Edit</a></li>'
+        assert _remove_whitespace(link) == '<li><a href="/organization/edit/org-id"><i class="fa fa-pencil"></i> Edit</a></li>'
 
 
 class TestRemoveUrlParam:

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -345,12 +345,12 @@ class TestHelpersRenderMarkdown(object):
             ),
             (
                 'tag:"test-tag" foobar',
-                '<p><a href="/dataset/?tags=test-tag">tag:"test-tag"</a> foobar</p>',
+                '<p><a href="/dataset/?tags=test-tag">tag:&quot;test-tag&quot;</a> foobar</p>',
                 False,
             ),
             (
                 'tag:"test tag" foobar',
-                '<p><a href="/dataset/?tags=test+tag">tag:"test tag"</a> foobar</p>',
+                '<p><a href="/dataset/?tags=test+tag">tag:&quot;test tag&quot;</a> foobar</p>',
                 False,
             ),
             (
@@ -367,7 +367,7 @@ class TestHelpersRenderMarkdown(object):
             ),
             (
                 'tag:"Test- _." foobar',
-                '<p><a href="/dataset/?tags=Test-+_.">tag:"Test- _."</a> foobar</p>',
+                '<p><a href="/dataset/?tags=Test-+_.">tag:&quot;Test- _.&quot;</a> foobar</p>',
                 False,
             ),
             (
@@ -377,7 +377,7 @@ class TestHelpersRenderMarkdown(object):
             ),
             (
                 u'tag:"Japanese katakana \u30a1" blah',
-                u'<p><a href="/dataset/?tags=Japanese+katakana+%E3%82%A1">tag:"Japanese katakana \u30a1"</a> blah</p>',
+                u'<p><a href="/dataset/?tags=Japanese+katakana+%E3%82%A1">tag:&quot;Japanese katakana \u30a1&quot;</a> blah</p>',
                 False,
             ),
             (
@@ -419,7 +419,7 @@ class TestHelpersRenderMarkdown(object):
     def test_tag_names_match_simple_punctuation(self):
         """Asserts punctuation and capital letters are matched in the tag name"""
         data = 'tag:"Test- _." foobar'
-        output = '<p><a href="/dataset/?tags=Test-+_.">tag:"Test- _."</a> foobar</p>'
+        output = '<p><a href="/dataset/?tags=Test-+_.">tag:&quot;Test- _.&quot;</a> foobar</p>'
         assert h.render_markdown(data) == output
 
     def test_tag_names_do_not_match_commas(self):

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -3,7 +3,6 @@
 import datetime
 import hashlib
 import os
-import re
 import sys
 from typing import Any
 
@@ -20,24 +19,6 @@ import ckan.exceptions
 from ckan.tests import helpers, factories
 
 CkanUrlException = ckan.exceptions.CkanUrlException
-
-
-def _remove_whitespace(text):
-    """
-    Remove new lines and indentation to make it easier to match markup
-    e.g.
-
-    <ul>
-        <li>
-            <span>Test</span>
-        </li>
-    </ul>
-
-    becomes
-
-    <ul><li><span>Test</span></li></ul>
-    """
-    return re.sub(r'\n\s+', '', text)
 
 
 class BaseUrlFor(object):
@@ -676,7 +657,7 @@ class TestBuildNavMain(object):
 
     def test_build_nav_icon(self):
         link = h.build_nav_icon('organization.edit', 'Edit', id='org-id', icon='pencil')
-        assert _remove_whitespace(link) == '<li><a href="/organization/edit/org-id"><i class="fa fa-pencil"></i> Edit</a></li>'
+        assert link == '<li><a href="/organization/edit/org-id"><i class="fa fa-pencil"></i>Edit</a></li>'
 
 
 class TestRemoveUrlParam:


### PR DESCRIPTION
Remove `raw_dom_tags()` usage from the `link_to()` helper, which could led to potential XSS attacks.

> [!NOTE] 
> This vulnerability was not released in a public CKAN version, it was present only in the master branch


This involved two changes to keep previous behaviour:

* Refactor `_link_to` passed markup to be used as the body of the <a> tags generated by `link_to`. This was a problem
because the markup got (correctly) escaped and didn't render properly. Now the markup is generated using dominate tags in _link_to directly.
* Update `render_markdown()` tests to reflect that quotes are outputted as html entities now

Many thanks to @Shirshaw64p for responsively reporting the original vulnerability in the master branch.

To report security related issues please use security@ckan.org