### PR TITLE
[#9233] Fix passwordless user creation

### DIFF
--- a/changes/9233.bugfix
+++ b/changes/9233.bugfix
@@ -1,0 +1,1 @@
+Allow extensions using ``ignore_auth`` to create users without a local password while keeping passwords required for normal user creation.

--- a/ckan/logic/schema/__init__.py
+++ b/ckan/logic/schema/__init__.py
@@ -442,7 +442,8 @@ def default_update_relationship_schema(
 def default_user_schema(
         ignore_missing: Validator, unicode_safe: Validator,
         name_validator: Validator, user_name_validator: Validator,
-        user_password_validator: Validator, user_password_not_empty: Validator,
+        user_password_validator: Validator,
+        not_empty_if_not_sysadmin: Validator,
         email_is_unique: Validator, ignore_not_sysadmin: Validator,
         not_empty: Validator, strip_value: Validator,
         email_validator: Validator, user_about_validator: Validator,
@@ -456,7 +457,7 @@ def default_user_schema(
         'name': [
             not_empty, name_validator, user_name_validator, unicode_safe],
         'fullname': [ignore_missing, unicode_safe],
-        'password': [user_password_validator, user_password_not_empty,
+        'password': [not_empty_if_not_sysadmin, user_password_validator,
                      ignore_missing, unicode_safe],
         'password_hash': [ignore_missing, ignore_not_sysadmin, unicode_safe],
         'email': [not_empty, strip_value, email_validator, email_is_unique,
@@ -484,10 +485,14 @@ def create_user_for_user_invite_schema(ignore_missing: Validator):
 
 @validator_args
 def user_new_form_schema(
-        unicode_safe: Validator, user_both_passwords_entered: Validator,
-        user_password_validator: Validator, user_passwords_match: Validator):
+        ignore_missing: Validator, unicode_safe: Validator,
+        user_both_passwords_entered: Validator,
+        user_password_validator: Validator, user_password_not_empty: Validator,
+        user_passwords_match: Validator):
     schema = default_user_schema()
 
+    schema['password'] = [user_password_validator, user_password_not_empty,
+                          ignore_missing, unicode_safe]
     schema['password1'] = [unicode_safe, user_both_passwords_entered,
                            user_password_validator, user_passwords_match]
     schema['password2'] = [unicode_safe]
@@ -497,13 +502,17 @@ def user_new_form_schema(
 
 @validator_args
 def user_perform_reset_form_schema(
-        not_empty: Validator, unicode_safe: Validator,
+        ignore_missing: Validator, not_empty: Validator,
+        unicode_safe: Validator,
         user_both_passwords_entered: Validator,
         user_id_or_name_exists: Validator,
-        user_password_validator: Validator, user_passwords_match: Validator):
+        user_password_validator: Validator, user_password_not_empty: Validator,
+        user_passwords_match: Validator):
     schema = default_user_schema()
 
     schema["id"] = [not_empty, user_id_or_name_exists, unicode_safe]
+    schema['password'] = [user_password_validator, user_password_not_empty,
+                          ignore_missing, unicode_safe]
     schema['password1'] = [unicode_safe, user_both_passwords_entered,
                            user_password_validator, user_passwords_match]
     schema['password2'] = [unicode_safe]

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -1045,6 +1045,20 @@ def empty_if_not_sysadmin(key: FlattenKey, data: FlattenDataDict,
     # Prevent further validation on the field now that is empty
     raise StopOnError()
 
+
+def not_empty_if_not_sysadmin(key: FlattenKey, data: FlattenDataDict,
+                              errors: FlattenErrorDict,
+                              context: Context) -> Any:
+    '''Require a value unless auth is ignored or the user is a sysadmin.'''
+    from ckan.lib.navl.validators import not_empty
+
+    user = context.get('user')
+    ignore_auth = context.get('ignore_auth')
+    if ignore_auth or (user and authz.is_sysadmin(user)):
+        return
+
+    not_empty(key, data, errors, context)
+
 #pattern from https://html.spec.whatwg.org/#e-mail-state-(type=email)
 email_pattern = re.compile(
                             # additional pattern to reject malformed dots usage

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -1469,9 +1469,11 @@ class TestUserCreate(object):
         assert user["name"] == name
         assert "password" not in user
 
+    @pytest.mark.ckan_config("ckan.auth.create_user_via_web", True)
     def test_user_create_parameters_missing(self):
+        context = {"user": None, "ignore_auth": False}
         with pytest.raises(logic.ValidationError) as err:
-            helpers.call_action("user_create")
+            helpers.call_action("user_create", context=context)
         assert err.value.error_dict == {
             "email": ["Missing value"],
             "name": ["Missing value"],

--- a/ckan/tests/logic/action/test_user_create_password_optional.py
+++ b/ckan/tests/logic/action/test_user_create_password_optional.py
@@ -1,0 +1,38 @@
+# encoding: utf-8
+
+import pytest
+
+import ckan.logic as logic
+import ckan.tests.factories as factories
+import ckan.tests.helpers as helpers
+
+
+@pytest.mark.usefixtures("non_clean_db")
+class TestUserCreatePasswordOptional:
+    def test_ignore_auth_can_create_user_without_password(self):
+        stub = factories.User.stub()
+
+        user = helpers.call_action(
+            "user_create",
+            context={"ignore_auth": True},
+            name=stub.name,
+            email=stub.email,
+        )
+
+        assert user["name"] == stub.name
+        assert user["email"] == stub.email
+
+    @pytest.mark.ckan_config("ckan.auth.create_user_via_web", True)
+    def test_normal_user_creation_still_requires_password(self):
+        stub = factories.User.stub()
+        context = {"user": None, "ignore_auth": False}
+
+        with pytest.raises(logic.ValidationError) as err:
+            helpers.call_action(
+                "user_create",
+                context=context,
+                name=stub.name,
+                email=stub.email,
+            )
+
+        assert err.value.error_dict == {"password": ["Missing value"]}


### PR DESCRIPTION
Fixes #9233

### Proposed fixes:

- Allow passwordless user creation for sysadmins and trusted internal calls.
- Keep passwords required for normal user creation and registration/reset forms.
- Add regression tests.

### Features:

- [X] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [X] includes bugfix for possible backport