### PR TITLE
fix: more "compatible" uploads_enabled helper

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2518,12 +2518,19 @@ def uploads_enabled(object_type: str | None = None) -> bool:
         group, user or admin
     :type object_type: string
     """
-    if not object_type:
-        log.warning("h.uploads_enabled call without object_type is non supported")
-        return False
-
     if not config["ckan.uploads_enabled"]:
         return False
+
+    has_classic_uploader = bool(
+        config["ckan.storage_path"]
+        or any(plugin for plugin in p.PluginImplementations(p.IUploader))
+    )
+
+    if not object_type:
+        log.warning(
+            "h.uploads_enabled must be called with object_type. Switch to legacy check"
+        )
+        return has_classic_uploader
 
     storage_name = config.get(f"ckan.files.default_storages.{object_type}")
     if not storage_name:
@@ -2538,10 +2545,7 @@ def uploads_enabled(object_type: str | None = None) -> bool:
     except files.exc.UnknownStorageError:
         # if the storage is not found, then we are using old upload rules: when
         # storage path is configured or uploader is customized, uploads are allowed
-        return bool(
-            config["ckan.storage_path"]
-            or any(plugin for plugin in p.PluginImplementations(p.IUploader))
-        )
+        return has_classic_uploader
 
     return storage.supports(files.Capability.CREATE)
 

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2511,7 +2511,7 @@ localised_filesize = formatters.localised_filesize
 
 
 @core_helper
-def uploads_enabled(object_type: str | None = None) -> bool:
+def uploads_enabled(storage_name: str | None = None) -> bool:
     """Returns True if uploads are enabled for the given object type.
 
     :param object_type: the type of object to check uploads for, e.g. resource,
@@ -2526,17 +2526,19 @@ def uploads_enabled(object_type: str | None = None) -> bool:
         or any(plugin for plugin in p.PluginImplementations(p.IUploader))
     )
 
-    if not object_type:
+    if not storage_name:
         log.warning(
-            "h.uploads_enabled must be called with object_type. Switch to legacy check"
+            "h.uploads_enabled must be called with object_type."
+            " Swithcing to legacy logic and checking availability of custom uploaders."
+            " In future this call will cause an exception."
         )
         return has_classic_uploader
 
-    storage_name = config.get(f"ckan.files.default_storages.{object_type}")
+    storage_name = config.get(f"ckan.files.default_storages.{storage_name}")
     if not storage_name:
         log.warning(
             "h.uploads_enabled call with an unexpected object_type '%s'",
-            object_type,
+            storage_name,
         )
         return False
 

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -13,8 +13,10 @@ import flask_babel
 from faker import Faker
 import pytest
 
+from ckan import types
 from ckan.config.middleware import flask_app
 import ckan.lib.helpers as h
+import ckan.plugins as p
 import ckan.exceptions
 from ckan.tests import helpers, factories
 
@@ -912,15 +914,19 @@ def test_get_translated(data_dict, locale, result, monkeypatch):
 
 
 class TestUploadsEnabled:
-    def test_disabled_with_no_type(self):
-        """Without upload type, helper returns False."""
+    def test_disabled_with_no_type_no_path_and_no_implementation(self):
+        """In simple case helper returns False."""
         assert not h.uploads_enabled()
 
-    @pytest.mark.ckan_config("ckan.uploads_enabled", False)
-    def test_disabled(self):
-        """When uploads are disabled globally, they are disabled for all types."""
-        for type in ["resource", "group", "user", "admin"]:
-            assert not h.uploads_enabled(type)
+    @pytest.mark.ckan_config("ckan.storage_path", "/tmp")
+    def test_enabled_with_path_and_no_type(self, reset_storages: Any):
+        """With storage_path set, uploads are enabled - that's a classic behavior."""
+        assert h.uploads_enabled()
+
+    @pytest.mark.with_plugins({"test_uploader": type("TestUploader", (p.IUploader, p.SingletonPlugin), {})})
+    def test_enabled_with_implementation_and_no_type(self, provide_plugin: types.FixtureProvidePlugin):
+        """With an implementation of IUploader, uploads are enabled - that's a classic behavior."""
+        assert h.uploads_enabled()
 
     @pytest.mark.ckan_config("ckan.files.storage.test.type", "ckan:memory")
     def test_enabled_with_storage(self):


### PR DESCRIPTION
Fixes #9490

Initially, I insisted on the strict rejection of the `h.uploads_enabled` call without specific upload types. In this way, we have controlled and predictable behavior of the helper.

But @ThrawnCA highlighted a valid point: some extensions are using a custom uploader for a custom endpoint. They will handle one specific upload type on a completely new page, and they don't want to make changes like `uploads_enabled(type) if ckan_version(2.12) else uploads_enabled()`.

Even though I still think that for such extensions it's a good idea to migrate now so that everything likely remains functional when v3.0 is out, we can make this immediate migration optional. For this, I made the following changes in `h.uploads_enabled`:

* When `object_type` is specified(`h.uploads_enabled(object_type)`) - it remains unchanged. In this way, CKAN core and changes we made for scheming and other plugins work exactly as planned.
* When `object_type` is not provied(`h.uploads_enabled()`), logic is changed. Previously, it immediately returned `False`. Now it returns `True` when:
  * `ckan.storage_path` is specified. In this case, even if there is no dedicated storage, `get_uploader`/`get_resource_uploader` will [return the classic uploader](https://github.com/ckan/ckan/blob/master/ckan/lib/uploader.py#L87-L88) class that handles uploads as it was done in the past.
  * A custom IUploader implementation exists. In this case, this [custom implementation will handle the upload](https://github.com/ckan/ckan/blob/master/ckan/lib/uploader.py#L78-L81). This case is fragile, but at least it gives the extension a chance to remain functional without any changes. It's up to the maintainer to test whether functionality is broken after the v2.12 upgrade. Previously, we enforced migration to `uploads_enabled` with object type; now we leave the final decision regarding this migration to the maintainer.