### PR TITLE
fix: allow group and organization follows with private user details

### DIFF
--- a/changes/9394.bugfix
+++ b/changes/9394.bugfix
@@ -1,0 +1,1 @@
+Allow users to follow and unfollow groups and organizations when ``ckan.auth.public_user_details`` is disabled.

--- a/ckan/tests/controllers/test_group.py
+++ b/ckan/tests/controllers/test_group.py
@@ -552,6 +552,25 @@ class TestGroupFollow:
           <dd><span>1</span></dd>
         ''' in response
 
+    @pytest.mark.ckan_config("ckan.auth.public_user_details", False)
+    def test_group_follow_without_public_user_details(self, app, user):
+        headers = {"Authorization": user["token"]}
+        group = factories.Group()
+
+        follow_url = url_for("group.follow", id=group["id"])
+        response = app.post(follow_url, headers=headers)
+
+        assert '<a class="btn btn-danger"' in response
+        assert 'hx-target="#group-info"' in response
+        assert 'fa-circle-minus"></i> Unfollow' in response
+
+        unfollow_url = url_for("group.unfollow", id=group["id"])
+        response = app.post(unfollow_url, headers=headers)
+
+        assert '<a class="btn btn-success"' in response
+        assert 'hx-target="#group-info"' in response
+        assert 'fa-circle-plus"></i> Follow' in response
+
     def test_group_follow_not_exist(self, app, user):
         """Pass an id for a group that doesn't exist"""
 

--- a/ckan/tests/controllers/test_organization.py
+++ b/ckan/tests/controllers/test_organization.py
@@ -676,6 +676,25 @@ class TestOrganizationFollow:
             <dd><span>1</span></dd>
         ''' in response
 
+    @pytest.mark.ckan_config("ckan.auth.public_user_details", False)
+    def test_organization_follow_without_public_user_details(self, app, user):
+        headers = {"Authorization": user["token"]}
+        organization = factories.Organization()
+
+        follow_url = url_for("organization.follow", id=organization["id"])
+        response = app.post(follow_url, headers=headers)
+
+        assert '<a class="btn btn-danger"' in response
+        assert 'hx-target="#organization-info"' in response
+        assert 'fa-circle-minus"></i> Unfollow' in response
+
+        unfollow_url = url_for("organization.unfollow", id=organization["id"])
+        response = app.post(unfollow_url, headers=headers)
+
+        assert '<a class="btn btn-success"' in response
+        assert 'hx-target="#organization-info"' in response
+        assert 'fa-circle-plus"></i> Follow' in response
+
     def test_organization_follow_not_exist(self, app, user):
         """Pass an id for a organization that doesn't exist"""
 

--- a/ckan/views/group.py
+++ b/ckan/views/group.py
@@ -695,7 +695,7 @@ def follow(id: str, group_type: str,
     data_dict = {
         'id': id,
         'include_datasets': True,
-        'include_users': True,
+        'include_users': False,
     }
     extra_vars = {
         'current_user': current_user,
@@ -734,7 +734,7 @@ def unfollow(id: str, group_type: str, is_organization: bool) -> str:
     data_dict = {
         'id': id,
         'include_datasets': True,
-        'include_users': True,
+        'include_users': False,
         'include_followers': True
     }
     extra_vars = {


### PR DESCRIPTION
Fixes #9242

### Problem:

- Users can receive a 404 response when trying to follow or unfollow a group or organization.
- This happens when `ckan.auth.public_user_details` is disabled, because the follow views request group or organization user details even though the rendered response does not use them.

### Proposed fixes:

- Allow users to follow and unfollow groups and organizations when `ckan.auth.public_user_details` is disabled.
- Avoid requesting group or organization users when rendering the follow button response.
- Add regression coverage for group and organization follow/unfollow with private user details.

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
