### PR TITLE
fix midnight-blue: remove unused html classes

### DIFF
--- a/ckan/templates-midnight-blue/group/index.html
+++ b/ckan/templates-midnight-blue/group/index.html
@@ -9,7 +9,7 @@
 
 {% block content_action %}
   {% if h.check_access('group_create') %}
-    {% link_for h.humanize_entity_type('group', group_type, 'add link') or _('Add Group'), named_route=group_type+'.new', class_='btn btn-primary float-md-end', icon='plus-square' %}
+    {% link_for h.humanize_entity_type('group', group_type, 'add link') or _('Add Group'), named_route=group_type+'.new', class_='btn btn-primary', icon='plus-square' %}
   {% endif %}
 {% endblock %}
 

--- a/ckan/templates-midnight-blue/organization/index.html
+++ b/ckan/templates-midnight-blue/organization/index.html
@@ -8,7 +8,7 @@
 
 {% block content_action %}
   {% if h.check_access('organization_create') %}
-    {% link_for h.humanize_entity_type('organization', group_type, 'add link') or _('Add Organization'), named_route=group_type ~ '.new', class_='btn btn-primary float-md-end', icon='plus-square' %}
+    {% link_for h.humanize_entity_type('organization', group_type, 'add link') or _('Add Organization'), named_route=group_type ~ '.new', class_='btn btn-primary', icon='plus-square' %}
   {% endif %}
 {% endblock %}
 

--- a/ckan/templates-midnight-blue/package/snippets/search_results.html
+++ b/ckan/templates-midnight-blue/package/snippets/search_results.html
@@ -2,7 +2,7 @@
   <div class="module-content">
     <div class="row">
     {% if heading %}
-      <h1 class="page-heading {% if h.check_access('package_create') %}col-md-9{% endif %}">
+      <h1 class="page-heading">
         {{ heading }}
         {% if state == 'deleted' %}
           [{{ _('Deleted') }}]

--- a/ckan/templates-midnight-blue/snippets/add_dataset.html
+++ b/ckan/templates-midnight-blue/snippets/add_dataset.html
@@ -7,5 +7,5 @@
 {% if group %}
     {% link_for link_label, named_route=route_name, group=group, class_='btn btn-primary', icon='plus-square' %}
 {% else %}
-    {% link_for link_label, named_route=route_name, class_='btn btn-primary float-md-end', icon='plus-square' %}
+    {% link_for link_label, named_route=route_name, class_='btn btn-primary', icon='plus-square' %}
 {% endif %}


### PR DESCRIPTION
Remove unused classes in midnight blue

1. The float property is ignored on flex items
2. No reason to add col-md-9, as the Add dataset/Create org buttons were moved above at some point

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

