### PR TITLE
Add new `package_reindex` API action

### DIFF
--- a/changes/9440.feature
+++ b/changes/9440.feature
@@ -1,0 +1,1 @@
+Add new 'package_reindex' function to update search index for a package

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -186,6 +186,7 @@ def resource_view_update(
         model.repo.commit()
     return model_dictize.resource_view_dictize(resource_view, context)
 
+
 def resource_view_reorder(
         context: Context, data_dict: DataDict) -> ActionResult.ResourceViewReorder:
     '''Reorder resource views.
@@ -301,8 +302,8 @@ def package_update(
         dataset_changed = dict(
             original_package, metadata_modified=None, resources=None
             ) != dict(data_dict, metadata_modified=None, resources=None)
-    if not dataset_changed and original_package.get('resources'
-            ) == data_dict.get('resources'):
+    if not dataset_changed and original_package.get('resources') \
+            == data_dict.get('resources'):
         return pkg.id if return_id_only else original_package
 
     res_deps = []
@@ -851,6 +852,7 @@ def group_update(context: Context, data_dict: DataDict) -> ActionResult.GroupUpd
     '''
     return _group_or_org_update(context, data_dict)
 
+
 def organization_update(
         context: Context, data_dict: DataDict) -> ActionResult.OrganizationUpdate:
     '''Update an organization.
@@ -878,6 +880,7 @@ def organization_update(
 
     '''
     return _group_or_org_update(context, data_dict, is_org=True)
+
 
 def user_update(context: Context, data_dict: DataDict) -> ActionResult.UserUpdate:
     '''Update a user account.
@@ -993,6 +996,7 @@ def task_status_update(
     session.close()
     return model_dictize.task_status_dictize(task_status, context)
 
+
 def task_status_update_many(
         context: Context, data_dict: DataDict) -> ActionResult.TaskStatusUpdateMany:
     '''Update many task statuses at once.
@@ -1017,6 +1021,7 @@ def task_status_update_many(
     if not context.get('defer_commit'):
         model.Session.commit()
     return {'results': results}
+
 
 def term_translation_update(
         context: Context, data_dict: DataDict) -> ActionResult.TermTranslationUpdate:
@@ -1054,7 +1059,7 @@ def term_translation_update(
     update = trans_table.update()
     update = update.where(trans_table.c["term"] == data['term'])
     update = update.where(trans_table.c["lang_code"] == data['lang_code'])
-    update = update.values(term_translation = data['term_translation'])
+    update = update.values(term_translation=data['term_translation'])
 
     conn = model.Session.connection()
     result = conn.execute(update)
@@ -1067,6 +1072,7 @@ def term_translation_update(
         model.Session.commit()
 
     return data
+
 
 def term_translation_update_many(
         context: Context, data_dict: DataDict) -> ActionResult.TermTranslationUpdateMany:
@@ -1229,6 +1235,7 @@ def bulk_update_private(context: Context, data_dict: DataDict) -> ActionResult.B
     _check_access('bulk_update_private', context, data_dict)
     _bulk_update_dataset(context, data_dict, {'private': True})
 
+
 def bulk_update_public(context: Context, data_dict: DataDict) -> ActionResult.BulkUpdatePublic:
     ''' Make a list of datasets public
 
@@ -1241,6 +1248,7 @@ def bulk_update_public(context: Context, data_dict: DataDict) -> ActionResult.Bu
 
     _check_access('bulk_update_public', context, data_dict)
     _bulk_update_dataset(context, data_dict, {'private': False})
+
 
 def bulk_update_delete(context: Context, data_dict: DataDict) -> ActionResult.BulkUpdateDelete:
     ''' Make a list of datasets deleted

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -232,6 +232,32 @@ def resource_view_reorder(
     return {'id': id, 'order': new_order}
 
 
+def package_reindex(
+        context: Context, data_dict: DataDict) -> None:
+    '''Rebuild the search index for a dataset (package).
+
+    You must be authorized to edit the dataset
+    and the group(s) it belongs to.
+
+    :param id: the name or id of the dataset to reindex
+    :type id: string
+    '''
+    name_or_id = data_dict.get('id') or data_dict.get('name')
+    if name_or_id is None:
+        raise ValidationError({'id': _('Missing value')})
+
+    pkg = model.Package.get(name_or_id)
+    if pkg is None:
+        raise NotFound(_('Package was not found.'))
+    context["package"] = pkg
+
+    data_dict["id"] = pkg.id
+
+    _check_access('package_reindex', context, data_dict)
+
+    logic.index_update_package(context, pkg.id)
+
+
 def package_update(
         context: Context, data_dict: DataDict) -> ActionResult.PackageUpdate:
     '''Update a dataset (package).

--- a/ckan/logic/action/update.py
+++ b/ckan/logic/action/update.py
@@ -249,9 +249,8 @@ def package_reindex(
     pkg = model.Package.get(name_or_id)
     if pkg is None:
         raise NotFound(_('Package was not found.'))
-    context["package"] = pkg
 
-    data_dict["id"] = pkg.id
+    data_dict = {"id": pkg.id}
 
     _check_access('package_reindex', context, data_dict)
 

--- a/ckan/logic/auth/update.py
+++ b/ckan/logic/auth/update.py
@@ -12,6 +12,11 @@ from ckan.types import Context, DataDict, AuthResult
 
 
 @logic.auth_allow_anonymous_access
+def package_reindex(context: Context, data_dict: DataDict) -> AuthResult:
+    return package_update(context, data_dict)
+
+
+@logic.auth_allow_anonymous_access
 def package_update(context: Context, data_dict: DataDict) -> AuthResult:
     user = context.get('user')
 
@@ -66,8 +71,9 @@ def package_revise(context: Context, data_dict: DataDict) -> AuthResult:
 
 def package_resource_reorder(context: Context,
                              data_dict: DataDict) -> AuthResult:
-    ## the action function runs package update so no need to run it twice
+    # the action function runs package update so no need to run it twice
     return {'success': True}
+
 
 def resource_update(context: Context, data_dict: DataDict) -> AuthResult:
     user = context.get('user')
@@ -95,6 +101,7 @@ def resource_update(context: Context, data_dict: DataDict) -> AuthResult:
 def resource_view_update(context: Context, data_dict: DataDict) -> AuthResult:
     return authz.is_authorized('resource_update', context, {'id': data_dict['resource_id']})
 
+
 def resource_view_reorder(context: Context, data_dict: DataDict) -> AuthResult:
     return authz.is_authorized('resource_update', context, {'id': data_dict['resource_id']})
 
@@ -102,8 +109,8 @@ def resource_view_reorder(context: Context, data_dict: DataDict) -> AuthResult:
 def package_relationship_update(context: Context,
                                 data_dict: DataDict) -> AuthResult:
     return authz.is_authorized('package_relationship_create',
-                                   context,
-                                   data_dict)
+                               context,
+                               data_dict)
 
 
 def package_change_state(context: Context, data_dict: DataDict) -> AuthResult:
@@ -112,8 +119,8 @@ def package_change_state(context: Context, data_dict: DataDict) -> AuthResult:
 
     # use the logic for package_update
     authorized = authz.is_authorized_boolean('package_update',
-                                                 context,
-                                                 data_dict)
+                                             context,
+                                             data_dict)
     if not authorized:
         return {
             'success': False,
@@ -128,8 +135,8 @@ def group_update(context: Context, data_dict: DataDict) -> AuthResult:
     group = logic_auth.get_group_object(context, data_dict)
     user = context['user']
     authorized = authz.has_user_permission_for_group_or_org(group.id,
-                                                                user,
-                                                                'update')
+                                                            user,
+                                                            'update')
     if not authorized:
         return {'success': False,
                 'msg': _('User %s not authorized to edit group %s') %
@@ -157,8 +164,8 @@ def group_change_state(context: Context, data_dict: DataDict) -> AuthResult:
 
     # use logic for group_update
     authorized = authz.is_authorized_boolean('group_update',
-                                                 context,
-                                                 data_dict)
+                                             context,
+                                             data_dict)
     if not authorized:
         return {
             'success': False,

--- a/ckan/logic/auth/update.py
+++ b/ckan/logic/auth/update.py
@@ -13,7 +13,7 @@ from ckan.types import Context, DataDict, AuthResult
 
 @logic.auth_allow_anonymous_access
 def package_reindex(context: Context, data_dict: DataDict) -> AuthResult:
-    return package_update(context, data_dict)
+    return authz.is_authorized('package_update', context, data_dict)
 
 
 @logic.auth_allow_anonymous_access

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -777,6 +777,14 @@ class TestDatasetUpdate(object):
         index_update_package_mock.assert_called()
         assert index_update_package_mock.call_args[0][1] == dataset_id
 
+        # missing ID
+        with pytest.raises(logic.ValidationError):
+            helpers.call_action('package_reindex')
+
+        # invalid ID
+        with pytest.raises(logic.NotFound):
+            helpers.call_action('package_reindex', id="nonexistent")
+
 
 @pytest.mark.ckan_config("ckan.views.default_views", "")
 @pytest.mark.ckan_config("ckan.plugins", "image_view")

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -768,6 +768,15 @@ class TestDatasetUpdate(object):
         ))
         assert unchanged["metadata_modified"] == "2020-02-25T12:00:00"
 
+    @mock.patch("ckan.logic.index_update_package")
+    def test_reindex(self, index_update_package_mock):
+        # test that authorized users can trigger a reindex
+        dataset = factories.Dataset()
+        dataset_id = dataset['id']
+        helpers.call_action('package_reindex', id=dataset_id)
+        index_update_package_mock.assert_called()
+        assert index_update_package_mock.call_args[0][1] == dataset_id
+
 
 @pytest.mark.ckan_config("ckan.views.default_views", "")
 @pytest.mark.ckan_config("ckan.plugins", "image_view")

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -768,6 +768,21 @@ class TestDatasetUpdate(object):
         ))
         assert unchanged["metadata_modified"] == "2020-02-25T12:00:00"
 
+    @mock.patch("ckan.logic.index_update_package")
+    def test_reindex(self, index_update_package_mock):
+        # test that authorized users can trigger a reindex
+        dataset = factories.Dataset()
+        dataset_id = dataset['id']
+        helpers.call_action('package_reindex', id=dataset_id)
+        index_update_package_mock.assert_called()
+        assert index_update_package_mock.call_args[0][1] == dataset_id
+
+        # but not unauthorized users
+        user = factories.User()
+        context = {"user": user["name"], "ignore_auth": False}
+        with pytest.raises(logic.NotAuthorized):
+            helpers.call_action('package_reindex', context, id=dataset_id)
+
 
 @pytest.mark.ckan_config("ckan.views.default_views", "")
 @pytest.mark.ckan_config("ckan.plugins", "image_view")

--- a/ckan/tests/logic/auth/test_update.py
+++ b/ckan/tests/logic/auth/test_update.py
@@ -291,6 +291,8 @@ class TestUpdateAuthWithCollaborators(object):
         ('package_update', False),
         ('package_update', True),
         ('package_update', True),
+        ('package_reindex', False),
+        ('package_reindex', True),
         ('package_delete', False),
         ('package_delete', False),
         ('package_delete', True),


### PR DESCRIPTION
### Proposed fixes:

Add a `package_reindex` API action to trigger an index rebuild for a package without making changes.

This is useful when eg plugins have registered `before_dataset_index` hooks that they want to manually run. See https://github.com/ckan/ckan/pull/8396#discussion_r3626992080

### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
