### PR TITLE
fix: fix resource social jinja block name

### DIFF
--- a/ckan/templates-midnight-blue/package/resource_read.html
+++ b/ckan/templates-midnight-blue/package/resource_read.html
@@ -188,7 +188,7 @@
     {% snippet "package/snippets/resources.html", pkg=pkg, active=res.id, action='read' %}
   {% endblock %}
 
-  {% block resource_license %}
+  {% block resource_social %}
     {% snippet "snippets/social.html" %}
   {% endblock %}
 {% endblock %}


### PR DESCRIPTION
Fix the name for the social block. By itself it doesn't break anything, but when the scheming is enabled, it uses the `resource_license` block name and it looks like that:

<img width="1238" height="416" alt="image" src="https://github.com/user-attachments/assets/37ced990-2eff-42c0-8e50-1972ed919233" />


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

