### PR TITLE
Update ecosystem catalog references and fix typos in documentation

### DIFF
--- a/doc/extensions/index.rst
+++ b/doc/extensions/index.rst
@@ -22,9 +22,10 @@ features by developing your own CKAN extensions.
 
     **External extensions** are CKAN extensions that don't come packaged with
     CKAN, but must be downloaded and installed separately. Find
-    external extensions at `https://extensions.ckan.org/
-    <https://extensions.ckan.org/>`_.  Again, follow
+    external extensions at `https://ecosystem.ckan.org/extension/
+    <https://ecosystem.ckan.org/extension/>`_.  Again, follow
     each extension's own documentation to install, setup, and use the extension.
+
 
 .. toctree::
    :maxdepth: 2

--- a/doc/extensions/signals.rst
+++ b/doc/extensions/signals.rst
@@ -42,7 +42,7 @@ that will be passed to subscriber. For particular CKAN version one can
 use signlal-listing below as a reference, but in future versions
 signature may change. In addition, any event can be fired by
 a third-party plugin, so it is always safer to check whether a particular
-argument is available inisde the provided `kwargs`.
+argument is available inside the provided `kwargs`.
 
 Even though it is possible to register subscribers using decorators::
 
@@ -99,7 +99,7 @@ always use your plugin's name as prefix for the signal.::
   import ckan.plugins.toolkit as tk
 
   # create signal and use it somewhere inside your extension
-  custom_something_happened = tk.signals.ckanext.signal('custom_something_happened)
+  custom_something_happened = tk.signals.ckanext.signal('custom_something_happened')
 
   # after this, you can notify subscribers using following code:
   custom_signal_happened.send(SENDER, ARG1=VALUE1, ARG2=VALUE2, ...)

--- a/doc/extensions/tutorial.rst
+++ b/doc/extensions/tutorial.rst
@@ -530,6 +530,13 @@ for writing CKAN extensions, including:
 * Using the :doc:`plugins toolkit <plugins-toolkit>`
 * Handling exceptions
 
+.. seealso::
+
+   Now that you've built your extension, consider sharing it with the CKAN
+   community by listing it on the `CKAN Ecosystem catalog
+   <https://ecosystem.ckan.org/extension/>`_. It's a great way to let other
+   users discover and explore your work.
+
 
 Troubleshooting
 ===============

--- a/doc/extensions/tutorial.rst
+++ b/doc/extensions/tutorial.rst
@@ -123,7 +123,7 @@ Creating a plugin class
    extension's features.
 
 
-``cookiecutter`` should have created the following file file
+``cookiecutter`` should have created the following file
 ``ckanext-iauthfunctions/ckanext/iauthfunctions/plugin.py``.
 Edit it to match the following:
 
@@ -552,7 +552,7 @@ it means that your plugin class does not implement one of the plugin
 interface's methods. A plugin must implement every method of every plugin
 interface that it implements.
 
-.. todo:: Can you user inherit=True to avoid having to implement them all?
+.. todo:: Can you use inherit=True to avoid having to implement them all?
 
 Other ``AttributeError``\ s can happen if your method returns the wrong type of
 value, check the documentation for each plugin interface method to see what


### PR DESCRIPTION
Fixes #

### Proposed fixes:

Ecosystem catalog: brief mention in index.rst, replacing extensions.ckan.org and call-to-action at the end of the tutorial
Fix typos in signals and tutorial pages

### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
