### PR TITLE
Fix devcontainer Python variant parsing and Codespaces setup/startup issues

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Python version: 3, 3.8, 3.7, 3.6
-ARG VARIANT=3
+# [Choice] Python version: 3.10, 3.9, 3.8, 3.7, 3.6
+ARG VARIANT=3.10
 FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
 
 ENV PYTHONUNBUFFERED 1
@@ -18,6 +18,7 @@ RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/
 # RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
 #    && rm -rf /tmp/pip-tmp
 
- RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-     && apt-get -y install --no-install-recommends \
-     postgresql-client
+RUN rm -f /etc/apt/sources.list.d/yarn.list /etc/apt/sources.list.d/yarn*.list /etc/apt/sources.list.d/yarn*.sources \
+    && apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+    postgresql-client

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,9 @@
-// Update the VARIANT arg in docker-compose.yml to pick a Python version: 3, 3.8, 3.7, 3.6
+// Update the VARIANT arg in docker-compose.yml to pick a Python version: 3.10, 3.9, 3.8, 3.7, 3.6
 {
 	"name": "CKAN 2.10",
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "ckan",
-	"workspaceFolder": "/workspace",
+	"workspaceFolder": "/workspaces/ckan",
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
@@ -55,7 +55,7 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"onCreateCommand": "pip install --user -r requirements.txt && pip install --user -r dev-requirements.txt",
 	"postCreateCommand": "./.devcontainer/setup.sh",
-	"postAttachCommand": "ckan run",
+	"postAttachCommand": "ckan run --host 0.0.0.0 --port 5000",
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,8 +6,8 @@ services:
       context: ..
       dockerfile: .devcontainer/Dockerfile
       args:
-        # [Choice] Python version: 3, 3.8, 3.7, 3.6
-        VARIANT: 3.9
+        # [Choice] Python version: 3.10, 3.9, 3.8, 3.7, 3.6
+        VARIANT: "3.10"
         # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
         NODE_VERSION: "lts/*"
         # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
@@ -15,7 +15,7 @@ services:
         USER_GID: 1000
 
     volumes:
-      - ..:/workspace:cached
+      - ..:/workspaces/ckan:cached
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -5,8 +5,8 @@ python setup.py develop --user
 ckan generate config ckan.ini
 
 # Set up storage
-mkdir /workspace/data
-ckan config-tool ckan.ini ckan.storage_path=/workspace/data
+mkdir -p /workspaces/ckan/data
+ckan config-tool ckan.ini ckan.storage_path=/workspaces/ckan/data
 
 # Set up site URL
 ckan config-tool ckan.ini ckan.site_url=https://$CODESPACE_NAME-5000.$GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN
@@ -15,8 +15,12 @@ ckan config-tool ckan.ini ckan.site_url=https://$CODESPACE_NAME-5000.$GITHUB_COD
 ckan db init
 
 # Create sysadmin user
-ckan user add ckan_admin email=admin@example.com password=test1234
-ckan sysadmin add ckan_admin
+if ! ckan user list | grep -q '^name=ckan_admin$'; then
+    ckan user add ckan_admin email=admin@example.com password=test1234
+fi
+if ! ckan sysadmin list | grep -q 'name=ckan_admin '; then
+    ckan sysadmin add ckan_admin
+fi
 
 # Set up DataStore + DataPusher
 ckan config-tool ckan.ini "ckan.datapusher.api_token=$(ckan user token add ckan_admin datapusher | tail -n 1 | tr -d '\t')"


### PR DESCRIPTION
## Summary
- Quote `VARIANT` as `"3.10"` in `.devcontainer/docker-compose.yml` so YAML does not coerce it to `3.1`
- Set Dockerfile default `VARIANT` to `3.10`
- Fix setup storage path to `/workspaces/ckan/data` (writable in Codespaces)
- Make admin creation in `.devcontainer/setup.sh` idempotent to avoid interactive hangs
- Start CKAN on attach with `--host 0.0.0.0 --port 5000` for reliable Codespaces forwarding

## Problem
Codespaces container creation failed because Docker tried to pull `mcr.microsoft.com/vscode/devcontainers/python:3.1`. YAML numeric coercion turned `3.10` into `3.1` when unquoted. Subsequent setup issues also caused permission errors and interactive prompts.

## Verification
- Confirmed `VARIANT` is now a quoted string in compose config
- Confirmed setup script syntax is valid (`bash -n .devcontainer/setup.sh`)
- Confirmed CKAN responds locally on port 5000 and can run bound to `0.0.0.0`
