### PR TITLE
Fix CORS headers for fetch preflight requests

### DIFF
--- a/ckan/tests/lib/test_base.py
+++ b/ckan/tests/lib/test_base.py
@@ -415,6 +415,29 @@ def test_cors_config_custom_auth_header(app):
     )
 
 
+@pytest.mark.ckan_config("ckan.cors.origin_allow_all", "true")
+@pytest.mark.ckan_config("ckan.site_url", "http://test.ckan.org")
+@pytest.mark.ckan_config("apitoken_header_name", "X-CKAN-API-KEY")
+@pytest.mark.ckan_config("ckan.plugins", "test_blueprint_plugin")
+@pytest.mark.usefixtures("with_plugins")
+def test_cors_config_includes_fetch_normalized_headers(app):
+    """
+    CORS preflight responses should include lower-case header names used by
+    fetch when it normalizes the requested headers.
+    """
+    request_headers = {
+        "Origin": "http://thirdpartyrequests.org",
+        "Access-Control-Request-Headers": "x-ckan-api-key, content-type",
+    }
+    response = app.options("/simple_url", headers=request_headers)
+    response_headers = dict(response.headers)
+
+    assert (
+        response_headers["Access-Control-Allow-Headers"]
+        == "X-CKAN-API-KEY, Content-Type, x-ckan-api-key, content-type"
+    )
+
+
 @pytest.mark.ckan_config("ckan.cors.origin_allow_all", "false")
 @pytest.mark.ckan_config(
     "ckan.cors.origin_whitelist", "http://google.com http://yahoo.co.uk"

--- a/ckan/views/__init__.py
+++ b/ckan/views/__init__.py
@@ -34,8 +34,14 @@ def set_cors_headers_for_response(response: Response) -> Response:
                 cors_origin_allowed
             response.headers['Access-Control-Allow-Methods'] = \
                 'POST, PUT, GET, DELETE, OPTIONS'
+            apitoken_header_name = config.get("apitoken_header_name")
+            allowed_headers = [apitoken_header_name, "Content-Type"]
+            if request.headers.get("Access-Control-Request-Headers"):
+                allowed_headers.extend(
+                    header.lower() for header in allowed_headers.copy()
+                )
             response.headers['Access-Control-Allow-Headers'] = \
-                f'{config.get("apitoken_header_name")}, Content-Type'
+                ", ".join(dict.fromkeys(allowed_headers))
 
     return response
 


### PR DESCRIPTION
## What does this PR do?

Fixes CORS preflight responses for JavaScript `fetch` requests whose header names are normalized to lower case.

When `Access-Control-Request-Headers` is present, the response now advertises lower-case variants of the configured `apitoken_header_name` and `Content-Type`, while retaining the existing header values and order. Ordinary CORS responses keep their previous behavior.

## Why is this needed?

The Fetch API can normalize requested header names to lower case. The existing `Access-Control-Allow-Headers` value only contained the configured casing, which caused browsers or web engines to reject otherwise valid preflight requests.

## Testing

- Added a regression test covering a preflight with `x-ckan-api-key, content-type`.
- Focused CORS suite: 18 passed, 11 deselected.
- New regression test: passed.
- Python compilation check passed.
- `git diff --check` passed.

Closes #9448

*This PR was prepared with Codex using GPT-5.6 Luna (Extra High), under the supervision of jmtdev0.*