### PR TITLE
Fixes for setuptools>=82

### DIFF
--- a/changes/9246.bugfix
+++ b/changes/9246.bugfix
@@ -1,0 +1,2 @@
+Remove unnecessary declare_namespace in ckanext/stats/__init__.py
+to resolve compatibility with setuptools>=82

--- a/ckanext/stats/__init__.py
+++ b/ckanext/stats/__init__.py
@@ -1,3 +1,0 @@
-# encoding: utf-8
-
-__import__('pkg_resources').declare_namespace(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools<82"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 

--- a/test-infrastructure/install_deps.sh
+++ b/test-infrastructure/install_deps.sh
@@ -9,7 +9,7 @@ apt-get install -y postgresql-client
 
 #Python Dependencies
 pip install -U pip
-pip install -U setuptools==81
+pip install -U setuptools
 pip install -r requirements.txt
 pip install -r dev-requirements.txt
 pip install -e .


### PR DESCRIPTION
Fixes #9246 

### Proposed fixes:

- Remove unnecessary declare_namespace in ckanext/stats/\_\_init\_\_.py

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport