### PR TITLE
fix: fix main content height

### DIFF
--- a/ckan/public-midnight-blue/base/css/main-rtl.css
+++ b/ckan/public-midnight-blue/base/css/main-rtl.css
@@ -13853,9 +13853,16 @@ td.diff_header {
   position: relative;
 }
 
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
 .main {
   padding: 20px 0;
   background-color: #fff;
+  flex: 1;
 }
 
 .main:after,

--- a/ckan/public-midnight-blue/base/css/main.css
+++ b/ckan/public-midnight-blue/base/css/main.css
@@ -13853,9 +13853,16 @@ td.diff_header {
   position: relative;
 }
 
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
 .main {
   padding: 20px 0;
   background-color: #fff;
+  flex: 1;
 }
 
 .main:after,

--- a/ckan/public-midnight-blue/base/scss/_layout.scss
+++ b/ckan/public-midnight-blue/base/scss/_layout.scss
@@ -3,9 +3,16 @@
     position: relative;
 }
 
+body {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
 .main {
     padding: 20px 0;
     background-color: $white;
+    flex: 1;
 }
 
 .main:after,

--- a/ckan/public/base/css/main-rtl.css
+++ b/ckan/public/base/css/main-rtl.css
@@ -13821,7 +13821,6 @@ td.diff_header {
 }
 .wrapper {
   position: relative;
-  min-height: 300px;
   background-color: #fff;
 }
 @media (min-width: 768px) {
@@ -13849,9 +13848,16 @@ td.diff_header {
   position: relative;
 }
 
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
 .main {
   padding: 20px 0;
   background: #eee url("../../../base/images/bg.png");
+  flex: 1;
 }
 
 .main:after,

--- a/ckan/public/base/css/main.css
+++ b/ckan/public/base/css/main.css
@@ -13821,7 +13821,6 @@ td.diff_header {
 }
 .wrapper {
   position: relative;
-  min-height: 300px;
   background-color: #fff;
 }
 @media (min-width: 768px) {
@@ -13849,9 +13848,16 @@ td.diff_header {
   position: relative;
 }
 
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
 .main {
   padding: 20px 0;
   background: #eee url("../../../base/images/bg.png");
+  flex: 1;
 }
 
 .main:after,

--- a/ckan/public/base/scss/_layout.scss
+++ b/ckan/public/base/scss/_layout.scss
@@ -2,7 +2,6 @@
     @include clearfix();
     @extend .box;
     position: relative;
-    min-height: 300px;
     background-color: #fff;
     @include media-breakpoint-up(md) {
         &:before {
@@ -29,22 +28,22 @@
     }
 }
 
-// @media (min-width: $screen-md-min) {
-//   .wrapper {
-//     background-position:0px 0px;
-//   }
-// }
-// .wrapper.no-nav {
-//     background-image: none;
-// }
+
 [role=main],
 .main {
     position: relative;
 }
 
+body {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
 .main {
     padding: 20px 0;
     background: $layoutBackgroundColor url("#{$bgPath}");
+    flex: 1;
 }
 
 .main:after,


### PR DESCRIPTION
Might be controversial, but I’ve never liked this when the content isn’t tall enough to fill the page. Changed it for both themes. Also removed the `min-height` from the original theme, as it’s actually causing a bug on mobile views.


<img width="1090" height="1274" alt="image" src="https://github.com/user-attachments/assets/671e1d88-ac14-4d56-81bf-7bb288e251f1" />
<img width="1083" height="1274" alt="image" src="https://github.com/user-attachments/assets/c2cbb285-f9eb-4acc-b6c8-bfb63616511a" />




### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [X] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

