### PR TITLE
Fs storage improvements

### DIFF
--- a/ckan/lib/files/__init__.py
+++ b/ckan/lib/files/__init__.py
@@ -212,9 +212,9 @@ def collect_storages() -> dict[str, fk.Storage]:  # noqa: C901
         if not path.endswith(os.path.sep):
             path += os.path.sep
 
-        grouped[storage.settings.type][storage.settings.public].add(path)
+        storages_grouped_by_privacy[storage.settings.type][storage.settings.public].add(path)
 
-    for adapter, group in grouped.items():
+    for adapter, group in storages_grouped_by_privacy.items():
         if not group[False] or not group[True]:
             continue
 

--- a/ckan/lib/files/__init__.py
+++ b/ckan/lib/files/__init__.py
@@ -125,7 +125,7 @@ def _storages_from_config(
     return result
 
 
-def collect_storages() -> dict[str, fk.Storage]:
+def collect_storages() -> dict[str, fk.Storage]:  # noqa: C901
     """Initialize storages.
 
     :returns: mapping with storages
@@ -204,7 +204,7 @@ def collect_storages() -> dict[str, fk.Storage]:
             # functionality and we are won't interfere
             continue
 
-        path = storage.settings.path or ""
+        path = str(storage.settings.path or "")
 
         # for simplicity, append slash to the path. It allows using
         # `str.startswith` instead of `os.path.commonpath` which will complain

--- a/ckan/lib/files/__init__.py
+++ b/ckan/lib/files/__init__.py
@@ -223,7 +223,7 @@ def collect_storages() -> dict[str, fk.Storage]:  # noqa: C901
                 msg = (
                     f"{adapter} storage with path {private} is included into another"
                     + " storage with public access. Make sure paths of public"
-                    + " and private storages do not intersect."
+                    + " and private storages do not overlap."
                 )
                 raise CkanConfigurationException(msg)
 

--- a/ckan/lib/files/__init__.py
+++ b/ckan/lib/files/__init__.py
@@ -194,7 +194,7 @@ def collect_storages() -> dict[str, fk.Storage]:  # noqa: C901
     # check that there are no public storages that point to the parent folder
     # of another private storage, unintentionally exposing private files in
     # this way
-    grouped: dict[str, dict[bool, set[str]]] = defaultdict(
+    storages_grouped_by_privacy: dict[str, dict[bool, set[str]]] = defaultdict(
         lambda: {True: set(), False: set()}
     )
     for storage in result.values():

--- a/ckan/lib/files/__init__.py
+++ b/ckan/lib/files/__init__.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-
 import copy
 import logging
 import os
+from collections import defaultdict
 from typing import cast, Any
+
 
 import file_keeper as fk
 from file_keeper import Registry, Upload, adapters, exc, ext, make_storage, make_upload
@@ -182,11 +183,49 @@ def collect_storages() -> dict[str, fk.Storage]:
             config[f"ckan.files.default_storages.{object_type}"] in result
             for object_type in ["resource", "user", "group", "admin"]
         )
+        # storage path is used as fallback for webassets
+        and config["ckan.webassets.path"]
         and config["ckan.storage_path"]
     ):
         log.warning(
             "All uploads are handled by storages. `ckan.storage_path` has no effect"
         )
+
+    # check that there are no public storages that point to the parent folder
+    # of another private storage, unintentionally exposing private files in
+    # this way
+    grouped: dict[str, dict[bool, set[str]]] = defaultdict(
+        lambda: {True: set(), False: set()}
+    )
+    for storage in result.values():
+        if not isinstance(storage, Storage):
+            # it's raw file-keeper storage, not CKAN's wrapped storage. It
+            # means somebody is implementing new features using low-level
+            # functionality and we are won't interfere
+            continue
+
+        path = storage.settings.path or ""
+
+        # for simplicity, append slash to the path. It allows using
+        # `str.startswith` instead of `os.path.commonpath` which will complain
+        # about mixing relative and absolute paths.
+        if not path.endswith(os.path.sep):
+            path += os.path.sep
+
+        grouped[storage.settings.type][storage.settings.public].add(path)
+
+    for adapter, group in grouped.items():
+        if not group[False] or not group[True]:
+            continue
+
+        for private in group[False]:
+            if private.startswith(tuple(group[True])):
+                msg = (
+                    f"{adapter} storage with path {private} is included into another"
+                    + " storage with public access. Make sure paths of public"
+                    + " and private storages do not intersect."
+                )
+                raise CkanConfigurationException(msg)
 
     return result
 

--- a/ckan/lib/files/default/fs.py
+++ b/ckan/lib/files/default/fs.py
@@ -47,6 +47,16 @@ class FsStorage(base.Storage, fs.FsStorage):
     ReaderFactory = Reader
     ManagerFactory = type("Manager", (base.Manager, fs.Manager), {})
 
+    @override
+    @classmethod
+    def declare_config_options(cls, declaration: Declaration, key: Key):
+        super().declare_config_options(declaration, key)
+
+        declaration[key.path].required().append_validators('starts_with("/")').set_description(
+            "Absolute path to the storage's root."
+            "\nWill cause a configuration error if not absolute."
+        )
+
 
 @dataclasses.dataclass
 class PublicSettings(Settings):

--- a/ckan/lib/files/default/fs.py
+++ b/ckan/lib/files/default/fs.py
@@ -41,9 +41,7 @@ class FsStorage(base.Storage, fs.FsStorage):
 
     settings: Settings
     SettingsFactory = Settings
-    UploaderFactory = type(
-        "Uploader", (base.Uploader, fs.Uploader), {}
-    )
+    UploaderFactory = type("Uploader", (base.Uploader, fs.Uploader), {})
     ReaderFactory = Reader
     ManagerFactory = type("Manager", (base.Manager, fs.Manager), {})
 
@@ -52,9 +50,14 @@ class FsStorage(base.Storage, fs.FsStorage):
     def declare_config_options(cls, declaration: Declaration, key: Key):
         super().declare_config_options(declaration, key)
 
-        declaration[key.path].required().append_validators('starts_with("/")').set_description(
+        declaration[key.path].required().append_validators(
+            'starts_with("/")'
+        ).set_description(
             "Absolute path to the storage's root."
             "\nWill cause a configuration error if not absolute."
+        )
+        declaration.declare_bool(key.follow_symlinks).set_description(
+            "Whether to follow symlinks when accessing a file."
         )
 
 

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -1206,6 +1206,7 @@ def starts_with(*values: str):
     """Returns a validator that checks if the value has one of specified prefixes.
 
     .. code-block::
+
         data, errors = tk.navl_validate(
             {"input": "http://example.com"},
             {"input": [starts_with("http://", "https://")]}

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -1214,8 +1214,8 @@ def starts_with(*values: str):
         assert data == {"input": "http://example.com"}
 
     """
-    def validator(value: str):
-        if not value.startswith(values):
+    def validator(value: Any):
+        if isinstance(value, str) and not value.startswith(values):
             if len(values) == 1:
                 msg = _("Must start with {prefix}").format(prefix=values[0])
             else:

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -1200,3 +1200,28 @@ def extras_valid_json(extras: Any, context: Context) -> Any:
             raise Invalid(_(u'Could not parse extra \'{name}\' as valid JSON').
                           format(name=extra))
     return extras
+
+
+def starts_with(*values: str):
+    """Returns a validator that checks if the value has one of specified prefixes.
+
+    .. code-block::
+        data, errors = tk.navl_validate(
+            {"input": "http://example.com"},
+            {"input": [starts_with("http://", "https://")]}
+        )
+        assert data == {"input": "http://example.com"}
+
+    """
+    def validator(value: str):
+        if not value.startswith(values):
+            if len(values) == 1:
+                msg = _("Must start with {prefix}").format(prefix=values[0])
+            else:
+                msg = _("Must start with any of the prefixes: {prefixes}").format(
+                    prefixes=', '.join(values)
+                )
+            raise Invalid(msg)
+        return value
+
+    return validator

--- a/ckan/tests/config/declaration/test_load.py
+++ b/ckan/tests/config/declaration/test_load.py
@@ -100,6 +100,7 @@ class TestFilesLoader:
                 prefix.max_size,
                 prefix.hashing_algorithm,
                 prefix.supported_types,
+                prefix.follow_symlinks,
                 prefix.overwrite_existing,
                 prefix.name,
                 prefix.location_transformers,

--- a/ckan/tests/controllers/test_file.py
+++ b/ckan/tests/controllers/test_file.py
@@ -96,8 +96,8 @@ class TestPublicDownload:
         """Test that path traversal attempts are blocked when downloading from public storage."""
         base_path = str(tmpdir)
         monkeypatch.setitem(ckan_config, "ckan.files.storage.public.type", "ckan:fs")
-        monkeypatch.setitem(ckan_config, "ckan.files.storage.public.initialize", "true")
-        monkeypatch.setitem(ckan_config, "ckan.files.storage.public.public", "true")
+        monkeypatch.setitem(ckan_config, "ckan.files.storage.public.initialize", True)
+        monkeypatch.setitem(ckan_config, "ckan.files.storage.public.public", True)
         monkeypatch.setitem(ckan_config, "ckan.files.storage.public.path", os.path.join(base_path, "folder"))
         reset_storages()
 

--- a/ckan/tests/controllers/test_file.py
+++ b/ckan/tests/controllers/test_file.py
@@ -73,6 +73,7 @@ class TestPublicDownload:
         assert resp.status_code == 403
 
     @pytest.mark.ckan_config("ckan.files.storage.public_storage.type", "ckan:memory")
+    @pytest.mark.ckan_config("ckan.files.storage.public_storage.path", "public_storage")
     @pytest.mark.ckan_config("ckan.files.storage.public_storage.public", True)
     def test_public_download_from_public_storage(
         self, file_factory: types.TestFactory, app: types.FixtureApp, faker: Faker

--- a/ckan/tests/controllers/test_file.py
+++ b/ckan/tests/controllers/test_file.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+
+import os
 from typing import Any
 import pytest
 from faker import Faker
@@ -83,6 +85,33 @@ class TestPublicDownload:
 
         assert resp.status_code == 200
         assert resp.data == content
+
+    def test_public_download_path_traversal(
+            self, file_factory: types.TestFactory, app: types.FixtureApp, faker: Faker,
+            ckan_config: types.FixtureCkanConfig,
+            reset_storages: types.FixtureResetStorages,
+            tmpdir: Any,
+            monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Test that path traversal attempts are blocked when downloading from public storage."""
+        base_path = str(tmpdir)
+        monkeypatch.setitem(ckan_config, "ckan.files.storage.public.type", "ckan:fs")
+        monkeypatch.setitem(ckan_config, "ckan.files.storage.public.initialize", "true")
+        monkeypatch.setitem(ckan_config, "ckan.files.storage.public.public", "true")
+        monkeypatch.setitem(ckan_config, "ckan.files.storage.public.path", os.path.join(base_path, "folder"))
+        reset_storages()
+
+        with open(os.path.join(base_path, "parent.txt"), "w") as dest:
+            dest.write("test")
+        resp = app.get("/file/public-download/public/../parent.txt")
+        assert resp.status_code == 404
+
+        os.mkdir(os.path.join(base_path, "folder_evil"))
+        with open(os.path.join(base_path, "folder_evil/sibling.txt"), "w") as dest:
+            dest.write("test")
+        resp = app.get("/file/public-download/public/../folder_evil/sibling.txt")
+        assert resp.status_code == 404
+
 
 
 class TestTrustedDownload:

--- a/ckan/tests/lib/test_files.py
+++ b/ckan/tests/lib/test_files.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 from faker import Faker
 
+from ckan.exceptions import CkanConfigurationException
 import ckan.plugins as p
 from ckan.lib import files
 
@@ -108,3 +109,29 @@ class TestLocationTransformers:
         location = faker.file_path()
 
         assert storage.prepare_location(location) == location.upper()
+
+
+def test_public_storages_cannot_include_private_storages(
+    reset_storages: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    ckan_config: dict[str, Any],
+    tmp_path: Any,
+):
+    """Test that public storages cannot include private storages in their configuration."""
+    tmp_path = str(tmp_path)
+    prefix = "ckan.files.storage.test"
+    monkeypatch.setitem(ckan_config, f"{prefix}.type", "ckan:fs")
+    monkeypatch.setitem(ckan_config, f"{prefix}.path", tmp_path)
+    monkeypatch.setitem(ckan_config, f"{prefix}.public", True)
+
+    prefix = "ckan.files.storage.another"
+    monkeypatch.setitem(ckan_config, f"{prefix}.type", "ckan:fs")
+    monkeypatch.setitem(ckan_config, f"{prefix}.initialize", True)
+    monkeypatch.setitem(ckan_config, f"{prefix}.path", tmp_path + "/folder")
+
+    with pytest.raises(CkanConfigurationException):
+        reset_storages()
+
+    # storages with different backends do not overlap
+    monkeypatch.setitem(ckan_config, f"{prefix}.type", "ckan:memory")
+    reset_storages()

--- a/ckan/tests/lib/test_files.py
+++ b/ckan/tests/lib/test_files.py
@@ -135,27 +135,27 @@ def test_public_storages_cannot_include_private_storages(
     # storages with different backends do not overlap
     monkeypatch.setitem(ckan_config, f"{prefix}.type", "ckan:memory")
     reset_storages()
-    
-    
+
+
 def test_public_storages_cannot_include_private_storages_startup(
     monkeypatch: pytest.MonkeyPatch,
     ckan_config: dict[str, Any],
     tmp_path: Any,
 ):
     """Test that if public storages include private storages in their configuration
-        CKAN will fail on startup."""
+    CKAN will fail on startup."""
     tmp_path = str(tmp_path)
     prefix = "ckan.files.storage.test"
     monkeypatch.setitem(ckan_config, f"{prefix}.type", "ckan:fs")
     monkeypatch.setitem(ckan_config, f"{prefix}.path", tmp_path)
     monkeypatch.setitem(ckan_config, f"{prefix}.public", True)
-    
+
     prefix = "ckan.files.storage.another"
     monkeypatch.setitem(ckan_config, f"{prefix}.type", "ckan:fs")
     monkeypatch.setitem(ckan_config, f"{prefix}.initialize", True)
     monkeypatch.setitem(ckan_config, f"{prefix}.path", tmp_path + "/folder")
 
-    with pytest.raises(CkanConfigurationException) as e:
+    with pytest.raises(CkanConfigurationException):
         files.collect_storages()
 
 
@@ -165,15 +165,15 @@ def test_file_system_storage_path_must_be_absolute(
     ckan_config: dict[str, Any],
     tmp_path: Any,
 ):
-   """Test that public storages cannot include private storages in their configuration."""
+    """Test that public storages cannot include private storages in their configuration."""
     prefix = "ckan.files.storage.test"
     monkeypatch.setitem(ckan_config, f"{prefix}.type", "ckan:fs")
     monkeypatch.setitem(ckan_config, f"{prefix}.path", "some_path")
-    with pytest.raises(CkanConfigurationException) as e:
+    with pytest.raises(CkanConfigurationException):
         files.collect_storages()
 
     tmp_path = str(tmp_path)
     prefix = "ckan.files.storage.another"
     monkeypatch.setitem(ckan_config, f"{prefix}.type", "ckan:fs")
     monkeypatch.setitem(ckan_config, f"{prefix}.initialize", True)
-    monkeypatch.setitem(ckan_config, f"{prefix}.path", tmp_path + "/folder")    
+    monkeypatch.setitem(ckan_config, f"{prefix}.path", tmp_path + "/folder")

--- a/ckan/tests/lib/test_files.py
+++ b/ckan/tests/lib/test_files.py
@@ -135,3 +135,45 @@ def test_public_storages_cannot_include_private_storages(
     # storages with different backends do not overlap
     monkeypatch.setitem(ckan_config, f"{prefix}.type", "ckan:memory")
     reset_storages()
+    
+    
+def test_public_storages_cannot_include_private_storages_startup(
+    monkeypatch: pytest.MonkeyPatch,
+    ckan_config: dict[str, Any],
+    tmp_path: Any,
+):
+    """Test that if public storages include private storages in their configuration
+        CKAN will fail on startup."""
+    tmp_path = str(tmp_path)
+    prefix = "ckan.files.storage.test"
+    monkeypatch.setitem(ckan_config, f"{prefix}.type", "ckan:fs")
+    monkeypatch.setitem(ckan_config, f"{prefix}.path", tmp_path)
+    monkeypatch.setitem(ckan_config, f"{prefix}.public", True)
+    
+    prefix = "ckan.files.storage.another"
+    monkeypatch.setitem(ckan_config, f"{prefix}.type", "ckan:fs")
+    monkeypatch.setitem(ckan_config, f"{prefix}.initialize", True)
+    monkeypatch.setitem(ckan_config, f"{prefix}.path", tmp_path + "/folder")
+
+    with pytest.raises(CkanConfigurationException) as e:
+        files.collect_storages()
+
+
+def test_file_system_storage_path_must_be_absolute(
+    reset_storages: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    ckan_config: dict[str, Any],
+    tmp_path: Any,
+):
+   """Test that public storages cannot include private storages in their configuration."""
+    prefix = "ckan.files.storage.test"
+    monkeypatch.setitem(ckan_config, f"{prefix}.type", "ckan:fs")
+    monkeypatch.setitem(ckan_config, f"{prefix}.path", "some_path")
+    with pytest.raises(CkanConfigurationException) as e:
+        files.collect_storages()
+
+    tmp_path = str(tmp_path)
+    prefix = "ckan.files.storage.another"
+    monkeypatch.setitem(ckan_config, f"{prefix}.type", "ckan:fs")
+    monkeypatch.setitem(ckan_config, f"{prefix}.initialize", True)
+    monkeypatch.setitem(ckan_config, f"{prefix}.path", tmp_path + "/folder")    

--- a/ckan/views/resource.py
+++ b/ckan/views/resource.py
@@ -175,11 +175,15 @@ def download(package_type: str,
             if mimetype:
                 overrides["content_type"] = mimetype
             location = files.Location(filepath)
-            file_data = files.FileData(
-                location,
-                size=storage.size(location),
-                **overrides,
-            )
+            try:
+                file_data = files.FileData(
+                    location,
+                    size=storage.size(location),
+                    **overrides,
+                )
+            except files.exc.LocationError:
+                return base.abort(404, _('No download is available'))
+
             if isinstance(storage, files.Storage):
                 resp = storage.as_response(file_data, filename)
             else:

--- a/doc/maintaining/filestore.rst
+++ b/doc/maintaining/filestore.rst
@@ -720,6 +720,33 @@ Use location and storage name to generate URL for the ``public_download`` view:
 This URL can be accessed by anyone as long as storage is marked as
 ``public``. Without ``public`` flag, the URL will cause 403 HTTP response.
 
+.. warning:: Marking storage as ``public`` makes **all** files in the storage
+   accessible to everyone. This includes any file from any sub-folder of the
+   storage. Make sure you do not have another non-public storage inside the
+   same folder, or else files from that storage will also be publicly
+   accessible.
+
+   The following example shows the problem. Storage for ``resources`` is
+   private. But ``shared`` storage points at folder one level above and marked
+   as public, making all the files from ``resources`` storage accessible to
+   everyone, even though ``resources`` storage is not public::
+
+     ckan.files.storage.resources.path = /var/data/storage/resources
+
+     # DO NOT DO THIS: resources are now not protected
+     ckan.files.storage.shared.path = /var/data/storage
+     ckan.files.storage.shared.public = true
+
+
+   If you need to have a public storage and a non-public storage, make sure
+   they are configured to use different folders in the filesystem::
+
+     ckan.files.storage.resources.path = /var/data/storage/resources
+
+     ckan.files.storage.shared.path = /var/data/storage/shared
+     ckan.files.storage.shared.public = true
+
+
 As an alternative, when writing custom view functions,
 :py:meth:`ckan.lib.files.Storage.as_response` method can be used to create
 Flask's response object with the file content. Depending on the storage

--- a/doc/maintaining/filestore.rst
+++ b/doc/maintaining/filestore.rst
@@ -727,8 +727,8 @@ This URL can be accessed by anyone as long as storage is marked as
    accessible.
 
    The following example shows the problem. Storage for ``resources`` is
-   private. But ``shared`` storage points at folder one level above and marked
-   as public, making all the files from ``resources`` storage accessible to
+   private. But the ``shared`` storage points at a folder one level above and it is marked
+   as public, making all the files from the ``resources`` storage accessible to
    everyone, even though ``resources`` storage is not public::
 
      ckan.files.storage.resources.path = /var/data/storage/resources

--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ certifi
 click==8.4.2
 dominate==2.9.1
 feedgen==1.0.0
-file-keeper==0.2.5
+file-keeper==0.2.6
 Flask==3.1.3
 Flask-Babel==4.0.0
 Flask-Login==0.6.3

--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ certifi
 click==8.4.2
 dominate==2.9.1
 feedgen==1.0.0
-file-keeper==0.2.4
+file-keeper==0.2.5
 Flask==3.1.3
 Flask-Babel==4.0.0
 Flask-Login==0.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ dominate==2.9.1
     # via -r requirements.in
 feedgen==1.0.0
     # via -r requirements.in
-file-keeper==0.2.5
+file-keeper==0.2.6
     # via -r requirements.in
 flask==3.1.3
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ dominate==2.9.1
     # via -r requirements.in
 feedgen==1.0.0
     # via -r requirements.in
-file-keeper==0.2.4
+file-keeper==0.2.5
     # via -r requirements.in
 flask==3.1.3
     # via


### PR DESCRIPTION
Fixes for FS adapter

* If there is any public storage that includes another private storage, stop CKAN and report an error during startup
* Add new validator `starts_with` and use it to ensure that FS storages uses only absolute path. I decided to use it instead of preserving Windows compatibility, because `starts_with` sounds more usful than `is_path_absolute`
* add new config option `follow_symlinks` to FS storage(disabled by default)
* Update file-keeper
* Few tests to cover changes

> [!NOTE] 
> This PR addressed vulnerabilities that were not released in a public CKAN version, only in the master branch. Thanks to @phuongmai1212 and @AuQuangDuc for reporting them