### PR TITLE
Fix flaky test and remove SolrSettings

### DIFF
--- a/ckan/config/environment.py
+++ b/ckan/config/environment.py
@@ -168,13 +168,6 @@ def update_config() -> None:
             "ckan.display_timezone is not 'server' or a valid timezone"
         )
 
-    # Init SOLR settings and check if the schema is compatible
-    # from ckan.lib.search import SolrSettings, check_solr_schema_version
-
-    # lib.search is imported here as we need the config enabled and parsed
-    search.SolrSettings.init(config.get('solr_url'),
-                             config.get('solr_user'),
-                             config.get('solr_password'))
     search.check_solr_schema_version()
 
     lib_plugins.reset_package_plugins()

--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -16,11 +16,12 @@ import ckan.model as model
 import ckan.model.domain_object as domain_object
 import ckan.logic as logic
 from ckan.types import Context
+from ckan.common import config
 
 from ckan.lib.search.common import (
     make_connection, SearchIndexError, SearchQueryError,  # type: ignore
     SolrConnectionError, # type: ignore
-    SearchError, is_available, SolrSettings, config
+    SearchError, is_available
 )
 from ckan.lib.search.index import (
     SearchIndex, PackageSearchIndex, NoopSearchIndex
@@ -30,7 +31,6 @@ from ckan.lib.search.query import (
     TagSearchQuery, ResourceSearchQuery, PackageSearchQuery,
     QueryOptions, convert_legacy_parameters_to_solr  # type: ignore
 )
-from ckan.lib.search.index import SearchIndex
 
 
 log = logging.getLogger(__name__)
@@ -239,7 +239,9 @@ def _get_schema_from_solr(file_offset: str):
 
     timeout = config.get('ckan.requests.timeout')
 
-    solr_url, solr_user, solr_password = SolrSettings.get()
+    solr_url: str = config["solr_url"]
+    solr_user: str | None = config["solr_user"]
+    solr_password: str | None = config["solr_password"]
 
     url = solr_url.strip('/') + file_offset
 

--- a/ckan/lib/search/common.py
+++ b/ckan/lib/search/common.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import datetime
 import logging
 import re
-from typing import Any, Optional
+from typing import Any
 
 import pysolr
 import simplejson
@@ -33,37 +33,6 @@ class SolrConnectionError(Exception):
     pass
 
 
-DEFAULT_SOLR_URL = 'http://127.0.0.1:8983/solr/ckan'
-
-
-class SolrSettings(object):
-    _is_initialised: bool = False
-    _url: Optional[str] = None
-    _user: Optional[str] = None
-    _password: Optional[str] = None
-
-    @classmethod
-    def init(cls,
-             url: Optional[str],
-             user: Optional[str] = None,
-             password: Optional[str] = None) -> None:
-        if url is not None:
-            cls._url = url
-            cls._user = user
-            cls._password = password
-        else:
-            cls._url = DEFAULT_SOLR_URL
-        cls._is_initialised = True
-
-    @classmethod
-    def get(cls) -> tuple[str, Optional[str], Optional[str]]:
-        if not cls._is_initialised:
-            raise SearchIndexError('SOLR URL not initialised')
-        if not cls._url:
-            raise SearchIndexError('SOLR URL is blank')
-        return (cls._url, cls._user, cls._password)
-
-
 def is_available() -> bool:
     """
     Return true if we can successfully connect to Solr.
@@ -78,7 +47,9 @@ def is_available() -> bool:
 
 
 def make_connection(decode_dates: bool = True) -> Solr:
-    solr_url, solr_user, solr_password = SolrSettings.get()
+    solr_url: str = config["solr_url"]
+    solr_user: str | None = config["solr_user"]
+    solr_password: str | None = config["solr_password"]
 
     if solr_url and solr_user and solr_password:
         # Rebuild the URL with the username/password

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -68,24 +68,18 @@ class TestPackageNew(object):
 
         assert plugin.id_in_dict
 
+    @pytest.mark.ckan_config("solr_url", "http://example.com/badsolrurl")
     @pytest.mark.usefixtures("clean_index")
     def test_new_indexerror(self, app, user):
-        from ckan.lib.search.common import SolrSettings
-        bad_solr_url = "http://example.com/badsolrurl"
-        solr_url = SolrSettings.get()[0]
-        try:
-            SolrSettings.init(bad_solr_url)
-            new_package_name = u"new-package-missing-solr"
-            offset = url_for("dataset.new")
-            headers = {"Authorization": user["token"]}
-            res = app.post(
-                offset,
-                headers=headers,
-                data={"save": "", "name": new_package_name},
-            )
-            assert "Unable to add package to search index" in res, res
-        finally:
-            SolrSettings.init(solr_url)
+        new_package_name = u"new-package-missing-solr"
+        offset = url_for("dataset.new")
+        headers = {"Authorization": user["token"]}
+        res = app.post(
+            offset,
+            headers=headers,
+            data={"save": "", "name": new_package_name},
+        )
+        assert "Unable to add package to search index" in res, res
 
     def test_change_locale(self, app, user):
         url = url_for("dataset.new")


### PR DESCRIPTION
There is a test from GroupController that is randomly fails in the pipeline. You can reproduce the problem on master with 

```sh
pytest --ckan-ini test-core.ini \
     ckan/tests/controllers/test_api.py ckan/tests/controllers/test_group.py \
     -k 'errors or test_group_search_results'
```

It fails because solr connection is created using cached parameters instead of the values from the config. This code was written ~14 years ago and now we can rely on stable config dictionary without using additional classes.

I removed extra code, no new features added.