### PR TITLE
Don't use 'literal_binds' in executed SQL — it's a debugging option

### DIFF
--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -99,22 +99,26 @@ else:
         def __init__(self, error_dict: ErrorDict):
             pprint.pprint(error_dict)
 
-def is_single_statement(sql: str, params: dict[str, Any] | None = None) -> bool:
-    # Most calls to this have sqlalchemy `:abc` parameters
-    # pglast doesn't support these, since they're not the postgres format
-    # Compile the sqlachemy query to a string with psycopg2-style specifiers,
-    # then get psycopg2 to inline the parameters
-    # See also https://docs.sqlalchemy.org/en/21/faq/sqlexpressions.html#faq-sql-expression-string
-    #
-    # This requires a connection for the cursor, but shouldn't actually execute anything
-    engine = get_read_engine()
-    compiled = sa.text(sql).bindparams(**params or {}).compile(engine)
-    with engine.connect() as conn:
-        sql = conn.connection.cursor().mogrify(str(compiled), compiled.params).decode()
-    try:
-        return len(pglast.parser.parse_sql(sql)) == 1
-    except pglast.parser.ParseError:
-        return False
+ def inline_sql_parameters(sql: str, params: dict) -> str:
+     """Inline values for sqlalchemy bind parameters
+     """
+      # Compile the sqlachemy query to a string with psycopg2-style specifiers,
+      # then get psycopg2 to inline the parameters
+      # See also https://docs.sqlalchemy.org/en/21/faq/sqlexpressions.html#faq-sql-expression-string
+      #
+      # This requires a connection for the cursor, but shouldn't actually execute anything
+      engine = get_read_engine()
+      compiled = sa.text(sql).bindparams(**params or {}).compile(engine)
+      with engine.connect() as conn:
+          return conn.connection.cursor().mogrify(str(compiled), compiled.params).decode()
+
+ def is_single_statement(sql: str, params: dict[str, Any] | None = None) -> bool:
+     # Most calls to this have sqlalchemy `:abc` parameters
+     # pglast doesn't support these, since they're not the postgres format
+     try:
+          return len(pglast.parser.parse_sql(inline_sql_parameters(sql, params or {}))) == 1
+      except pglast.parser.ParseError:
+          return False
 
 _engines = {}
 
@@ -1689,16 +1693,15 @@ def _execute_single_statement_copy_to(
     for chunk in where_values:
         params.update(chunk)
 
-    if not is_single_statement(sql_string, params):
+    clause = inline_sql_parameters(sql_string, params)
+
+    if not is_single_statement(clause):
         raise ValidationError({
             'query': ['Query is not a single statement.']
         })
 
-    clause = sa.text(sql_string).bindparams(
-        **params).compile(compile_kwargs={"literal_binds": True})
-
     cursor = context['connection'].connection.cursor()
-    cursor.copy_expert(str(clause), buf)
+    cursor.copy_expert(clause, buf)
     cursor.close()
 
 


### PR DESCRIPTION
`literal_binds` is documented as generally being for logging or debugging purposes, and the result shouldn't be passed to databases.

We can use psycopg2's provided mechanism to do this.
