### PR TITLE
Add csrf_input to tabledesigner row forms

### DIFF
--- a/changes/9372.bugfix
+++ b/changes/9372.bugfix
@@ -1,0 +1,3 @@
+Add the missing CSRF token (``h.csrf_input()``) to the Table Designer add-row,
+edit-row and delete-rows forms, so they are protected and continue to work when
+extension CSRF protection is enforced (``ckan.csrf_protection.ignore_extensions = false``).

--- a/ckanext/tabledesigner/templates/tabledesigner/add_row.html
+++ b/ckanext/tabledesigner/templates/tabledesigner/add_row.html
@@ -10,6 +10,7 @@
   <h1>{{ _('Add row') }}</h1>
 
   <form method="post" action="{{ action }}" >
+    {{ h.csrf_input() }}
     {% block add_row %}
       {% for field in fields %}
         {% set ct = h.tabledesigner_column_type(field) %}

--- a/ckanext/tabledesigner/templates/tabledesigner/delete_rows.html
+++ b/ckanext/tabledesigner/templates/tabledesigner/delete_rows.html
@@ -25,6 +25,7 @@
   </table>
 
   <form method="post" >
+    {{ h.csrf_input() }}
     <button class="btn btn-primary" name="save" type="submit">
       <i class="fa fa-alert"></i> {{ _('Delete') }}
     </button>

--- a/ckanext/tabledesigner/templates/tabledesigner/edit_row.html
+++ b/ckanext/tabledesigner/templates/tabledesigner/edit_row.html
@@ -10,6 +10,7 @@
   <h1>{{ _('Edit row') }}</h1>
 
   <form method="post" action="{{ action }}?_id={{ row['_id'] }}" >
+    {{ h.csrf_input() }}
     {% block add_row %}
       {% for field in fields %}
         {% set ct = h.tabledesigner_column_type(field) %}


### PR DESCRIPTION
## Fixes #9372

The Table Designer add-row, edit-row and delete-rows forms were missing `{{ h.csrf_input() }}`, so these state-changing POSTs carried no CSRF token:

- `ckanext/tabledesigner/templates/tabledesigner/add_row.html`
- `ckanext/tabledesigner/templates/tabledesigner/edit_row.html`
- `ckanext/tabledesigner/templates/tabledesigner/delete_rows.html`

Because `tabledesigner` registers an `IBlueprint`, its routes are exempt from CSRF by default (`ckan.csrf_protection.ignore_extensions = true`), so this went unnoticed. But:

- when the extension is enabled, add/edit/delete-row POSTs are reachable with no CSRF protection; and
- under enforced extension CSRF (`ckan.csrf_protection.ignore_extensions = false`, which the docs recommend and which is slated to become the default) tabledesigner's own forms break with HTTP 400.

This adds the token inside each `<form method="post">`, consistent with the other bundled extensions (`datastore`, `datapusher`, `datatablesview`), which already emit it.

A changelog fragment is included (`changes/9372.bugfix`).

See #9372 for the full analysis and reproduction.