### PR TITLE
Idatastore formats

### DIFF
--- a/changes/9345.feature
+++ b/changes/9345.feature
@@ -1,0 +1,1 @@
+Add a new interface called `IDatastoreDump` to allow users to add or modify datastore dump formats.

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -17,7 +17,7 @@ from ckan.plugins.toolkit import (
     ObjectNotFound, NotAuthorized, get_action, get_validator, _, request,
     abort, render, g, h, ValidationError, asbool, check_access, config,
 )
-from ckan.types import Schema, ValidatorFactory
+from ckan.types import Context, Schema, ValidatorFactory
 
 from ckanext.datastore.interfaces import IDatastoreDump
 from ckanext.datastore.logic.schema import (
@@ -116,7 +116,7 @@ def build_dump_context(
     sp = search_params or {}
     # If the caller already provides total and fields, we can skip the DB query here
     if total is None or fields is None:
-        ds_context = {'user': user} if user is not None else {}
+        ds_context = cast(Context, {'user': user} if user is not None else {})
         result = get_action('datastore_search')(
             ds_context,
             dict(sp, resource_id=resource_id, limit=0, include_total=True),

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -62,28 +62,28 @@ def get_dump_format_configs() -> dict[str, dict[str, Any]]:
             "label": "CSV",
             "writer_factory": csv_writer,
             "records_format": "csv",
-            "content_type": b"text/csv; charset=utf-8",
+            "content_type": "text/csv; charset=utf-8",
             "file_extension": "csv",
         },
         "tsv": {
             "label": "TSV",
             "writer_factory": tsv_writer,
             "records_format": "tsv",
-            "content_type": b"text/tab-separated-values; charset=utf-8",
+            "content_type": "text/tab-separated-values; charset=utf-8",
             "file_extension": "tsv",
         },
         "json": {
             "label": "JSON",
             "writer_factory": json_writer,
             "records_format": "lists",
-            "content_type": b"application/json; charset=utf-8",
+            "content_type": "application/json; charset=utf-8",
             "file_extension": "json",
         },
         "xml": {
             "label": "XML",
             "writer_factory": xml_writer,
             "records_format": "objects",
-            "content_type": b"text/xml; charset=utf-8",
+            "content_type": "text/xml; charset=utf-8",
             "file_extension": "xml",
         },
     }
@@ -188,7 +188,6 @@ def dump(resource_id: str):
                                 sort=sort,
                                 search_params=search_params,
                                 user=user_context),
-                        mimetype='application/octet-stream',
                         headers=headers)
     except ObjectNotFound:
         abort(404, _('DataStore resource not found'))

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -153,7 +153,7 @@ def dump(resource_id: str):
     dump_formats = get_dump_format_configs()
 
     if fmt not in dump_formats:
-        abort(404, _("Unsupported format"))
+        abort(400, _("Unsupported format"))
 
     format_config = dump_formats[fmt]
     file_extension = format_config["file_extension"]
@@ -298,7 +298,7 @@ def dump_to(
     dump_formats = get_dump_format_configs()
 
     if fmt not in dump_formats:
-        assert False, "Unsupported format"
+        abort(400, _("Unsupported format"))
 
     format_config = dump_formats[fmt]
     writer_factory = format_config["writer_factory"]

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -59,28 +59,28 @@ def get_dump_format_configs() -> dict[str, dict[str, Any]]:
     """Get dump format configurations from all plugins"""
     all_formats = {
         "csv": {
-            "label": "CSV",
+            "label": _("CSV"),
             "writer_factory": csv_writer,
             "records_format": "csv",
             "content_type": "text/csv; charset=utf-8",
             "file_extension": "csv",
         },
         "tsv": {
-            "label": "TSV",
+            "label": _("TSV"),
             "writer_factory": tsv_writer,
             "records_format": "tsv",
             "content_type": "text/tab-separated-values; charset=utf-8",
             "file_extension": "tsv",
         },
         "json": {
-            "label": "JSON",
+            "label": _("JSON"),
             "writer_factory": json_writer,
             "records_format": "lists",
             "content_type": "application/json; charset=utf-8",
             "file_extension": "json",
         },
         "xml": {
-            "label": "XML",
+            "label": _("XML"),
             "writer_factory": xml_writer,
             "records_format": "objects",
             "content_type": "text/xml; charset=utf-8",

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -169,6 +169,16 @@ def dump(resource_id: str):
     file_extension = format_config["file_extension"]
     content_type = format_config["content_type"]
 
+    # If the format declares a validator, run it before we start
+    # streaming. A 400 here is the only way to surface a reason
+    # cleanly; once the chunked response starts, dropping the
+    # connection is the best we can do.
+    validate = format_config.get("validate")
+    if validate is not None:
+        reason = validate(resource_id)
+        if reason:
+            abort(400, reason)
+
     content_disposition = 'attachment; filename="{name}.{ext}"'.format(
         name=resource_id, ext=file_extension
     )

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -78,9 +78,8 @@ def get_dump_format_configs() -> dict[str, dict[str, Any]]:
         },
     }
 
-    # Allow plugins to add, override, or remove formats.
-    # A value of None is a sentinel meaning "remove this format"
-    # for sites that want to disable a default (e.g. {"xml": None}).
+    # Plugins can add, override, or remove formats. A None value
+    # removes a default (e.g. {"xml": None}).
     for plugin in p.PluginImplementations(IDatastoreDump):
         plugin_formats = plugin.register_dump_formats()
         for name, cfg in plugin_formats.items():
@@ -99,22 +98,8 @@ def build_dump_context(
     total: Optional[int] = None,
     fields: Optional[list[dict[str, Any]]] = None,
 ) -> dict[str, Any]:
-    """Resolve a dump's effective (filtered) scope for format validators.
-
-    Returns the context dict passed to a format's ``validate`` callable
-    and to :func:`evaluate_format_availability`. It describes *what is
-    actually being exported* -- the post-filter row count and the
-    resolved field set -- not the resource totals, so a user who has
-    filtered a large resource down is judged on the filtered result.
-
-    A single ``datastore_search`` with ``limit=0`` and
-    ``include_total=True`` resolves ``total`` and ``fields``. Callers
-    that already have them (e.g. a page that just rendered the table, or
-    a future JS/HTMX endpoint that knows the current filtered counts)
-    may pass them in to skip the query entirely.
-    """
+    """ Prepare the to `evaluate_format_availability` """
     sp = search_params or {}
-    # If the caller already provides total and fields, we can skip the DB query here
     if total is None or fields is None:
         ds_context = cast(Context, {'user': user} if user is not None else {})
         result = get_action('datastore_search')(
@@ -139,20 +124,8 @@ def build_dump_context(
 def evaluate_format_availability(
     cfg: dict[str, Any], context: dict[str, Any]
 ) -> Optional[str]:
-    """Decide whether a format can be produced for a given dump scope.
-
-    Returns ``None`` when the format is available, otherwise a
-    translatable reason string suitable for a tooltip and for the
-    HTTP 400 body. Resolution order (first failure wins, cheapest
-    checks first):
-
-    1. ``max_columns`` -- compared against the number of exported
-       columns. The framework writes the reason message.
-    2. ``max_rows`` -- compared against the post-filter row count. The
-       framework writes the reason message.
-    3. ``validate`` -- the format's own ``(context) -> Optional[str]``
-       callable, for constraints that counts cannot express (e.g. a geo
-       format requiring geometry columns).
+    """ Decide whether a format can be produced for a given dump scope.
+    Returns ``None`` when available, otherwise a translatable reason string
     """
     n_cols = len(context['fields'])
     max_cols = cfg.get('max_columns')
@@ -234,7 +207,6 @@ def dump(resource_id: str):
 
     user_context = g.user
 
-    # Get format configuration from plugin registry
     dump_formats = get_dump_format_configs()
 
     if fmt not in dump_formats:
@@ -244,12 +216,6 @@ def dump(resource_id: str):
     file_extension = format_config["file_extension"]
     content_type = format_config["content_type"]
 
-    # Check availability (declarative row/column limits and/or a custom
-    # validator) against the *filtered* export scope before we start
-    # streaming. A 400 here is the only way to surface a reason cleanly;
-    # once the chunked response starts, dropping the connection is the
-    # best we can do. Formats without any availability controls (the
-    # built-in csv/tsv/json/xml) skip this.
     config_to_evaluate = ("max_columns", "max_rows", "validate")
     evaluation_required = any(k in format_config for k in config_to_evaluate)
     if evaluation_required:
@@ -385,7 +351,6 @@ def dump_to(
     limit: Optional[int], options: dict[str, Any], sort: str,
     search_params: dict[str, Any], user: str
 ):
-    # Get format configuration from plugin registry
     dump_formats = get_dump_format_configs()
 
     if fmt not in dump_formats:

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -8,6 +8,7 @@ from flask import Blueprint, Response
 from flask.views import MethodView
 
 import ckan.lib.navl.dictization_functions as dict_fns
+from ckan import plugins as p
 from ckan.logic import (
     tuplize_dict,
     parse_params,
@@ -17,6 +18,8 @@ from ckan.plugins.toolkit import (
     abort, render, g, h, ValidationError, asbool, check_access, config,
 )
 from ckan.types import Schema, ValidatorFactory
+
+from ckanext.datastore.interfaces import IDatastoreDump
 from ckanext.datastore.logic.schema import (
     list_of_strings_or_string,
     json_validator,
@@ -37,17 +40,69 @@ one_of = cast(ValidatorFactory, get_validator(u'one_of'))
 default = cast(ValidatorFactory, get_validator(u'default'))
 unicode_only = get_validator(u'unicode_only')
 
-DUMP_FORMATS = u'csv', u'tsv', u'json', u'xml'
 PAGINATE_BY = 32000
 
 datastore = Blueprint(u'datastore', __name__)
+
+
+def get_dump_formats() -> tuple[str, ...]:
+    """Get available dump formats from plugins"""
+    dump_format_configs = get_dump_format_configs()
+    return tuple(dump_format_configs.keys())
+
+
+def get_dump_format_configs() -> dict[str, dict[str, Any]]:
+    """Get dump format configurations from all plugins"""
+    all_formats = {
+        "csv": {
+            "label": "CSV",
+            "writer_factory": csv_writer,
+            "records_format": "csv",
+            "content_type": b"text/csv; charset=utf-8",
+            "file_extension": "csv",
+        },
+        "tsv": {
+            "label": "TSV",
+            "writer_factory": tsv_writer,
+            "records_format": "tsv",
+            "content_type": b"text/tab-separated-values; charset=utf-8",
+            "file_extension": "tsv",
+        },
+        "json": {
+            "label": "JSON",
+            "writer_factory": json_writer,
+            "records_format": "lists",
+            "content_type": b"application/json; charset=utf-8",
+            "file_extension": "json",
+        },
+        "xml": {
+            "label": "XML",
+            "writer_factory": xml_writer,
+            "records_format": "objects",
+            "content_type": b"text/xml; charset=utf-8",
+            "file_extension": "xml",
+        },
+    }
+
+    # Allow plugins to add, override, or remove formats.
+    # A value of None is a sentinel meaning "remove this format"
+    # for sites that want to disable a default (e.g. {"xml": None}).
+    for plugin in p.PluginImplementations(IDatastoreDump):
+        plugin_formats = plugin.register_dump_formats()
+        for name, cfg in plugin_formats.items():
+            if cfg is None:
+                all_formats.pop(name, None)
+            else:
+                all_formats[name] = cfg
+
+    return all_formats
 
 
 def dump_schema() -> Schema:
     return {
         u'offset': [default(0), int_validator],
         u'limit': [ignore_missing, int_validator],
-        u'format': [default(u'csv'), one_of(DUMP_FORMATS)],
+        u'format': [default(u'csv'), one_of(get_dump_formats())],
         u'bom': [default(False), boolean_validator],
         u'filters': [ignore_missing, json_validator],
         u'q': [ignore_missing, unicode_or_json_validator],
@@ -100,27 +155,19 @@ def dump(resource_id: str):
 
     user_context = g.user
 
-    content_type = None
-    content_disposition = None
+    # Get format configuration from plugin registry
+    dump_formats = get_dump_format_configs()
 
-    if fmt == 'csv':
-        content_disposition = 'attachment; filename="{name}.csv"'.format(
-            name=resource_id)
-        content_type = b'text/csv; charset=utf-8'
-    elif fmt == 'tsv':
-        content_disposition = 'attachment; filename="{name}.tsv"'.format(
-            name=resource_id)
-        content_type = b'text/tab-separated-values; charset=utf-8'
-    elif fmt == 'json':
-        content_disposition = 'attachment; filename="{name}.json"'.format(
-            name=resource_id)
-        content_type = b'application/json; charset=utf-8'
-    elif fmt == 'xml':
-        content_disposition = 'attachment; filename="{name}.xml"'.format(
-            name=resource_id)
-        content_type = b'text/xml; charset=utf-8'
-    else:
-        abort(404, _('Unsupported format'))
+    if fmt not in dump_formats:
+        abort(404, _("Unsupported format"))
+
+    format_config = dump_formats[fmt]
+    file_extension = format_config["file_extension"]
+    content_type = format_config["content_type"]
+
+    content_disposition = 'attachment; filename="{name}.{ext}"'.format(
+        name=resource_id, ext=file_extension
+    )
 
     headers = {}
     if content_type:
@@ -244,20 +291,15 @@ def dump_to(
     limit: Optional[int], options: dict[str, Any], sort: str,
     search_params: dict[str, Any], user: str
 ):
-    if fmt == 'csv':
-        writer_factory = csv_writer
-        records_format = 'csv'
-    elif fmt == 'tsv':
-        writer_factory = tsv_writer
-        records_format = 'tsv'
-    elif fmt == 'json':
-        writer_factory = json_writer
-        records_format = 'lists'
-    elif fmt == 'xml':
-        writer_factory = xml_writer
-        records_format = 'objects'
-    else:
-        assert False, 'Unsupported format'
+    # Get format configuration from plugin registry
+    dump_formats = get_dump_format_configs()
+
+    if fmt not in dump_formats:
+        assert False, "Unsupported format"
+
+    format_config = dump_formats[fmt]
+    writer_factory = format_config["writer_factory"]
+    records_format = format_config["records_format"]
 
     bom = options.get('bom', False)
 

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -45,16 +45,6 @@ PAGINATE_BY = 32000
 datastore = Blueprint(u'datastore', __name__)
 
 
-def get_dump_formats() -> list[str]:
-    """Get available dump formats from plugins.
-
-    Returns a list
-    List > Tuple when we have one element only
-    """
-    dump_format_configs = get_dump_format_configs()
-    return list(dump_format_configs.keys())
-
-
 def get_dump_format_configs() -> dict[str, dict[str, Any]]:
     """Get dump format configurations from all plugins"""
     all_formats = {
@@ -106,7 +96,7 @@ def dump_schema() -> Schema:
     return {
         u'offset': [default(0), int_validator],
         u'limit': [ignore_missing, int_validator],
-        u'format': [default(u'csv'), one_of(get_dump_formats())],
+        u'format': [default(u'csv'), one_of(list(get_dump_format_configs()))],
         u'bom': [default(False), boolean_validator],
         u'filters': [ignore_missing, json_validator],
         u'q': [ignore_missing, unicode_or_json_validator],

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -45,10 +45,14 @@ PAGINATE_BY = 32000
 datastore = Blueprint(u'datastore', __name__)
 
 
-def get_dump_formats() -> tuple[str, ...]:
-    """Get available dump formats from plugins"""
+def get_dump_formats() -> list[str]:
+    """Get available dump formats from plugins.
+
+    Returns a list
+    List > Tuple when we have one element only
+    """
     dump_format_configs = get_dump_format_configs()
-    return tuple(dump_format_configs.keys())
+    return list(dump_format_configs.keys())
 
 
 def get_dump_format_configs() -> dict[str, dict[str, Any]]:

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -114,7 +114,7 @@ def build_dump_context(
     may pass them in to skip the query entirely.
     """
     sp = search_params or {}
-    # If the caller already provide total and fields, we can skip the DB query here
+    # If the caller already provides total and fields, we can skip the DB query here
     if total is None or fields is None:
         ds_context = {'user': user} if user is not None else {}
         result = get_action('datastore_search')(

--- a/ckanext/datastore/blueprint.py
+++ b/ckanext/datastore/blueprint.py
@@ -92,6 +92,91 @@ def get_dump_format_configs() -> dict[str, dict[str, Any]]:
     return all_formats
 
 
+def build_dump_context(
+    resource_id: str,
+    search_params: Optional[dict[str, Any]] = None,
+    user: Optional[str] = None,
+    total: Optional[int] = None,
+    fields: Optional[list[dict[str, Any]]] = None,
+) -> dict[str, Any]:
+    """Resolve a dump's effective (filtered) scope for format validators.
+
+    Returns the context dict passed to a format's ``validate`` callable
+    and to :func:`evaluate_format_availability`. It describes *what is
+    actually being exported* -- the post-filter row count and the
+    resolved field set -- not the resource totals, so a user who has
+    filtered a large resource down is judged on the filtered result.
+
+    A single ``datastore_search`` with ``limit=0`` and
+    ``include_total=True`` resolves ``total`` and ``fields``. Callers
+    that already have them (e.g. a page that just rendered the table, or
+    a future JS/HTMX endpoint that knows the current filtered counts)
+    may pass them in to skip the query entirely.
+    """
+    sp = search_params or {}
+    # If the caller already provide total and fields, we can skip the DB query here
+    if total is None or fields is None:
+        ds_context = {'user': user} if user is not None else {}
+        result = get_action('datastore_search')(
+            ds_context,
+            dict(sp, resource_id=resource_id, limit=0, include_total=True),
+        )
+        total = result['total']
+        fields = result['fields']
+    return {
+        'resource_id': resource_id,
+        'fields': fields,          # exported columns, raw (incl. _id)
+        'total': total,            # post-filter row count
+        'filters': sp.get('filters'),
+        'q': sp.get('q'),
+        'distinct': bool(sp.get('distinct')),
+        'selected_fields': sp.get('fields'),
+        'sort': sp.get('sort'),
+        'user': user,
+    }
+
+
+def evaluate_format_availability(
+    cfg: dict[str, Any], context: dict[str, Any]
+) -> Optional[str]:
+    """Decide whether a format can be produced for a given dump scope.
+
+    Returns ``None`` when the format is available, otherwise a
+    translatable reason string suitable for a tooltip and for the
+    HTTP 400 body. Resolution order (first failure wins, cheapest
+    checks first):
+
+    1. ``max_columns`` -- compared against the number of exported
+       columns. The framework writes the reason message.
+    2. ``max_rows`` -- compared against the post-filter row count. The
+       framework writes the reason message.
+    3. ``validate`` -- the format's own ``(context) -> Optional[str]``
+       callable, for constraints that counts cannot express (e.g. a geo
+       format requiring geometry columns).
+    """
+    n_cols = len(context['fields'])
+    max_cols = cfg.get('max_columns')
+    if max_cols is not None and n_cols > max_cols:
+        return _(
+            '{label} supports at most {max:,} columns; '
+            'this export has {n:,}.'
+        ).format(label=cfg.get('label', ''), max=max_cols, n=n_cols)
+
+    n_rows = context['total']
+    max_rows = cfg.get('max_rows')
+    if max_rows is not None and n_rows > max_rows:
+        return _(
+            '{label} supports at most {max:,} rows; '
+            'this export has {n:,}.'
+        ).format(label=cfg.get('label', ''), max=max_rows, n=n_rows)
+
+    validate = cfg.get('validate')
+    if validate is not None:
+        return validate(context)
+
+    return None
+
+
 def dump_schema() -> Schema:
     return {
         u'offset': [default(0), int_validator],
@@ -159,13 +244,19 @@ def dump(resource_id: str):
     file_extension = format_config["file_extension"]
     content_type = format_config["content_type"]
 
-    # If the format declares a validator, run it before we start
-    # streaming. A 400 here is the only way to surface a reason
-    # cleanly; once the chunked response starts, dropping the
-    # connection is the best we can do.
-    validate = format_config.get("validate")
-    if validate is not None:
-        reason = validate(resource_id)
+    # Check availability (declarative row/column limits and/or a custom
+    # validator) against the *filtered* export scope before we start
+    # streaming. A 400 here is the only way to surface a reason cleanly;
+    # once the chunked response starts, dropping the connection is the
+    # best we can do. Formats without any availability controls (the
+    # built-in csv/tsv/json/xml) skip this.
+    config_to_evaluate = ("max_columns", "max_rows", "validate")
+    evaluation_required = any(k in format_config for k in config_to_evaluate)
+    if evaluation_required:
+        dump_context = build_dump_context(
+            resource_id, search_params, user_context
+        )
+        reason = evaluate_format_availability(format_config, dump_context)
         if reason:
             abort(400, reason)
 

--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -22,7 +22,7 @@ from ckanext.datastore.backend.postgres import (
     _get_raw_field_info,
     _TIMEOUT,
 )
-from ckanext.datastore.blueprint import DUMP_FORMATS, dump_to
+from ckanext.datastore.blueprint import dump_to, get_dump_formats
 
 log = logging.getLogger(__name__)
 
@@ -93,7 +93,7 @@ def permissions_sql(maindb: str, datastoredb: str, mainuser: str,
     type=click.File(u'wb'),
     default=click.get_binary_stream(u'stdout')
 )
-@click.option(u'--format', default=u'csv', type=click.Choice(DUMP_FORMATS))
+@click.option(u'--format', default=u'csv')
 @click.option(u'--offset', type=click.IntRange(0, None), default=0)
 @click.option(u'--limit', type=click.IntRange(0))
 @click.option(u'--bom', is_flag=True)
@@ -103,6 +103,13 @@ def dump(ctx: Any, resource_id: str, output_file: Any, format: str,
     u'''Dump a datastore resource.
     '''
     flask_app = ctx.meta['flask_app']
+    # Validated here (not via click.Choice) so the IDatastoreDump plugin
+    # registry is consulted at run time, after CKAN has loaded plugins.
+    valid_formats = get_dump_formats()
+    if format not in valid_formats:
+        raise click.BadParameter(
+            u'Format must be one of: {0}'.format(u', '.join(valid_formats))
+        )
     user = logic.get_action('get_site_user')(
             {'ignore_auth': True}, {})
     with flask_app.test_request_context():

--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -104,8 +104,7 @@ def dump(ctx: Any, resource_id: str, output_file: Any, format: str,
     u'''Dump a datastore resource.
     '''
     flask_app = ctx.meta['flask_app']
-    # Validated here (not via click.Choice) so the IDatastoreDump plugin
-    # registry is consulted at run time, after CKAN has loaded plugins.
+    # Resolved at run time so plugin-registered formats are included.
     valid_formats = list(get_dump_format_configs())
     if format not in valid_formats:
         raise click.BadParameter(

--- a/ckanext/datastore/cli.py
+++ b/ckanext/datastore/cli.py
@@ -22,7 +22,8 @@ from ckanext.datastore.backend.postgres import (
     _get_raw_field_info,
     _TIMEOUT,
 )
-from ckanext.datastore.blueprint import dump_to, get_dump_formats
+from ckanext.datastore.blueprint import dump_to, get_dump_format_configs
+
 
 log = logging.getLogger(__name__)
 
@@ -105,7 +106,7 @@ def dump(ctx: Any, resource_id: str, output_file: Any, format: str,
     flask_app = ctx.meta['flask_app']
     # Validated here (not via click.Choice) so the IDatastoreDump plugin
     # registry is consulted at run time, after CKAN has loaded plugins.
-    valid_formats = get_dump_formats()
+    valid_formats = list(get_dump_format_configs())
     if format not in valid_formats:
         raise click.BadParameter(
             u'Format must be one of: {0}'.format(u', '.join(valid_formats))

--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -271,26 +271,9 @@ def datastore_dump_formats(
         resource_id: Optional[str] = None,
         search_params: Optional[dict[str, Any]] = None,
 ) -> list[dict[str, Any]]:
-    """
-    Return the list of dump formats registered via the IDatastoreDump
-    interface, in registration order, for rendering the download dropdown.
-
-    Each entry exposes only what templates need (no writer/content-type
-    internals): ``name`` (the ?format= value), ``label`` (display text),
+    """ Return registered dump formats for the download dropdown.
+    Each entry exposes only what templates need: ``name``, ``label``,
     ``available`` (bool) and ``reason`` (str or None).
-
-    When ``resource_id`` is provided and at least one registered format
-    declares availability controls (``max_rows``/``max_columns`` and/or
-    a ``validate`` callable), the export scope is resolved once (a single
-    ``datastore_search``) and each such format is evaluated against it. A
-    non-empty reason marks the format ``available=False`` with that
-    string as the ``reason`` (intended for a tooltip). ``search_params``
-    (``filters``/``q``/``distinct``/``fields``/``sort``) narrows that
-    scope so a filtered download is judged on the filtered result; omit
-    it to evaluate the whole resource.
-
-    Vanilla CKAN ships no availability controls, so this call adds no
-    extra DB work unless an extension opts in.
     """
     from ckanext.datastore.blueprint import (
         get_dump_format_configs,
@@ -304,11 +287,8 @@ def datastore_dump_formats(
         return any(
             k in cfg for k in ("max_columns", "max_rows", "validate"))
 
-    # Only resolve the (potentially expensive) export scope when there's
-    # actually something to check, so the common formats-only case stays
-    # free of extra DB work.
+    # Only resolve the export scope when a format actually has controls.
     context = None
-    # Build a context only if required
     has_controls = any(_has_controls(cfg) for cfg in formats.values())
     if resource_id is not None and has_controls:
         context = build_dump_context(resource_id, search_params)

--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -268,7 +268,9 @@ def datastore_show_resource_actions():
 
 
 def datastore_dump_formats(
-        resource_id: Optional[str] = None) -> list[dict[str, Any]]:
+        resource_id: Optional[str] = None,
+        search_params: Optional[dict[str, Any]] = None,
+) -> list[dict[str, Any]]:
     """
     Return the list of dump formats registered via the IDatastoreDump
     interface, in registration order, for rendering the download dropdown.
@@ -277,22 +279,45 @@ def datastore_dump_formats(
     internals): ``name`` (the ?format= value), ``label`` (display text),
     ``available`` (bool) and ``reason`` (str or None).
 
-    When ``resource_id`` is provided and a registered format declares
-    an optional ``validate`` callable, the validator is invoked with
-    the resource id; if it returns a non-empty string, the format is
-    flagged ``available=False`` with that string as the ``reason``
-    (intended for a tooltip). Formats without a validator are always
-    available. Vanilla CKAN ships no validators, so this call adds no
+    When ``resource_id`` is provided and at least one registered format
+    declares availability controls (``max_rows``/``max_columns`` and/or
+    a ``validate`` callable), the export scope is resolved once (a single
+    ``datastore_search``) and each such format is evaluated against it. A
+    non-empty reason marks the format ``available=False`` with that
+    string as the ``reason`` (intended for a tooltip). ``search_params``
+    (``filters``/``q``/``distinct``/``fields``/``sort``) narrows that
+    scope so a filtered download is judged on the filtered result; omit
+    it to evaluate the whole resource.
+
+    Vanilla CKAN ships no availability controls, so this call adds no
     extra DB work unless an extension opts in.
     """
-    from ckanext.datastore.blueprint import get_dump_format_configs
+    from ckanext.datastore.blueprint import (
+        get_dump_format_configs,
+        build_dump_context,
+        evaluate_format_availability,
+    )
+
+    formats = get_dump_format_configs()
+
+    def _has_controls(cfg: dict[str, Any]) -> bool:
+        return any(
+            k in cfg for k in ("max_columns", "max_rows", "validate"))
+
+    # Only resolve the (potentially expensive) export scope when there's
+    # actually something to check, so the common formats-only case stays
+    # free of extra DB work.
+    context = None
+    # Build a context only if required
+    has_controls = any(_has_controls(cfg) for cfg in formats.values())
+    if resource_id is not None and has_controls:
+        context = build_dump_context(resource_id, search_params)
 
     out = []
-    for name, cfg in get_dump_format_configs().items():
+    for name, cfg in formats.items():
         reason = None
-        validate = cfg.get("validate")
-        if validate is not None and resource_id is not None:
-            reason = validate(resource_id)
+        if context is not None and _has_controls(cfg):
+            reason = evaluate_format_availability(cfg, context)
         out.append({
             "name": name,
             "label": cfg.get("label", name.upper()),

--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -267,20 +267,36 @@ def datastore_show_resource_actions():
     return "midnight-blue" not in tk.config.get("ckan.base_templates_folder")
 
 
-def datastore_dump_formats() -> list[dict[str, Any]]:
+def datastore_dump_formats(
+        resource_id: Optional[str] = None) -> list[dict[str, Any]]:
     """
     Return the list of dump formats registered via the IDatastoreDump
     interface, in registration order, for rendering the download dropdown.
 
     Each entry exposes only what templates need (no writer/content-type
-    internals): ``name`` (the ?format= value) and ``label`` (display text).
+    internals): ``name`` (the ?format= value), ``label`` (display text),
+    ``available`` (bool) and ``reason`` (str or None).
+
+    When ``resource_id`` is provided and a registered format declares
+    an optional ``validate`` callable, the validator is invoked with
+    the resource id; if it returns a non-empty string, the format is
+    flagged ``available=False`` with that string as the ``reason``
+    (intended for a tooltip). Formats without a validator are always
+    available. Vanilla CKAN ships no validators, so this call adds no
+    extra DB work unless an extension opts in.
     """
     from ckanext.datastore.blueprint import get_dump_format_configs
 
-    return [
-        {
+    out = []
+    for name, cfg in get_dump_format_configs().items():
+        reason = None
+        validate = cfg.get("validate")
+        if validate is not None and resource_id is not None:
+            reason = validate(resource_id)
+        out.append({
             "name": name,
             "label": cfg.get("label", name.upper()),
-        }
-        for name, cfg in get_dump_format_configs().items()
-    ]
+            "available": reason is None,
+            "reason": reason,
+        })
+    return out

--- a/ckanext/datastore/helpers.py
+++ b/ckanext/datastore/helpers.py
@@ -265,3 +265,22 @@ def datastore_show_resource_actions():
     """
 
     return "midnight-blue" not in tk.config.get("ckan.base_templates_folder")
+
+
+def datastore_dump_formats() -> list[dict[str, Any]]:
+    """
+    Return the list of dump formats registered via the IDatastoreDump
+    interface, in registration order, for rendering the download dropdown.
+
+    Each entry exposes only what templates need (no writer/content-type
+    internals): ``name`` (the ?format= value) and ``label`` (display text).
+    """
+    from ckanext.datastore.blueprint import get_dump_format_configs
+
+    return [
+        {
+            "name": name,
+            "label": cfg.get("label", name.upper()),
+        }
+        for name, cfg in get_dump_format_configs().items()
+    ]

--- a/ckanext/datastore/interfaces.py
+++ b/ckanext/datastore/interfaces.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from ckan.types import Context, Schema
-from typing import Any, Optional
+from typing import Any
 import ckan.plugins.interfaces as interfaces
 
 

--- a/ckanext/datastore/interfaces.py
+++ b/ckanext/datastore/interfaces.py
@@ -263,7 +263,7 @@ class IDatastoreDump(interfaces.Interface):
           writer
         - 'records_format': The format for records ('csv', 'tsv',
           'lists', 'objects')
-        - 'content_type': The MIME type for the response (bytes)
+        - 'content_type': The MIME type for the response (str)
         - 'file_extension': The file extension for downloads
 
         Example: add ``xlsx`` and remove ``xml``::
@@ -274,8 +274,8 @@ class IDatastoreDump(interfaces.Interface):
                     'writer_factory': xlsx_writer,
                     'records_format': 'objects',
                     'content_type': (
-                        b'application/vnd.openxmlformats-'
-                        b'officedocument.spreadsheetml.sheet'
+                        'application/vnd.openxmlformats-'
+                        'officedocument.spreadsheetml.sheet'
                     ),
                     'file_extension': 'xlsx',
                 },

--- a/ckanext/datastore/interfaces.py
+++ b/ckanext/datastore/interfaces.py
@@ -248,112 +248,34 @@ class IDatastoreDump(interfaces.Interface):
         """
         Register, override, or remove dump formats for datastore exports.
 
+        The initial dump format list is defined at
+        ``ckanext.datastore.blueprint.get_dump_format_configs``.
         Return a dictionary where each key is a format name. The value
         is either:
 
         - A configuration dict to add a new format or replace an
           existing one (defaults: csv, tsv, json, xml).
-        - ``None``, which acts as a sentinel meaning "remove this
-          format". Returning ``{"xml": None}`` disables the built-in
-          XML dump entirely (UI dropdown entry, schema validation,
-          and the ``?format=xml`` URL).
+        - ``None``, which acts as a sentinel meaning "remove this format".
+
+        You can see a usage sample at
+        ``ckanext/datastore/tests/sample_dump_plugin.py``
 
         A configuration dict must include:
 
-        - 'label': Human-readable name shown in the download dropdown UI.
-          User-facing, so wrap it in ``toolkit._()`` to make it
-          translatable. ``register_dump_formats`` is called per
-          request, so the translation evaluates in the current locale.
-        - 'writer_factory': A context manager function that creates a
-          writer
-        - 'records_format': The format for records ('csv', 'tsv',
-          'lists', 'objects')
+        - 'label': Human-readable name
+        - 'writer_factory': A context manager function that creates a writer
+        - 'records_format': The format for records
         - 'content_type': The MIME type for the response (str)
         - 'file_extension': The file extension for downloads
 
-        And may optionally include any of the following availability
-        controls. They decide whether the format can be produced for a
-        given export: when any of them rejects, the format is rendered
-        disabled in the download dropdown with the reason shown as a
-        tooltip, and direct download URLs return HTTP 400. They are
-        evaluated against the *filtered* export scope (post-filter row
-        count, selected columns), not the resource totals, so a user
-        who has filtered a large resource down is judged on the
-        filtered result. Vanilla CKAN ships none of these, so they add
-        no extra work unless a plugin opts in.
+        And may optionally include availability controls.
 
-        - 'max_columns': An int. The framework marks the format
-          unavailable when the export has more columns than this and
-          writes the reason message itself. Use for hard column limits
-          (e.g. Excel's 16,384-column ceiling).
-        - 'max_rows': An int. As ``max_columns`` but for the
-          post-filter row count. ``max_rows`` is the largest number of
-          rows the format can hold; the export is rejected when its row
-          count is strictly greater (e.g. Excel allows 1,048,576 rows
-          *including* the header row, so set ``max_rows`` to
-          ``1048575``).
+        - 'max_columns': int.
+        - 'max_rows': int.
         - 'validate': A callable ``(context: dict) -> Optional[str]``
           for constraints that ``max_rows``/``max_columns`` cannot
-          express (e.g. a geo format that needs geometry columns).
-          Returns ``None`` if the format can be produced, or a
-          (translatable) reason string if not. The ``context`` carries
-          the export scope so the callable does not need to fetch it:
+          express. Returns ``None`` if the format can be produced, or a
+          (translatable) reason string if not.
 
-          - ``resource_id``: the (resolved) resource id.
-          - ``fields``: the exported columns as ``[{'id', 'type'},...]``
-            (raw, including ``_id``); ``len(fields)`` is the column
-            count.
-          - ``total``: the post-filter row count.
-          - ``filters`` / ``q`` / ``distinct`` / ``selected_fields`` /
-            ``sort``: the query that produced the scope, for advanced
-            checks.
-          - ``user``: the requesting user (may be ``None``).
-
-          The controls run on every dropdown render and before serving
-          a dump, but the scope is resolved once per call (a single
-          ``datastore_search``) and shared across formats.
-
-        When more than one control is present they are evaluated cheapest
-        first and the first rejection wins:
-        ``max_columns`` -> ``max_rows`` -> ``validate``.
-
-        Example: add ``xlsx`` with declarative limits, add ``geojson``
-        with a column-presence validator, and remove ``xml``::
-
-            def geojson_validate(context):
-                names = {f['id'] for f in context['fields']}
-                if not ({'lat', 'lng'} <= names or 'geom' in names):
-                    return toolkit._('No geometry columns for GeoJSON.')
-                return None
-
-            {
-                'xlsx': {
-                    'label': toolkit._('Excel'),
-                    'writer_factory': xlsx_writer,
-                    'records_format': 'objects',
-                    'content_type': (
-                        'application/vnd.openxmlformats-'
-                        'officedocument.spreadsheetml.sheet'
-                    ),
-                    'file_extension': 'xlsx',
-                    'max_columns': 16384,
-                    'max_rows': 1048575,
-                },
-                'geojson': {
-                    'label': toolkit._('GeoJSON'),
-                    'writer_factory': geojson_writer,
-                    'records_format': 'objects',
-                    'content_type': 'application/geo+json; charset=utf-8',
-                    'file_extension': 'geojson',
-                    'validate': geojson_validate,
-                },
-                'xml': None,
-            }
-
-        Plugins are applied in load order, so a later plugin can undo
-        or replace an earlier plugin's registration.
-
-        :returns: Mapping of format name to config dict or ``None``
-        :rtype: dict
         """
         return {}

--- a/ckanext/datastore/interfaces.py
+++ b/ckanext/datastore/interfaces.py
@@ -271,33 +271,59 @@ class IDatastoreDump(interfaces.Interface):
         - 'content_type': The MIME type for the response (str)
         - 'file_extension': The file extension for downloads
 
-        And may optionally include:
+        And may optionally include any of the following availability
+        controls. They decide whether the format can be produced for a
+        given export: when any of them rejects, the format is rendered
+        disabled in the download dropdown with the reason shown as a
+        tooltip, and direct download URLs return HTTP 400. They are
+        evaluated against the *filtered* export scope (post-filter row
+        count, selected columns), not the resource totals, so a user
+        who has filtered a large resource down is judged on the
+        filtered result. Vanilla CKAN ships none of these, so they add
+        no extra work unless a plugin opts in.
 
-        - 'validate': A callable ``(resource_id: str) -> Optional[str]``
-          that returns ``None`` if the format can be produced for the
-          given resource, or a (translatable) reason string if not.
-          When set, the format is rendered as disabled in the download
-          dropdown with the reason shown as a tooltip, and direct
-          download URLs return HTTP 400. Use this for hard format
-          limits (e.g. Excel's 1,048,576-row / 16,384-column ceiling).
-          The validator is called on every dropdown render and before
-          serving a dump, so it must be cheap on the common path.
-          It is responsible for fetching whatever data it needs;
-          typically via ``toolkit.get_action('datastore_search')`` with
-          ``limit=0, include_total=True``, which is O(1) after the
-          first call thanks to CKAN's cached row count.
+        - 'max_columns': An int. The framework marks the format
+          unavailable when the export has more columns than this and
+          writes the reason message itself. Use for hard column limits
+          (e.g. Excel's 16,384-column ceiling).
+        - 'max_rows': An int. As ``max_columns`` but for the
+          post-filter row count. ``max_rows`` is the largest number of
+          rows the format can hold; the export is rejected when its row
+          count is strictly greater (e.g. Excel allows 1,048,576 rows
+          *including* the header row, so set ``max_rows`` to
+          ``1048575``).
+        - 'validate': A callable ``(context: dict) -> Optional[str]``
+          for constraints that ``max_rows``/``max_columns`` cannot
+          express (e.g. a geo format that needs geometry columns).
+          Returns ``None`` if the format can be produced, or a
+          (translatable) reason string if not. The ``context`` carries
+          the export scope so the callable does not need to fetch it:
 
-        Example: add ``xlsx`` with a row/column-limit validator and
-        remove ``xml``::
+          - ``resource_id``: the (resolved) resource id.
+          - ``fields``: the exported columns as ``[{'id', 'type'},...]``
+            (raw, including ``_id``); ``len(fields)`` is the column
+            count.
+          - ``total``: the post-filter row count.
+          - ``filters`` / ``q`` / ``distinct`` / ``selected_fields`` /
+            ``sort``: the query that produced the scope, for advanced
+            checks.
+          - ``user``: the requesting user (may be ``None``).
 
-            def xlsx_validate(resource_id):
-                result = toolkit.get_action('datastore_search')(
-                    {}, {'resource_id': resource_id,
-                         'limit': 0, 'include_total': True})
-                if len(result['fields']) > 16384:
-                    return toolkit._('Too many columns for XLSX.')
-                if result['total'] >= 1048576:
-                    return toolkit._('Too many rows for XLSX.')
+          The controls run on every dropdown render and before serving
+          a dump, but the scope is resolved once per call (a single
+          ``datastore_search``) and shared across formats.
+
+        When more than one control is present they are evaluated cheapest
+        first and the first rejection wins:
+        ``max_columns`` -> ``max_rows`` -> ``validate``.
+
+        Example: add ``xlsx`` with declarative limits, add ``geojson``
+        with a column-presence validator, and remove ``xml``::
+
+            def geojson_validate(context):
+                names = {f['id'] for f in context['fields']}
+                if not ({'lat', 'lng'} <= names or 'geom' in names):
+                    return toolkit._('No geometry columns for GeoJSON.')
                 return None
 
             {
@@ -310,7 +336,16 @@ class IDatastoreDump(interfaces.Interface):
                         'officedocument.spreadsheetml.sheet'
                     ),
                     'file_extension': 'xlsx',
-                    'validate': xlsx_validate,
+                    'max_columns': 16384,
+                    'max_rows': 1048575,
+                },
+                'geojson': {
+                    'label': toolkit._('GeoJSON'),
+                    'writer_factory': geojson_writer,
+                    'records_format': 'objects',
+                    'content_type': 'application/geo+json; charset=utf-8',
+                    'file_extension': 'geojson',
+                    'validate': geojson_validate,
                 },
                 'xml': None,
             }

--- a/ckanext/datastore/interfaces.py
+++ b/ckanext/datastore/interfaces.py
@@ -271,7 +271,34 @@ class IDatastoreDump(interfaces.Interface):
         - 'content_type': The MIME type for the response (str)
         - 'file_extension': The file extension for downloads
 
-        Example: add ``xlsx`` and remove ``xml``::
+        And may optionally include:
+
+        - 'validate': A callable ``(resource_id: str) -> Optional[str]``
+          that returns ``None`` if the format can be produced for the
+          given resource, or a (translatable) reason string if not.
+          When set, the format is rendered as disabled in the download
+          dropdown with the reason shown as a tooltip, and direct
+          download URLs return HTTP 400. Use this for hard format
+          limits (e.g. Excel's 1,048,576-row / 16,384-column ceiling).
+          The validator is called on every dropdown render and before
+          serving a dump, so it must be cheap on the common path.
+          It is responsible for fetching whatever data it needs;
+          typically via ``toolkit.get_action('datastore_search')`` with
+          ``limit=0, include_total=True``, which is O(1) after the
+          first call thanks to CKAN's cached row count.
+
+        Example: add ``xlsx`` with a row/column-limit validator and
+        remove ``xml``::
+
+            def xlsx_validate(resource_id):
+                result = toolkit.get_action('datastore_search')(
+                    {}, {'resource_id': resource_id,
+                         'limit': 0, 'include_total': True})
+                if len(result['fields']) > 16384:
+                    return toolkit._('Too many columns for XLSX.')
+                if result['total'] >= 1048576:
+                    return toolkit._('Too many rows for XLSX.')
+                return None
 
             {
                 'xlsx': {
@@ -283,6 +310,7 @@ class IDatastoreDump(interfaces.Interface):
                         'officedocument.spreadsheetml.sheet'
                     ),
                     'file_extension': 'xlsx',
+                    'validate': xlsx_validate,
                 },
                 'xml': None,
             }

--- a/ckanext/datastore/interfaces.py
+++ b/ckanext/datastore/interfaces.py
@@ -260,7 +260,10 @@ class IDatastoreDump(interfaces.Interface):
 
         A configuration dict must include:
 
-        - 'label': Human-readable name shown in the download dropdown UI
+        - 'label': Human-readable name shown in the download dropdown UI.
+          User-facing, so wrap it in ``toolkit._()`` to make it
+          translatable. ``register_dump_formats`` is called per
+          request, so the translation evaluates in the current locale.
         - 'writer_factory': A context manager function that creates a
           writer
         - 'records_format': The format for records ('csv', 'tsv',

--- a/ckanext/datastore/interfaces.py
+++ b/ckanext/datastore/interfaces.py
@@ -272,7 +272,7 @@ class IDatastoreDump(interfaces.Interface):
 
             {
                 'xlsx': {
-                    'label': 'Excel',
+                    'label': toolkit._('Excel'),
                     'writer_factory': xlsx_writer,
                     'records_format': 'objects',
                     'content_type': (

--- a/ckanext/datastore/interfaces.py
+++ b/ckanext/datastore/interfaces.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from ckan.types import Context, Schema
-from typing import Any
+from typing import Any, Optional
 import ckan.plugins.interfaces as interfaces
 
 
@@ -232,3 +232,60 @@ class IDataDictionaryForm(interfaces.Interface):
         in the data dictionary page.
         """
         return field
+
+
+class IDatastoreDump(interfaces.Interface):
+    """
+    Allow plugins to register custom dump formats and writers for datastore
+    exports
+    """
+
+    def register_dump_formats(
+        self,
+    ) -> dict[str, dict[str, Any] | None]:
+        """
+        Register, override, or remove dump formats for datastore exports.
+
+        Return a dictionary where each key is a format name. The value
+        is either:
+
+        - A configuration dict to add a new format or replace an
+          existing one (defaults: csv, tsv, json, xml).
+        - ``None``, which acts as a sentinel meaning "remove this
+          format". Returning ``{"xml": None}`` disables the built-in
+          XML dump entirely (UI dropdown entry, schema validation,
+          and the ``?format=xml`` URL).
+
+        A configuration dict must include:
+
+        - 'label': Human-readable name shown in the download dropdown UI
+        - 'writer_factory': A context manager function that creates a
+          writer
+        - 'records_format': The format for records ('csv', 'tsv',
+          'lists', 'objects')
+        - 'content_type': The MIME type for the response (bytes)
+        - 'file_extension': The file extension for downloads
+
+        Example: add ``xlsx`` and remove ``xml``::
+
+            {
+                'xlsx': {
+                    'label': 'Excel',
+                    'writer_factory': xlsx_writer,
+                    'records_format': 'objects',
+                    'content_type': (
+                        b'application/vnd.openxmlformats-'
+                        b'officedocument.spreadsheetml.sheet'
+                    ),
+                    'file_extension': 'xlsx',
+                },
+                'xml': None,
+            }
+
+        Plugins are applied in load order, so a later plugin can undo
+        or replace an earlier plugin's registration.
+
+        :returns: Mapping of format name to config dict or ``None``
+        :rtype: dict
+        """
+        return {}

--- a/ckanext/datastore/interfaces.py
+++ b/ckanext/datastore/interfaces.py
@@ -240,6 +240,8 @@ class IDatastoreDump(interfaces.Interface):
     exports
     """
 
+    _reverse_iteration_order = True
+
     def register_dump_formats(
         self,
     ) -> dict[str, dict[str, Any] | None]:

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -47,6 +47,7 @@ class DatastorePlugin(p.SingletonPlugin):
     p.implements(p.IForkObserver, inherit=True)
     p.implements(interfaces.IDatastore, inherit=True)
     p.implements(interfaces.IDatastoreBackend, inherit=True)
+    p.implements(interfaces.IDatastoreDump, inherit=True)
     p.implements(p.IBlueprint)
 
     resource_show_action = None
@@ -71,6 +72,12 @@ class DatastorePlugin(p.SingletonPlugin):
             'postgresql': DatastorePostgresqlBackend,
             'postgres': DatastorePostgresqlBackend,
         }
+
+    # IDatastoreDump
+
+    def register_dump_formats(self) -> dict[str, dict[str, Any]]:
+        """Register default dump formats - can be overridden by plugins"""
+        return {}
 
     # IConfigurer
 
@@ -261,12 +268,14 @@ class DatastorePlugin(p.SingletonPlugin):
         datastore_show_resource_actions = (
             datastore_helpers.datastore_show_resource_actions
         )
+        datastore_dump_formats = datastore_helpers.datastore_dump_formats
 
         return {
             'datastore_dictionary': conf_dictionary,
             'datastore_search_sql_enabled': conf_sql_enabled,
             'datastore_rw_resource_url_types': rw_url_types,
             'datastore_show_resource_actions': datastore_show_resource_actions,
+            'datastore_dump_formats': datastore_dump_formats,
         }
 
     # IForkObserver

--- a/ckanext/datastore/templates/package/resource_read.html
+++ b/ckanext/datastore/templates/package/resource_read.html
@@ -14,12 +14,14 @@
       {% for fmt in h.datastore_dump_formats(resource_id=res.id) %}
       <li>
         {% if fmt.available %}
-        <a class="dropdown-item" href="{{ h.url_for('datastore.dump', resource_id=res.id, format=fmt.name, bom=True) }}"
-          target="_blank" rel="noreferrer"><span>{{ fmt.label }}</span></a>
+          <a class="dropdown-item" href="{{ h.url_for('datastore.dump', resource_id=res.id, format=fmt.name, bom=True) }}"
+            target="_blank" rel="noreferrer"><span>{{ fmt.label }}</span></a>
         {% else %}
-        <span class="dropdown-item disabled" title="{{ fmt.reason }}" aria-disabled="true">
-          {{ fmt.label }} <small class="text-muted">({{ _('unavailable') }})</small>
-        </span>
+          <span class="dropdown-item disabled" title="{{ fmt.reason }}" aria-disabled="true">
+            {% trans format_label=fmt.label %}
+              {{ format_label }} <small class="text-muted">(unavailable)</small>
+            {% endtrans %}
+          </span>
         {% endif %}
       </li>
       {% endfor %}

--- a/ckanext/datastore/templates/package/resource_read.html
+++ b/ckanext/datastore/templates/package/resource_read.html
@@ -11,10 +11,16 @@
 {% if res.datastore_active %}
     <button class="btn btn-primary dropdown-toggle" role="button" id="dropdownDownloadFormat" data-bs-toggle="dropdown" aria-expanded="false" aria-label="list of downloadable formats"></button>
     <ul class="dropdown-menu" aria-labelledby="dropdownDownloadFormat">
-      {% for fmt in h.datastore_dump_formats() %}
+      {% for fmt in h.datastore_dump_formats(resource_id=res.id) %}
       <li>
+        {% if fmt.available %}
         <a class="dropdown-item" href="{{ h.url_for('datastore.dump', resource_id=res.id, format=fmt.name, bom=True) }}"
           target="_blank" rel="noreferrer"><span>{{ fmt.label }}</span></a>
+        {% else %}
+        <span class="dropdown-item disabled" title="{{ fmt.reason }}" aria-disabled="true">
+          {{ fmt.label }} <small class="text-muted">({{ _('unavailable') }})</small>
+        </span>
+        {% endif %}
       </li>
       {% endfor %}
     </ul>

--- a/ckanext/datastore/templates/package/resource_read.html
+++ b/ckanext/datastore/templates/package/resource_read.html
@@ -11,22 +11,12 @@
 {% if res.datastore_active %}
     <button class="btn btn-primary dropdown-toggle" role="button" id="dropdownDownloadFormat" data-bs-toggle="dropdown" aria-expanded="false" aria-label="list of downloadable formats"></button>
     <ul class="dropdown-menu" aria-labelledby="dropdownDownloadFormat">
+      {% for fmt in h.datastore_dump_formats() %}
       <li>
-        <a class="dropdown-item" href="{{ h.url_for('datastore.dump', resource_id=res.id, bom=True) }}"
-          target="_blank" rel="noreferrer"><span>CSV</span></a>
+        <a class="dropdown-item" href="{{ h.url_for('datastore.dump', resource_id=res.id, format=fmt.name, bom=True) }}"
+          target="_blank" rel="noreferrer"><span>{{ fmt.label }}</span></a>
       </li>
-      <li>
-        <a class="dropdown-item" href="{{ h.url_for('datastore.dump', resource_id=res.id, format='tsv', bom=True) }}"
-          target="_blank" rel="noreferrer"><span>TSV</span></a>
-      </li>
-      <li>
-          <a class="dropdown-item" href="{{ h.url_for('datastore.dump', resource_id=res.id, format='json') }}"
-          target="_blank" rel="noreferrer"><span>JSON</span></a>
-      </li>
-      <li>
-          <a class="dropdown-item" href="{{ h.url_for('datastore.dump', resource_id=res.id, format='xml') }}"
-          target="_blank" rel="noreferrer"><span>XML</span></a>
-      </li>
+      {% endfor %}
     </ul>
 {% endif %}
 {% endblock download_resource_button %}

--- a/ckanext/datastore/tests/sample_dump_plugin.py
+++ b/ckanext/datastore/tests/sample_dump_plugin.py
@@ -9,23 +9,12 @@ ALWAYS_INVALID_REASON = "Always invalid format"
 
 
 def invalid_validate(context):
-    """Validator that always rejects the format.
-
-    Used by tests to confirm that a ``validate`` callable on a
-    registered format flows through to the helper, the blueprint, and
-    the resource-read template. Receives the dump context dict (see
-    :class:`~ckanext.datastore.interfaces.IDatastoreDump`).
-    """
+    """Validator that always rejects (tests the reason path)."""
     return ALWAYS_INVALID_REASON
 
 
 def valid_validate(context):
-    """Validator that always approves.
-
-    Used by tests to cover the branch where a format declares a
-    ``validate`` callable but the resource passes it (the validator
-    runs, returns ``None``, and the format stays available).
-    """
+    """Validator that always approves (tests the None path)."""
     return None
 
 
@@ -34,15 +23,10 @@ class SampleDumpPlugin(p.SingletonPlugin):
 
     Registers:
 
-    * ``faux`` — a no-validator format reusing ``csv_writer``.
-    * ``gated`` — a format whose ``validate`` callable always rejects
-      (covers the "validator returns reason" path).
-    * ``passes`` — a format whose ``validate`` callable always
-      approves (covers the "validator returns None" path).
-    * ``capped`` — a format with declarative ``max_rows``/``max_columns``
-      and no ``validate`` callable (covers the framework-evaluated path).
-      ``max_rows`` is 1 so any resource with more than one (post-filter)
-      row trips it.
+    * ``faux`` - no validator, reuses ``csv_writer``.
+    * ``gated`` - ``validate`` always rejects (reason path).
+    * ``passes`` - ``validate`` always approves (None path).
+    * ``capped`` - declarative ``max_rows``/``max_columns`` (framework path).
     * Removes the built-in ``xml`` format via the ``None`` sentinel.
     """
 
@@ -57,7 +41,6 @@ class SampleDumpPlugin(p.SingletonPlugin):
                 "content_type": "application/x-faux; charset=utf-8",
                 "file_extension": "faux",
             },
-            # Include an always invalid format for testing
             "gated": {
                 "label": "Gated",
                 "writer_factory": csv_writer,
@@ -66,8 +49,6 @@ class SampleDumpPlugin(p.SingletonPlugin):
                 "file_extension": "gated",
                 "validate": invalid_validate,
             },
-            # Validator present but always approves — exercises the
-            # "validate returned None" branch in core.
             "passes": {
                 "label": "Passes",
                 "writer_factory": csv_writer,
@@ -76,9 +57,6 @@ class SampleDumpPlugin(p.SingletonPlugin):
                 "file_extension": "passes",
                 "validate": valid_validate,
             },
-            # Declarative limits evaluated by core (no validate callable).
-            # max_rows=1 lets tests trip the row limit with a 2-row
-            # resource and confirm a filter can bring it back under.
             "capped": {
                 "label": "Capped",
                 "writer_factory": csv_writer,

--- a/ckanext/datastore/tests/sample_dump_plugin.py
+++ b/ckanext/datastore/tests/sample_dump_plugin.py
@@ -5,13 +5,40 @@ import ckan.plugins as p
 from ckanext.datastore.interfaces import IDatastoreDump
 from ckanext.datastore.writer import csv_writer
 
+ALWAYS_INVALID_REASON = "Always invalid format"
+
+
+def invalid_validate(resource_id):
+    """Validator that always rejects the format.
+
+    Used by tests to confirm that a ``validate`` callable on a
+    registered format flows through to the helper, the blueprint, and
+    the resource-read template.
+    """
+    return ALWAYS_INVALID_REASON
+
+
+def valid_validate(resource_id):
+    """Validator that always approves.
+
+    Used by tests to cover the branch where a format declares a
+    ``validate`` callable but the resource passes it (the validator
+    runs, returns ``None``, and the format stays available).
+    """
+    return None
+
 
 class SampleDumpPlugin(p.SingletonPlugin):
     """Test plugin exercising :class:`IDatastoreDump`.
 
-    Registers a fake ``faux`` format (reusing ``csv_writer`` so we don't
-    need a real implementation) and removes the built-in ``xml`` format
-    via the ``None`` sentinel.
+    Registers:
+
+    * ``faux`` — a no-validator format reusing ``csv_writer``.
+    * ``gated`` — a format whose ``validate`` callable always rejects
+      (covers the "validator returns reason" path).
+    * ``passes`` — a format whose ``validate`` callable always
+      approves (covers the "validator returns None" path).
+    * Removes the built-in ``xml`` format via the ``None`` sentinel.
     """
 
     p.implements(IDatastoreDump)
@@ -24,6 +51,25 @@ class SampleDumpPlugin(p.SingletonPlugin):
                 "records_format": "csv",
                 "content_type": "application/x-faux; charset=utf-8",
                 "file_extension": "faux",
+            },
+            # Include an always invalid format for testing
+            "gated": {
+                "label": "Gated",
+                "writer_factory": csv_writer,
+                "records_format": "csv",
+                "content_type": "application/x-gated; charset=utf-8",
+                "file_extension": "gated",
+                "validate": invalid_validate,
+            },
+            # Validator present but always approves — exercises the
+            # "validate returned None" branch in core.
+            "passes": {
+                "label": "Passes",
+                "writer_factory": csv_writer,
+                "records_format": "csv",
+                "content_type": "application/x-passes; charset=utf-8",
+                "file_extension": "passes",
+                "validate": valid_validate,
             },
             "xml": None,
         }

--- a/ckanext/datastore/tests/sample_dump_plugin.py
+++ b/ckanext/datastore/tests/sample_dump_plugin.py
@@ -1,0 +1,29 @@
+# encoding: utf-8
+
+import ckan.plugins as p
+
+from ckanext.datastore.interfaces import IDatastoreDump
+from ckanext.datastore.writer import csv_writer
+
+
+class SampleDumpPlugin(p.SingletonPlugin):
+    """Test plugin exercising :class:`IDatastoreDump`.
+
+    Registers a fake ``faux`` format (reusing ``csv_writer`` so we don't
+    need a real implementation) and removes the built-in ``xml`` format
+    via the ``None`` sentinel.
+    """
+
+    p.implements(IDatastoreDump)
+
+    def register_dump_formats(self):
+        return {
+            "faux": {
+                "label": "Faux",
+                "writer_factory": csv_writer,
+                "records_format": "csv",
+                "content_type": b"application/x-faux; charset=utf-8",
+                "file_extension": "faux",
+            },
+            "xml": None,
+        }

--- a/ckanext/datastore/tests/sample_dump_plugin.py
+++ b/ckanext/datastore/tests/sample_dump_plugin.py
@@ -8,17 +8,18 @@ from ckanext.datastore.writer import csv_writer
 ALWAYS_INVALID_REASON = "Always invalid format"
 
 
-def invalid_validate(resource_id):
+def invalid_validate(context):
     """Validator that always rejects the format.
 
     Used by tests to confirm that a ``validate`` callable on a
     registered format flows through to the helper, the blueprint, and
-    the resource-read template.
+    the resource-read template. Receives the dump context dict (see
+    :class:`~ckanext.datastore.interfaces.IDatastoreDump`).
     """
     return ALWAYS_INVALID_REASON
 
 
-def valid_validate(resource_id):
+def valid_validate(context):
     """Validator that always approves.
 
     Used by tests to cover the branch where a format declares a
@@ -38,6 +39,10 @@ class SampleDumpPlugin(p.SingletonPlugin):
       (covers the "validator returns reason" path).
     * ``passes`` — a format whose ``validate`` callable always
       approves (covers the "validator returns None" path).
+    * ``capped`` — a format with declarative ``max_rows``/``max_columns``
+      and no ``validate`` callable (covers the framework-evaluated path).
+      ``max_rows`` is 1 so any resource with more than one (post-filter)
+      row trips it.
     * Removes the built-in ``xml`` format via the ``None`` sentinel.
     """
 
@@ -70,6 +75,18 @@ class SampleDumpPlugin(p.SingletonPlugin):
                 "content_type": "application/x-passes; charset=utf-8",
                 "file_extension": "passes",
                 "validate": valid_validate,
+            },
+            # Declarative limits evaluated by core (no validate callable).
+            # max_rows=1 lets tests trip the row limit with a 2-row
+            # resource and confirm a filter can bring it back under.
+            "capped": {
+                "label": "Capped",
+                "writer_factory": csv_writer,
+                "records_format": "csv",
+                "content_type": "application/x-capped; charset=utf-8",
+                "file_extension": "capped",
+                "max_rows": 1,
+                "max_columns": 5,
             },
             "xml": None,
         }

--- a/ckanext/datastore/tests/sample_dump_plugin.py
+++ b/ckanext/datastore/tests/sample_dump_plugin.py
@@ -22,7 +22,7 @@ class SampleDumpPlugin(p.SingletonPlugin):
                 "label": "Faux",
                 "writer_factory": csv_writer,
                 "records_format": "csv",
-                "content_type": b"application/x-faux; charset=utf-8",
+                "content_type": "application/x-faux; charset=utf-8",
                 "file_extension": "faux",
             },
             "xml": None,

--- a/ckanext/datastore/tests/test_dump.py
+++ b/ckanext/datastore/tests/test_dump.py
@@ -911,3 +911,75 @@ def get_csv_record_values(response_body):
 
 def get_json_record_values(response_body):
     return [record[1] for record in json.loads(response_body)["records"]]
+
+
+class TestDatastoreDumpInterface(object):
+    """Tests for the IDatastoreDump plugin interface.
+
+    Uses ``sample_dump_plugin`` (see
+    ``ckanext/datastore/tests/sample_dump_plugin.py``), which adds a
+    ``faux`` format and removes the built-in ``xml`` format.
+    """
+
+    @pytest.mark.ckan_config("ckan.plugins", "datastore")
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    def test_unknown_format_rejected(self, app):
+        # Sanity check: the schema's one_of validator rejects formats
+        # not in the registry, regardless of any plugin.
+        resource = factories.Resource()
+        helpers.call_action(
+            "datastore_create",
+            resource_id=resource["id"],
+            force=True,
+            records=[{"book": "annakarenina"}],
+        )
+
+        app.get(
+            f"/datastore/dump/{resource['id']}?format=bogus", status=400
+        )
+
+    @pytest.mark.ckan_config(
+        "ckan.plugins", "datastore sample_dump_plugin"
+    )
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    def test_dump_custom_format_added_via_plugin(self, app):
+        resource = factories.Resource()
+        helpers.call_action(
+            "datastore_create",
+            resource_id=resource["id"],
+            force=True,
+            records=[{"book": "annakarenina"}, {"book": "warandpeace"}],
+        )
+
+        response = app.get(
+            f"/datastore/dump/{resource['id']}?format=faux"
+        )
+        assert response.status_code == 200
+        assert (
+            response.headers["Content-Type"]
+            == "application/x-faux; charset=utf-8"
+        )
+        assert (
+            f'filename="{resource["id"]}.faux"'
+            in response.headers["Content-disposition"]
+        )
+
+    @pytest.mark.ckan_config(
+        "ckan.plugins", "datastore sample_dump_plugin"
+    )
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    def test_dump_xml_disabled_via_plugin(self, app):
+        # The plugin returns {"xml": None}, which removes the format
+        # from the registry. The schema's one_of validator then rejects
+        # ?format=xml at validation time (HTTP 400).
+        resource = factories.Resource()
+        helpers.call_action(
+            "datastore_create",
+            resource_id=resource["id"],
+            force=True,
+            records=[{"book": "annakarenina"}],
+        )
+
+        app.get(
+            f"/datastore/dump/{resource['id']}?format=xml", status=400
+        )

--- a/ckanext/datastore/tests/test_dump.py
+++ b/ckanext/datastore/tests/test_dump.py
@@ -3,11 +3,15 @@
 import unittest.mock as mock
 import json
 import pytest
+import ckan.plugins.toolkit as toolkit
 import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
 import xml.etree.ElementTree as ET
 
+from ckan.lib.helpers import url_for
 from ckanext.datastore.backend.postgres import search_data
+from ckanext.datastore.tests.sample_dump_plugin import ALWAYS_INVALID_REASON
+
 
 class TestDatastoreDump(object):
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
@@ -980,3 +984,133 @@ class TestDatastoreDumpInterface(object):
         app.get(
             f"/datastore/dump/{resource['id']}?format=xml", status=400
         )
+
+
+@pytest.mark.ckan_config("ckan.plugins", "datastore sample_dump_plugin")
+@pytest.mark.usefixtures("clean_datastore", "with_plugins")
+class TestDatastoreDumpValidate(object):
+    """Tests for the optional ``validate`` callable on a format config.
+
+    Uses the ``gated`` format from ``sample_dump_plugin`` (its
+    validator always rejects with :data:`ALWAYS_INVALID_REASON`) so the contract
+    can be exercised without needing a real extension installed.
+    """
+
+    def test_helper_marks_format_unavailable_with_reason(self):
+        # The helper should report the gated format as unavailable
+        # with the validator's reason, while formats whose validator
+        # approves (``passes``) and those without a validator
+        # (csv/tsv/json/faux) stay available.
+        resource = factories.Resource(url_type="datastore")
+        helpers.call_action(
+            "datastore_create",
+            resource_id=resource["id"],
+            records=[{"book": "annakarenina"}],
+        )
+
+        formats = toolkit.h.datastore_dump_formats(
+            resource_id=resource["id"]
+        )
+        by_name = {f["name"]: f for f in formats}
+
+        assert by_name["gated"]["available"] is False
+        assert by_name["gated"]["reason"] == ALWAYS_INVALID_REASON
+
+        # Validator present but returns None => available.
+        assert by_name["passes"]["available"] is True
+        assert by_name["passes"]["reason"] is None
+
+        # No validator at all => available.
+        for name in ("csv", "tsv", "json", "faux"):
+            assert by_name[name]["available"] is True
+            assert by_name[name]["reason"] is None
+
+    def test_helper_skips_validators_when_no_resource_id(self):
+        # Without a resource_id, the helper can't run validators, so
+        # every format should still appear (no crash, no validator
+        # call). available/reason fall back to "always available".
+        formats = toolkit.h.datastore_dump_formats()
+        by_name = {f["name"]: f for f in formats}
+
+        assert "gated" in by_name
+        assert by_name["gated"]["available"] is True
+        assert by_name["gated"]["reason"] is None
+
+    def test_dump_endpoint_rejects_with_400(self, app):
+        # A direct GET to /datastore/dump/<id>?format=gated should
+        # return HTTP 400 with the validator's reason in the body.
+        resource = factories.Resource(url_type="datastore")
+        helpers.call_action(
+            "datastore_create",
+            resource_id=resource["id"],
+            records=[{"book": "annakarenina"}],
+        )
+
+        response = app.get(
+            f"/datastore/dump/{resource['id']}?format=gated",
+            status=400,
+        )
+        assert ALWAYS_INVALID_REASON in response.get_data(as_text=True)
+
+    def test_dump_endpoint_allows_format_without_validator(self, app):
+        # Sanity check that the gated validator doesn't bleed into
+        # other formats on the same resource.
+        resource = factories.Resource(url_type="datastore")
+        helpers.call_action(
+            "datastore_create",
+            resource_id=resource["id"],
+            records=[{"book": "annakarenina"}],
+        )
+
+        response = app.get(
+            f"/datastore/dump/{resource['id']}?format=faux"
+        )
+        assert response.status_code == 200
+
+    def test_dump_endpoint_allows_format_whose_validator_approves(self, app):
+        # Covers the blueprint branch where ``validate`` is defined but
+        # returns ``None`` (no abort). The ``passes`` format reuses the
+        # csv writer, so the response should also be a normal dump.
+        resource = factories.Resource(url_type="datastore")
+        helpers.call_action(
+            "datastore_create",
+            resource_id=resource["id"],
+            records=[{"book": "annakarenina"}],
+        )
+
+        response = app.get(
+            f"/datastore/dump/{resource['id']}?format=passes"
+        )
+        assert response.status_code == 200
+        assert (
+            response.headers["Content-Type"]
+            == "application/x-passes; charset=utf-8"
+        )
+
+    def test_resource_read_page_renders_disabled_dropdown_item(self, app):
+        # The download dropdown on the resource page should render the
+        # gated format as a disabled item with the validator's reason
+        # exposed as the ``title`` attribute, while the other formats
+        # remain regular clickable links.
+        resource = factories.Resource(url_type="datastore")
+        helpers.call_action(
+            "datastore_create",
+            resource_id=resource["id"],
+            records=[{"book": "annakarenina"}],
+        )
+
+        url = url_for(
+            "dataset_resource.read",
+            id=resource["package_id"],
+            resource_id=resource["id"],
+        )
+        response = app.get(url)
+        body = response.get_data(as_text=True)
+
+        assert response.status_code == 200
+        # The disabled <span> for gated must carry the reason as title.
+        assert 'class="dropdown-item disabled"' in body
+        assert f'title="{ALWAYS_INVALID_REASON}"' in body
+        # And the built-in CSV format must still render as an active
+        # dropdown-item link (not disabled).
+        assert 'class="dropdown-item"' in body

--- a/ckanext/datastore/tests/test_dump.py
+++ b/ckanext/datastore/tests/test_dump.py
@@ -2,6 +2,7 @@
 
 import unittest.mock as mock
 import json
+import urllib.parse
 import pytest
 import ckan.plugins.toolkit as toolkit
 import ckan.tests.helpers as helpers
@@ -1114,3 +1115,95 @@ class TestDatastoreDumpValidate(object):
         # And the built-in CSV format must still render as an active
         # dropdown-item link (not disabled).
         assert 'class="dropdown-item"' in body
+
+
+@pytest.mark.ckan_config("ckan.plugins", "datastore sample_dump_plugin")
+@pytest.mark.usefixtures("clean_datastore", "with_plugins")
+class TestDatastoreDumpDeclarativeLimits(object):
+    """Tests for declarative ``max_rows``/``max_columns`` controls.
+
+    Uses the ``capped`` format from ``sample_dump_plugin`` (``max_rows``
+    is 1, ``max_columns`` is 5, no ``validate`` callable). These exercise
+    the framework-evaluated availability path and, crucially, that the
+    decision is made against the *filtered* export scope rather than the
+    resource totals.
+    """
+
+    def _make_resource(self, records):
+        resource = factories.Resource(url_type="datastore")
+        helpers.call_action(
+            "datastore_create",
+            resource_id=resource["id"],
+            records=records,
+        )
+        return resource
+
+    def test_helper_marks_over_row_limit_unavailable(self):
+        # 2 rows > max_rows=1 -> capped is unavailable with a
+        # framework-generated reason mentioning rows.
+        resource = self._make_resource(
+            [{"book": "annakarenina"}, {"book": "warandpeace"}])
+
+        formats = toolkit.h.datastore_dump_formats(
+            resource_id=resource["id"])
+        by_name = {f["name"]: f for f in formats}
+
+        assert by_name["capped"]["available"] is False
+        assert "rows" in by_name["capped"]["reason"].lower()
+        # Formats without controls stay available.
+        assert by_name["csv"]["available"] is True
+
+    def test_helper_within_limit_available(self):
+        # 1 row == max_rows=1 (rejected only when strictly greater).
+        resource = self._make_resource([{"book": "annakarenina"}])
+
+        formats = toolkit.h.datastore_dump_formats(
+            resource_id=resource["id"])
+        by_name = {f["name"]: f for f in formats}
+
+        assert by_name["capped"]["available"] is True
+        assert by_name["capped"]["reason"] is None
+
+    def test_dump_endpoint_rejects_over_limit_with_400(self, app):
+        resource = self._make_resource(
+            [{"book": "annakarenina"}, {"book": "warandpeace"}])
+
+        response = app.get(
+            f"/datastore/dump/{resource['id']}?format=capped",
+            status=400,
+        )
+        assert "rows" in response.get_data(as_text=True).lower()
+
+    def test_dump_endpoint_filtered_under_limit_succeeds(self, app):
+        # The resource has 2 rows (over the cap), but a filter reduces
+        # the export to a single row, so the capped format becomes
+        # available and the download succeeds. This is the case a
+        # resource-id-only validator would get wrong.
+        resource = self._make_resource(
+            [{"book": "annakarenina"}, {"book": "warandpeace"}])
+
+        qs = urllib.parse.urlencode({
+            "format": "capped",
+            "filters": json.dumps({"book": "annakarenina"}),
+        })
+        response = app.get(f"/datastore/dump/{resource['id']}?{qs}")
+
+        assert response.status_code == 200
+        assert "annakarenina" in response.get_data(as_text=True)
+        assert "warandpeace" not in response.get_data(as_text=True)
+
+    def test_helper_filtered_scope_marks_available(self):
+        # Same as above but through the helper: passing search_params
+        # that filter to one row flips capped from unavailable to
+        # available.
+        resource = self._make_resource(
+            [{"book": "annakarenina"}, {"book": "warandpeace"}])
+
+        formats = toolkit.h.datastore_dump_formats(
+            resource_id=resource["id"],
+            search_params={"filters": {"book": "annakarenina"}},
+        )
+        by_name = {f["name"]: f for f in formats}
+
+        assert by_name["capped"]["available"] is True
+        assert by_name["capped"]["reason"] is None

--- a/ckanext/datastore/tests/test_dump.py
+++ b/ckanext/datastore/tests/test_dump.py
@@ -926,11 +926,10 @@ class TestDatastoreDumpInterface(object):
     def test_unknown_format_rejected(self, app):
         # Sanity check: the schema's one_of validator rejects formats
         # not in the registry, regardless of any plugin.
-        resource = factories.Resource()
+        resource = factories.Resource(url_type='datastore')
         helpers.call_action(
             "datastore_create",
             resource_id=resource["id"],
-            force=True,
             records=[{"book": "annakarenina"}],
         )
 
@@ -943,11 +942,10 @@ class TestDatastoreDumpInterface(object):
     )
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_dump_custom_format_added_via_plugin(self, app):
-        resource = factories.Resource()
+        resource = factories.Resource(url_type='datastore')
         helpers.call_action(
             "datastore_create",
             resource_id=resource["id"],
-            force=True,
             records=[{"book": "annakarenina"}, {"book": "warandpeace"}],
         )
 
@@ -972,11 +970,10 @@ class TestDatastoreDumpInterface(object):
         # The plugin returns {"xml": None}, which removes the format
         # from the registry. The schema's one_of validator then rejects
         # ?format=xml at validation time (HTTP 400).
-        resource = factories.Resource()
+        resource = factories.Resource(url_type='datastore')
         helpers.call_action(
             "datastore_create",
             resource_id=resource["id"],
-            force=True,
             records=[{"book": "annakarenina"}],
         )
 

--- a/ckanext/datastore/tests/test_dump.py
+++ b/ckanext/datastore/tests/test_dump.py
@@ -929,8 +929,6 @@ class TestDatastoreDumpInterface(object):
     @pytest.mark.ckan_config("ckan.plugins", "datastore")
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_unknown_format_rejected(self, app):
-        # Sanity check: the schema's one_of validator rejects formats
-        # not in the registry, regardless of any plugin.
         resource = factories.Resource(url_type='datastore')
         helpers.call_action(
             "datastore_create",
@@ -972,9 +970,7 @@ class TestDatastoreDumpInterface(object):
     )
     @pytest.mark.usefixtures("clean_datastore", "with_plugins")
     def test_dump_xml_disabled_via_plugin(self, app):
-        # The plugin returns {"xml": None}, which removes the format
-        # from the registry. The schema's one_of validator then rejects
-        # ?format=xml at validation time (HTTP 400).
+        # {"xml": None} removes the format, so ?format=xml is rejected.
         resource = factories.Resource(url_type='datastore')
         helpers.call_action(
             "datastore_create",
@@ -997,11 +993,7 @@ class TestDatastoreDumpValidate(object):
     can be exercised without needing a real extension installed.
     """
 
-    def test_helper_marks_format_unavailable_with_reason(self):
-        # The helper should report the gated format as unavailable
-        # with the validator's reason, while formats whose validator
-        # approves (``passes``) and those without a validator
-        # (csv/tsv/json/faux) stay available.
+    def test_helper_marks_format_unavailable_with_reason(self, app):
         resource = factories.Resource(url_type="datastore")
         helpers.call_action(
             "datastore_create",
@@ -1027,9 +1019,8 @@ class TestDatastoreDumpValidate(object):
             assert by_name[name]["reason"] is None
 
     def test_helper_skips_validators_when_no_resource_id(self):
-        # Without a resource_id, the helper can't run validators, so
-        # every format should still appear (no crash, no validator
-        # call). available/reason fall back to "always available".
+        # Without a resource_id no validators run; every format still
+        # appears as available.
         formats = toolkit.h.datastore_dump_formats()
         by_name = {f["name"]: f for f in formats}
 
@@ -1038,8 +1029,7 @@ class TestDatastoreDumpValidate(object):
         assert by_name["gated"]["reason"] is None
 
     def test_dump_endpoint_rejects_with_400(self, app):
-        # A direct GET to /datastore/dump/<id>?format=gated should
-        # return HTTP 400 with the validator's reason in the body.
+        # A gated dump returns HTTP 400 with the reason in the body.
         resource = factories.Resource(url_type="datastore")
         helpers.call_action(
             "datastore_create",
@@ -1054,8 +1044,7 @@ class TestDatastoreDumpValidate(object):
         assert ALWAYS_INVALID_REASON in response.get_data(as_text=True)
 
     def test_dump_endpoint_allows_format_without_validator(self, app):
-        # Sanity check that the gated validator doesn't bleed into
-        # other formats on the same resource.
+        # The gated validator must not affect other formats.
         resource = factories.Resource(url_type="datastore")
         helpers.call_action(
             "datastore_create",
@@ -1069,9 +1058,7 @@ class TestDatastoreDumpValidate(object):
         assert response.status_code == 200
 
     def test_dump_endpoint_allows_format_whose_validator_approves(self, app):
-        # Covers the blueprint branch where ``validate`` is defined but
-        # returns ``None`` (no abort). The ``passes`` format reuses the
-        # csv writer, so the response should also be a normal dump.
+        # validate defined but returning None -> normal dump.
         resource = factories.Resource(url_type="datastore")
         helpers.call_action(
             "datastore_create",
@@ -1089,10 +1076,8 @@ class TestDatastoreDumpValidate(object):
         )
 
     def test_resource_read_page_renders_disabled_dropdown_item(self, app):
-        # The download dropdown on the resource page should render the
-        # gated format as a disabled item with the validator's reason
-        # exposed as the ``title`` attribute, while the other formats
-        # remain regular clickable links.
+        # The dropdown renders gated as a disabled item carrying the
+        # reason as title, with other formats as normal links.
         resource = factories.Resource(url_type="datastore")
         helpers.call_action(
             "datastore_create",
@@ -1109,11 +1094,9 @@ class TestDatastoreDumpValidate(object):
         body = response.get_data(as_text=True)
 
         assert response.status_code == 200
-        # The disabled <span> for gated must carry the reason as title.
         assert 'class="dropdown-item disabled"' in body
         assert f'title="{ALWAYS_INVALID_REASON}"' in body
-        # And the built-in CSV format must still render as an active
-        # dropdown-item link (not disabled).
+        # CSV still renders as an active link.
         assert 'class="dropdown-item"' in body
 
 
@@ -1122,11 +1105,9 @@ class TestDatastoreDumpValidate(object):
 class TestDatastoreDumpDeclarativeLimits(object):
     """Tests for declarative ``max_rows``/``max_columns`` controls.
 
-    Uses the ``capped`` format from ``sample_dump_plugin`` (``max_rows``
-    is 1, ``max_columns`` is 5, no ``validate`` callable). These exercise
-    the framework-evaluated availability path and, crucially, that the
-    decision is made against the *filtered* export scope rather than the
-    resource totals.
+    Uses the ``capped`` format (``max_rows`` 1, ``max_columns`` 5) to
+    check the framework-evaluated path and that the decision uses the
+    filtered export scope, not the resource totals.
     """
 
     def _make_resource(self, records):
@@ -1139,8 +1120,7 @@ class TestDatastoreDumpDeclarativeLimits(object):
         return resource
 
     def test_helper_marks_over_row_limit_unavailable(self):
-        # 2 rows > max_rows=1 -> capped is unavailable with a
-        # framework-generated reason mentioning rows.
+        # 2 rows > max_rows=1 -> capped unavailable, reason mentions rows.
         resource = self._make_resource(
             [{"book": "annakarenina"}, {"book": "warandpeace"}])
 
@@ -1175,10 +1155,8 @@ class TestDatastoreDumpDeclarativeLimits(object):
         assert "rows" in response.get_data(as_text=True).lower()
 
     def test_dump_endpoint_filtered_under_limit_succeeds(self, app):
-        # The resource has 2 rows (over the cap), but a filter reduces
-        # the export to a single row, so the capped format becomes
-        # available and the download succeeds. This is the case a
-        # resource-id-only validator would get wrong.
+        # 2-row resource is over the cap, but a filter brings the export
+        # to one row, so the capped download succeeds.
         resource = self._make_resource(
             [{"book": "annakarenina"}, {"book": "warandpeace"}])
 
@@ -1193,9 +1171,7 @@ class TestDatastoreDumpDeclarativeLimits(object):
         assert "warandpeace" not in response.get_data(as_text=True)
 
     def test_helper_filtered_scope_marks_available(self):
-        # Same as above but through the helper: passing search_params
-        # that filter to one row flips capped from unavailable to
-        # available.
+        # Same via the helper: a filter to one row makes capped available.
         resource = self._make_resource(
             [{"book": "annakarenina"}, {"book": "warandpeace"}])
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -129,6 +129,7 @@ ckan.test_plugins =
     test_package_controller_plugin = tests.plugins.ckantestplugins:MockPackageControllerPlugin
     test_resource_view = tests.plugins.ckantestplugins:MockResourceViewExtension
     sample_datastore_plugin = ckanext.datastore.tests.sample_datastore_plugin:SampleDataStorePlugin
+    sample_dump_plugin = ckanext.datastore.tests.sample_dump_plugin:SampleDumpPlugin
     example_datastore_deleted_with_count_plugin = ckanext.datastore.tests.test_chained_action:ExampleDataStoreDeletedWithCountPlugin
     example_data_store_search_sql_plugin = ckanext.datastore.tests.test_chained_auth_functions:ExampleDataStoreSearchSQLPlugin
     test_datastore_view = ckan.tests.lib.test_datapreview:MockDatastoreBasedResourceView


### PR DESCRIPTION
### Proposed fixes:

Adding a new `IDatastoreDump` interface for the datastore so users can add, remove or modify current dump formats.
Now the list of file types to downloads from datastore is fixed (csv, tsv, xml, etc)

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
