### PR TITLE
fix search error after re-running datastore set-permissions

### DIFF
--- a/ckanext/datastore/set_permissions.sql
+++ b/ckanext/datastore/set_permissions.sql
@@ -102,7 +102,8 @@ DO $body$
                 ON t.tgrelid = relname::regclass AND t.tgname = 'zfulltext'
             WHERE relkind = 'r'::"char" AND t.tgname IS NULL
                 AND relnamespace = (
-                    SELECT oid FROM pg_namespace WHERE nspname='public')),
+                    SELECT oid FROM pg_namespace WHERE nspname='public')
+                AND NOT starts_with(relname, '_')),
             'SELECT 1;');
     END;
 $body$;


### PR DESCRIPTION
Fixes issue with `datastore_search` after running `ckan datastore set-permissions | psql ...` a second time

### Proposed fixes:

- zfulltext trigger should not be applied to `_table_stats` table

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport