### PR TITLE
Fix featured_orgs not hideable when config is empty

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2579,7 +2579,10 @@ def featured_group_org(items: list[str], get_action: str, list_action: str,
 
     groups_data = []
 
-    extras = logic.get_action(list_action)({}, {})
+    # When items is explicitly configured as empty, return no results.
+    # This allows hiding featured orgs/groups by setting the config
+    # value to an empty string.
+    extras = logic.get_action(list_action)({}, {}) if items else []
 
     # list of found ids to prevent duplicates
     found = []


### PR DESCRIPTION
Fixes #9290

## Summary

When `ckan.featured_orgs` is set to an empty value, the homepage still shows the first organization. The `featured_group_org()` function always fetches the full org list as extras and iterates through it, so even with an empty config, the first org from the database gets displayed.

## Fix

Skip fetching the full organization/group list when the configured items list is empty. This makes an empty `ckan.featured_orgs` config actually hide featured organizations from the homepage. Same logic applies to `ckan.featured_groups`.

## Changes

One line change in `ckan/lib/helpers.py`:

```python
# Before: always fetch extras regardless of items
extras = logic.get_action(list_action)({}, {})

# After: only fetch extras when items are configured
extras = logic.get_action(list_action)({}, {}) if items else []
```

## Test plan

- [ ] Set `ckan.featured_orgs=` (empty) and verify homepage shows no featured organizations
- [ ] Set `ckan.featured_orgs=org_one` and verify it still works as before
- [ ] Verify `ckan.featured_groups` behaves the same way