### PR TITLE
Fix file_rename docs example

### DIFF
--- a/ckan/logic/action/file.py
+++ b/ckan/logic/action/file.py
@@ -607,7 +607,7 @@ def file_rename(context: Context, data_dict: dict[str, Any]) -> ActionResult.Fil
 
     .. code-block:: sh
 
-        $ ckanapi action file_show id=226056e2-6f83-47c5-8bd2-102e2b82ab9a \\
+        $ ckanapi action file_rename id=226056e2-6f83-47c5-8bd2-102e2b82ab9a \\
             name=new-name.txt
 
     :param id: ID of the file


### PR DESCRIPTION
Fixes #9400.

Summary:
- Update the ckanapi example in the file_rename action docstring to call file_rename instead of file_show.

Validation:
- Confirmed the file_show example remains under file_show and the file_rename example now uses file_rename.
- git diff --check passes.
- python -m compileall -q ckan/logic/action/file.py passes.