### PR TITLE
group_show, organization_show include_users default to False

### DIFF
--- a/changes/9232.misc
+++ b/changes/9232.misc
@@ -1,3 +1,0 @@
-After CKAN 2.12 the include_users parameter to organization_show and group_show
-actions will default to False regardless of the ckan.auth.public_user_details
-configuration setting.

--- a/changes/9507.misc
+++ b/changes/9507.misc
@@ -1,1 +1,3 @@
-group_show and organization_show ``include_users`` parameter now defaults to False
+The ``include_users`` parameter to organization_show and group_show
+now default to False regardless of the ``ckan.auth.public_user_details``
+configuration setting.

--- a/changes/9507.misc
+++ b/changes/9507.misc
@@ -1,0 +1,1 @@
+group_show and organization_show ``include_users`` parameter now defaults to False

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -753,9 +753,11 @@ def _group_or_org_create(context: Context,
     return_id_only = context.get('return_id_only', False)
     action = 'organization_show' if is_org else 'group_show'
 
-    output = context['id'] if return_id_only \
-        else _get_action(action)(context, {'id': group.id})
-    return output
+    if return_id_only:
+        return context['id']
+
+    return _get_action(action)(context, {
+        'id': group.id, 'include_users': 'users' in data})
 
 
 def group_create(context: Context,

--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -1155,10 +1155,7 @@ def _group_or_org_show(
         packages_field = None
 
     try:
-        if config.get('ckan.auth.public_user_details'):
-            include_users = asbool(data_dict.get('include_users', True))
-        else:
-            include_users = asbool(data_dict.get('include_users', False))
+        include_users = asbool(data_dict.get('include_users', False))
         include_groups = asbool(data_dict.get('include_groups', True))
         include_extras = asbool(data_dict.get('include_extras', True))
         include_followers = asbool(data_dict.get('include_followers', True))
@@ -1233,10 +1230,7 @@ def group_show(context: Context, data_dict: DataDict) -> ActionResult.GroupShow:
          (optional, default: ``True``)
     :type include_extras: bool
     :param include_users: include the group's users
-         (optional, default: ``True`` if ``ckan.auth.public_user_details``
-         is ``True`` otherwise ``False``)
-         NOTE: after CKAN 2.12 this parameter will default to ``False``
-         regardless of the ``ckan.auth.public_user_details`` setting
+         (optional, default: ``False``)
     :type include_users: bool
     :param include_groups: include the group's sub groups
          (optional, default: ``True``)
@@ -1268,10 +1262,7 @@ def organization_show(context: Context, data_dict: DataDict) -> ActionResult.Org
          (optional, default: ``True``)
     :type include_extras: bool
     :param include_users: include the organization's users
-         (optional, default: ``True`` if ``ckan.auth.public_user_details``
-         is ``True`` otherwise ``False``)
-         NOTE: after CKAN 2.12 this parameter will default to ``False``
-         regardless of the ``ckan.auth.public_user_details`` setting
+         (optional, default: ``False``)
     :type include_users: bool
     :param include_groups: include the organization's sub groups
          (optional, default: ``True``)

--- a/ckan/tests/controllers/test_organization.py
+++ b/ckan/tests/controllers/test_organization.py
@@ -643,7 +643,9 @@ class TestOrganizationMembership(object):
                 url_for("organization.member_delete", id=org["id"], user=user["id"]),
                 headers=headers,
             )
-            org = helpers.call_action('organization_show', id=org['id'])
+            org = helpers.call_action(
+                'organization_show', id=org['id'], include_users=True,
+            )
 
             # only test.ckan.net
             assert len(org['users']) == 1

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -1186,11 +1186,23 @@ class TestGroupCreate(object):
             "group_create", context=context, name=factories.Group.stub().name
         )
 
-        assert len(group["users"]) == 1
         assert group["display_name"] == group["name"]
         assert group["package_count"] == 0
         assert not group["is_organization"]
         assert group["type"] == "group"
+        group_users = helpers.call_action(
+            "group_show",
+            context=context,
+            id=group['id'],
+            include_users=True,
+        )
+        assert group_users["users"] == [{
+            "capacity": "admin",
+            **{
+                k:v for k,v in user.items()
+                if k not in ('apikey', 'email')
+            }
+        }]
 
     def test_create_group_validation_fail(self):
         user = factories.User()
@@ -1314,11 +1326,23 @@ class TestOrganizationCreate(object):
             name=factories.Organization.stub().name,
         )
 
-        assert len(org["users"]) == 1
         assert org["display_name"] == org["name"]
         assert org["package_count"] == 0
         assert org["is_organization"]
         assert org["type"] == "organization"
+        org_users = helpers.call_action(
+            "organization_show",
+            context=context,
+            id=org['id'],
+            include_users=True,
+        )
+        assert org_users["users"] == [{
+            "capacity": "admin",
+            **{
+                k:v for k,v in user.items()
+                if k not in ('apikey', 'email')
+            }
+        }]
 
     def test_create_organization_validation_fail(self):
         user = factories.User()
@@ -1378,7 +1402,6 @@ class TestOrganizationCreate(object):
             type=custom_org_type,
         )
 
-        assert len(org["users"]) == 1
         assert org["display_name"] == org["name"]
         assert org["package_count"] == 0
         assert org["is_organization"]

--- a/ckan/tests/logic/action/test_get.py
+++ b/ckan/tests/logic/action/test_get.py
@@ -326,8 +326,8 @@ class TestGroupList(object):
         group_list = helpers.call_action("group_list", all_fields=True)
 
         expected_group = dict(group)
-        for field in ("users", "extras", "groups"):
-            del expected_group[field]
+        del expected_group["extras"]
+        del expected_group["groups"]
 
         assert group_list[0] == expected_group
         assert "extras" not in group_list[0]

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -709,7 +709,6 @@ class TestDatasetUpdate(object):
 
     def test_groups_unchanged_if_missing(self):
         group = factories.Group()
-        del group['users']  # avoid validation error
         dataset = factories.Dataset(groups=[group])
         assert dataset['groups']
 
@@ -723,7 +722,6 @@ class TestDatasetUpdate(object):
 
     def test_groups_removed_if_empty_list(self):
         group = factories.Group()
-        del group['users']  # avoid validation error
         dataset = factories.Dataset(groups=[group])
         assert dataset['groups']
 


### PR DESCRIPTION
### Proposed fixes:

group_show, organization_show include_users default to False after 2.12 as documented in #9263

Essentially the same changes as #9232 which was partially reverted on master for some reason.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [X] includes API changes
- [ ] includes bugfix for possible backport