### PR TITLE
bcp47 language codes for js translation files

### DIFF
--- a/changes/9508.misc
+++ b/changes/9508.misc
@@ -1,0 +1,1 @@
+store JS translation files with BCP47 names instead of unix locale names

--- a/ckan/lib/i18n.py
+++ b/ckan/lib/i18n.py
@@ -327,6 +327,8 @@ def build_js_translations() -> None:
     ``ckan.i18n_directory``. These include only those translation
     strings that are actually used in JS files.
     '''
+    from ckan.lib.helpers import helper_functions as h
+
     log.debug(u'Generating JavaScript translations')
     ckan_i18n_dir = get_ckan_i18n_dir()
     dest_dir = get_js_translations_dir()
@@ -370,6 +372,7 @@ def build_js_translations() -> None:
             continue
 
         latest = max(os.path.getmtime(fn) for fn in po_files)
+        lang = h.unix_locale_to_bcp47(lang)
         dest_file = os.path.join(dest_dir, lang + u'.js')
 
         if (not os.path.isfile(dest_file) or

--- a/ckan/public/base/javascript/client.js
+++ b/ckan/public/base/javascript/client.js
@@ -77,7 +77,6 @@
      * Returns a jQuery xhr promise.
      */
     getLocaleData: function (locale, success, error) {
-      locale = locale.replace('-', '_');
       var url = this.url('/api/i18n/' + (locale || ''));
       return jQuery.getJSON(url).then(success, error);
     },

--- a/ckan/tests/lib/test_i18n.py
+++ b/ckan/tests/lib/test_i18n.py
@@ -15,6 +15,7 @@ import pytest
 from ckan.lib import i18n
 from ckan import plugins
 from ckan.lib.plugins import DefaultTranslation
+from ckan.lib.helpers import helper_functions as h
 
 
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -75,7 +76,9 @@ class TestBuildJSTranslations(object):
         files = os.listdir(self.temp_dir)
 
         # Check that all locales have been generated
-        assert set(i18n.get_locales()).difference(["en"]) == set(
+        assert set(
+            h.unix_locale_to_bcp47(loc) for loc in i18n.get_locales()
+        ).difference(["en"]) == set(
             os.path.splitext(fn)[0] for fn in files
         )
 


### PR DESCRIPTION
### Proposed fixes:
Instead of using a string replace in base.js let's store and serve the JS translations with BCP47 language codes as their names, as described in
https://github.com/ckan/ckan/pull/9474#issuecomment-5297647011


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport
