### PR TITLE
Declare WTF_CSRF_META_NAMEwq from flask-wtf v1.3.0

### DIFF
--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -779,6 +779,12 @@ groups:
           Set to False to disable Flask-Babel I18N support.
           Also set to False if you want to use WTForms’s built-in messages directly, see more info here.
 
+      - key: WTF_CSRF_META_NAME
+        flask: true
+        default: csrf-token
+        description: |
+          Value of the name attribute rendered by csrf_meta_tag().
+
   - annotation: Flask-Login Remember me cookie settings
     options:
       - key: REMEMBER_COOKIE_NAME

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -27,7 +27,7 @@ from werkzeug.exceptions import (
 from flask_babel import Babel
 
 from flask_login import LoginManager
-from flask_wtf.csrf import CSRFProtect, generate_csrf
+from flask_wtf.csrf import CSRFProtect, generate_csrf, csrf_meta_tag
 from ckan.common import current_user, config_declaration
 
 import ckan.model as model
@@ -97,11 +97,15 @@ class CSRFProtectPerRequest(CSRFProtect):
         )
         app.config.setdefault("WTF_CSRF_FIELD_NAME", "csrf_token")
         app.config.setdefault("WTF_CSRF_HEADERS", ["X-CSRFToken", "X-CSRF-Token"])
+        app.config.setdefault("WTF_CSRF_META_NAME", "csrf-token")
         app.config.setdefault("WTF_CSRF_TIME_LIMIT", 3600)
         app.config.setdefault("WTF_CSRF_SSL_STRICT", True)
 
         app.jinja_env.globals["csrf_token"] = generate_csrf
-        app.context_processor(lambda: {"csrf_token": generate_csrf})
+        app.context_processor(lambda: {
+            "csrf_token": generate_csrf,
+            "csrf_meta_tag": csrf_meta_tag,
+        })
 
         @app.before_request
         def csrf_protect(): # type: ignore


### PR DESCRIPTION
Fix for issue discovered in #9423 

We have custom wrapper around CSRF middleware. It was created for flask-wtf v1.2 and miss few lines added in v1.3. This PR adds those lines and declares new config option available in flask-wtf v1.3