### PR TITLE
Update GitHub Actions workflows

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -2,3 +2,4 @@ name: "CKAN CodeQL config"
 
 paths-ignore:
   - '**/vendor/**'
+  - '**/cookiecutter/**'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/backports.yml
+++ b/.github/workflows/backports.yml
@@ -12,7 +12,9 @@ jobs:
     permissions:
       contents: write # so it can comment
       pull-requests: write # so it can create pull requests
-
+    environment:
+      name: backports
+      deployment: false
     name: Backport pull request
     runs-on: ubuntu-latest
     # Only run when a pull request is merged

--- a/.github/workflows/backports.yml
+++ b/.github/workflows/backports.yml
@@ -27,6 +27,8 @@ jobs:
       }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Create backport pull requests
         uses: korthout/backport-action@v4
         with:

--- a/.github/workflows/backports.yml
+++ b/.github/workflows/backports.yml
@@ -4,11 +4,15 @@ on:
     types: [closed]
   issue_comment:
     types: [created]
-permissions:
-  contents: write # so it can comment
-  pull-requests: write # so it can create pull requests
+
+permissions: {}
+
 jobs:
   backport:
+    permissions:
+      contents: write # so it can comment
+      pull-requests: write # so it can create pull requests
+
     name: Backport pull request
     runs-on: ubuntu-latest
     # Only run when a pull request is merged

--- a/.github/workflows/backports.yml
+++ b/.github/workflows/backports.yml
@@ -26,11 +26,11 @@ jobs:
         )
       }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Create backport pull requests
-        uses: korthout/backport-action@7c3f6cd5843cac11bc59a04a1b7699af93261670 # v4
+        uses: korthout/backport-action@7c3f6cd5843cac11bc59a04a1b7699af93261670 # v4.5.0
         with:
           # Token to authenticate requests to GitHub. This is a Personal Access Token
           # from the ckanbot user
@@ -63,7 +63,7 @@ jobs:
       }}
     steps:
       - name: Add Backport failed label to PR
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.BACKPORT_ACTION_PAT }}
           script: |

--- a/.github/workflows/backports.yml
+++ b/.github/workflows/backports.yml
@@ -26,11 +26,11 @@ jobs:
         )
       }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Create backport pull requests
-        uses: korthout/backport-action@v4
+        uses: korthout/backport-action@7c3f6cd5843cac11bc59a04a1b7699af93261670 # v4
         with:
           # Token to authenticate requests to GitHub. This is a Personal Access Token
           # from the ckanbot user
@@ -63,7 +63,7 @@ jobs:
       }}
     steps:
       - name: Add Backport failed label to PR
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.BACKPORT_ACTION_PAT }}
           script: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,10 +7,13 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches: 
+      - 'master'
+      - 'dev-v**'
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: 
+      - 'master'
+      - 'dev-v**'
   schedule:
     - cron: '0 3 * * 2'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,17 +31,19 @@ jobs:
       matrix:
         # Override automatic language detection by changing the below list
         # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
-        language: ['python', 'javascript']
+        language: ['python', 'javascript', 'actions']
         # Learn more...
         # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
@@ -54,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +70,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,13 +40,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
+      uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
@@ -59,7 +59,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
+      uses: github/codeql-action/autobuild@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -73,4 +73,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
+      uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,13 +40,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
@@ -59,7 +59,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -73,4 +73,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,8 +17,7 @@ on:
   schedule:
     - cron: '0 3 * * 2'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   analyze:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -29,7 +29,7 @@ jobs:
           POSTGRES_DB: ckan_test
 
       ckan_redis:
-        image: redis
+        image: redis:7
         ports:
           - 6379:6379
       ckan_solr:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -7,12 +7,13 @@ env:
   NODE_VERSION: '16'
   PYTHON_VERSION: '3.10'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   cypress:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     services:
       ckan_postgres:
         image: postgres:15

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -44,6 +44,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -43,14 +43,14 @@ jobs:
       CKAN_REDIS_URL: redis://localhost:6379/1
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -68,18 +68,18 @@ jobs:
           ckan config-tool test-core-ci.ini "ckan.plugins = activity"
 
       - name: Run Cypress
-        uses: cypress-io/github-action@c495c3ddffba403ba11be95fffb67e25203b3799 # v7
+        uses: cypress-io/github-action@c495c3ddffba403ba11be95fffb67e25203b3799 # v7.1.10
         with:
           start: ckan -c test-core-ci.ini run
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: cypress-screenshots
           path: cypress/screenshots
           if-no-files-found: ignore
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: cypress-videos

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -43,14 +43,14 @@ jobs:
       CKAN_REDIS_URL: redis://localhost:6379/1
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -68,18 +68,18 @@ jobs:
           ckan config-tool test-core-ci.ini "ckan.plugins = activity"
 
       - name: Run Cypress
-        uses: cypress-io/github-action@v7
+        uses: cypress-io/github-action@c495c3ddffba403ba11be95fffb67e25203b3799 # v7
         with:
           start: ckan -c test-core-ci.ini run
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: cypress-screenshots
           path: cypress/screenshots
           if-no-files-found: ignore
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: cypress-videos

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0  # Fetch all history, including tags
           persist-credentials: false
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,12 +5,13 @@ on:
 env:
   PYTHON_VERSION: '3.10'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # Fetch all history, including tags
           persist-credentials: false
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history, including tags
+          persist-credentials: false
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -14,7 +14,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
     - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
 

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Build Changelog URL and create release
       run: |
-        TAG_NAME=${{ github.ref_name }}
+        TAG_NAME=${GITHUB_REF_NAME}
         CKAN_VERSION=$(echo $TAG_NAME | sed -s 's/ckan-//')
         MAJOR=$(echo $CKAN_VERSION | cut -d'.' -f1)
         MINOR=$(echo $CKAN_VERSION | cut -d'.' -f2)

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -14,7 +14,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false
 

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -6,10 +6,14 @@ on:
     tags:
       - 'ckan-**'
 
+permissions: {}
+
 jobs:
   build:
     name: Create GitHub release
     runs-on: ubuntu-latest
+    permissions:
+      content: write  # So it can create the release via the API
     env:
       GH_TOKEN: ${{ github.token }}
     steps:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Build Changelog URL and create release
       run: |

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Create GitHub release
     runs-on: ubuntu-latest
     permissions:
-      content: write  # So it can create the release via the API
+      contents: write  # So it can create the release via the API
     env:
       GH_TOKEN: ${{ github.token }}
     steps:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@v6
       with:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -12,11 +12,11 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: "3.10"
     - name: Install pypa/build
@@ -28,7 +28,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: python-package-distributions
         path: dist/
@@ -45,12 +45,12 @@ jobs:
       id-token: write
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: python-package-distributions
         path: dist/
     - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
   publishSkipped:
     if: github.repository != 'ckan/ckan'

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -12,11 +12,11 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "3.10"
     - name: Install pypa/build
@@ -28,7 +28,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: python-package-distributions
         path: dist/
@@ -45,7 +45,7 @@ jobs:
       id-token: write
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -6,11 +6,16 @@ on:
     tags:
       - 'ckan-**'
 
+permissions: {}
+
+
 jobs:
   build:
     if: github.repository == 'ckan/ckan'
     name: Build distribution
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
@@ -55,6 +60,7 @@ jobs:
   publishSkipped:
     if: github.repository != 'ckan/ckan'
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - run: |
           echo "## Skipping PyPI publish on downstream repository" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@v6
       with:

--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -6,10 +6,15 @@ on:
     branches:
       - 'master'
 
+permissions: {}
+
+
 jobs:
   build:
     if: github.repository == 'ckan/ckan'
     name: Build distribution
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -59,8 +64,10 @@ jobs:
         repository-url: https://test.pypi.org/legacy/
 
   publishSkipped:
+
     if: github.repository != 'ckan/ckan'
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - run: |
           echo "## Skipping PyPI publish on downstream repository" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -12,11 +12,11 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: "3.10"
     - name: Add timestamp to version number
@@ -32,7 +32,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: python-package-distributions
         path: dist/
@@ -49,12 +49,12 @@ jobs:
       id-token: write
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: python-package-distributions
         path: dist/
     - name: Publish distribution to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
       with:
         repository-url: https://test.pypi.org/legacy/
 

--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -12,11 +12,11 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "3.10"
     - name: Add timestamp to version number
@@ -32,7 +32,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: python-package-distributions
         path: dist/
@@ -49,7 +49,7 @@ jobs:
       id-token: write
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -14,14 +14,14 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -14,14 +14,14 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -7,12 +7,13 @@ env:
   NODE_VERSION: '18'
   PYTHON_VERSION: '3.10'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   typecheck:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -116,7 +116,7 @@ jobs:
     services:
       ckan-postgres:
 
-        image: postgres:12
+        image: postgres:14
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -83,7 +83,7 @@ jobs:
       # I went with `/tmp/.test_durations`.
       - name: Restore test durations
         id: restore-test-durations
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /tmp/.test_durations
           key: tests-durations-${{ github.sha }}
@@ -97,7 +97,7 @@ jobs:
       # retry the exact same tests, even if the cache has been updated in the meantime).
       - name: Upload test durations
         if: steps.restore-test-durations.outputs.cache-hit != ''
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-durations-before
           path: /tmp/.test_durations
@@ -151,7 +151,7 @@ jobs:
         env:
           MATRIX_SPLIT: ${{ matrix.split }}
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1  # Fetch all history, including tags
           persist-credentials: false
@@ -160,7 +160,7 @@ jobs:
       # job is retried, it will reuse the same artifact, to execute the exact same split.
       - name: Download test durations
         if: needs.define-matrix.outputs.restored == 'true'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: test-durations-before
 
@@ -176,7 +176,7 @@ jobs:
           gunzip .test_durations.gz
 
       - name: Cache pip
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ env.PIP_CACHE_DIR }}
           key: ${{ runner.os }}-pip-${{ hashFiles('*requirements.txt') }}
@@ -212,7 +212,7 @@ jobs:
           MATRIX_SPLIT: ${{ matrix.split }}
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         if: ${{ !cancelled() }}
         continue-on-error: true #don't fail if we can't upload (ie a fork that does not have integration plugged in)
         with:
@@ -220,7 +220,7 @@ jobs:
           verbose: false # optional (default = false)
 
       - name: Upload test results to Codecov
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
         if: ${{ !cancelled() }}
         continue-on-error: true #don't fail if we can't upload (ie a fork that does not have integration plugged in)
         with:
@@ -231,7 +231,7 @@ jobs:
       # within one final file in the "Merge all partial test durations" step below.
       - name: Upload test durations
         if: github.run_attempt == 1
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-durations-after-partial-${{ matrix.split }}
           path: ./.test_durations
@@ -246,7 +246,7 @@ jobs:
           MATRIX_SPLIT: ${{ matrix.split }}
 
       - name: Upload coverage artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: internal_coverage-${{ matrix.split }}
           path: coverage-${{ matrix.split }}
@@ -255,7 +255,7 @@ jobs:
           retention-days: 1
 
       - name: Store test results
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: internal_junit-results-${{ matrix.split }}
@@ -263,20 +263,20 @@ jobs:
           retention-days: 1
 
       - name: Test Summary (if Failure)
-        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2.4
         with:
           paths: "./junit/result/*.xml"
         if: failure()
 
       - name: Test Summary Local copy (If Failure)
-        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2.4
         with:
           paths: "./junit/result/*.xml"
           output: "./junit/result/test-summary.md"
         if: failure()
 
       - name: Store Test Summary results (If Failure)
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: split-test-summary-${{ matrix.split }}.md
           path: "./junit/result/test-summary.md"
@@ -291,7 +291,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all partial test durations
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: test-durations-after-partial-*
 
@@ -308,7 +308,7 @@ jobs:
       # and use it to manually commit file gzip `.test_durations` from time to time,
       # to keep an up-to-date fallback:
       - name: Upload final test durations
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-durations-after
           path: /tmp/.test_durations
@@ -318,7 +318,7 @@ jobs:
       # Finally, we cache the new test durations. This file will be restored in next CI execution
       # (see step "Restore test durations" above).
       - name: Cache final test durations
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /tmp/.test_durations
           key: tests-durations-${{ github.sha }}
@@ -334,12 +334,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Cache pip
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ env.PIP_CACHE_DIR }}
           key: ${{ runner.os }}-pip-${{ hashFiles('*requirements.txt') }}
@@ -351,14 +351,14 @@ jobs:
           pip install -r dev-requirements.txt
 
       - name: Download all coverage artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: internal_coverage-*
           path: coverage-data
           merge-multiple: 'true'
 
       - name: Download all JUnit XML results
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: internal_junit-results-*
           merge-multiple: true
@@ -395,7 +395,7 @@ jobs:
           coverage report -m
 
       - name: Upload HTML coverage report
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: combined-test-coverage-reports
           path: results

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,12 +17,12 @@ on:
 env:
   PIP_CACHE_DIR: /root/.cache/pip
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   define-matrix:
     runs-on: ubuntu-latest
+    permissions: {}
 
     outputs:
       SPLIT_LIST: ${{ steps.splits.outputs.SPLIT_LIST }}
@@ -106,6 +106,8 @@ jobs:
   pytest:
     needs: define-matrix
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -289,6 +291,7 @@ jobs:
     needs: pytest
     if: github.run_attempt == 1 && (success() || failure())
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Download all partial test durations
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -328,6 +331,8 @@ jobs:
     needs: pytest
     if: github.run_attempt == 1 && (success() || failure()) && needs.define-matrix.outputs.IS_PYTEST_COMBINE_TEST_RESULTS_DISABLED == 'false'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     container:
       # Needs to run on the same image the tests were run
       image: python:3.10-bookworm

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -152,6 +152,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 1  # Fetch all history, including tags
+          persist-credentials: false
 
       # These two steps will be executed only when there IS a cache hit (exact match or not). When a matrix
       # job is retried, it will reuse the same artifact, to execute the exact same split.
@@ -328,6 +329,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Cache pip
         uses: actions/cache@v5

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -83,7 +83,7 @@ jobs:
       # I went with `/tmp/.test_durations`.
       - name: Restore test durations
         id: restore-test-durations
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: /tmp/.test_durations
           key: tests-durations-${{ github.sha }}
@@ -97,7 +97,7 @@ jobs:
       # retry the exact same tests, even if the cache has been updated in the meantime).
       - name: Upload test durations
         if: steps.restore-test-durations.outputs.cache-hit != ''
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: test-durations-before
           path: /tmp/.test_durations
@@ -151,7 +151,7 @@ jobs:
         env:
           MATRIX_SPLIT: ${{ matrix.split }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1  # Fetch all history, including tags
           persist-credentials: false
@@ -160,7 +160,7 @@ jobs:
       # job is retried, it will reuse the same artifact, to execute the exact same split.
       - name: Download test durations
         if: needs.define-matrix.outputs.restored == 'true'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: test-durations-before
 
@@ -176,7 +176,7 @@ jobs:
           gunzip .test_durations.gz
 
       - name: Cache pip
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ${{ env.PIP_CACHE_DIR }}
           key: ${{ runner.os }}-pip-${{ hashFiles('*requirements.txt') }}
@@ -212,7 +212,7 @@ jobs:
           MATRIX_SPLIT: ${{ matrix.split }}
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         if: ${{ !cancelled() }}
         continue-on-error: true #don't fail if we can't upload (ie a fork that does not have integration plugged in)
         with:
@@ -220,7 +220,7 @@ jobs:
           verbose: false # optional (default = false)
 
       - name: Upload test results to Codecov
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
         if: ${{ !cancelled() }}
         continue-on-error: true #don't fail if we can't upload (ie a fork that does not have integration plugged in)
         with:
@@ -231,7 +231,7 @@ jobs:
       # within one final file in the "Merge all partial test durations" step below.
       - name: Upload test durations
         if: github.run_attempt == 1
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: test-durations-after-partial-${{ matrix.split }}
           path: ./.test_durations
@@ -246,7 +246,7 @@ jobs:
           MATRIX_SPLIT: ${{ matrix.split }}
 
       - name: Upload coverage artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: internal_coverage-${{ matrix.split }}
           path: coverage-${{ matrix.split }}
@@ -255,7 +255,7 @@ jobs:
           retention-days: 1
 
       - name: Store test results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: internal_junit-results-${{ matrix.split }}
@@ -263,20 +263,20 @@ jobs:
           retention-days: 1
 
       - name: Test Summary (if Failure)
-        uses: test-summary/action@v2
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2
         with:
           paths: "./junit/result/*.xml"
         if: failure()
 
       - name: Test Summary Local copy (If Failure)
-        uses: test-summary/action@v2
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2
         with:
           paths: "./junit/result/*.xml"
           output: "./junit/result/test-summary.md"
         if: failure()
 
       - name: Store Test Summary results (If Failure)
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: split-test-summary-${{ matrix.split }}.md
           path: "./junit/result/test-summary.md"
@@ -291,7 +291,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all partial test durations
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: test-durations-after-partial-*
 
@@ -308,7 +308,7 @@ jobs:
       # and use it to manually commit file gzip `.test_durations` from time to time,
       # to keep an up-to-date fallback:
       - name: Upload final test durations
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: test-durations-after
           path: /tmp/.test_durations
@@ -318,7 +318,7 @@ jobs:
       # Finally, we cache the new test durations. This file will be restored in next CI execution
       # (see step "Restore test durations" above).
       - name: Cache final test durations
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: /tmp/.test_durations
           key: tests-durations-${{ github.sha }}
@@ -334,12 +334,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Cache pip
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ${{ env.PIP_CACHE_DIR }}
           key: ${{ runner.os }}-pip-${{ hashFiles('*requirements.txt') }}
@@ -351,14 +351,14 @@ jobs:
           pip install -r dev-requirements.txt
 
       - name: Download all coverage artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: internal_coverage-*
           path: coverage-data
           merge-multiple: 'true'
 
       - name: Download all JUnit XML results
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: internal_junit-results-*
           merge-multiple: true
@@ -395,7 +395,7 @@ jobs:
           coverage report -m
 
       - name: Upload HTML coverage report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: combined-test-coverage-reports
           path: results

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -147,7 +147,9 @@ jobs:
 
     steps:
       - run: |
-          echo "${{ matrix.split }} of $SPLIT_COUNT"
+          echo "${MATRIX_SPLIT} of $SPLIT_COUNT"
+        env:
+          MATRIX_SPLIT: ${{ matrix.split }}
 
       - uses: actions/checkout@v6
         with:
@@ -200,12 +202,14 @@ jobs:
           set -ex
 
           mkdir -p ./junit/result
-          echo "${{ matrix.split }} of $SPLIT_COUNT"
+          echo "${MATRIX_SPLIT} of $SPLIT_COUNT"
 
           echo "::group::pytest"
           #we ignore test 'test_building_the_docs' as its looked after by the docs.yml workflow which provides the sphinx documentation build artifact and it also takes 50 seconds to run
-          pytest $PYTEST_COMMON_OPTIONS --splits $SPLIT_COUNT --group ${{ matrix.split }} --splitting-algorithm least_duration --store-durations --clean-durations  -k 'not test_building_the_docs'
+          pytest $PYTEST_COMMON_OPTIONS --splits $SPLIT_COUNT --group ${MATRIX_SPLIT} --splitting-algorithm least_duration --store-durations --clean-durations  -k 'not test_building_the_docs'
           echo "::endgroup::"
+        env:
+          MATRIX_SPLIT: ${{ matrix.split }}
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
@@ -237,7 +241,9 @@ jobs:
 
       - name: Prep test coverage split file
         run: |
-          mv .coverage coverage-${{ matrix.split }}
+          mv .coverage coverage-${MATRIX_SPLIT}
+        env:
+          MATRIX_SPLIT: ${{ matrix.split }}
 
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,6 +4,9 @@ name: Pytest
 on:
   #pull_request: #disabled as its called via test.yml uses delegation
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: false
   workflow_dispatch:
     inputs:
       splits:

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -12,5 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: astral-sh/ruff-action@v3
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -11,8 +11,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
+      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3.6.1
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -4,12 +4,13 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -11,8 +11,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: astral-sh/ruff-action@v3
+      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,32 +9,41 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }} # workflow limits it to this workflow, ref includes a pushed branch or on pull request merge branch
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
 
   ruff:
     name: Lint (Ruff)
     uses: ./.github/workflows/ruff.yml # Call the reusable workflow
+    permissions:
+      contents: read
     secrets: inherit
 
   pyright:
     name: Lint (PyRight)
     uses: ./.github/workflows/pyright.yml # Call the reusable workflow
+    permissions:
+      contents: read
     secrets: inherit
 
   cypress:
     name: Test (Cypress)
     uses: ./.github/workflows/cypress.yml # Call the reusable workflow
+    permissions:
+      contents: read
     secrets: inherit
 
   docs:
     name: Documentation
     uses: ./.github/workflows/docs.yml # Call the reusable workflow
+    permissions:
+      contents: read
     secrets: inherit
 
   pytest:
     name: Test (Pytest)
     uses: ./.github/workflows/pytest.yml # Call the reusable workflow
+    permissions:
+      contents: read
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,32 +18,29 @@ jobs:
     uses: ./.github/workflows/ruff.yml # Call the reusable workflow
     permissions:
       contents: read
-    secrets: inherit
 
   pyright:
     name: Lint (PyRight)
     uses: ./.github/workflows/pyright.yml # Call the reusable workflow
     permissions:
       contents: read
-    secrets: inherit
 
   cypress:
     name: Test (Cypress)
     uses: ./.github/workflows/cypress.yml # Call the reusable workflow
     permissions:
       contents: read
-    secrets: inherit
 
   docs:
     name: Documentation
     uses: ./.github/workflows/docs.yml # Call the reusable workflow
     permissions:
       contents: read
-    secrets: inherit
 
   pytest:
     name: Test (Pytest)
     uses: ./.github/workflows/pytest.yml # Call the reusable workflow
     permissions:
       contents: read
-    secrets: inherit
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/towncrier.yml
+++ b/.github/workflows/towncrier.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'No changelog') }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/.github/workflows/towncrier.yml
+++ b/.github/workflows/towncrier.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'

--- a/.github/workflows/towncrier.yml
+++ b/.github/workflows/towncrier.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'No changelog') }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/.github/workflows/towncrier.yml
+++ b/.github/workflows/towncrier.yml
@@ -1,13 +1,14 @@
 name: Changelog entries
 on: [pull_request]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   towncrier:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'No changelog') }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/doc/contributing/maintenance-tools.rst
+++ b/doc/contributing/maintenance-tools.rst
@@ -43,13 +43,13 @@ The behaviour of this action is the following:
   already closed PRs adding a comment starting with ``/backport`` (and
   adding the relevant label)
 
-There are two repository variables and a repository secret needed to run the action
+There are two repository variables and a environment secret needed to run the action
 (check the `documentation <https://docs.github.com/en/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository>`_
 on how to set up these):
 
 * The public variable ``TECH_TEAM_USER_IDS`` is a JSON list of the GitHub user ids of the Tech Team members. User ids can be found using the ``https://api.github.com/users/<user_name>`` endpoint.
 * The public variable ``CKANBOT_USER_ID`` is the user id of the :ref:`ckanbot`.
-* The secret ``BACKPORT_ACTION_PAT`` is a `Personal Access Token <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens>`_ (PAT) of the ckanbot account, with enough permissions to write to the ckan/ckan repository.
+* The ``backports`` environment secret ``BACKPORT_ACTION_PAT`` is a `Personal Access Token <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens>`_ (PAT) of the ckanbot account, with enough permissions to write to the ckan/ckan repository.
 
 When creating a new PAT, make sure to select the following settings:
 


### PR DESCRIPTION
Improve and fix various issues flagged by [zizmor](https://docs.zizmor.sh/) in our workflows:

* Explicitly set `persist-credentials: false` in checkout actions so credentials are not stored
* Use vars instead of template expansions when possible to avoid template injections (e.g. content coming from a PR comment)
* Pin actions to hash + Dependabot config to upgrade them (check once a week, cooldown and send a single PR)
* Restrict all permissions to all workflows by default, apply to jobs as needed.
* Run backports in a separate environment, so we can restrict the token used to just that environment.
* Improve CodeQL workflows: Ignore files in the cookiecutter template as syntax errors are raised
when trying to analyze them, test release branches

This might break some workflow but we can tweak the config as needed going forward.