### PR TITLE
fix: Case-sensitive reset-link by email

### DIFF
--- a/changes/9370.bugfix
+++ b/changes/9370.bugfix
@@ -1,0 +1,1 @@
+Use case-insensitive email search when requesting password reset.

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -856,7 +856,7 @@ def user_list(
     if q:
         query = model.User.search(q, query, user_name=context.get('user'))
     if email:
-        query = query.filter_by(email=email)
+        query = query.filter(_func.lower(model.User.email) == email.lower())
 
     order_by_field = None
     if order_by == 'edits':

--- a/ckan/tests/controllers/test_user.py
+++ b/ckan/tests/controllers/test_user.py
@@ -608,6 +608,18 @@ class TestUser(object):
         assert send_reset_link.call_args[0][0].id == user["id"]
 
     @mock.patch("ckan.lib.mailer.send_reset_link")
+    def test_request_reset_by_email_case_insensitive(self, send_reset_link, app):
+        """User can request password reset by email in a case-insensitive way."""
+        user = factories.User()
+
+        offset = url_for("user.request_reset")
+        response = app.post(offset, data=dict(user=user["email"].upper()))
+
+        assert "A reset link has been emailed to you" in response
+        assert send_reset_link.call_args[0][0].id == user["id"]
+
+
+    @mock.patch("ckan.lib.mailer.send_reset_link")
     def test_request_reset_by_name(self, send_reset_link, app):
         user = factories.User()
 

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -961,6 +961,18 @@ class TestUserList(object):
         got_user = got_users[0]
         assert got_user == user_a["name"]
 
+    def test_user_list_filtered_by_email_with_random_case(self):
+        user_a = factories.User(email="a@example.com")
+        factories.User(email="b@example.com")
+
+        got_users = helpers.call_action(
+            "user_list", email="A@example.COM", all_fields=False
+        )
+
+        assert len(got_users) == 1
+        got_user = got_users[0]
+        assert got_user == user_a["name"]
+
     def test_user_list_order_by_default(self):
         default_user = helpers.call_action("get_site_user", ignore_auth=True)
 


### PR DESCRIPTION
Password reset relies on a case-sensitive email search. If the user is registered with `Sergey@gmailcom`, he won't be able to reset his password using `sergey@gmail.com`.

This PR is similar to #9178 (case-insensitive duplicate check) and #8626 (case-insensitive `User.by_email`). But because pasword reset endpoint relies on `user_list` action, which in turn builds complex query and instead of calling `User.by_email` it calls `query.filter(email==email)`, previous fixes are not applied to the current problem.