### PR TITLE
[2.11] Restore ALLOWED_UPLOAD_TYPES from uploader module

### DIFF
--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -18,6 +18,7 @@ import ckan.plugins as plugins
 from ckan.common import config
 from ckan.types import ErrorDict, PUploader, PResourceUploader
 
+ALLOWED_UPLOAD_TYPES = (FlaskFileStorage,)
 MB = 1 << 20
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
The file wrappers were removed in https://github.com/ckan/ckan/pull/9236 but the var should not have been dropped to preserve compatibility (some extensions import it)
