### PR TITLE
fix: handle DataPusher timeout exceptions

### DIFF
--- a/ckanext/datapusher/logic/action.py
+++ b/ckanext/datapusher/logic/action.py
@@ -155,6 +155,16 @@ def datapusher_submit(context: Context, data_dict: dict[str, Any]):
                     'original_url': resource_dict.get('url'),
                 }
             }))
+    except requests.exceptions.Timeout as e:
+        error: dict[str, Any] = {
+            'message': 'DataPusher request timed out.',
+            'details': str(e),
+        }
+        task['error'] = json.dumps(error)
+        task['state'] = 'error'
+        task['last_updated'] = str(datetime.datetime.utcnow()),
+        p.toolkit.get_action('task_status_update')(context, task)
+        raise p.toolkit.ValidationError(error)
     except requests.exceptions.ConnectionError as e:
         error: dict[str, Any] = {'message': 'Could not connect to DataPusher.',
                                  'details': str(e)}

--- a/ckanext/datapusher/tests/test_action.py
+++ b/ckanext/datapusher/tests/test_action.py
@@ -1,10 +1,13 @@
 # encoding: utf-8
 
 import datetime
+import json
 
 import unittest.mock as mock
 import pytest
+import requests
 from ckan.logic import _actions
+import ckan.logic as logic
 
 from ckan.tests import helpers, factories
 from ckanext.datapusher.tests import get_api_token
@@ -339,6 +342,35 @@ class TestSubmit:
                 submit(res, user)
 
                 assert r_mock.call_count == 1
+
+    def test_read_timeout_marks_task_as_error(self, app, monkeypatch):
+        user = factories.User()
+        resource = factories.Resource(user=user)
+        monkeypatch.setattr(
+            "requests.post",
+            mock.Mock(side_effect=requests.exceptions.ReadTimeout(
+                "timed out")),
+        )
+
+        with app.flask_app.test_request_context():
+            with pytest.raises(logic.ValidationError):
+                helpers.call_action(
+                    "datapusher_submit",
+                    context={"user": user["name"]},
+                    resource_id=resource["id"],
+                )
+
+        task = helpers.call_action(
+            "task_status_show",
+            {},
+            entity_id=resource["id"],
+            task_type="datapusher",
+            key="datapusher",
+        )
+        assert task["state"] == "error"
+        assert json.loads(task["error"])["message"] == (
+            "DataPusher request timed out."
+        )
 
     def test_task_status_changes(self, create_with_upload):
         """While updating task status, datapusher commits changes to database.


### PR DESCRIPTION
## Summary

- Handle all DataPusher request timeout exceptions.
- Persist the task as `error` instead of leaving it in `submitting`.
- Add regression coverage for `ReadTimeout`.

Closes the remaining edge case identified in #2357.

## Testing

- `ckanext/datapusher/tests/test_action.py`: 10 passed
