### PR TITLE
fix: return 404 for missing dataset resource edit

### DIFF
--- a/changes/9375.bugfix
+++ b/changes/9375.bugfix
@@ -1,0 +1,1 @@
+Return a 404 response instead of a 500 error when opening a resource edit page for a dataset that does not exist.

--- a/ckan/tests/controllers/test_package.py
+++ b/ckan/tests/controllers/test_package.py
@@ -1065,6 +1065,20 @@ class TestResourceNew(object):
                 status=403,
             )
 
+    def test_edit_resource_for_dataset_that_does_not_exist_404s(
+        self, app, user
+    ):
+        headers = {"Authorization": user["token"]}
+        response = app.get(
+            url_for(
+                "dataset_resource.edit",
+                id="does-not-exist",
+                resource_id="does-not-exist",
+            ),
+            headers=headers,
+        )
+        assert response.status_code == 404
+
 
 @pytest.mark.usefixtures("non_clean_db", "with_plugins")
 class TestResourceDownload(object):

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -386,6 +386,8 @@ class EditView(MethodView):
                 403,
                 _(u'User %r not authorized to edit %s') % (user, id)
             )
+        except NotFound:
+            return base.abort(404, _(u'Dataset not found'))
         return context
 
     def post(self, package_type: str, id: str,
@@ -429,7 +431,10 @@ class EditView(MethodView):
             errors: Optional[dict[str, Any]] = None,
             error_summary: Optional[dict[str, Any]] = None) -> str:
         context = self._prepare(id)
-        pkg_dict = get_action(u'package_show')(context, {u'id': id})
+        try:
+            pkg_dict = get_action(u'package_show')(context, {u'id': id})
+        except NotFound:
+            return base.abort(404, _(u'Dataset not found'))
 
         try:
             resource_dict = get_action(u'resource_show')(


### PR DESCRIPTION
Fixes #

### Proposed fixes:

- Return a 404 response instead of a 500 error when opening a resource edit URL for a dataset that does not exist.
- Handle missing datasets during resource edit authorization and dataset lookup.
- Add regression coverage for the missing-dataset route.


### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
