### PR TITLE
a11y: add accessible name to resource actions dropdown button (refs #7188)

### DIFF
--- a/changes/7188.bugfix
+++ b/changes/7188.bugfix
@@ -1,0 +1,1 @@
+Add an accessible name to the resource actions dropdown button (the icon-only "wrench" toggle in the resource list) so it has discernible text for screen readers, fixing a WCAG 4.1.2 button-name issue.

--- a/ckan/templates/package/snippets/resources.html
+++ b/ckan/templates/package/snippets/resources.html
@@ -32,7 +32,7 @@ Example:
                 <li class="nav-item d-flex justify-content-between position-relative">
                   <a class="flex-fill" href="{{ url }}" aria-label="{{ _('Navigate to resource: {name}').format(name=h.resource_display_name(resource)) }}">{{ h.resource_display_name(resource)|truncate(25) }}</a>
                   <div class="dropdown position-absolute end-0 me-2">
-                    <button class="btn btn-secondary btn-sm dropdown-toggle" type="button" id="dropdownRes{{ loop.index }}" data-bs-toggle="dropdown" aria-expanded="false"><i class="fa fa-wrench"></i></button>
+                    <button class="btn btn-secondary btn-sm dropdown-toggle" type="button" id="dropdownRes{{ loop.index }}" data-bs-toggle="dropdown" aria-expanded="false" aria-label="{{ _('Manage resource: {name}').format(name=h.resource_display_name(resource)) }}"><i class="fa fa-wrench" aria-hidden="true"></i></button>
                     <ul class="dropdown-menu" aria-labelledby="dropdownRes{{ loop.index }}">
                       <li>{% link_for _('Edit resource'), named_route=pkg.type ~ '_resource.edit', id=pkg.name, resource_id=resource.id, class_='dropdown-item', icon='pencil' %}</li>
                       {% block resources_list_edit_dropdown_inner scoped %}{% endblock %}


### PR DESCRIPTION
Refs #7188 (dropdown buttons lacking discernible text).

## What

The resource-actions dropdown toggle in the resource list (`ckan/templates/package/snippets/resources.html`) is icon-only:

```html
<button class="btn btn-secondary btn-sm dropdown-toggle" ...><i class="fa fa-wrench"></i></button>
```

It has no accessible name, so screen readers announce it as just "button", with no indication of its purpose or which resource it controls.

- WCAG 4.1.2 Name, Role, Value (button-name)

**Note on #7188:** that report pointed at a resource download button that has since gained a visible text label (the current "Explore" and "New view" dropdown buttons both have text). This PR fixes a remaining instance of the same button-name issue: the icon-only "wrench" actions toggle in the resource list.

## Change

- Add `aria-label` to the toggle, following the pattern already used by the adjacent resource link (`_('Navigate to resource: {name}')`), so the name is translatable and includes the resource name for context.
- Mark the decorative icon `aria-hidden="true"`.
- Add a changelog fragment (`changes/7188.bugfix`).

Non-visual change; no layout or styling impact.
