### PR TITLE
fix: Use original resource name when download from FS

### DIFF
--- a/ckan/lib/files/base.py
+++ b/ckan/lib/files/base.py
@@ -327,7 +327,7 @@ class Storage(fk.Storage):
 
         """
         try:
-            resp = self.reader.response(data, kwargs)
+            resp = self.reader.response(data, dict(kwargs, filename=filename))
         except fk.exc.MissingFileError:
             return flask.Response(status=404)
 

--- a/ckan/lib/files/default/fs.py
+++ b/ckan/lib/files/default/fs.py
@@ -31,7 +31,7 @@ class Reader(base.Reader, fs.Reader):
         filepath = self.storage.full_path(data.location)
         return flask.send_file(
             filepath,
-            download_name=data.location,
+            download_name=extras.get("filename") or data.location,
             mimetype=data.content_type,
         )
 

--- a/ckan/tests/controllers/test_file.py
+++ b/ckan/tests/controllers/test_file.py
@@ -31,6 +31,30 @@ class TestDownload:
         assert resp.data == content
 
 
+    def test_download_fs(
+        self,
+        faker: Faker,
+        file_factory: types.TestFactory,
+        app: types.FixtureApp,
+        tmpdir: Any,
+        reset_storages: types.FixtureResetStorages,
+        ckan_config: types.FixtureCkanConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Test downloaded file has correct name."""
+        name = ckan_config["ckan.files.default_storages.default"]
+        monkeypatch.setitem(ckan_config, f"ckan.files.storage.{name}.type", "ckan:fs")
+        monkeypatch.setitem(ckan_config, f"ckan.files.storage.{name}.path", str(tmpdir))
+        monkeypatch.setitem(ckan_config, f"ckan.files.storage.{name}.location_transformers", ["uuid4"])
+        reset_storages()
+
+        file = file_factory()
+
+        app.set_session_user(file["owner_id"])
+        resp = app.get(f"/file/download/{file['id']}")
+        assert file["name"] in resp.headers["content-disposition"]
+
+
 class TestPublicDownload:
     @pytest.mark.ckan_config(
         "ckan.files.storage.non_public_storage.type", "ckan:memory"

--- a/ckan/views/file.py
+++ b/ckan/views/file.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 blueprint = Blueprint("file", __name__)
 
 
-def _as_response(storage_name: str, data: files.FileData):
+def _as_response(storage_name: str, data: files.FileData, filename: str | None = None):
     """Return a response for a file stored in the given location.
 
     The storage is looked up by name, and the file data is created from the
@@ -28,7 +28,7 @@ def _as_response(storage_name: str, data: files.FileData):
         return base.abort(404)
 
     if isinstance(storage, files.Storage):
-        resp = storage.as_response(data)
+        resp = storage.as_response(data, filename)
         if resp.status_code >= 400:
             return base.abort(resp.status_code)
         return resp
@@ -51,7 +51,11 @@ def download(id: str) -> Response:
     except (logic.NotFound, logic.NotAuthorized):
         return base.abort(404)
 
-    return _as_response(item["storage"], files.FileData.from_dict(item))
+    return _as_response(
+        item["storage"],
+        files.FileData.from_dict(item),
+        filename=item["name"],
+    )
 
 
 @blueprint.route("/file/trusted-download/<token>")
@@ -102,7 +106,11 @@ def trusted_download(token: str) -> Response:
     if not item:
         return base.abort(404)
 
-    return _as_response(item.storage, files.FileData.from_object(item))
+    return _as_response(
+        item.storage,
+        files.FileData.from_object(item),
+        filename=item.name,
+    )
 
 
 @blueprint.route("/file/public-download/<storage_name>/<path:location>")


### PR DESCRIPTION
When a resource is downloaded from the local fs, we are using Flask's `send_file` but do not pass the original resource's name into it. As a result, the downloaded file is named after the resource's ID, according to its location in the filesystem.

This PR makes use of the resource's filename, which is already available in the method that builds the download response.