### PR TITLE
Support keep_email in user_list_dictize

### DIFF
--- a/changes/9317.bugfix
+++ b/changes/9317.bugfix
@@ -1,0 +1,1 @@
+Add `keep_email` support to `user_list_dictize`

--- a/ckan/lib/dictization/model_dictize.py
+++ b/ckan/lib/dictization/model_dictize.py
@@ -565,7 +565,8 @@ def user_list_dictize(
         user_dict = user_dictize(obj, context)
         user_dict.pop('reset_key', None)
         user_dict.pop('apikey', None)
-        user_dict.pop('email', None)
+        if not context.get('keep_email', False):
+            user_dict.pop('email', None)
         result_list.append(user_dict)
     return sorted(result_list, key=sort_key, reverse=reverse)
 


### PR DESCRIPTION
Fixes #9317

### Proposed fixes:
- Add support for `keep_email` context value in `user_list_dictize`


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
