### PR TITLE
[2.11][#9380] Fix organization patch on orgs with extras

### DIFF
--- a/ckan/logic/action/patch.py
+++ b/ckan/logic/action/patch.py
@@ -132,9 +132,6 @@ def organization_patch(
     patched = dict(organization_dict)
     patched.pop('display_name', None)
     patched.update(data_dict)
-    if patched.get("extras"):
-        for extra in patched["extras"]:
-            extra.pop("id", None)
 
     patch_context = context.copy()
     patch_context['allow_partial_update'] = True

--- a/ckan/logic/action/patch.py
+++ b/ckan/logic/action/patch.py
@@ -132,6 +132,9 @@ def organization_patch(
     patched = dict(organization_dict)
     patched.pop('display_name', None)
     patched.update(data_dict)
+    if patched.get("extras"):
+        for extra in patched["extras"]:
+            extra.pop("id", None)
 
     patch_context = context.copy()
     patch_context['allow_partial_update'] = True

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -383,7 +383,7 @@ def default_extras_schema(ignore: Validator, not_empty: Validator,
                           ignore_missing: Validator, uuid_validator: Validator,
                           ignore_not_sysadmin: Validator) -> Schema:
     return {
-        'id': [ignore_missing, ignore_not_sysadmin, uuid_validator],
+        'id': [ignore_not_sysadmin, ignore_missing, uuid_validator],
         'key': [not_empty, extra_key_not_in_root_schema, unicode_safe],
         'value': [not_missing],
         'state': [ignore],

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -381,9 +381,9 @@ def default_extras_schema(ignore: Validator, not_empty: Validator,
                           extra_key_not_in_root_schema: Validator,
                           unicode_safe: Validator, not_missing: Validator,
                           ignore_missing: Validator, uuid_validator: Validator,
-                          empty_if_not_sysadmin: Validator) -> Schema:
+                          ignore_not_sysadmin: Validator) -> Schema:
     return {
-        'id': [ignore_missing, empty_if_not_sysadmin, uuid_validator],
+        'id': [ignore_missing, ignore_not_sysadmin, uuid_validator],
         'key': [not_empty, extra_key_not_in_root_schema, unicode_safe],
         'value': [not_missing],
         'state': [ignore],

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -1013,15 +1013,15 @@ class TestDatasetCreate(object):
         user = factories.User()
         context = {"user": user["name"], "ignore_auth": False}
         _id = str(uuid.uuid4())
-        with pytest.raises(logic.ValidationError) as exception:
-            helpers.call_action(
-                "package_create",
-                context=context,
-                name=factories.Dataset.stub().name,
-                title="Test Extras",
-                extras=[{"id": _id, "key": "original media", "value": '"book"'}],
-            )
-        assert "The input field id was not expected" in str(exception.value)
+        dataset = helpers.call_action(
+            "package_create",
+            context=context,
+            name=factories.Dataset.stub().name,
+            title="Test Extras",
+            extras=[{"id": _id, "key": "original media", "value": '"book"'}],
+        )
+        assert _id != model.Session.query(model.PackageExtra.id).filter(
+            model.PackageExtra.package_id==dataset['id']).scalar()
 
     def test_license(self):
         dataset = helpers.call_action(
@@ -1234,14 +1234,14 @@ class TestGroupCreate(object):
         user = factories.User()
         context = {"user": user["name"], "ignore_auth": False}
         _id = str(uuid.uuid4())
-        with pytest.raises(logic.ValidationError) as exception:
-            helpers.call_action(
-                "group_create",
-                context=context,
-                name=f"test-group-{_id}",
-                extras=[{"id": _id, "key": "area", "value": '"non profit"'}]
-            )
-        assert "The input field id was not expected" in str(exception.value)
+        group = helpers.call_action(
+            "group_create",
+            context=context,
+            name=f"test-group-{_id}",
+            extras=[{"id": _id, "key": "area", "value": '"non profit"'}]
+        )
+        assert _id != model.Session.query(model.GroupExtra.id).filter(
+            model.GroupExtra.group_id==group['id']).scalar()
 
     def test_sysadmin_user_cant_set_extras_id(self):
         user = factories.Sysadmin()

--- a/ckan/tests/logic/action/test_patch.py
+++ b/ckan/tests/logic/action/test_patch.py
@@ -163,6 +163,45 @@ class TestPatch(object):
         assert organization2["name"] == name
         assert organization2["description"] == "somethingnew"
 
+    def test_organization_patch_with_extras(self):
+        user = factories.User()
+        organization = factories.Organization(
+            description="some test now", user=user,
+            extras=[
+                {"key": "k1", "value": "v1"},
+                {"key": "k2", "value": "v2"},
+            ]
+        )
+        name = organization["name"]
+
+        new_extras = [
+            {"key": "k1", "value": "v1"},
+            {"key": "k3", "value": "v3"},
+        ]
+
+        organization = helpers.call_action(
+            "organization_patch",
+            id=organization["id"],
+            description="somethingnew",
+            extras=new_extras,
+            context={
+                "user": user["name"],
+                "ignore_auth": False,
+            },
+
+        )
+
+        organization = helpers.call_action(
+            "organization_show", id=organization["id"]
+        )
+
+        assert organization["name"] == name
+        assert organization["description"] == "somethingnew"
+        cleaned_extras = []
+        for extra in organization["extras"]:
+            cleaned_extras.append({"key": extra["key"], "value": extra["value"]})
+        assert cleaned_extras == new_extras
+
     @pytest.mark.ckan_config(u"ckan.auth.public_user_details", u"false")
     def test_organization_patch_updating_single_field_when_public_user_details_is_false(
         self,


### PR DESCRIPTION
Fixes #9380

Removing the `id` field from extras before passing the data dict to `organization_update`. Rather than changing the schema this seems like a safer fix to backport
