### PR TITLE
no create org permission by default

### DIFF
--- a/changes/9456.misc
+++ b/changes/9456.misc
@@ -1,0 +1,1 @@
+ckan.auth.user_create_organizations is now false by default

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -549,7 +549,7 @@ groups:
 
       - key: ckan.auth.user_create_organizations
         type: bool
-        default: true
+        default: false
         example: "false"
         description: Allow users to create organizations.
 


### PR DESCRIPTION
normal ckan users, even with new accounts and no special permissions, can create orgs and become admins of those orgs by default

### Proposed fixes:
- set `ckan.auth.user_create_organizations` to false by default

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

