### PR TITLE
Revert "Hide invite user form if can't create users"

### DIFF
--- a/changes/9369.bugfix
+++ b/changes/9369.bugfix
@@ -1,0 +1,1 @@
+Organization admins are allowed to invite new users again, even when public registration is closed.

--- a/ckan/templates-midnight-blue/group/member_new.html
+++ b/ckan/templates-midnight-blue/group/member_new.html
@@ -41,7 +41,7 @@
           </div>
         </div>
       </div>
-      {% if not user and h.check_access('user_create') %}
+      {% if not user %}
       <div class="col-md-2">
         <div class="add-member-or">
           {{ _('or') }}

--- a/ckan/templates-midnight-blue/organization/member_new.html
+++ b/ckan/templates-midnight-blue/organization/member_new.html
@@ -43,7 +43,7 @@
           </div>
         </div>
       </div>
-      {% if not user and h.check_access('user_create') %}
+      {% if not user %}
       <div class="col-md-2">
         <div class="add-member-or">
           {{ _('or') }}

--- a/ckan/templates/group/member_new.html
+++ b/ckan/templates/group/member_new.html
@@ -36,7 +36,7 @@
           </div>
         </div>
       </div>
-      {% if not user and h.check_access('user_create') %}
+      {% if not user %}
       <div class="col-md-2">
         <div class="add-member-or">
           {{ _('or') }}

--- a/ckan/templates/organization/member_new.html
+++ b/ckan/templates/organization/member_new.html
@@ -38,7 +38,7 @@
           </div>
         </div>
       </div>
-      {% if not user and h.check_access('user_create') %}
+      {% if not user %}
       <div class="col-md-2">
         <div class="add-member-or">
           {{ _('or') }}

--- a/ckan/tests/controllers/test_organization.py
+++ b/ckan/tests/controllers/test_organization.py
@@ -543,23 +543,6 @@ class TestOrganizationInnerSearch(object):
 
 @pytest.mark.usefixtures("non_clean_db")
 class TestOrganizationMembership(object):
-
-    @pytest.mark.ckan_config("ckan.auth.create_user_via_web", False)
-    def test_admin_users_cannot_invite_members(self, app, user):
-        """ Org admin users can't invite users if they can't create users """
-        headers = {"Authorization": user["token"]}
-        organization = factories.Organization(
-            users=[{"name": user["name"], "capacity": "admin"}]
-        )
-
-        with app.flask_app.test_request_context():
-            response = app.get(
-                url_for("organization.member_new", id=organization["id"]),
-                headers=headers,
-            )
-            assert response.status_code == 200
-            assert "invite a new user" not in response
-
     def test_editor_users_cannot_add_members(self, app, user):
         headers = {"Authorization": user["token"]}
         organization = factories.Organization(


### PR DESCRIPTION
Reverts ckan/ckan#8141

As discussed in dev meeting and #9368 

Also removed the change from midnight blue templates since those where created since the original PR was merged.