### PR TITLE
setuptools < 82 compat

### DIFF
--- a/changes/9414.bugfix
+++ b/changes/9414.bugfix
@@ -1,0 +1,2 @@
+Restore declare_namespace in ckanext/stats/__init__.py with except block
+to resolve compatibility with setuptools<82

--- a/ckanext/stats/__init__.py
+++ b/ckanext/stats/__init__.py
@@ -1,0 +1,7 @@
+# workaround for compatibility with setuptools<82
+# see https://github.com/ckan/ckan/discussions/9340
+try:
+    import pkg_resources
+    pkg_resources.declare_namespace(__name__)
+except ImportError:
+    pass


### PR DESCRIPTION
Fixes #9414 

### Proposed fixes:

- Restore declare_namespace in ckanext/stats/__init__.py with except block
to resolve compatibility with setuptools<82

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport