### PR TITLE
Datastore Select distinct fix

### DIFF
--- a/changes/9365.bugfix
+++ b/changes/9365.bugfix
@@ -1,0 +1,1 @@
+Fix datastore distinct queries with limit/offset

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1458,6 +1458,7 @@ def search_data(context: Context, data_dict: dict[str, Any]):
     limit = query_dict['limit']
     offset = query_dict['offset']
 
+    distinct_final_statement = ''
     if query_dict.get('distinct'):
         distinct = 'DISTINCT'
     else:
@@ -1490,17 +1491,24 @@ def search_data(context: Context, data_dict: dict[str, Any]):
             last_id_select = 'max(_id)'
             is_keyset = any(i[0].startswith( '_id > ') for i in query_dict['where'])
 
-    if is_keyset:
-        final_statement = '{where} {sort} LIMIT {limit}'
+    if not distinct:
+        if is_keyset:
+            final_statement = '{where} {sort} LIMIT {limit}'
+        else:
+            # UNDONE -- this probably isn't necessary if the offset is 0 by
+            # default on the limit
+            final_statement = '{where} {sort} LIMIT {limit} OFFSET {offset}'
     else:
-        final_statement = '{where} {sort} LIMIT {limit} OFFSET {offset}'
+        # This should be fine for keyset or not final statement
+        final_statement = '{where}'
+        distinct_final_statement = '{sort} LIMIT {limit} OFFSET {offset}'
 
     if records_format == 'objects':
         sql_fmt = '''
             WITH records_page AS (
                 SELECT * FROM {resource} {ts_query} {final_statement}
             ), select_cols AS (
-                SELECT {distinct} {select} FROM records_page
+                SELECT {distinct} {select} FROM records_page {distinct_final_statement}
             ), json_cols AS (
                 SELECT array_to_json(array_agg(select_cols))::text j
                 FROM select_cols
@@ -1520,6 +1528,7 @@ def search_data(context: Context, data_dict: dict[str, Any]):
                 SELECT * FROM {resource} {ts_query} {final_statement}
             ), select_cols AS (
                 SELECT {distinct} '[' || {select} || ']' v FROM records_page
+                {distinct_final_statement}
             ), list_cols AS (
                 SELECT '[' || array_to_string(array_agg(select_cols.v), ',') || ']' lc
                 FROM select_cols
@@ -1537,7 +1546,7 @@ def search_data(context: Context, data_dict: dict[str, Any]):
             COPY (
                 WITH records_page AS (
                     SELECT * FROM {resource} {ts_query} {final_statement}
-                ) SELECT {distinct} {select} FROM records_page
+                ) SELECT {distinct} {select} FROM records_page {distinct_final_statement}
             ) TO STDOUT csv
         '''
 
@@ -1546,7 +1555,7 @@ def search_data(context: Context, data_dict: dict[str, Any]):
             COPY (
                 WITH records_page AS (
                     SELECT * FROM {resource} {ts_query} {final_statement}
-                ) SELECT {distinct} {select} FROM records_page
+                ) SELECT {distinct} {select} FROM records_page {distinct_final_statement}
             ) TO STDOUT csv DELIMITER '\t'
         '''
 
@@ -1559,13 +1568,21 @@ def search_data(context: Context, data_dict: dict[str, Any]):
         offset=offset,
         sort=sort_clause,
     )
+    distinct_final_statement = distinct_final_statement.format(
+        limit=limit,
+        offset=offset,
+        sort=sort_clause,
+    )
     sql_string = sql_fmt.format(
         distinct=distinct,
         select=select_columns,
         resource=identifier(resource_id),
         ts_query=ts_query,
         last_id_select=last_id_select,
-        final_statement=final_statement)
+        final_statement=final_statement,
+        distinct_final_statement=distinct_final_statement,
+
+    )
 
     if records_format == 'csv' or records_format == 'tsv':
         buf = StringIO()

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1546,7 +1546,8 @@ def search_data(context: Context, data_dict: dict[str, Any]):
             COPY (
                 WITH records_page AS (
                     SELECT * FROM {resource} {ts_query} {final_statement}
-                ) SELECT {distinct} {select} FROM records_page {distinct_final_statement}
+                ) SELECT {distinct} {select}
+                FROM records_page {distinct_final_statement}
             ) TO STDOUT csv
         '''
 
@@ -1555,7 +1556,8 @@ def search_data(context: Context, data_dict: dict[str, Any]):
             COPY (
                 WITH records_page AS (
                     SELECT * FROM {resource} {ts_query} {final_statement}
-                ) SELECT {distinct} {select} FROM records_page {distinct_final_statement}
+                ) SELECT {distinct} {select}
+                FROM records_page {distinct_final_statement}
             ) TO STDOUT csv DELIMITER '\t'
         '''
 

--- a/ckanext/datastore/tests/test_search.py
+++ b/ckanext/datastore/tests/test_search.py
@@ -2433,3 +2433,76 @@ class TestDatastoreSearchFilters(object):
             {"_id": 2, "course": "appetizer", "special": False},
             {"_id": 4, "course": "dessert", "special": False},
         ]
+
+
+class TestDatastoreSearchDistinctTests(object):
+    sysadmin_user = None
+    normal_user = None
+
+    @pytest.fixture(autouse=True)
+    def initial_data(self, clean_datastore, app):
+        ctd.CreateTestData.create()
+        self.sysadmin_user = factories.Sysadmin()
+        self.sysadmin_token = factories.APIToken(user=self.sysadmin_user["id"])
+        self.sysadmin_token = self.sysadmin_token["token"]
+        self.normal_user = factories.User()
+        self.normal_user_token = factories.APIToken(user=self.normal_user["id"])
+        self.normal_user_token = self.normal_user_token["token"]
+        self.dataset = model.Package.get("annakarenina")
+        self.resource = self.dataset.resources[0]
+
+        self.records = [{'val': 'foo'} for r in range(5)]
+        self.records.append({'val': 'bar'})
+
+        self.data = {
+            "resource_id": self.resource.id,
+            "force": True,
+            "aliases": "distinct_with_limit",
+            "fields": [
+                {"id": "val", "type": "text"},
+            ],
+            "records": self.records,
+        }
+        headers = {"Authorization": self.sysadmin_token}
+        res = app.post(
+            "/api/action/datastore_create", json=self.data, headers=headers,
+        )
+        res_dict = json.loads(res.data)
+        assert res_dict["success"] is True
+
+        # Make an organization, because private datasets must belong to one.
+        self.organization = helpers.call_action(
+            "organization_create",
+            {"user": self.sysadmin_user["name"]},
+            name="test_org",
+        )
+
+        engine = db.get_write_engine()
+        self.Session = orm.scoped_session(orm.sessionmaker(bind=engine))
+
+    @pytest.mark.ckan_config("ckan.plugins", "datastore")
+    @pytest.mark.usefixtures("clean_datastore", "with_plugins")
+    @pytest.mark.parametrize("limit, result_len", [
+        (2, 2),
+        (1, 1),
+        (3, 2),
+        (None, 2),
+    ])
+    def test_search_distinct(self, app, limit, result_len):
+        ''' test for distinct + limits returning the limit on the distinct
+            not the limit of the base query '''
+        data = {
+            "resource_id": self.data["resource_id"],
+            "fields": [u"val"],
+            "distinct": True,
+            "limit": limit,
+        }
+
+        headers = {"Authorization": self.normal_user_token}
+        res = app.post(
+            "/api/action/datastore_search", json=data, headers=headers,
+        )
+        res_dict = json.loads(res.data)
+        assert res_dict["success"] is True
+        result = res_dict["result"]
+        assert len(result["records"]) == result_len


### PR DESCRIPTION
Select distinct, seen in the filters for the datastore, is returning incorrect data after #9028 (master/2.12)

The sql query that's generated is this:
```
datastore-1  | 	            WITH records_page AS (
datastore-1  | 	                SELECT * FROM "beaa4a4e-04ec-455f-a79a-08f201ce6296"   ORDER BY "bidding_zone" asc LIMIT 20 OFFSET 0
datastore-1  | 	            ), select_cols AS (
datastore-1  | 	                SELECT DISTINCT "bidding_zone" as "bidding_zone" FROM records_page
datastore-1  | 	            ), json_cols AS (
datastore-1  | 	                SELECT array_to_json(array_agg(select_cols))::text j
datastore-1  | 	                FROM select_cols
datastore-1  | 	            ) SELECT json_cols.j FROM json_cols
```

This is selecting the first 20 records by id, and then running select distinct on the bidding_zone column, however the limit/offset needs do be done in the distinct section, otherwise we're only sampling that first 20 rows. 

### Proposed fixes:

```
            WITH records_page AS (
                SELECT * FROM {resource} {ts_query} {final_statement}
            ), select_cols AS (
                SELECT {distinct} {select} FROM records_page
            ), json_cols AS (
                SELECT array_to_json(array_agg(select_cols))::text j
                FROM select_cols
            )
```

This splits the final_statement into final_statement and distinct_final_statement, so that the sort/order/limit can be done in the distinct segment if required.


### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
