### PR TITLE
feat: add dark theme toggle for midnight blue theme

### DIFF
--- a/changes/9503.feature
+++ b/changes/9503.feature
@@ -1,0 +1,1 @@
+Add dark theme support to the ``midnight-blue`` theme: a theme toggle button in the account masthead lets visitors switch between light and dark mode (persisted in ``localStorage``), and the initial theme follows the browser's ``prefers-color-scheme`` setting. This can be turned off with the new :ref:`ckan.theme.enable_dark_mode` config option, which is enabled by default.

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -1178,6 +1178,20 @@ groups:
           With this option, instead of using the default `css/main` asset with
           the theme, you can use your own.
 
+      - key: ckan.theme.enable_dark_mode
+        type: bool
+        default: true
+        example: false
+        description: |
+          Enables dark theme support for the ``midnight-blue`` theme.
+
+          When enabled (the default), visitors can switch between light and dark
+          mode with the toggle button in the account masthead, and the initial
+          theme follows the browser's ``prefers-color-scheme`` setting.
+
+          When disabled, the toggle button is hidden and the automatic detection
+          is turned off, so the site is always rendered in light mode.
+
       - key: ckan.favicon
         default: /base/images/ckan.ico
         example: http://okfn.org/wp-content/themes/okfn-master-wordpress-theme/images/favicon.ico

--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -702,6 +702,18 @@ def get_rtl_theme() -> str:
 
 
 @core_helper
+def dark_mode_enabled() -> bool:
+    '''Return whether dark theme support is enabled for the ``midnight-blue``
+    theme.
+
+    Controlled by the :ref:`ckan.theme.enable_dark_mode` config option. When
+    disabled, the theme toggle button and the ``prefers-color-scheme``
+    autodetection are turned off.
+    '''
+    return config.get('ckan.theme.enable_dark_mode')
+
+
+@core_helper
 def flash_notice(message: Any, allow_html: bool = False) -> None:
     ''' Show a flash message of type notice '''
     if allow_html:

--- a/ckan/public-midnight-blue/base/css/main-rtl.css
+++ b/ckan/public-midnight-blue/base/css/main-rtl.css
@@ -15534,6 +15534,9 @@ html[data-theme=dark] ::selection {
   background-color: var(--dm-link);
   color: var(--dm-bg);
 }
+html[data-theme=dark] .card {
+  --bs-card-border-color: var(--dm-border);
+}
 
 @media (min-width: 576px) {
   .wrapper:before {

--- a/ckan/public-midnight-blue/base/css/main-rtl.css
+++ b/ckan/public-midnight-blue/base/css/main-rtl.css
@@ -15231,6 +15231,7 @@ html[data-theme=dark] {
   --dm-link: #8ea9e8;
   --dm-link-hover: #b3c6f2;
   --bs-secondary-color: var(--dm-text-muted);
+  --bs-border-color: var(--dm-border);
   background-color: var(--dm-bg);
   color: var(--dm-text);
 }
@@ -15353,6 +15354,31 @@ html[data-theme=dark] .nav-simple > li,
 html[data-theme=dark] .nav-aside > li {
   background-color: var(--dm-surface);
   border-bottom-color: var(--dm-border);
+}
+html[data-theme=dark] .accordion {
+  --bs-accordion-color: var(--dm-text);
+  --bs-accordion-bg: var(--dm-surface);
+  --bs-accordion-border-color: var(--dm-border);
+  --bs-accordion-btn-color: var(--dm-text);
+  --bs-accordion-btn-bg: var(--dm-surface-alt);
+  --bs-accordion-active-color: var(--dm-text);
+  --bs-accordion-active-bg: var(--dm-surface-alt);
+}
+html[data-theme=dark] .accordion-item {
+  background-color: var(--dm-surface);
+  border-color: var(--dm-border);
+}
+html[data-theme=dark] .accordion-button,
+html[data-theme=dark] .accordion-button:not(.collapsed) {
+  background-color: var(--dm-surface-alt);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .accordion-button::after,
+html[data-theme=dark] .accordion-button:not(.collapsed)::after {
+  background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23e6e9f0'><path fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/></svg>");
+}
+html[data-theme=dark] .accordion-collapse.show {
+  background-color: var(--dm-surface);
 }
 html[data-theme=dark] .secondary .accordion .accordion-item:has(.accordion-button:disabled),
 html[data-theme=dark] .secondary .accordion .accordion-item .module-content {
@@ -15536,6 +15562,17 @@ html[data-theme=dark] ::selection {
 }
 html[data-theme=dark] .card {
   --bs-card-border-color: var(--dm-border);
+}
+html[data-theme=dark] .modal {
+  --bs-modal-bg: var(--dm-surface);
+  --bs-modal-color: var(--dm-text);
+  --bs-modal-border-color: var(--dm-border);
+  --bs-modal-header-border-color: var(--dm-border);
+  --bs-modal-footer-border-color: var(--dm-border);
+  --bs-modal-footer-bg: var(--dm-surface);
+}
+html[data-theme=dark] .modal-header .btn-close {
+  filter: var(--bs-btn-close-white-filter);
 }
 
 @media (min-width: 576px) {

--- a/ckan/public-midnight-blue/base/css/main-rtl.css
+++ b/ckan/public-midnight-blue/base/css/main-rtl.css
@@ -12061,7 +12061,7 @@ a.tag:hover {
   border-radius: 0.375rem;
 }
 .module-narrow .module-group .module-heading {
-  border-radius: 8px 8px 0 0;
+  border-radius: 6px 6px 0 0;
   border-bottom: 1px solid #e4e7ec;
 }
 .module-narrow .module-group .nav-simple > li:not(:last-of-type),
@@ -12220,15 +12220,6 @@ a.tag:hover {
 .module-narrow .nav-aside li a .item-label {
   width: 70%;
 }
-.module-narrow .nav-item > a .item-state,
-.module-narrow .nav-aside li a .item-state {
-  position: relative;
-  transform: translateY(0);
-  left: 10px;
-  width: 24px;
-  height: 24px;
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none'%3e%3cpath d='M12 8V16M8 12H16M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z' stroke='black' stroke-linecap='round' stroke-linejoin='round'/%3e%3c/svg%3e");
-}
 .module-narrow .nav-item > a .item-count-span,
 .module-narrow .nav-aside li a .item-count-span {
   display: flex;
@@ -12237,10 +12228,6 @@ a.tag:hover {
 .module-narrow .nav-item.active,
 .module-narrow .nav-aside li.active {
   background-color: #153084;
-}
-.module-narrow .nav-item.active .item-state,
-.module-narrow .nav-aside li.active .item-state {
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none'%3e%3cpath d='M8 12H16M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z' stroke='white' stroke-linecap='round' stroke-linejoin='round'/%3e%3c/svg%3e");
 }
 .module-narrow .nav-item.active > a,
 .module-narrow .nav-aside li.active a {
@@ -13181,14 +13168,6 @@ select[data-module=autocomplete] {
 .dataset-item {
   border-bottom: 1px solid #d0d5dd;
   padding: 16px 0;
-  background-color: #f2f4f7;
-  margin-bottom: 0;
-  border-radius: 4px;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  align-self: stretch;
-  width: 100%;
 }
 .dataset-item .dataset-content {
   width: 100%;
@@ -13673,8 +13652,8 @@ td.diff_header {
   font-size: 1rem;
   position: absolute;
   right: 0;
-  top: 1px;
-  height: 93%;
+  top: 2px;
+  height: 91%;
 }
 
 .groups-list {
@@ -15241,6 +15220,321 @@ input[id^=lang-].btn-check + label.btn:hover {
     width: 0%;
   }
 }
+html[data-theme=dark] {
+  color-scheme: dark;
+  --dm-bg: #0b1220;
+  --dm-surface: #141b2d;
+  --dm-surface-alt: #1c2540;
+  --dm-border: #2a3555;
+  --dm-text: #e6e9f0;
+  --dm-text-muted: #97a0b8;
+  --dm-link: #8ea9e8;
+  --dm-link-hover: #b3c6f2;
+  --bs-secondary-color: var(--dm-text-muted);
+  background-color: var(--dm-bg);
+  color: var(--dm-text);
+}
+html[data-theme=dark] body {
+  background-color: var(--dm-bg);
+  color: var(--dm-text);
+}
+html[data-theme=dark] a:not(.btn) {
+  color: var(--dm-link);
+}
+html[data-theme=dark] a:not(.btn):hover,
+html[data-theme=dark] a:not(.btn):focus {
+  color: var(--dm-link-hover);
+}
+html[data-theme=dark] h1, html[data-theme=dark] .h1, html[data-theme=dark] h2, html[data-theme=dark] .h2, html[data-theme=dark] h3, html[data-theme=dark] .h3, html[data-theme=dark] h4, html[data-theme=dark] .h4, html[data-theme=dark] h5, html[data-theme=dark] .h5, html[data-theme=dark] h6, html[data-theme=dark] .h6 {
+  color: var(--dm-text);
+}
+html[data-theme=dark] hr {
+  border-color: var(--dm-border);
+}
+html[data-theme=dark] .masthead {
+  background: var(--dm-surface);
+  border-bottom-color: var(--dm-border);
+}
+html[data-theme=dark] .masthead hgroup a,
+html[data-theme=dark] .masthead .navbar-toggler .fa {
+  color: var(--dm-text);
+}
+html[data-theme=dark] .masthead .logo-light {
+  display: none;
+}
+html[data-theme=dark] .masthead .logo-dark {
+  display: inline-block !important;
+}
+html[data-theme=dark] .masthead .main-navbar li a {
+  color: var(--dm-text);
+}
+html[data-theme=dark] .masthead .main-navbar li:hover a,
+html[data-theme=dark] .masthead .main-navbar li:focus a,
+html[data-theme=dark] .masthead .main-navbar li.active a {
+  background-color: var(--dm-surface-alt);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .account-masthead {
+  background: var(--dm-surface-alt);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .account-masthead .account li a.image {
+  background-color: var(--dm-surface);
+  color: var(--dm-text);
+  border-color: var(--dm-border);
+}
+html[data-theme=dark] .main,
+html[data-theme=dark] .main .primary,
+html[data-theme=dark] [role=main] {
+  background-color: var(--dm-bg);
+}
+html[data-theme=dark] .stages li,
+html[data-theme=dark] .list-group-item,
+html[data-theme=dark] .popover,
+html[data-theme=dark] .dropdown-menu,
+html[data-theme=dark] .pagination .page-link,
+html[data-theme=dark] .dataset-item {
+  background-color: var(--dm-surface);
+  border-color: var(--dm-border);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .dataset-item {
+  background-color: transparent;
+}
+html[data-theme=dark] .groups-cards {
+  background-color: var(--dm-surface-alt);
+  border-color: var(--dm-border);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .resource-list .resource-item .heading {
+  color: var(--dm-text);
+}
+html[data-theme=dark] .resource-list .resource-item:hover {
+  background-color: var(--dm-surface-alt);
+}
+html[data-theme=dark] .resource-view-list li {
+  border-color: var(--dm-border);
+}
+html[data-theme=dark] .login-main {
+  background-color: var(--dm-bg);
+}
+html[data-theme=dark] .login-main .login-wrapper {
+  background-color: var(--dm-surface);
+}
+html[data-theme=dark] .homepage .module-feeds:nth-of-type(even) {
+  background: var(--dm-surface);
+}
+html[data-theme=dark] .module,
+html[data-theme=dark] .module-shallow,
+html[data-theme=dark] .package-info,
+html[data-theme=dark] .context-info {
+  border-color: var(--dm-border);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .context-info .nums dl {
+  color: var(--dm-text);
+}
+html[data-theme=dark] .module-heading,
+html[data-theme=dark] .nav-pills,
+html[data-theme=dark] .secondary .nav-options,
+html[data-theme=dark] .table thead th {
+  background-color: var(--dm-surface-alt);
+}
+html[data-theme=dark] .module-narrow .module-group {
+  border-color: var(--dm-border);
+}
+html[data-theme=dark] .module-narrow .module-group .module-heading {
+  border-bottom-color: var(--dm-border);
+}
+html[data-theme=dark] .add-new-res {
+  border-top-color: var(--dm-border);
+}
+html[data-theme=dark] .nav-simple > li,
+html[data-theme=dark] .nav-aside > li {
+  background-color: var(--dm-surface);
+  border-bottom-color: var(--dm-border);
+}
+html[data-theme=dark] .secondary .accordion .accordion-item:has(.accordion-button:disabled),
+html[data-theme=dark] .secondary .accordion .accordion-item .module-content {
+  background-color: var(--dm-surface);
+}
+html[data-theme=dark] .secondary .accordion .accordion-button.collapsed {
+  background-color: var(--dm-surface-alt);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .secondary .accordion .accordion-collapse.show {
+  background-color: var(--dm-surface);
+}
+html[data-theme=dark] .secondary .accordion .package-accordion .accordion-body {
+  background-color: var(--dm-surface);
+}
+html[data-theme=dark] .accordion-button.collapsed::after {
+  background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23e6e9f0'><path fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/></svg>");
+}
+html[data-theme=dark] .nav-pills li.active {
+  background-color: var(--dm-surface-alt);
+}
+html[data-theme=dark] .module-narrow .nav-item > a,
+html[data-theme=dark] .module-narrow .nav-aside li a,
+html[data-theme=dark] .nav-pills li a,
+html[data-theme=dark] .secondary .nav-options li a,
+html[data-theme=dark] .dropdown-item {
+  color: var(--dm-text);
+}
+html[data-theme=dark] .module-narrow .nav-item:hover > a,
+html[data-theme=dark] .module-narrow .nav-aside li:hover a,
+html[data-theme=dark] .nav-pills li:hover,
+html[data-theme=dark] .secondary .nav-options li:hover,
+html[data-theme=dark] .dropdown-item:hover {
+  background-color: var(--dm-surface-alt);
+}
+html[data-theme=dark] .nav-tabs {
+  --bs-nav-tabs-border-color: var(--dm-border);
+  --bs-nav-tabs-link-hover-border-color: var(--dm-border) var(--dm-border) var(--dm-border);
+  --bs-nav-tabs-link-active-color: var(--dm-text);
+  --bs-nav-tabs-link-active-bg: var(--dm-surface);
+  --bs-nav-tabs-link-active-border-color: var(--dm-border) var(--dm-border) var(--dm-surface);
+}
+html[data-theme=dark] .toolbar .breadcrumb a {
+  color: var(--dm-text-muted);
+}
+html[data-theme=dark] .toolbar .breadcrumb .active a,
+html[data-theme=dark] .toolbar .breadcrumb a.active {
+  color: var(--dm-text);
+}
+html[data-theme=dark] .toolbar .breadcrumb li:not(:first-child)::before {
+  color: var(--dm-text-muted);
+}
+html[data-theme=dark] .table {
+  --bs-table-color: var(--dm-text);
+  --bs-table-bg: var(--dm-surface);
+  --bs-table-striped-bg: var(--dm-surface-alt);
+  --bs-table-striped-color: var(--dm-text);
+  --bs-table-hover-bg: var(--dm-surface-alt);
+  --bs-table-hover-color: var(--dm-text);
+  --bs-table-active-bg: var(--dm-surface-alt);
+  --bs-table-active-color: var(--dm-text);
+  --bs-table-border-color: var(--dm-border);
+}
+html[data-theme=dark] .table-selected td {
+  background-color: var(--dm-surface-alt);
+}
+html[data-theme=dark] .table-bulk-edit .context p {
+  color: var(--dm-text);
+}
+html[data-theme=dark] .form-control,
+html[data-theme=dark] .form-select,
+html[data-theme=dark] input[type=text],
+html[data-theme=dark] input[type=email],
+html[data-theme=dark] input[type=password],
+html[data-theme=dark] input[type=search],
+html[data-theme=dark] input[type=number],
+html[data-theme=dark] textarea {
+  background-color: var(--dm-surface);
+  border-color: var(--dm-border);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .form-control::placeholder {
+  color: var(--dm-text-muted);
+}
+html[data-theme=dark] .form-select {
+  --bs-form-select-bg-img: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='%23e6e9f0' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/></svg>");
+}
+html[data-theme=dark] .input-group-text {
+  background-color: var(--dm-surface-alt);
+  border-color: var(--dm-border);
+  color: var(--dm-text);
+}
+html[data-theme=dark] label {
+  color: var(--dm-text);
+}
+html[data-theme=dark] .select2-container .select2-choice,
+html[data-theme=dark] .select2-container-multi .select2-choices,
+html[data-theme=dark] .select2-dropdown-open .select2-choice {
+  background-color: var(--dm-surface) !important;
+  border-color: var(--dm-border) !important;
+  color: var(--dm-text) !important;
+}
+html[data-theme=dark] .select2-dropdown {
+  background-color: var(--dm-surface);
+  border-color: var(--dm-border);
+}
+html[data-theme=dark] .select2-results__option {
+  color: var(--dm-text);
+}
+html[data-theme=dark] .select2-results__option--selected {
+  background-color: var(--dm-surface-alt);
+}
+html[data-theme=dark] .select2-search--dropdown .select2-search__field {
+  background-color: var(--dm-surface);
+  border-color: var(--dm-border);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .select2-container--default .select2-selection--single {
+  background-color: var(--dm-surface);
+  border-color: var(--dm-border);
+}
+html[data-theme=dark] .select2-container--default .select2-selection--single .select2-selection__rendered {
+  color: var(--dm-text);
+}
+html[data-theme=dark] .select2-container--default .select2-selection--multiple {
+  background-color: var(--dm-surface);
+  border-color: var(--dm-border);
+}
+html[data-theme=dark] .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: var(--dm-surface-alt);
+  border-color: var(--dm-border);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: var(--dm-text-muted);
+  border-right-color: var(--dm-border);
+}
+html[data-theme=dark] .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover,
+html[data-theme=dark] .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:focus {
+  background-color: var(--dm-border);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .editor-info-block {
+  background-color: var(--dm-surface-alt);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .editor-info-block a {
+  color: var(--dm-link);
+}
+html[data-theme=dark] .slug-preview-inner {
+  background-color: var(--dm-surface);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .slug-preview-value {
+  background-color: var(--dm-surface-alt);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .btn:not(.btn-primary):not(.btn-secondary):not(.btn-danger):not(.btn-success):not(.btn-warning):not(.btn-info) {
+  background-color: var(--dm-surface);
+  border-color: var(--dm-border);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .btn-secondary {
+  background-color: var(--dm-surface);
+  border-color: var(--dm-border);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .btn-secondary:hover {
+  background-color: var(--dm-surface-alt) !important;
+  border-color: var(--dm-border);
+  color: var(--dm-text);
+}
+html[data-theme=dark] code,
+html[data-theme=dark] pre {
+  background-color: var(--dm-surface-alt);
+  color: var(--dm-text);
+}
+html[data-theme=dark] ::selection {
+  background-color: var(--dm-link);
+  color: var(--dm-bg);
+}
+
 @media (min-width: 576px) {
   .wrapper:before {
     left: initial;

--- a/ckan/public-midnight-blue/base/css/main.css
+++ b/ckan/public-midnight-blue/base/css/main.css
@@ -15534,3 +15534,6 @@ html[data-theme=dark] ::selection {
   background-color: var(--dm-link);
   color: var(--dm-bg);
 }
+html[data-theme=dark] .card {
+  --bs-card-border-color: var(--dm-border);
+}

--- a/ckan/public-midnight-blue/base/css/main.css
+++ b/ckan/public-midnight-blue/base/css/main.css
@@ -12061,7 +12061,7 @@ a.tag:hover {
   border-radius: 0.375rem;
 }
 .module-narrow .module-group .module-heading {
-  border-radius: 8px 8px 0 0;
+  border-radius: 6px 6px 0 0;
   border-bottom: 1px solid #e4e7ec;
 }
 .module-narrow .module-group .nav-simple > li:not(:last-of-type),
@@ -12220,15 +12220,6 @@ a.tag:hover {
 .module-narrow .nav-aside li a .item-label {
   width: 70%;
 }
-.module-narrow .nav-item > a .item-state,
-.module-narrow .nav-aside li a .item-state {
-  position: relative;
-  transform: translateY(0);
-  left: 10px;
-  width: 24px;
-  height: 24px;
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none'%3e%3cpath d='M12 8V16M8 12H16M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z' stroke='black' stroke-linecap='round' stroke-linejoin='round'/%3e%3c/svg%3e");
-}
 .module-narrow .nav-item > a .item-count-span,
 .module-narrow .nav-aside li a .item-count-span {
   display: flex;
@@ -12237,10 +12228,6 @@ a.tag:hover {
 .module-narrow .nav-item.active,
 .module-narrow .nav-aside li.active {
   background-color: #153084;
-}
-.module-narrow .nav-item.active .item-state,
-.module-narrow .nav-aside li.active .item-state {
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none'%3e%3cpath d='M8 12H16M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z' stroke='white' stroke-linecap='round' stroke-linejoin='round'/%3e%3c/svg%3e");
 }
 .module-narrow .nav-item.active > a,
 .module-narrow .nav-aside li.active a {
@@ -13181,14 +13168,6 @@ select[data-module=autocomplete] {
 .dataset-item {
   border-bottom: 1px solid #d0d5dd;
   padding: 16px 0;
-  background-color: #f2f4f7;
-  margin-bottom: 0;
-  border-radius: 4px;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  align-self: stretch;
-  width: 100%;
 }
 .dataset-item .dataset-content {
   width: 100%;
@@ -13673,8 +13652,8 @@ td.diff_header {
   font-size: 1rem;
   position: absolute;
   right: 0;
-  top: 1px;
-  height: 93%;
+  top: 2px;
+  height: 91%;
 }
 
 .groups-list {
@@ -15240,4 +15219,318 @@ input[id^=lang-].btn-check + label.btn:hover {
   to {
     width: 0%;
   }
+}
+html[data-theme=dark] {
+  color-scheme: dark;
+  --dm-bg: #0b1220;
+  --dm-surface: #141b2d;
+  --dm-surface-alt: #1c2540;
+  --dm-border: #2a3555;
+  --dm-text: #e6e9f0;
+  --dm-text-muted: #97a0b8;
+  --dm-link: #8ea9e8;
+  --dm-link-hover: #b3c6f2;
+  --bs-secondary-color: var(--dm-text-muted);
+  background-color: var(--dm-bg);
+  color: var(--dm-text);
+}
+html[data-theme=dark] body {
+  background-color: var(--dm-bg);
+  color: var(--dm-text);
+}
+html[data-theme=dark] a:not(.btn) {
+  color: var(--dm-link);
+}
+html[data-theme=dark] a:not(.btn):hover,
+html[data-theme=dark] a:not(.btn):focus {
+  color: var(--dm-link-hover);
+}
+html[data-theme=dark] h1, html[data-theme=dark] .h1, html[data-theme=dark] h2, html[data-theme=dark] .h2, html[data-theme=dark] h3, html[data-theme=dark] .h3, html[data-theme=dark] h4, html[data-theme=dark] .h4, html[data-theme=dark] h5, html[data-theme=dark] .h5, html[data-theme=dark] h6, html[data-theme=dark] .h6 {
+  color: var(--dm-text);
+}
+html[data-theme=dark] hr {
+  border-color: var(--dm-border);
+}
+html[data-theme=dark] .masthead {
+  background: var(--dm-surface);
+  border-bottom-color: var(--dm-border);
+}
+html[data-theme=dark] .masthead hgroup a,
+html[data-theme=dark] .masthead .navbar-toggler .fa {
+  color: var(--dm-text);
+}
+html[data-theme=dark] .masthead .logo-light {
+  display: none;
+}
+html[data-theme=dark] .masthead .logo-dark {
+  display: inline-block !important;
+}
+html[data-theme=dark] .masthead .main-navbar li a {
+  color: var(--dm-text);
+}
+html[data-theme=dark] .masthead .main-navbar li:hover a,
+html[data-theme=dark] .masthead .main-navbar li:focus a,
+html[data-theme=dark] .masthead .main-navbar li.active a {
+  background-color: var(--dm-surface-alt);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .account-masthead {
+  background: var(--dm-surface-alt);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .account-masthead .account li a.image {
+  background-color: var(--dm-surface);
+  color: var(--dm-text);
+  border-color: var(--dm-border);
+}
+html[data-theme=dark] .main,
+html[data-theme=dark] .main .primary,
+html[data-theme=dark] [role=main] {
+  background-color: var(--dm-bg);
+}
+html[data-theme=dark] .stages li,
+html[data-theme=dark] .list-group-item,
+html[data-theme=dark] .popover,
+html[data-theme=dark] .dropdown-menu,
+html[data-theme=dark] .pagination .page-link,
+html[data-theme=dark] .dataset-item {
+  background-color: var(--dm-surface);
+  border-color: var(--dm-border);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .dataset-item {
+  background-color: transparent;
+}
+html[data-theme=dark] .groups-cards {
+  background-color: var(--dm-surface-alt);
+  border-color: var(--dm-border);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .resource-list .resource-item .heading {
+  color: var(--dm-text);
+}
+html[data-theme=dark] .resource-list .resource-item:hover {
+  background-color: var(--dm-surface-alt);
+}
+html[data-theme=dark] .resource-view-list li {
+  border-color: var(--dm-border);
+}
+html[data-theme=dark] .login-main {
+  background-color: var(--dm-bg);
+}
+html[data-theme=dark] .login-main .login-wrapper {
+  background-color: var(--dm-surface);
+}
+html[data-theme=dark] .homepage .module-feeds:nth-of-type(even) {
+  background: var(--dm-surface);
+}
+html[data-theme=dark] .module,
+html[data-theme=dark] .module-shallow,
+html[data-theme=dark] .package-info,
+html[data-theme=dark] .context-info {
+  border-color: var(--dm-border);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .context-info .nums dl {
+  color: var(--dm-text);
+}
+html[data-theme=dark] .module-heading,
+html[data-theme=dark] .nav-pills,
+html[data-theme=dark] .secondary .nav-options,
+html[data-theme=dark] .table thead th {
+  background-color: var(--dm-surface-alt);
+}
+html[data-theme=dark] .module-narrow .module-group {
+  border-color: var(--dm-border);
+}
+html[data-theme=dark] .module-narrow .module-group .module-heading {
+  border-bottom-color: var(--dm-border);
+}
+html[data-theme=dark] .add-new-res {
+  border-top-color: var(--dm-border);
+}
+html[data-theme=dark] .nav-simple > li,
+html[data-theme=dark] .nav-aside > li {
+  background-color: var(--dm-surface);
+  border-bottom-color: var(--dm-border);
+}
+html[data-theme=dark] .secondary .accordion .accordion-item:has(.accordion-button:disabled),
+html[data-theme=dark] .secondary .accordion .accordion-item .module-content {
+  background-color: var(--dm-surface);
+}
+html[data-theme=dark] .secondary .accordion .accordion-button.collapsed {
+  background-color: var(--dm-surface-alt);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .secondary .accordion .accordion-collapse.show {
+  background-color: var(--dm-surface);
+}
+html[data-theme=dark] .secondary .accordion .package-accordion .accordion-body {
+  background-color: var(--dm-surface);
+}
+html[data-theme=dark] .accordion-button.collapsed::after {
+  background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23e6e9f0'><path fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/></svg>");
+}
+html[data-theme=dark] .nav-pills li.active {
+  background-color: var(--dm-surface-alt);
+}
+html[data-theme=dark] .module-narrow .nav-item > a,
+html[data-theme=dark] .module-narrow .nav-aside li a,
+html[data-theme=dark] .nav-pills li a,
+html[data-theme=dark] .secondary .nav-options li a,
+html[data-theme=dark] .dropdown-item {
+  color: var(--dm-text);
+}
+html[data-theme=dark] .module-narrow .nav-item:hover > a,
+html[data-theme=dark] .module-narrow .nav-aside li:hover a,
+html[data-theme=dark] .nav-pills li:hover,
+html[data-theme=dark] .secondary .nav-options li:hover,
+html[data-theme=dark] .dropdown-item:hover {
+  background-color: var(--dm-surface-alt);
+}
+html[data-theme=dark] .nav-tabs {
+  --bs-nav-tabs-border-color: var(--dm-border);
+  --bs-nav-tabs-link-hover-border-color: var(--dm-border) var(--dm-border) var(--dm-border);
+  --bs-nav-tabs-link-active-color: var(--dm-text);
+  --bs-nav-tabs-link-active-bg: var(--dm-surface);
+  --bs-nav-tabs-link-active-border-color: var(--dm-border) var(--dm-border) var(--dm-surface);
+}
+html[data-theme=dark] .toolbar .breadcrumb a {
+  color: var(--dm-text-muted);
+}
+html[data-theme=dark] .toolbar .breadcrumb .active a,
+html[data-theme=dark] .toolbar .breadcrumb a.active {
+  color: var(--dm-text);
+}
+html[data-theme=dark] .toolbar .breadcrumb li:not(:first-child)::before {
+  color: var(--dm-text-muted);
+}
+html[data-theme=dark] .table {
+  --bs-table-color: var(--dm-text);
+  --bs-table-bg: var(--dm-surface);
+  --bs-table-striped-bg: var(--dm-surface-alt);
+  --bs-table-striped-color: var(--dm-text);
+  --bs-table-hover-bg: var(--dm-surface-alt);
+  --bs-table-hover-color: var(--dm-text);
+  --bs-table-active-bg: var(--dm-surface-alt);
+  --bs-table-active-color: var(--dm-text);
+  --bs-table-border-color: var(--dm-border);
+}
+html[data-theme=dark] .table-selected td {
+  background-color: var(--dm-surface-alt);
+}
+html[data-theme=dark] .table-bulk-edit .context p {
+  color: var(--dm-text);
+}
+html[data-theme=dark] .form-control,
+html[data-theme=dark] .form-select,
+html[data-theme=dark] input[type=text],
+html[data-theme=dark] input[type=email],
+html[data-theme=dark] input[type=password],
+html[data-theme=dark] input[type=search],
+html[data-theme=dark] input[type=number],
+html[data-theme=dark] textarea {
+  background-color: var(--dm-surface);
+  border-color: var(--dm-border);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .form-control::placeholder {
+  color: var(--dm-text-muted);
+}
+html[data-theme=dark] .form-select {
+  --bs-form-select-bg-img: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='%23e6e9f0' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/></svg>");
+}
+html[data-theme=dark] .input-group-text {
+  background-color: var(--dm-surface-alt);
+  border-color: var(--dm-border);
+  color: var(--dm-text);
+}
+html[data-theme=dark] label {
+  color: var(--dm-text);
+}
+html[data-theme=dark] .select2-container .select2-choice,
+html[data-theme=dark] .select2-container-multi .select2-choices,
+html[data-theme=dark] .select2-dropdown-open .select2-choice {
+  background-color: var(--dm-surface) !important;
+  border-color: var(--dm-border) !important;
+  color: var(--dm-text) !important;
+}
+html[data-theme=dark] .select2-dropdown {
+  background-color: var(--dm-surface);
+  border-color: var(--dm-border);
+}
+html[data-theme=dark] .select2-results__option {
+  color: var(--dm-text);
+}
+html[data-theme=dark] .select2-results__option--selected {
+  background-color: var(--dm-surface-alt);
+}
+html[data-theme=dark] .select2-search--dropdown .select2-search__field {
+  background-color: var(--dm-surface);
+  border-color: var(--dm-border);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .select2-container--default .select2-selection--single {
+  background-color: var(--dm-surface);
+  border-color: var(--dm-border);
+}
+html[data-theme=dark] .select2-container--default .select2-selection--single .select2-selection__rendered {
+  color: var(--dm-text);
+}
+html[data-theme=dark] .select2-container--default .select2-selection--multiple {
+  background-color: var(--dm-surface);
+  border-color: var(--dm-border);
+}
+html[data-theme=dark] .select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: var(--dm-surface-alt);
+  border-color: var(--dm-border);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: var(--dm-text-muted);
+  border-right-color: var(--dm-border);
+}
+html[data-theme=dark] .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover,
+html[data-theme=dark] .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:focus {
+  background-color: var(--dm-border);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .editor-info-block {
+  background-color: var(--dm-surface-alt);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .editor-info-block a {
+  color: var(--dm-link);
+}
+html[data-theme=dark] .slug-preview-inner {
+  background-color: var(--dm-surface);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .slug-preview-value {
+  background-color: var(--dm-surface-alt);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .btn:not(.btn-primary):not(.btn-secondary):not(.btn-danger):not(.btn-success):not(.btn-warning):not(.btn-info) {
+  background-color: var(--dm-surface);
+  border-color: var(--dm-border);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .btn-secondary {
+  background-color: var(--dm-surface);
+  border-color: var(--dm-border);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .btn-secondary:hover {
+  background-color: var(--dm-surface-alt) !important;
+  border-color: var(--dm-border);
+  color: var(--dm-text);
+}
+html[data-theme=dark] code,
+html[data-theme=dark] pre {
+  background-color: var(--dm-surface-alt);
+  color: var(--dm-text);
+}
+html[data-theme=dark] ::selection {
+  background-color: var(--dm-link);
+  color: var(--dm-bg);
 }

--- a/ckan/public-midnight-blue/base/css/main.css
+++ b/ckan/public-midnight-blue/base/css/main.css
@@ -15231,6 +15231,7 @@ html[data-theme=dark] {
   --dm-link: #8ea9e8;
   --dm-link-hover: #b3c6f2;
   --bs-secondary-color: var(--dm-text-muted);
+  --bs-border-color: var(--dm-border);
   background-color: var(--dm-bg);
   color: var(--dm-text);
 }
@@ -15353,6 +15354,31 @@ html[data-theme=dark] .nav-simple > li,
 html[data-theme=dark] .nav-aside > li {
   background-color: var(--dm-surface);
   border-bottom-color: var(--dm-border);
+}
+html[data-theme=dark] .accordion {
+  --bs-accordion-color: var(--dm-text);
+  --bs-accordion-bg: var(--dm-surface);
+  --bs-accordion-border-color: var(--dm-border);
+  --bs-accordion-btn-color: var(--dm-text);
+  --bs-accordion-btn-bg: var(--dm-surface-alt);
+  --bs-accordion-active-color: var(--dm-text);
+  --bs-accordion-active-bg: var(--dm-surface-alt);
+}
+html[data-theme=dark] .accordion-item {
+  background-color: var(--dm-surface);
+  border-color: var(--dm-border);
+}
+html[data-theme=dark] .accordion-button,
+html[data-theme=dark] .accordion-button:not(.collapsed) {
+  background-color: var(--dm-surface-alt);
+  color: var(--dm-text);
+}
+html[data-theme=dark] .accordion-button::after,
+html[data-theme=dark] .accordion-button:not(.collapsed)::after {
+  background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23e6e9f0'><path fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/></svg>");
+}
+html[data-theme=dark] .accordion-collapse.show {
+  background-color: var(--dm-surface);
 }
 html[data-theme=dark] .secondary .accordion .accordion-item:has(.accordion-button:disabled),
 html[data-theme=dark] .secondary .accordion .accordion-item .module-content {
@@ -15536,4 +15562,15 @@ html[data-theme=dark] ::selection {
 }
 html[data-theme=dark] .card {
   --bs-card-border-color: var(--dm-border);
+}
+html[data-theme=dark] .modal {
+  --bs-modal-bg: var(--dm-surface);
+  --bs-modal-color: var(--dm-text);
+  --bs-modal-border-color: var(--dm-border);
+  --bs-modal-header-border-color: var(--dm-border);
+  --bs-modal-footer-border-color: var(--dm-border);
+  --bs-modal-footer-bg: var(--dm-surface);
+}
+html[data-theme=dark] .modal-header .btn-close {
+  filter: var(--bs-btn-close-white-filter);
 }

--- a/ckan/public-midnight-blue/base/javascript/modules/theme-toggle.js
+++ b/ckan/public-midnight-blue/base/javascript/modules/theme-toggle.js
@@ -1,0 +1,50 @@
+/* Toggles the midnight-blue theme between light and dark mode.
+ *
+ * Sets/clears `data-theme="dark"` on the <html> element and remembers the
+ * choice in localStorage so it persists across page loads. The initial
+ * theme (based on the stored preference, falling back to the OS-level
+ * `prefers-color-scheme`) is applied by an inline script in
+ * templates-midnight-blue/base.html, before this module runs, to avoid a
+ * flash of the wrong theme.
+ */
+ckan.module('theme-toggle', function (jQuery) {
+  var STORAGE_KEY = 'ckan.theme-mode';
+
+  return {
+    initialize: function () {
+      jQuery.proxyAll(this, /_on/);
+      this.el.on('click', this._onClick);
+      this._render(this._isDark());
+    },
+
+    _isDark: function () {
+      return document.documentElement.getAttribute('data-theme') === 'dark';
+    },
+
+    _onClick: function (event) {
+      event.preventDefault();
+
+      var dark = !this._isDark();
+
+      document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+
+      try {
+        localStorage.setItem(STORAGE_KEY, dark ? 'dark' : 'light');
+      } catch (e) {}
+
+      this._render(dark);
+    },
+
+    _render: function (dark) {
+      this.el.attr('aria-pressed', dark ? 'true' : 'false');
+
+      var label = dark ? this._('Switch to light theme') : this._('Switch to dark theme');
+      this.el.attr('aria-label', label);
+      this.el.attr('data-bs-original-title', label);
+
+      this.el.find('[data-icon]')
+        .toggleClass('fa-moon', !dark)
+        .toggleClass('fa-sun', dark);
+    }
+  };
+});

--- a/ckan/public-midnight-blue/base/javascript/webassets.yml
+++ b/ckan/public-midnight-blue/base/javascript/webassets.yml
@@ -54,6 +54,7 @@ ckan:
     - modules/image-upload.js
     - modules/metadata-button.js
     - modules/copy-into-buffer.js
+    - modules/theme-toggle.js
 
 view-filters:
   output: base/%(version)s_view-filters.js

--- a/ckan/public-midnight-blue/base/scss/_ckan.scss
+++ b/ckan/public-midnight-blue/base/scss/_ckan.scss
@@ -25,3 +25,4 @@
 @import "login.scss";
 @import "fonts.scss";
 @import "animations.scss";
+@import "dark-mode.scss";

--- a/ckan/public-midnight-blue/base/scss/_dark-mode.scss
+++ b/ckan/public-midnight-blue/base/scss/_dark-mode.scss
@@ -1,0 +1,391 @@
+html[data-theme="dark"] {
+    color-scheme: dark;
+
+    --dm-bg: #0b1220;
+    --dm-surface: #141b2d;
+    --dm-surface-alt: #1c2540;
+    --dm-border: #2a3555;
+    --dm-text: #e6e9f0;
+    --dm-text-muted: #97a0b8;
+    --dm-link: #8ea9e8;
+    --dm-link-hover: #b3c6f2;
+
+    --bs-secondary-color: var(--dm-text-muted);
+
+    background-color: var(--dm-bg);
+    color: var(--dm-text);
+
+    body {
+        background-color: var(--dm-bg);
+        color: var(--dm-text);
+    }
+
+    a:not(.btn) {
+        color: var(--dm-link);
+    }
+
+    a:not(.btn):hover,
+    a:not(.btn):focus {
+        color: var(--dm-link-hover);
+    }
+
+    h1, h2, h3, h4, h5, h6 {
+        color: var(--dm-text);
+    }
+
+    hr {
+        border-color: var(--dm-border);
+    }
+
+    .masthead {
+        background: var(--dm-surface);
+        border-bottom-color: var(--dm-border);
+
+        hgroup a,
+        .navbar-toggler .fa {
+            color: var(--dm-text);
+        }
+
+        .logo-light {
+            display: none;
+        }
+
+        .logo-dark {
+            display: inline-block !important;
+        }
+
+        .main-navbar li a {
+            color: var(--dm-text);
+        }
+
+        .main-navbar li:hover a,
+        .main-navbar li:focus a,
+        .main-navbar li.active a {
+            background-color: var(--dm-surface-alt);
+            color: var(--dm-text);
+        }
+    }
+
+    .account-masthead {
+        background: var(--dm-surface-alt);
+        color: var(--dm-text);
+
+        .account li a.image {
+            background-color: var(--dm-surface);
+            color: var(--dm-text);
+            border-color: var(--dm-border);
+        }
+    }
+
+    .main,
+    .main .primary,
+    [role=main] {
+        background-color: var(--dm-bg);
+    }
+
+    .stages li,
+    .list-group-item,
+    .popover,
+    .dropdown-menu,
+    .pagination .page-link,
+    .dataset-item {
+        background-color: var(--dm-surface);
+        border-color: var(--dm-border);
+        color: var(--dm-text);
+    }
+
+    .dataset-item {
+        background-color: transparent;
+    }
+
+    .groups-cards {
+        background-color: var(--dm-surface-alt);
+        border-color: var(--dm-border);
+        color: var(--dm-text);
+    }
+
+    .resource-list .resource-item {
+        .heading {
+            color: var(--dm-text);
+        }
+
+        &:hover {
+            background-color: var(--dm-surface-alt);
+        }
+    }
+
+    .resource-view-list li {
+        border-color: var(--dm-border);
+    }
+
+    .login-main {
+        background-color: var(--dm-bg);
+
+        .login-wrapper {
+            background-color: var(--dm-surface);
+        }
+    }
+
+    .homepage .module-feeds:nth-of-type(even) {
+        background: var(--dm-surface);
+    }
+
+    .module,
+    .module-shallow,
+    .package-info,
+    .context-info {
+        border-color: var(--dm-border);
+        color: var(--dm-text);
+    }
+
+    .context-info .nums dl {
+        color: var(--dm-text);
+    }
+
+    .module-heading,
+    .nav-pills,
+    .secondary .nav-options,
+    .table thead th {
+        background-color: var(--dm-surface-alt);
+    }
+
+    .module-narrow .module-group {
+        border-color: var(--dm-border);
+
+        .module-heading {
+            border-bottom-color: var(--dm-border);
+        }
+    }
+
+    .add-new-res {
+        border-top-color: var(--dm-border);
+    }
+
+    .nav-simple > li,
+    .nav-aside > li {
+        background-color: var(--dm-surface);
+        border-bottom-color: var(--dm-border);
+    }
+
+    .secondary .accordion {
+        .accordion-item:has(.accordion-button:disabled),
+        .accordion-item .module-content {
+            background-color: var(--dm-surface);
+        }
+
+        .accordion-button.collapsed {
+            background-color: var(--dm-surface-alt);
+            color: var(--dm-text);
+        }
+
+        .accordion-collapse.show {
+            background-color: var(--dm-surface);
+        }
+
+        .package-accordion .accordion-body {
+            background-color: var(--dm-surface);
+        }
+    }
+
+    .accordion-button.collapsed::after {
+        background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23e6e9f0'><path fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/></svg>");
+    }
+
+    .nav-pills li.active {
+        background-color: var(--dm-surface-alt);
+    }
+
+    .module-narrow .nav-item > a,
+    .module-narrow .nav-aside li a,
+    .nav-pills li a,
+    .secondary .nav-options li a,
+    .dropdown-item {
+        color: var(--dm-text);
+    }
+
+    .module-narrow .nav-item:hover > a,
+    .module-narrow .nav-aside li:hover a,
+    .nav-pills li:hover,
+    .secondary .nav-options li:hover,
+    .dropdown-item:hover {
+        background-color: var(--dm-surface-alt);
+    }
+
+    .nav-tabs {
+        --bs-nav-tabs-border-color: var(--dm-border);
+        --bs-nav-tabs-link-hover-border-color: var(--dm-border) var(--dm-border) var(--dm-border);
+        --bs-nav-tabs-link-active-color: var(--dm-text);
+        --bs-nav-tabs-link-active-bg: var(--dm-surface);
+        --bs-nav-tabs-link-active-border-color: var(--dm-border) var(--dm-border) var(--dm-surface);
+    }
+
+    .toolbar .breadcrumb a {
+        color: var(--dm-text-muted);
+    }
+
+    .toolbar .breadcrumb .active a,
+    .toolbar .breadcrumb a.active {
+        color: var(--dm-text);
+    }
+
+    .toolbar .breadcrumb li:not(:first-child)::before {
+        color: var(--dm-text-muted);
+    }
+
+    .table {
+        --bs-table-color: var(--dm-text);
+        --bs-table-bg: var(--dm-surface);
+        --bs-table-striped-bg: var(--dm-surface-alt);
+        --bs-table-striped-color: var(--dm-text);
+        --bs-table-hover-bg: var(--dm-surface-alt);
+        --bs-table-hover-color: var(--dm-text);
+        --bs-table-active-bg: var(--dm-surface-alt);
+        --bs-table-active-color: var(--dm-text);
+        --bs-table-border-color: var(--dm-border);
+    }
+
+    .table-selected td {
+        background-color: var(--dm-surface-alt);
+    }
+
+    .table-bulk-edit .context p {
+        color: var(--dm-text);
+    }
+
+    .form-control,
+    .form-select,
+    input[type="text"],
+    input[type="email"],
+    input[type="password"],
+    input[type="search"],
+    input[type="number"],
+    textarea {
+        background-color: var(--dm-surface);
+        border-color: var(--dm-border);
+        color: var(--dm-text);
+    }
+
+    .form-control::placeholder {
+        color: var(--dm-text-muted);
+    }
+
+    .form-select {
+        --bs-form-select-bg-img: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='%23e6e9f0' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/></svg>");
+    }
+
+    .input-group-text {
+        background-color: var(--dm-surface-alt);
+        border-color: var(--dm-border);
+        color: var(--dm-text);
+    }
+
+    label {
+        color: var(--dm-text);
+    }
+
+    .select2-container .select2-choice,
+    .select2-container-multi .select2-choices,
+    .select2-dropdown-open .select2-choice {
+        background-color: var(--dm-surface) !important;
+        border-color: var(--dm-border) !important;
+        color: var(--dm-text) !important;
+    }
+
+    .select2-dropdown {
+        background-color: var(--dm-surface);
+        border-color: var(--dm-border);
+    }
+
+    .select2-results__option {
+        color: var(--dm-text);
+    }
+
+    .select2-results__option--selected {
+        background-color: var(--dm-surface-alt);
+    }
+
+    .select2-search--dropdown .select2-search__field {
+        background-color: var(--dm-surface);
+        border-color: var(--dm-border);
+        color: var(--dm-text);
+    }
+
+    .select2-container--default .select2-selection--single {
+        background-color: var(--dm-surface);
+        border-color: var(--dm-border);
+    }
+
+    .select2-container--default .select2-selection--single .select2-selection__rendered {
+        color: var(--dm-text);
+    }
+
+    .select2-container--default .select2-selection--multiple {
+        background-color: var(--dm-surface);
+        border-color: var(--dm-border);
+    }
+
+    .select2-container--default .select2-selection--multiple .select2-selection__choice {
+        background-color: var(--dm-surface-alt);
+        border-color: var(--dm-border);
+        color: var(--dm-text);
+    }
+
+    .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+        color: var(--dm-text-muted);
+        border-right-color: var(--dm-border);
+    }
+
+    .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover,
+    .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:focus {
+        background-color: var(--dm-border);
+        color: var(--dm-text);
+    }
+
+    .editor-info-block {
+        background-color: var(--dm-surface-alt);
+        color: var(--dm-text);
+    }
+
+    .editor-info-block a {
+        color: var(--dm-link);
+    }
+
+    .slug-preview-inner {
+        background-color: var(--dm-surface);
+        color: var(--dm-text);
+    }
+
+    .slug-preview-value {
+        background-color: var(--dm-surface-alt);
+        color: var(--dm-text);
+    }
+
+    .btn:not(.btn-primary):not(.btn-secondary):not(.btn-danger):not(.btn-success):not(.btn-warning):not(.btn-info) {
+        background-color: var(--dm-surface);
+        border-color: var(--dm-border);
+        color: var(--dm-text);
+    }
+
+    .btn-secondary {
+        background-color: var(--dm-surface);
+        border-color: var(--dm-border);
+        color: var(--dm-text);
+
+        &:hover {
+            background-color: var(--dm-surface-alt) !important;
+            border-color: var(--dm-border);
+            color: var(--dm-text);
+        }
+    }
+
+    code,
+    pre {
+        background-color: var(--dm-surface-alt);
+        color: var(--dm-text);
+    }
+
+    ::selection {
+        background-color: var(--dm-link);
+        color: var(--dm-bg);
+    }
+}

--- a/ckan/public-midnight-blue/base/scss/_dark-mode.scss
+++ b/ckan/public-midnight-blue/base/scss/_dark-mode.scss
@@ -11,6 +11,7 @@ html[data-theme="dark"] {
     --dm-link-hover: #b3c6f2;
 
     --bs-secondary-color: var(--dm-text-muted);
+    --bs-border-color: var(--dm-border);
 
     background-color: var(--dm-bg);
     color: var(--dm-text);
@@ -165,6 +166,36 @@ html[data-theme="dark"] {
     .nav-aside > li {
         background-color: var(--dm-surface);
         border-bottom-color: var(--dm-border);
+    }
+
+    .accordion {
+        --bs-accordion-color: var(--dm-text);
+        --bs-accordion-bg: var(--dm-surface);
+        --bs-accordion-border-color: var(--dm-border);
+        --bs-accordion-btn-color: var(--dm-text);
+        --bs-accordion-btn-bg: var(--dm-surface-alt);
+        --bs-accordion-active-color: var(--dm-text);
+        --bs-accordion-active-bg: var(--dm-surface-alt);
+    }
+
+    .accordion-item {
+        background-color: var(--dm-surface);
+        border-color: var(--dm-border);
+    }
+
+    .accordion-button,
+    .accordion-button:not(.collapsed) {
+        background-color: var(--dm-surface-alt);
+        color: var(--dm-text);
+    }
+
+    .accordion-button::after,
+    .accordion-button:not(.collapsed)::after {
+        background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23e6e9f0'><path fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/></svg>");
+    }
+
+    .accordion-collapse.show {
+        background-color: var(--dm-surface);
     }
 
     .secondary .accordion {
@@ -391,5 +422,18 @@ html[data-theme="dark"] {
 
     .card {
         --bs-card-border-color: var(--dm-border);
+    }
+
+    .modal {
+        --bs-modal-bg: var(--dm-surface);
+        --bs-modal-color: var(--dm-text);
+        --bs-modal-border-color: var(--dm-border);
+        --bs-modal-header-border-color: var(--dm-border);
+        --bs-modal-footer-border-color: var(--dm-border);
+        --bs-modal-footer-bg: var(--dm-surface);
+    }
+
+    .modal-header .btn-close {
+        filter: var(--bs-btn-close-white-filter);
     }
 }

--- a/ckan/public-midnight-blue/base/scss/_dark-mode.scss
+++ b/ckan/public-midnight-blue/base/scss/_dark-mode.scss
@@ -388,4 +388,8 @@ html[data-theme="dark"] {
         background-color: var(--dm-link);
         color: var(--dm-bg);
     }
+
+    .card {
+        --bs-card-border-color: var(--dm-border);
+    }
 }

--- a/ckan/public-midnight-blue/base/scss/_dataset.scss
+++ b/ckan/public-midnight-blue/base/scss/_dataset.scss
@@ -1,14 +1,6 @@
 .dataset-item {
     border-bottom: 1px solid $genericBorderColor;
     padding: 16px 0;
-    background-color: $gray-100;
-    margin-bottom: 0;
-    border-radius: 4px;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    align-self: stretch;
-    width: 100%;
 
     .dataset-content {
         width: 100%;

--- a/ckan/public-midnight-blue/base/scss/_module.scss
+++ b/ckan/public-midnight-blue/base/scss/_module.scss
@@ -66,7 +66,7 @@
         border: 1px solid $gray-300;
         border-radius: $border-radius;
         .module-heading {
-            border-radius: 8px 8px 0 0;
+            border-radius: 6px 6px 0 0;
             border-bottom: 1px solid $gray-200;
         }
         .nav-simple > li:not(:last-of-type),

--- a/ckan/public-midnight-blue/base/scss/_nav.scss
+++ b/ckan/public-midnight-blue/base/scss/_nav.scss
@@ -45,15 +45,6 @@
             width: 70%;
         }
 
-        .item-state {
-            position: relative;
-            transform: translateY(0);
-            left: 10px;
-            width: 24px;
-            height: 24px;
-            background-image: escape-svg($addStateIcon);
-        }
-
         .item-count-span {
             display: flex;
             align-self: center;
@@ -63,10 +54,6 @@
     .nav-item.active,
     .nav-aside li.active {
         background-color: $primary;
-
-        .item-state {
-            background-image: escape-svg($removeStateIcon);
-        }
     }
 
     .nav-item.active>a,

--- a/ckan/public-midnight-blue/base/scss/_search.scss
+++ b/ckan/public-midnight-blue/base/scss/_search.scss
@@ -122,8 +122,8 @@
             font-size: 1rem;
             position: absolute;
             right: 0;
-            top: 1px;
-            height: 93%;
+            top: 2px;
+            height: 91%;
         }
     }
 }

--- a/ckan/public-midnight-blue/base/scss/_variables.scss
+++ b/ckan/public-midnight-blue/base/scss/_variables.scss
@@ -116,5 +116,3 @@ $zindex-navbar: 1;
 
 // Icons
 $chevronActiveIcon: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='#{$white}'><path fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/></svg>");
-$removeStateIcon: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none'><path d='M8 12H16M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z' stroke='white' stroke-linecap='round' stroke-linejoin='round'/></svg>");
-$addStateIcon: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none'><path d='M12 8V16M8 12H16M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z' stroke='black' stroke-linecap='round' stroke-linejoin='round'/></svg>");

--- a/ckan/templates-midnight-blue/base.html
+++ b/ckan/templates-midnight-blue/base.html
@@ -21,6 +21,22 @@
     {% endblock %}
 
     #}
+    {# Applies the saved light/dark theme preference before the page renders
+       so there is no flash of the wrong theme #}
+    <script>
+      (function () {
+        try {
+          var stored = localStorage.getItem('ckan.theme-mode');
+          var dark = stored
+            ? stored === 'dark'
+            : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+          if (dark) {
+            document.documentElement.setAttribute('data-theme', 'dark');
+          }
+        } catch (e) {}
+      })();
+    </script>
+
     {%- block meta -%}
       <meta charset="utf-8" />
       <meta name="csrf_field_name" content="{{ g.csrf_field_name }}" />

--- a/ckan/templates-midnight-blue/base.html
+++ b/ckan/templates-midnight-blue/base.html
@@ -21,21 +21,25 @@
     {% endblock %}
 
     #}
-    {# Applies the saved light/dark theme preference before the page renders
-       so there is no flash of the wrong theme #}
-    <script>
-      (function () {
-        try {
-          var stored = localStorage.getItem('ckan.theme-mode');
-          var dark = stored
-            ? stored === 'dark'
-            : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-          if (dark) {
-            document.documentElement.setAttribute('data-theme', 'dark');
-          }
-        } catch (e) {}
-      })();
-    </script>
+    {% block theme_mode_script %}
+      {% if h.dark_mode_enabled() %}
+        {# Applies the saved light/dark theme preference before the page renders
+           so there is no flash of the wrong theme #}
+        <script>
+          (function () {
+            try {
+              var stored = localStorage.getItem('ckan.theme-mode');
+              var dark = stored
+                ? stored === 'dark'
+                : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+              if (dark) {
+                document.documentElement.setAttribute('data-theme', 'dark');
+              }
+            } catch (e) {}
+          })();
+        </script>
+      {% endif %}
+    {% endblock %}
 
     {%- block meta -%}
       <meta charset="utf-8" />

--- a/ckan/templates-midnight-blue/header.html
+++ b/ckan/templates-midnight-blue/header.html
@@ -3,12 +3,20 @@
 
 {% block header_wrapper %}
   {% block header_account %}
-    {% if c.userobj %}
-      <div class="account-masthead">
-        <div class="container">
-          {% block header_account_container_content %}
-            <div class="account avatar authed" data-module="me" data-me="{{ c.userobj.id }}">
-              <ul class="list-unstyled">
+    <div class="account-masthead">
+      <div class="container">
+        {% block header_account_container_content %}
+          <div class="account{% if c.userobj %} avatar authed{% endif %}"{% if c.userobj %} data-module="me" data-me="{{ c.userobj.id }}"{% endif %}>
+            <ul class="list-unstyled">
+              {% block header_account_theme_toggle %}
+                <li>
+                  <button type="button" class="btn btn-primary" data-module="theme-toggle" aria-pressed="false" aria-label="{{ _('Switch to dark theme') }}" data-bs-title="{{ _('Switch to dark theme') }}" data-bs-toggle="tooltip">
+                    <i class="fa fa-moon" aria-hidden="true" data-icon></i>
+                    <span class="text">{{ _('Theme') }}</span>
+                  </button>
+                </li>
+              {% endblock %}
+              {% if c.userobj %}
                 {% block header_account_logged %}
                   {% block header_account_profile %}
                     <li>
@@ -45,12 +53,12 @@
                     </li>
                   {% endblock %}
                 {% endblock %}
-              </ul>
-            </div>
-          {% endblock %}
-        </div>
+              {% endif %}
+            </ul>
+          </div>
+        {% endblock %}
       </div>
-    {% endif %}
+    </div>
   {% endblock %}
   <header class="masthead">
     <div class="container">
@@ -64,8 +72,17 @@
           {% block header_logo %}
             {% if g.site_logo %}
               <a class="logo" href="{{ h.url_for('home.index') }}">
-                <img src="{{ h.url_for_static_or_external(g.site_logo) }}" alt="{{ g.site_title }}"
-                  aria-label="{{ _('Navigate to Home - {site_title}').format(site_title=g.site_title) }}"/>
+                {% if g.site_logo == '/base/images/ckan-logo.png' %}
+                  <img src="{{ h.url_for_static_or_external(g.site_logo) }}" alt="{{ g.site_title }}"
+                    aria-label="{{ _('Navigate to Home - {site_title}').format(site_title=g.site_title) }}"
+                    class="logo-light"/>
+                  <img src="{{ h.url_for_static_or_external('/base/images/ckan-logo-white.png') }}" alt="{{ g.site_title }}"
+                    aria-label="{{ _('Navigate to Home - {site_title}').format(site_title=g.site_title) }}"
+                    class="logo-dark" style="display:none"/>
+                {% else %}
+                  <img src="{{ h.url_for_static_or_external(g.site_logo) }}" alt="{{ g.site_title }}"
+                    aria-label="{{ _('Navigate to Home - {site_title}').format(site_title=g.site_title) }}"/>
+                {% endif %}
               </a>
             {% else %}
               <a href="{{ h.url_for('home.index') }}">{{ g.site_title }}</a>

--- a/ckan/templates-midnight-blue/header.html
+++ b/ckan/templates-midnight-blue/header.html
@@ -9,12 +9,14 @@
           <div class="account{% if c.userobj %} avatar authed{% endif %}"{% if c.userobj %} data-module="me" data-me="{{ c.userobj.id }}"{% endif %}>
             <ul class="list-unstyled">
               {% block header_account_theme_toggle %}
-                <li>
-                  <button type="button" class="btn btn-primary" data-module="theme-toggle" aria-pressed="false" aria-label="{{ _('Switch to dark theme') }}" data-bs-title="{{ _('Switch to dark theme') }}" data-bs-toggle="tooltip">
-                    <i class="fa fa-moon" aria-hidden="true" data-icon></i>
-                    <span class="text">{{ _('Theme') }}</span>
-                  </button>
-                </li>
+                {% if h.dark_mode_enabled() %}
+                  <li>
+                    <button type="button" class="btn btn-primary" data-module="theme-toggle" aria-pressed="false" aria-label="{{ _('Switch to dark theme') }}" data-bs-title="{{ _('Switch to dark theme') }}" data-bs-toggle="tooltip">
+                      <i class="fa fa-moon" aria-hidden="true" data-icon></i>
+                      <span class="text">{{ _('Theme') }}</span>
+                    </button>
+                  </li>
+                {% endif %}
               {% endblock %}
               {% if c.userobj %}
                 {% block header_account_logged %}

--- a/ckan/templates-midnight-blue/snippets/facet_list.html
+++ b/ckan/templates-midnight-blue/snippets/facet_list.html
@@ -74,9 +74,9 @@ Dictionary with search facets
                         <li class="nav-item {% if item.active %} active{% endif %}">
                         <a hx-boost="true" href="{{ href }}" aria-label="{{ _('Search datasets by {name}: {label}').format(name=name, label=label_truncated) }}" {% if label != label_truncated %} data-bs-title="{{ label }}" data-bs-toggle="tooltip" {% endif %}>
                           <span class="item-label">{{ label_truncated }}</span>
-                          <span class="item-count-span">
+                          <span class="item-count-span align-items-center gap-2">
                             <span class="item-count badge">{{ count }}</span>
-                            <span class="item-state"></span>
+                            <span class="fa {{ 'fa-minus-circle' if active_facet else 'fa-plus-circle' }}"></span>
                           </span>
                         </a>
                         </li>

--- a/ckan/tests/lib/test_helpers.py
+++ b/ckan/tests/lib/test_helpers.py
@@ -1141,6 +1141,15 @@ def test_unix_locale_to_bcp47():
     assert h.unix_locale_to_bcp47('fr_FR') == 'fr-FR'
 
 
+class TestDarkModeEnabled(object):
+    def test_enabled_by_default(self):
+        assert h.dark_mode_enabled() is True
+
+    @pytest.mark.ckan_config("ckan.theme.enable_dark_mode", False)
+    def test_can_be_disabled(self):
+        assert h.dark_mode_enabled() is False
+
+
 def test_get_facet_items_dict(test_request_context: Any):
     """get_facet_items_dict returns a list of facet items with the correct active state based on the current request parameters."""
     facets = [


### PR DESCRIPTION
Propose adding a dark theme switcher for the midnight blue theme.

<img width="1198" height="1259" alt="image" src="https://github.com/user-attachments/assets/a34c6cb2-3aaf-4366-80df-f5a4a3295f20" />

<img width="1208" height="1113" alt="image" src="https://github.com/user-attachments/assets/1610a309-c1c8-4990-ad5f-e6c6b1ccd340" />

<img width="1166" height="1199" alt="image" src="https://github.com/user-attachments/assets/914635f1-a794-4a17-8cd1-f83c53780b70" />


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

