### PR TITLE
docs: update outdated url from architecture.rst

### DIFF
--- a/doc/contributing/architecture.rst
+++ b/doc/contributing/architecture.rst
@@ -117,7 +117,7 @@ The functions in ``ckan.logic.action`` are exposed to the world as the
 from the function name, for example
 ``ckan.logic.action.create.package_create()`` is exposed at
 ``/api/action/package_create``. See `Steve Yegge's Google platforms rant
-<https://plus.google.com/112678702228711889851/posts/eVeouesvaVX>`_ for some
+<https://gist.github.com/chitchcock/1281611#file-20111011_steveyeggegoogleplatformrant-md>`_ for some
 interesting discussion about APIs.
 
 **All** publicly visible functions in the

--- a/doc/contributing/architecture.rst
+++ b/doc/contributing/architecture.rst
@@ -116,9 +116,7 @@ The functions in ``ckan.logic.action`` are exposed to the world as the
 :doc:`/api/index`.  The API URL for an action function is automatically generated
 from the function name, for example
 ``ckan.logic.action.create.package_create()`` is exposed at
-``/api/action/package_create``. See `Steve Yegge's Google platforms rant
-<https://gist.github.com/chitchcock/1281611#file-20111011_steveyeggegoogleplatformrant-md>`_ for some
-interesting discussion about APIs.
+``/api/action/package_create``.
 
 **All** publicly visible functions in the
 ``ckan.logic.action.{create,delete,get,update}`` namespaces will be exposed


### PR DESCRIPTION
Fixes #9316

### Proposed fixes:
- Update the outdated Google Plus URL from `doc/contributing/architecture.rst` as it is no longer valid.


### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
