### PR TITLE
chore: cloud storages has duplicated path in download links

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,7 @@ certifi>=2026.1.4
 click==8.1.8
 dominate==2.9.1
 feedgen==1.0.0
-file-keeper==0.2.3
+file-keeper==0.2.4
 Flask==3.1.3
 Flask-Babel==4.0.0
 Flask-Login==0.6.3

--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,7 @@ certifi>=2026.1.4
 click==8.1.8
 dominate==2.9.1
 feedgen==1.0.0
-file-keeper==0.2.2
+file-keeper==0.2.3
 Flask==3.1.3
 Flask-Babel==4.0.0
 Flask-Login==0.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ dominate==2.9.1
     # via -r requirements.in
 feedgen==1.0.0
     # via -r requirements.in
-file-keeper==0.2.3
+file-keeper==0.2.4
     # via -r requirements.in
 flask==3.1.3
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ dominate==2.9.1
     # via -r requirements.in
 feedgen==1.0.0
     # via -r requirements.in
-file-keeper==0.2.2
+file-keeper==0.2.3
     # via -r requirements.in
 flask==3.1.3
     # via


### PR DESCRIPTION
I noticed a bug in file-keeper while experimenting with cloud storage. When `path` is specified in cloud storage(i.e, files uploaded to a subfolder of the bucket), download links are generated with a duplicated path section(something like `resource/resource/file.txt`). 

The fix is added to [new file-keeper version](https://github.com/DataShades/file-keeper/releases/tag/v0.2.3)