### PR TITLE
a11y: add accessible names to icon-only search and copy buttons (refs #7188)

### DIFF
--- a/changes/9471.bugfix
+++ b/changes/9471.bugfix
@@ -1,0 +1,1 @@
+Add accessible names to the icon-only user-search submit button and the API-token "copy to clipboard" button so screen readers announce them with discernible text (WCAG 4.1.2).

--- a/ckan/templates/user/snippets/api_token_create_form.html
+++ b/ckan/templates/user/snippets/api_token_create_form.html
@@ -30,7 +30,7 @@
               </code>
             </label>
           </div>
-          {% set copy_button %}<button class="btn btn-secondary btn-xs" data-module="copy-into-buffer" data-module-copy-value="{{ created.token }}" type="button"><i class="fa fa-copy"></i></button>{% endset %}
+          {% set copy_button %}<button class="btn btn-secondary btn-xs" data-module="copy-into-buffer" data-module-copy-value="{{ created.token }}" type="button" aria-label="{{ _('Copy to clipboard') }}"><i class="fa fa-copy" aria-hidden="true"></i></button>{% endset %}
           {{ _("API Token created: <code style=\"word-break:break-all;\">"
                "{token}</code> {copy}<br>"
                "Make sure to copy it now, "

--- a/ckan/templates/user/snippets/user_search.html
+++ b/ckan/templates/user/snippets/user_search.html
@@ -4,7 +4,7 @@
     <div class="field">
       <label for="field-user-search">{{ _('Search Users') }}</label>
       <input id="field-user-search" value="{{ q }}" class="field form-control" name="q" placeholder="{{ _('Search') }}" />
-      <button class="btn-search" type="submit"><i class="fa fa-search"></i></button>
+      <button class="btn-search" type="submit" aria-label="{{ _('Search') }}"><i class="fa fa-search" aria-hidden="true"></i></button>
     </div>
   </form>
   <ul class="nav nav-simple">


### PR DESCRIPTION
Refs #7188 (buttons need discernible text).

## What

Two icon-only buttons have no accessible name, so screen readers announce them only as "button" (WCAG 4.1.2 Name, Role, Value):

- `ckan/templates/user/snippets/user_search.html` — the search submit button (`fa-search`). The search *input* has a label, but the submit button does not.
- `ckan/templates/user/snippets/api_token_create_form.html` — the "copy to clipboard" button shown for a newly created API token (`fa-copy`).

## Change

Add a translatable `aria-label` to each button and mark the decorative icons `aria-hidden="true"`.

This continues the button-name work referenced in #7188 (see also #9469, which fixed the resource-actions toggle). Includes a changelog fragment. Non-visual change; no layout or styling impact.
