### PR TITLE
fix: restore activity stream type filter

### DIFF
--- a/changes/9388.bugfix
+++ b/changes/9388.bugfix
@@ -1,0 +1,1 @@
+Restore the activity stream type dropdown filter on dataset, group, and organization activity pages.

--- a/ckanext/activity/templates-midnight-blue/group/activity_stream.html
+++ b/ckanext/activity/templates-midnight-blue/group/activity_stream.html
@@ -8,6 +8,7 @@
      id=id,
      object_type='group',
      group_type=group_type,
+     activity_type=activity_type,
      activity_types=activity_types,
      blueprint='activity.group_activity',
      newer_activities_url=newer_activities_url,

--- a/ckanext/activity/templates-midnight-blue/organization/activity_stream.html
+++ b/ckanext/activity/templates-midnight-blue/organization/activity_stream.html
@@ -8,6 +8,7 @@
      id=id,
      object_type='organization',
      group_type=group_type,
+     activity_type=activity_type,
      activity_types=activity_types,
      blueprint='activity.organization_activity',
      newer_activities_url=newer_activities_url,

--- a/ckanext/activity/templates-midnight-blue/package/activity_stream.html
+++ b/ckanext/activity/templates-midnight-blue/package/activity_stream.html
@@ -8,6 +8,7 @@
      id=id,
      object_type='package',
      group_type=group_type,
+     activity_type=activity_type,
      activity_types=activity_types,
      blueprint='activity.package_activity',
      newer_activities_url=newer_activities_url,

--- a/ckanext/activity/templates-midnight-blue/snippets/activity_type_selector.html
+++ b/ckanext/activity/templates-midnight-blue/snippets/activity_type_selector.html
@@ -1,7 +1,7 @@
 {#
   Renders a select element to filter the activity stream
 
-  It uses the activity-stream.js module to dinamically request for a new URl upon selection.
+  It uses HTMX to request a new URL upon selection.
 
   id - the id or current name of the object (e.g. package name, user id)
   activity_type - the current selected activity type
@@ -13,12 +13,12 @@
   <label for="activity_types_filter_select" class="form-label">
     {{ _('Activity type') }}
   </label>
-  <select id="activity_types_filter_select" class="form-select">
-    <option {% if not activity_types %}selected{% endif %} hx-get="{{ h.url_for(blueprint, id=id) }}" hx-target="closest .module-content" hx-push-url="true">
+  <select id="activity_types_filter_select" name="activity_type" class="form-select" hx-get="{{ h.url_for(blueprint, id=id) }}" hx-target="closest .module-content" hx-push-url="true">
+    <option value="" {% if not activity_type %}selected{% endif %}>
       {{ _('All activity types') }}
     </option>
     {% for type_ in activity_types %}
-      <option {% if activity_type == type_ %}selected{% endif %} hx-get="{{ h.url_for(blueprint, id=id, activity_type=type_) }}" hx-target="closest .module-content" hx-push-url="true">
+      <option value="{{ type_ }}" {% if activity_type == type_ %}selected{% endif %}>
         {# TODO: Calling humanize gets complex when displaying orgs/groups since the activities also contains dataset activities #}
         {{ type_ | title }}
       </option>

--- a/ckanext/activity/templates/group/activity_stream.html
+++ b/ckanext/activity/templates/group/activity_stream.html
@@ -8,6 +8,7 @@
      id=id,
      object_type='group',
      group_type=group_type,
+     activity_type=activity_type,
      activity_types=activity_types,
      blueprint='activity.group_activity',
      newer_activities_url=newer_activities_url,

--- a/ckanext/activity/templates/organization/activity_stream.html
+++ b/ckanext/activity/templates/organization/activity_stream.html
@@ -8,6 +8,7 @@
      id=id,
      object_type='organization',
      group_type=group_type,
+     activity_type=activity_type,
      activity_types=activity_types,
      blueprint='activity.organization_activity',
      newer_activities_url=newer_activities_url,

--- a/ckanext/activity/templates/package/activity_stream.html
+++ b/ckanext/activity/templates/package/activity_stream.html
@@ -8,6 +8,7 @@
      id=id,
      object_type='package',
      group_type=group_type,
+     activity_type=activity_type,
      activity_types=activity_types,
      blueprint='activity.package_activity',
      newer_activities_url=newer_activities_url,

--- a/ckanext/activity/templates/snippets/activity_type_selector.html
+++ b/ckanext/activity/templates/snippets/activity_type_selector.html
@@ -1,7 +1,7 @@
 {#
   Renders a select element to filter the activity stream
 
-  It uses the activity-stream.js module to dinamically request for a new URl upon selection.
+  It uses HTMX to request a new URL upon selection.
 
   id - the id or current name of the object (e.g. package name, user id)
   activity_type - the current selected activity type
@@ -13,12 +13,12 @@
   <label for="activity_types_filter_select" class="form-label">
     {{ _('Activity type') }}
   </label>
-  <select id="activity_types_filter_select" class="form-select">
-    <option {% if not activity_types %}selected{% endif %} hx-get="{{ h.url_for(blueprint, id=id) }}" hx-target="closest .module-content" hx-push-url="true">
+  <select id="activity_types_filter_select" name="activity_type" class="form-select" hx-get="{{ h.url_for(blueprint, id=id) }}" hx-target="closest .module-content" hx-push-url="true">
+    <option value="" {% if not activity_type %}selected{% endif %}>
       {{ _('All activity types') }}
     </option>
     {% for type_ in activity_types %}
-      <option {% if activity_type == type_ %}selected{% endif %} hx-get="{{ h.url_for(blueprint, id=id, activity_type=type_) }}" hx-target="closest .module-content" hx-push-url="true">
+      <option value="{{ type_ }}" {% if activity_type == type_ %}selected{% endif %}>
         {# TODO: Calling humanize gets complex when displaying orgs/groups since the activities also contains dataset activities #}
         {{ type_ | title }}
       </option>

--- a/ckanext/activity/tests/test_views.py
+++ b/ckanext/activity/tests/test_views.py
@@ -377,6 +377,41 @@ class TestPackage:
         assert dataset["id"] in href.select_one("a")["href"].split("/", 2)[-1]
         assert dataset["title"] in href.text.strip()
 
+    def test_activity_type_selector_uses_select_as_htmx_trigger(self, app):
+        user = factories.User()
+        dataset = factories.Dataset(user=user)
+
+        url = url_for("activity.package_activity", id=dataset["id"])
+        response = app.get(url)
+        page = BeautifulSoup(response.body)
+
+        select = page.select_one("#activity_types_filter_select")
+        assert select["name"] == "activity_type"
+        assert select["hx-get"] == url
+        assert not page.select("#activity_types_filter_select option[hx-get]")
+
+    def test_activity_type_filter_shows_only_matching_activities(self, app):
+        user = factories.User()
+        dataset = factories.Dataset(user=user)
+        dataset["title"] = "Dataset with changed title"
+        helpers.call_action(
+            "package_update", context={"user": user["name"]}, **dataset
+        )
+
+        url = url_for("activity.package_activity", id=dataset["id"])
+        response = app.get(
+            url, query_string={"activity_type": "new package"}
+        )
+
+        assert "created the dataset" in response
+        assert "updated the dataset" not in response
+
+        page = BeautifulSoup(response.body)
+        selected_option = page.select_one(
+            "#activity_types_filter_select option[selected]"
+        )
+        assert selected_option["value"] == "new package"
+
     def test_create_tag_directly(self, app):
 
         user = factories.User()


### PR DESCRIPTION
Fixes #

### Proposed fixes:

- Restore the activity stream type dropdown so selecting a type sends the selected `activity_type` and updates the stream.
- Move HTMX request handling from `<option>` elements to the `<select>` control and keep the selected activity type when rendering full activity stream pages.
- Add regression coverage for the activity type selector markup and filtered package activity stream output.

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
