### PR TITLE
fix: Resource form allows creation of empty resources

### DIFF
--- a/changes/9397.bugfix
+++ b/changes/9397.bugfix
@@ -1,0 +1,1 @@
+Resource form allows creation of empty resources.

--- a/ckan/tests/controllers/test_resource.py
+++ b/ckan/tests/controllers/test_resource.py
@@ -1,9 +1,13 @@
-# encoding: utf-8
+from __future__ import annotations
 
+from typing import Any
+from faker import Faker
+from file_keeper.core.upload import BytesIO
 import pytest
 import ckan.lib.helpers as h
 import ckan.plugins as plugins
 import ckan.tests.factories as factories
+from ckan import types
 from ckan.tests.helpers import call_action
 
 
@@ -61,3 +65,46 @@ class TestPluggablePreviews:
 
         assert "mock-preview" in result
         assert "mock-preview.js" in result
+
+
+@pytest.mark.usefixtrues("with_plugins", "non_clean_db")
+class TestCreate:
+    """Tests for the resource creation page."""
+
+    def test_empty_form(
+        self, user: dict[str, Any], app: types.FixtureApp, package: dict[str, Any]
+    ):
+        """Submitting an empty resource form does not create a resource."""
+        app.set_session_user(user["name"])
+        app.post(
+            f"/dataset/{package['name']}/resource/new",
+            data={"save": "", "id": "", "upload": (BytesIO(), "")},
+        )
+
+        pkg = call_action("package_show", id=package["id"])
+        assert not pkg["resources"]
+
+    def test_form_with_upload(
+        self,
+        user: dict[str, Any],
+        app: types.FixtureApp,
+        package: dict[str, Any],
+        faker: Faker,
+    ):
+        """Submitting a resource form with an uploaded file creates a new resource."""
+        content = faker.binary(42)
+        filename = faker.file_name(extension="txt")
+        app.set_session_user(user["name"])
+        app.post(
+            f"/dataset/{package['name']}/resource/new",
+            data={"save": "", "id": "", "upload": (BytesIO(content), filename)},
+        )
+
+        pkg = call_action("package_show", id=package["id"])
+
+        assert len(pkg["resources"]) == 1
+        res = pkg["resources"][0]
+
+        assert res["size"] == len(content)
+        assert res["format"] == "TXT"
+        assert res["url"].endswith(filename)

--- a/ckan/tests/controllers/test_resource.py
+++ b/ckan/tests/controllers/test_resource.py
@@ -76,6 +76,11 @@ class TestCreate:
     ):
         """Submitting an empty resource form does not create a resource."""
         app.set_session_user(user["name"])
+
+        # when form is submitted, even if `upload` field is empty, it's sent to
+        # flask as unnamed file with no content. To reliably test creation of
+        # empty resource, `upload` must be provided in the same way in the
+        # following payload.
         app.post(
             f"/dataset/{package['name']}/resource/new",
             data={"save": "", "id": "", "upload": (BytesIO(), "")},

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -4,8 +4,6 @@ import json
 import logging
 from typing import Any, Optional, Union
 
-from werkzeug.datastructures import FileStorage as FlaskFileStorage
-
 from werkzeug.wrappers.response import Response as WerkzeugResponse
 import flask
 from flask.views import MethodView

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -229,9 +229,9 @@ class CreateView(MethodView):
         # see if we have any data that we are trying to save
         data_provided = False
         for key, value in data.items():
-            if (
-                    (value or isinstance(value, FlaskFileStorage))
-                    and key != u'resource_type'):
+            # in case of empty upload, value will be set to FileStorage without
+            # `filename` attribute, which evaluates to False in boolean context
+            if value and key != "resource_type":
                 data_provided = True
                 break
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ showcontent = true
 [tool.pytest.ini_options]
 filterwarnings = [
     "ignore::DeprecationWarning",
-    "ignore::bs4.GuessedAtParserWarning",  # using lxml as default parser
 ]
 markers = [
     "ckan_config: patch configuration used by other fixtures via (key, value) pair.",


### PR DESCRIPTION
When the empty resource form is submitted, if the resource schema has no required fields(which means an empty form is technically valid), a new _empty_ resource is created.

This PR improves the existing logic that attempts to prevent the creation of such resources. The current version checks the presence of an uploaded file via `isinstance(upload, FileStorage)`. This does not work for an empty form because Flask will create an empty upload field as long as `input[type=file]` is present on the form. The correct way of checking whether the actual file was uploaded is `if upload: ...` - when a file was not provided, the upload object will evaluate to False.