### PR TITLE
fix: Search index is not updated when package added/removed from group

### DIFF
--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -29,6 +29,7 @@ import ckan.authz as authz
 
 from ckan import model
 from ckan.common import _, asbool
+from ckan.lib.search import rebuild
 from ckan.types import Context, DataDict, ErrorDict, Schema
 
 # FIXME this looks nasty and should be shared better
@@ -605,6 +606,9 @@ def member_create(context: Context,
     model.Session.add(member)
     if not context.get("defer_commit"):
         model.repo.commit()
+        # add group info to the indexed package dictionary
+        if obj_type == "package":
+            rebuild(obj_id)
 
     return model_dictize.member_dictize(member, context)
 

--- a/ckan/logic/action/delete.py
+++ b/ckan/logic/action/delete.py
@@ -19,6 +19,7 @@ from  ckan.lib.navl.dictization_functions import validate
 from ckan.model.follower import ModelFollowingModel
 
 from ckan.common import _
+from ckan.lib.search import rebuild
 from ckan.types import Context, DataDict, ErrorDict, Schema
 
 log = logging.getLogger('ckan.logic')
@@ -316,6 +317,10 @@ def member_delete(context: Context, data_dict: DataDict) -> ActionResult.MemberD
     if member:
         member.delete()
         model.repo.commit()
+        # remove group info from the indexed package dictionary
+        if obj_type == "package":
+            rebuild(obj_id)
+
 
 
 def package_collaborator_delete(context: Context, data_dict: DataDict) -> ActionResult.PackageCollaboratorDelete:

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -1,12 +1,13 @@
-# encoding: utf-8
 """Unit tests for ckan/logic/action/create.py.
 
 """
+from __future__ import annotations
+
 import datetime
 import operator
 import unittest.mock as mock
 import uuid
-
+from typing import Any
 import pytest
 import sqlalchemy as sa
 
@@ -2557,6 +2558,25 @@ class TestMemberCreate2:
                 object_type="notvalid",
                 capacity="member",
             )
+
+    def test_member_create_updates_search_index(
+            self, package: dict[str, Any], group: dict[str, Any]
+    ):
+        """When a package is added to a group, the search index needs to be
+        updated so that the package appears in the group's search results."""
+        pkg = helpers.call_action("package_show", id=package["name"])
+        assert not pkg["groups"]
+
+        helpers.call_action(
+                "member_create",
+                object=pkg["name"],
+                id=group["id"],
+                object_type="package",
+                capacity="public",
+        )
+        pkg = helpers.call_action("package_show", id=package["name"])
+        assert len(pkg["groups"]) == 1
+        assert pkg["groups"][0]["name"] == group["name"]
 
 
 @pytest.mark.usefixtures("clean_db")

--- a/ckan/tests/logic/action/test_delete.py
+++ b/ckan/tests/logic/action/test_delete.py
@@ -2,7 +2,7 @@
 
 import re
 from unittest import mock
-
+from typing import Any
 import pytest
 
 import ckan.lib.jobs as jobs
@@ -989,3 +989,29 @@ class TestMemberDelete:
                 object_type="notvalid",
                 capacity="member",
             )
+
+    def test_member_delete_updates_search_index(
+            self, package: dict[str, Any], group: dict[str, Any]
+    ):
+        """Deleting a package from the group updates the search index so that
+        the package no longer shows as being in the group.
+        """
+        helpers.call_action(
+                "member_create",
+                object=package["name"],
+                id=group["id"],
+                object_type="package",
+                capacity="public",
+        )
+        pkg = helpers.call_action("package_show", id=package["name"])
+        assert pkg["groups"]
+
+        helpers.call_action(
+                "member_delete",
+                object=package["name"],
+                id=group["id"],
+                object_type="package",
+                capacity="public",
+        )
+        pkg = helpers.call_action("package_show", id=package["name"])
+        assert not pkg["groups"]


### PR DESCRIPTION
When a package is added to the group or removed from it, a change is committed to the DB, but the search index is not updated, and in the UI it looks as if the change was not applied.