### PR TITLE
Idea: Page layout

### DIFF
--- a/ckan/public-midnight-blue/base/css/main-rtl.css
+++ b/ckan/public-midnight-blue/base/css/main-rtl.css
@@ -515,12 +515,14 @@ legend {
   padding: 0;
   margin-bottom: 0.5rem;
   font-size: calc(1.275rem + 0.3vw);
-  line-height: inherit;
 }
 @media (min-width: 1200px) {
   legend {
     font-size: 1.5rem;
   }
+}
+legend {
+  line-height: inherit;
 }
 legend + * {
   clear: left;
@@ -594,68 +596,80 @@ progress {
 
 .display-1 {
   font-size: calc(1.625rem + 4.5vw);
-  font-weight: 300;
-  line-height: 1.2;
 }
 @media (min-width: 1200px) {
   .display-1 {
     font-size: 5rem;
   }
 }
+.display-1 {
+  font-weight: 300;
+  line-height: 1.2;
+}
 
 .display-2 {
   font-size: calc(1.575rem + 3.9vw);
-  font-weight: 300;
-  line-height: 1.2;
 }
 @media (min-width: 1200px) {
   .display-2 {
     font-size: 4.5rem;
   }
 }
+.display-2 {
+  font-weight: 300;
+  line-height: 1.2;
+}
 
 .display-3 {
   font-size: calc(1.525rem + 3.3vw);
-  font-weight: 300;
-  line-height: 1.2;
 }
 @media (min-width: 1200px) {
   .display-3 {
     font-size: 4rem;
   }
 }
+.display-3 {
+  font-weight: 300;
+  line-height: 1.2;
+}
 
 .display-4 {
   font-size: calc(1.475rem + 2.7vw);
-  font-weight: 300;
-  line-height: 1.2;
 }
 @media (min-width: 1200px) {
   .display-4 {
     font-size: 3.5rem;
   }
 }
+.display-4 {
+  font-weight: 300;
+  line-height: 1.2;
+}
 
 .display-5 {
   font-size: calc(1.425rem + 2.1vw);
-  font-weight: 300;
-  line-height: 1.2;
 }
 @media (min-width: 1200px) {
   .display-5 {
     font-size: 3rem;
   }
 }
+.display-5 {
+  font-weight: 300;
+  line-height: 1.2;
+}
 
 .display-6 {
   font-size: calc(1.375rem + 1.5vw);
-  font-weight: 300;
-  line-height: 1.2;
 }
 @media (min-width: 1200px) {
   .display-6 {
     font-size: 2.5rem;
   }
+}
+.display-6 {
+  font-weight: 300;
+  line-height: 1.2;
 }
 
 .list-unstyled {
@@ -5456,12 +5470,14 @@ textarea.form-control-lg {
 }
 .modal.fade .modal-dialog {
   transition: transform 0.3s ease-out;
-  transform: translate(0, -50px);
 }
 @media (prefers-reduced-motion: reduce) {
   .modal.fade .modal-dialog {
     transition: none;
   }
+}
+.modal.fade .modal-dialog {
+  transform: translate(0, -50px);
 }
 .modal.show .modal-dialog {
   transform: none;
@@ -11988,17 +12004,17 @@ a.tag:hover {
   color: #153084;
 }
 
+.module-heading::after {
+  display: block;
+  clear: both;
+  content: "";
+}
 .module-heading {
   margin: 0;
   padding: 1rem 0.9em;
   font-size: 1rem;
   background-color: #f2f4f7;
   border-radius: 8px;
-}
-.module-heading::after {
-  display: block;
-  clear: both;
-  content: "";
 }
 
 .module-content {
@@ -12178,10 +12194,6 @@ a.tag:hover {
   padding-bottom: 8px;
 }
 
-.no-nav .module:last-child {
-  margin-top: 0;
-}
-
 .module-image {
   float: left;
   width: 50px;
@@ -12199,17 +12211,19 @@ a.tag:hover {
 .media-grid, .module-grid {
   margin: 0;
   list-style: none;
+}
+.media-grid::after, .module-grid::after {
+  display: block;
+  clear: both;
+  content: "";
+}
+.media-grid, .module-grid {
   padding-left: 0px;
   min-height: 205px;
   padding-top: 0.75rem;
   background: rgb(242.9673913043, 244.3043478261, 246.5326086957);
   border: 1px solid #ddd;
   border-width: 1px 0;
-}
-.media-grid::after, .module-grid::after {
-  display: block;
-  clear: both;
-  content: "";
 }
 
 .media-item, .module-item {
@@ -12255,12 +12269,14 @@ a.tag:hover {
   border: 1px solid #ddd;
   overflow: hidden;
   transition: all 0.2s ease-in;
-  border-radius: 3px;
 }
 @media (prefers-reduced-motion: reduce) {
   .media-view {
     transition: none;
   }
+}
+.media-view {
+  border-radius: 3px;
 }
 .media-view:hover, .media-view.hovered {
   border-color: #fff;
@@ -12324,16 +12340,18 @@ a.tag:hover {
 
 .media-item.is-expander .truncator-link, .is-expander.module-item .truncator-link {
   transition: opacity 0.2s ease-in;
-  position: absolute;
-  z-index: 10;
-  left: 15px;
-  bottom: 15px;
-  opacity: 0;
 }
 @media (prefers-reduced-motion: reduce) {
   .media-item.is-expander .truncator-link, .is-expander.module-item .truncator-link {
     transition: none;
   }
+}
+.media-item.is-expander .truncator-link, .is-expander.module-item .truncator-link {
+  position: absolute;
+  z-index: 10;
+  left: 15px;
+  bottom: 15px;
+  opacity: 0;
 }
 .media-item.is-expander:hover, .is-expander.module-item:hover {
   padding-bottom: 35px;
@@ -12346,18 +12364,16 @@ a.tag:hover {
   width: 186px;
 }
 
-.nav-simple,
-.nav-aside {
-  margin: 0;
-  list-style: none;
-  padding-bottom: 0;
-  display: block;
-}
 .nav-simple::after,
 .nav-aside::after {
   display: block;
   clear: both;
   content: "";
+}
+.nav-simple,
+.nav-aside {
+  margin: 0;
+  list-style: none;
 }
 .nav-simple > li,
 .nav-aside > li {
@@ -12370,6 +12386,11 @@ a.tag:hover {
 .nav-simple > li:last-of-type,
 .nav-aside > li:last-of-type {
   border-bottom: 0;
+}
+.nav-simple,
+.nav-aside {
+  padding-bottom: 0;
+  display: block;
 }
 
 .nav-aside {
@@ -13170,13 +13191,15 @@ select[data-module=autocomplete] {
   border-radius: 3px;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   transition: border linear 0.2s, box-shadow linear 0.2s;
-  background-color: #fff;
-  border: 1px solid #ccc;
 }
 @media (prefers-reduced-motion: reduce) {
   .select2-container-multi .select2-choices {
     transition: none;
   }
+}
+.select2-container-multi .select2-choices {
+  background-color: #fff;
+  border: 1px solid #ccc;
 }
 
 .select2-container-active .select2-choices,
@@ -13974,17 +13997,22 @@ td.diff_header {
   margin-top: 1rem;
 }
 
-.toolbar {
-  position: relative;
-  margin-bottom: 10px;
-  padding: 5px 0;
-}
 .toolbar::after {
   display: block;
   clear: both;
   content: "";
 }
+.toolbar {
+  position: relative;
+  margin-bottom: 10px;
+  padding: 5px 0;
+}
 
+.toolbar .breadcrumb::after {
+  display: block;
+  clear: both;
+  content: "";
+}
 .toolbar .breadcrumb {
   box-shadow: none;
   position: relative;
@@ -13994,11 +14022,6 @@ td.diff_header {
   border: none;
   background: none;
   font-size: 14px;
-}
-.toolbar .breadcrumb::after {
-  display: block;
-  clear: both;
-  content: "";
 }
 
 .toolbar .breadcrumb li:not(:first-child) {
@@ -14055,12 +14078,12 @@ td.diff_header {
   margin-right: 0;
 }
 
-.page-header {
-  margin-top: 1.5rem;
-}
 .page-header.module-content {
   padding-top: 0.75rem;
   padding-bottom: 0;
+}
+.page-header {
+  margin-top: 1.5rem;
 }
 .page-header::after {
   display: block;
@@ -14084,10 +14107,6 @@ td.diff_header {
 .content_action {
   display: flex;
   justify-content: flex-end;
-}
-
-.no-nav .page-header {
-  border-radius: 3px 3px 0 0;
 }
 
 .nav-tabs-plain {
@@ -14143,28 +14162,14 @@ td.diff_header {
   font-style: italic;
 }
 
-[role=main],
-.main {
-  position: relative;
-}
-
 .main {
   padding: 20px 0;
   background-color: #fff;
 }
 
-.main:after,
-[role=main]:after {
-  bottom: 0;
-  border-top-width: 1px;
-}
-
 .main .primary {
   border-radius: 20px;
   background-color: #f2f4f7;
-  position: relative;
-  float: right;
-  margin-left: 0;
 }
 
 .main .secondary {
@@ -14691,8 +14696,6 @@ footer .lang-select {
 }
 footer .lang-select .form-group {
   margin-bottom: 0;
-  display: flex;
-  padding: 1rem 0;
 }
 footer .lang-select .form-group label {
   font-size: 1rem;
@@ -14703,6 +14706,10 @@ footer .lang-select .form-group label::after {
 }
 footer .lang-select .form-group label i {
   vertical-align: middle;
+}
+footer .lang-select .form-group {
+  display: flex;
+  padding: 1rem 0;
 }
 footer .lang-select .form-group .select2-container--default .select2-selection--single .select2-selection__rendered {
   color: #fff;
@@ -14815,6 +14822,12 @@ footer .ckan-footer-logo {
   z-index: 1;
 }
 
+#followee-popover:focus {
+  box-shadow: 0 0 0 0.25rem rgba(21, 48, 132, 0.25);
+}
+#followee-popover:hover {
+  text-decoration: none;
+}
 #followee-popover {
   color: #000;
   width: 100%;
@@ -14824,12 +14837,6 @@ footer .ckan-footer-logo {
   background-color: #fff;
   display: flex;
   justify-content: space-between;
-}
-#followee-popover:focus {
-  box-shadow: 0 0 0 0.25rem rgba(21, 48, 132, 0.25);
-}
-#followee-popover:hover {
-  text-decoration: none;
 }
 @media (min-width: 768px) {
   #followee-popover {
@@ -14874,18 +14881,18 @@ footer .ckan-footer-logo {
   background: transparent url("${imagePath}/dashboard-followee-related.png");
 }
 
+.followee-container .popover-title {
+  display: none;
+}
+.followee-container .empty {
+  padding: 10px;
+}
 .followee-container {
   padding: 0;
   margin: 0;
   max-height: 205px;
   overflow: auto;
   border-radius: 0 0 3px 3px;
-}
-.followee-container .popover-title {
-  display: none;
-}
-.followee-container .empty {
-  padding: 10px;
 }
 .followee-container li i {
   margin-right: 11px;
@@ -14908,13 +14915,13 @@ footer .ckan-footer-logo {
   box-shadow: inset 0 1px 2x rgba(0, 0, 0, 0.2);
 }
 
-.dashboard-me {
-  padding: 15px 15px 0 15px;
-}
 .dashboard-me::after {
   display: block;
   clear: both;
   content: "";
+}
+.dashboard-me {
+  padding: 15px 15px 0 15px;
 }
 .dashboard-me img {
   float: left;
@@ -15597,15 +15604,6 @@ input[id^=lang-].btn-check + label.btn:hover {
     width: 0%;
   }
 }
-@media (min-width: 576px) {
-  .wrapper:before {
-    left: initial;
-    right: 0;
-    width: 25%;
-    border-left: 1px solid #d0d5dd;
-  }
-}
-
 .simple-input .field .btn-search {
   right: initial;
   left: 0;

--- a/ckan/public-midnight-blue/base/css/main.css
+++ b/ckan/public-midnight-blue/base/css/main.css
@@ -515,12 +515,14 @@ legend {
   padding: 0;
   margin-bottom: 0.5rem;
   font-size: calc(1.275rem + 0.3vw);
-  line-height: inherit;
 }
 @media (min-width: 1200px) {
   legend {
     font-size: 1.5rem;
   }
+}
+legend {
+  line-height: inherit;
 }
 legend + * {
   clear: left;
@@ -594,68 +596,80 @@ progress {
 
 .display-1 {
   font-size: calc(1.625rem + 4.5vw);
-  font-weight: 300;
-  line-height: 1.2;
 }
 @media (min-width: 1200px) {
   .display-1 {
     font-size: 5rem;
   }
 }
+.display-1 {
+  font-weight: 300;
+  line-height: 1.2;
+}
 
 .display-2 {
   font-size: calc(1.575rem + 3.9vw);
-  font-weight: 300;
-  line-height: 1.2;
 }
 @media (min-width: 1200px) {
   .display-2 {
     font-size: 4.5rem;
   }
 }
+.display-2 {
+  font-weight: 300;
+  line-height: 1.2;
+}
 
 .display-3 {
   font-size: calc(1.525rem + 3.3vw);
-  font-weight: 300;
-  line-height: 1.2;
 }
 @media (min-width: 1200px) {
   .display-3 {
     font-size: 4rem;
   }
 }
+.display-3 {
+  font-weight: 300;
+  line-height: 1.2;
+}
 
 .display-4 {
   font-size: calc(1.475rem + 2.7vw);
-  font-weight: 300;
-  line-height: 1.2;
 }
 @media (min-width: 1200px) {
   .display-4 {
     font-size: 3.5rem;
   }
 }
+.display-4 {
+  font-weight: 300;
+  line-height: 1.2;
+}
 
 .display-5 {
   font-size: calc(1.425rem + 2.1vw);
-  font-weight: 300;
-  line-height: 1.2;
 }
 @media (min-width: 1200px) {
   .display-5 {
     font-size: 3rem;
   }
 }
+.display-5 {
+  font-weight: 300;
+  line-height: 1.2;
+}
 
 .display-6 {
   font-size: calc(1.375rem + 1.5vw);
-  font-weight: 300;
-  line-height: 1.2;
 }
 @media (min-width: 1200px) {
   .display-6 {
     font-size: 2.5rem;
   }
+}
+.display-6 {
+  font-weight: 300;
+  line-height: 1.2;
 }
 
 .list-unstyled {
@@ -5456,12 +5470,14 @@ textarea.form-control-lg {
 }
 .modal.fade .modal-dialog {
   transition: transform 0.3s ease-out;
-  transform: translate(0, -50px);
 }
 @media (prefers-reduced-motion: reduce) {
   .modal.fade .modal-dialog {
     transition: none;
   }
+}
+.modal.fade .modal-dialog {
+  transform: translate(0, -50px);
 }
 .modal.show .modal-dialog {
   transform: none;
@@ -11988,17 +12004,17 @@ a.tag:hover {
   color: #153084;
 }
 
+.module-heading::after {
+  display: block;
+  clear: both;
+  content: "";
+}
 .module-heading {
   margin: 0;
   padding: 1rem 0.9em;
   font-size: 1rem;
   background-color: #f2f4f7;
   border-radius: 8px;
-}
-.module-heading::after {
-  display: block;
-  clear: both;
-  content: "";
 }
 
 .module-content {
@@ -12178,10 +12194,6 @@ a.tag:hover {
   padding-bottom: 8px;
 }
 
-.no-nav .module:last-child {
-  margin-top: 0;
-}
-
 .module-image {
   float: left;
   width: 50px;
@@ -12199,17 +12211,19 @@ a.tag:hover {
 .media-grid, .module-grid {
   margin: 0;
   list-style: none;
+}
+.media-grid::after, .module-grid::after {
+  display: block;
+  clear: both;
+  content: "";
+}
+.media-grid, .module-grid {
   padding-left: 0px;
   min-height: 205px;
   padding-top: 0.75rem;
   background: rgb(242.9673913043, 244.3043478261, 246.5326086957);
   border: 1px solid #ddd;
   border-width: 1px 0;
-}
-.media-grid::after, .module-grid::after {
-  display: block;
-  clear: both;
-  content: "";
 }
 
 .media-item, .module-item {
@@ -12255,12 +12269,14 @@ a.tag:hover {
   border: 1px solid #ddd;
   overflow: hidden;
   transition: all 0.2s ease-in;
-  border-radius: 3px;
 }
 @media (prefers-reduced-motion: reduce) {
   .media-view {
     transition: none;
   }
+}
+.media-view {
+  border-radius: 3px;
 }
 .media-view:hover, .media-view.hovered {
   border-color: #fff;
@@ -12324,16 +12340,18 @@ a.tag:hover {
 
 .media-item.is-expander .truncator-link, .is-expander.module-item .truncator-link {
   transition: opacity 0.2s ease-in;
-  position: absolute;
-  z-index: 10;
-  left: 15px;
-  bottom: 15px;
-  opacity: 0;
 }
 @media (prefers-reduced-motion: reduce) {
   .media-item.is-expander .truncator-link, .is-expander.module-item .truncator-link {
     transition: none;
   }
+}
+.media-item.is-expander .truncator-link, .is-expander.module-item .truncator-link {
+  position: absolute;
+  z-index: 10;
+  left: 15px;
+  bottom: 15px;
+  opacity: 0;
 }
 .media-item.is-expander:hover, .is-expander.module-item:hover {
   padding-bottom: 35px;
@@ -12346,18 +12364,16 @@ a.tag:hover {
   width: 186px;
 }
 
-.nav-simple,
-.nav-aside {
-  margin: 0;
-  list-style: none;
-  padding-bottom: 0;
-  display: block;
-}
 .nav-simple::after,
 .nav-aside::after {
   display: block;
   clear: both;
   content: "";
+}
+.nav-simple,
+.nav-aside {
+  margin: 0;
+  list-style: none;
 }
 .nav-simple > li,
 .nav-aside > li {
@@ -12370,6 +12386,11 @@ a.tag:hover {
 .nav-simple > li:last-of-type,
 .nav-aside > li:last-of-type {
   border-bottom: 0;
+}
+.nav-simple,
+.nav-aside {
+  padding-bottom: 0;
+  display: block;
 }
 
 .nav-aside {
@@ -13170,13 +13191,15 @@ select[data-module=autocomplete] {
   border-radius: 3px;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   transition: border linear 0.2s, box-shadow linear 0.2s;
-  background-color: #fff;
-  border: 1px solid #ccc;
 }
 @media (prefers-reduced-motion: reduce) {
   .select2-container-multi .select2-choices {
     transition: none;
   }
+}
+.select2-container-multi .select2-choices {
+  background-color: #fff;
+  border: 1px solid #ccc;
 }
 
 .select2-container-active .select2-choices,
@@ -13974,17 +13997,22 @@ td.diff_header {
   margin-top: 1rem;
 }
 
-.toolbar {
-  position: relative;
-  margin-bottom: 10px;
-  padding: 5px 0;
-}
 .toolbar::after {
   display: block;
   clear: both;
   content: "";
 }
+.toolbar {
+  position: relative;
+  margin-bottom: 10px;
+  padding: 5px 0;
+}
 
+.toolbar .breadcrumb::after {
+  display: block;
+  clear: both;
+  content: "";
+}
 .toolbar .breadcrumb {
   box-shadow: none;
   position: relative;
@@ -13994,11 +14022,6 @@ td.diff_header {
   border: none;
   background: none;
   font-size: 14px;
-}
-.toolbar .breadcrumb::after {
-  display: block;
-  clear: both;
-  content: "";
 }
 
 .toolbar .breadcrumb li:not(:first-child) {
@@ -14055,12 +14078,12 @@ td.diff_header {
   margin-right: 0;
 }
 
-.page-header {
-  margin-top: 1.5rem;
-}
 .page-header.module-content {
   padding-top: 0.75rem;
   padding-bottom: 0;
+}
+.page-header {
+  margin-top: 1.5rem;
 }
 .page-header::after {
   display: block;
@@ -14084,10 +14107,6 @@ td.diff_header {
 .content_action {
   display: flex;
   justify-content: flex-end;
-}
-
-.no-nav .page-header {
-  border-radius: 3px 3px 0 0;
 }
 
 .nav-tabs-plain {
@@ -14143,28 +14162,14 @@ td.diff_header {
   font-style: italic;
 }
 
-[role=main],
-.main {
-  position: relative;
-}
-
 .main {
   padding: 20px 0;
   background-color: #fff;
 }
 
-.main:after,
-[role=main]:after {
-  bottom: 0;
-  border-top-width: 1px;
-}
-
 .main .primary {
   border-radius: 20px;
   background-color: #f2f4f7;
-  position: relative;
-  float: right;
-  margin-left: 0;
 }
 
 .main .secondary {
@@ -14691,8 +14696,6 @@ footer .lang-select {
 }
 footer .lang-select .form-group {
   margin-bottom: 0;
-  display: flex;
-  padding: 1rem 0;
 }
 footer .lang-select .form-group label {
   font-size: 1rem;
@@ -14703,6 +14706,10 @@ footer .lang-select .form-group label::after {
 }
 footer .lang-select .form-group label i {
   vertical-align: middle;
+}
+footer .lang-select .form-group {
+  display: flex;
+  padding: 1rem 0;
 }
 footer .lang-select .form-group .select2-container--default .select2-selection--single .select2-selection__rendered {
   color: #fff;
@@ -14815,6 +14822,12 @@ footer .ckan-footer-logo {
   z-index: 1;
 }
 
+#followee-popover:focus {
+  box-shadow: 0 0 0 0.25rem rgba(21, 48, 132, 0.25);
+}
+#followee-popover:hover {
+  text-decoration: none;
+}
 #followee-popover {
   color: #000;
   width: 100%;
@@ -14824,12 +14837,6 @@ footer .ckan-footer-logo {
   background-color: #fff;
   display: flex;
   justify-content: space-between;
-}
-#followee-popover:focus {
-  box-shadow: 0 0 0 0.25rem rgba(21, 48, 132, 0.25);
-}
-#followee-popover:hover {
-  text-decoration: none;
 }
 @media (min-width: 768px) {
   #followee-popover {
@@ -14874,18 +14881,18 @@ footer .ckan-footer-logo {
   background: transparent url("${imagePath}/dashboard-followee-related.png");
 }
 
+.followee-container .popover-title {
+  display: none;
+}
+.followee-container .empty {
+  padding: 10px;
+}
 .followee-container {
   padding: 0;
   margin: 0;
   max-height: 205px;
   overflow: auto;
   border-radius: 0 0 3px 3px;
-}
-.followee-container .popover-title {
-  display: none;
-}
-.followee-container .empty {
-  padding: 10px;
 }
 .followee-container li i {
   margin-right: 11px;
@@ -14908,13 +14915,13 @@ footer .ckan-footer-logo {
   box-shadow: inset 0 1px 2x rgba(0, 0, 0, 0.2);
 }
 
-.dashboard-me {
-  padding: 15px 15px 0 15px;
-}
 .dashboard-me::after {
   display: block;
   clear: both;
   content: "";
+}
+.dashboard-me {
+  padding: 15px 15px 0 15px;
 }
 .dashboard-me img {
   float: left;

--- a/ckan/public-midnight-blue/base/scss/_ckan-rtl.scss
+++ b/ckan/public-midnight-blue/base/scss/_ckan-rtl.scss
@@ -1,14 +1,4 @@
 @use "sass:math";
-.wrapper {
-  @include media-breakpoint-up(sm) {
-    &:before {
-      left: initial;
-      right: 0;
-      width: 25%;
-      border-left: 1px solid $genericBorderColor;
-    }
-  }
-}
 
 .simple-input .field .btn-search {
   right: initial;

--- a/ckan/public-midnight-blue/base/scss/_layout.scss
+++ b/ckan/public-midnight-blue/base/scss/_layout.scss
@@ -1,25 +1,11 @@
-[role=main],
-.main {
-    position: relative;
-}
-
 .main {
     padding: 20px 0;
     background-color: $white;
 }
 
-.main:after,
-[role=main]:after {
-    bottom: 0;
-    border-top-width: 1px;
-}
-
 .main .primary {
     border-radius: 20px;
     background-color: $layoutPrimaryBackgroundColor;
-    position: relative;
-    float: right;
-    margin-left: 0; // Remove grid margin.
 }
 
 .main .secondary {

--- a/ckan/public-midnight-blue/base/scss/_module.scss
+++ b/ckan/public-midnight-blue/base/scss/_module.scss
@@ -218,10 +218,6 @@
     padding-bottom: 8px;
 }
 
-.no-nav .module:last-child {
-    margin-top: 0;
-}
-
 .module-image {
     float: left;
     width: 50px;

--- a/ckan/public-midnight-blue/base/scss/_toolbar.scss
+++ b/ckan/public-midnight-blue/base/scss/_toolbar.scss
@@ -110,10 +110,6 @@
     justify-content: flex-end;
 }
 
-.no-nav .page-header {
-    @include border-radius(3px 3px 0 0);
-}
-
 .nav-tabs-plain {
     padding: 0 $gutterX;
     &>.active>a,

--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -34,7 +34,7 @@
   --bs-success: #3A833A;
   --bs-info: #0dcaf0;
   --bs-warning: #fd7e14;
-  --bs-danger: #d43f3a;
+  --bs-danger: rgb(212.4719626168, 62.5046728972, 58.0280373832);
   --bs-light: #fff;
   --bs-dark: #333333;
   --bs-primary-rgb: 32, 107, 130;
@@ -45,28 +45,28 @@
   --bs-danger-rgb: 212, 63, 58;
   --bs-light-rgb: 255, 255, 255;
   --bs-dark-rgb: 51, 51, 51;
-  --bs-primary-text-emphasis: #0d2b34;
-  --bs-secondary-text-emphasis: #2b2f32;
-  --bs-success-text-emphasis: #173417;
-  --bs-info-text-emphasis: #055160;
-  --bs-warning-text-emphasis: #653208;
-  --bs-danger-text-emphasis: #551917;
+  --bs-primary-text-emphasis: rgb(12.8, 42.8, 52);
+  --bs-secondary-text-emphasis: rgb(43.2, 46.8, 50);
+  --bs-success-text-emphasis: rgb(23.2, 52.4, 23.2);
+  --bs-info-text-emphasis: rgb(5.2, 80.8, 96);
+  --bs-warning-text-emphasis: rgb(101.2, 50.4, 8);
+  --bs-danger-text-emphasis: rgb(84.9887850467, 25.0018691589, 23.2112149533);
   --bs-light-text-emphasis: #495057;
   --bs-dark-text-emphasis: #495057;
-  --bs-primary-bg-subtle: #d2e1e6;
-  --bs-secondary-bg-subtle: #e2e3e5;
-  --bs-success-bg-subtle: #d8e6d8;
-  --bs-info-bg-subtle: #cff4fc;
-  --bs-warning-bg-subtle: #ffe5d0;
-  --bs-danger-bg-subtle: #f6d9d8;
-  --bs-light-bg-subtle: #fcfcfd;
+  --bs-primary-bg-subtle: rgb(210.4, 225.4, 230);
+  --bs-secondary-bg-subtle: rgb(225.6, 227.4, 229);
+  --bs-success-bg-subtle: rgb(215.6, 230.2, 215.6);
+  --bs-info-bg-subtle: rgb(206.6, 244.4, 252);
+  --bs-warning-bg-subtle: rgb(254.6, 229.2, 208);
+  --bs-danger-bg-subtle: rgb(246.4943925234, 216.5009345794, 215.6056074766);
+  --bs-light-bg-subtle: rgb(251.5, 252, 252.5);
   --bs-dark-bg-subtle: #ced4da;
-  --bs-primary-border-subtle: #a6c4cd;
-  --bs-secondary-border-subtle: #c4c8cb;
-  --bs-success-border-subtle: #b0cdb0;
-  --bs-info-border-subtle: #9eeaf9;
-  --bs-warning-border-subtle: #fecba1;
-  --bs-danger-border-subtle: #eeb2b0;
+  --bs-primary-border-subtle: rgb(165.8, 195.8, 205);
+  --bs-secondary-border-subtle: rgb(196.2, 199.8, 203);
+  --bs-success-border-subtle: rgb(176.2, 205.4, 176.2);
+  --bs-info-border-subtle: rgb(158.2, 233.8, 249);
+  --bs-warning-border-subtle: rgb(254.2, 203.4, 161);
+  --bs-danger-border-subtle: rgb(237.9887850467, 178.0018691589, 176.2112149533);
   --bs-light-border-subtle: #e9ecef;
   --bs-dark-border-subtle: #adb5bd;
   --bs-white-rgb: 255, 255, 255;
@@ -96,7 +96,7 @@
   --bs-link-color: #206b82;
   --bs-link-color-rgb: 32, 107, 130;
   --bs-link-decoration: none;
-  --bs-link-hover-color: #1a5668;
+  --bs-link-hover-color: rgb(25.6, 85.6, 104);
   --bs-link-hover-color-rgb: 26, 86, 104;
   --bs-link-hover-decoration: underline;
   --bs-code-color: #d63384;
@@ -122,8 +122,8 @@
   --bs-focus-ring-color: rgba(32, 107, 130, 0.25);
   --bs-form-valid-color: #3A833A;
   --bs-form-valid-border-color: #3A833A;
-  --bs-form-invalid-color: #d43f3a;
-  --bs-form-invalid-border-color: #d43f3a;
+  --bs-form-invalid-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
+  --bs-form-invalid-border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
 }
 
 [data-bs-theme=dark] {
@@ -140,46 +140,46 @@
   --bs-secondary-bg-rgb: 52, 58, 64;
   --bs-tertiary-color: rgba(222, 226, 230, 0.5);
   --bs-tertiary-color-rgb: 222, 226, 230;
-  --bs-tertiary-bg: #34373a;
+  --bs-tertiary-bg: rgb(51.5, 54.5, 57.5);
   --bs-tertiary-bg-rgb: 52, 55, 58;
-  --bs-primary-text-emphasis: #79a6b4;
-  --bs-secondary-text-emphasis: #a7acb1;
-  --bs-success-text-emphasis: #89b589;
-  --bs-info-text-emphasis: #6edff6;
-  --bs-warning-text-emphasis: #feb272;
-  --bs-danger-text-emphasis: #e58c89;
+  --bs-primary-text-emphasis: rgb(121.2, 166.2, 180);
+  --bs-secondary-text-emphasis: rgb(166.8, 172.2, 177);
+  --bs-success-text-emphasis: rgb(136.8, 180.6, 136.8);
+  --bs-info-text-emphasis: rgb(109.8, 223.2, 246);
+  --bs-warning-text-emphasis: rgb(253.8, 177.6, 114);
+  --bs-danger-text-emphasis: rgb(229.4831775701, 139.5028037383, 136.8168224299);
   --bs-light-text-emphasis: #f8f9fa;
   --bs-dark-text-emphasis: #dee2e6;
-  --bs-primary-bg-subtle: #06151a;
-  --bs-secondary-bg-subtle: #161719;
-  --bs-success-bg-subtle: #0c1a0c;
-  --bs-info-bg-subtle: #032830;
-  --bs-warning-bg-subtle: #331904;
-  --bs-danger-bg-subtle: #2a0d0c;
+  --bs-primary-bg-subtle: rgb(6.4, 21.4, 26);
+  --bs-secondary-bg-subtle: rgb(21.6, 23.4, 25);
+  --bs-success-bg-subtle: rgb(11.6, 26.2, 11.6);
+  --bs-info-bg-subtle: rgb(2.6, 40.4, 48);
+  --bs-warning-bg-subtle: rgb(50.6, 25.2, 4);
+  --bs-danger-bg-subtle: rgb(42.4943925234, 12.5009345794, 11.6056074766);
   --bs-light-bg-subtle: #343a40;
   --bs-dark-bg-subtle: #1a1d20;
-  --bs-primary-border-subtle: #13404e;
-  --bs-secondary-border-subtle: #41464b;
-  --bs-success-border-subtle: #234f23;
-  --bs-info-border-subtle: #087990;
-  --bs-warning-border-subtle: #984c0c;
-  --bs-danger-border-subtle: #7f2623;
+  --bs-primary-border-subtle: rgb(19.2, 64.2, 78);
+  --bs-secondary-border-subtle: rgb(64.8, 70.2, 75);
+  --bs-success-border-subtle: rgb(34.8, 78.6, 34.8);
+  --bs-info-border-subtle: rgb(7.8, 121.2, 144);
+  --bs-warning-border-subtle: rgb(151.8, 75.6, 12);
+  --bs-danger-border-subtle: rgb(127.4831775701, 37.5028037383, 34.8168224299);
   --bs-light-border-subtle: #495057;
   --bs-dark-border-subtle: #343a40;
   --bs-heading-color: inherit;
-  --bs-link-color: #79a6b4;
-  --bs-link-hover-color: #94b8c3;
+  --bs-link-color: rgb(121.2, 166.2, 180);
+  --bs-link-hover-color: rgb(147.96, 183.96, 195);
   --bs-link-color-rgb: 121, 166, 180;
   --bs-link-hover-color-rgb: 148, 184, 195;
-  --bs-code-color: #e685b5;
+  --bs-code-color: rgb(230.4, 132.6, 181.2);
   --bs-highlight-color: #dee2e6;
-  --bs-highlight-bg: #653208;
+  --bs-highlight-bg: rgb(101.2, 50.4, 8);
   --bs-border-color: #495057;
   --bs-border-color-translucent: rgba(255, 255, 255, 0.15);
-  --bs-form-valid-color: #89b589;
-  --bs-form-valid-border-color: #89b589;
-  --bs-form-invalid-color: #e89895;
-  --bs-form-invalid-border-color: #e89895;
+  --bs-form-valid-color: rgb(136.8, 180.6, 136.8);
+  --bs-form-valid-border-color: rgb(136.8, 180.6, 136.8);
+  --bs-form-invalid-color: rgb(232.2, 151.8, 149.4);
+  --bs-form-invalid-border-color: rgb(232.2, 151.8, 149.4);
 }
 
 *,
@@ -513,8 +513,8 @@ legend {
   width: 100%;
   padding: 0;
   margin-bottom: 0.5rem;
-  font-size: calc(1.275rem + 0.3vw);
   line-height: inherit;
+  font-size: calc(1.275rem + 0.3vw);
 }
 @media (min-width: 1200px) {
   legend {
@@ -542,6 +542,10 @@ legend + * {
 [type=search] {
   -webkit-appearance: textfield;
   outline-offset: -2px;
+}
+[type=search]::-webkit-search-cancel-button {
+  cursor: pointer;
+  filter: grayscale(1);
 }
 
 /* rtl:raw:
@@ -592,9 +596,9 @@ progress {
 }
 
 .display-1 {
-  font-size: calc(1.625rem + 4.5vw);
   font-weight: 300;
   line-height: 1.2;
+  font-size: calc(1.625rem + 4.5vw);
 }
 @media (min-width: 1200px) {
   .display-1 {
@@ -603,9 +607,9 @@ progress {
 }
 
 .display-2 {
-  font-size: calc(1.575rem + 3.9vw);
   font-weight: 300;
   line-height: 1.2;
+  font-size: calc(1.575rem + 3.9vw);
 }
 @media (min-width: 1200px) {
   .display-2 {
@@ -614,9 +618,9 @@ progress {
 }
 
 .display-3 {
-  font-size: calc(1.525rem + 3.3vw);
   font-weight: 300;
   line-height: 1.2;
+  font-size: calc(1.525rem + 3.3vw);
 }
 @media (min-width: 1200px) {
   .display-3 {
@@ -625,9 +629,9 @@ progress {
 }
 
 .display-4 {
-  font-size: calc(1.475rem + 2.7vw);
   font-weight: 300;
   line-height: 1.2;
+  font-size: calc(1.475rem + 2.7vw);
 }
 @media (min-width: 1200px) {
   .display-4 {
@@ -636,9 +640,9 @@ progress {
 }
 
 .display-5 {
-  font-size: calc(1.425rem + 2.1vw);
   font-weight: 300;
   line-height: 1.2;
+  font-size: calc(1.425rem + 2.1vw);
 }
 @media (min-width: 1200px) {
   .display-5 {
@@ -647,9 +651,9 @@ progress {
 }
 
 .display-6 {
-  font-size: calc(1.375rem + 1.5vw);
   font-weight: 300;
   line-height: 1.2;
+  font-size: calc(1.375rem + 1.5vw);
 }
 @media (min-width: 1200px) {
   .display-6 {
@@ -795,7 +799,7 @@ progress {
 }
 
 .col {
-  flex: 1 0 0%;
+  flex: 1 0 0;
 }
 
 .row-cols-auto > * {
@@ -1004,7 +1008,7 @@ progress {
 
 @media (min-width: 576px) {
   .col-sm {
-    flex: 1 0 0%;
+    flex: 1 0 0;
   }
   .row-cols-sm-auto > * {
     flex: 0 0 auto;
@@ -1173,7 +1177,7 @@ progress {
 }
 @media (min-width: 768px) {
   .col-md {
-    flex: 1 0 0%;
+    flex: 1 0 0;
   }
   .row-cols-md-auto > * {
     flex: 0 0 auto;
@@ -1342,7 +1346,7 @@ progress {
 }
 @media (min-width: 992px) {
   .col-lg {
-    flex: 1 0 0%;
+    flex: 1 0 0;
   }
   .row-cols-lg-auto > * {
     flex: 0 0 auto;
@@ -1511,7 +1515,7 @@ progress {
 }
 @media (min-width: 1200px) {
   .col-xl {
-    flex: 1 0 0%;
+    flex: 1 0 0;
   }
   .row-cols-xl-auto > * {
     flex: 0 0 auto;
@@ -1680,7 +1684,7 @@ progress {
 }
 @media (min-width: 1300px) {
   .col-xxl {
-    flex: 1 0 0%;
+    flex: 1 0 0;
   }
   .row-cols-xxl-auto > * {
     flex: 0 0 auto;
@@ -1929,13 +1933,13 @@ progress {
 
 .table-primary {
   --bs-table-color: #000;
-  --bs-table-bg: #d2e1e6;
-  --bs-table-border-color: #bdcbcf;
-  --bs-table-striped-bg: #c8d6db;
+  --bs-table-bg: rgb(210.4, 225.4, 230);
+  --bs-table-border-color: rgb(189.36, 202.86, 207);
+  --bs-table-striped-bg: rgb(199.88, 214.13, 218.5);
   --bs-table-striped-color: #000;
-  --bs-table-active-bg: #bdcbcf;
+  --bs-table-active-bg: rgb(189.36, 202.86, 207);
   --bs-table-active-color: #000;
-  --bs-table-hover-bg: #c2d0d5;
+  --bs-table-hover-bg: rgb(194.62, 208.495, 212.75);
   --bs-table-hover-color: #000;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -1943,13 +1947,13 @@ progress {
 
 .table-secondary {
   --bs-table-color: #000;
-  --bs-table-bg: #e2e3e5;
-  --bs-table-border-color: #cbccce;
-  --bs-table-striped-bg: #d7d8da;
+  --bs-table-bg: rgb(225.6, 227.4, 229);
+  --bs-table-border-color: rgb(203.04, 204.66, 206.1);
+  --bs-table-striped-bg: rgb(214.32, 216.03, 217.55);
   --bs-table-striped-color: #000;
-  --bs-table-active-bg: #cbccce;
+  --bs-table-active-bg: rgb(203.04, 204.66, 206.1);
   --bs-table-active-color: #000;
-  --bs-table-hover-bg: #d1d2d4;
+  --bs-table-hover-bg: rgb(208.68, 210.345, 211.825);
   --bs-table-hover-color: #000;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -1957,13 +1961,13 @@ progress {
 
 .table-success {
   --bs-table-color: #000;
-  --bs-table-bg: #d8e6d8;
-  --bs-table-border-color: #c2cfc2;
-  --bs-table-striped-bg: #cddbcd;
+  --bs-table-bg: rgb(215.6, 230.2, 215.6);
+  --bs-table-border-color: rgb(194.04, 207.18, 194.04);
+  --bs-table-striped-bg: rgb(204.82, 218.69, 204.82);
   --bs-table-striped-color: #000;
-  --bs-table-active-bg: #c2cfc2;
+  --bs-table-active-bg: rgb(194.04, 207.18, 194.04);
   --bs-table-active-color: #000;
-  --bs-table-hover-bg: #c8d5c8;
+  --bs-table-hover-bg: rgb(199.43, 212.935, 199.43);
   --bs-table-hover-color: #000;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -1971,13 +1975,13 @@ progress {
 
 .table-info {
   --bs-table-color: #000;
-  --bs-table-bg: #cff4fc;
-  --bs-table-border-color: #badce3;
-  --bs-table-striped-bg: #c5e8ef;
+  --bs-table-bg: rgb(206.6, 244.4, 252);
+  --bs-table-border-color: rgb(185.94, 219.96, 226.8);
+  --bs-table-striped-bg: rgb(196.27, 232.18, 239.4);
   --bs-table-striped-color: #000;
-  --bs-table-active-bg: #badce3;
+  --bs-table-active-bg: rgb(185.94, 219.96, 226.8);
   --bs-table-active-color: #000;
-  --bs-table-hover-bg: #bfe2e9;
+  --bs-table-hover-bg: rgb(191.105, 226.07, 233.1);
   --bs-table-hover-color: #000;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -1985,13 +1989,13 @@ progress {
 
 .table-warning {
   --bs-table-color: #000;
-  --bs-table-bg: #ffe5d0;
-  --bs-table-border-color: #e6cebb;
-  --bs-table-striped-bg: #f2dac6;
+  --bs-table-bg: rgb(254.6, 229.2, 208);
+  --bs-table-border-color: rgb(229.14, 206.28, 187.2);
+  --bs-table-striped-bg: rgb(241.87, 217.74, 197.6);
   --bs-table-striped-color: #000;
-  --bs-table-active-bg: #e6cebb;
+  --bs-table-active-bg: rgb(229.14, 206.28, 187.2);
   --bs-table-active-color: #000;
-  --bs-table-hover-bg: #ecd4c0;
+  --bs-table-hover-bg: rgb(235.505, 212.01, 192.4);
   --bs-table-hover-color: #000;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -1999,13 +2003,13 @@ progress {
 
 .table-danger {
   --bs-table-color: #000;
-  --bs-table-bg: #f6d9d8;
-  --bs-table-border-color: #ddc3c2;
-  --bs-table-striped-bg: #eacecd;
+  --bs-table-bg: rgb(246.4943925234, 216.5009345794, 215.6056074766);
+  --bs-table-border-color: rgb(221.844953271, 194.8508411215, 194.045046729);
+  --bs-table-striped-bg: rgb(234.1696728972, 205.6758878505, 204.8253271028);
   --bs-table-striped-color: #000;
-  --bs-table-active-bg: #ddc3c2;
+  --bs-table-active-bg: rgb(221.844953271, 194.8508411215, 194.045046729);
   --bs-table-active-color: #000;
-  --bs-table-hover-bg: #e4c9c8;
+  --bs-table-hover-bg: rgb(228.0073130841, 200.263364486, 199.4351869159);
   --bs-table-hover-color: #000;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -2014,12 +2018,12 @@ progress {
 .table-light {
   --bs-table-color: #000;
   --bs-table-bg: #fff;
-  --bs-table-border-color: #e6e6e6;
-  --bs-table-striped-bg: #f2f2f2;
+  --bs-table-border-color: rgb(229.5, 229.5, 229.5);
+  --bs-table-striped-bg: rgb(242.25, 242.25, 242.25);
   --bs-table-striped-color: #000;
-  --bs-table-active-bg: #e6e6e6;
+  --bs-table-active-bg: rgb(229.5, 229.5, 229.5);
   --bs-table-active-color: #000;
-  --bs-table-hover-bg: #ececec;
+  --bs-table-hover-bg: rgb(235.875, 235.875, 235.875);
   --bs-table-hover-color: #000;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -2028,12 +2032,12 @@ progress {
 .table-dark {
   --bs-table-color: #fff;
   --bs-table-bg: #333333;
-  --bs-table-border-color: #474747;
-  --bs-table-striped-bg: #3d3d3d;
+  --bs-table-border-color: rgb(71.4, 71.4, 71.4);
+  --bs-table-striped-bg: rgb(61.2, 61.2, 61.2);
   --bs-table-striped-color: #fff;
-  --bs-table-active-bg: #474747;
+  --bs-table-active-bg: rgb(71.4, 71.4, 71.4);
   --bs-table-active-color: #fff;
-  --bs-table-hover-bg: #424242;
+  --bs-table-hover-bg: rgb(66.3, 66.3, 66.3);
   --bs-table-hover-color: #fff;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -2134,7 +2138,7 @@ progress {
 .form-control:focus {
   color: #333333;
   background-color: #fff;
-  border-color: #90b5c1;
+  border-color: rgb(143.5, 181, 192.5);
   outline: 0;
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.075), 0 0 0 0.25rem rgba(32, 107, 130, 0.25);
 }
@@ -2175,7 +2179,7 @@ progress {
   }
 }
 .form-control:hover:not(:disabled):not([readonly])::file-selector-button {
-  background-color: #dde0e3;
+  background-color: rgb(221.35, 224.2, 227.05);
 }
 
 .form-control-plaintext {
@@ -2280,7 +2284,7 @@ textarea.form-control-lg {
   }
 }
 .form-select:focus {
-  border-color: #90b5c1;
+  border-color: rgb(143.5, 181, 192.5);
   outline: 0;
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.075), 0 0 0 0.25rem rgba(32, 107, 130, 0.25);
 }
@@ -2364,7 +2368,7 @@ textarea.form-control-lg {
   filter: brightness(90%);
 }
 .form-check-input:focus {
-  border-color: #90b5c1;
+  border-color: rgb(143.5, 181, 192.5);
   outline: 0;
   box-shadow: 0 0 0 0.25rem rgba(32, 107, 130, 0.25);
 }
@@ -2411,7 +2415,7 @@ textarea.form-control-lg {
   }
 }
 .form-switch .form-check-input:focus {
-  --bs-form-switch-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%2390b5c1'/%3e%3c/svg%3e");
+  --bs-form-switch-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='rgb%28143.5, 181, 192.5%29'/%3e%3c/svg%3e");
 }
 .form-switch .form-check-input:checked {
   background-position: right center;
@@ -2482,7 +2486,7 @@ textarea.form-control-lg {
   }
 }
 .form-range::-webkit-slider-thumb:active {
-  background-color: #bcd3da;
+  background-color: rgb(188.1, 210.6, 217.5);
 }
 .form-range::-webkit-slider-runnable-track {
   width: 100%;
@@ -2510,7 +2514,7 @@ textarea.form-control-lg {
   }
 }
 .form-range::-moz-range-thumb:active {
-  background-color: #bcd3da;
+  background-color: rgb(188.1, 210.6, 217.5);
 }
 .form-range::-moz-range-track {
   width: 100%;
@@ -2547,9 +2551,11 @@ textarea.form-control-lg {
   top: 0;
   left: 0;
   z-index: 2;
+  max-width: 100%;
   height: 100%;
   padding: 1rem 0.75rem;
   overflow: hidden;
+  color: rgba(var(--bs-body-color-rgb), 0.65);
   text-align: start;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -2585,18 +2591,19 @@ textarea.form-control-lg {
 .form-floating > .form-select {
   padding-top: 1.625rem;
   padding-bottom: 0.625rem;
+  padding-left: 0.75rem;
 }
 .form-floating > .form-control:focus ~ label,
 .form-floating > .form-control:not(:placeholder-shown) ~ label,
 .form-floating > .form-control-plaintext ~ label,
 .form-floating > .form-select ~ label {
-  color: rgba(var(--bs-body-color-rgb), 0.65);
   transform: scale(0.85) translateY(-0.5rem) translateX(0.15rem);
 }
-.form-floating > .form-control:focus ~ label::after,
-.form-floating > .form-control:not(:placeholder-shown) ~ label::after,
-.form-floating > .form-control-plaintext ~ label::after,
-.form-floating > .form-select ~ label::after {
+.form-floating > .form-control:-webkit-autofill ~ label {
+  transform: scale(0.85) translateY(-0.5rem) translateX(0.15rem);
+}
+.form-floating > textarea:focus ~ label::after,
+.form-floating > textarea:not(:placeholder-shown) ~ label::after {
   position: absolute;
   inset: 1rem 0.375rem;
   z-index: -1;
@@ -2605,9 +2612,8 @@ textarea.form-control-lg {
   background-color: #fff;
   border-radius: 0.25rem;
 }
-.form-floating > .form-control:-webkit-autofill ~ label {
-  color: rgba(var(--bs-body-color-rgb), 0.65);
-  transform: scale(0.85) translateY(-0.5rem) translateX(0.15rem);
+.form-floating > textarea:disabled ~ label::after {
+  background-color: #e9ecef;
 }
 .form-floating > .form-control-plaintext ~ label {
   border-width: 1px 0;
@@ -2615,10 +2621,6 @@ textarea.form-control-lg {
 .form-floating > :disabled ~ label,
 .form-floating > .form-control:disabled ~ label {
   color: #6c757d;
-}
-.form-floating > :disabled ~ label::after,
-.form-floating > .form-control:disabled ~ label::after {
-  background-color: #e9ecef;
 }
 
 .input-group {
@@ -2702,7 +2704,7 @@ textarea.form-control-lg {
   border-bottom-right-radius: 0;
 }
 .input-group > :not(:first-child):not(.dropdown-menu):not(.valid-tooltip):not(.valid-feedback):not(.invalid-tooltip):not(.invalid-feedback) {
-  margin-left: calc(1px * -1);
+  margin-left: calc(-1 * 1px);
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
 }
@@ -2807,7 +2809,7 @@ textarea.form-control-lg {
   width: 100%;
   margin-top: 0.25rem;
   font-size: 0.875em;
-  color: #d43f3a;
+  color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
 }
 
 .invalid-tooltip {
@@ -2820,7 +2822,7 @@ textarea.form-control-lg {
   margin-top: 0.1rem;
   font-size: 0.765625rem;
   color: #fff;
-  background-color: rgba(212, 63, 58, 0.9);
+  background-color: rgba(212.4719626168, 62.5046728972, 58.0280373832, 0.9);
   border-radius: 0.25rem;
 }
 
@@ -2832,16 +2834,16 @@ textarea.form-control-lg {
 }
 
 .was-validated .form-control:invalid, .form-control.is-invalid {
-  border-color: #d43f3a;
+  border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
   padding-right: calc(1.5em + 0.75rem);
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='%23d43f3a'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23d43f3a' stroke='none'/%3e%3c/svg%3e");
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='rgb%28212.4719626168, 62.5046728972, 58.0280373832%29'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='rgb%28212.4719626168, 62.5046728972, 58.0280373832%29' stroke='none'/%3e%3c/svg%3e");
   background-repeat: no-repeat;
   background-position: right calc(0.375em + 0.1875rem) center;
   background-size: calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
 }
 .was-validated .form-control:invalid:focus, .form-control.is-invalid:focus {
-  border-color: #d43f3a;
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.075), 0 0 0 0.25rem rgba(212, 63, 58, 0.25);
+  border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.075), 0 0 0 0.25rem rgba(212.4719626168, 62.5046728972, 58.0280373832, 0.25);
 }
 
 .was-validated textarea.form-control:invalid, textarea.form-control.is-invalid {
@@ -2850,17 +2852,17 @@ textarea.form-control-lg {
 }
 
 .was-validated .form-select:invalid, .form-select.is-invalid {
-  border-color: #d43f3a;
+  border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
 }
 .was-validated .form-select:invalid:not([multiple]):not([size]), .was-validated .form-select:invalid:not([multiple])[size="1"], .form-select.is-invalid:not([multiple]):not([size]), .form-select.is-invalid:not([multiple])[size="1"] {
-  --bs-form-select-bg-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='%23d43f3a'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23d43f3a' stroke='none'/%3e%3c/svg%3e");
+  --bs-form-select-bg-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='rgb%28212.4719626168, 62.5046728972, 58.0280373832%29'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='rgb%28212.4719626168, 62.5046728972, 58.0280373832%29' stroke='none'/%3e%3c/svg%3e");
   padding-right: 4.125rem;
   background-position: right 0.75rem center, center right 2.25rem;
   background-size: 16px 12px, calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
 }
 .was-validated .form-select:invalid:focus, .form-select.is-invalid:focus {
-  border-color: #d43f3a;
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.075), 0 0 0 0.25rem rgba(212, 63, 58, 0.25);
+  border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.075), 0 0 0 0.25rem rgba(212.4719626168, 62.5046728972, 58.0280373832, 0.25);
 }
 
 .was-validated .form-control-color:invalid, .form-control-color.is-invalid {
@@ -2868,16 +2870,16 @@ textarea.form-control-lg {
 }
 
 .was-validated .form-check-input:invalid, .form-check-input.is-invalid {
-  border-color: #d43f3a;
+  border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
 }
 .was-validated .form-check-input:invalid:checked, .form-check-input.is-invalid:checked {
-  background-color: #d43f3a;
+  background-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
 }
 .was-validated .form-check-input:invalid:focus, .form-check-input.is-invalid:focus {
-  box-shadow: 0 0 0 0.25rem rgba(212, 63, 58, 0.25);
+  box-shadow: 0 0 0 0.25rem rgba(212.4719626168, 62.5046728972, 58.0280373832, 0.25);
 }
 .was-validated .form-check-input:invalid ~ .form-check-label, .form-check-input.is-invalid ~ .form-check-label {
-  color: #d43f3a;
+  color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
 }
 
 .form-check-inline .form-check-input ~ .invalid-feedback {
@@ -2979,12 +2981,12 @@ textarea.form-control-lg {
   --bs-btn-bg: #206b82;
   --bs-btn-border-color: #206b82;
   --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #1b5b6f;
-  --bs-btn-hover-border-color: #1a5668;
+  --bs-btn-hover-bg: rgb(27.2, 90.95, 110.5);
+  --bs-btn-hover-border-color: rgb(25.6, 85.6, 104);
   --bs-btn-focus-shadow-rgb: 65, 129, 149;
   --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #1a5668;
-  --bs-btn-active-border-color: #185062;
+  --bs-btn-active-bg: rgb(25.6, 85.6, 104);
+  --bs-btn-active-border-color: rgb(24, 80.25, 97.5);
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   --bs-btn-disabled-color: #fff;
   --bs-btn-disabled-bg: #206b82;
@@ -2996,12 +2998,12 @@ textarea.form-control-lg {
   --bs-btn-bg: #6c757d;
   --bs-btn-border-color: #6c757d;
   --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #5c636a;
-  --bs-btn-hover-border-color: #565e64;
+  --bs-btn-hover-bg: rgb(91.8, 99.45, 106.25);
+  --bs-btn-hover-border-color: rgb(86.4, 93.6, 100);
   --bs-btn-focus-shadow-rgb: 130, 138, 145;
   --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #565e64;
-  --bs-btn-active-border-color: #51585e;
+  --bs-btn-active-bg: rgb(86.4, 93.6, 100);
+  --bs-btn-active-border-color: rgb(81, 87.75, 93.75);
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   --bs-btn-disabled-color: #fff;
   --bs-btn-disabled-bg: #6c757d;
@@ -3013,12 +3015,12 @@ textarea.form-control-lg {
   --bs-btn-bg: #3A833A;
   --bs-btn-border-color: #3A833A;
   --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #316f31;
-  --bs-btn-hover-border-color: #2e692e;
+  --bs-btn-hover-bg: rgb(49.3, 111.35, 49.3);
+  --bs-btn-hover-border-color: rgb(46.4, 104.8, 46.4);
   --bs-btn-focus-shadow-rgb: 88, 150, 88;
   --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #2e692e;
-  --bs-btn-active-border-color: #2c622c;
+  --bs-btn-active-bg: rgb(46.4, 104.8, 46.4);
+  --bs-btn-active-border-color: rgb(43.5, 98.25, 43.5);
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   --bs-btn-disabled-color: #fff;
   --bs-btn-disabled-bg: #3A833A;
@@ -3030,12 +3032,12 @@ textarea.form-control-lg {
   --bs-btn-bg: #0dcaf0;
   --bs-btn-border-color: #0dcaf0;
   --bs-btn-hover-color: #000;
-  --bs-btn-hover-bg: #31d2f2;
-  --bs-btn-hover-border-color: #25cff2;
+  --bs-btn-hover-bg: rgb(49.3, 209.95, 242.25);
+  --bs-btn-hover-border-color: rgb(37.2, 207.3, 241.5);
   --bs-btn-focus-shadow-rgb: 11, 172, 204;
   --bs-btn-active-color: #000;
-  --bs-btn-active-bg: #3dd5f3;
-  --bs-btn-active-border-color: #25cff2;
+  --bs-btn-active-bg: rgb(61.4, 212.6, 243);
+  --bs-btn-active-border-color: rgb(37.2, 207.3, 241.5);
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   --bs-btn-disabled-color: #000;
   --bs-btn-disabled-bg: #0dcaf0;
@@ -3047,12 +3049,12 @@ textarea.form-control-lg {
   --bs-btn-bg: #fd7e14;
   --bs-btn-border-color: #fd7e14;
   --bs-btn-hover-color: #000;
-  --bs-btn-hover-bg: #fd9137;
-  --bs-btn-hover-border-color: #fd8b2c;
+  --bs-btn-hover-bg: rgb(253.3, 145.35, 55.25);
+  --bs-btn-hover-border-color: rgb(253.2, 138.9, 43.5);
   --bs-btn-focus-shadow-rgb: 215, 107, 17;
   --bs-btn-active-color: #000;
-  --bs-btn-active-bg: #fd9843;
-  --bs-btn-active-border-color: #fd8b2c;
+  --bs-btn-active-bg: rgb(253.4, 151.8, 67);
+  --bs-btn-active-border-color: rgb(253.2, 138.9, 43.5);
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   --bs-btn-disabled-color: #000;
   --bs-btn-disabled-bg: #fd7e14;
@@ -3061,19 +3063,19 @@ textarea.form-control-lg {
 
 .btn-danger, .control-custom.disabled .checkbox.btn {
   --bs-btn-color: #fff;
-  --bs-btn-bg: #d43f3a;
-  --bs-btn-border-color: #d43f3a;
+  --bs-btn-bg: rgb(212.4719626168, 62.5046728972, 58.0280373832);
+  --bs-btn-border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
   --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #b43631;
-  --bs-btn-hover-border-color: #aa322e;
-  --bs-btn-focus-shadow-rgb: 218, 92, 88;
+  --bs-btn-hover-bg: rgb(180.6011682243, 53.1289719626, 49.3238317757);
+  --bs-btn-hover-border-color: rgb(169.9775700935, 50.0037383178, 46.4224299065);
+  --bs-btn-focus-shadow-rgb: 219, 91, 88;
   --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #aa322e;
-  --bs-btn-active-border-color: #9f2f2c;
+  --bs-btn-active-bg: rgb(169.9775700935, 50.0037383178, 46.4224299065);
+  --bs-btn-active-border-color: rgb(159.3539719626, 46.8785046729, 43.5210280374);
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   --bs-btn-disabled-color: #fff;
-  --bs-btn-disabled-bg: #d43f3a;
-  --bs-btn-disabled-border-color: #d43f3a;
+  --bs-btn-disabled-bg: rgb(212.4719626168, 62.5046728972, 58.0280373832);
+  --bs-btn-disabled-border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
 }
 
 .btn-light, .btn-secondary {
@@ -3081,12 +3083,12 @@ textarea.form-control-lg {
   --bs-btn-bg: #fff;
   --bs-btn-border-color: #fff;
   --bs-btn-hover-color: #000;
-  --bs-btn-hover-bg: #d9d9d9;
+  --bs-btn-hover-bg: rgb(216.75, 216.75, 216.75);
   --bs-btn-hover-border-color: #cccccc;
   --bs-btn-focus-shadow-rgb: 217, 217, 217;
   --bs-btn-active-color: #000;
   --bs-btn-active-bg: #cccccc;
-  --bs-btn-active-border-color: #bfbfbf;
+  --bs-btn-active-border-color: rgb(191.25, 191.25, 191.25);
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   --bs-btn-disabled-color: #000;
   --bs-btn-disabled-bg: #fff;
@@ -3098,12 +3100,12 @@ textarea.form-control-lg {
   --bs-btn-bg: #333333;
   --bs-btn-border-color: #333333;
   --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #525252;
-  --bs-btn-hover-border-color: #474747;
+  --bs-btn-hover-bg: rgb(81.6, 81.6, 81.6);
+  --bs-btn-hover-border-color: rgb(71.4, 71.4, 71.4);
   --bs-btn-focus-shadow-rgb: 82, 82, 82;
   --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #5c5c5c;
-  --bs-btn-active-border-color: #474747;
+  --bs-btn-active-bg: rgb(91.8, 91.8, 91.8);
+  --bs-btn-active-border-color: rgb(71.4, 71.4, 71.4);
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   --bs-btn-disabled-color: #fff;
   --bs-btn-disabled-bg: #333333;
@@ -3196,19 +3198,19 @@ textarea.form-control-lg {
 }
 
 .btn-outline-danger {
-  --bs-btn-color: #d43f3a;
-  --bs-btn-border-color: #d43f3a;
+  --bs-btn-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
+  --bs-btn-border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
   --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #d43f3a;
-  --bs-btn-hover-border-color: #d43f3a;
+  --bs-btn-hover-bg: rgb(212.4719626168, 62.5046728972, 58.0280373832);
+  --bs-btn-hover-border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
   --bs-btn-focus-shadow-rgb: 212, 63, 58;
   --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #d43f3a;
-  --bs-btn-active-border-color: #d43f3a;
+  --bs-btn-active-bg: rgb(212.4719626168, 62.5046728972, 58.0280373832);
+  --bs-btn-active-border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #d43f3a;
+  --bs-btn-disabled-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
   --bs-btn-disabled-bg: transparent;
-  --bs-btn-disabled-border-color: #d43f3a;
+  --bs-btn-disabled-border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
   --bs-gradient: none;
 }
 
@@ -3251,9 +3253,9 @@ textarea.form-control-lg {
   --bs-btn-color: #206b82;
   --bs-btn-bg: transparent;
   --bs-btn-border-color: transparent;
-  --bs-btn-hover-color: #1a5668;
+  --bs-btn-hover-color: rgb(25.6, 85.6, 104);
   --bs-btn-hover-border-color: transparent;
-  --bs-btn-active-color: #1a5668;
+  --bs-btn-active-color: rgb(25.6, 85.6, 104);
   --bs-btn-active-border-color: transparent;
   --bs-btn-disabled-color: #6c757d;
   --bs-btn-disabled-border-color: transparent;
@@ -3365,7 +3367,7 @@ textarea.form-control-lg {
   --bs-dropdown-divider-margin-y: 0.5rem;
   --bs-dropdown-box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
   --bs-dropdown-link-color: #333333;
-  --bs-dropdown-link-hover-color: #2e2e2e;
+  --bs-dropdown-link-hover-color: rgb(45.9, 45.9, 45.9);
   --bs-dropdown-link-hover-bg: #e9ecef;
   --bs-dropdown-link-active-color: #fff;
   --bs-dropdown-link-active-bg: #206b82;
@@ -3680,7 +3682,7 @@ textarea.form-control-lg {
 }
 .btn-group > :not(.btn-check:first-child) + .btn,
 .btn-group > .btn-group:not(:first-child) {
-  margin-left: calc(1px * -1);
+  margin-left: calc(-1 * 1px);
 }
 .btn-group > .btn:not(:last-child):not(.dropdown-toggle),
 .btn-group > .btn.dropdown-toggle-split:first-child,
@@ -3734,14 +3736,15 @@ textarea.form-control-lg {
 }
 .btn-group-vertical > .btn:not(:first-child),
 .btn-group-vertical > .btn-group:not(:first-child) {
-  margin-top: calc(1px * -1);
+  margin-top: calc(-1 * 1px);
 }
 .btn-group-vertical > .btn:not(:last-child):not(.dropdown-toggle),
 .btn-group-vertical > .btn-group:not(:last-child) > .btn {
   border-bottom-right-radius: 0;
   border-bottom-left-radius: 0;
 }
-.btn-group-vertical > .btn ~ .btn,
+.btn-group-vertical > .btn:nth-child(n+3),
+.btn-group-vertical > :not(.btn-check) + .btn,
 .btn-group-vertical > .btn-group:not(:first-child) > .btn {
   border-top-left-radius: 0;
   border-top-right-radius: 0;
@@ -3752,7 +3755,7 @@ textarea.form-control-lg {
   --bs-nav-link-padding-y: 0.5rem;
   --bs-nav-link-font-weight: ;
   --bs-nav-link-color: #206b82;
-  --bs-nav-link-hover-color: #1a5668;
+  --bs-nav-link-hover-color: rgb(25.6, 85.6, 104);
   --bs-nav-link-disabled-color: #6c757d;
   display: flex;
   flex-wrap: wrap;
@@ -3871,8 +3874,8 @@ textarea.form-control-lg {
 
 .nav-justified > .nav-link, .page-header .nav-tabs li .nav-justified > a,
 .nav-justified .nav-item {
-  flex-basis: 0;
   flex-grow: 1;
+  flex-basis: 0;
   text-align: center;
 }
 
@@ -3975,8 +3978,8 @@ textarea.form-control-lg {
 }
 
 .navbar-collapse {
-  flex-basis: 100%;
   flex-grow: 1;
+  flex-basis: 100%;
   align-items: center;
 }
 
@@ -4481,7 +4484,7 @@ textarea.form-control-lg {
     flex-flow: row wrap;
   }
   .card-group > .card {
-    flex: 1 0 0%;
+    flex: 1 0 0;
     margin-bottom: 0;
   }
   .card-group > .card + .card {
@@ -4492,24 +4495,24 @@ textarea.form-control-lg {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
   }
-  .card-group > .card:not(:last-child) .card-img-top,
-  .card-group > .card:not(:last-child) .card-header {
+  .card-group > .card:not(:last-child) > .card-img-top,
+  .card-group > .card:not(:last-child) > .card-header {
     border-top-right-radius: 0;
   }
-  .card-group > .card:not(:last-child) .card-img-bottom,
-  .card-group > .card:not(:last-child) .card-footer {
+  .card-group > .card:not(:last-child) > .card-img-bottom,
+  .card-group > .card:not(:last-child) > .card-footer {
     border-bottom-right-radius: 0;
   }
   .card-group > .card:not(:first-child) {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-  .card-group > .card:not(:first-child) .card-img-top,
-  .card-group > .card:not(:first-child) .card-header {
+  .card-group > .card:not(:first-child) > .card-img-top,
+  .card-group > .card:not(:first-child) > .card-header {
     border-top-left-radius: 0;
   }
-  .card-group > .card:not(:first-child) .card-img-bottom,
-  .card-group > .card:not(:first-child) .card-footer {
+  .card-group > .card:not(:first-child) > .card-img-bottom,
+  .card-group > .card:not(:first-child) > .card-footer {
     border-bottom-left-radius: 0;
   }
 }
@@ -4530,12 +4533,12 @@ textarea.form-control-lg {
   --bs-accordion-btn-icon-width: 1.25rem;
   --bs-accordion-btn-icon-transform: rotate(-180deg);
   --bs-accordion-btn-icon-transition: transform 0.2s ease-in-out;
-  --bs-accordion-btn-active-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%231d6075'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
+  --bs-accordion-btn-active-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='rgb%2828.8, 96.3, 117%29'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
   --bs-accordion-btn-focus-box-shadow: 0 0 0 0.25rem rgba(32, 107, 130, 0.25);
   --bs-accordion-body-padding-x: 1.25rem;
   --bs-accordion-body-padding-y: 1rem;
-  --bs-accordion-active-color: #1d6075;
-  --bs-accordion-active-bg: #e9f0f3;
+  --bs-accordion-active-color: rgb(28.8, 96.3, 117);
+  --bs-accordion-active-bg: rgb(232.7, 240.2, 242.5);
 }
 
 .accordion-button {
@@ -4640,16 +4643,15 @@ textarea.form-control-lg {
 .accordion-flush > .accordion-item:last-child {
   border-bottom: 0;
 }
-.accordion-flush > .accordion-item > .accordion-header .accordion-button, .accordion-flush > .accordion-item > .accordion-header .accordion-button.collapsed {
-  border-radius: 0;
-}
-.accordion-flush > .accordion-item > .accordion-collapse {
+.accordion-flush > .accordion-item > .accordion-collapse,
+.accordion-flush > .accordion-item > .accordion-header .accordion-button,
+.accordion-flush > .accordion-item > .accordion-header .accordion-button.collapsed {
   border-radius: 0;
 }
 
 [data-bs-theme=dark] .accordion-button::after {
-  --bs-accordion-btn-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%2379a6b4'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
-  --bs-accordion-btn-active-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%2379a6b4'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
+  --bs-accordion-btn-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='rgb%28121.2, 166.2, 180%29'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708'/%3e%3c/svg%3e");
+  --bs-accordion-btn-active-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='rgb%28121.2, 166.2, 180%29'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708'/%3e%3c/svg%3e");
 }
 
 .breadcrumb {
@@ -4693,10 +4695,10 @@ textarea.form-control-lg {
   --bs-pagination-border-width: 1px;
   --bs-pagination-border-color: #dee2e6;
   --bs-pagination-border-radius: 0.25rem;
-  --bs-pagination-hover-color: #1a5668;
+  --bs-pagination-hover-color: rgb(25.6, 85.6, 104);
   --bs-pagination-hover-bg: #e9ecef;
   --bs-pagination-hover-border-color: #dee2e6;
-  --bs-pagination-focus-color: #1a5668;
+  --bs-pagination-focus-color: rgb(25.6, 85.6, 104);
   --bs-pagination-focus-bg: #e9ecef;
   --bs-pagination-focus-box-shadow: 0 0 0 0.25rem rgba(32, 107, 130, 0.25);
   --bs-pagination-active-color: #fff;
@@ -4897,7 +4899,7 @@ textarea.form-control-lg {
 
 @keyframes progress-bar-stripes {
   0% {
-    background-position-x: 1rem;
+    background-position-x: var(--bs-progress-height);
   }
 }
 .progress,
@@ -4992,22 +4994,6 @@ textarea.form-control-lg {
   counter-increment: section;
 }
 
-.list-group-item-action {
-  width: 100%;
-  color: var(--bs-list-group-action-color);
-  text-align: inherit;
-}
-.list-group-item-action:hover, .list-group-item-action:focus {
-  z-index: 1;
-  color: var(--bs-list-group-action-hover-color);
-  text-decoration: none;
-  background-color: var(--bs-list-group-action-hover-bg);
-}
-.list-group-item-action:active {
-  color: var(--bs-list-group-action-active-color);
-  background-color: var(--bs-list-group-action-active-bg);
-}
-
 .list-group-item {
   position: relative;
   display: block;
@@ -5041,6 +5027,22 @@ textarea.form-control-lg {
 .list-group-item + .list-group-item.active {
   margin-top: calc(-1 * var(--bs-list-group-border-width));
   border-top-width: var(--bs-list-group-border-width);
+}
+
+.list-group-item-action {
+  width: 100%;
+  color: var(--bs-list-group-action-color);
+  text-align: inherit;
+}
+.list-group-item-action:not(.active):hover, .list-group-item-action:not(.active):focus {
+  z-index: 1;
+  color: var(--bs-list-group-action-hover-color);
+  text-decoration: none;
+  background-color: var(--bs-list-group-action-hover-bg);
+}
+.list-group-item-action:not(.active):active {
+  color: var(--bs-list-group-action-active-color);
+  background-color: var(--bs-list-group-action-active-bg);
 }
 
 .list-group-horizontal {
@@ -5308,13 +5310,13 @@ textarea.form-control-lg {
   --bs-btn-close-focus-shadow: 0 0 0 0.25rem rgba(32, 107, 130, 0.25);
   --bs-btn-close-focus-opacity: 1;
   --bs-btn-close-disabled-opacity: 0.25;
-  --bs-btn-close-white-filter: invert(1) grayscale(100%) brightness(200%);
   box-sizing: content-box;
   width: 1em;
   height: 1em;
   padding: 0.25em 0.25em;
   color: var(--bs-btn-close-color);
   background: transparent var(--bs-btn-close-bg) center/1em auto no-repeat;
+  filter: var(--bs-btn-close-filter);
   border: 0;
   border-radius: 0.25rem;
   opacity: var(--bs-btn-close-opacity);
@@ -5336,11 +5338,16 @@ textarea.form-control-lg {
 }
 
 .btn-close-white {
-  filter: var(--bs-btn-close-white-filter);
+  --bs-btn-close-filter: invert(1) grayscale(100%) brightness(200%);
 }
 
-[data-bs-theme=dark] .btn-close {
-  filter: var(--bs-btn-close-white-filter);
+:root,
+[data-bs-theme=light] {
+  --bs-btn-close-filter: ;
+}
+
+[data-bs-theme=dark] {
+  --bs-btn-close-filter: invert(1) grayscale(100%) brightness(200%);
 }
 
 .toast {
@@ -5415,7 +5422,7 @@ textarea.form-control-lg {
   --bs-modal-width: 500px;
   --bs-modal-padding: 1rem;
   --bs-modal-margin: 0.5rem;
-  --bs-modal-color: ;
+  --bs-modal-color: var(--bs-body-color);
   --bs-modal-bg: #fff;
   --bs-modal-border-color: rgba(0, 0, 0, 0.2);
   --bs-modal-border-width: 1px;
@@ -5451,8 +5458,8 @@ textarea.form-control-lg {
   pointer-events: none;
 }
 .modal.fade .modal-dialog {
-  transition: transform 0.3s ease-out;
   transform: translate(0, -50px);
+  transition: transform 0.3s ease-out;
 }
 @media (prefers-reduced-motion: reduce) {
   .modal.fade .modal-dialog {
@@ -5528,7 +5535,10 @@ textarea.form-control-lg {
 }
 .modal-header .btn-close {
   padding: calc(var(--bs-modal-header-padding-y) * 0.5) calc(var(--bs-modal-header-padding-x) * 0.5);
-  margin: calc(-0.5 * var(--bs-modal-header-padding-y)) calc(-0.5 * var(--bs-modal-header-padding-x)) calc(-0.5 * var(--bs-modal-header-padding-y)) auto;
+  margin-top: calc(-0.5 * var(--bs-modal-header-padding-y));
+  margin-right: calc(-0.5 * var(--bs-modal-header-padding-x));
+  margin-bottom: calc(-0.5 * var(--bs-modal-header-padding-y));
+  margin-left: auto;
 }
 
 .modal-title {
@@ -5818,7 +5828,7 @@ textarea.form-control-lg {
   --bs-popover-header-padding-y: 0.5rem;
   --bs-popover-header-font-size: 0.875rem;
   --bs-popover-header-color: inherit;
-  --bs-popover-header-bg: #f0f0f0;
+  --bs-popover-header-bg: rgb(239.7, 239.7, 239.7);
   --bs-popover-body-padding-x: 1rem;
   --bs-popover-body-padding-y: 1rem;
   --bs-popover-body-color: #333333;
@@ -6049,6 +6059,7 @@ textarea.form-control-lg {
   color: #fff;
   text-align: center;
   background: none;
+  filter: var(--bs-carousel-control-icon-filter);
   border: 0;
   opacity: 0.5;
   transition: opacity 0.15s ease;
@@ -6117,7 +6128,7 @@ textarea.form-control-lg {
   margin-left: 3px;
   text-indent: -999px;
   cursor: pointer;
-  background-color: #fff;
+  background-color: var(--bs-carousel-indicator-active-bg);
   background-clip: padding-box;
   border: 0;
   border-top: 10px solid transparent;
@@ -6141,36 +6152,33 @@ textarea.form-control-lg {
   left: 15%;
   padding-top: 1.25rem;
   padding-bottom: 1.25rem;
-  color: #fff;
+  color: var(--bs-carousel-caption-color);
   text-align: center;
 }
 
-.carousel-dark .carousel-control-prev-icon,
-.carousel-dark .carousel-control-next-icon {
-  filter: invert(1) grayscale(100);
-}
-.carousel-dark .carousel-indicators [data-bs-target] {
-  background-color: #000;
-}
-.carousel-dark .carousel-caption {
-  color: #000;
+.carousel-dark {
+  --bs-carousel-indicator-active-bg: #000;
+  --bs-carousel-caption-color: #000;
+  --bs-carousel-control-icon-filter: invert(1) grayscale(100);
 }
 
-[data-bs-theme=dark] .carousel .carousel-control-prev-icon,
-[data-bs-theme=dark] .carousel .carousel-control-next-icon, [data-bs-theme=dark].carousel .carousel-control-prev-icon,
-[data-bs-theme=dark].carousel .carousel-control-next-icon {
-  filter: invert(1) grayscale(100);
+:root,
+[data-bs-theme=light] {
+  --bs-carousel-indicator-active-bg: #fff;
+  --bs-carousel-caption-color: #fff;
+  --bs-carousel-control-icon-filter: ;
 }
-[data-bs-theme=dark] .carousel .carousel-indicators [data-bs-target], [data-bs-theme=dark].carousel .carousel-indicators [data-bs-target] {
-  background-color: #000;
-}
-[data-bs-theme=dark] .carousel .carousel-caption, [data-bs-theme=dark].carousel .carousel-caption {
-  color: #000;
+
+[data-bs-theme=dark] {
+  --bs-carousel-indicator-active-bg: #000;
+  --bs-carousel-caption-color: #000;
+  --bs-carousel-control-icon-filter: invert(1) grayscale(100);
 }
 
 .spinner-grow,
 .spinner-border {
   display: inline-block;
+  flex-shrink: 0;
   width: var(--bs-spinner-width);
   height: var(--bs-spinner-height);
   vertical-align: var(--bs-spinner-vertical-align);
@@ -6721,7 +6729,10 @@ textarea.form-control-lg {
 }
 .offcanvas-header .btn-close {
   padding: calc(var(--bs-offcanvas-padding-y) * 0.5) calc(var(--bs-offcanvas-padding-x) * 0.5);
-  margin: calc(-0.5 * var(--bs-offcanvas-padding-y)) calc(-0.5 * var(--bs-offcanvas-padding-x)) calc(-0.5 * var(--bs-offcanvas-padding-y)) auto;
+  margin-top: calc(-0.5 * var(--bs-offcanvas-padding-y));
+  margin-right: calc(-0.5 * var(--bs-offcanvas-padding-x));
+  margin-bottom: calc(-0.5 * var(--bs-offcanvas-padding-y));
+  margin-left: auto;
 }
 
 .offcanvas-title {
@@ -7041,6 +7052,10 @@ textarea.form-control-lg {
 .visually-hidden:not(caption),
 .visually-hidden-focusable:not(:focus):not(:focus-within):not(caption) {
   position: absolute !important;
+}
+.visually-hidden *,
+.visually-hidden-focusable:not(:focus):not(:focus-within) * {
+  overflow: hidden !important;
 }
 
 .stretched-link::after {
@@ -11856,7 +11871,7 @@ h6, .h6, h5, .h5, h4, .h4, h3, .h3, h2, .h2, h1, .h1 {
   color: #111;
   background-color: #f6f6f6;
   padding: 1px 10px;
-  border: 1px solid #dddddd;
+  border: 1px solid rgb(220.5, 220.5, 220.5);
   border-radius: 100px;
   box-shadow: inset 0 1px 0 white;
 }
@@ -11865,13 +11880,13 @@ a.tag:hover {
   text-decoration: none;
   color: #fff;
   background-color: #30778d;
-  border: 1px solid #235767;
-  box-shadow: inset 0 1px 0 #3d97b3;
+  border: 1px solid rgb(35.0476190476, 86.8888888889, 102.9523809524);
+  box-shadow: inset 0 1px 0 rgb(60.9523809524, 151.1111111111, 179.0476190476);
 }
 
 .pill {
   display: inline-block;
-  background-color: #4e5f65;
+  background-color: rgb(77.8260869565, 94.947826087, 101.1739130435);
   color: #FFF;
   padding: 2px 10px 1px 10px;
   margin-right: 5px;
@@ -11928,6 +11943,11 @@ a.tag:hover {
   padding-top: 1.5rem;
 }
 
+.module-heading::after {
+  display: block;
+  clear: both;
+  content: "";
+}
 .module-heading {
   margin: 0;
   padding: 0.5rem 25px;
@@ -11936,11 +11956,6 @@ a.tag:hover {
   background-color: #f6f6f6;
   border-top: 1px solid #ddd;
   border-bottom: 1px solid #ddd;
-}
-.module-heading::after {
-  display: block;
-  clear: both;
-  content: "";
 }
 
 .module-content {
@@ -12078,10 +12093,6 @@ a.tag:hover {
   padding-bottom: 8px;
 }
 
-.no-nav .module:last-child {
-  margin-top: 0;
-}
-
 .module-image {
   float: left;
   width: 50px;
@@ -12099,17 +12110,19 @@ a.tag:hover {
 .media-grid, .module-grid {
   margin: 0;
   list-style: none;
-  padding-left: 0px;
-  min-height: 205px;
-  padding-top: 0.75rem;
-  background: #fbfbfb url("../../../base/images/bg.png");
-  border: 1px solid #ddd;
-  border-width: 1px 0;
 }
 .media-grid::after, .module-grid::after {
   display: block;
   clear: both;
   content: "";
+}
+.media-grid, .module-grid {
+  padding-left: 0px;
+  min-height: 205px;
+  padding-top: 0.75rem;
+  background: rgb(250.75, 250.75, 250.75) url("../../../base/images/bg.png");
+  border: 1px solid #ddd;
+  border-width: 1px 0;
 }
 
 .media-item, .module-item {
@@ -12155,12 +12168,14 @@ a.tag:hover {
   border: 1px solid #ddd;
   overflow: hidden;
   transition: all 0.2s ease-in;
-  border-radius: 3px;
 }
 @media (prefers-reduced-motion: reduce) {
   .media-view {
     transition: none;
   }
+}
+.media-view {
+  border-radius: 3px;
 }
 .media-view:hover, .media-view.hovered {
   border-color: #005d7a;
@@ -12224,16 +12239,18 @@ a.tag:hover {
 
 .media-item.is-expander .truncator-link, .is-expander.module-item .truncator-link {
   transition: opacity 0.2s ease-in;
-  position: absolute;
-  z-index: 10;
-  left: 15px;
-  bottom: 15px;
-  opacity: 0;
 }
 @media (prefers-reduced-motion: reduce) {
   .media-item.is-expander .truncator-link, .is-expander.module-item .truncator-link {
     transition: none;
   }
+}
+.media-item.is-expander .truncator-link, .is-expander.module-item .truncator-link {
+  position: absolute;
+  z-index: 10;
+  left: 15px;
+  bottom: 15px;
+  opacity: 0;
 }
 .media-item.is-expander:hover, .is-expander.module-item:hover {
   padding-bottom: 35px;
@@ -12246,18 +12263,16 @@ a.tag:hover {
   width: 186px;
 }
 
-.nav-simple,
-.nav-aside {
-  margin: 0;
-  list-style: none;
-  padding-bottom: 0;
-  display: block;
-}
 .nav-simple::after,
 .nav-aside::after {
   display: block;
   clear: both;
   content: "";
+}
+.nav-simple,
+.nav-aside {
+  margin: 0;
+  list-style: none;
 }
 .nav-simple > li,
 .nav-aside > li {
@@ -12269,6 +12284,11 @@ a.tag:hover {
 .nav-simple > li:last-of-type,
 .nav-aside > li:last-of-type {
   border-bottom: 0;
+}
+.nav-simple,
+.nav-aside {
+  padding-bottom: 0;
+  display: block;
 }
 
 .nav-aside {
@@ -12794,16 +12814,18 @@ select[data-module=autocomplete] {
 .stages {
   margin: 0;
   list-style: none;
-  color: #aeaeae;
-  counter-reset: stage;
-  overflow: hidden;
-  margin-bottom: 1.5rem;
-  padding: 0;
 }
 .stages::after {
   display: block;
   clear: both;
   content: "";
+}
+.stages {
+  color: #aeaeae;
+  counter-reset: stage;
+  overflow: hidden;
+  margin-bottom: 1.5rem;
+  padding: 0;
 }
 .stages li {
   line-height: 27px;
@@ -12974,13 +12996,15 @@ select[data-module=autocomplete] {
   border-radius: 3px;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   transition: border linear 0.2s, box-shadow linear 0.2s;
-  background-color: #fff;
-  border: 1px solid #ccc;
 }
 @media (prefers-reduced-motion: reduce) {
   .select2-container-multi .select2-choices {
     transition: none;
   }
+}
+.select2-container-multi .select2-choices {
+  background-color: #fff;
+  border: 1px solid #ccc;
 }
 
 .select2-container-active .select2-choices,
@@ -13611,21 +13635,26 @@ td.diff_header {
   max-width: 85px;
 }
 
-.toolbar {
-  position: relative;
-  margin-bottom: 10px;
-  padding: 5px 0;
-}
 .toolbar::after {
   display: block;
   clear: both;
   content: "";
+}
+.toolbar {
+  position: relative;
+  margin-bottom: 10px;
+  padding: 5px 0;
 }
 
 .page_primary_action {
   margin-bottom: 20px;
 }
 
+.toolbar .breadcrumb::after {
+  display: block;
+  clear: both;
+  content: "";
+}
 .toolbar .breadcrumb {
   box-shadow: none;
   position: relative;
@@ -13635,11 +13664,6 @@ td.diff_header {
   border: none;
   background: none;
   font-size: 1.09375rem;
-}
-.toolbar .breadcrumb::after {
-  display: block;
-  clear: both;
-  content: "";
 }
 
 .toolbar .breadcrumb li {
@@ -13704,20 +13728,22 @@ td.diff_header {
   display: none;
 }
 
-.page-header {
-  margin-top: 1.5rem;
-  border-bottom: 1px solid #ddd;
-  background-color: #f6f6f6;
-  border-radius: 0 3px 0 0;
-}
 .page-header.module-content {
   padding-top: 0.75rem;
   padding-bottom: 0;
+}
+.page-header {
+  margin-top: 1.5rem;
 }
 .page-header::after {
   display: block;
   clear: both;
   content: "";
+}
+.page-header {
+  border-bottom: 1px solid #ddd;
+  background-color: #f6f6f6;
+  border-radius: 0 3px 0 0;
 }
 .page-header .nav-tabs {
   float: left;
@@ -13737,7 +13763,7 @@ td.diff_header {
   margin-top: -3px;
 }
 
-.no-nav .page-header {
+.wrapper:not(:has(> .secondary)) .page-header {
   border-radius: 3px 3px 0 0;
 }
 
@@ -13784,39 +13810,20 @@ td.diff_header {
   white-space: nowrap;
 }
 
-.wrapper {
-  position: relative;
-  min-height: 300px;
-  background-color: #fff;
-}
 .wrapper::after {
   display: block;
   clear: both;
   content: "";
 }
-@media (min-width: 768px) {
-  .wrapper:before {
-    content: "";
-    display: block;
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    width: 25%;
-    border-right: 1px solid #ddd;
-    z-index: 1;
-  }
-  .wrapper.no-nav:before {
-    display: none;
-  }
-  .wrapper.no-nav .module > .page-header {
-    margin-top: 0;
-  }
-}
-
-[role=main],
-.main {
+.wrapper {
   position: relative;
+  min-height: 300px;
+  background-color: #fff;
+}
+@media (min-width: 768px) {
+  .wrapper .primary + .secondary, .wrapper .secondary + .primary {
+    border-inline-start: 1px solid #ddd;
+  }
 }
 
 .main {
@@ -13824,22 +13831,9 @@ td.diff_header {
   background: #eee url("../../../base/images/bg.png");
 }
 
-.main:after,
-[role=main]:after {
-  bottom: 0;
-  border-top-width: 1px;
-}
-
-.main .primary {
-  position: relative;
-  float: right;
-  margin-left: 0;
-}
-
 .main .secondary {
   padding: 0;
   z-index: 1;
-  padding-right: 1px;
 }
 
 /* Filters modal */
@@ -13949,7 +13943,7 @@ td.diff_header {
   background-image: linear-gradient(top, rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0));
   background-repeat: repeat-x;
   background-color: #f6f6f6;
-  border-bottom: 1px solid #d0d0d0;
+  border-bottom: 1px solid rgb(208.25, 208.25, 208.25);
   border-radius: 3px 3px 0 0;
   box-shadow: inset 0 -4px 0 rgba(0, 0, 0, 0.03);
 }
@@ -13985,8 +13979,7 @@ td.diff_header {
   margin: 0;
   overflow: auto;
 }
-.context-info h1.heading, .context-info .heading.h1,
-.context-info h2.heading, .context-info .heading.h2 {
+.context-info h1.heading, .context-info .heading.h1 {
   margin: 0 0 5px 0;
   font-size: 18px;
   line-height: 1.3;
@@ -14009,17 +14002,17 @@ td.diff_header {
   margin-top: 3px;
   margin-left: 0;
 }
+.context-info .nums::after {
+  display: block;
+  clear: both;
+  content: "";
+}
 .context-info .nums {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
   padding-top: 10px;
   border-top: 1px dotted #DDD;
-}
-.context-info .nums::after {
-  display: block;
-  clear: both;
-  content: "";
 }
 .context-info .nums dl {
   color: #444;
@@ -14078,16 +14071,16 @@ td.diff_header {
   margin-left: -30px;
   align-items: center;
 }
-.homepage .module-search .tags {
-  margin-top: -5px;
-  padding: 5px 10px 10px 10px;
-  background-color: #003647;
-}
 .homepage .module-search .tags h3, .homepage .module-search .tags .h3 {
   font-size: 0.875rem;
   line-height: 1.5;
   padding: 2px 8px;
   margin-top: -5px;
+}
+.homepage .module-search .tags {
+  margin-top: -5px;
+  padding: 5px 10px 10px 10px;
+  background-color: rgb(0, 54.1229508197, 71);
 }
 .homepage .module-search .tags h3, .homepage .module-search .tags .h3,
 .homepage .module-search .tags .tag {
@@ -14112,7 +14105,7 @@ td.diff_header {
 .account-masthead {
   min-height: 30px;
   color: #fff;
-  background: #003647 url("../../../base/images/bg.png");
+  background: rgb(0, 54.1229508197, 71) url("../../../base/images/bg.png");
 }
 .account-masthead .account {
   float: right;
@@ -14120,12 +14113,12 @@ td.diff_header {
 .account-masthead .account ul li {
   display: block;
   float: left;
-  border-left: 1px solid #00232e;
+  border-left: 1px solid rgb(0, 34.6844262295, 45.5);
 }
 .account-masthead .account ul li a {
   display: block;
   text-decoration: none;
-  color: #bfd7de;
+  color: rgb(191.25, 214.5, 221.75);
   font-size: 13px;
   font-weight: bold;
   padding: 0 10px;
@@ -14141,8 +14134,8 @@ td.diff_header {
   left: -9999px;
 }
 .account-masthead .account ul li a:hover {
-  color: #d9e7eb;
-  background-color: #00232e;
+  color: rgb(216.75, 230.7, 235.05);
+  background-color: rgb(0, 34.6844262295, 45.5);
   text-decoration: none;
 }
 .account-masthead .account ul li a.sub {
@@ -14156,14 +14149,14 @@ td.diff_header {
   font-size: 12px;
   margin-left: 3px;
   padding: 1px 6px;
-  background-color: #00232e;
+  background-color: rgb(0, 34.6844262295, 45.5);
   border-radius: 4px;
   text-shadow: none;
-  color: #bfd7de;
+  color: rgb(191.25, 214.5, 221.75);
 }
 .account-masthead .account .notifications a:hover span {
   color: #fff;
-  background-color: #000f14;
+  background-color: rgb(0, 15.2459016393, 20);
 }
 .account-masthead .account .notifications.notifications-important a span.badge {
   color: #fff;
@@ -14232,7 +14225,7 @@ td.diff_header {
 }
 .masthead .main-navbar ul li:hover a, .masthead .main-navbar ul li:focus a, .masthead .main-navbar ul li.active a {
   border-radius: 0.3rem;
-  background-color: #003647;
+  background-color: rgb(0, 54.1229508197, 71);
 }
 .masthead .main-navbar .site-search button {
   display: flex;
@@ -14300,13 +14293,13 @@ td.diff_header {
   background: url("../../../base/images/ckan-logo-footer.png") no-repeat top left;
   text-indent: -900em;
 }
+.site-footer .lang-select .form-group label {
+  font-size: 0.875rem;
+}
 .site-footer .lang-select .form-group {
   width: 100%;
   display: flex;
   flex-direction: column;
-}
-.site-footer .lang-select .form-group label {
-  font-size: 0.875rem;
 }
 
 .table-selected td {
@@ -14416,17 +14409,19 @@ td.diff_header {
 
 .followee-container {
   padding: 0;
-  padding: 0;
-  margin: 0;
-  max-height: 205px;
-  overflow: auto;
-  border-radius: 0 0 3px 3px;
 }
 .followee-container .popover-title {
   display: none;
 }
 .followee-container .empty {
   padding: 10px;
+}
+.followee-container {
+  padding: 0;
+  margin: 0;
+  max-height: 205px;
+  overflow: auto;
+  border-radius: 0 0 3px 3px;
 }
 .followee-container li i {
   margin-right: 11px;
@@ -14446,13 +14441,13 @@ td.diff_header {
   box-shadow: inset 0 1px 2x rgba(0, 0, 0, 0.2);
 }
 
-.dashboard-me {
-  padding: 15px 15px 0 15px;
-}
 .dashboard-me::after {
   display: block;
   clear: both;
   content: "";
+}
+.dashboard-me {
+  padding: 15px 15px 0 15px;
 }
 .dashboard-me img {
   float: left;
@@ -14923,15 +14918,6 @@ td.diff_header {
     width: 0%;
   }
 }
-@media (min-width: 576px) {
-  .wrapper:before {
-    left: initial;
-    right: 0;
-    width: 25%;
-    border-left: 1px solid #ddd;
-  }
-}
-
 .simple-input .field .btn-search {
   right: initial;
   left: 0;

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -34,7 +34,7 @@
   --bs-success: #3A833A;
   --bs-info: #0dcaf0;
   --bs-warning: #fd7e14;
-  --bs-danger: #d43f3a;
+  --bs-danger: rgb(212.4719626168, 62.5046728972, 58.0280373832);
   --bs-light: #fff;
   --bs-dark: #333333;
   --bs-primary-rgb: 32, 107, 130;
@@ -45,28 +45,28 @@
   --bs-danger-rgb: 212, 63, 58;
   --bs-light-rgb: 255, 255, 255;
   --bs-dark-rgb: 51, 51, 51;
-  --bs-primary-text-emphasis: #0d2b34;
-  --bs-secondary-text-emphasis: #2b2f32;
-  --bs-success-text-emphasis: #173417;
-  --bs-info-text-emphasis: #055160;
-  --bs-warning-text-emphasis: #653208;
-  --bs-danger-text-emphasis: #551917;
+  --bs-primary-text-emphasis: rgb(12.8, 42.8, 52);
+  --bs-secondary-text-emphasis: rgb(43.2, 46.8, 50);
+  --bs-success-text-emphasis: rgb(23.2, 52.4, 23.2);
+  --bs-info-text-emphasis: rgb(5.2, 80.8, 96);
+  --bs-warning-text-emphasis: rgb(101.2, 50.4, 8);
+  --bs-danger-text-emphasis: rgb(84.9887850467, 25.0018691589, 23.2112149533);
   --bs-light-text-emphasis: #495057;
   --bs-dark-text-emphasis: #495057;
-  --bs-primary-bg-subtle: #d2e1e6;
-  --bs-secondary-bg-subtle: #e2e3e5;
-  --bs-success-bg-subtle: #d8e6d8;
-  --bs-info-bg-subtle: #cff4fc;
-  --bs-warning-bg-subtle: #ffe5d0;
-  --bs-danger-bg-subtle: #f6d9d8;
-  --bs-light-bg-subtle: #fcfcfd;
+  --bs-primary-bg-subtle: rgb(210.4, 225.4, 230);
+  --bs-secondary-bg-subtle: rgb(225.6, 227.4, 229);
+  --bs-success-bg-subtle: rgb(215.6, 230.2, 215.6);
+  --bs-info-bg-subtle: rgb(206.6, 244.4, 252);
+  --bs-warning-bg-subtle: rgb(254.6, 229.2, 208);
+  --bs-danger-bg-subtle: rgb(246.4943925234, 216.5009345794, 215.6056074766);
+  --bs-light-bg-subtle: rgb(251.5, 252, 252.5);
   --bs-dark-bg-subtle: #ced4da;
-  --bs-primary-border-subtle: #a6c4cd;
-  --bs-secondary-border-subtle: #c4c8cb;
-  --bs-success-border-subtle: #b0cdb0;
-  --bs-info-border-subtle: #9eeaf9;
-  --bs-warning-border-subtle: #fecba1;
-  --bs-danger-border-subtle: #eeb2b0;
+  --bs-primary-border-subtle: rgb(165.8, 195.8, 205);
+  --bs-secondary-border-subtle: rgb(196.2, 199.8, 203);
+  --bs-success-border-subtle: rgb(176.2, 205.4, 176.2);
+  --bs-info-border-subtle: rgb(158.2, 233.8, 249);
+  --bs-warning-border-subtle: rgb(254.2, 203.4, 161);
+  --bs-danger-border-subtle: rgb(237.9887850467, 178.0018691589, 176.2112149533);
   --bs-light-border-subtle: #e9ecef;
   --bs-dark-border-subtle: #adb5bd;
   --bs-white-rgb: 255, 255, 255;
@@ -96,7 +96,7 @@
   --bs-link-color: #206b82;
   --bs-link-color-rgb: 32, 107, 130;
   --bs-link-decoration: none;
-  --bs-link-hover-color: #1a5668;
+  --bs-link-hover-color: rgb(25.6, 85.6, 104);
   --bs-link-hover-color-rgb: 26, 86, 104;
   --bs-link-hover-decoration: underline;
   --bs-code-color: #d63384;
@@ -122,8 +122,8 @@
   --bs-focus-ring-color: rgba(32, 107, 130, 0.25);
   --bs-form-valid-color: #3A833A;
   --bs-form-valid-border-color: #3A833A;
-  --bs-form-invalid-color: #d43f3a;
-  --bs-form-invalid-border-color: #d43f3a;
+  --bs-form-invalid-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
+  --bs-form-invalid-border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
 }
 
 [data-bs-theme=dark] {
@@ -140,46 +140,46 @@
   --bs-secondary-bg-rgb: 52, 58, 64;
   --bs-tertiary-color: rgba(222, 226, 230, 0.5);
   --bs-tertiary-color-rgb: 222, 226, 230;
-  --bs-tertiary-bg: #34373a;
+  --bs-tertiary-bg: rgb(51.5, 54.5, 57.5);
   --bs-tertiary-bg-rgb: 52, 55, 58;
-  --bs-primary-text-emphasis: #79a6b4;
-  --bs-secondary-text-emphasis: #a7acb1;
-  --bs-success-text-emphasis: #89b589;
-  --bs-info-text-emphasis: #6edff6;
-  --bs-warning-text-emphasis: #feb272;
-  --bs-danger-text-emphasis: #e58c89;
+  --bs-primary-text-emphasis: rgb(121.2, 166.2, 180);
+  --bs-secondary-text-emphasis: rgb(166.8, 172.2, 177);
+  --bs-success-text-emphasis: rgb(136.8, 180.6, 136.8);
+  --bs-info-text-emphasis: rgb(109.8, 223.2, 246);
+  --bs-warning-text-emphasis: rgb(253.8, 177.6, 114);
+  --bs-danger-text-emphasis: rgb(229.4831775701, 139.5028037383, 136.8168224299);
   --bs-light-text-emphasis: #f8f9fa;
   --bs-dark-text-emphasis: #dee2e6;
-  --bs-primary-bg-subtle: #06151a;
-  --bs-secondary-bg-subtle: #161719;
-  --bs-success-bg-subtle: #0c1a0c;
-  --bs-info-bg-subtle: #032830;
-  --bs-warning-bg-subtle: #331904;
-  --bs-danger-bg-subtle: #2a0d0c;
+  --bs-primary-bg-subtle: rgb(6.4, 21.4, 26);
+  --bs-secondary-bg-subtle: rgb(21.6, 23.4, 25);
+  --bs-success-bg-subtle: rgb(11.6, 26.2, 11.6);
+  --bs-info-bg-subtle: rgb(2.6, 40.4, 48);
+  --bs-warning-bg-subtle: rgb(50.6, 25.2, 4);
+  --bs-danger-bg-subtle: rgb(42.4943925234, 12.5009345794, 11.6056074766);
   --bs-light-bg-subtle: #343a40;
   --bs-dark-bg-subtle: #1a1d20;
-  --bs-primary-border-subtle: #13404e;
-  --bs-secondary-border-subtle: #41464b;
-  --bs-success-border-subtle: #234f23;
-  --bs-info-border-subtle: #087990;
-  --bs-warning-border-subtle: #984c0c;
-  --bs-danger-border-subtle: #7f2623;
+  --bs-primary-border-subtle: rgb(19.2, 64.2, 78);
+  --bs-secondary-border-subtle: rgb(64.8, 70.2, 75);
+  --bs-success-border-subtle: rgb(34.8, 78.6, 34.8);
+  --bs-info-border-subtle: rgb(7.8, 121.2, 144);
+  --bs-warning-border-subtle: rgb(151.8, 75.6, 12);
+  --bs-danger-border-subtle: rgb(127.4831775701, 37.5028037383, 34.8168224299);
   --bs-light-border-subtle: #495057;
   --bs-dark-border-subtle: #343a40;
   --bs-heading-color: inherit;
-  --bs-link-color: #79a6b4;
-  --bs-link-hover-color: #94b8c3;
+  --bs-link-color: rgb(121.2, 166.2, 180);
+  --bs-link-hover-color: rgb(147.96, 183.96, 195);
   --bs-link-color-rgb: 121, 166, 180;
   --bs-link-hover-color-rgb: 148, 184, 195;
-  --bs-code-color: #e685b5;
+  --bs-code-color: rgb(230.4, 132.6, 181.2);
   --bs-highlight-color: #dee2e6;
-  --bs-highlight-bg: #653208;
+  --bs-highlight-bg: rgb(101.2, 50.4, 8);
   --bs-border-color: #495057;
   --bs-border-color-translucent: rgba(255, 255, 255, 0.15);
-  --bs-form-valid-color: #89b589;
-  --bs-form-valid-border-color: #89b589;
-  --bs-form-invalid-color: #e89895;
-  --bs-form-invalid-border-color: #e89895;
+  --bs-form-valid-color: rgb(136.8, 180.6, 136.8);
+  --bs-form-valid-border-color: rgb(136.8, 180.6, 136.8);
+  --bs-form-invalid-color: rgb(232.2, 151.8, 149.4);
+  --bs-form-invalid-border-color: rgb(232.2, 151.8, 149.4);
 }
 
 *,
@@ -513,8 +513,8 @@ legend {
   width: 100%;
   padding: 0;
   margin-bottom: 0.5rem;
-  font-size: calc(1.275rem + 0.3vw);
   line-height: inherit;
+  font-size: calc(1.275rem + 0.3vw);
 }
 @media (min-width: 1200px) {
   legend {
@@ -542,6 +542,10 @@ legend + * {
 [type=search] {
   -webkit-appearance: textfield;
   outline-offset: -2px;
+}
+[type=search]::-webkit-search-cancel-button {
+  cursor: pointer;
+  filter: grayscale(1);
 }
 
 /* rtl:raw:
@@ -592,9 +596,9 @@ progress {
 }
 
 .display-1 {
-  font-size: calc(1.625rem + 4.5vw);
   font-weight: 300;
   line-height: 1.2;
+  font-size: calc(1.625rem + 4.5vw);
 }
 @media (min-width: 1200px) {
   .display-1 {
@@ -603,9 +607,9 @@ progress {
 }
 
 .display-2 {
-  font-size: calc(1.575rem + 3.9vw);
   font-weight: 300;
   line-height: 1.2;
+  font-size: calc(1.575rem + 3.9vw);
 }
 @media (min-width: 1200px) {
   .display-2 {
@@ -614,9 +618,9 @@ progress {
 }
 
 .display-3 {
-  font-size: calc(1.525rem + 3.3vw);
   font-weight: 300;
   line-height: 1.2;
+  font-size: calc(1.525rem + 3.3vw);
 }
 @media (min-width: 1200px) {
   .display-3 {
@@ -625,9 +629,9 @@ progress {
 }
 
 .display-4 {
-  font-size: calc(1.475rem + 2.7vw);
   font-weight: 300;
   line-height: 1.2;
+  font-size: calc(1.475rem + 2.7vw);
 }
 @media (min-width: 1200px) {
   .display-4 {
@@ -636,9 +640,9 @@ progress {
 }
 
 .display-5 {
-  font-size: calc(1.425rem + 2.1vw);
   font-weight: 300;
   line-height: 1.2;
+  font-size: calc(1.425rem + 2.1vw);
 }
 @media (min-width: 1200px) {
   .display-5 {
@@ -647,9 +651,9 @@ progress {
 }
 
 .display-6 {
-  font-size: calc(1.375rem + 1.5vw);
   font-weight: 300;
   line-height: 1.2;
+  font-size: calc(1.375rem + 1.5vw);
 }
 @media (min-width: 1200px) {
   .display-6 {
@@ -795,7 +799,7 @@ progress {
 }
 
 .col {
-  flex: 1 0 0%;
+  flex: 1 0 0;
 }
 
 .row-cols-auto > * {
@@ -1004,7 +1008,7 @@ progress {
 
 @media (min-width: 576px) {
   .col-sm {
-    flex: 1 0 0%;
+    flex: 1 0 0;
   }
   .row-cols-sm-auto > * {
     flex: 0 0 auto;
@@ -1173,7 +1177,7 @@ progress {
 }
 @media (min-width: 768px) {
   .col-md {
-    flex: 1 0 0%;
+    flex: 1 0 0;
   }
   .row-cols-md-auto > * {
     flex: 0 0 auto;
@@ -1342,7 +1346,7 @@ progress {
 }
 @media (min-width: 992px) {
   .col-lg {
-    flex: 1 0 0%;
+    flex: 1 0 0;
   }
   .row-cols-lg-auto > * {
     flex: 0 0 auto;
@@ -1511,7 +1515,7 @@ progress {
 }
 @media (min-width: 1200px) {
   .col-xl {
-    flex: 1 0 0%;
+    flex: 1 0 0;
   }
   .row-cols-xl-auto > * {
     flex: 0 0 auto;
@@ -1680,7 +1684,7 @@ progress {
 }
 @media (min-width: 1300px) {
   .col-xxl {
-    flex: 1 0 0%;
+    flex: 1 0 0;
   }
   .row-cols-xxl-auto > * {
     flex: 0 0 auto;
@@ -1929,13 +1933,13 @@ progress {
 
 .table-primary {
   --bs-table-color: #000;
-  --bs-table-bg: #d2e1e6;
-  --bs-table-border-color: #bdcbcf;
-  --bs-table-striped-bg: #c8d6db;
+  --bs-table-bg: rgb(210.4, 225.4, 230);
+  --bs-table-border-color: rgb(189.36, 202.86, 207);
+  --bs-table-striped-bg: rgb(199.88, 214.13, 218.5);
   --bs-table-striped-color: #000;
-  --bs-table-active-bg: #bdcbcf;
+  --bs-table-active-bg: rgb(189.36, 202.86, 207);
   --bs-table-active-color: #000;
-  --bs-table-hover-bg: #c2d0d5;
+  --bs-table-hover-bg: rgb(194.62, 208.495, 212.75);
   --bs-table-hover-color: #000;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -1943,13 +1947,13 @@ progress {
 
 .table-secondary {
   --bs-table-color: #000;
-  --bs-table-bg: #e2e3e5;
-  --bs-table-border-color: #cbccce;
-  --bs-table-striped-bg: #d7d8da;
+  --bs-table-bg: rgb(225.6, 227.4, 229);
+  --bs-table-border-color: rgb(203.04, 204.66, 206.1);
+  --bs-table-striped-bg: rgb(214.32, 216.03, 217.55);
   --bs-table-striped-color: #000;
-  --bs-table-active-bg: #cbccce;
+  --bs-table-active-bg: rgb(203.04, 204.66, 206.1);
   --bs-table-active-color: #000;
-  --bs-table-hover-bg: #d1d2d4;
+  --bs-table-hover-bg: rgb(208.68, 210.345, 211.825);
   --bs-table-hover-color: #000;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -1957,13 +1961,13 @@ progress {
 
 .table-success {
   --bs-table-color: #000;
-  --bs-table-bg: #d8e6d8;
-  --bs-table-border-color: #c2cfc2;
-  --bs-table-striped-bg: #cddbcd;
+  --bs-table-bg: rgb(215.6, 230.2, 215.6);
+  --bs-table-border-color: rgb(194.04, 207.18, 194.04);
+  --bs-table-striped-bg: rgb(204.82, 218.69, 204.82);
   --bs-table-striped-color: #000;
-  --bs-table-active-bg: #c2cfc2;
+  --bs-table-active-bg: rgb(194.04, 207.18, 194.04);
   --bs-table-active-color: #000;
-  --bs-table-hover-bg: #c8d5c8;
+  --bs-table-hover-bg: rgb(199.43, 212.935, 199.43);
   --bs-table-hover-color: #000;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -1971,13 +1975,13 @@ progress {
 
 .table-info {
   --bs-table-color: #000;
-  --bs-table-bg: #cff4fc;
-  --bs-table-border-color: #badce3;
-  --bs-table-striped-bg: #c5e8ef;
+  --bs-table-bg: rgb(206.6, 244.4, 252);
+  --bs-table-border-color: rgb(185.94, 219.96, 226.8);
+  --bs-table-striped-bg: rgb(196.27, 232.18, 239.4);
   --bs-table-striped-color: #000;
-  --bs-table-active-bg: #badce3;
+  --bs-table-active-bg: rgb(185.94, 219.96, 226.8);
   --bs-table-active-color: #000;
-  --bs-table-hover-bg: #bfe2e9;
+  --bs-table-hover-bg: rgb(191.105, 226.07, 233.1);
   --bs-table-hover-color: #000;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -1985,13 +1989,13 @@ progress {
 
 .table-warning {
   --bs-table-color: #000;
-  --bs-table-bg: #ffe5d0;
-  --bs-table-border-color: #e6cebb;
-  --bs-table-striped-bg: #f2dac6;
+  --bs-table-bg: rgb(254.6, 229.2, 208);
+  --bs-table-border-color: rgb(229.14, 206.28, 187.2);
+  --bs-table-striped-bg: rgb(241.87, 217.74, 197.6);
   --bs-table-striped-color: #000;
-  --bs-table-active-bg: #e6cebb;
+  --bs-table-active-bg: rgb(229.14, 206.28, 187.2);
   --bs-table-active-color: #000;
-  --bs-table-hover-bg: #ecd4c0;
+  --bs-table-hover-bg: rgb(235.505, 212.01, 192.4);
   --bs-table-hover-color: #000;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -1999,13 +2003,13 @@ progress {
 
 .table-danger {
   --bs-table-color: #000;
-  --bs-table-bg: #f6d9d8;
-  --bs-table-border-color: #ddc3c2;
-  --bs-table-striped-bg: #eacecd;
+  --bs-table-bg: rgb(246.4943925234, 216.5009345794, 215.6056074766);
+  --bs-table-border-color: rgb(221.844953271, 194.8508411215, 194.045046729);
+  --bs-table-striped-bg: rgb(234.1696728972, 205.6758878505, 204.8253271028);
   --bs-table-striped-color: #000;
-  --bs-table-active-bg: #ddc3c2;
+  --bs-table-active-bg: rgb(221.844953271, 194.8508411215, 194.045046729);
   --bs-table-active-color: #000;
-  --bs-table-hover-bg: #e4c9c8;
+  --bs-table-hover-bg: rgb(228.0073130841, 200.263364486, 199.4351869159);
   --bs-table-hover-color: #000;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -2014,12 +2018,12 @@ progress {
 .table-light {
   --bs-table-color: #000;
   --bs-table-bg: #fff;
-  --bs-table-border-color: #e6e6e6;
-  --bs-table-striped-bg: #f2f2f2;
+  --bs-table-border-color: rgb(229.5, 229.5, 229.5);
+  --bs-table-striped-bg: rgb(242.25, 242.25, 242.25);
   --bs-table-striped-color: #000;
-  --bs-table-active-bg: #e6e6e6;
+  --bs-table-active-bg: rgb(229.5, 229.5, 229.5);
   --bs-table-active-color: #000;
-  --bs-table-hover-bg: #ececec;
+  --bs-table-hover-bg: rgb(235.875, 235.875, 235.875);
   --bs-table-hover-color: #000;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -2028,12 +2032,12 @@ progress {
 .table-dark {
   --bs-table-color: #fff;
   --bs-table-bg: #333333;
-  --bs-table-border-color: #474747;
-  --bs-table-striped-bg: #3d3d3d;
+  --bs-table-border-color: rgb(71.4, 71.4, 71.4);
+  --bs-table-striped-bg: rgb(61.2, 61.2, 61.2);
   --bs-table-striped-color: #fff;
-  --bs-table-active-bg: #474747;
+  --bs-table-active-bg: rgb(71.4, 71.4, 71.4);
   --bs-table-active-color: #fff;
-  --bs-table-hover-bg: #424242;
+  --bs-table-hover-bg: rgb(66.3, 66.3, 66.3);
   --bs-table-hover-color: #fff;
   color: var(--bs-table-color);
   border-color: var(--bs-table-border-color);
@@ -2134,7 +2138,7 @@ progress {
 .form-control:focus {
   color: #333333;
   background-color: #fff;
-  border-color: #90b5c1;
+  border-color: rgb(143.5, 181, 192.5);
   outline: 0;
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.075), 0 0 0 0.25rem rgba(32, 107, 130, 0.25);
 }
@@ -2175,7 +2179,7 @@ progress {
   }
 }
 .form-control:hover:not(:disabled):not([readonly])::file-selector-button {
-  background-color: #dde0e3;
+  background-color: rgb(221.35, 224.2, 227.05);
 }
 
 .form-control-plaintext {
@@ -2280,7 +2284,7 @@ textarea.form-control-lg {
   }
 }
 .form-select:focus {
-  border-color: #90b5c1;
+  border-color: rgb(143.5, 181, 192.5);
   outline: 0;
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.075), 0 0 0 0.25rem rgba(32, 107, 130, 0.25);
 }
@@ -2364,7 +2368,7 @@ textarea.form-control-lg {
   filter: brightness(90%);
 }
 .form-check-input:focus {
-  border-color: #90b5c1;
+  border-color: rgb(143.5, 181, 192.5);
   outline: 0;
   box-shadow: 0 0 0 0.25rem rgba(32, 107, 130, 0.25);
 }
@@ -2411,7 +2415,7 @@ textarea.form-control-lg {
   }
 }
 .form-switch .form-check-input:focus {
-  --bs-form-switch-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%2390b5c1'/%3e%3c/svg%3e");
+  --bs-form-switch-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='rgb%28143.5, 181, 192.5%29'/%3e%3c/svg%3e");
 }
 .form-switch .form-check-input:checked {
   background-position: right center;
@@ -2482,7 +2486,7 @@ textarea.form-control-lg {
   }
 }
 .form-range::-webkit-slider-thumb:active {
-  background-color: #bcd3da;
+  background-color: rgb(188.1, 210.6, 217.5);
 }
 .form-range::-webkit-slider-runnable-track {
   width: 100%;
@@ -2510,7 +2514,7 @@ textarea.form-control-lg {
   }
 }
 .form-range::-moz-range-thumb:active {
-  background-color: #bcd3da;
+  background-color: rgb(188.1, 210.6, 217.5);
 }
 .form-range::-moz-range-track {
   width: 100%;
@@ -2547,9 +2551,11 @@ textarea.form-control-lg {
   top: 0;
   left: 0;
   z-index: 2;
+  max-width: 100%;
   height: 100%;
   padding: 1rem 0.75rem;
   overflow: hidden;
+  color: rgba(var(--bs-body-color-rgb), 0.65);
   text-align: start;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -2585,18 +2591,19 @@ textarea.form-control-lg {
 .form-floating > .form-select {
   padding-top: 1.625rem;
   padding-bottom: 0.625rem;
+  padding-left: 0.75rem;
 }
 .form-floating > .form-control:focus ~ label,
 .form-floating > .form-control:not(:placeholder-shown) ~ label,
 .form-floating > .form-control-plaintext ~ label,
 .form-floating > .form-select ~ label {
-  color: rgba(var(--bs-body-color-rgb), 0.65);
   transform: scale(0.85) translateY(-0.5rem) translateX(0.15rem);
 }
-.form-floating > .form-control:focus ~ label::after,
-.form-floating > .form-control:not(:placeholder-shown) ~ label::after,
-.form-floating > .form-control-plaintext ~ label::after,
-.form-floating > .form-select ~ label::after {
+.form-floating > .form-control:-webkit-autofill ~ label {
+  transform: scale(0.85) translateY(-0.5rem) translateX(0.15rem);
+}
+.form-floating > textarea:focus ~ label::after,
+.form-floating > textarea:not(:placeholder-shown) ~ label::after {
   position: absolute;
   inset: 1rem 0.375rem;
   z-index: -1;
@@ -2605,9 +2612,8 @@ textarea.form-control-lg {
   background-color: #fff;
   border-radius: 0.25rem;
 }
-.form-floating > .form-control:-webkit-autofill ~ label {
-  color: rgba(var(--bs-body-color-rgb), 0.65);
-  transform: scale(0.85) translateY(-0.5rem) translateX(0.15rem);
+.form-floating > textarea:disabled ~ label::after {
+  background-color: #e9ecef;
 }
 .form-floating > .form-control-plaintext ~ label {
   border-width: 1px 0;
@@ -2615,10 +2621,6 @@ textarea.form-control-lg {
 .form-floating > :disabled ~ label,
 .form-floating > .form-control:disabled ~ label {
   color: #6c757d;
-}
-.form-floating > :disabled ~ label::after,
-.form-floating > .form-control:disabled ~ label::after {
-  background-color: #e9ecef;
 }
 
 .input-group {
@@ -2702,7 +2704,7 @@ textarea.form-control-lg {
   border-bottom-right-radius: 0;
 }
 .input-group > :not(:first-child):not(.dropdown-menu):not(.valid-tooltip):not(.valid-feedback):not(.invalid-tooltip):not(.invalid-feedback) {
-  margin-left: calc(1px * -1);
+  margin-left: calc(-1 * 1px);
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
 }
@@ -2807,7 +2809,7 @@ textarea.form-control-lg {
   width: 100%;
   margin-top: 0.25rem;
   font-size: 0.875em;
-  color: #d43f3a;
+  color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
 }
 
 .invalid-tooltip {
@@ -2820,7 +2822,7 @@ textarea.form-control-lg {
   margin-top: 0.1rem;
   font-size: 0.765625rem;
   color: #fff;
-  background-color: rgba(212, 63, 58, 0.9);
+  background-color: rgba(212.4719626168, 62.5046728972, 58.0280373832, 0.9);
   border-radius: 0.25rem;
 }
 
@@ -2832,16 +2834,16 @@ textarea.form-control-lg {
 }
 
 .was-validated .form-control:invalid, .form-control.is-invalid {
-  border-color: #d43f3a;
+  border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
   padding-right: calc(1.5em + 0.75rem);
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='%23d43f3a'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23d43f3a' stroke='none'/%3e%3c/svg%3e");
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='rgb%28212.4719626168, 62.5046728972, 58.0280373832%29'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='rgb%28212.4719626168, 62.5046728972, 58.0280373832%29' stroke='none'/%3e%3c/svg%3e");
   background-repeat: no-repeat;
   background-position: right calc(0.375em + 0.1875rem) center;
   background-size: calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
 }
 .was-validated .form-control:invalid:focus, .form-control.is-invalid:focus {
-  border-color: #d43f3a;
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.075), 0 0 0 0.25rem rgba(212, 63, 58, 0.25);
+  border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.075), 0 0 0 0.25rem rgba(212.4719626168, 62.5046728972, 58.0280373832, 0.25);
 }
 
 .was-validated textarea.form-control:invalid, textarea.form-control.is-invalid {
@@ -2850,17 +2852,17 @@ textarea.form-control-lg {
 }
 
 .was-validated .form-select:invalid, .form-select.is-invalid {
-  border-color: #d43f3a;
+  border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
 }
 .was-validated .form-select:invalid:not([multiple]):not([size]), .was-validated .form-select:invalid:not([multiple])[size="1"], .form-select.is-invalid:not([multiple]):not([size]), .form-select.is-invalid:not([multiple])[size="1"] {
-  --bs-form-select-bg-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='%23d43f3a'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23d43f3a' stroke='none'/%3e%3c/svg%3e");
+  --bs-form-select-bg-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='rgb%28212.4719626168, 62.5046728972, 58.0280373832%29'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='rgb%28212.4719626168, 62.5046728972, 58.0280373832%29' stroke='none'/%3e%3c/svg%3e");
   padding-right: 4.125rem;
   background-position: right 0.75rem center, center right 2.25rem;
   background-size: 16px 12px, calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
 }
 .was-validated .form-select:invalid:focus, .form-select.is-invalid:focus {
-  border-color: #d43f3a;
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.075), 0 0 0 0.25rem rgba(212, 63, 58, 0.25);
+  border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.075), 0 0 0 0.25rem rgba(212.4719626168, 62.5046728972, 58.0280373832, 0.25);
 }
 
 .was-validated .form-control-color:invalid, .form-control-color.is-invalid {
@@ -2868,16 +2870,16 @@ textarea.form-control-lg {
 }
 
 .was-validated .form-check-input:invalid, .form-check-input.is-invalid {
-  border-color: #d43f3a;
+  border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
 }
 .was-validated .form-check-input:invalid:checked, .form-check-input.is-invalid:checked {
-  background-color: #d43f3a;
+  background-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
 }
 .was-validated .form-check-input:invalid:focus, .form-check-input.is-invalid:focus {
-  box-shadow: 0 0 0 0.25rem rgba(212, 63, 58, 0.25);
+  box-shadow: 0 0 0 0.25rem rgba(212.4719626168, 62.5046728972, 58.0280373832, 0.25);
 }
 .was-validated .form-check-input:invalid ~ .form-check-label, .form-check-input.is-invalid ~ .form-check-label {
-  color: #d43f3a;
+  color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
 }
 
 .form-check-inline .form-check-input ~ .invalid-feedback {
@@ -2979,12 +2981,12 @@ textarea.form-control-lg {
   --bs-btn-bg: #206b82;
   --bs-btn-border-color: #206b82;
   --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #1b5b6f;
-  --bs-btn-hover-border-color: #1a5668;
+  --bs-btn-hover-bg: rgb(27.2, 90.95, 110.5);
+  --bs-btn-hover-border-color: rgb(25.6, 85.6, 104);
   --bs-btn-focus-shadow-rgb: 65, 129, 149;
   --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #1a5668;
-  --bs-btn-active-border-color: #185062;
+  --bs-btn-active-bg: rgb(25.6, 85.6, 104);
+  --bs-btn-active-border-color: rgb(24, 80.25, 97.5);
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   --bs-btn-disabled-color: #fff;
   --bs-btn-disabled-bg: #206b82;
@@ -2996,12 +2998,12 @@ textarea.form-control-lg {
   --bs-btn-bg: #6c757d;
   --bs-btn-border-color: #6c757d;
   --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #5c636a;
-  --bs-btn-hover-border-color: #565e64;
+  --bs-btn-hover-bg: rgb(91.8, 99.45, 106.25);
+  --bs-btn-hover-border-color: rgb(86.4, 93.6, 100);
   --bs-btn-focus-shadow-rgb: 130, 138, 145;
   --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #565e64;
-  --bs-btn-active-border-color: #51585e;
+  --bs-btn-active-bg: rgb(86.4, 93.6, 100);
+  --bs-btn-active-border-color: rgb(81, 87.75, 93.75);
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   --bs-btn-disabled-color: #fff;
   --bs-btn-disabled-bg: #6c757d;
@@ -3013,12 +3015,12 @@ textarea.form-control-lg {
   --bs-btn-bg: #3A833A;
   --bs-btn-border-color: #3A833A;
   --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #316f31;
-  --bs-btn-hover-border-color: #2e692e;
+  --bs-btn-hover-bg: rgb(49.3, 111.35, 49.3);
+  --bs-btn-hover-border-color: rgb(46.4, 104.8, 46.4);
   --bs-btn-focus-shadow-rgb: 88, 150, 88;
   --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #2e692e;
-  --bs-btn-active-border-color: #2c622c;
+  --bs-btn-active-bg: rgb(46.4, 104.8, 46.4);
+  --bs-btn-active-border-color: rgb(43.5, 98.25, 43.5);
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   --bs-btn-disabled-color: #fff;
   --bs-btn-disabled-bg: #3A833A;
@@ -3030,12 +3032,12 @@ textarea.form-control-lg {
   --bs-btn-bg: #0dcaf0;
   --bs-btn-border-color: #0dcaf0;
   --bs-btn-hover-color: #000;
-  --bs-btn-hover-bg: #31d2f2;
-  --bs-btn-hover-border-color: #25cff2;
+  --bs-btn-hover-bg: rgb(49.3, 209.95, 242.25);
+  --bs-btn-hover-border-color: rgb(37.2, 207.3, 241.5);
   --bs-btn-focus-shadow-rgb: 11, 172, 204;
   --bs-btn-active-color: #000;
-  --bs-btn-active-bg: #3dd5f3;
-  --bs-btn-active-border-color: #25cff2;
+  --bs-btn-active-bg: rgb(61.4, 212.6, 243);
+  --bs-btn-active-border-color: rgb(37.2, 207.3, 241.5);
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   --bs-btn-disabled-color: #000;
   --bs-btn-disabled-bg: #0dcaf0;
@@ -3047,12 +3049,12 @@ textarea.form-control-lg {
   --bs-btn-bg: #fd7e14;
   --bs-btn-border-color: #fd7e14;
   --bs-btn-hover-color: #000;
-  --bs-btn-hover-bg: #fd9137;
-  --bs-btn-hover-border-color: #fd8b2c;
+  --bs-btn-hover-bg: rgb(253.3, 145.35, 55.25);
+  --bs-btn-hover-border-color: rgb(253.2, 138.9, 43.5);
   --bs-btn-focus-shadow-rgb: 215, 107, 17;
   --bs-btn-active-color: #000;
-  --bs-btn-active-bg: #fd9843;
-  --bs-btn-active-border-color: #fd8b2c;
+  --bs-btn-active-bg: rgb(253.4, 151.8, 67);
+  --bs-btn-active-border-color: rgb(253.2, 138.9, 43.5);
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   --bs-btn-disabled-color: #000;
   --bs-btn-disabled-bg: #fd7e14;
@@ -3061,19 +3063,19 @@ textarea.form-control-lg {
 
 .btn-danger, .control-custom.disabled .checkbox.btn {
   --bs-btn-color: #fff;
-  --bs-btn-bg: #d43f3a;
-  --bs-btn-border-color: #d43f3a;
+  --bs-btn-bg: rgb(212.4719626168, 62.5046728972, 58.0280373832);
+  --bs-btn-border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
   --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #b43631;
-  --bs-btn-hover-border-color: #aa322e;
-  --bs-btn-focus-shadow-rgb: 218, 92, 88;
+  --bs-btn-hover-bg: rgb(180.6011682243, 53.1289719626, 49.3238317757);
+  --bs-btn-hover-border-color: rgb(169.9775700935, 50.0037383178, 46.4224299065);
+  --bs-btn-focus-shadow-rgb: 219, 91, 88;
   --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #aa322e;
-  --bs-btn-active-border-color: #9f2f2c;
+  --bs-btn-active-bg: rgb(169.9775700935, 50.0037383178, 46.4224299065);
+  --bs-btn-active-border-color: rgb(159.3539719626, 46.8785046729, 43.5210280374);
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   --bs-btn-disabled-color: #fff;
-  --bs-btn-disabled-bg: #d43f3a;
-  --bs-btn-disabled-border-color: #d43f3a;
+  --bs-btn-disabled-bg: rgb(212.4719626168, 62.5046728972, 58.0280373832);
+  --bs-btn-disabled-border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
 }
 
 .btn-light, .btn-secondary {
@@ -3081,12 +3083,12 @@ textarea.form-control-lg {
   --bs-btn-bg: #fff;
   --bs-btn-border-color: #fff;
   --bs-btn-hover-color: #000;
-  --bs-btn-hover-bg: #d9d9d9;
+  --bs-btn-hover-bg: rgb(216.75, 216.75, 216.75);
   --bs-btn-hover-border-color: #cccccc;
   --bs-btn-focus-shadow-rgb: 217, 217, 217;
   --bs-btn-active-color: #000;
   --bs-btn-active-bg: #cccccc;
-  --bs-btn-active-border-color: #bfbfbf;
+  --bs-btn-active-border-color: rgb(191.25, 191.25, 191.25);
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   --bs-btn-disabled-color: #000;
   --bs-btn-disabled-bg: #fff;
@@ -3098,12 +3100,12 @@ textarea.form-control-lg {
   --bs-btn-bg: #333333;
   --bs-btn-border-color: #333333;
   --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #525252;
-  --bs-btn-hover-border-color: #474747;
+  --bs-btn-hover-bg: rgb(81.6, 81.6, 81.6);
+  --bs-btn-hover-border-color: rgb(71.4, 71.4, 71.4);
   --bs-btn-focus-shadow-rgb: 82, 82, 82;
   --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #5c5c5c;
-  --bs-btn-active-border-color: #474747;
+  --bs-btn-active-bg: rgb(91.8, 91.8, 91.8);
+  --bs-btn-active-border-color: rgb(71.4, 71.4, 71.4);
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   --bs-btn-disabled-color: #fff;
   --bs-btn-disabled-bg: #333333;
@@ -3196,19 +3198,19 @@ textarea.form-control-lg {
 }
 
 .btn-outline-danger {
-  --bs-btn-color: #d43f3a;
-  --bs-btn-border-color: #d43f3a;
+  --bs-btn-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
+  --bs-btn-border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
   --bs-btn-hover-color: #fff;
-  --bs-btn-hover-bg: #d43f3a;
-  --bs-btn-hover-border-color: #d43f3a;
+  --bs-btn-hover-bg: rgb(212.4719626168, 62.5046728972, 58.0280373832);
+  --bs-btn-hover-border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
   --bs-btn-focus-shadow-rgb: 212, 63, 58;
   --bs-btn-active-color: #fff;
-  --bs-btn-active-bg: #d43f3a;
-  --bs-btn-active-border-color: #d43f3a;
+  --bs-btn-active-bg: rgb(212.4719626168, 62.5046728972, 58.0280373832);
+  --bs-btn-active-border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #d43f3a;
+  --bs-btn-disabled-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
   --bs-btn-disabled-bg: transparent;
-  --bs-btn-disabled-border-color: #d43f3a;
+  --bs-btn-disabled-border-color: rgb(212.4719626168, 62.5046728972, 58.0280373832);
   --bs-gradient: none;
 }
 
@@ -3251,9 +3253,9 @@ textarea.form-control-lg {
   --bs-btn-color: #206b82;
   --bs-btn-bg: transparent;
   --bs-btn-border-color: transparent;
-  --bs-btn-hover-color: #1a5668;
+  --bs-btn-hover-color: rgb(25.6, 85.6, 104);
   --bs-btn-hover-border-color: transparent;
-  --bs-btn-active-color: #1a5668;
+  --bs-btn-active-color: rgb(25.6, 85.6, 104);
   --bs-btn-active-border-color: transparent;
   --bs-btn-disabled-color: #6c757d;
   --bs-btn-disabled-border-color: transparent;
@@ -3365,7 +3367,7 @@ textarea.form-control-lg {
   --bs-dropdown-divider-margin-y: 0.5rem;
   --bs-dropdown-box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
   --bs-dropdown-link-color: #333333;
-  --bs-dropdown-link-hover-color: #2e2e2e;
+  --bs-dropdown-link-hover-color: rgb(45.9, 45.9, 45.9);
   --bs-dropdown-link-hover-bg: #e9ecef;
   --bs-dropdown-link-active-color: #fff;
   --bs-dropdown-link-active-bg: #206b82;
@@ -3680,7 +3682,7 @@ textarea.form-control-lg {
 }
 .btn-group > :not(.btn-check:first-child) + .btn,
 .btn-group > .btn-group:not(:first-child) {
-  margin-left: calc(1px * -1);
+  margin-left: calc(-1 * 1px);
 }
 .btn-group > .btn:not(:last-child):not(.dropdown-toggle),
 .btn-group > .btn.dropdown-toggle-split:first-child,
@@ -3734,14 +3736,15 @@ textarea.form-control-lg {
 }
 .btn-group-vertical > .btn:not(:first-child),
 .btn-group-vertical > .btn-group:not(:first-child) {
-  margin-top: calc(1px * -1);
+  margin-top: calc(-1 * 1px);
 }
 .btn-group-vertical > .btn:not(:last-child):not(.dropdown-toggle),
 .btn-group-vertical > .btn-group:not(:last-child) > .btn {
   border-bottom-right-radius: 0;
   border-bottom-left-radius: 0;
 }
-.btn-group-vertical > .btn ~ .btn,
+.btn-group-vertical > .btn:nth-child(n+3),
+.btn-group-vertical > :not(.btn-check) + .btn,
 .btn-group-vertical > .btn-group:not(:first-child) > .btn {
   border-top-left-radius: 0;
   border-top-right-radius: 0;
@@ -3752,7 +3755,7 @@ textarea.form-control-lg {
   --bs-nav-link-padding-y: 0.5rem;
   --bs-nav-link-font-weight: ;
   --bs-nav-link-color: #206b82;
-  --bs-nav-link-hover-color: #1a5668;
+  --bs-nav-link-hover-color: rgb(25.6, 85.6, 104);
   --bs-nav-link-disabled-color: #6c757d;
   display: flex;
   flex-wrap: wrap;
@@ -3871,8 +3874,8 @@ textarea.form-control-lg {
 
 .nav-justified > .nav-link, .page-header .nav-tabs li .nav-justified > a,
 .nav-justified .nav-item {
-  flex-basis: 0;
   flex-grow: 1;
+  flex-basis: 0;
   text-align: center;
 }
 
@@ -3975,8 +3978,8 @@ textarea.form-control-lg {
 }
 
 .navbar-collapse {
-  flex-basis: 100%;
   flex-grow: 1;
+  flex-basis: 100%;
   align-items: center;
 }
 
@@ -4481,7 +4484,7 @@ textarea.form-control-lg {
     flex-flow: row wrap;
   }
   .card-group > .card {
-    flex: 1 0 0%;
+    flex: 1 0 0;
     margin-bottom: 0;
   }
   .card-group > .card + .card {
@@ -4492,24 +4495,24 @@ textarea.form-control-lg {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
   }
-  .card-group > .card:not(:last-child) .card-img-top,
-  .card-group > .card:not(:last-child) .card-header {
+  .card-group > .card:not(:last-child) > .card-img-top,
+  .card-group > .card:not(:last-child) > .card-header {
     border-top-right-radius: 0;
   }
-  .card-group > .card:not(:last-child) .card-img-bottom,
-  .card-group > .card:not(:last-child) .card-footer {
+  .card-group > .card:not(:last-child) > .card-img-bottom,
+  .card-group > .card:not(:last-child) > .card-footer {
     border-bottom-right-radius: 0;
   }
   .card-group > .card:not(:first-child) {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-  .card-group > .card:not(:first-child) .card-img-top,
-  .card-group > .card:not(:first-child) .card-header {
+  .card-group > .card:not(:first-child) > .card-img-top,
+  .card-group > .card:not(:first-child) > .card-header {
     border-top-left-radius: 0;
   }
-  .card-group > .card:not(:first-child) .card-img-bottom,
-  .card-group > .card:not(:first-child) .card-footer {
+  .card-group > .card:not(:first-child) > .card-img-bottom,
+  .card-group > .card:not(:first-child) > .card-footer {
     border-bottom-left-radius: 0;
   }
 }
@@ -4530,12 +4533,12 @@ textarea.form-control-lg {
   --bs-accordion-btn-icon-width: 1.25rem;
   --bs-accordion-btn-icon-transform: rotate(-180deg);
   --bs-accordion-btn-icon-transition: transform 0.2s ease-in-out;
-  --bs-accordion-btn-active-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%231d6075'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
+  --bs-accordion-btn-active-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='rgb%2828.8, 96.3, 117%29'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
   --bs-accordion-btn-focus-box-shadow: 0 0 0 0.25rem rgba(32, 107, 130, 0.25);
   --bs-accordion-body-padding-x: 1.25rem;
   --bs-accordion-body-padding-y: 1rem;
-  --bs-accordion-active-color: #1d6075;
-  --bs-accordion-active-bg: #e9f0f3;
+  --bs-accordion-active-color: rgb(28.8, 96.3, 117);
+  --bs-accordion-active-bg: rgb(232.7, 240.2, 242.5);
 }
 
 .accordion-button {
@@ -4640,16 +4643,15 @@ textarea.form-control-lg {
 .accordion-flush > .accordion-item:last-child {
   border-bottom: 0;
 }
-.accordion-flush > .accordion-item > .accordion-header .accordion-button, .accordion-flush > .accordion-item > .accordion-header .accordion-button.collapsed {
-  border-radius: 0;
-}
-.accordion-flush > .accordion-item > .accordion-collapse {
+.accordion-flush > .accordion-item > .accordion-collapse,
+.accordion-flush > .accordion-item > .accordion-header .accordion-button,
+.accordion-flush > .accordion-item > .accordion-header .accordion-button.collapsed {
   border-radius: 0;
 }
 
 [data-bs-theme=dark] .accordion-button::after {
-  --bs-accordion-btn-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%2379a6b4'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
-  --bs-accordion-btn-active-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%2379a6b4'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
+  --bs-accordion-btn-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='rgb%28121.2, 166.2, 180%29'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708'/%3e%3c/svg%3e");
+  --bs-accordion-btn-active-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='rgb%28121.2, 166.2, 180%29'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708'/%3e%3c/svg%3e");
 }
 
 .breadcrumb {
@@ -4693,10 +4695,10 @@ textarea.form-control-lg {
   --bs-pagination-border-width: 1px;
   --bs-pagination-border-color: #dee2e6;
   --bs-pagination-border-radius: 0.25rem;
-  --bs-pagination-hover-color: #1a5668;
+  --bs-pagination-hover-color: rgb(25.6, 85.6, 104);
   --bs-pagination-hover-bg: #e9ecef;
   --bs-pagination-hover-border-color: #dee2e6;
-  --bs-pagination-focus-color: #1a5668;
+  --bs-pagination-focus-color: rgb(25.6, 85.6, 104);
   --bs-pagination-focus-bg: #e9ecef;
   --bs-pagination-focus-box-shadow: 0 0 0 0.25rem rgba(32, 107, 130, 0.25);
   --bs-pagination-active-color: #fff;
@@ -4897,7 +4899,7 @@ textarea.form-control-lg {
 
 @keyframes progress-bar-stripes {
   0% {
-    background-position-x: 1rem;
+    background-position-x: var(--bs-progress-height);
   }
 }
 .progress,
@@ -4992,22 +4994,6 @@ textarea.form-control-lg {
   counter-increment: section;
 }
 
-.list-group-item-action {
-  width: 100%;
-  color: var(--bs-list-group-action-color);
-  text-align: inherit;
-}
-.list-group-item-action:hover, .list-group-item-action:focus {
-  z-index: 1;
-  color: var(--bs-list-group-action-hover-color);
-  text-decoration: none;
-  background-color: var(--bs-list-group-action-hover-bg);
-}
-.list-group-item-action:active {
-  color: var(--bs-list-group-action-active-color);
-  background-color: var(--bs-list-group-action-active-bg);
-}
-
 .list-group-item {
   position: relative;
   display: block;
@@ -5041,6 +5027,22 @@ textarea.form-control-lg {
 .list-group-item + .list-group-item.active {
   margin-top: calc(-1 * var(--bs-list-group-border-width));
   border-top-width: var(--bs-list-group-border-width);
+}
+
+.list-group-item-action {
+  width: 100%;
+  color: var(--bs-list-group-action-color);
+  text-align: inherit;
+}
+.list-group-item-action:not(.active):hover, .list-group-item-action:not(.active):focus {
+  z-index: 1;
+  color: var(--bs-list-group-action-hover-color);
+  text-decoration: none;
+  background-color: var(--bs-list-group-action-hover-bg);
+}
+.list-group-item-action:not(.active):active {
+  color: var(--bs-list-group-action-active-color);
+  background-color: var(--bs-list-group-action-active-bg);
 }
 
 .list-group-horizontal {
@@ -5308,13 +5310,13 @@ textarea.form-control-lg {
   --bs-btn-close-focus-shadow: 0 0 0 0.25rem rgba(32, 107, 130, 0.25);
   --bs-btn-close-focus-opacity: 1;
   --bs-btn-close-disabled-opacity: 0.25;
-  --bs-btn-close-white-filter: invert(1) grayscale(100%) brightness(200%);
   box-sizing: content-box;
   width: 1em;
   height: 1em;
   padding: 0.25em 0.25em;
   color: var(--bs-btn-close-color);
   background: transparent var(--bs-btn-close-bg) center/1em auto no-repeat;
+  filter: var(--bs-btn-close-filter);
   border: 0;
   border-radius: 0.25rem;
   opacity: var(--bs-btn-close-opacity);
@@ -5336,11 +5338,16 @@ textarea.form-control-lg {
 }
 
 .btn-close-white {
-  filter: var(--bs-btn-close-white-filter);
+  --bs-btn-close-filter: invert(1) grayscale(100%) brightness(200%);
 }
 
-[data-bs-theme=dark] .btn-close {
-  filter: var(--bs-btn-close-white-filter);
+:root,
+[data-bs-theme=light] {
+  --bs-btn-close-filter: ;
+}
+
+[data-bs-theme=dark] {
+  --bs-btn-close-filter: invert(1) grayscale(100%) brightness(200%);
 }
 
 .toast {
@@ -5415,7 +5422,7 @@ textarea.form-control-lg {
   --bs-modal-width: 500px;
   --bs-modal-padding: 1rem;
   --bs-modal-margin: 0.5rem;
-  --bs-modal-color: ;
+  --bs-modal-color: var(--bs-body-color);
   --bs-modal-bg: #fff;
   --bs-modal-border-color: rgba(0, 0, 0, 0.2);
   --bs-modal-border-width: 1px;
@@ -5451,8 +5458,8 @@ textarea.form-control-lg {
   pointer-events: none;
 }
 .modal.fade .modal-dialog {
-  transition: transform 0.3s ease-out;
   transform: translate(0, -50px);
+  transition: transform 0.3s ease-out;
 }
 @media (prefers-reduced-motion: reduce) {
   .modal.fade .modal-dialog {
@@ -5528,7 +5535,10 @@ textarea.form-control-lg {
 }
 .modal-header .btn-close {
   padding: calc(var(--bs-modal-header-padding-y) * 0.5) calc(var(--bs-modal-header-padding-x) * 0.5);
-  margin: calc(-0.5 * var(--bs-modal-header-padding-y)) calc(-0.5 * var(--bs-modal-header-padding-x)) calc(-0.5 * var(--bs-modal-header-padding-y)) auto;
+  margin-top: calc(-0.5 * var(--bs-modal-header-padding-y));
+  margin-right: calc(-0.5 * var(--bs-modal-header-padding-x));
+  margin-bottom: calc(-0.5 * var(--bs-modal-header-padding-y));
+  margin-left: auto;
 }
 
 .modal-title {
@@ -5818,7 +5828,7 @@ textarea.form-control-lg {
   --bs-popover-header-padding-y: 0.5rem;
   --bs-popover-header-font-size: 0.875rem;
   --bs-popover-header-color: inherit;
-  --bs-popover-header-bg: #f0f0f0;
+  --bs-popover-header-bg: rgb(239.7, 239.7, 239.7);
   --bs-popover-body-padding-x: 1rem;
   --bs-popover-body-padding-y: 1rem;
   --bs-popover-body-color: #333333;
@@ -6049,6 +6059,7 @@ textarea.form-control-lg {
   color: #fff;
   text-align: center;
   background: none;
+  filter: var(--bs-carousel-control-icon-filter);
   border: 0;
   opacity: 0.5;
   transition: opacity 0.15s ease;
@@ -6117,7 +6128,7 @@ textarea.form-control-lg {
   margin-left: 3px;
   text-indent: -999px;
   cursor: pointer;
-  background-color: #fff;
+  background-color: var(--bs-carousel-indicator-active-bg);
   background-clip: padding-box;
   border: 0;
   border-top: 10px solid transparent;
@@ -6141,36 +6152,33 @@ textarea.form-control-lg {
   left: 15%;
   padding-top: 1.25rem;
   padding-bottom: 1.25rem;
-  color: #fff;
+  color: var(--bs-carousel-caption-color);
   text-align: center;
 }
 
-.carousel-dark .carousel-control-prev-icon,
-.carousel-dark .carousel-control-next-icon {
-  filter: invert(1) grayscale(100);
-}
-.carousel-dark .carousel-indicators [data-bs-target] {
-  background-color: #000;
-}
-.carousel-dark .carousel-caption {
-  color: #000;
+.carousel-dark {
+  --bs-carousel-indicator-active-bg: #000;
+  --bs-carousel-caption-color: #000;
+  --bs-carousel-control-icon-filter: invert(1) grayscale(100);
 }
 
-[data-bs-theme=dark] .carousel .carousel-control-prev-icon,
-[data-bs-theme=dark] .carousel .carousel-control-next-icon, [data-bs-theme=dark].carousel .carousel-control-prev-icon,
-[data-bs-theme=dark].carousel .carousel-control-next-icon {
-  filter: invert(1) grayscale(100);
+:root,
+[data-bs-theme=light] {
+  --bs-carousel-indicator-active-bg: #fff;
+  --bs-carousel-caption-color: #fff;
+  --bs-carousel-control-icon-filter: ;
 }
-[data-bs-theme=dark] .carousel .carousel-indicators [data-bs-target], [data-bs-theme=dark].carousel .carousel-indicators [data-bs-target] {
-  background-color: #000;
-}
-[data-bs-theme=dark] .carousel .carousel-caption, [data-bs-theme=dark].carousel .carousel-caption {
-  color: #000;
+
+[data-bs-theme=dark] {
+  --bs-carousel-indicator-active-bg: #000;
+  --bs-carousel-caption-color: #000;
+  --bs-carousel-control-icon-filter: invert(1) grayscale(100);
 }
 
 .spinner-grow,
 .spinner-border {
   display: inline-block;
+  flex-shrink: 0;
   width: var(--bs-spinner-width);
   height: var(--bs-spinner-height);
   vertical-align: var(--bs-spinner-vertical-align);
@@ -6721,7 +6729,10 @@ textarea.form-control-lg {
 }
 .offcanvas-header .btn-close {
   padding: calc(var(--bs-offcanvas-padding-y) * 0.5) calc(var(--bs-offcanvas-padding-x) * 0.5);
-  margin: calc(-0.5 * var(--bs-offcanvas-padding-y)) calc(-0.5 * var(--bs-offcanvas-padding-x)) calc(-0.5 * var(--bs-offcanvas-padding-y)) auto;
+  margin-top: calc(-0.5 * var(--bs-offcanvas-padding-y));
+  margin-right: calc(-0.5 * var(--bs-offcanvas-padding-x));
+  margin-bottom: calc(-0.5 * var(--bs-offcanvas-padding-y));
+  margin-left: auto;
 }
 
 .offcanvas-title {
@@ -7041,6 +7052,10 @@ textarea.form-control-lg {
 .visually-hidden:not(caption),
 .visually-hidden-focusable:not(:focus):not(:focus-within):not(caption) {
   position: absolute !important;
+}
+.visually-hidden *,
+.visually-hidden-focusable:not(:focus):not(:focus-within) * {
+  overflow: hidden !important;
 }
 
 .stretched-link::after {
@@ -11856,7 +11871,7 @@ h6, .h6, h5, .h5, h4, .h4, h3, .h3, h2, .h2, h1, .h1 {
   color: #111;
   background-color: #f6f6f6;
   padding: 1px 10px;
-  border: 1px solid #dddddd;
+  border: 1px solid rgb(220.5, 220.5, 220.5);
   border-radius: 100px;
   box-shadow: inset 0 1px 0 white;
 }
@@ -11865,13 +11880,13 @@ a.tag:hover {
   text-decoration: none;
   color: #fff;
   background-color: #30778d;
-  border: 1px solid #235767;
-  box-shadow: inset 0 1px 0 #3d97b3;
+  border: 1px solid rgb(35.0476190476, 86.8888888889, 102.9523809524);
+  box-shadow: inset 0 1px 0 rgb(60.9523809524, 151.1111111111, 179.0476190476);
 }
 
 .pill {
   display: inline-block;
-  background-color: #4e5f65;
+  background-color: rgb(77.8260869565, 94.947826087, 101.1739130435);
   color: #FFF;
   padding: 2px 10px 1px 10px;
   margin-right: 5px;
@@ -11928,6 +11943,11 @@ a.tag:hover {
   padding-top: 1.5rem;
 }
 
+.module-heading::after {
+  display: block;
+  clear: both;
+  content: "";
+}
 .module-heading {
   margin: 0;
   padding: 0.5rem 25px;
@@ -11936,11 +11956,6 @@ a.tag:hover {
   background-color: #f6f6f6;
   border-top: 1px solid #ddd;
   border-bottom: 1px solid #ddd;
-}
-.module-heading::after {
-  display: block;
-  clear: both;
-  content: "";
 }
 
 .module-content {
@@ -12078,10 +12093,6 @@ a.tag:hover {
   padding-bottom: 8px;
 }
 
-.no-nav .module:last-child {
-  margin-top: 0;
-}
-
 .module-image {
   float: left;
   width: 50px;
@@ -12099,17 +12110,19 @@ a.tag:hover {
 .media-grid, .module-grid {
   margin: 0;
   list-style: none;
-  padding-left: 0px;
-  min-height: 205px;
-  padding-top: 0.75rem;
-  background: #fbfbfb url("../../../base/images/bg.png");
-  border: 1px solid #ddd;
-  border-width: 1px 0;
 }
 .media-grid::after, .module-grid::after {
   display: block;
   clear: both;
   content: "";
+}
+.media-grid, .module-grid {
+  padding-left: 0px;
+  min-height: 205px;
+  padding-top: 0.75rem;
+  background: rgb(250.75, 250.75, 250.75) url("../../../base/images/bg.png");
+  border: 1px solid #ddd;
+  border-width: 1px 0;
 }
 
 .media-item, .module-item {
@@ -12155,12 +12168,14 @@ a.tag:hover {
   border: 1px solid #ddd;
   overflow: hidden;
   transition: all 0.2s ease-in;
-  border-radius: 3px;
 }
 @media (prefers-reduced-motion: reduce) {
   .media-view {
     transition: none;
   }
+}
+.media-view {
+  border-radius: 3px;
 }
 .media-view:hover, .media-view.hovered {
   border-color: #005d7a;
@@ -12224,16 +12239,18 @@ a.tag:hover {
 
 .media-item.is-expander .truncator-link, .is-expander.module-item .truncator-link {
   transition: opacity 0.2s ease-in;
-  position: absolute;
-  z-index: 10;
-  left: 15px;
-  bottom: 15px;
-  opacity: 0;
 }
 @media (prefers-reduced-motion: reduce) {
   .media-item.is-expander .truncator-link, .is-expander.module-item .truncator-link {
     transition: none;
   }
+}
+.media-item.is-expander .truncator-link, .is-expander.module-item .truncator-link {
+  position: absolute;
+  z-index: 10;
+  left: 15px;
+  bottom: 15px;
+  opacity: 0;
 }
 .media-item.is-expander:hover, .is-expander.module-item:hover {
   padding-bottom: 35px;
@@ -12246,18 +12263,16 @@ a.tag:hover {
   width: 186px;
 }
 
-.nav-simple,
-.nav-aside {
-  margin: 0;
-  list-style: none;
-  padding-bottom: 0;
-  display: block;
-}
 .nav-simple::after,
 .nav-aside::after {
   display: block;
   clear: both;
   content: "";
+}
+.nav-simple,
+.nav-aside {
+  margin: 0;
+  list-style: none;
 }
 .nav-simple > li,
 .nav-aside > li {
@@ -12269,6 +12284,11 @@ a.tag:hover {
 .nav-simple > li:last-of-type,
 .nav-aside > li:last-of-type {
   border-bottom: 0;
+}
+.nav-simple,
+.nav-aside {
+  padding-bottom: 0;
+  display: block;
 }
 
 .nav-aside {
@@ -12794,16 +12814,18 @@ select[data-module=autocomplete] {
 .stages {
   margin: 0;
   list-style: none;
-  color: #aeaeae;
-  counter-reset: stage;
-  overflow: hidden;
-  margin-bottom: 1.5rem;
-  padding: 0;
 }
 .stages::after {
   display: block;
   clear: both;
   content: "";
+}
+.stages {
+  color: #aeaeae;
+  counter-reset: stage;
+  overflow: hidden;
+  margin-bottom: 1.5rem;
+  padding: 0;
 }
 .stages li {
   line-height: 27px;
@@ -12974,13 +12996,15 @@ select[data-module=autocomplete] {
   border-radius: 3px;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   transition: border linear 0.2s, box-shadow linear 0.2s;
-  background-color: #fff;
-  border: 1px solid #ccc;
 }
 @media (prefers-reduced-motion: reduce) {
   .select2-container-multi .select2-choices {
     transition: none;
   }
+}
+.select2-container-multi .select2-choices {
+  background-color: #fff;
+  border: 1px solid #ccc;
 }
 
 .select2-container-active .select2-choices,
@@ -13611,21 +13635,26 @@ td.diff_header {
   max-width: 85px;
 }
 
-.toolbar {
-  position: relative;
-  margin-bottom: 10px;
-  padding: 5px 0;
-}
 .toolbar::after {
   display: block;
   clear: both;
   content: "";
+}
+.toolbar {
+  position: relative;
+  margin-bottom: 10px;
+  padding: 5px 0;
 }
 
 .page_primary_action {
   margin-bottom: 20px;
 }
 
+.toolbar .breadcrumb::after {
+  display: block;
+  clear: both;
+  content: "";
+}
 .toolbar .breadcrumb {
   box-shadow: none;
   position: relative;
@@ -13635,11 +13664,6 @@ td.diff_header {
   border: none;
   background: none;
   font-size: 1.09375rem;
-}
-.toolbar .breadcrumb::after {
-  display: block;
-  clear: both;
-  content: "";
 }
 
 .toolbar .breadcrumb li {
@@ -13704,20 +13728,22 @@ td.diff_header {
   display: none;
 }
 
-.page-header {
-  margin-top: 1.5rem;
-  border-bottom: 1px solid #ddd;
-  background-color: #f6f6f6;
-  border-radius: 0 3px 0 0;
-}
 .page-header.module-content {
   padding-top: 0.75rem;
   padding-bottom: 0;
+}
+.page-header {
+  margin-top: 1.5rem;
 }
 .page-header::after {
   display: block;
   clear: both;
   content: "";
+}
+.page-header {
+  border-bottom: 1px solid #ddd;
+  background-color: #f6f6f6;
+  border-radius: 0 3px 0 0;
 }
 .page-header .nav-tabs {
   float: left;
@@ -13737,7 +13763,7 @@ td.diff_header {
   margin-top: -3px;
 }
 
-.no-nav .page-header {
+.wrapper:not(:has(> .secondary)) .page-header {
   border-radius: 3px 3px 0 0;
 }
 
@@ -13784,39 +13810,20 @@ td.diff_header {
   white-space: nowrap;
 }
 
-.wrapper {
-  position: relative;
-  min-height: 300px;
-  background-color: #fff;
-}
 .wrapper::after {
   display: block;
   clear: both;
   content: "";
 }
-@media (min-width: 768px) {
-  .wrapper:before {
-    content: "";
-    display: block;
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    width: 25%;
-    border-right: 1px solid #ddd;
-    z-index: 1;
-  }
-  .wrapper.no-nav:before {
-    display: none;
-  }
-  .wrapper.no-nav .module > .page-header {
-    margin-top: 0;
-  }
-}
-
-[role=main],
-.main {
+.wrapper {
   position: relative;
+  min-height: 300px;
+  background-color: #fff;
+}
+@media (min-width: 768px) {
+  .wrapper .primary + .secondary, .wrapper .secondary + .primary {
+    border-inline-start: 1px solid #ddd;
+  }
 }
 
 .main {
@@ -13824,22 +13831,9 @@ td.diff_header {
   background: #eee url("../../../base/images/bg.png");
 }
 
-.main:after,
-[role=main]:after {
-  bottom: 0;
-  border-top-width: 1px;
-}
-
-.main .primary {
-  position: relative;
-  float: right;
-  margin-left: 0;
-}
-
 .main .secondary {
   padding: 0;
   z-index: 1;
-  padding-right: 1px;
 }
 
 /* Filters modal */
@@ -13949,7 +13943,7 @@ td.diff_header {
   background-image: linear-gradient(top, rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0));
   background-repeat: repeat-x;
   background-color: #f6f6f6;
-  border-bottom: 1px solid #d0d0d0;
+  border-bottom: 1px solid rgb(208.25, 208.25, 208.25);
   border-radius: 3px 3px 0 0;
   box-shadow: inset 0 -4px 0 rgba(0, 0, 0, 0.03);
 }
@@ -13985,8 +13979,7 @@ td.diff_header {
   margin: 0;
   overflow: auto;
 }
-.context-info h1.heading, .context-info .heading.h1,
-.context-info h2.heading, .context-info .heading.h2 {
+.context-info h1.heading, .context-info .heading.h1 {
   margin: 0 0 5px 0;
   font-size: 18px;
   line-height: 1.3;
@@ -14009,17 +14002,17 @@ td.diff_header {
   margin-top: 3px;
   margin-left: 0;
 }
+.context-info .nums::after {
+  display: block;
+  clear: both;
+  content: "";
+}
 .context-info .nums {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
   padding-top: 10px;
   border-top: 1px dotted #DDD;
-}
-.context-info .nums::after {
-  display: block;
-  clear: both;
-  content: "";
 }
 .context-info .nums dl {
   color: #444;
@@ -14078,16 +14071,16 @@ td.diff_header {
   margin-left: -30px;
   align-items: center;
 }
-.homepage .module-search .tags {
-  margin-top: -5px;
-  padding: 5px 10px 10px 10px;
-  background-color: #003647;
-}
 .homepage .module-search .tags h3, .homepage .module-search .tags .h3 {
   font-size: 0.875rem;
   line-height: 1.5;
   padding: 2px 8px;
   margin-top: -5px;
+}
+.homepage .module-search .tags {
+  margin-top: -5px;
+  padding: 5px 10px 10px 10px;
+  background-color: rgb(0, 54.1229508197, 71);
 }
 .homepage .module-search .tags h3, .homepage .module-search .tags .h3,
 .homepage .module-search .tags .tag {
@@ -14112,7 +14105,7 @@ td.diff_header {
 .account-masthead {
   min-height: 30px;
   color: #fff;
-  background: #003647 url("../../../base/images/bg.png");
+  background: rgb(0, 54.1229508197, 71) url("../../../base/images/bg.png");
 }
 .account-masthead .account {
   float: right;
@@ -14120,12 +14113,12 @@ td.diff_header {
 .account-masthead .account ul li {
   display: block;
   float: left;
-  border-left: 1px solid #00232e;
+  border-left: 1px solid rgb(0, 34.6844262295, 45.5);
 }
 .account-masthead .account ul li a {
   display: block;
   text-decoration: none;
-  color: #bfd7de;
+  color: rgb(191.25, 214.5, 221.75);
   font-size: 13px;
   font-weight: bold;
   padding: 0 10px;
@@ -14141,8 +14134,8 @@ td.diff_header {
   left: -9999px;
 }
 .account-masthead .account ul li a:hover {
-  color: #d9e7eb;
-  background-color: #00232e;
+  color: rgb(216.75, 230.7, 235.05);
+  background-color: rgb(0, 34.6844262295, 45.5);
   text-decoration: none;
 }
 .account-masthead .account ul li a.sub {
@@ -14156,14 +14149,14 @@ td.diff_header {
   font-size: 12px;
   margin-left: 3px;
   padding: 1px 6px;
-  background-color: #00232e;
+  background-color: rgb(0, 34.6844262295, 45.5);
   border-radius: 4px;
   text-shadow: none;
-  color: #bfd7de;
+  color: rgb(191.25, 214.5, 221.75);
 }
 .account-masthead .account .notifications a:hover span {
   color: #fff;
-  background-color: #000f14;
+  background-color: rgb(0, 15.2459016393, 20);
 }
 .account-masthead .account .notifications.notifications-important a span.badge {
   color: #fff;
@@ -14232,7 +14225,7 @@ td.diff_header {
 }
 .masthead .main-navbar ul li:hover a, .masthead .main-navbar ul li:focus a, .masthead .main-navbar ul li.active a {
   border-radius: 0.3rem;
-  background-color: #003647;
+  background-color: rgb(0, 54.1229508197, 71);
 }
 .masthead .main-navbar .site-search button {
   display: flex;
@@ -14300,13 +14293,13 @@ td.diff_header {
   background: url("../../../base/images/ckan-logo-footer.png") no-repeat top left;
   text-indent: -900em;
 }
+.site-footer .lang-select .form-group label {
+  font-size: 0.875rem;
+}
 .site-footer .lang-select .form-group {
   width: 100%;
   display: flex;
   flex-direction: column;
-}
-.site-footer .lang-select .form-group label {
-  font-size: 0.875rem;
 }
 
 .table-selected td {
@@ -14416,17 +14409,19 @@ td.diff_header {
 
 .followee-container {
   padding: 0;
-  padding: 0;
-  margin: 0;
-  max-height: 205px;
-  overflow: auto;
-  border-radius: 0 0 3px 3px;
 }
 .followee-container .popover-title {
   display: none;
 }
 .followee-container .empty {
   padding: 10px;
+}
+.followee-container {
+  padding: 0;
+  margin: 0;
+  max-height: 205px;
+  overflow: auto;
+  border-radius: 0 0 3px 3px;
 }
 .followee-container li i {
   margin-right: 11px;
@@ -14446,13 +14441,13 @@ td.diff_header {
   box-shadow: inset 0 1px 2x rgba(0, 0, 0, 0.2);
 }
 
-.dashboard-me {
-  padding: 15px 15px 0 15px;
-}
 .dashboard-me::after {
   display: block;
   clear: both;
   content: "";
+}
+.dashboard-me {
+  padding: 15px 15px 0 15px;
 }
 .dashboard-me img {
   float: left;

--- a/ckan/public/base/scss/_ckan-rtl.scss
+++ b/ckan/public/base/scss/_ckan-rtl.scss
@@ -1,14 +1,4 @@
 @use "sass:math";
-.wrapper {
-  @include media-breakpoint-up(sm) {
-    &:before {
-      left: initial;
-      right: 0;
-      width: 25%;
-      border-left: 1px solid $genericBorderColor;
-    }
-  }
-}
 
 .simple-input .field .btn-search {
   right: initial;

--- a/ckan/public/base/scss/_layout.scss
+++ b/ckan/public/base/scss/_layout.scss
@@ -5,41 +5,10 @@
     min-height: 300px;
     background-color: #fff;
     @include media-breakpoint-up(md) {
-        &:before {
-            content: '';
-            display: block;
-            position: absolute;
-            top: 0;
-            bottom: 0;
-            left: 0;
-            width: 25%;
-            border-right: 1px solid $genericBorderColor;
-            z-index: 1; // Fixes overlapping .secondary on the Resource view page
-        }
-        &.no-nav {
-            &:before {
-                display: none;
-            }
-            .module {
-                >.page-header {
-                    margin-top: 0;
-                }
-            }
+        .primary + .secondary, .secondary + .primary {
+            border-inline-start: 1px solid $genericBorderColor;
         }
     }
-}
-
-// @media (min-width: $screen-md-min) {
-//   .wrapper {
-//     background-position:0px 0px;
-//   }
-// }
-// .wrapper.no-nav {
-//     background-image: none;
-// }
-[role=main],
-.main {
-    position: relative;
 }
 
 .main {
@@ -47,22 +16,9 @@
     background: $layoutBackgroundColor url("#{$bgPath}");
 }
 
-.main:after,
-[role=main]:after {
-    bottom: 0;
-    border-top-width: 1px;
-}
-
-.main .primary {
-    position: relative;
-    float: right;
-    margin-left: 0; // Remove grid margin.
-}
-
 .main .secondary {
     padding: 0;
     z-index: 1;
-    padding-right: 1px;
 }
 
 

--- a/ckan/public/base/scss/_module.scss
+++ b/ckan/public/base/scss/_module.scss
@@ -170,10 +170,6 @@
     padding-bottom: 8px;
 }
 
-.no-nav .module:last-child {
-    margin-top: 0;
-}
-
 .module-image {
     float: left;
     width: 50px;

--- a/ckan/public/base/scss/_toolbar.scss
+++ b/ckan/public/base/scss/_toolbar.scss
@@ -120,7 +120,7 @@
     }
 }
 
-.no-nav .page-header {
+.wrapper:not(:has(> .secondary)) .page-header {
     @include border-radius(3px 3px 0 0);
 }
 

--- a/ckan/templates-midnight-blue/layout.html
+++ b/ckan/templates-midnight-blue/layout.html
@@ -1,0 +1,134 @@
+{% extends "base.html" %}
+
+{%- block page -%}
+
+  {% block skip %}
+    <div class="visually-hidden-focusable"><a href="#content">{{ _('Skip to main content') }}</a></div>
+  {% endblock %}
+
+  {#
+  Override the header on a page by page basis by extending this block. If
+  making sitewide header changes it is preferable to override the header.html
+  file.
+  #}
+  {%- block header %}
+    {% include "header.html" %}
+  {% endblock -%}
+
+  {# The content block allows you to replace the content of the page if needed #}
+  {%- block content %}
+    {% block maintag %}<div class="main">{% endblock %}
+      <div id="content" class="container">
+        {% block main_content %}
+          {% block flash %}
+            <div class="flash-messages">
+              {% block flash_inner %}
+                {% for category, message in h.get_flashed_messages(with_categories=true) %}
+                  <div class="alert alert-dismissible fade show {{ category }}" role="alert">
+                    {{ h.literal(message) }}
+                  </div>
+                {% endfor %}
+              {% endblock %}
+            </div>
+          {% endblock %}
+
+          {% block toolbar %}
+            <div class="toolbar" role="navigation" aria-label="{{ _('Breadcrumb') }}">
+              {% block breadcrumb %}
+                {% if self.breadcrumb_content() | trim %}
+                  <ol class="breadcrumb">
+                    {% snippet 'snippets/home_breadcrumb_item.html' %}
+                    {% block breadcrumb_content %}{% endblock %}
+                  </ol>
+                {% endif %}
+              {% endblock %}
+            </div>
+          {% endblock %}
+
+          <div class="row{% block wrapper_class %}{% endblock %}">
+            {#
+            The pre_primary block can be used to add content to before the
+            rendering of the main content columns of the page.
+            #}
+            {% block pre_primary %}
+              {% if self.content_action() | trim %}
+                <div class="content_action gap-1 mb-md-3">
+                  {% block content_action %}{% endblock %}
+                </div>
+              {% endif %}
+            {% endblock %}
+
+            {% block secondary %}
+              <aside class="secondary col-md-4 col-lg-3">
+                {#
+                The secondary_content block can be used to add content to the
+                sidebar of the page. This is the main block that is likely to be
+                used within a template.
+
+                Example:
+
+                  {% block secondary_content %}
+                    <h2>A sidebar item</h2>
+                    <p>Some content for the item</p>
+                  {% endblock %}
+                #}
+                {% block secondary_content %}{% endblock %}
+              </aside>
+            {% endblock %}
+
+            {% block primary %}
+              <div class="primary col" role="main">
+                {#
+                The primary_content block can be used to add content to the page.
+                This is the main block that is likely to be used within a template.
+
+                Example:
+
+                  {% block primary_content %}
+                    <h1>My page content</h1>
+                    <p>Some content for the page</p>
+                  {% endblock %}
+                #}
+                {% block primary_content %}
+                  <article class="module">
+                    {% block page_header %}
+                      <header class="module-content page-header">
+                        <ul class="nav nav-pills">
+                          {% block content_primary_nav %}{% endblock %}
+                        </ul>
+                      </header>
+                    {% endblock %}
+                    <div class="module-content">
+                      {% if self.page_primary_action() | trim %}
+                        <div class="page_primary_action mb-3 mb-md-0 ms-3 pull-right">
+                          {% block page_primary_action %}{% endblock %}
+                        </div>
+                      {% endif %}
+                      {% block primary_content_inner %}
+                      {% endblock %}
+                    </div>
+                  </article>
+                {% endblock %}
+              </div>
+            {% endblock %}
+          </div>
+        {% endblock %}
+      </div>
+    </div>
+  {% endblock -%}
+
+  {#
+  Override the footer on a page by page basis by extending this block. If
+  making sitewide header changes it is preferable to override the footer.html-u
+  file.
+  #}
+  {%- block footer %}
+    {% include "footer.html" %}
+  {% endblock -%}
+{%- endblock -%}
+
+{%- block scripts %}
+  {% asset 'base/main' %}
+  {% asset 'base/ckan' %}
+  {{ super() }}
+{% endblock -%}

--- a/ckan/templates-midnight-blue/layout.html
+++ b/ckan/templates-midnight-blue/layout.html
@@ -45,7 +45,7 @@
             </div>
           {% endblock %}
 
-          <div class="row{% block wrapper_class %}{% endblock %}">
+          <div class="row {% block wrapper_class %}{% endblock %}">
             {#
             The pre_primary block can be used to add content to before the
             rendering of the main content columns of the page.

--- a/ckan/templates-midnight-blue/package/view_edit_base.html
+++ b/ckan/templates-midnight-blue/package/view_edit_base.html
@@ -23,7 +23,7 @@
   {% if h.resource_view_full_page(resource_view) %}
     {{ self.flash() }}
     {{ self.toolbar() }}
-    <div class="wrapper no-nav">
+    <div class="wrapper">
       {{ self.primary_content() }}
     </div>
   {% else %}
@@ -31,7 +31,7 @@
   {% endif %}
 
   {% if to_preview and h.resource_view_display_preview(resource_view) %}
-    <div class="row wrapper no-nav view-preview-container">
+    <div class="row wrapper view-preview-container">
       <section class="module module-narrow module-shallow">
         <h2 class="module-heading">
           <i class="fa fa-image"></i> {{ _('View preview') }}

--- a/ckan/templates-midnight-blue/page.html
+++ b/ckan/templates-midnight-blue/page.html
@@ -1,134 +1,24 @@
-{% extends "base.html" %}
+{% extends "layout.html" %}
+{%- set _layout = _layout | default("sidebar-start" if self.secondary()|trim else "no-sidebar") -%}
 
-{%- block page -%}
+{% block main_content %}
+  {{ self.flash() }}
+  {{ self.toolbar() }}
 
-  {% block skip %}
-    <div class="visually-hidden-focusable"><a href="#content">{{ _('Skip to main content') }}</a></div>
-  {% endblock %}
+  <div class="row ckan-layout--{{ _layout }} {{ self.wrapper_class() }}">
+    {{ self.pre_primary() }}
 
-  {#
-  Override the header on a page by page basis by extending this block. If
-  making sitewide header changes it is preferable to override the header.html
-  file.
-  #}
-  {%- block header %}
-    {% include "header.html" %}
-  {% endblock -%}
+    {%- if _layout == "no-sidebar" -%}
+      {{ self.primary() }}
 
-  {# The content block allows you to replace the content of the page if needed #}
-  {%- block content %}
-    {% block maintag %}<div class="main">{% endblock %}
-      <div id="content" class="container">
-        {% block main_content %}
-          {% block flash %}
-            <div class="flash-messages">
-              {% block flash_inner %}
-                {% for category, message in h.get_flashed_messages(with_categories=true) %}
-                  <div class="alert alert-dismissible fade show {{ category }}" role="alert">
-                    {{ h.literal(message) }}
-                  </div>
-                {% endfor %}
-              {% endblock %}
-            </div>
-          {% endblock %}
+    {%- elif _layout == "sidebar-end" -%}
+      {{ self.primary() }}
+      {{ self.secondary() }}
 
-          {% block toolbar %}
-            <div class="toolbar" role="navigation" aria-label="{{ _('Breadcrumb') }}">
-              {% block breadcrumb %}
-                {% if self.breadcrumb_content() | trim %}
-                  <ol class="breadcrumb">
-                    {% snippet 'snippets/home_breadcrumb_item.html' %}
-                    {% block breadcrumb_content %}{% endblock %}
-                  </ol>
-                {% endif %}
-              {% endblock %}
-            </div>
-          {% endblock %}
+    {%- else -%}
+      {{ self.secondary() }}
+      {{ self.primary() }}
 
-          <div class="row {% block wrapper_class %}{% endblock %}{% if self.secondary()|trim == '' or c.action=='resource_read' %} no-nav{% endif %}">
-            {#
-            The pre_primary block can be used to add content to before the
-            rendering of the main content columns of the page.
-            #}
-            {% block pre_primary %}
-              {% if self.content_action() | trim %}
-                <div class="content_action gap-1 mb-md-3">
-                  {% block content_action %}{% endblock %}
-                </div>
-              {% endif %}
-            {% endblock %}
-
-            {% block secondary %}
-              <aside class="secondary col-md-4 col-lg-3">
-                {#
-                The secondary_content block can be used to add content to the
-                sidebar of the page. This is the main block that is likely to be
-                used within a template.
-
-                Example:
-
-                  {% block secondary_content %}
-                    <h2>A sidebar item</h2>
-                    <p>Some content for the item</p>
-                  {% endblock %}
-                #}
-                {% block secondary_content %}{% endblock %}
-              </aside>
-            {% endblock %}
-
-            {% block primary %}
-              <div class="primary col-md-8 col-lg-9 col-xs-12" role="main">
-                {#
-                The primary_content block can be used to add content to the page.
-                This is the main block that is likely to be used within a template.
-
-                Example:
-
-                  {% block primary_content %}
-                    <h1>My page content</h1>
-                    <p>Some content for the page</p>
-                  {% endblock %}
-                #}
-                {% block primary_content %}
-                  <article class="module">
-                    {% block page_header %}
-                      <header class="module-content page-header">
-                        <ul class="nav nav-pills">
-                          {% block content_primary_nav %}{% endblock %}
-                        </ul>
-                      </header>
-                    {% endblock %}
-                    <div class="module-content">
-                      {% if self.page_primary_action() | trim %}
-                        <div class="page_primary_action mb-3 mb-md-0 ms-3 pull-right">
-                          {% block page_primary_action %}{% endblock %}
-                        </div>
-                      {% endif %}
-                      {% block primary_content_inner %}
-                      {% endblock %}
-                    </div>
-                  </article>
-                {% endblock %}
-              </div>
-            {% endblock %}
-          </div>
-        {% endblock %}
-      </div>
-    </div>
-  {% endblock -%}
-
-  {#
-  Override the footer on a page by page basis by extending this block. If
-  making sitewide header changes it is preferable to override the footer.html-u
-  file.
-  #}
-  {%- block footer %}
-    {% include "footer.html" %}
-  {% endblock -%}
-{%- endblock -%}
-
-{%- block scripts %}
-  {% asset 'base/main' %}
-  {% asset 'base/ckan' %}
-  {{ super() }}
-{% endblock -%}
+    {%- endif %}
+  </div>
+{% endblock %}

--- a/ckan/templates/layout.html
+++ b/ckan/templates/layout.html
@@ -1,0 +1,134 @@
+{% extends "base.html" %}
+
+{%- block page -%}
+
+  {% block skip %}
+    <div class="visually-hidden-focusable"><a href="#content">{{ _('Skip to main content') }}</a></div>
+  {% endblock %}
+
+  {#
+  Override the header on a page by page basis by extending this block. If
+  making sitewide header changes it is preferable to override the header.html
+  file.
+  #}
+  {%- block header %}
+    {% include "header.html" %}
+  {% endblock -%}
+
+  {# The content block allows you to replace the content of the page if needed #}
+  {%- block content %}
+    {% block maintag %}<div class="main">{% endblock %}
+      <div id="content" class="container">
+        {% block main_content %}
+          {% block flash %}
+            <div class="flash-messages">
+              {% block flash_inner %}
+                {% for category, message in h.get_flashed_messages(with_categories=true) %}
+                  <div class="alert alert-dismissible fade show {{ category }}">
+                    {{ h.literal(message) }}
+                  </div>
+                {% endfor %}
+              {% endblock %}
+            </div>
+          {% endblock %}
+
+          {% block toolbar %}
+            <div class="toolbar" role="navigation" aria-label="{{ _('Breadcrumb') }}">
+              {% block breadcrumb %}
+                {% if self.breadcrumb_content() | trim %}
+                  <ol class="breadcrumb">
+                    {% snippet 'snippets/home_breadcrumb_item.html' %}
+                    {% block breadcrumb_content %}{% endblock %}
+                  </ol>
+                {% endif %}
+              {% endblock %}
+            </div>
+          {% endblock %}
+
+          <div class="row wrapper{% block wrapper_class %}{% endblock %}">
+            {#
+            The pre_primary block can be used to add content to before the
+            rendering of the main content columns of the page.
+            #}
+            {% block pre_primary %}
+            {% endblock %}
+
+            {% block secondary %}
+              <aside class="secondary col-md-3">
+                {#
+                The secondary_content block can be used to add content to the
+                sidebar of the page. This is the main block that is likely to be
+                used within a template.
+
+                Example:
+
+                  {% block secondary_content %}
+                    <h2>A sidebar item</h2>
+                    <p>Some content for the item</p>
+                  {% endblock %}
+                #}
+                {% block secondary_content %}{% endblock %}
+              </aside>
+            {% endblock %}
+
+            {% block primary %}
+              <div class="primary col" role="main">
+                {#
+                The primary_content block can be used to add content to the page.
+                This is the main block that is likely to be used within a template.
+
+                Example:
+
+                  {% block primary_content %}
+                    <h1>My page content</h1>
+                    <p>Some content for the page</p>
+                  {% endblock %}
+                #}
+                {% block primary_content %}
+                  <article class="module">
+                    {% block page_header %}
+                      <header class="module-content page-header">
+                        {% if self.content_action() | trim %}
+                          <div class="content_action">
+                            {% block content_action %}{% endblock %}
+                          </div>
+                        {% endif %}
+                        <ul class="nav nav-tabs">
+                          {% block content_primary_nav %}{% endblock %}
+                        </ul>
+                      </header>
+                    {% endblock %}
+                    <div class="module-content">
+                      {% if self.page_primary_action() | trim %}
+                        <div class="page_primary_action">
+                          {% block page_primary_action %}{% endblock %}
+                        </div>
+                      {% endif %}
+                      {% block primary_content_inner %}
+                      {% endblock %}
+                    </div>
+                  </article>
+                {% endblock %}
+              </div>
+            {% endblock %}
+          </div>
+        {% endblock %}
+      </div>
+    </div>
+  {% endblock -%}
+
+  {#
+  Override the footer on a page by page basis by extending this block. If
+  making sitewide header changes it is preferable to override the footer.html-u
+  file.
+  #}
+  {%- block footer %}
+    {% include "footer.html" %}
+  {% endblock -%}
+{%- endblock -%}
+
+{%- block scripts %}
+  {% asset 'base/main' %}
+  {% asset 'base/ckan' %}
+  {{ super() }}
+{% endblock -%}

--- a/ckan/templates/package/view_edit_base.html
+++ b/ckan/templates/package/view_edit_base.html
@@ -23,7 +23,7 @@
   {% if h.resource_view_full_page(resource_view) %}
     {{ self.flash() }}
     {{ self.toolbar() }}
-    <div class="wrapper no-nav">
+    <div class="wrapper">
       {{ self.primary_content() }}
     </div>
   {% else %}
@@ -31,7 +31,7 @@
   {% endif %}
 
   {% if to_preview and h.resource_view_display_preview(resource_view) %}
-    <div class="row wrapper no-nav view-preview-container">
+    <div class="row wrapper view-preview-container">
       <section class="module module-narrow module-shallow">
         <h2 class="module-heading">
           <i class="fa fa-image"></i> {{ _('View preview') }}

--- a/ckan/templates/page.html
+++ b/ckan/templates/page.html
@@ -1,134 +1,24 @@
-{% extends "base.html" %}
+{% extends "layout.html" %}
+{%- set _layout = _layout | default("sidebar-start" if self.secondary()|trim else "no-sidebar") -%}
 
-{%- block page -%}
+{% block main_content %}
+  {{ self.flash() }}
+  {{ self.toolbar() }}
 
-  {% block skip %}
-    <div class="visually-hidden-focusable"><a href="#content">{{ _('Skip to main content') }}</a></div>
-  {% endblock %}
+  <div class="row ckan-layout--{{ _layout }} wrapper{{ self.wrapper_class() }}">
+    {{ self.pre_primary() }}
 
-  {#
-  Override the header on a page by page basis by extending this block. If
-  making sitewide header changes it is preferable to override the header.html
-  file.
-  #}
-  {%- block header %}
-    {% include "header.html" %}
-  {% endblock -%}
+    {%- if _layout == "no-sidebar" -%}
+      {{ self.primary() }}
 
-  {# The content block allows you to replace the content of the page if needed #}
-  {%- block content %}
-    {% block maintag %}<div class="main">{% endblock %}
-      <div id="content" class="container">
-        {% block main_content %}
-          {% block flash %}
-            <div class="flash-messages">
-              {% block flash_inner %}
-                {% for category, message in h.get_flashed_messages(with_categories=true) %}
-                  <div class="alert alert-dismissible fade show {{ category }}">
-                    {{ h.literal(message) }}
-                  </div>
-                {% endfor %}
-              {% endblock %}
-            </div>
-          {% endblock %}
+    {%- elif _layout == "sidebar-end" -%}
+      {{ self.primary() }}
+      {{ self.secondary() }}
 
-          {% block toolbar %}
-            <div class="toolbar" role="navigation" aria-label="{{ _('Breadcrumb') }}">
-              {% block breadcrumb %}
-                {% if self.breadcrumb_content() | trim %}
-                  <ol class="breadcrumb">
-                    {% snippet 'snippets/home_breadcrumb_item.html' %}
-                    {% block breadcrumb_content %}{% endblock %}
-                  </ol>
-                {% endif %}
-              {% endblock %}
-            </div>
-          {% endblock %}
+    {%- else -%}
+      {{ self.secondary() }}
+      {{ self.primary() }}
 
-          <div class="row wrapper{% block wrapper_class %}{% endblock %}{% if self.secondary()|trim == '' or c.action=='resource_read' %} no-nav{% endif %}">
-            {#
-            The pre_primary block can be used to add content to before the
-            rendering of the main content columns of the page.
-            #}
-            {% block pre_primary %}
-            {% endblock %}
-
-            {% block secondary %}
-              <aside class="secondary col-md-3">
-                {#
-                The secondary_content block can be used to add content to the
-                sidebar of the page. This is the main block that is likely to be
-                used within a template.
-
-                Example:
-
-                  {% block secondary_content %}
-                    <h2>A sidebar item</h2>
-                    <p>Some content for the item</p>
-                  {% endblock %}
-                #}
-                {% block secondary_content %}{% endblock %}
-              </aside>
-            {% endblock %}
-
-            {% block primary %}
-              <div class="primary col-md-9 col-xs-12" role="main">
-                {#
-                The primary_content block can be used to add content to the page.
-                This is the main block that is likely to be used within a template.
-
-                Example:
-
-                  {% block primary_content %}
-                    <h1>My page content</h1>
-                    <p>Some content for the page</p>
-                  {% endblock %}
-                #}
-                {% block primary_content %}
-                  <article class="module">
-                    {% block page_header %}
-                      <header class="module-content page-header">
-                        {% if self.content_action() | trim %}
-                          <div class="content_action">
-                            {% block content_action %}{% endblock %}
-                          </div>
-                        {% endif %}
-                        <ul class="nav nav-tabs">
-                          {% block content_primary_nav %}{% endblock %}
-                        </ul>
-                      </header>
-                    {% endblock %}
-                    <div class="module-content">
-                      {% if self.page_primary_action() | trim %}
-                        <div class="page_primary_action">
-                          {% block page_primary_action %}{% endblock %}
-                        </div>
-                      {% endif %}
-                      {% block primary_content_inner %}
-                      {% endblock %}
-                    </div>
-                  </article>
-                {% endblock %}
-              </div>
-            {% endblock %}
-          </div>
-        {% endblock %}
-      </div>
-    </div>
-  {% endblock -%}
-
-  {#
-  Override the footer on a page by page basis by extending this block. If
-  making sitewide header changes it is preferable to override the footer.html-u
-  file.
-  #}
-  {%- block footer %}
-    {% include "footer.html" %}
-  {% endblock -%}
-{%- endblock -%}
-
-{%- block scripts %}
-  {% asset 'base/main' %}
-  {% asset 'base/ckan' %}
-  {{ super() }}
-{% endblock -%}
+    {%- endif %}
+  </div>
+{% endblock %}


### PR DESCRIPTION
Add an intermediate template between `page.html` and the final template rendered by the view. This new template can be used to modify page layout like this:

```django
{% block main_content %}
 
    {%- if _layout == "no-sidebar" -%}
      {{ self.primary() }}

    {%- elif _layout == "sidebar-end" -%}
      {{ self.primary() }}
      {{ self.secondary() }}

    {%- else -%} # the default layout if `_layout` is not specified or has unknown value
      {{ self.secondary() }}
      {{ self.primary() }}

    {%- endif %}

{% endblock %}
```

This approach significantly simplifies swapping the sidebar and main content area, moving the sidebar to the top/bottom of the page, or completely hiding it. Further, it can be used to add banners on a specific group of pages(for example, a banner with the organization name and logo for every page showing datasets of a specific organization).

The new intermediate template is required because Jinja2 does not allow the creation of block duplicates or condition branches. For example, the code snippet above will not work if you rewrite it like this:


```django
{% block main_content %}
 
    {%- if _layout == "no-sidebar" -%}
      {%block primary%}{%endblock%}

    {%- elif _layout == "sidebar-end" -%}
      {%block primary%}{%endblock%}
      {%block secondary%}{%endblock%}

    {%- else -%} # the default layout if `_layout` is not specified or has unknown value
      {%block secondary%}{%endblock%}
      {%block primary%}{%endblock%}

    {%- endif %}

{% endblock %}
```

Because of Jinja2 restrictions, the base template must define all blocks, while its descendant moves **existing** blocks around.

Current PR is compatible with existing templates - by default, it keeps existing behavior. When it sees `_layout` variables inside the template, it starts changing the template: try adding `{% set _layout = 'no-sidebar' %}` (or `sidebar-end`) in the `package/search.html` to see the difference. Implemented layouts are extremely straightforward, and mainly they serve as an example for extensions.

To keep this new feature compatible with existing code, I moved `page.html` into the new `layout.html` and replaced the content of `page.html` with a layout management example. This updated `page.html` extends the new `layout.html`, so any further extensions of the template and block overrides will work, and there will be absolutely no difference. Because of reusing `page.html`, I don't have to update all existing templates that extend `page.html`.

---

There are a few CSS modifications: I removed custom CSS and replaced it with native Bootstrap 5 functionality. 