### PR TITLE
[2.11][#9359]  Fix performance regression in ``PluginImplementations`` on CKAN 2.11

### DIFF
--- a/changes/9367.bugfix
+++ b/changes/9367.bugfix
@@ -1,0 +1,1 @@
+Fix performance regression in ``PluginImplementations`` on CKAN 2.11

--- a/ckan/plugins/core.py
+++ b/ckan/plugins/core.py
@@ -30,8 +30,9 @@ __all__ = [
     'unload_non_system_plugins',
 ]
 
-# System plugins references. Do not use this directly, use ``find_system_plugins()`` instead.
-_system_plugins = None
+# System plugins references. Do not use this directly, use
+# ``find_system_plugins()`` instead.
+_system_plugins = []
 
 TInterface = TypeVar('TInterface', bound="Interface")
 
@@ -244,9 +245,9 @@ def find_system_plugins() -> list[str]:
     enabled/disabled through the configuration file.
     '''
     global _system_plugins
+    ep_names = []
 
     if _system_plugins:
-        ep_names = []
         for ep in _system_plugins:
             ep.load()
             ep_names.append(ep.name)
@@ -258,7 +259,6 @@ def find_system_plugins() -> list[str]:
         # Python 3.9
         eps = [ep for ep in entry_points().get(SYSTEM_PLUGINS_ENTRY_POINT_GROUP)]    # type: ignore
 
-    ep_names = []
     _system_plugins = []
     for ep in eps:
         _system_plugins.append(ep)

--- a/ckan/plugins/core.py
+++ b/ckan/plugins/core.py
@@ -30,6 +30,9 @@ __all__ = [
     'unload_non_system_plugins',
 ]
 
+# System plugins references. Do not use this directly, use ``find_system_plugins()`` instead.
+_system_plugins = None
+
 TInterface = TypeVar('TInterface', bound="Interface")
 
 log = logging.getLogger(__name__)
@@ -240,6 +243,14 @@ def find_system_plugins() -> list[str]:
     These are essential for operation and therefore cannot be
     enabled/disabled through the configuration file.
     '''
+    global _system_plugins
+
+    if _system_plugins:
+        ep_names = []
+        for ep in _system_plugins:
+            ep.load()
+            ep_names.append(ep.name)
+        return ep_names
 
     try:
         eps = [ep for ep in entry_points(group=SYSTEM_PLUGINS_ENTRY_POINT_GROUP)]
@@ -248,7 +259,9 @@ def find_system_plugins() -> list[str]:
         eps = [ep for ep in entry_points().get(SYSTEM_PLUGINS_ENTRY_POINT_GROUP)]    # type: ignore
 
     ep_names = []
+    _system_plugins = []
     for ep in eps:
+        _system_plugins.append(ep)
         ep.load()
         ep_names.append(ep.name)
 


### PR DESCRIPTION
Cache calls to `find_system_plugins()` to avoid performance issues with `importlib.metadata.entry_points()`.
This is a 2.11 only patch