### PR TITLE
Fix secret name in backports workflow

### DIFF
--- a/.github/workflows/backports.yml
+++ b/.github/workflows/backports.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           # Token to authenticate requests to GitHub. This is a Personal Access Token
           # from the ckanbot user
-          github_token: ${{ secrets.BACKPORT_ACTION_PAT }}
+          github_token: ${{ secrets.BACKPORTS_ACTION_PAT }}
           # Run when there is one or more "Backport <branch>" labels,
           # excluding "Backport pending"
           label_pattern: "Backport (?!pending)([^ ]+)$"
@@ -71,7 +71,7 @@ jobs:
       - name: Add Backport failed label to PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.BACKPORT_ACTION_PAT }}
+          github-token: ${{ secrets.BACKPORTS_ACTION_PAT }}
           script: |
             await github.rest.issues.addLabels({
               owner: context.repo.owner,

--- a/doc/contributing/maintenance-tools.rst
+++ b/doc/contributing/maintenance-tools.rst
@@ -49,7 +49,7 @@ on how to set up these):
 
 * The public variable ``TECH_TEAM_USER_IDS`` is a JSON list of the GitHub user ids of the Tech Team members. User ids can be found using the ``https://api.github.com/users/<user_name>`` endpoint.
 * The public variable ``CKANBOT_USER_ID`` is the user id of the :ref:`ckanbot`.
-* The ``backports`` environment secret ``BACKPORT_ACTION_PAT`` is a `Personal Access Token <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens>`_ (PAT) of the ckanbot account, with enough permissions to write to the ckan/ckan repository.
+* The ``backports`` environment secret ``BACKPORTS_ACTION_PAT`` is a `Personal Access Token <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens>`_ (PAT) of the ckanbot account, with enough permissions to write to the ckan/ckan repository.
 
 When creating a new PAT, make sure to select the following settings:
 


### PR DESCRIPTION
The automated backports were broken because of this, I made a typo when recreating the secret