### PR TITLE
Use JSONB instead of customized text for nested data

### DIFF
--- a/changes/9344.feature
+++ b/changes/9344.feature
@@ -1,0 +1,1 @@
+Change type of columns ``Resource.extras``, ``ResourceView.config``, and ``Activity.data`` to JSONB.

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -2079,34 +2079,26 @@ def resource_search(context: Context, data_dict: DataDict) -> ActionResult.Resou
             raise ValidationError({'query': msg})
 
         # prevent pattern injection
-        term = misc.escape_sql_like_special_characters(term)
+        safe_term = misc.escape_sql_like_special_characters(term)
 
         model_attr = getattr(model.Resource, field)
 
         # Treat the has field separately, see docstring.
         if field == 'hash':
-            q = q.filter(model_attr.ilike(str(term) + '%'))
+            q = q.filter(model_attr.ilike(str(safe_term) + '%'))
 
         # Resource extras are stored in a json blob.  So searching for
         # matching fields is a bit trickier. See the docstring.
         elif field in model.Resource.get_extra_columns():
-            model_attr = getattr(model.Resource, 'extras')
-
-            like = _or_(
-                model_attr.ilike(
-                    u'''%%"%s": "%%%s%%",%%''' % (field, term)),
-                model_attr.ilike(
-                    u'''%%"%s": "%%%s%%"}''' % (field, term))
-            )
-            q = q.filter(like)
+            q = q.filter(model.Resource.extras[field].astext == term)
 
         # Just a regular field
         else:
             column = model_attr.property.columns[0]
             if isinstance(column.type, sqlalchemy.UnicodeText):
-                q = q.filter(model_attr.ilike('%' + str(term) + '%'))
+                q = q.filter(model_attr.ilike('%' + str(safe_term) + '%'))
             else:
-                q = q.filter(model_attr == term)
+                q = q.filter(model_attr == safe_term)
 
     if order_by is not None:
         if hasattr(model.Resource, order_by):

--- a/ckan/migration/versions/110_a6da0c623f10_use_jsonb_type_instead_of_customized_string.py
+++ b/ckan/migration/versions/110_a6da0c623f10_use_jsonb_type_instead_of_customized_string.py
@@ -1,0 +1,82 @@
+"""Replace custom JSON type with JSONB column.
+
+Revision ID: a6da0c623f10
+Revises: 9445ce34fc23
+Create Date: 2026-05-08 13:34:31.431283
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "a6da0c623f10"
+down_revision = "9445ce34fc23"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "activity",
+        "data",
+        existing_type=sa.TEXT(),
+        type_=postgresql.JSONB(astext_type=sa.Text()),
+        postgresql_using="data::jsonb",
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "activity_detail",
+        "data",
+        existing_type=sa.TEXT(),
+        type_=postgresql.JSONB(astext_type=sa.Text()),
+        postgresql_using="data::jsonb",
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "resource",
+        "extras",
+        existing_type=sa.TEXT(),
+        type_=postgresql.JSONB(astext_type=sa.Text()),
+        postgresql_using="extras::jsonb",
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "resource_view",
+        "config",
+        existing_type=sa.TEXT(),
+        type_=postgresql.JSONB(astext_type=sa.Text()),
+        postgresql_using="config::jsonb",
+        existing_nullable=True,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "resource_view",
+        "config",
+        existing_type=postgresql.JSONB(astext_type=sa.Text()),
+        type_=sa.TEXT(),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "resource",
+        "extras",
+        existing_type=postgresql.JSONB(astext_type=sa.Text()),
+        type_=sa.TEXT(),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "activity_detail",
+        "data",
+        existing_type=postgresql.JSONB(astext_type=sa.Text()),
+        type_=sa.TEXT(),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "activity",
+        "data",
+        existing_type=postgresql.JSONB(astext_type=sa.Text()),
+        type_=sa.TEXT(),
+        existing_nullable=True,
+    )

--- a/ckan/model/resource.py
+++ b/ckan/model/resource.py
@@ -10,6 +10,8 @@ from sqlalchemy.ext.orderinglist import ordering_list
 from sqlalchemy import orm
 from ckan.common import config
 from sqlalchemy import types, Column, Table, ForeignKey, Index
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.mutable import MutableDict
 from typing_extensions import Self
 
 import ckan.model.meta as meta
@@ -54,7 +56,7 @@ resource_table = Table(
     Column('cache_url', types.UnicodeText),
     Column('cache_last_updated', types.DateTime),
     Column('url_type', types.UnicodeText),
-    Column('extras', _types.JsonDictType),
+    Column('extras', MutableDict.as_mutable(JSONB)),
     Column('state', types.UnicodeText, default=core.State.ACTIVE),
     Index('idx_package_resource_id', 'id'),
     Index('idx_package_resource_package_id', 'package_id'),

--- a/ckan/model/resource_view.py
+++ b/ckan/model/resource_view.py
@@ -5,6 +5,8 @@ from typing import Any, Collection, Optional
 
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.mutable import MutableDict
 from typing_extensions import Self
 
 import ckan.model.meta as meta
@@ -25,7 +27,7 @@ resource_view_table = sa.Table(
     sa.Column('description', sa.types.UnicodeText, nullable=True),
     sa.Column('view_type', sa.types.UnicodeText, nullable=False),
     sa.Column('order', sa.types.Integer, nullable=False),
-    sa.Column('config', _types.JsonDictType),
+    sa.Column('config', MutableDict.as_mutable(JSONB)),
     sa.Index('idx_view_resource_id', 'resource_id'),
 )
 

--- a/ckan/model/types.py
+++ b/ckan/model/types.py
@@ -1,16 +1,12 @@
 # encoding: utf-8
 
-import copy
 import uuid
 from typing import Any, cast
-
-import simplejson as json
 
 from sqlalchemy import types
 
 
-__all__ = ['make_uuid', 'UuidType',
-           'JsonType', 'JsonDictType']
+__all__ = ['make_uuid', 'UuidType']
 
 
 def make_uuid() -> str:
@@ -32,58 +28,3 @@ class UuidType(types.TypeDecorator):  # type: ignore
     @classmethod
     def default(cls):
         return str(uuid.uuid4())
-
-
-class JsonType(types.TypeDecorator):  # type: ignore
-    '''Store data as JSON serializing on save and unserializing on use.
-
-    Note that default values don\'t appear to work correctly with this
-    type, a workaround is to instead override ``__init__()`` to explicitly
-    set any default values you expect.
-    '''
-    impl = types.UnicodeText
-
-    cache_ok = False
-
-    def process_bind_param(self, value: Any, dialect: Any):
-        # ensure we stores nulls in db not json "null"
-        if value is None or value == {}:
-            return None
-
-        # ensure_ascii=False => allow unicode but still need to convert
-        return str(json.dumps(value, ensure_ascii=False))
-
-    def process_result_value(self, value: Any, dialect: Any) -> Any:
-        if value is None:
-            return {}
-
-        return json.loads(value)
-
-    def copy(self, **kw: Any):
-        return JsonType(cast(Any, self.impl).length)
-
-    def is_mutable(self):
-        return True
-
-    def copy_value(self, value: Any):
-        return copy.copy(value)
-
-
-class JsonDictType(JsonType):
-
-    impl = types.UnicodeText
-
-    cache_ok = False
-
-    def process_bind_param(self, value: Any, dialect: Any):
-        # ensure we stores nulls in db not json "null"
-        if value is None or value == {}:
-            return None
-
-        if isinstance(value, str):
-            return str(value)
-
-        return str(json.dumps(value, ensure_ascii=False))
-
-    def copy(self, **kw: Any):
-        return JsonDictType(cast(Any, self.impl).length)

--- a/ckanext/activity/model/activity.py
+++ b/ckanext/activity/model/activity.py
@@ -19,6 +19,8 @@ from sqlalchemy import (
     Index,
     Table,
 )
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.mutable import MutableDict
 
 from ckan.common import config
 import ckan.model as model
@@ -47,7 +49,7 @@ class Activity(domain_object.DomainObject, BaseModel):
         Column("user_id", types.UnicodeText),
         Column("object_id", types.UnicodeText),
         Column("activity_type", types.UnicodeText),
-        Column("data", _types.JsonDictType),
+        Column("data", MutableDict.as_mutable(JSONB)),
         Column("permission_labels", types.Text),
     )
 
@@ -192,7 +194,7 @@ class ActivityDetail(domain_object.DomainObject, BaseModel):
     object_id = Column("object_id", types.UnicodeText)
     object_type = Column("object_type", types.UnicodeText)
     activity_type = Column("activity_type", types.UnicodeText)
-    data = Column("data", _types.JsonDictType)
+    data = Column("data", MutableDict.as_mutable(JSONB))
 
     activity: Mapped[Activity] = relationship(
         Activity,

--- a/ckanext/activity/model/activity.py
+++ b/ckanext/activity/model/activity.py
@@ -20,7 +20,6 @@ from sqlalchemy import (
     Table,
 )
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.ext.mutable import MutableDict
 
 from ckan.common import config
 import ckan.model as model
@@ -49,7 +48,7 @@ class Activity(domain_object.DomainObject, BaseModel):
         Column("user_id", types.UnicodeText),
         Column("object_id", types.UnicodeText),
         Column("activity_type", types.UnicodeText),
-        Column("data", MutableDict.as_mutable(JSONB)),
+        Column("data", JSONB),
         Column("permission_labels", types.Text),
     )
 
@@ -194,7 +193,7 @@ class ActivityDetail(domain_object.DomainObject, BaseModel):
     object_id = Column("object_id", types.UnicodeText)
     object_type = Column("object_type", types.UnicodeText)
     activity_type = Column("activity_type", types.UnicodeText)
-    data = Column("data", MutableDict.as_mutable(JSONB))
+    data = Column("data", JSONB)
 
     activity: Mapped[Activity] = relationship(
         Activity,

--- a/ckanext/tracking/model.py
+++ b/ckanext/tracking/model.py
@@ -16,12 +16,12 @@ ckan/migrations/versions/057_660a5aae527e_tracking.py
 from __future__ import annotations
 
 import datetime
+from typing import Any
 
 from sqlalchemy import types, Column, text, Index, Table
 
 import ckan.model.meta as meta
 import ckan.model.domain_object as domain_object
-import ckan.model.types as _types
 from ckan.model.base import BaseModel
 
 __all__ = ['TrackingSummary', 'TrackingRaw']
@@ -51,13 +51,13 @@ class TrackingRaw(domain_object.DomainObject, BaseModel):
         self.tracking_type = tracking_type
 
     @classmethod
-    def get(cls, **kw: _types.Any) -> TrackingRaw | None:
+    def get(cls, **kw: Any) -> TrackingRaw | None:
         """Get tracking raw entry."""
         query = meta.Session.query(cls).autoflush(False)
         return query.filter_by(**kw).first()
 
     @classmethod
-    def create(cls, **kw: _types.Any) -> TrackingRaw:
+    def create(cls, **kw: Any) -> TrackingRaw:
         """Create a new tracking raw entry."""
         obj = cls(**kw)
         meta.Session.add(obj)
@@ -101,20 +101,20 @@ class TrackingSummary(domain_object.DomainObject, BaseModel):
         self.tracking_date = tracking_date
 
     @classmethod
-    def get(cls, **kw: _types.Any) -> TrackingSummary | None:
+    def get(cls, **kw: Any) -> TrackingSummary | None:
         obj = meta.Session.query(cls).autoflush(False)
         return obj.filter_by(**kw).first()
 
     @classmethod
-    def create(cls, **kwargs: _types.Any) -> TrackingSummary:
+    def create(cls, **kwargs: Any) -> TrackingSummary:
         obj = cls(**kwargs)
         meta.Session.add(obj)
         meta.Session.commit()
         return obj
 
     @classmethod
-    def update(cls, filters: dict[str, _types.Any],
-               **kwargs: _types.Any) -> TrackingSummary | None:
+    def update(cls, filters: dict[str, Any],
+               **kwargs: Any) -> TrackingSummary | None:
         obj = meta.Session.query(cls).filter_by(**filters).first()
         if obj:
             for key, value in kwargs.items():


### PR DESCRIPTION
The following columns are still using a text column that is serialized/deserialized upon access to the DB:

* Resource extras
* ResourceView config
* Activity data
* ActivityDetail data (this is a deprecated model, and it will be removed in the future)

This PR alters given columns to JSONB

