### PR TITLE
Remove unused UuidType(sqlalchemy column type)

### DIFF
--- a/changes/9342.removal
+++ b/changes/9342.removal
@@ -1,0 +1,1 @@
+Remove :py:class:`ckan.model.types.UuidType`.

--- a/ckan/model/types.py
+++ b/ckan/model/types.py
@@ -9,29 +9,11 @@ import simplejson as json
 from sqlalchemy import types
 
 
-__all__ = ['make_uuid', 'UuidType',
-           'JsonType', 'JsonDictType']
+__all__ = ['make_uuid', 'JsonType', 'JsonDictType']
 
 
 def make_uuid() -> str:
     return str(uuid.uuid4())
-
-
-class UuidType(types.TypeDecorator):  # type: ignore
-    impl = types.Unicode
-
-    def process_bind_param(self, value: Any, dialect: Any):
-        return str(value)
-
-    def process_result_value(self, value: Any, dialect: Any):
-        return value
-
-    def copy(self, **kw: Any):
-        return UuidType(cast(Any, self.impl).length)
-
-    @classmethod
-    def default(cls):
-        return str(uuid.uuid4())
 
 
 class JsonType(types.TypeDecorator):  # type: ignore


### PR DESCRIPTION
UuidType was replaced by `make_uuid` function long time ago and no longer used