### PR TITLE
fix midnight-blue: replace bare text status with badges

### DIFF
--- a/ckan/templates-midnight-blue/group/snippets/info.html
+++ b/ckan/templates-midnight-blue/group/snippets/info.html
@@ -16,7 +16,7 @@
       <span class="heading">
         {{ group.display_name }}
         {% if group.state == 'deleted' %}
-          [{{ _('Deleted') }}]
+          <span class="badge bg-danger">{{ _('Deleted') }}</span>
         {% endif %}
       </span>
       {% endblock %}

--- a/ckan/templates-midnight-blue/organization/snippets/info.html
+++ b/ckan/templates-midnight-blue/organization/snippets/info.html
@@ -33,7 +33,7 @@
           {% block heading %}
           <span class="heading">{{ organization.title or organization.name }}
             {% if organization.state == 'deleted' %}
-              [{{ _('Deleted') }}]
+              <span class="badge bg-danger">{{ _('Deleted') }}</span>
             {% endif %}
           </span>
           {% endblock %}

--- a/ckan/templates-midnight-blue/package/read.html
+++ b/ckan/templates-midnight-blue/package/read.html
@@ -13,10 +13,10 @@
       {% block page_heading %}
         {{ h.dataset_display_name(pkg) }}
         {% if pkg.state.startswith('draft') %}
-          [{{ _('Draft') }}]
+          <span class="badge bg-info">{{ _('Draft') }}</span>
         {% endif %}
         {% if pkg.state == 'deleted' %}
-          [{{ _('Deleted') }}]
+          <span class="badge bg-danger">{{ _('Deleted') }}</span>
         {% endif %}
       {% endblock %}
     </h1>

--- a/ckan/templates-midnight-blue/package/snippets/search_results.html
+++ b/ckan/templates-midnight-blue/package/snippets/search_results.html
@@ -5,7 +5,7 @@
       <h1 class="page-heading {% if h.check_access('package_create') %}col-md-9{% endif %}">
         {{ heading }}
         {% if state == 'deleted' %}
-          [{{ _('Deleted') }}]
+          <span class="badge bg-danger">{{ _('Deleted') }}</span>
         {% endif %}
       </h1>
     {% endif %}


### PR DESCRIPTION
Replace `[{{ _('Deleted') }}]` with with proper badges, e.g. `<span class="badge bg-danger">{{ _('Deleted') }}</span>`

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

