### PR TITLE
a11y: meet WCAG AA contrast for resource format badges (fixes #7185)

### DIFF
--- a/changes/7185.bugfix
+++ b/changes/7185.bugfix
@@ -1,0 +1,2 @@
+Darken the JSON/XML, TEXT and API resource format badge colours so they meet
+the WCAG 2.1 AA 4.5:1 contrast minimum in both bundled themes.

--- a/ckan/public-midnight-blue/base/css/main-rtl.css
+++ b/ckan/public-midnight-blue/base/css/main-rtl.css
@@ -13323,20 +13323,20 @@ select[data-module=autocomplete] {
 
 .badge[data-format=json],
 .badge[data-format*=json] {
-  border: 1px solid #D63B00;
-  color: #D63B00;
+  border: 1px solid #CD3900;
+  color: #CD3900;
 }
 
 .badge[data-format=xml],
 .badge[data-format*=xml] {
-  border: 1px solid #D63B00;
-  color: #D63B00;
+  border: 1px solid #CD3900;
+  color: #CD3900;
 }
 
 .badge[data-format=text],
 .badge[data-format*=text] {
-  border: 1px solid #1A7EA3;
-  color: #1A7EA3;
+  border: 1px solid #19779A;
+  color: #19779A;
 }
 
 .badge[data-format=csv],
@@ -13359,8 +13359,8 @@ select[data-module=autocomplete] {
 
 .badge[data-format=api],
 .badge[data-format*=api] {
-  border: 1px solid #D22D81;
-  color: #D22D81;
+  border: 1px solid #CB2B7D;
+  color: #CB2B7D;
 }
 
 .badge[data-format=pdf],

--- a/ckan/public-midnight-blue/base/css/main.css
+++ b/ckan/public-midnight-blue/base/css/main.css
@@ -13323,20 +13323,20 @@ select[data-module=autocomplete] {
 
 .badge[data-format=json],
 .badge[data-format*=json] {
-  border: 1px solid #D63B00;
-  color: #D63B00;
+  border: 1px solid #CD3900;
+  color: #CD3900;
 }
 
 .badge[data-format=xml],
 .badge[data-format*=xml] {
-  border: 1px solid #D63B00;
-  color: #D63B00;
+  border: 1px solid #CD3900;
+  color: #CD3900;
 }
 
 .badge[data-format=text],
 .badge[data-format*=text] {
-  border: 1px solid #1A7EA3;
-  color: #1A7EA3;
+  border: 1px solid #19779A;
+  color: #19779A;
 }
 
 .badge[data-format=csv],
@@ -13359,8 +13359,8 @@ select[data-module=autocomplete] {
 
 .badge[data-format=api],
 .badge[data-format*=api] {
-  border: 1px solid #D22D81;
-  color: #D22D81;
+  border: 1px solid #CB2B7D;
+  color: #CB2B7D;
 }
 
 .badge[data-format=pdf],

--- a/ckan/public-midnight-blue/base/scss/_dataset.scss
+++ b/ckan/public-midnight-blue/base/scss/_dataset.scss
@@ -164,20 +164,20 @@
 
 .badge[data-format=json],
 .badge[data-format*=json] {
-    border: 1px solid #D63B00;
-    color: #D63B00;
+    border: 1px solid #CD3900;
+    color: #CD3900;
 }
 
 .badge[data-format=xml],
 .badge[data-format*=xml] {
-    border: 1px solid #D63B00;
-    color: #D63B00;
+    border: 1px solid #CD3900;
+    color: #CD3900;
 }
 
 .badge[data-format=text],
 .badge[data-format*=text] {
-    border: 1px solid #1A7EA3;
-    color: #1A7EA3;
+    border: 1px solid #19779A;
+    color: #19779A;
 }
 
 .badge[data-format=csv],
@@ -200,8 +200,8 @@
 
 .badge[data-format=api],
 .badge[data-format*=api] {
-    border: 1px solid #D22D81;
-    color: #D22D81;
+    border: 1px solid #CB2B7D;
+    color: #CB2B7D;
 }
 
 .badge[data-format=pdf],

--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -13317,17 +13317,17 @@ select[data-module=autocomplete] {
 
 .badge[data-format=json],
 .badge[data-format*=json] {
-  background-color: #D63B00;
+  background-color: #CD3900;
 }
 
 .badge[data-format=xml],
 .badge[data-format*=xml] {
-  background-color: #D63B00;
+  background-color: #CD3900;
 }
 
 .badge[data-format=text],
 .badge[data-format*=text] {
-  background-color: #1A7EA3;
+  background-color: #19779A;
 }
 
 .badge[data-format=csv],
@@ -13347,7 +13347,7 @@ select[data-module=autocomplete] {
 
 .badge[data-format=api],
 .badge[data-format*=api] {
-  background-color: #D22D81;
+  background-color: #CB2B7D;
 }
 
 .badge[data-format=pdf],

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -13317,17 +13317,17 @@ select[data-module=autocomplete] {
 
 .badge[data-format=json],
 .badge[data-format*=json] {
-  background-color: #D63B00;
+  background-color: #CD3900;
 }
 
 .badge[data-format=xml],
 .badge[data-format*=xml] {
-  background-color: #D63B00;
+  background-color: #CD3900;
 }
 
 .badge[data-format=text],
 .badge[data-format*=text] {
-  background-color: #1A7EA3;
+  background-color: #19779A;
 }
 
 .badge[data-format=csv],
@@ -13347,7 +13347,7 @@ select[data-module=autocomplete] {
 
 .badge[data-format=api],
 .badge[data-format*=api] {
-  background-color: #D22D81;
+  background-color: #CB2B7D;
 }
 
 .badge[data-format=pdf],

--- a/ckan/public/base/scss/_dataset.scss
+++ b/ckan/public/base/scss/_dataset.scss
@@ -179,17 +179,17 @@
 
 .badge[data-format=json],
 .badge[data-format*=json] {
-    background-color: #D63B00;
+    background-color: #CD3900;
 }
 
 .badge[data-format=xml],
 .badge[data-format*=xml] {
-    background-color: #D63B00;
+    background-color: #CD3900;
 }
 
 .badge[data-format=text],
 .badge[data-format*=text] {
-    background-color: #1A7EA3;
+    background-color: #19779A;
 }
 
 .badge[data-format=csv],
@@ -209,7 +209,7 @@
 
 .badge[data-format=api],
 .badge[data-format*=api] {
-    background-color: #D22D81;
+    background-color: #CB2B7D;
 }
 
 .badge[data-format=pdf],


### PR DESCRIPTION
Fixes #7185

### Proposed fixes:

Three resource format badge colours fall below the WCAG 2.1 AA 4.5:1 contrast minimum.

This is only visible in the **midnight-blue** theme. There the badge has no background of its own, so the format colour is the *text* colour, rendered on the `.dataset-item` background `#f2f4f7` rather than on white:

| format | colour | on `#f2f4f7` | |
|---|---|---|---|
| JSON / XML | `#D63B00` | 4.24:1 | fail |
| TEXT | `#1A7EA3` | 4.18:1 | fail |
| API | `#D22D81` | 4.29:1 | fail |

Darkening those three is enough to clear it:

| format | before | after | on `#f2f4f7` |
|---|---|---|---|
| JSON / XML | `#D63B00` | `#CD3900` | 4.24 to 4.56 |
| TEXT | `#1A7EA3` | `#19779A` | 4.18 to 4.60 |
| API | `#D22D81` | `#CB2B7D` | 4.29 to 4.56 |

Hue and saturation are held. Only lightness moves, by about 2%, so the badges read as the same colours.

![Before and after comparison of the format badge colours in both themes](https://raw.githubusercontent.com/opensource-joe/ckan/1f248a0bc1f15ec38caab19598e1abc9d95ced49/badge-contrast.png)

**Why both themes are touched.** The default theme uses the same palette the other way round, as badge *backgrounds* with white text, where it already passed at 4.61 to 4.74:1. I updated both stylesheets to the same new hexes so the two palettes do not drift apart. Darkening helps in that direction too, taking the default theme to 5.02 to 5.06:1.

The remaining format colours already pass on `#f2f4f7` (HTML 4.59, CSV 4.70, XLS 4.62, ZIP 5.06, PDF 4.53, RDF 8.31) and are left alone, so the diff stays limited to the actual failures.

`main.css` and `main-rtl.css` for both themes are rebuilt with `gulp build` and `gulp buildMidnightBlue`. The compiled diff is colour values only, no unrelated churn.

**Note on the original report.** #7185 was filed against 2.9 and quotes `a[data-format="geojson"]` at `#9855e0` with the old `label label-default` markup. That specific colour and markup are long gone. I re-audited the current palette rather than the reported one, and the four failing elements above are what is left of it on master.

### Verification

axe-core in headless Chromium, run against the compiled theme CSS and the badge markup from `snippets/package_item.html`, checking `color-contrast` only:

```
before   midnight-blue   4 violations   json, xml, text, api
after    midnight-blue   0 violations   13 passes
after    default         0 violations   13 passes
```

axe resolves the effective background by walking ancestors, so the `#f2f4f7` figure is what the browser actually computes rather than an assumption.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport
