### PR TITLE
feat: Allow using composite PK in test factories

### DIFF
--- a/changes/9341.feature
+++ b/changes/9341.feature
@@ -1,0 +1,1 @@
+Test factories support composite primary key via ``primary_key = ("part1", "part2")``.

--- a/changes/9341.feature
+++ b/changes/9341.feature
@@ -1,1 +1,1 @@
-Test factories support composite primary key via ``primary_key = ("part1", "part2")``.
+Test factories can be used with models that have composite primary key.

--- a/ckan/tests/factories.py
+++ b/ckan/tests/factories.py
@@ -69,10 +69,6 @@ Usage::
  # * create `Meta` class inside it, with the two properties:
  #   * model: corresponding SQLAlchemy model
  #   * action: API action that can create instances of the model
- #   * primary_key (optional): Name of the model's primary key column. The default
- #         value is `id`. Override this only if PK has a different name or consists
- #         of multiple columns(use tuple with column names in this case,
- #         i.e `primary_key = ("a", "b")`)
  # * define any extra attributes
  # * register factory as a fixture using :py:func:`~pytest_factoryboy.register`
  import factory
@@ -106,6 +102,7 @@ from functools import partial
 from typing import Any, Optional
 
 import factory
+import sqlalchemy as sa
 from faker import Faker
 
 import ckan.model
@@ -166,7 +163,7 @@ class CKANOptions(factory.alchemy.SQLAlchemyOptions):
     def _build_default_options(self):
         return super()._build_default_options() + [
             factory.base.OptionDefault("action", None, inherit=True),
-            factory.base.OptionDefault("primary_key", "id", inherit=True),
+            factory.base.OptionDefault("primary_key", None, inherit=True),
         ]
 
 
@@ -214,9 +211,15 @@ class CKANFactory(factory.alchemy.SQLAlchemyModelFactory):
         result = cls(**kwargs)
 
         key = cls._meta.primary_key
+        if not key:
+            # if key is not specified in factory definition, compute it via
+            # model inspection
+            key = tuple(k.name for k in sa.inspect(cls._meta.model).primary_key)
+
         if isinstance(key, str):
             key = (key, )
         getter = operator.itemgetter(*key)
+
         return cls._meta.sqlalchemy_session.get(
             cls._meta.model,
             getter(result),

--- a/ckan/tests/factories.py
+++ b/ckan/tests/factories.py
@@ -69,6 +69,10 @@ Usage::
  # * create `Meta` class inside it, with the two properties:
  #   * model: corresponding SQLAlchemy model
  #   * action: API action that can create instances of the model
+ #   * primary_key (optional): Name of the model's primary key column. The default
+ #         value is `id`. Override this only if PK has a different name or consists
+ #         of multiple columns(use tuple with column names in this case,
+ #         i.e `primary_key = ("a", "b")`)
  # * define any extra attributes
  # * register factory as a fixture using :py:func:`~pytest_factoryboy.register`
  import factory
@@ -95,6 +99,7 @@ https://pytest-factoryboy.readthedocs.io/en/latest/
 from __future__ import annotations
 
 import string
+import operator
 import unittest.mock as mock
 
 from functools import partial
@@ -204,12 +209,17 @@ class CKANFactory(factory.alchemy.SQLAlchemyModelFactory):
         return cls._api_postprocess_result(result)
 
     @classmethod
-    def model(cls, **kwargs):
+    def model(cls, **kwargs: Any):
         """Create entity via API and retrieve result directly from the DB."""
         result = cls(**kwargs)
+
+        key = cls._meta.primary_key
+        if isinstance(key, str):
+            key = (key, )
+        getter = operator.itemgetter(*key)
         return cls._meta.sqlalchemy_session.get(
             cls._meta.model,
-            result[cls._meta.primary_key],
+            getter(result),
         )
 
     @classmethod

--- a/ckan/tests/test_factories.py
+++ b/ckan/tests/test_factories.py
@@ -1,12 +1,12 @@
-# encoding: utf-8
-
 import pytest
+from faker import Faker
 
 import ckan.tests.factories as factories
+from ckan import model, types
 
 
 @pytest.mark.parametrize(
-    u"entity",
+    "entity",
     [
         factories.User,
         factories.Resource,
@@ -20,7 +20,7 @@ import ckan.tests.factories as factories
 @pytest.mark.usefixtures("non_clean_db")
 def test_id_uniqueness(entity):
     first, second = entity(), entity()
-    assert first[u"id"] != second[u"id"]
+    assert first["id"] != second["id"]
 
 
 # START-CONFIG-OVERRIDE
@@ -29,7 +29,7 @@ def test_id_uniqueness(entity):
 def test_resource_view_factory():
     resource_view1 = factories.ResourceView()
     resource_view2 = factories.ResourceView()
-    assert resource_view1[u"id"] != resource_view2[u"id"]
+    assert resource_view1["id"] != resource_view2["id"]
 
 
 # END-CONFIG-OVERRIDE
@@ -38,4 +38,36 @@ def test_resource_view_factory():
 @pytest.mark.usefixtures("non_clean_db")
 def test_dataset_factory_allows_creation_by_anonymous_user():
     dataset = factories.Dataset(user=None)
-    assert dataset[u"creator_user_id"] is None
+    assert dataset["creator_user_id"] is None
+
+
+@pytest.mark.usefixtures("non_clean_db")
+def test_factory_model(package_factory: types.TestFactory, faker: Faker):
+    """Factory can create a model object instead of a dictionary."""
+    notes = faker.sentence()
+    package = package_factory.model(notes=notes)
+    assert isinstance(package, model.Package)
+    assert package.notes == notes
+
+
+class UserFollowFactory(factories.CKANFactory):
+    class Meta:
+        model = model.UserFollowingUser
+        action = "follow_user"
+        primary_key = ("follower_id", "object_id")
+
+
+@pytest.mark.usefixtures("non_clean_db")
+def test_factory_model_with_composite_key(user_factory: types.TestFactory):
+    """Factory can create a model object with a composite primary key.
+
+    In this case, the UserFollowingUser model has a composite primary key
+    consisting of follower_id and object_id.
+    """
+    john = user_factory()
+    jane = user_factory()
+
+    result = UserFollowFactory.model(id=john["id"], user=jane)
+    assert isinstance(result, model.UserFollowingUser)
+    assert result.object_id == john["id"]
+    assert result.follower_id == jane["id"]

--- a/ckan/tests/test_factories.py
+++ b/ckan/tests/test_factories.py
@@ -50,15 +50,21 @@ def test_factory_model(package_factory: types.TestFactory, faker: Faker):
     assert package.notes == notes
 
 
-class UserFollowFactory(factories.CKANFactory):
+class UserFollowFactoryWithKey(factories.CKANFactory):
     class Meta:
         model = model.UserFollowingUser
         action = "follow_user"
         primary_key = ("follower_id", "object_id")
 
 
+class UserFollowFactoryWithoutKey(factories.CKANFactory):
+    class Meta:
+        model = model.UserFollowingUser
+        action = "follow_user"
+
+
 @pytest.mark.usefixtures("non_clean_db")
-def test_factory_model_with_composite_key(user_factory: types.TestFactory):
+def test_factory_model_with_explicit_composite_key(user_factory: types.TestFactory):
     """Factory can create a model object with a composite primary key.
 
     In this case, the UserFollowingUser model has a composite primary key
@@ -67,7 +73,19 @@ def test_factory_model_with_composite_key(user_factory: types.TestFactory):
     john = user_factory()
     jane = user_factory()
 
-    result = UserFollowFactory.model(id=john["id"], user=jane)
+    result = UserFollowFactoryWithKey.model(id=john["id"], user=jane)
+    assert isinstance(result, model.UserFollowingUser)
+    assert result.object_id == john["id"]
+    assert result.follower_id == jane["id"]
+
+
+@pytest.mark.usefixtures("non_clean_db")
+def test_factory_model_with_implicit_composite_key(user_factory: types.TestFactory):
+    """If primary key is not specified, factory will guess it."""
+    john = user_factory()
+    jane = user_factory()
+
+    result = UserFollowFactoryWithoutKey.model(id=john["id"], user=jane)
     assert isinstance(result, model.UserFollowingUser)
     assert result.object_id == john["id"]
     assert result.follower_id == jane["id"]


### PR DESCRIPTION
Test factories inherited from `ckan.tests.factories.CKANFactory` have a `model` method that returns the model object instead of a dictionary. This method uses the entity's primary key to fetch from the DB object created via API. At the moment, it supports only plain primary keys, like `id`.

This PR uses model inspection to compute PK of the model and enables `model` method for models with composite primary key, like `UserFollowingUser`, which has PK = `follower_id, object_id`