### PR TITLE
fix: Active state of facets is not computed properly

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1202,7 +1202,7 @@ def get_facet_items_dict(
     if not items:
         return []
 
-    params: list[tuple[str, str]] = request.args.items(multi=True)
+    params: list[tuple[str, str]] = list(request.args.items(multi=True))
     facets = []
 
     for facet_item in items:

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -1127,3 +1127,21 @@ class TestHasMoreFacets:
             assert (
                 h.has_more_facets("test", {"test": {"items": facets}}, 7, True) is True
             )
+
+
+def test_get_facet_items_dict(test_request_context: Any):
+    """get_facet_items_dict returns a list of facet items with the correct active state based on the current request parameters."""
+    facets = [
+        {"name": name, "display_name": name, "count": 1} for name in ["aaa", "bbb", "ccc"]
+    ]
+
+    with test_request_context("/dataset?test=ccc&test=aaa"):
+        result = h.get_facet_items_dict("test", {"test": {"items": facets}})
+        assert result[0]["name"] == "aaa"
+        assert result[0]["active"]
+
+        assert result[1]["name"] == "bbb"
+        assert not result[1]["active"]
+
+        assert result[2]["name"] == "ccc"
+        assert result[2]["active"]


### PR DESCRIPTION
`active` state of facets is computed against `request.args.items(...)` that [returns generator](https://werkzeug.palletsprojects.com/en/stable/datastructures/#werkzeug.datastructures.MultiDict.items). Because of it, not all active facets are marked as such.

This issue appears only in v2.12 and does not require backporting to older versions.