### PR TITLE
Allow deleting empty organizations when create_unowned_dataset is false

### DIFF
--- a/changes/9311.bugfix
+++ b/changes/9311.bugfix
@@ -1,0 +1,2 @@
+Fix `organization_delete` incorrectly failing for organizations with no datasets
+when `ckan.auth.create_unowned_dataset` is disabled.

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -396,7 +396,7 @@ def _group_or_org_delete(
         dataset_ids = model.Session.query(model.Package.id) \
                         .filter_by(owner_org=group.id) \
                         .filter(model.Package.state != 'deleted')
-        if dataset_ids:
+        if dataset_ids.count():
             if not authz.check_config_permission(
                     'ckan.auth.create_unowned_dataset'):
                 raise ValidationError({

--- a/ckan/tests/logic/action/test_delete.py
+++ b/ckan/tests/logic/action/test_delete.py
@@ -316,6 +316,22 @@ class TestGroupPurge(object):
 
 
 @pytest.mark.usefixtures("non_clean_db")
+class TestOrganizationDelete(object):
+    @pytest.mark.ckan_config("ckan.auth.create_unowned_dataset", False)
+    def test_delete_org_without_datasets(self):
+        user = factories.User()
+        org = factories.Organization(user=user)
+
+        helpers.call_action(
+            "organization_delete",
+            context={"user": user["name"]},
+            id=org["name"],
+        )
+
+        assert model.Group.get(org["id"]).state == "deleted"
+
+
+@pytest.mark.usefixtures("non_clean_db")
 class TestOrganizationPurge(object):
     def test_a_non_sysadmin_cant_purge_org(self):
         user = factories.User()


### PR DESCRIPTION
### Proposed fixes:

- Fix `organization_delete()` for empty organizations when `ckan.auth.create_unowned_dataset = False`.
- Replace the query truthiness check with a real dataset count check.
- Add a regression test for deleting an organization with no datasets.


### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
