### PR TITLE
datastore sequences action API

### DIFF
--- a/changes/9404.feature
+++ b/changes/9404.feature
@@ -1,0 +1,2 @@
+new datastore_sequence_create, datastore_sequence_delete, datastore_sequence_next
+actions for sysadmins to generate unique identifiers.

--- a/ckanext/datastore/backend/__init__.py
+++ b/ckanext/datastore/backend/__init__.py
@@ -245,3 +245,18 @@ class DatastoreBackend:
         """Remove number or records and any other stats cached for
         a resource.
         """
+
+    def create_sequence(self, name: str, if_not_exists: bool) -> None:
+        """Called by `datastore_sequence_create` action.
+        """
+        raise NotImplementedError()
+
+    def drop_sequence(self, name: str, if_exists: bool) -> None:
+        """Called by `datastore_sequence_delete` action.
+        """
+        raise NotImplementedError()
+
+    def sequence_nextval(self, name: str) -> int:
+        """Called by `datastore_sequence_next` action.
+        """
+        raise NotImplementedError()

--- a/ckanext/datastore/backend/__init__.py
+++ b/ckanext/datastore/backend/__init__.py
@@ -246,7 +246,9 @@ class DatastoreBackend:
         a resource.
         """
 
-    def create_sequence(self, name: str, if_not_exists: bool) -> None:
+    def create_sequence(
+        self, name: str, if_not_exists: bool, last_value: int | None
+    ) -> None:
         """Called by `datastore_sequence_create` action.
         """
         raise NotImplementedError()

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -7,6 +7,7 @@ from typing_extensions import TypeAlias
 
 from sqlalchemy.engine.base import Engine
 from sqlalchemy.dialects.postgresql import REGCLASS
+from sqlalchemy.schema import CreateSequence, DropSequence
 from ckan.types import Context, ErrorDict
 import copy
 import logging
@@ -2528,6 +2529,16 @@ class DatastorePostgresqlBackend(DatastoreBackend):
             except DatabaseError as err:
                 raise DatastoreException(err)
 
+    def create_sequence(self, *args: Any, **kwargs: Any) -> None:
+        return create_sequence(*args, **kwargs)
+
+    def drop_sequence(self, *args: Any, **kwargs: Any) -> None:
+        return drop_sequence(*args, **kwargs)
+
+    def sequence_nextval(self, *args: Any, **kwargs: Any) -> int:
+        return sequence_nextval(*args, **kwargs)
+
+
 
 def create_function(name: str, arguments: Iterable[dict[str, Any]],
                     rettype: Any, definition: str, or_replace: bool):
@@ -2569,6 +2580,33 @@ def drop_function(name: str, if_exists: bool):
         _write_engine_execute(sql)
     except ProgrammingError as pe:
         raise ValidationError({u'name': [_programming_error_summary(pe)]})
+
+
+def create_sequence(name: str, if_not_exists: bool) -> None:
+    try:
+        with get_write_engine().begin() as conn:
+            seq = sa.Sequence(name)
+            conn.execute(CreateSequence(seq, if_not_exists=if_not_exists))
+    except ProgrammingError as pe:
+        raise ValidationError({'name': [_programming_error_summary(pe)]})
+
+
+def drop_sequence(name: str, if_exists: bool) -> None:
+    try:
+        with get_write_engine().begin() as conn:
+            seq = sa.Sequence(name)
+            conn.execute(DropSequence(seq, if_exists=if_exists))
+    except ProgrammingError as pe:
+        raise ValidationError({'name': [_programming_error_summary(pe)]})
+
+
+def sequence_nextval(name: str) -> int:
+    try:
+        with get_write_engine().begin() as conn:
+            seq = sa.Sequence(name)
+            return conn.execute(sa.select(seq.next_value())).scalar()
+    except ProgrammingError as pe:
+        raise ValidationError({'name': [_programming_error_summary(pe)]})
 
 
 def _write_engine_execute(sql: str):

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -2604,7 +2604,9 @@ def sequence_nextval(name: str) -> int:
     try:
         with get_write_engine().begin() as conn:
             seq = sa.Sequence(name)
-            return conn.execute(sa.select(seq.next_value())).scalar()
+            num = conn.execute(sa.select(seq.next_value())).scalar()
+            assert isinstance(num, int)
+            return num
     except ProgrammingError as pe:
         raise ValidationError({'name': [_programming_error_summary(pe)]})
 

--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -2582,11 +2582,19 @@ def drop_function(name: str, if_exists: bool):
         raise ValidationError({u'name': [_programming_error_summary(pe)]})
 
 
-def create_sequence(name: str, if_not_exists: bool) -> None:
+def create_sequence(
+    name: str, if_not_exists: bool, last_value: int | None
+) -> None:
     try:
         with get_write_engine().begin() as conn:
             seq = sa.Sequence(name)
             conn.execute(CreateSequence(seq, if_not_exists=if_not_exists))
+
+            if last_value is not None:
+                conn.execute(
+                    sa.text('SELECT setval(:seq, :last_value)'),
+                    {"seq": name, "last_value": last_value}
+                )
     except ProgrammingError as pe:
         raise ValidationError({'name': [_programming_error_summary(pe)]})
 

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -958,3 +958,49 @@ def datastore_function_delete(context: Context, data_dict: dict[str, Any]):
     p.toolkit.check_access('datastore_function_delete', context, data_dict)
     backend = DatastoreBackend.get_active_backend()
     backend.drop_function(data_dict['name'], data_dict['if_exists'])
+
+
+@logic.validate(dsschema.datastore_sequence_create_schema)
+def datastore_sequence_create(context: Context, data_dict: dict[str, Any]):
+    u'''
+    Create a sequence for use with trigger functions
+
+    :param name: sequence name
+    :type name: string
+    :param if_not_exists: True to skip existing sequences
+        (default: False)
+    '''
+    p.toolkit.check_access('datastore_sequence_create', context, data_dict)
+    backend = DatastoreBackend.get_active_backend()
+    backend.create_sequence(
+        name=data_dict['name'],
+        if_not_exists=data_dict['if_not_exists'])
+
+
+@logic.validate(dsschema.datastore_sequence_delete_schema)
+def datastore_sequence_delete(context: Context, data_dict: dict[str, Any]):
+    u'''
+    Delete a sequence
+
+    :param name: sequence name
+    :type name: string
+    :param if_exists: True to skip missing sequences
+        (default: False)
+    '''
+    p.toolkit.check_access('datastore_sequence_delete', context, data_dict)
+    backend = DatastoreBackend.get_active_backend()
+    backend.drop_sequence(
+        name=data_dict['name'], if_exists=data_dict['if_exists'])
+
+
+@logic.validate(dsschema.datastore_sequence_next_schema)
+def datastore_sequence_next(context: Context, data_dict: dict[str, Any]):
+    u'''
+    Delete a sequence
+
+    :param name: sequence name
+    :type name: string
+    '''
+    p.toolkit.check_access('datastore_sequence_next', context, data_dict)
+    backend = DatastoreBackend.get_active_backend()
+    return backend.sequence_nextval(name=data_dict['name'])

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -962,8 +962,9 @@ def datastore_function_delete(context: Context, data_dict: dict[str, Any]):
 
 @logic.validate(dsschema.datastore_sequence_create_schema)
 def datastore_sequence_create(context: Context, data_dict: dict[str, Any]):
-    u'''
-    Create a sequence for use with trigger functions
+    '''
+    Create a sequence for use with trigger functions or
+    datastore_sequence_next
 
     :param name: sequence name
     :type name: string
@@ -979,7 +980,7 @@ def datastore_sequence_create(context: Context, data_dict: dict[str, Any]):
 
 @logic.validate(dsschema.datastore_sequence_delete_schema)
 def datastore_sequence_delete(context: Context, data_dict: dict[str, Any]):
-    u'''
+    '''
     Delete a sequence
 
     :param name: sequence name
@@ -995,11 +996,12 @@ def datastore_sequence_delete(context: Context, data_dict: dict[str, Any]):
 
 @logic.validate(dsschema.datastore_sequence_next_schema)
 def datastore_sequence_next(context: Context, data_dict: dict[str, Any]):
-    u'''
-    Delete a sequence
+    '''
+    Return the next value and advance a sequence
 
     :param name: sequence name
     :type name: string
+    :rtype: int
     '''
     p.toolkit.check_access('datastore_sequence_next', context, data_dict)
     backend = DatastoreBackend.get_active_backend()

--- a/ckanext/datastore/logic/action.py
+++ b/ckanext/datastore/logic/action.py
@@ -963,19 +963,24 @@ def datastore_function_delete(context: Context, data_dict: dict[str, Any]):
 @logic.validate(dsschema.datastore_sequence_create_schema)
 def datastore_sequence_create(context: Context, data_dict: dict[str, Any]):
     '''
-    Create a sequence for use with trigger functions or
-    datastore_sequence_next
+    Create a sequence or update the last value for a sequence. Sequences
+    may be used with trigger functions or datastore_sequence_next.
 
     :param name: sequence name
     :type name: string
-    :param if_not_exists: True to skip existing sequences
-        (default: False)
+    :param if_not_exists: set True to not fail if the sequence already
+        exists (default: False)
+    :param last_value: set the last value given for a sequence
+        i.e. the number before the next one that will be issued
+        (default: leave unchanged, 0 for new sequences)
     '''
     p.toolkit.check_access('datastore_sequence_create', context, data_dict)
     backend = DatastoreBackend.get_active_backend()
     backend.create_sequence(
         name=data_dict['name'],
-        if_not_exists=data_dict['if_not_exists'])
+        if_not_exists=data_dict['if_not_exists'],
+        last_value=data_dict.get('last_value'),
+    )
 
 
 @logic.validate(dsschema.datastore_sequence_delete_schema)

--- a/ckanext/datastore/logic/auth.py
+++ b/ckanext/datastore/logic/auth.py
@@ -97,3 +97,20 @@ def datastore_run_triggers(
 
 def datastore_analyze(context: Context, data_dict: DataDict) -> AuthResult:
     return {'success': False}
+
+def datastore_sequence_create(
+        context: Context, data_dict: DataDict) -> AuthResult:
+    '''sysadmin-only: sequences are shared across datastore'''
+    return {'success': False}
+
+
+def datastore_sequence_delete(
+        context: Context, data_dict: DataDict) -> AuthResult:
+    '''sysadmin-only: sequences are shared across datastore'''
+    return {'success': False}
+
+
+def datastore_sequence_next(
+        context: Context, data_dict: DataDict) -> AuthResult:
+    '''sysadmin-only: sequences are shared across datastore'''
+    return {'success': False}

--- a/ckanext/datastore/logic/schema.py
+++ b/ckanext/datastore/logic/schema.py
@@ -259,3 +259,23 @@ def datastore_info_schema() -> Schema:
         'include_fields_schema': [default(True), boolean_validator],
         '__before': [rename('id', 'resource_id')]
     }
+
+
+def datastore_sequence_create_schema() -> Schema:
+    return {
+        'name': [unicode_only, not_empty],
+        'if_not_exists': [default(False), boolean_validator],
+    }
+
+
+def datastore_sequence_delete_schema() -> Schema:
+    return {
+        'name': [unicode_only, not_empty],
+        'if_exists': [default(False), boolean_validator],
+    }
+
+
+def datastore_sequence_next_schema() -> Schema:
+    return {
+        'name': [unicode_only, not_empty],
+    }

--- a/ckanext/datastore/logic/schema.py
+++ b/ckanext/datastore/logic/schema.py
@@ -265,6 +265,7 @@ def datastore_sequence_create_schema() -> Schema:
     return {
         'name': [unicode_only, not_empty],
         'if_not_exists': [default(False), boolean_validator],
+        'last_value': [ignore_missing, int_validator],
     }
 
 

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -128,6 +128,9 @@ class DatastorePlugin(p.SingletonPlugin):
             'datastore_function_create': auth.datastore_function_create,
             'datastore_function_delete': auth.datastore_function_delete,
             'datastore_run_triggers': auth.datastore_run_triggers,
+            'datastore_sequence_create': auth.datastore_sequence_create,
+            'datastore_sequence_delete': auth.datastore_sequence_delete,
+            'datastore_sequence_next': auth.datastore_sequence_next,
         }
 
     # IResourceController

--- a/ckanext/datastore/plugin.py
+++ b/ckanext/datastore/plugin.py
@@ -102,6 +102,9 @@ class DatastorePlugin(p.SingletonPlugin):
             'datastore_function_create': action.datastore_function_create,
             'datastore_function_delete': action.datastore_function_delete,
             'datastore_run_triggers': action.datastore_run_triggers,
+            'datastore_sequence_create': action.datastore_sequence_create,
+            'datastore_sequence_delete': action.datastore_sequence_delete,
+            'datastore_sequence_next': action.datastore_sequence_next,
         }
         if getattr(self.backend, 'enable_sql_search', False):
             # Only enable search_sql if the config/backend does not disable it

--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -6,6 +6,8 @@ import sqlalchemy as sa
 import sqlalchemy.orm as orm
 from time import sleep
 
+from faker import Faker
+
 import ckan.lib.create_test_data as ctd
 import ckan.model as model
 import ckan.plugins as p
@@ -19,6 +21,8 @@ from ckanext.datastore.tests.helpers import (
     execute_sql,
     when_was_last_analyze,
 )
+
+fake = Faker()
 
 
 @pytest.mark.ckan_config("ckan.plugins", "datastore")
@@ -1526,3 +1530,39 @@ def test_create_schedules_record_count():
             ), {'resource_id': resource['id']}
         )
     assert list(stats) == [('{"rows": 7}',)]
+
+
+@pytest.mark.ckan_config("ckan.plugins", "datastore")
+@pytest.mark.usefixtures("with_plugins", "with_request_context")
+def test_sequences():
+    seqname = fake.unique.user_name()
+    helpers.call_action("datastore_sequence_create", name=seqname)
+    assert helpers.call_action("datastore_sequence_next", name=seqname) == 1
+    assert helpers.call_action("datastore_sequence_next", name=seqname) == 2
+    helpers.call_action("datastore_sequence_delete", name=seqname)
+
+    with pytest.raises(ValidationError) as error:
+        helpers.call_action("datastore_sequence_next", name=seqname)
+    assert error.value.error_dict == {
+        "name": [f'relation "{seqname}" does not exist']
+    }
+
+    helpers.call_action("datastore_sequence_create", name=seqname)
+    with pytest.raises(ValidationError) as error:
+        helpers.call_action("datastore_sequence_create", name=seqname)
+    assert error.value.error_dict == {
+        "name": [f'relation "{seqname}" already exists']
+    }
+    helpers.call_action(
+        "datastore_sequence_create", name=seqname, if_not_exists=True,
+    )
+
+    helpers.call_action("datastore_sequence_delete", name=seqname)
+    with pytest.raises(ValidationError) as error:
+        helpers.call_action("datastore_sequence_delete", name=seqname)
+    assert error.value.error_dict == {
+        "name": [f'sequence "{seqname}" does not exist']
+    }
+    helpers.call_action(
+        "datastore_sequence_delete", name=seqname, if_exists=True,
+    )

--- a/ckanext/datastore/tests/test_create.py
+++ b/ckanext/datastore/tests/test_create.py
@@ -1566,3 +1566,12 @@ def test_sequences():
     helpers.call_action(
         "datastore_sequence_delete", name=seqname, if_exists=True,
     )
+
+    helpers.call_action("datastore_sequence_create", name=seqname, last_value=10)
+    assert helpers.call_action("datastore_sequence_next", name=seqname) == 11
+    assert helpers.call_action("datastore_sequence_next", name=seqname) == 12
+    helpers.call_action(
+        "datastore_sequence_create", name=seqname, if_not_exists=True, last_value=50
+    )
+    assert helpers.call_action("datastore_sequence_next", name=seqname) == 51
+    assert helpers.call_action("datastore_sequence_next", name=seqname) == 52


### PR DESCRIPTION
Fixes #9404

### Proposed fixes:
- provide `datastore_sequence_create`, `datastore_sequence_delete`, `datastore_sequence_next` actions
- sysadmin-only because sequences are shared across datastore


### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport