### PR TITLE
Fix creating values in single-value autocomplete fields

### DIFF
--- a/ckan/public-midnight-blue/base/javascript/modules/autocomplete.js
+++ b/ckan/public-midnight-blue/base/javascript/modules/autocomplete.js
@@ -66,10 +66,19 @@ this.ckan.module('autocomplete', function (jQuery) {
       if (!this.el.is('select')) {
 
         settings.dataAdapter = this.dataAdapter();
-        if ( this.options.tags ){
-          var Utils = $.fn.select2.amd.require('select2/utils');
+
+        var Utils = $.fn.select2.amd.require('select2/utils');
+
+        // Providing a custom data adapter prevents Select2 from automatically
+        // installing its Tags adapter. Install it whenever creating new values
+        // is enabled, including for single-value autocomplete fields.
+        if (this.options.tags || this.options.createtags) {
           var Tags = $.fn.select2.amd.require('select2/data/tags');
           settings.dataAdapter = Utils.Decorate(settings.dataAdapter, Tags)
+        }
+
+        // The tags option controls multiple-value and tokenization behaviour.
+        if (this.options.tags) {
           settings.multiple = "multiple"
 
           // tokenizer is not applied when custom data adapter is used
@@ -81,7 +90,6 @@ this.ckan.module('autocomplete', function (jQuery) {
 
         // minimum input length is not applied when custom data adapter is used
         if (this.options.minimumInputLength > 0) {
-          var Utils = $.fn.select2.amd.require('select2/utils');
           var MinimumInputLength = $.fn.select2.amd.require('select2/data/minimumInputLength');
           settings.dataAdapter = Utils.Decorate(settings.dataAdapter, MinimumInputLength)
         }

--- a/ckan/public/base/javascript/modules/autocomplete.js
+++ b/ckan/public/base/javascript/modules/autocomplete.js
@@ -66,10 +66,19 @@ this.ckan.module('autocomplete', function (jQuery) {
       if (!this.el.is('select')) {
 
         settings.dataAdapter = this.dataAdapter();
-        if ( this.options.tags ){
-          var Utils = $.fn.select2.amd.require('select2/utils');
+
+        var Utils = $.fn.select2.amd.require('select2/utils');
+
+        // Providing a custom data adapter prevents Select2 from automatically
+        // installing its Tags adapter. Install it whenever creating new values
+        // is enabled, including for single-value autocomplete fields.
+        if (this.options.tags || this.options.createtags) {
           var Tags = $.fn.select2.amd.require('select2/data/tags');
           settings.dataAdapter = Utils.Decorate(settings.dataAdapter, Tags)
+        }
+
+        // The tags option controls multiple-value and tokenization behaviour.
+        if (this.options.tags) {
           settings.multiple = "multiple"
 
           // tokenizer is not applied when custom data adapter is used
@@ -81,7 +90,6 @@ this.ckan.module('autocomplete', function (jQuery) {
 
         // minimum input length is not applied when custom data adapter is used
         if (this.options.minimumInputLength > 0) {
-          var Utils = $.fn.select2.amd.require('select2/utils');
           var MinimumInputLength = $.fn.select2.amd.require('select2/data/minimumInputLength');
           settings.dataAdapter = Utils.Decorate(settings.dataAdapter, MinimumInputLength)
         }

--- a/cypress/e2e/modules/autocomplete.cy.js
+++ b/cypress/e2e/modules/autocomplete.cy.js
@@ -63,9 +63,16 @@ describe('ckan.modules.AutocompleteModule()', {testIsolation: false}, function (
 
   describe('.setupAutoComplete()', {testIsolation: false}, function () {
     it('should initialize the autocomplete plugin', function () {
-      cy.stub(this.module, 'dataAdapter')
+      var dataAdapter = {};
+      cy.stub(this.module, 'dataAdapter').returns(dataAdapter)
+
+      var Utils = this.select2.amd.require('select2/utils');
+      var Tags = this.select2.amd.require('select2/data/tags');
+      var decorate = cy.stub(Utils, 'Decorate').returns(dataAdapter)
+
       this.module.setupAutoComplete();
 
+      expect(decorate).to.be.calledWith(dataAdapter, Tags);
       expect(this.select2).to.be.called;
       expect(this.select2).to.be.calledWith({
         width: 'resolve',
@@ -78,10 +85,26 @@ describe('ckan.modules.AutocompleteModule()', {testIsolation: false}, function (
         },
         templateResult: this.module.templateResult,
         createTag: this.module.formatTerm,
-        dataAdapter: function () {}(),
-	      tokenSeparators: [','],
+        dataAdapter: dataAdapter,
+        tokenSeparators: [','],
         minimumInputLength: 0
       });
+    });
+
+    it('should not create new values if options.createtags is false', function () {
+      var dataAdapter = {};
+      cy.stub(this.module, 'dataAdapter').returns(dataAdapter)
+
+      var Utils = this.select2.amd.require('select2/utils');
+      var decorate = cy.spy(Utils, 'Decorate');
+
+      this.module.options.createtags = false;
+      this.module.setupAutoComplete();
+
+      var settings = this.select2.firstCall.args[0];
+      expect(decorate).not.to.be.called;
+      expect(settings.dataAdapter).to.equal(dataAdapter);
+      expect(settings.createTag({term: 'custom'})).to.be.undefined;
     });
 
     it('should initialize the autocomplete plugin with a multiple attribute if options.tags is true', function () {
@@ -114,6 +137,10 @@ describe('ckan.modules.AutocompleteModule()', {testIsolation: false}, function (
 
     it('should allow a custom css class to be added to the dropdown', function () {
       cy.stub(this.module, 'dataAdapter').returns({})
+
+      var Utils = this.select2.amd.require('select2/utils');
+      cy.stub(Utils, 'Decorate').returns({})
+
       this.module.options.dropdownClass = 'tags';
       this.module.setupAutoComplete();
 
@@ -137,6 +164,10 @@ describe('ckan.modules.AutocompleteModule()', {testIsolation: false}, function (
 
     it('should allow a custom css class to be added to the container', function () {
       cy.stub(this.module, 'dataAdapter').returns({})
+
+      var Utils = this.select2.amd.require('select2/utils');
+      cy.stub(Utils, 'Decorate').returns({})
+
       this.module.options.containerClass = 'tags';
       this.module.setupAutoComplete();
 


### PR DESCRIPTION
Generic single-value autocomplete fields previously allowed users to select a value that was not returned by the autocomplete API. After the Select2 4 migration, CKAN still defines createTag, but its custom data adapter is only decorated with Select2’s Tags adapter when the field uses the multi-value tags option. As a result, createTag is never called for single-value autocomplete fields.

Resource formats are single-value autocomplete fields, so enabling tags would incorrectly turn them into multi-value fields. This change installs the Tags data adapter whenever createtags is enabled, while keeping multiple-value and tokenization behavior exclusive to fields using tags.



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport

Please [X] all the boxes above that apply
