### PR TITLE
Update copyright year to 2026

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ ckan-dev mailing list or on Gitter.
 Copying and License
 -------------------
 
-This material is copyright (c) 2006-2023 Open Knowledge Foundation and contributors.
+This material is copyright (c) 2006-2026 Open Knowledge Foundation and contributors.
 
 It is open and licensed under the GNU Affero General Public License (AGPL) v3.0
 whose full text may be found at:


### PR DESCRIPTION
Fixes #

### Proposed fixes:

Update copyright year to 2026 in Readme.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
