### PR TITLE
Pass ckan.feeds.author_link through to the Atom feed author

### DIFF
--- a/changes/9514.bugfix
+++ b/changes/9514.bugfix
@@ -1,0 +1,5 @@
+Honour the ``ckan.feeds.author_link`` config option again. It was dropped when the
+feeds controller was ported to a Flask blueprint, so the Atom feeds never emitted an
+``atom:uri`` for the feed author even though the option and the ``IFeed`` contract still
+documented it. Feed classes provided via ``IFeed.get_feed_class`` now receive the
+``author_link`` argument their documented signature already listed.

--- a/ckan/config/config_declaration.yaml
+++ b/ckan/config/config_declaration.yaml
@@ -1717,6 +1717,7 @@ groups:
         description: This controls the feed author's name. If unspecified, it'll use :ref:`ckan.site_id`.
 
       - key: ckan.feeds.author_link
+        default: ""
         example: http://okfn.org
         description: This controls the feed author's link. If unspecified, it'll use :ref:`ckan.site_url`.
 

--- a/ckan/tests/controllers/test_feed.py
+++ b/ckan/tests/controllers/test_feed.py
@@ -35,6 +35,13 @@ class TestFeeds(object):
         assert helpers.body_contains(res, u"<title>{0}</title>".format(dataset["title"]))
         assert helpers.body_contains(res, u"<content/>")
 
+    @pytest.mark.ckan_config("ckan.feeds.author_link", "http://example.org/me")
+    def test_general_atom_feed_includes_author_link(self, app):
+        factories.Dataset()
+        offset = url_for(u"feeds.general")
+        res = app.get(offset)
+        assert helpers.body_contains(res, u"<uri>http://example.org/me</uri>")
+
     def test_group_atom_feed_works(self, app):
         group = factories.Group()
         dataset = factories.Dataset(groups=[{"id": group["id"]}])

--- a/ckan/types/__init__.py
+++ b/ckan/types/__init__.py
@@ -210,6 +210,7 @@ class PFeedFactory(Protocol):
         feed_description: str,
         language: Optional[str],
         author_name: Optional[str],
+        author_link: Optional[str],
         feed_guid: Optional[str],
         feed_url: Optional[str],
         previous_page: Optional[str],

--- a/ckan/views/feed.py
+++ b/ckan/views/feed.py
@@ -77,6 +77,7 @@ class CKANFeed(FeedGenerator):
         feed_description: str,
         language: Optional[str],
         author_name: Optional[str],
+        author_link: Optional[str],
         feed_guid: Optional[str],
         feed_url: Optional[str],
         previous_page: Optional[str],
@@ -86,11 +87,15 @@ class CKANFeed(FeedGenerator):
     ) -> None:
         super(CKANFeed, self).__init__()
 
+        author: dict[str, Any] = {u"name": author_name}
+        if author_link:
+            author[u"uri"] = author_link
+
         self.title(feed_title)
         self.link(href=feed_link, rel=u"alternate")
         self.description(feed_description)
         self.language(language)
-        self.author({u"name": author_name})
+        self.author(author)
         self.id(feed_guid)
         self.link(href=feed_url, rel=u"self")
         links = (
@@ -136,6 +141,8 @@ def output_feed(
         feed_guid: str) -> Response:
     author_name = config.get(u'ckan.feeds.author_name').strip() or \
         config.get(u'ckan.site_id').strip()
+    author_link = config.get(u'ckan.feeds.author_link').strip() or \
+        config.get(u'ckan.site_url').strip()
 
     def remove_control_characters(s: str):
         if not s:
@@ -155,6 +162,7 @@ def output_feed(
         feed_description,
         language=u'en',
         author_name=author_name,
+        author_link=author_link,
         feed_guid=feed_guid,
         feed_url=feed_url,
         previous_page=navigation_urls[u'previous'],


### PR DESCRIPTION
Fixes: no open issue.

### Proposed fixes:

`ckan.feeds.author_link` is declared and documented, and
`IFeed.get_feed_class`'s docstring lists `author_link` as the sixth constructor argument, but
nothing reads it. `output_feed` reads `ckan.feeds.author_name` and stops there, and
`CKANFeed.__init__` has no such parameter, so every CKAN Atom feed emits an author with no
`atom:uri` and any operator who set the option in their ini has been silently ignored.

It is a regression rather than a missing feature: the Pylons controller did read it
(`ckan/controllers/feed.py` before #3586 deleted it), and the port to the Flask blueprint
dropped it.

Before / after, with `ckan.feeds.author_link = http://example.org/me`:

```
<author><name>Test Author</name></author>
<author><name>Test Author</name><uri>http://example.org/me</uri></author>
```

Unset, it falls back to `ckan.site_url`, which is what the declaration promises.

Two things worth a maintainer's eye:

- The declaration was the only one of the four `ckan.feeds.*` string options with no
  `default`, so `config.get()` returned `None` and `.strip()` would have raised. Added
  `default: ""` alongside its siblings.
- This is a plugin-facing change: a third-party `get_feed_class` written against the *actual*
  signature rather than the documented one now receives an unexpected `author_link` keyword. I
  put the parameter at position 6 because that is where the docstring says it goes, so docstring,
  `PFeedFactory` and the implementation finally agree — but a trailing
  `author_link: Optional[str] = None` would be more forgiving, and I am happy to switch.

Nothing outside `views/feed.py`, `types/__init__.py` and `plugins/interfaces.py` references
`CKANFeed`, `IFeed`, `get_feed_class` or `PFeedFactory`.

Collision note: #7456 touches these same three files (no `author_link` in its diff, so a
textual conflict only), and #9306 would move feeds out of core entirely, carrying this bug
with them.

Tests: `ckan/tests/controllers/test_feed.py` had six tests, all asserting per-item content —
no assertion anywhere touched the feed-level `<author>` block, which is why this went
unnoticed. Added one that sets the option and asserts the `<uri>`. Reverting only the source
change makes it the single failure (`1 failed, 8 passed`). Ran `ckan/tests/config` and
`ckan/tests/controllers` in full against Postgres, Redis and Solr: 494 passed. `ruff` clean;
`mypy` reports no new errors on the changed lines. Not run: the rest of the suite, and
Python 3.10 (I used 3.13).

### Features:

- [x] includes tests covering changes
- [ ] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [x] includes bugfix for possible backport
