### PR TITLE
Replace bleach with nh3

### DIFF
--- a/changes/9472.misc
+++ b/changes/9472.misc
@@ -1,0 +1,1 @@
+HTML cleaning is done with ``nh3`` instead of ``bleach`` from now on. More tags and attributes are allowed by default and ``clean_html`` now strips unknown tags instead of escaping HTML-entities.

--- a/changes/9472.misc
+++ b/changes/9472.misc
@@ -1,1 +1,3 @@
-HTML cleaning is done with ``nh3`` instead of ``bleach`` from now on. More tags and attributes are allowed by default and ``clean_html`` now strips unknown tags instead of escaping HTML-entities.
+HTML cleaning is done with ``nh3`` instead of ``bleach`` from now on. 
+More tags and attributes are allowed by default and ``clean_html`` now strips unknown tags instead of escaping HTML-entities.
+``render_markdown`` with ``allow_html=False`` now strips ``script`` and ``style`` tags alongside with  their content; previously, only the tag was removed, while content was kept.

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -29,7 +29,7 @@ from typing import (
 
 import dominate.tags as dom_tags
 from markdown import markdown
-from bleach import clean as bleach_clean, ALLOWED_TAGS, ALLOWED_ATTRIBUTES
+from nh3 import clean as nh3_clean, ALLOWED_TAGS, ALLOWED_ATTRIBUTES
 from ckan.common import asbool, config, current_user
 from flask import flash, has_request_context, current_app
 from flask import get_flashed_messages as _flask_get_flashed_messages
@@ -67,14 +67,11 @@ Helper = TypeVar("Helper", bound=Callable[..., Any])
 
 log = logging.getLogger(__name__)
 
-MARKDOWN_TAGS = set([
-    'del', 'dd', 'dl', 'dt', 'h1', 'h2',
-    'h3', 'img', 'kbd', 'p', 'pre', 's',
-    'sup', 'sub', 'strike', 'br', 'hr'
-]).union(ALLOWED_TAGS)
+MARKDOWN_TAGS = copy.copy(ALLOWED_TAGS)
 
 MARKDOWN_ATTRIBUTES = copy.deepcopy(ALLOWED_ATTRIBUTES)
-MARKDOWN_ATTRIBUTES.setdefault('img', []).extend(['src', 'alt', 'title'])
+MARKDOWN_ATTRIBUTES['img'].add('title')
+MARKDOWN_ATTRIBUTES['a'].add('title')
 
 LEGACY_ROUTE_NAMES = {
     'home': 'home.index',
@@ -1406,7 +1403,7 @@ def markdown_extract(text: str,
     will not be truncated.'''
     if not text:
         return ''
-    plain = bleach_clean(markdown(text), tags=(), strip=True)
+    plain = nh3_clean(markdown(text), tags=set())
     if not extract_length or len(plain) < extract_length:
         return literal(plain)
     return literal(
@@ -2267,8 +2264,8 @@ def render_markdown(data: str,
     if allow_html:
         data = markdown(data.strip())
     else:
-        data = bleach_clean(
-            markdown(data), strip=True,
+        data = nh3_clean(
+            markdown(data),
             tags=MARKDOWN_TAGS,
             attributes=MARKDOWN_ATTRIBUTES)
     # tags can be added by tag:... or tag:"...." and a link will be made
@@ -2760,7 +2757,7 @@ def mail_to(email_address: str, name: str) -> Markup:
 
 @core_helper
 def clean_html(html: Any) -> str:
-    return bleach_clean(str(html))
+    return nh3_clean(str(html))
 
 
 core_helper(flash, name='flash')

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -283,7 +283,7 @@ class TestHelpersRenderMarkdown(object):
                 u'<ul>\n<li>[Foo (<a href="http://foo.bar" target="_blank" rel="nofollow">http://foo.bar</a>) * Bar] (<a href="http://foo.bar" target="_blank" rel="nofollow">http://foo.bar</a>)</li>\n</ul>',
                 False,
             ),
-            (u"[text](javascript: alert(1))", u"<p><a>text</a></p>", False),
+            (u"[text](javascript: alert(1))", '<p><a rel="noopener noreferrer>text</a></p>', False),
             (
                 u'<p onclick="some.script"><img onmouseover="some.script" src="image.png" /> and text</p>',
                 '<p><img src="image.png"> and text</p>',
@@ -309,7 +309,7 @@ class TestHelpersRenderMarkdown(object):
             ),
             (
                 u"[link](/url?a=1&b=2)",
-                u'<p><a href="/url?a=1&amp;b=2">link</a></p>',
+                u'<p><a href="/url?a=1&amp;b=2" rel="noopener noreferrer">link</a></p>',
                 False,
             ),
             (
@@ -383,7 +383,7 @@ class TestHelpersRenderMarkdown(object):
             ),
             (
                 "<a href=\u201dsomelink\u201d>somelink</a>",
-                '<p><a href="\u201dsomelink\u201d">somelink</a></p>',
+                '<p><a href="\u201dsomelink\u201d" rel="noopener noreferrer">somelink</a></p>',
                 False,
             ),
         ],
@@ -565,7 +565,7 @@ def test_time_ago_from_timestamp(date, exp):
 
 
 def test_clean_html_disallowed_tag():
-    assert h.clean_html("<b><bad-tag>Hello") == u"<b>&lt;bad-tag&gt;Hello</b>"
+    assert h.clean_html("<b><bad-tag>Hello") == u"<b>Hello</b>"
 
 
 def test_clean_html_non_string():

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -261,8 +261,8 @@ class TestHelpersRenderMarkdown(object):
     @pytest.mark.parametrize(
         "data,output,allow_html",
         [
-            ("<foo>moo</foo>", "<foo>moo</foo>", True),
-            ("<foo>moo</foo>", "moo", False),
+            ("<foo>moo</foo>", "<p><foo>moo</foo></p>", True),
+            ("<foo>moo</foo>", "<p>moo</p>", False),
             ("<script>moo</script>", "", False), # script and style tags are removed with content by nh3
             (
                 "http://example.com",

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -261,8 +261,9 @@ class TestHelpersRenderMarkdown(object):
     @pytest.mark.parametrize(
         "data,output,allow_html",
         [
-            ("<script>moo</script>", "<script>moo</script>", True),
-            ("<script>moo</script>", "moo", False),
+            ("<foo>moo</foo>", "<foo>moo</foo>", True),
+            ("<foo>moo</foo>", "moo", False),
+            ("<script>moo</script>", "", False), # script and style tags are removed with content by nh3
             (
                 "http://example.com",
                 '<p><a href="http://example.com" target="_blank" rel="nofollow">http://example.com</a></p>',
@@ -283,7 +284,7 @@ class TestHelpersRenderMarkdown(object):
                 u'<ul>\n<li>[Foo (<a href="http://foo.bar" target="_blank" rel="nofollow">http://foo.bar</a>) * Bar] (<a href="http://foo.bar" target="_blank" rel="nofollow">http://foo.bar</a>)</li>\n</ul>',
                 False,
             ),
-            (u"[text](javascript: alert(1))", '<p><a rel="noopener noreferrer>text</a></p>', False),
+            (u"[text](javascript: alert(1))", '<p><a rel="noopener noreferrer">text</a></p>', False),
             (
                 u'<p onclick="some.script"><img onmouseover="some.script" src="image.png" /> and text</p>',
                 '<p><img src="image.png"> and text</p>',

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,6 @@
 # Use pip-compile to create a requirements.txt file from this
 alembic==1.18.5
 Babel==2.18.0
-bleach==6.4.0
 blinker==1.9.0
 certifi
 click==8.4.2
@@ -17,6 +16,7 @@ Flask-WTF==1.3.0
 Jinja2==3.1.6
 Markdown==3.10.2
 msgspec==0.21.1
+nh3==0.3.6
 packaging==26.2
 passlib==1.7.4
 polib==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,6 @@ babel==2.18.0
     # via
     #   -r requirements.in
     #   flask-babel
-bleach==6.4.0
-    # via -r requirements.in
 blinker==1.9.0
     # via
     #   -r requirements.in
@@ -84,6 +82,8 @@ msgspec==0.21.1
     # via
     #   -r requirements.in
     #   flask-session
+nh3==0.3.6
+    # via -r requirements.in
 packaging==26.2
     # via -r requirements.in
 passlib==1.7.4
@@ -152,8 +152,6 @@ watchdog==6.0.0
     # via werkzeug
 webassets==3.0.0
     # via -r requirements.in
-webencodings==0.5.1
-    # via bleach
 werkzeug[watchdog]==3.1.8
     # via
     #   -r requirements.in


### PR DESCRIPTION
[Bleach is no longer maintained](https://github.com/mozilla/bleach/issues/698). 

There is one library that resembles bleach API, [nh3](https://nh3.readthedocs.io/en/latest/). There are some distinctions, but generally it fits into CKAN as we are using bleach sparingly.

The main risk is the fact that nh3 is not written in python, and instead it provides bindings for the rust library and is built with maturin. From my experience, maturin provides decent support for platforms and looks like there are enough wheels available on pypi to work without extra steps on popular Linux distros such as ubuntu, centos, AWS linux, arch, debian, etc (and MacOS + Windows, btw). 
Users of unsupported distors may be required to install rust compiler in order to build this library, but I was unable to identify any popular image of linux that would require such step, so it should not be a frequent scenario.

Apart from that, there is a number of differences, that will be observed unless we deliberately replicate behavior of bleach. Here's the changes that I identified:

### nh3 allows more tags by default

Bleach allows 12 tags: `['a', 'abbr', 'acronym', 'b', 'blockquote', 'code', 'em', 'i', 'li', 'ol', 'strong', 'ul']`

nh3 allows 75 tags: `['a', 'abbr', 'acronym', 'area', 'article', 'aside', 'b', 'bdi', 'bdo', 'blockquote', 'br', 'caption', 'center', 'cite', 'code', 'col', 'colgroup', 'data', 'dd', 'del', 'details', 'dfn', 'div', 'dl', 'dt', 'em', 'figcaption', 'figure', 'footer', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'hgroup', 'hr', 'i', 'img', 'ins', 'kbd', 'li', 'map', 'mark', 'nav', 'ol', 'p', 'pre', 'q', 'rp', 'rt', 'rtc', 'ruby', 's', 'samp', 'small', 'span', 'strike', 'strong', 'sub', 'summary', 'sup', 'table', 'tbody', 'td', 'th', 'thead', 'time', 'tr', 'tt', 'u', 'ul', 'var', 'wbr']`

All tags from bleach are included into this list and there are 63 more tags. They look safe enough: table, cite, dl, etc. - looks like they provide reacher output without any unsafe attributes.

### Allowed attributes are different

Bleach allows just few attributes: `{'a': ['href', 'title'], 'abbr': ['title'], 'acronym': ['title']}`

nh3 uses much wider list:
```py
{'tbody': {'align', 'char', 'charoff'},
 'blockquote': {'cite'},
 'del': {'cite', 'datetime'},
 'table': {'align', 'char', 'charoff', 'summary'},
 'thead': {'align', 'char', 'charoff'},
 'ol': {'start'},
 'colgroup': {'align', 'char', 'charoff', 'span'},
 'tr': {'align', 'char', 'charoff'},
 'col': {'align', 'char', 'charoff', 'span'},
 'bdo': {'dir'},
 'hr': {'align', 'size', 'width'},
 'img': {'align', 'alt', 'height', 'src', 'width'},
 'q': {'cite'},
 'tfoot': {'align', 'char', 'charoff'},
 'ins': {'cite', 'datetime'},
 'td': {'align', 'char', 'charoff', 'colspan', 'headers', 'rowspan'},
 'th': {'align', 'char', 'charoff', 'colspan', 'headers', 'rowspan', 'scope'},
 'a': {'href', 'hreflang'}}
```

I've added `title` to the allowed attributes of `a` and `img` tags; everything else is kept as is.

### Signature of the `clean` function

Bleach clean:
```py
  clean(text, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
        protocols=ALLOWED_PROTOCOLS, strip=False, strip_comments=True,
        css_sanitizer=None)
```

nh3 clean:
```py 
 clean(html, tags=None, clean_content_tags=None, attributes=None,
        attribute_filter=None, strip_comments=True, link_rel='noopener noreferrer',
        generic_attribute_prefixes=None, tag_attribute_values=None,
        set_tag_attribute_values=None, url_schemes=None, allowed_classes=None,
        filter_style_properties=None, url_relative=None)
```

they are different,  but we are only using `tags`( :heavy_check_mark: ), `attributes`( :heavy_check_mark: ), and `strip`( :exclamation: ) arguments of `bleach.clean`. The latter is responsible for keeping HTML-escaped tags(i.e., `<xxx>` is replaced with `&lt;xxx&gt;`) - nh3 has no such thing, and it always strips disallowed tags. Mainly, we also expecting that bleach would strip such tags, but for some reason, DataPusher's logs snippet keeps escaped html instead of stripping it completely. I don't see any other place in core that can be affected by this difference.

### other differences

nh3 does additional work apart from cleaning. Most noticeable, it adds `rel='nofollow noopener'` to links. Here's the same input that is processed differently by bleach and nh3:


Input: `<a href="/test" onclick="alert(1)">Link</a>`   
Bleach: `<a href="/test">Link</a>`
NH3:      
```html
<a href="/test" rel="noopener noreferrer">Link</a> 
```

I kept this behavior as it seems appropriate to mark potentially unsafe links with this no-sniff option.


Also, nh3 removes `script` and `style` tags alongside with their content, while bleach removed the wrapping tag, but kept the content. It's possible to restore such behavior, but I don't see value in keeping scripts and styles as plain-text.
