### PR TITLE
fix: load fontawesome with base/main asset

### DIFF
--- a/ckan/public-midnight-blue/base/vendor/webassets.yml
+++ b/ckan/public-midnight-blue/base/vendor/webassets.yml
@@ -29,6 +29,7 @@ vendor:
     preload:
       - vendor/select2-css
       - vendor/jquery
+      - vendor/fontawesome
   contents:
     - jed.js
     - moment-with-locales.js

--- a/ckan/public/base/vendor/webassets.yml
+++ b/ckan/public/base/vendor/webassets.yml
@@ -29,6 +29,7 @@ vendor:
     preload:
       - vendor/select2-css
       - vendor/jquery
+      - vendor/fontawesome
   contents:
     - jed.js
     - moment-with-locales.js


### PR DESCRIPTION
Fixes: missing icons on datatablesview 

CKAN has two main web assets that load CSS and JS: 

* `base/main`: loads the module system and jQuery
* `base/ckan`: loads Bootstrap and modules

This separation is done to reduce the weight of view pages by enabling only `base/main` and excluding Bootstrap and unused modules from the page.

After recent changes, FontAwesome was accidentally excluded from the `base/main` asset, making fa-icons unavailable on views. This PR adds FA back

