### PR TITLE
fix: gracefully handle missing context fields in API call

### DIFF
--- a/ckan/logic/action/patch.py
+++ b/ckan/logic/action/patch.py
@@ -37,9 +37,9 @@ def package_patch(
     _check_access('package_patch', context, data_dict)
 
     show_context: Context = {
-        'session': context['session'],
-        'user': context['user'],
-        'auth_user_obj': context['auth_user_obj'],
+        'session': context.get('session'),
+        'user': context.get('user'),
+        'auth_user_obj': context.get('auth_user_obj'),
         'ignore_auth': context.get('ignore_auth', False),
         'for_update': True
     }


### PR DESCRIPTION
When calling an API internally and setting ignore_auth, we should not need to supply a user object.

### Proposed fixes:

Use `context.get('user')` instead of `context['user']` so we can gracefully handle absent keys.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport

Please [X] all the boxes above that apply
