### PR TITLE
Fix spacing in Font awesome icons in tabs

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -873,6 +873,8 @@ def _link_to(text: str, *args: Any, **kwargs: Any) -> Markup:
 
     if icon:
         link.add(dom_tags.i(cls=f"fa fa-{icon}"))   # type: ignore
+        if not inner_span:
+            text = f" {text}"
 
     link.add(dom_tags.span(text) if inner_span else f"{text}")  # type: ignore
 

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -658,7 +658,7 @@ class TestBuildNavMain(object):
 
     def test_build_nav_icon(self):
         link = h.build_nav_icon('organization.edit', 'Edit', id='org-id', icon='pencil')
-        assert link == '<li><a href="/organization/edit/org-id"><i class="fa fa-pencil"></i>Edit</a></li>'
+        assert link == '<li><a href="/organization/edit/org-id"><i class="fa fa-pencil"></i> Edit</a></li>'
 
 
 class TestRemoveUrlParam:


### PR DESCRIPTION
2.12 only

This was introduced in https://github.com/ckan/ckan/pull/9297, in the refactoring to use dominate to generate tags we dropped a space that was explicitly added.

This would probably be better done via CSS but this small fix keeps the old behaviour and won't break themes

Before:

<img width="588" height="142" alt="Screenshot 2026-08-25 at 12-01-05 Test new public dataset 2 - Dataset - CKAN" src="https://github.com/user-attachments/assets/5c258c82-7903-409f-a9fc-9a65ef561340" />

After:

<img width="556" height="118" alt="Screenshot 2026-08-25 at 12-03-27 Test new public dataset 2 - Dataset - CKAN" src="https://github.com/user-attachments/assets/11305b2b-a0f7-4767-961f-a099b84bf15e" />

