### PR TITLE
a11y: set lang attribute on language selector options (fixes #7198)

### DIFF
--- a/changes/7198.bugfix
+++ b/changes/7198.bugfix
@@ -1,0 +1,1 @@
+Add a ``lang`` attribute to each option in the language selector so assistive technologies announce each language name using that language's pronunciation (WCAG 3.1.2 Language of Parts).

--- a/ckan/templates/snippets/language_selector.html
+++ b/ckan/templates/snippets/language_selector.html
@@ -5,7 +5,7 @@
     <label for="field-lang-select">{{ _('Language') }}</label>
     <select id="field-lang-select" name="url" data-module="autocomplete" data-module-dropdown-class="lang-dropdown" data-module-container-class="lang-container">
       {% for locale in h.get_available_locales() %}
-        <option value="{% url_for h.current_url(), locale=locale.short_name %}" {% if locale.short_name == current_lang %}selected="selected"{% endif %}>
+        <option value="{% url_for h.current_url(), locale=locale.short_name %}" lang="{{ locale.short_name.replace('_', '-') }}" {% if locale.short_name == current_lang %}selected="selected"{% endif %}>
           {{ locale.display_name or locale.english_name }}
         </option>
       {% endfor %}


### PR DESCRIPTION
Fixes #7198.

## What

Each `<option>` in the language selector (`ckan/templates/snippets/language_selector.html`) shows a language's name in that language, e.g. "Deutsch", "Português (Brasil)", "日本語". But the options have no `lang` attribute, so a screen reader announces every name using the page's language (typically English). This fails **WCAG 3.1.2 Language of Parts**.

## Change

Add `lang` to each option. CKAN's `locale.short_name` uses underscores (e.g. `pt_BR`), while the HTML `lang` attribute expects BCP-47 hyphenated tags (`pt-BR`), so the value is converted with `.replace('_', '-')`:

```html
<option value="..." lang="{{ locale.short_name.replace('_', '-') }}" ...>
```

Plain codes like `en`/`de` are unaffected; region/script variants like `pt_BR`/`zh_CN`/`sr_Latn` become valid `pt-BR`/`zh-CN`/`sr-Latn`.

Includes a changelog fragment (`changes/7198.bugfix`). Non-visual change; no layout or styling impact.
