### PR TITLE
Re-add the "Add resource" button on the left hand sidebar

### DIFF
--- a/ckan/templates/package/snippets/resources.html
+++ b/ckan/templates/package/snippets/resources.html
@@ -53,7 +53,7 @@ Example:
   {% endblock %}
 {% endif %}
 
-{% if can_edit and active and not is_activity_archive %}
+{% if can_edit and not is_activity_archive %}
   <div class="module-content">
     {% link_for _('Add new resource'), named_route=pkg.type ~ '_resource.new', id=pkg.name, class_='btn btn-secondary btn-sm', icon='plus' %}
   </div>


### PR DESCRIPTION
2.12 only

Otherwise it is really confusing how to get the new resource page. The `active` check was added in https://github.com/ckan/ckan/pull/8309 but I don't see why the button appearing or not should depend on the current resource being active (shown in the current page)

Before:
<img width="492" height="527" alt="Screenshot 2026-08-25 at 11-39-08 Dataset - CKAN" src="https://github.com/user-attachments/assets/7afd5881-6331-49c1-b826-6b599db2f71d" />



After:

<img width="442" height="403" alt="Screenshot 2026-08-25 at 11-38-52 Dataset - CKAN" src="https://github.com/user-attachments/assets/7e7fe85a-0d2d-4f8f-af95-6810b782925c" />