### PR TITLE
fix: Restore `ckan.root_path` in JS

### DIFF
--- a/ckan/public-midnight-blue/base/javascript/main.js
+++ b/ckan/public-midnight-blue/base/javascript/main.js
@@ -18,17 +18,17 @@ this.ckan = this.ckan || {};
    * Returns nothing.
    */
   ckan.initialize = function () {
-    var body = jQuery('body');
     var locale = jQuery('html').attr('lang');
     var location = window.location;
     var root = location.protocol + '//' + location.host;
 
     function getRootFromData(key) {
-      return (body.data(key) || root).replace(/\/$/, '');
+      const value = document.head.querySelector([`meta[name=${key}]`])?.content
+      return (value || root).replace(/\/$/, '');
     }
 
-    ckan.SITE_ROOT   = getRootFromData('siteRoot');
-    ckan.LOCALE_ROOT = getRootFromData('localeRoot');
+    ckan.SITE_ROOT   = getRootFromData('site-root');
+    ckan.LOCALE_ROOT = getRootFromData('locale-root');
 
     // Convert all datetimes to the users timezone
     jQuery('.automatic-local-datetime').each(function() {

--- a/ckan/public/base/javascript/main.js
+++ b/ckan/public/base/javascript/main.js
@@ -18,17 +18,17 @@ this.ckan = this.ckan || {};
    * Returns nothing.
    */
   ckan.initialize = function () {
-    var body = jQuery('body');
     var locale = jQuery('html').attr('lang');
     var location = window.location;
     var root = location.protocol + '//' + location.host;
 
     function getRootFromData(key) {
-      return (body.data(key) || root).replace(/\/$/, '');
+      const value = document.head.querySelector([`meta[name=${key}]`])?.content
+      return (value || root).replace(/\/$/, '');
     }
 
-    ckan.SITE_ROOT   = getRootFromData('siteRoot');
-    ckan.LOCALE_ROOT = getRootFromData('localeRoot');
+    ckan.SITE_ROOT   = getRootFromData('site-root');
+    ckan.LOCALE_ROOT = getRootFromData('locale-root');
 
     // Convert all datetimes to the users timezone
     jQuery('.automatic-local-datetime').each(function() {


### PR DESCRIPTION
Restore `ckan.root_path` value in JS. 

The root path value was moved from the `body` tag to the' meta' section in the `head`. On one of our portals that uses `ckan.root_path`, we found an additional place in the JS that needs to be adapted to this change.