### PR TITLE
[#9118] Fix group and organization context reuse

### DIFF
--- a/changes/9118.bugfix
+++ b/changes/9118.bugfix
@@ -1,0 +1,1 @@
+Fixed group and organization creation reusing a previously created group when the same action context is reused.

--- a/ckan/logic/action/create.py
+++ b/ckan/logic/action/create.py
@@ -686,6 +686,11 @@ def package_collaborator_create(
 def _group_or_org_create(context: Context,
                          data_dict: DataDict,
                          is_org: bool = False) -> Union[str, dict[str, Any]]:
+    # Do not let state left by earlier actions affect this create.
+    context = context.copy()
+    context.pop("group", None)
+    context.pop("id", None)
+
     user = context['user']
     session = context['session']
     data_dict['is_organization'] = is_org

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -1314,6 +1314,36 @@ class TestGroupCreate(object):
         )
 
 
+    @pytest.mark.parametrize(
+        "action_name", ["group_create", "organization_create"]
+    )
+    def test_create_with_reused_context_creates_distinct_groups(
+        self, action_name
+    ):
+        user = factories.User()
+        context = {"user": user["name"], "ignore_auth": True}
+
+        first_name = factories.Group.stub().name
+        second_name = factories.Group.stub().name
+
+        first = helpers.call_action(
+            action_name, context=context, name=first_name
+        )
+
+        assert "group" not in context
+        assert "id" not in context
+
+        second = helpers.call_action(
+            action_name, context=context, name=second_name
+        )
+
+        assert first["id"] != second["id"]
+        assert model.Group.get(first_name) is not None
+        assert model.Group.get(second_name) is not None
+        assert "group" not in context
+        assert "id" not in context
+
+
 @pytest.mark.usefixtures("non_clean_db")
 class TestOrganizationCreate(object):
     def test_create_organization(self):


### PR DESCRIPTION
Fixes #9118

### Proposed fixes:

- Checked the other create actions for the same pattern. Package creation is already isolated; user creation clears a stale `user_obj` before saving, and package-relationship creation does not consume a stale `relationship` on the next create. So this change is intentionally limited to groups and organizations.

- Use a private copy of the action context for group and organization creation and remove stale `group` / `id` state before saving.

- Add regression coverage for repeated `group_create` and `organization_create` calls with the same context.

