### PR TITLE
Fix DataTables view JS error

### DIFF
--- a/ckanext/datatablesview/templates/datatables/datatables_view.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_view.html
@@ -2,7 +2,7 @@
 
 {% block title %}{{ h.dataset_display_name(package)}}&mdash;{{ h.resource_display_name(resource)}} - {{ super() }}{% endblock %}
 {% block bodytag %}
-  {{- super() -}}
+  {{ super() }}
   class="dt-view"
 {%- endblock -%}
 

--- a/ckanext/datatablesview/tests/test_plugin.py
+++ b/ckanext/datatablesview/tests/test_plugin.py
@@ -1,0 +1,35 @@
+import bs4
+import pytest
+
+from ckan.lib.helpers import url_for
+from ckan.tests import factories, helpers
+
+
+@pytest.mark.ckan_config("ckan.plugins", "datastore datatables_view")
+@pytest.mark.usefixtures("with_plugins")
+def test_ajax_data(app):  # type: ignore
+    dataset = factories.Dataset()
+    ds = helpers.call_action(
+        "datastore_create",
+        resource={"package_id": dataset["id"]},
+        fields=[{"id": "a", "type": "text"}, {"id": "b", "type": "int"}],
+        records=[
+            {"a": "one", "b": 1},
+            {"a": "two", "b": 2},
+        ],
+    )
+    view = factories.ResourceView(
+        view_type="datatables_view", resource_id=ds["resource_id"]
+    )
+    url = url_for(
+        "resource.view",
+        id=dataset["id"],
+        resource_id=ds["resource_id"],
+        view_id=view["id"],
+    )
+
+    resp = app.get(url)
+
+    page = bs4.BeautifulSoup(resp.body)
+
+    assert page.body["class"] == ["dt-view"]  # type: ignore


### PR DESCRIPTION
2.12/master only

Because of whitespace handling changes (probably introduced in https://github.com/ckan/ckan/pull/9284) now the body class name renders incorrectly:

```html
  <bodyclass="dt-view">
```

The error didn't seem to affect much how the view worked, so that logic probably needs reviewing