### PR TITLE
Fix tracking summary on dataset history resources

### DIFF
--- a/ckanext/activity/tests/test_views.py
+++ b/ckanext/activity/tests/test_views.py
@@ -703,6 +703,47 @@ class TestPackage:
         )
         assert helpers.body_contains(response, "Original title")
 
+    @pytest.mark.with_plugins("tracking")
+    def test_read_dataset_as_it_used_to_be_with_tracking(self, app):
+        dataset = factories.Dataset(title="Dataset title")
+        resource = factories.Resource(package_id=dataset["id"])
+        activity = (
+            model.Session.query(Activity)
+            .filter_by(object_id=dataset["id"])
+            .order_by(Activity.timestamp.desc())
+            .limit(1)
+            .one()
+        )
+
+        # Older activity snapshots do not contain the optional tracking fields.
+        archived_package = dict(activity.data["package"])
+        archived_package.pop("tracking_summary", None)
+        archived_package["resources"] = [
+            {
+                key: value
+                for key, value in archived_resource.items()
+                if key != "tracking_summary"
+            }
+            for archived_resource in archived_package["resources"]
+        ]
+        assert archived_package["resources"]
+        assert "tracking_summary" not in archived_package["resources"][0]
+        activity.data = {**activity.data, "package": archived_package}
+        model.repo.commit()
+
+        sysadmin = factories.SysadminWithToken()
+        headers = {"Authorization": sysadmin["token"]}
+        response = app.get(
+            url_for(
+                "activity.package_history",
+                id=dataset["name"],
+                activity_id=activity.id,
+            ),
+            headers=headers,
+        )
+        assert response.status_code == 200
+        assert helpers.body_contains(response, resource["name"])
+
     def test_read_dataset_as_it_used_to_be_but_is_unmigrated(self, app):
         # Renders the dataset using the activity detail, when that Activity was
         # created with an earlier version of CKAN, and it has not been migrated

--- a/ckanext/tracking/templates/package/snippets/resource_item.html
+++ b/ckanext/tracking/templates/package/snippets/resource_item.html
@@ -2,5 +2,5 @@
 
 {% block resource_item_title %}
 {{ super() }}
-{{ h.popular('views', res.tracking_summary.total, min=10) }}
+{{ h.popular('views', res.tracking_summary.total, min=10) if res.tracking_summary }}
 {% endblock %}


### PR DESCRIPTION
<details>

<summary>AI Disclaimer</summary>

This pull request was primarily by OpenAI Codex, an AI coding agent. For this PR, Codex analyzed issue #9459, inspected the relevant CKAN code, implemented the fix, added the regression test, and ran the reported validation commands under the supervision of `jmtdev0`.

Human involvement in this PR was very low.

If you do not agree with the use of AI assistance or with the level of human involvement in this PR, please feel free to disregard it, close it, or request changes. I will fully respect that decision.

</details>

## Summary

- Guard the optional `tracking_summary` field in the tracking resource snippet.
- Add a regression test for dataset history snapshots that contain resources without tracking metadata.

## Context

When the tracking plugin renders a historical dataset snapshot, archived resource dictionaries may not contain `tracking_summary`. The resource snippet dereferenced the field unconditionally, causing an HTTP 500 while rendering the history page.

The fix keeps the existing popularity marker for normal enriched resources and skips it when the optional metadata is absent.

## Testing

- Focused regression test: 1 passed.
- Activity view tests: 56 passed.
- Existing tracking-summary tests: 2 passed, 13 deselected.
- `git diff --check`: passed.
- The full tracking module remains affected by 12 pre-existing failures caused by an `update_all` signature mismatch in this checkout; 3 tests passed.

Fixes #9459
