### PR TITLE
Fix R datastore API examples

### DIFF
--- a/changes/9371.bugfix
+++ b/changes/9371.bugfix
@@ -1,0 +1,1 @@
+Fix the R datastore API examples so the httr2 request pipelines are complete.

--- a/ckanext/datastore/templates/datastore/api_examples/r.html
+++ b/ckanext/datastore/templates/datastore/api_examples/r.html
@@ -13,9 +13,9 @@ result &lt;- req %&gt;%
     req_body_json(list(
         resource_id = '{{ resource_id }}',
         limit = 5,
-        q = 'jones'))
-    req_perform %&gt;% 
-    resp_body_json</code></pre>
+        q = 'jones')) %&gt;%
+    req_perform() %&gt;%
+    resp_body_json()</code></pre>
 {% endcall %}
 
 
@@ -30,9 +30,9 @@ result &lt;- req %&gt;%
         resource_id='{{ resource_id }}', 
         filters = list(
             subject = list("watershed", "survey"), 
-            stage = "active")))
-    req_perform %&gt;% 
-    resp_body_json</code></pre>
+            stage = "active"))) %&gt;%
+    req_perform() %&gt;%
+    resp_body_json()</code></pre>
 {% endcall %}
 
 
@@ -44,9 +44,9 @@ req &lt;- request("{{ h.url_for('api.action', logic_function='datastore_search_s
 result &lt;- req %&gt;% 
     req_headers(Authorization = API_TOKEN) %&gt;% 
     req_body_json(list(
-        sql = "SELECT * FROM \"{{resource_id}}\" WHERE title LIKE 'jones'"))
-    req_perform %&gt;% 
-    resp_body_json
+        sql = "SELECT * FROM \"{{resource_id}}\" WHERE title LIKE 'jones'")) %&gt;%
+    req_perform() %&gt;%
+    resp_body_json()
 </code></pre>
 {% endcall %}
 

--- a/ckanext/datastore/templates/datastore/api_examples/r.html
+++ b/ckanext/datastore/templates/datastore/api_examples/r.html
@@ -9,7 +9,7 @@ R
 
 req &lt;- request("{{ h.url_for('api.action', logic_function='datastore_search', qualified=True) }}")
 result &lt;- req %&gt;% 
-    req_headers(Authorization = API_TOKEN) %>% 
+    req_headers(Authorization = API_TOKEN) %&gt;%
     req_body_json(list(
         resource_id = '{{ resource_id }}',
         limit = 5,
@@ -25,7 +25,7 @@ result &lt;- req %&gt;%
 
 req &lt;- request("{{ h.url_for('api.action', logic_function='datastore_search', qualified=True) }}")
 result &lt;- req %&gt;% 
-    req_headers(Authorization = API_TOKEN) %>% 
+    req_headers(Authorization = API_TOKEN) %&gt;%
     req_body_json(list(
         resource_id='{{ resource_id }}', 
         filters = list(

--- a/ckanext/tabledesigner/templates/datastore/api_examples/r.html
+++ b/ckanext/tabledesigner/templates/datastore/api_examples/r.html
@@ -21,13 +21,13 @@
 
 req &lt;- request("{{ h.url_for('api.action', logic_function='datastore_search', qualified=True) }}")
 result &lt;- req %&gt;% 
-    req_headers(Authorization = API_TOKEN) %>% 
+    req_headers(Authorization = API_TOKEN) %&gt;%
     req_body_json(list(
         resource_id = '{{ resource_id }}', 
         filters = list(
-            {{ r_data(examples.text_column_filters_object) | indent(12) }})))
-    req_perform %&gt;% 
-    resp_body_json</code></pre>
+            {{ r_data(examples.text_column_filters_object) | indent(12) }}))) %&gt;%
+    req_perform() %&gt;%
+    resp_body_json()</code></pre>
   {% endcall %}
 
   {% call register_example('r', 'request_sql_custom') %}
@@ -38,9 +38,9 @@ req &lt;- request("{{ h.url_for('api.action', logic_function='datastore_search_s
 result &lt;- req %&gt;% 
     req_headers(Authorization = API_TOKEN) %&gt;% 
     req_body_json(list(
-        sql = "SELECT * FROM \"{{resource_id}}\" WHERE {{ examples.text_column_name_sql }} LIKE 'jones'"))
-    req_perform %&gt;% 
-    resp_body_json
+        sql = "SELECT * FROM \"{{resource_id}}\" WHERE {{ examples.text_column_name_sql }} LIKE 'jones'")) %&gt;%
+    req_perform() %&gt;%
+    resp_body_json()
 </code></pre>
 {% endcall %}
 
@@ -50,14 +50,14 @@ result &lt;- req %&gt;%
 
 req &lt;- request("{{ h.url_for('api.action', logic_function='datastore_upsert', qualified=True) }}")
 result &lt;- req %&gt;% 
-    req_headers(Authorization = API_TOKEN) %>% 
+    req_headers(Authorization = API_TOKEN) %&gt;%
     req_body_json(list(
         resource_id = '{{ resource_id }}', 
         method = 'insert',
         records = list(list(
-            {{ r_data(examples.insert_record_object) | indent(12) }}))))
-    req_perform %&gt;% 
-    resp_body_json</code></pre>
+            {{ r_data(examples.insert_record_object) | indent(12) }})))) %&gt;%
+    req_perform() %&gt;%
+    resp_body_json()</code></pre>
   {% endcall %}
 
   {% call register_example('r', 'request_update') %}
@@ -66,14 +66,14 @@ result &lt;- req %&gt;%
 
 req &lt;- request("{{ h.url_for('api.action', logic_function='datastore_upsert', qualified=True) }}")
 result &lt;- req %&gt;% 
-    req_headers(Authorization = API_TOKEN) %>% 
+    req_headers(Authorization = API_TOKEN) %&gt;%
     req_body_json(list(
         resource_id = '{{ resource_id }}', 
         method = 'update',
         records = list(list(
-            {{ r_data(examples.update_record_object) | indent(12) }}))))
-    req_perform %&gt;% 
-    resp_body_json</code></pre>
+            {{ r_data(examples.update_record_object) | indent(12) }})))) %&gt;%
+    req_perform() %&gt;%
+    resp_body_json()</code></pre>
   {% endcall %}
 
   {% call register_example('r', 'request_delete') %}
@@ -82,13 +82,13 @@ result &lt;- req %&gt;%
 
 req &lt;- request("{{ h.url_for('api.action', logic_function='datastore_records_delete', qualified=True) }}")
 result &lt;- req %&gt;% 
-    req_headers(Authorization = API_TOKEN) %>% 
+    req_headers(Authorization = API_TOKEN) %&gt;%
     req_body_json(list(
         resource_id = '{{ resource_id }}', 
         filters = list(
-            {{ r_data(examples.unique_filter_object) | indent(12) }})))
-    req_perform %&gt;% 
-    resp_body_json</code></pre>
+            {{ r_data(examples.unique_filter_object) | indent(12) }}))) %&gt;%
+    req_perform() %&gt;%
+    resp_body_json()</code></pre>
   {% endcall %}
   {% endif %}
 


### PR DESCRIPTION
## Summary
- add the missing pipes after `req_body_json(...)` in the R datastore API examples
- call `req_perform()` and `resp_body_json()` as functions so the examples are complete httr2 pipelines

Fixes #9371.

## Validation
- Ran `git diff --check`.
- Searched the edited R example template for remaining `req_perform` / `resp_body_json` calls without parentheses.