### PR TITLE
fix: reindex datasets after group membership changes

### DIFF
--- a/changes/9381.bugfix
+++ b/changes/9381.bugfix
@@ -1,0 +1,1 @@
+Reindex datasets after ``member_create`` and ``member_delete`` change package group memberships, ensuring group pages show the correct datasets.

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -29,6 +29,7 @@ import ckan.authz as authz
 
 from ckan import model
 from ckan.common import _, asbool
+from ckan.lib.search import rebuild
 from ckan.types import Context, DataDict, ErrorDict, Schema
 
 # FIXME this looks nasty and should be shared better
@@ -604,10 +605,9 @@ def member_create(context: Context,
 
     model.Session.add(member)
     if not context.get("defer_commit"):
-        model.Session.flush()
-        if isinstance(obj, model.Package):
-            logic.index_update_package(context, obj.id)
         model.repo.commit()
+        if isinstance(obj, model.Package):
+            rebuild(obj.id)
 
     return model_dictize.member_dictize(member, context)
 

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -604,6 +604,9 @@ def member_create(context: Context,
 
     model.Session.add(member)
     if not context.get("defer_commit"):
+        model.Session.flush()
+        if isinstance(obj, model.Package):
+            logic.index_update_package(context, obj.id)
         model.repo.commit()
 
     return model_dictize.member_dictize(member, context)

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -315,6 +315,9 @@ def member_delete(context: Context, data_dict: DataDict) -> ActionResult.MemberD
             filter(model.Member.state    == 'active').first()
     if member:
         member.delete()
+        model.Session.flush()
+        if isinstance(obj, model.Package):
+            ckan.logic.index_update_package(context, obj.id)
         model.repo.commit()
 
 

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -16,6 +16,7 @@ import ckan.plugins as plugins
 import ckan.lib.api_token as api_token
 from ckan import authz, model
 from  ckan.lib.navl.dictization_functions import validate
+from ckan.lib.search import rebuild
 from ckan.model.follower import ModelFollowingModel
 
 from ckan.common import _
@@ -315,10 +316,9 @@ def member_delete(context: Context, data_dict: DataDict) -> ActionResult.MemberD
             filter(model.Member.state    == 'active').first()
     if member:
         member.delete()
-        model.Session.flush()
-        if isinstance(obj, model.Package):
-            ckan.logic.index_update_package(context, obj.id)
         model.repo.commit()
+        if isinstance(obj, model.Package):
+            rebuild(obj.id)
 
 
 def package_collaborator_delete(context: Context, data_dict: DataDict) -> ActionResult.PackageCollaboratorDelete:

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -2476,6 +2476,29 @@ class TestTagCreate:
 
 @pytest.mark.usefixtures("non_clean_db")
 class TestMemberCreate2:
+    @pytest.mark.usefixtures("clean_index")
+    def test_member_create_reindexes_package_groups(self):
+        group = factories.Group()
+        package = factories.Dataset()
+
+        def get_search_result_groups():
+            results = helpers.call_action(
+                "package_search", q=package["title"]
+            )["results"]
+            return [group["name"] for group in results[0]["groups"]]
+
+        assert get_search_result_groups() == []
+
+        helpers.call_action(
+            "member_create",
+            object=package["id"],
+            id=group["id"],
+            object_type="package",
+            capacity="public",
+        )
+
+        assert get_search_result_groups() == [group["name"]]
+
     def test_member_create_accepts_object_name_or_id(self):
         org = factories.Organization()
         package = factories.Dataset()

--- a/ckan/tests/logic/action/test_delete.py
+++ b/ckan/tests/logic/action/test_delete.py
@@ -908,6 +908,28 @@ class TestVocabularyDelete(object):
 
 @pytest.mark.usefixtures("non_clean_db")
 class TestMemberDelete:
+    @pytest.mark.usefixtures("clean_index")
+    def test_member_delete_reindexes_package_groups(self):
+        group = factories.Group()
+        package = factories.Dataset(groups=[{"id": group["id"]}])
+
+        def get_search_result_groups():
+            results = helpers.call_action(
+                "package_search", q=package["title"]
+            )["results"]
+            return [group["name"] for group in results[0]["groups"]]
+
+        assert get_search_result_groups() == [group["name"]]
+
+        helpers.call_action(
+            "member_delete",
+            object=package["id"],
+            id=group["id"],
+            object_type="package",
+        )
+
+        assert get_search_result_groups() == []
+
     def test_member_delete_accepts_object_name_or_id(self):
         org = factories.Organization()
         user = factories.User()


### PR DESCRIPTION
Fixes #

Datasets added to groups through `member_create` were stored correctly in the database, but their Solr documents were not updated. As group pages use Solr to find datasets, newly added datasets were not displayed.

### Proposed fixes:

- Reindex dataset documents after package group memberships are added or removed through `member_create` and `member_delete`.
- Flush pending membership changes before indexing so the updated `groups` field is included in Solr.
- Add regression tests covering both membership creation and deletion.




### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [x] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
