### PR TITLE
Sysadmin Schema for User API Tokens

### DIFF
--- a/changes/9339.feature
+++ b/changes/9339.feature
@@ -1,0 +1,1 @@
+Added sysadmin params `id`, `created_at`, and `last_access` to the default `api_token_create` Schema. This allows for sysadmin migrations for User API Tokens.

--- a/ckan/lib/dictization/model_save.py
+++ b/ckan/lib/dictization/model_save.py
@@ -666,11 +666,24 @@ def api_token_save(data_dict: dict[str, Any],
                    context: Context) -> 'model.ApiToken':
     user = model.User.get(data_dict['user'])
     assert user
-    token, _change = d.table_dict_save(
-        {
-            u"user_id": user.id,
-            u"name": data_dict[u"name"]
-        },
-        model.ApiToken, context
-    )
+    if 'id' in data_dict:
+        # sysadmin insertion / migration
+        token, _change = d.table_dict_save(
+            {
+                "user_id": user.id,
+                "name": data_dict[u"name"],
+                "id": data_dict["id"],
+                "created_at": data_dict.get("created_at"),
+                "last_access": data_dict.get("last_access")
+            },
+            model.ApiToken, context
+        )
+    else:
+        token, _change = d.table_dict_save(
+            {
+                u"user_id": user.id,
+                u"name": data_dict[u"name"]
+            },
+            model.ApiToken, context
+        )
     return token

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -1454,7 +1454,7 @@ def api_token_create(context: Context,
     :rtype: dictionary
 
     """
-    user, name = _get_or_bust(data_dict, [u'user', u'name'])
+    user, _name = _get_or_bust(data_dict, [u'user', u'name'])
 
     if model.User.get(user) is None:
         raise NotFound("User not found")

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -1437,6 +1437,15 @@ def api_token_create(context: Context,
     :type user: string
     :param name: distinctive name for API Token
     :type name: string
+    :param created_at: datetime string for when the API Token was made.
+        Only sysadmin users may set this value, used for data migrations.
+    :type created_at: timestamp
+    :param id: UUID of the API Token (a.k.a the encoded token).
+        Only sysadmin users may set this value, used for data migrations.
+    :type id: string
+    :param last_access: datetime string for when the API Token was last used.
+        Only sysadmin users may set this value, used for data migrations.
+    :type last_access: timestamp
 
     :returns: Returns a dict with the key "token" containing the
               encoded token value. Extensions can provide additional
@@ -1462,7 +1471,7 @@ def api_token_create(context: Context,
         raise ValidationError(errors)
 
     token_obj = model_save.api_token_save(
-        {u'user': user, u'name': name}, context
+        validated_data_dict, context
     )
     model.Session.commit()
     data = {

--- a/ckan/logic/schema/__init__.py
+++ b/ckan/logic/schema/__init__.py
@@ -869,6 +869,9 @@ def default_create_api_token_schema(not_empty: Validator,
         u'name': [not_empty, unicode_safe],
         u'user': [not_empty, unicode_safe],
         u'plugin_extras': [ignore_missing, json_object, ignore_not_sysadmin],
+        'created_at': [ignore_missing, ignore_not_sysadmin],
+        'id': [ignore_missing, ignore_not_sysadmin],
+        'last_access': [ignore_missing, ignore_not_sysadmin],
     }
 
 

--- a/ckan/logic/schema/__init__.py
+++ b/ckan/logic/schema/__init__.py
@@ -863,15 +863,16 @@ def default_create_api_token_schema(not_empty: Validator,
                                     unicode_safe: Validator,
                                     ignore_missing: Validator,
                                     json_object: Validator,
-                                    ignore_not_sysadmin: Validator
+                                    ignore_not_sysadmin: Validator,
+                                    isodate: Validator
                                     ) -> Schema:
     return {
         u'name': [not_empty, unicode_safe],
         u'user': [not_empty, unicode_safe],
         u'plugin_extras': [ignore_missing, json_object, ignore_not_sysadmin],
-        'created_at': [ignore_missing, ignore_not_sysadmin],
+        'created_at': [ignore_missing, isodate, ignore_not_sysadmin],
         'id': [ignore_missing, ignore_not_sysadmin],
-        'last_access': [ignore_missing, ignore_not_sysadmin],
+        'last_access': [ignore_missing, isodate, ignore_not_sysadmin],
     }
 
 

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -1940,6 +1940,54 @@ class TestApiToken(object):
         assert res.last_access is None
         assert res.id == jti
 
+    def test_token_created_insert(self):
+        """
+        Sysadmins should be able to insert id, created_at, last_access
+        """
+        from ckan.lib.api_token import decode
+
+        # normal users cannot insert API Tokens
+        user = factories.User()
+        data = helpers.call_action(
+            'api_token_create',
+            context={'model': model, 'user': user['name'],
+                     'ignore_auth': False},
+            user=user['name'],
+            name='token-name-create',
+            id='thisisthetoken',
+            created_at='2025-09-12T19:06:35.989399',
+            last_access='2025-09-12T19:06:35.989399'
+        )
+        token = data['token']
+        jti = decode(token)['jti']
+        res = model.ApiToken.get(jti)
+        assert res.user_id == user['id']
+        assert res.last_access != datetime.datetime.fromisoformat('2025-09-12T19:06:35.989399')
+        assert res.created_at != datetime.datetime.fromisoformat('2025-09-12T19:06:35.989399')
+        assert res.id == jti
+        assert res.id != 'thisisthetoken'
+
+        # sysadmin users can insert API Tokens
+        user = factories.Sysadmin()
+        data = helpers.call_action(
+            'api_token_create',
+            context={'model': model, 'user': user['name'],
+                     'ignore_auth': False},
+            user=user['name'],
+            name='token-name-create',
+            id='thisisthetoken',
+            created_at='2025-09-12T19:06:35.989399',
+            last_access='2025-09-12T19:06:35.989399'
+        )
+        token = data['token']
+        jti = decode(token)['jti']
+        res = model.ApiToken.get(jti)
+        assert res.user_id == user['id']
+        assert res.last_access == datetime.datetime.fromisoformat('2025-09-12T19:06:35.989399')
+        assert res.created_at == datetime.datetime.fromisoformat('2025-09-12T19:06:35.989399')
+        assert res.id == jti
+        assert res.id == 'thisisthetoken'
+
 
 @pytest.mark.usefixtures("non_clean_db")
 @pytest.mark.ckan_config("ckan.auth.allow_dataset_collaborators", False)


### PR DESCRIPTION
feat(logic): user api tokens;

- Sysadmin schema for create api token.

Fixes #

### Proposed fixes:

This just allows for CKANAPI dump and load of User API Tokens (https://github.com/ckan/ckanapi/pull/230). Of course you are only dumping encoded tokens. So the JWT encoded value is not useful without the secret.

cc: @wardi 

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
