### PR TITLE
fix: resolve fixable Sass deprecation warnings in midnight-blue theme

### DIFF
--- a/ckan/public-midnight-blue/base/css/main-rtl.css
+++ b/ckan/public-midnight-blue/base/css/main-rtl.css
@@ -11932,7 +11932,7 @@ a.open-data span.suffix {
   padding: 1px 10px;
   border: 1px solid rgb(220.5, 220.5, 220.5);
   border-radius: 100px;
-  box-shadow: inset 0 1px 0 white;
+  box-shadow: inset 0 1px 0 hsl(0, 0%, 106.4705882353%);
 }
 
 a.tag:hover {
@@ -13108,8 +13108,6 @@ select[data-module=autocomplete] {
 .slug-preview {
   font-size: 14px;
   line-height: 1.5;
-  margin-top: 5px;
-  margin-left: 10px;
 }
 
 .slug-preview-value {

--- a/ckan/public-midnight-blue/base/css/main.css
+++ b/ckan/public-midnight-blue/base/css/main.css
@@ -11932,7 +11932,7 @@ a.open-data span.suffix {
   padding: 1px 10px;
   border: 1px solid rgb(220.5, 220.5, 220.5);
   border-radius: 100px;
-  box-shadow: inset 0 1px 0 white;
+  box-shadow: inset 0 1px 0 hsl(0, 0%, 106.4705882353%);
 }
 
 a.tag:hover {
@@ -13108,8 +13108,6 @@ select[data-module=autocomplete] {
 .slug-preview {
   font-size: 14px;
   line-height: 1.5;
-  margin-top: 5px;
-  margin-left: 10px;
 }
 
 .slug-preview-value {

--- a/ckan/public-midnight-blue/base/scss/_bootstrap-variables.scss
+++ b/ckan/public-midnight-blue/base/scss/_bootstrap-variables.scss
@@ -92,7 +92,7 @@ $secondary:     $gray-500 !default;
 $success:       $green !default;
 $info:          $cyan !default;
 $warning:       $yellow !default;
-$danger:        darken($red, 5%) !default;
+$danger:        color.adjust($red, $lightness: -5%) !default;
 $light:         $gray-100 !default;
 $dark:          $gray-900 !default;
 // scss-docs-end theme-color-variables
@@ -495,7 +495,7 @@ $headings-font-family:        null !default;
 $headings-font-style:         null !default;
 $headings-font-weight:        500 !default;
 $headings-line-height:        1.2 !default;
-$headings-color:              darken($brand-700, 5%) !default;
+$headings-color:              color.adjust($brand-700, $lightness: -5%) !default;
 // scss-docs-end headings-variables
 
 // scss-docs-start display-headings
@@ -1220,7 +1220,7 @@ $popover-arrow-width:               1rem !default;
 $popover-arrow-height:              .5rem !default;
 $popover-arrow-color:               $popover-bg !default;
 
-$popover-arrow-outer-color:         fade-in($popover-border-color, .05) !default;
+$popover-arrow-outer-color:         color.adjust($popover-border-color, $alpha: 0.05) !default;
 // scss-docs-end popover-variables
 
 

--- a/ckan/public-midnight-blue/base/scss/_bootstrap.scss
+++ b/ckan/public-midnight-blue/base/scss/_bootstrap.scss
@@ -5,6 +5,8 @@
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
  */
 
+@use "sass:color";
+
 // scss-docs-start import-stack
 // Configuration
 @import "../vendor/bootstrap/scss/functions";

--- a/ckan/public-midnight-blue/base/scss/_ckan.scss
+++ b/ckan/public-midnight-blue/base/scss/_ckan.scss
@@ -1,4 +1,5 @@
 @use "sass:math";
+@use "sass:color";
 @import "variables.scss";
 @import "custom.scss";
 @import "mixins.scss";

--- a/ckan/public-midnight-blue/base/scss/_dataset.scss
+++ b/ckan/public-midnight-blue/base/scss/_dataset.scss
@@ -332,7 +332,7 @@
         }
         &::-webkit-scrollbar-thumb {
             border-radius: 10px;
-            background-color: darken($navActiveBackgroundColor, 20%);
+            background-color: color.adjust($navActiveBackgroundColor, $lightness: -20%);
             &:hover {
                 background-color: $layoutLinkColor;
             }

--- a/ckan/public-midnight-blue/base/scss/_layout.scss
+++ b/ckan/public-midnight-blue/base/scss/_layout.scss
@@ -106,7 +106,7 @@
     // #gradient it breaks the filter property in IE7.
    @include rgba-vertial-gradient(rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0));
     background-color: $moduleHeadingBackgroundColor;
-    border-bottom: 1px solid darken($moduleHeadingBorderColor, 5%);
+    border-bottom: 1px solid color.adjust($moduleHeadingBorderColor, $lightness: -5%);
     @include border-radius(3px 3px 0 0);
     @include box-shadow(inset 0 -4px 0 rgba(0,0,0,0.03));
     .back:hover {

--- a/ckan/public-midnight-blue/base/scss/_masthead.scss
+++ b/ckan/public-midnight-blue/base/scss/_masthead.scss
@@ -32,7 +32,7 @@ $notificationsBg: #CF1322;
                     }
                     &:hover {
                         color: $white;
-                        background-color: darken($primary, 15%);
+                        background-color: color.adjust($primary, $lightness: -15%);
                         text-decoration: none;
                     }
                     &.sub {
@@ -44,7 +44,7 @@ $notificationsBg: #CF1322;
                     color: $black;
                     border: 1px solid #d0d5dd;
                     &:hover {
-                        background-color: darken($white, 15%);
+                        background-color: color.adjust($white, $lightness: -15%);
                     }
                 }
             }
@@ -55,14 +55,14 @@ $notificationsBg: #CF1322;
                     font-size: 12px;
                     margin-left: 3px;
                     padding: 1px 6px;
-                    background-color: darken($mastheadBackgroundColor, 15%);
+                    background-color: color.adjust($mastheadBackgroundColor, $lightness: -15%);
                     @include border-radius(4px);
                     text-shadow: none;
-                    color: mix($mastheadBackgroundColor, $mastheadLinkColor, 25%);
+                    color: color.mix($mastheadBackgroundColor, $mastheadLinkColor, 25%);
                 }
                 &:hover span {
                     color: $mastheadLinkColor;
-                    background-color: darken($mastheadBackgroundColor, 20%);
+                    background-color: color.adjust($mastheadBackgroundColor, $lightness: -20%);
                 }
             }
             &.notifications-important a {

--- a/ckan/public-midnight-blue/base/scss/_media.scss
+++ b/ckan/public-midnight-blue/base/scss/_media.scss
@@ -4,7 +4,7 @@
     padding-left: 0px;
     min-height: 205px;
     padding-top: math.div($grid-gutter-width, 2);
-    background: lighten($layoutBackgroundColor, 5%);
+    background: color.adjust($layoutBackgroundColor, $lightness: 5%);
     border: 1px solid $moduleHeadingBorderColor;
     border-width: 1px 0;
 }

--- a/ckan/public-midnight-blue/base/scss/_mixins.scss
+++ b/ckan/public-midnight-blue/base/scss/_mixins.scss
@@ -30,7 +30,7 @@
 }
 // Allows use of rgba() in gradients. This will not provide a fallback for IE.
 @mixin rgba-vertial-gradient($startColor: #555, $endColor: #333) {
-    background-color: mix($startColor, $endColor, 60%);
+    background-color: color.mix($startColor, $endColor, 60%);
     background-image: -moz-linear-gradient(top, $startColor, $endColor); // FF 3.6+
     background-image: -ms-linear-gradient(top, $startColor, $endColor); // IE10
     background-image: -webkit-gradient(linear, 0 0, 0 100%, from($startColor), to($endColor)); // Safari 4+, Chrome 2+
@@ -41,7 +41,7 @@
 }
 
 @mixin rgba-vertical-gradient-three-colors($startColor: #00b3ee, $midColor: #7a43b6, $colorStop: 50%, $endColor: #c3325f) {
-    background-color: mix($midColor, $endColor, 80%);
+    background-color: color.mix($midColor, $endColor, 80%);
     background-image: -webkit-gradient(linear, 0 0, 0 100%, from($startColor), color-stop($colorStop, $midColor), to($endColor));
     background-image: -webkit-linear-gradient($startColor, $midColor $colorStop, $endColor);
     background-image: -moz-linear-gradient(top, $startColor, $midColor $colorStop, $endColor);
@@ -81,17 +81,17 @@
     color: $tabTextColor;
     background-color: $tagBackgroundColor;
     padding: 1px 10px;
-    border: 1px solid darken($tagBackgroundColor, 10%);
+    border: 1px solid color.adjust($tagBackgroundColor, $lightness: -10%);
     @include border-radius(100px);
-    @include box-shadow(inset 0 1px 0 lighten($tagBackgroundColor, 10%));
+    @include box-shadow(inset 0 1px 0 color.adjust($tagBackgroundColor, $lightness: 10%));
 }
 
 a.tag:hover {
     text-decoration: none;
     color: #fff;
     background-color: $btnPrimaryBackground;
-    border: 1px solid darken($btnPrimaryBackground, 10%);
-    @include box-shadow(inset 0 1px 0 lighten($btnPrimaryBackground, 10%));
+    border: 1px solid color.adjust($btnPrimaryBackground, $lightness: -10%);
+    @include box-shadow(inset 0 1px 0 color.adjust($btnPrimaryBackground, $lightness: 10%));
 }
 
 .pill {

--- a/ckan/public-midnight-blue/base/scss/_variables.scss
+++ b/ckan/public-midnight-blue/base/scss/_variables.scss
@@ -45,7 +45,7 @@ $navItemActiveBackgroundColor: $gray-500;
 $navItemActiveArrowSize: $spacer-1;
 
 $pillTextColor: $navItemActiveTextColor;
-$pillBackgroundColor: darken($navItemActiveBackgroundColor, 10%);
+$pillBackgroundColor: color.adjust($navItemActiveBackgroundColor, $lightness: -10%);
 
 $footerBackgroundColor: $brand-700;
 $footerTextColor: $white;
@@ -64,7 +64,7 @@ $highlightHoverBackground: #fdf3d9;
 // Forms
 
 $errorText: #b55457;
-$errorBackground: lighten(#a2191f, 30%);
+$errorBackground: color.adjust(#a2191f, $lightness: 30%);
 $errorBorder: #a2191f;
 
 $formInfoText: #707070;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,7 +39,10 @@ const buildMidnightBlue = () =>
     __dirname + "/ckan/public-midnight-blue/base/scss/main-rtl.scss",
     ])
     .pipe(if_(with_sourcemaps(), sourcemaps.init()))
-    .pipe(sass({ outputStyle: 'expanded' }).on('error', sass.logError))
+    .pipe(sass({
+        outputStyle: 'expanded',
+        silenceDeprecations: ['import', 'if-function', 'global-builtin', 'color-functions'] }
+    ).on('error', sass.logError))
     .pipe(if_(with_sourcemaps(), sourcemaps.write()))
     .pipe(rename(renamer))
     .pipe(dest(__dirname + "/ckan/public-midnight-blue/base/css/"));


### PR DESCRIPTION
Fix warnings that we can fix right now; others will probably be fixed during bootstrap 6 migration (if it happens). Hide other warnings, as they are very verbose and do not help at all during work on styles.

<img width="1182" height="1288" alt="image" src="https://github.com/user-attachments/assets/08c297ec-302a-44f4-954f-a9a1d606fae4" />
