### PR TITLE
Make DataStore Search Allow List Configurable

### DIFF
--- a/changes/9298.feature
+++ b/changes/9298.feature
@@ -1,1 +1,1 @@
-DataStore's `WHITELISTED_RESOURCES` is now configurable under `ckan.datastore.allow_table_search`
+DataStore's `WHITELISTED_RESOURCES` is now configurable under `ckan.datastore.public_table_search`

--- a/ckanext/datastore/config_declaration.yaml
+++ b/ckanext/datastore/config_declaration.yaml
@@ -118,13 +118,10 @@ groups:
       Indexes increase the time and disk space required to load data
       into the DataStore.
 
-  - key: ckan.datastore.allow_table_search
+  - key: ckan.datastore.public_table_search
     type: list
-    default: []
+    default: ["_table_metadata"]
     description: |
       Set a list of valid table names for users to query. Allows
       for additional custom tables to be queried without the need
       for an actual Resource object.
-
-      _table_metadata will always be allowed, as it is required for
-      other features to work correctly.

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -24,8 +24,6 @@ log = logging.getLogger(__name__)
 _get_or_bust = logic.get_or_bust
 _validate = ckan.lib.navl.dictization_functions.validate
 
-REQUIRED_ALLOW_RESOURCES = ['_table_metadata']
-
 RESOURCE_LAST_MODIFIED_SETTLE_TIME = timedelta(seconds=15)
 
 
@@ -701,7 +699,7 @@ def datastore_search(context: Context, data_dict: dict[str, Any]):
     res_id = data_dict['resource_id']
 
     if data_dict['resource_id'] not in p.toolkit.config.get(
-            'ckan.datastore.allow_table_search') + REQUIRED_ALLOW_RESOURCES:
+            'ckan.datastore.public_table_search'):
         res_exists, real_id = backend.resource_id_from_alias(res_id)
         # Resource only has to exist in the datastore (because it could be an
         # alias)


### PR DESCRIPTION
feat(dev): ds table search;

- `ckan.datastore.allow_table_search` config to allow for custom table searches.

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
