### PR TITLE
Idea: refine blocks inside base.html

### DIFF
--- a/changes/9327.misc
+++ b/changes/9327.misc
@@ -1,0 +1,5 @@
+Midnight blue theme use different blocks in `base.html`:
+
+* block `htmltag` that wraps whole `<html>` tag is replaced with `html_attrs` block that wraps only attributes of the tag
+* block `headtag` is removed.
+* block `bodytag` renamed to `body_attrs`

--- a/changes/9327.misc
+++ b/changes/9327.misc
@@ -1,5 +1,5 @@
-Midnight blue theme use different blocks in `base.html`:
+Following blocks  in `base.html` were updated:
 
 * block `htmltag` that wraps whole `<html>` tag is replaced with `html_attrs` block that wraps only attributes of the tag
-* block `headtag` is removed.
+* block `headtag` is removed
 * block `bodytag` renamed to `body_attrs`

--- a/ckan/templates-midnight-blue/base.html
+++ b/ckan/templates-midnight-blue/base.html
@@ -1,126 +1,140 @@
-{# Allows the DOCTYPE to be set on a page by page basis #}
-{%- block doctype %}<!DOCTYPE html>{% endblock -%}
+{#
+  Base template for the CKAN frontend.
+  This template defines the overall structure of the HTML document,
+  including blocks for the head, body, styles, and scripts. -#}
+{%- block document -%}
+  {# Allows the DOCTYPE to be set on a page by page basis #}
+  {%- block doctype %}<!DOCTYPE html>{% endblock -%}
 
-{# Allows custom attributes to be added to the <html> tag #}
-{%- block htmltag -%}
-{% set lang = h.lang() %}
-  <html lang="{{ lang }}" {% if h.is_rtl_language()  %} dir="rtl" {% endif %} class="js">
-{%- endblock -%}
+  {# Customize attributes of HTML tag such as lang and dir using `html_attrs` block #}
+  <html{% block html_attrs %} lang="{{ h.lang() }}"{% if h.is_rtl_language()  %} dir="rtl" {% endif %} class="js"{% endblock %}>
+    <head>
+      {#- This bblock contains meta tags, title, links to stylesheets, etc. -#}
+      {%- block document_head -%}
+        {#
+          Add custom meta tags to the page. Call super() to get the default tags
+          such as charset, viewport and generator:
 
-  {# Allows custom attributes to be added to the <head> tag #}
-  <head{% block headtag %}{% endblock %}>
-    {#
-    Add custom meta tags to the page. Call super() to get the default tags
-    such as charset, viewport and generator.
+          {% block meta %}
+          {{ super() }}
+          <meta name="description" value="My website description" />
+          {% endblock %}
 
-    Example:
+          #}
+        {%- block meta -%}
+          <meta charset="utf-8" />
+          <meta name="site-root" content="{{ h.url_for('home.index', locale='default', _external=true) }}" />
+          <meta name="locale-root" content="{{ h.url_for('home.index', _external=true) }}" />
+          {%- block meta_csrf -%}
+            <meta name="csrf_field_name" content="{{ g.csrf_field_name }}" />
+            <meta name="{{ g.csrf_field_name }}" content="{{ csrf_token() }}" />
+          {%- endblock %}
+          {%- block meta_generator %}<meta name="generator" content="ckan {{ h.ckan_version() }}" />{% endblock %}
+          {%- block meta_viewport %}<meta name="viewport" content="width=device-width, initial-scale=1.0">{% endblock %}
+        {%- endblock -%}
 
-    {% block meta %}
-      {{ super() }}
-      <meta name="description" value="My website description" />
-    {% endblock %}
+        {#
+          Add a custom title to the page by extending the title block. Call super()
+          to get the default page title.
 
-    #}
-    {%- block meta -%}
-      <meta charset="utf-8" />
-      <meta name="csrf_field_name" content="{{ g.csrf_field_name }}" />
-      <meta name="{{ g.csrf_field_name }}" content="{{ csrf_token() }}" />
-      <meta name="site-root" content="{{ h.url_for('home.index', locale='default', _external=true) }}" />
-      <meta name="locale-root" content="{{ h.url_for('home.index', _external=true) }}" />
+          Example:
 
-      {% block meta_generator %}<meta name="generator" content="ckan {{ h.ckan_version() }}" />{% endblock %}
-      {% block meta_viewport %}<meta name="viewport" content="width=device-width, initial-scale=1.0">{% endblock %}
-    {%- endblock -%}
+          {% block title %}My Subtitle {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
-    {#
-    Add a custom title to the page by extending the title block. Call super()
-    to get the default page title.
+          #}
+        <title>
+          {%- block title -%}
+            {%- set subtitle | trim -%}
+            {%- block subtitle %}{% endblock -%}
+            {%- endset -%}
+            {%- if subtitle %}{{ subtitle }} {{ g.template_title_delimiter }} {% endif -%}
+            {{ g.site_title }}
+          {%- endblock -%}
+        </title>
 
-    Example:
+        {#-
+          The links block allows you to add additional content before the stylesheets
+          such as rss feeds and favicons in the same way as the meta block.
+          #}
+        {%- block links -%}
+          <link rel="shortcut icon" href="{{ g.favicon }}" />
+        {%- endblock %}
 
-      {% block title %}My Subtitle - {{ super() }}{% endblock %}
+        {#-
+          The styles block allows you to add additional stylesheets to the page in
+          the same way as the meta block. Use super() to include the default
+          stylesheets before or after your own.
 
-    #}
-    <title>
-      {%- block title -%}
-        {%- block subtitle %}{% endblock -%}
-        {%- if self.subtitle()|trim %} {{ g.template_title_delimiter }} {% endif -%}
-        {{ g.site_title }}
-      {%- endblock -%}
-    </title>
+          Example:
 
-    {#
-    The links block allows you to add additional content before the stylesheets
-    such as rss feeds and favicons in the same way as the meta block.
-    #}
-    {% block links -%}
-      <link rel="shortcut icon" href="{{ g.favicon }}" />
-    {% endblock -%}
+          {% block styles %}
+          {{ super() }}
+          <link rel="stylesheet" href="/base/css/custom.css" />
+          {% endblock %}
+          #}
+        {%- block styles -%}
+          {%- set theme = h.get_rtl_theme() if h.is_rtl_language() else g.theme -%}
+          {% asset theme %}
+        {%- endblock %}
 
-    {#
-    The styles block allows you to add additional stylesheets to the page in
-    the same way as the meta block. Use super() to include the default
-    stylesheets before or after your own.
+        {#- Render all assets included in styles block till that moment. Any asset
+          included after this line must be included into footer via additional
+          call to `render_assets` #}
+        {{- h.render_assets('style') }}
 
-    Example:
+        {#- Custom styles block contains any additional CSS defined in site configuration.
+          Avoid using it to include styles from extension, always prefer using `asset` tag. #}
+        {%- block custom_styles %}
+          {%- if g.site_custom_css -%}
+            <style>
+              {{ g.site_custom_css | safe }}
+            </style>
+          {%- endif %}
+        {%- endblock %}
 
-      {% block styles %}
-        {{ super() }}
-        <link rel="stylesheet" href="/base/css/custom.css" />
-      {% endblock %}
-    #}
-    {%- block styles %}
-      {# TODO: store just name of asset instead of path to it. #}
-      {% set theme = h.get_rtl_theme() if h.is_rtl_language() else g.theme %}
-      {% asset theme %}
-    {% endblock %}
+        {#- Additional block for any extra head content. #}
+        {%- block head_extras %}{% endblock %}
+      {%- endblock document_head %}
+    </head>
 
-    {# render all assets included in styles block #}
-    {{ h.render_assets('style') }}
-    {%- block custom_styles %}
-      {%- if g.site_custom_css -%}
-      <style>
-        {{ g.site_custom_css | safe }}
-      </style>
-      {%- endif %}
-    {% endblock %}
+    {# Allows custom attributes to be added to the <body> tag #}
+    <body{% block body_attrs %}{% endblock %}>
+      {#- Document body contains the main content of the page -#}
+      {%- block document_body -%}
+        {#-
+          The page block allows you to add content to the page. Most of the time it is
+          recommended that you extend one of the page.html templates in order to get
+          the site header and footer. If you need a clean page then this is the
+          block to use.
 
-    {%- block head_extras %}
-    {% endblock %}
+          Example:
 
-  </head>
+          {% block page %}
+          <div>Some other page content</div>
+          {% endblock %}
+          #}
+        {%- block page %}{% endblock -%}
 
-  {# Allows custom attributes to be added to the <body> tag #}
-  <body{% block bodytag %}{% endblock %}>
+        {#
+          DO NOT USE THIS BLOCK FOR ADDING INLINE SCRIPTS.
+          Scripts should be loaded by the {% assets %} tag except in very special
+          circumstances. I.e, instead of this:
 
-    {#
-    The page block allows you to add content to the page. Most of the time it is
-    recommended that you extend one of the page.html templates in order to get
-    the site header and footer. If you need a clean page then this is the
-    block to use.
+          {%- block scripts -%}{{ super() }}<script>...</script>{%- endblock %}
 
-    Example:
+          do this:
+          {%- block scripts -%}{{ super() }}{%- asset "my-extension/my-asset" -%}{%- endblock %}
+          #}
+        {%- block scripts %}{% endblock -%}
 
-      {% block page %}
-        <div>Some other page content</div>
-      {% endblock %}
-    #}
-    {%- block page %}{% endblock -%}
+        {# render all assets included in scripts block and everywhere else #}
+        {# make sure there are no calls to `asset` tag after this point #}
+        {{ h.render_assets('style') }}
+        {{ h.render_assets('script') }}
 
-    {#
-    DO NOT USE THIS BLOCK FOR ADDING SCRIPTS
-    Scripts should be loaded by the {% assets %} tag except in very special
-    circumstances
-    #}
-    {%- block scripts %}
-    {% endblock -%}
-
-    {% block body_extras -%}
-    {%- endblock %}
-
-    {# render all assets included in scripts block and everywhere else #}
-    {# make sure there are no calls to `asset` tag after this point #}
-    {{ h.render_assets('style') }}
-    {{ h.render_assets('script') }}
-  </body>
-</html>
+        {#- Additional block for any extra body content -#}
+        {%- block body_extras -%}{%- endblock %}
+      {%- endblock document_body %}
+    </body>
+  </html>
+{%- endblock document %}

--- a/ckan/templates/base.html
+++ b/ckan/templates/base.html
@@ -1,126 +1,130 @@
-{# Allows the DOCTYPE to be set on a page by page basis #}
-{%- block doctype %}<!DOCTYPE html>{% endblock -%}
+{%- block document -%}
+  {# Allows the DOCTYPE to be set on a page by page basis #}
+  {%- block doctype %}<!DOCTYPE html>{% endblock -%}
 
-{# Allows custom attributes to be added to the <html> tag #}
-{%- block htmltag -%}
-{% set lang = h.lang() %}
-  <html lang="{{ lang }}" {% if h.is_rtl_language()  %} dir="rtl" {% endif %} class="js">
-{%- endblock -%}
+  {# Customize attributes of HTML tag such as lang and dir using `html_attrs` block #}
+  <html{% block html_attrs %} lang="{{ h.lang() }}"{% if h.is_rtl_language()  %} dir="rtl" {% endif %} class="js"{% endblock %}>
 
-  {# Allows custom attributes to be added to the <head> tag #}
-  <head{% block headtag %}{% endblock %}>
-    {#
-    Add custom meta tags to the page. Call super() to get the default tags
-    such as charset, viewport and generator.
+    {# Allows custom attributes to be added to the <head> tag #}
+    <head>
+      {%- block document_head -%}
+        {#
+          Add custom meta tags to the page. Call super() to get the default tags
+          such as charset, viewport and generator.
 
-    Example:
+          Example:
 
-    {% block meta %}
-      {{ super() }}
-      <meta name="description" value="My website description" />
-    {% endblock %}
+          {% block meta %}
+          {{ super() }}
+          <meta name="description" value="My website description" />
+          {% endblock %}
 
-    #}
-    {%- block meta -%}
-      <meta charset="utf-8" />
-      <meta name="csrf_field_name" content="{{ g.csrf_field_name }}" />
-      <meta name="{{ g.csrf_field_name }}" content="{{ csrf_token() }}" />
-      <meta name="site-root" content="{{ h.url_for('home.index', locale='default', _external=true) }}" />
-      <meta name="locale-root" content="{{ h.url_for('home.index', _external=true) }}" />
+          #}
+        {%- block meta -%}
+          <meta charset="utf-8" />
+          <meta name="site-root" content="{{ h.url_for('home.index', locale='default', _external=true) }}" />
+          <meta name="locale-root" content="{{ h.url_for('home.index', _external=true) }}" />
+          {%- block meta_csrf -%}
+            <meta name="csrf_field_name" content="{{ g.csrf_field_name }}" />
+            <meta name="{{ g.csrf_field_name }}" content="{{ csrf_token() }}" />
+          {%- endblock %}
+          {% block meta_generator %}<meta name="generator" content="ckan {{ h.ckan_version() }}" />{% endblock %}
+          {% block meta_viewport %}<meta name="viewport" content="width=device-width, initial-scale=1.0">{% endblock %}
+        {%- endblock -%}
 
-      {% block meta_generator %}<meta name="generator" content="ckan {{ h.ckan_version() }}" />{% endblock %}
-      {% block meta_viewport %}<meta name="viewport" content="width=device-width, initial-scale=1.0">{% endblock %}
-    {%- endblock -%}
+        {#
+          Add a custom title to the page by extending the title block. Call super()
+          to get the default page title.
 
-    {#
-    Add a custom title to the page by extending the title block. Call super()
-    to get the default page title.
+          Example:
 
-    Example:
+          {% block title %}My Subtitle - {{ super() }}{% endblock %}
 
-      {% block title %}My Subtitle - {{ super() }}{% endblock %}
+          #}
+        <title>
+          {%- block title -%}
+            {%- set subtitle | trim -%}
+            {%- block subtitle %}{% endblock -%}
+            {%- endset -%}
+            {%- if subtitle %}{{ subtitle }} {{ g.template_title_delimiter }} {% endif -%}
+            {{ g.site_title }}
+          {%- endblock -%}
+        </title>
 
-    #}
-    <title>
-      {%- block title -%}
-        {%- block subtitle %}{% endblock -%}
-        {%- if self.subtitle()|trim %} {{ g.template_title_delimiter }} {% endif -%}
-        {{ g.site_title }}
-      {%- endblock -%}
-    </title>
+        {#
+          The links block allows you to add additional content before the stylesheets
+          such as rss feeds and favicons in the same way as the meta block.
+          #}
+        {% block links -%}
+          <link rel="shortcut icon" href="{{ g.favicon }}" />
+        {% endblock -%}
 
-    {#
-    The links block allows you to add additional content before the stylesheets
-    such as rss feeds and favicons in the same way as the meta block.
-    #}
-    {% block links -%}
-      <link rel="shortcut icon" href="{{ g.favicon }}" />
-    {% endblock -%}
+        {#
+          The styles block allows you to add additional stylesheets to the page in
+          the same way as the meta block. Use super() to include the default
+          stylesheets before or after your own.
 
-    {#
-    The styles block allows you to add additional stylesheets to the page in
-    the same way as the meta block. Use super() to include the default
-    stylesheets before or after your own.
+          Example:
 
-    Example:
+          {% block styles %}
+          {{ super() }}
+          <link rel="stylesheet" href="/base/css/custom.css" />
+          {% endblock %}
+          #}
+        {%- block styles %}
+          {# TODO: store just name of asset instead of path to it. #}
+          {% set theme = h.get_rtl_theme() if h.is_rtl_language() else g.theme %}
+          {% asset theme %}
+        {% endblock %}
 
-      {% block styles %}
-        {{ super() }}
-        <link rel="stylesheet" href="/base/css/custom.css" />
-      {% endblock %}
-    #}
-    {%- block styles %}
-      {# TODO: store just name of asset instead of path to it. #}
-      {% set theme = h.get_rtl_theme() if h.is_rtl_language() else g.theme %}
-      {% asset theme %}
-    {% endblock %}
+        {# render all assets included in styles block #}
+        {{ h.render_assets('style') }}
+        {%- block custom_styles %}
+          {%- if g.site_custom_css -%}
+            <style>
+              {{ g.site_custom_css | safe }}
+            </style>
+          {%- endif %}
+        {% endblock %}
 
-    {# render all assets included in styles block #}
-    {{ h.render_assets('style') }}
-    {%- block custom_styles %}
-      {%- if g.site_custom_css -%}
-      <style>
-        {{ g.site_custom_css | safe }}
-      </style>
-      {%- endif %}
-    {% endblock %}
+        {%- block head_extras %}
+        {% endblock %}
+      {%- endblock document_head %}
+    </head>
 
-    {%- block head_extras %}
-    {% endblock %}
+    {# Allows custom attributes to be added to the <body> tag #}
+    <body{% block body_attrs %}{% endblock %}>
+      {#- Document body contains the main content of the page -#}
+      {%- block document_body -%}
+        {#
+          The page block allows you to add content to the page. Most of the time it is
+          recommended that you extend one of the page.html templates in order to get
+          the site header and footer. If you need a clean page then this is the
+          block to use.
 
-  </head>
+          Example:
 
-  {# Allows custom attributes to be added to the <body> tag #}
-  <body{% block bodytag %}{% endblock %}>
+          {% block page %}
+          <div>Some other page content</div>
+          {% endblock %}
+          #}
+        {%- block page %}{% endblock -%}
 
-    {#
-    The page block allows you to add content to the page. Most of the time it is
-    recommended that you extend one of the page.html templates in order to get
-    the site header and footer. If you need a clean page then this is the
-    block to use.
+        {#
+          DO NOT USE THIS BLOCK FOR ADDING SCRIPTS
+          Scripts should be loaded by the {% assets %} tag except in very special
+          circumstances
+          #}
+        {%- block scripts %}{% endblock -%}
 
-    Example:
+        {# render all assets included in scripts block and everywhere else #}
+        {# make sure there are no calls to `asset` tag after this point #}
+        {{ h.render_assets('style') }}
+        {{ h.render_assets('script') }}
 
-      {% block page %}
-        <div>Some other page content</div>
-      {% endblock %}
-    #}
-    {%- block page %}{% endblock -%}
+        {% block body_extras -%}{%- endblock %}
 
-    {#
-    DO NOT USE THIS BLOCK FOR ADDING SCRIPTS
-    Scripts should be loaded by the {% assets %} tag except in very special
-    circumstances
-    #}
-    {%- block scripts %}
-    {% endblock -%}
-
-    {% block body_extras -%}
-    {%- endblock %}
-
-    {# render all assets included in scripts block and everywhere else #}
-    {# make sure there are no calls to `asset` tag after this point #}
-    {{ h.render_assets('style') }}
-    {{ h.render_assets('script') }}
-  </body>
-</html>
+      {%- endblock document_body %}
+    </body>
+  </html>
+{%- endblock %}

--- a/doc/contributing/frontend/template-blocks.rst
+++ b/doc/contributing/frontend/template-blocks.rst
@@ -116,6 +116,15 @@ If making site wide header changes it is preferable to override the
 Blocks in base.html
 ===================
 
+document
+--------
+
+The document block is the root block for the entire page. It can be used to
+replace the entire page content if needed. It is not recommended to use this
+block as it will make it difficult to maintain the page structure and may cause
+issues with other blocks. It is better to use the other blocks to make changes
+to the page structure and content.
+
 doctype
 -------
 
@@ -123,26 +132,32 @@ Allows the DOCTYPE to be set on a page by page basis::
 
   {% block doctype %}<!DOCTYPE html>{% endblock %}
 
-htmltag
--------
+html_attrs
+----------
 
 Allows custom attributes to be added to the <html> tag::
 
-  {% block htmltag %}<html lang="en-gb" class="no-js">{% endblock %}
+  {% block html_attrs %}lang="en" data-tag="No idea what you'd add here"{% endblock %}
 
-headtag
--------
+head_extras
+-----------
 
-Allows custom attributes to be added to the <head> tag::
+The document_head block allows you to add additional content to the head of the
+page.
 
-  {% block headtag %}<head data-tag="No idea what you'd add here">{% endblock %}
+body_extras
+-----------
 
-bodytag
--------
+The document_head block allows you to add additional content to the body of the
+page.
+
+
+body_attrs
+----------
 
 Allows custom attributes to be added to the <body> tag::
 
-  {% block bodytag %}<body class="full-page">{% endblock %}
+  {% block body_attrs %}class="my-custom-class" data-tag="No idea what you'd add here"{% endblock %}
 
 meta
 ----


### PR DESCRIPTION
Few changes to blocks inside `base.html`. 

* block `htmltag` that wraps the whole `<html>` tag is replaced with `html_attrs` block that wraps only attributes of the tag. In this way, multiple extensions can combine custom attributes using a `super()` call.
* block `headtag` is removed: I cannot imagine a situation where custom attributes are required on the `head` tag.
* added block `document_head` that wraps the content of the `head` tag. In this way, it can be completely replaced or refactored
* block `subtitle` moved inside a `subtitle` variable. In this way, we avoid computing block content twice: first time for rendering and second time to decide whether the subtitle is non-empty and we need a delimiter after it.
* block `bodytag` renamed to `body_attrs` to reflect the purpose and match `html_attrs` pattern of naming.
* wrap content of the `body` tag with `document_body`. This matches the `document_head` block and can also be used to completely replace the content of the `body`.
* `body_extras` block is moved to the end of the body tag, to match the behavior of `head_extras` block
 
This change will not create exceptions due to the way Jinja2 processes inherited blocks. Imagine that your extension customizes the renamed `bodytag` block:
```django
# base.html
{% ckan_extends %}

{% block bodytag -%}
   {{ super() }} my-custom-attribute="value"
{%- endblock %}
```

When Jinja2 reads the template that extends another template, it ignores

* output outside blocks
* any unknown block on the top level.

Because `bodytag` is now renamed to `body_attrs`, the whole `bodytag` block, including the `super()` call, will not be executed and will not complain on missing parent block. 

The maintainer of the extension will read the CKAN changelog that mentions changes in block names and will either rename the block or copy its content into the new `body_attrs` block, making the extension compatible with all CKAN versions.

These changes should not affect common extensions, as renamed blocks are related to low-level customizations that are rarely required. Technically, it's possible to combine both versions of blocks into a messy nested structure. But we don't have a deprecation flow for templates, and we already made a few other changes that may require changes to templates, so this modification is not special.