### PR TITLE
Fix flaky file_rename test

### DIFF
--- a/ckan/lib/files/default/fs.py
+++ b/ckan/lib/files/default/fs.py
@@ -22,10 +22,13 @@ class Settings(base.Settings, fs.Settings):
 class Reader(base.Reader, fs.Reader):
     @override
     def response(self, data: base.FileData, extras: dict[str, Any]) -> types.Response:
-        filepath = os.path.join(self.storage.settings.path, data.location)
         if not self.storage.exists(data):
             raise exc.MissingFileError(self.storage, data.location)
 
+        # `full_path` prevents injection of null-byte and path-traversal. But
+        # even without it the location can be considered as safe, because
+        # `storage.exists` has not complains about it.
+        filepath = self.storage.full_path(data.location)
         return flask.send_file(
             filepath,
             download_name=data.location,

--- a/ckan/tests/logic/action/test_file.py
+++ b/ckan/tests/logic/action/test_file.py
@@ -285,7 +285,7 @@ class TestFileRename:
     def test_name_secured(self, file: dict[str, Any]):
         """Filename is sanitized."""
         bad_name = fake.unique.file_path()
-        good_name = bad_name.rsplit("/", 1)[-1]
+        good_name = bad_name.rsplit("/", 1)[-1].lower()
 
         result = call_action("file_rename", id=file["id"], name=bad_name)
 

--- a/ckan/views/file.py
+++ b/ckan/views/file.py
@@ -136,7 +136,8 @@ def public_download(storage_name: str, location: str) -> Response:
             size=storage.size(location),
             content_type=storage.content_type(location),
         )
-    except files.exc.MissingFileError:
+    except (files.exc.MissingFileError, files.exc.LocationError):
+        # LocationError happens during path-traversal attack
         return base.abort(404)
 
     return _as_response(storage_name, data)


### PR DESCRIPTION
Fixes [flaky test](https://github.com/ckan/ckan/actions/runs/25283465453/job/74124216139)

Additionally, I added a comment to `ckan:fs` storage that explains how it's protected from path-traversal