### PR TITLE
chore: Do not use six

### DIFF
--- a/ckan/lib/search/common.py
+++ b/ckan/lib/search/common.py
@@ -9,7 +9,7 @@ from typing import Any, Optional
 import pysolr
 import simplejson
 
-from six.moves.urllib.parse import quote_plus  # type: ignore
+from urllib.parse import quote_plus
 from pysolr import Solr
 
 from ckan.common import config

--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -10,7 +10,6 @@ import re
 from dateutil.parser import parse, ParserError as DateParserError
 from typing import Any, NoReturn, Optional
 
-import six
 import pysolr
 from ckan.common import config
 
@@ -220,7 +219,6 @@ class PackageSearchIndex(SearchIndex):
         # clean the dict fixing keys and dates
         new_dict = {}
         for key, value in pkg_dict.items():
-            key = six.ensure_str(key)
             if key.endswith('_date'):
                 if not value:
                     continue
@@ -262,7 +260,9 @@ class PackageSearchIndex(SearchIndex):
 
         # add a unique index_id to avoid conflicts
         import hashlib
-        pkg_dict['index_id'] = hashlib.md5(six.b('%s%s' % (pkg_dict['id'],config.get('ckan.site_id')))).hexdigest()
+        pkg_dict['index_id'] = hashlib.md5(
+            "{}{}".format(pkg_dict["id"], config["ckan.site_id"]).encode()
+        ).hexdigest()
 
         for item in PluginImplementations(IPackageController):
             pkg_dict = item.before_dataset_index(pkg_dict)

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -11,8 +11,6 @@ import datetime
 from socket import error as socket_error
 from typing import Any, Union, cast
 
-import six
-
 import ckan.lib.plugins as lib_plugins
 import ckan.logic as logic
 import ckan.plugins as plugins
@@ -182,11 +180,9 @@ def package_create(
 
     plugin_data = data.get('plugin_data', False)
     include_plugin_data = False
-    if user:
-        user_obj = model.User.by_name(six.ensure_text(user))
-        if user_obj:
-            data['creator_user_id'] = user_obj.id
-            include_plugin_data = user_obj.sysadmin and plugin_data
+    if user_obj := model.User.by_name(user):
+        data['creator_user_id'] = user_obj.id
+        include_plugin_data = user_obj.sysadmin and plugin_data
 
     pkg, _change = model_save.package_dict_save(
         data, context, include_plugin_data)
@@ -722,7 +718,7 @@ def _group_or_org_create(context: Context,
     for item in plugins.PluginImplementations(plugin_type):
         item.create(group)
 
-    user_obj = model.User.by_name(six.ensure_text(user))
+    user_obj = model.User.by_name(user)
     assert user_obj
 
     upload.upload(uploader.get_max_image_size())

--- a/ckan/tests/lib/search/test_index.py
+++ b/ckan/tests/lib/search/test_index.py
@@ -5,7 +5,6 @@ import hashlib
 import json
 from unittest import mock
 import pytest
-import six
 from ckan.common import config
 import ckan.lib.search as search
 from ckan.tests import factories, helpers
@@ -57,9 +56,9 @@ class TestSearchIndex(object):
         assert response.docs[0]["title"] == "Monkey"
 
         index_id = hashlib.md5(
-            six.b("{0}{1}".format(
+            "{0}{1}".format(
                 self.base_package_dict["id"], config["ckan.site_id"]
-            ))
+            ).encode()
         ).hexdigest()
 
         assert response.docs[0]["index_id"] == index_id


### PR DESCRIPTION
`six` library is intended for py 2to3 migration. We don't need to use it anymore.

Note, it's still added to dependencies, because feedgen and rq depend on it. But CKAN core is not calling its functions anymore,