### PR TITLE
Normalize slug preview input to NFC before mapping accented characters

### DIFF
--- a/ckan/public-midnight-blue/base/javascript/plugins/jquery.url-helpers.js
+++ b/ckan/public-midnight-blue/base/javascript/plugins/jquery.url-helpers.js
@@ -36,6 +36,16 @@
      * Returns the new slug.
      */
     slugify: function (string, trim) {
+      // Normalize to NFC so that Nordic characters such as å, ä and ö are
+      // a single code point regardless of whether they arrived precomposed
+      // (typing on a Nordic keyboard) or decomposed into a base letter
+      // plus a combining mark (for example text pasted from some word
+      // processors, or from applications that use decomposed Unicode
+      // internally). The character map below only has entries for
+      // precomposed code points, so a stray combining mark was silently
+      // turned into a hyphen, e.g. "Åsele" became "a-sele" instead of
+      // "asele" when the title had been pasted rather than typed.
+      string = (string || '').normalize('NFC');
       var str = '';
       var index = 0;
       var length = string.length;

--- a/ckan/public/base/javascript/plugins/jquery.url-helpers.js
+++ b/ckan/public/base/javascript/plugins/jquery.url-helpers.js
@@ -36,6 +36,16 @@
      * Returns the new slug.
      */
     slugify: function (string, trim) {
+      // Normalize to NFC so that Nordic characters such as å, ä and ö are
+      // a single code point regardless of whether they arrived precomposed
+      // (typing on a Nordic keyboard) or decomposed into a base letter
+      // plus a combining mark (for example text pasted from some word
+      // processors, or from applications that use decomposed Unicode
+      // internally). The character map below only has entries for
+      // precomposed code points, so a stray combining mark was silently
+      // turned into a hyphen, e.g. "Åsele" became "a-sele" instead of
+      // "asele" when the title had been pasted rather than typed.
+      string = (string || '').normalize('NFC');
       var str = '';
       var index = 0;
       var length = string.length;

--- a/cypress/e2e/plugins/jquery.url-helpers.cy.js
+++ b/cypress/e2e/plugins/jquery.url-helpers.cy.js
@@ -61,6 +61,23 @@ describe('jQuery.url', {testIsolation: false}, function () {
       })
     });
 
+    it('should produce the same slug for precomposed and decomposed Nordic characters', function () {
+      cy.window().then(win => {
+        // "Åsele" with a precomposed å (U+00E5) vs the same visible text
+        // with å built from a decomposed base "a" (U+0061) + COMBINING
+        // RING ABOVE (U+030A). Text pasted from some word processors or
+        // PDF extractors delivers the decomposed form, which used to be
+        // mangled into "a-sele" instead of "asele" because the character
+        // map only has an entry for the precomposed code point.
+        let precomposed = win.jQuery.url.slugify('\u00E5sele');
+        let decomposed = win.jQuery.url.slugify('\u0061\u030Asele');
+
+        assert.equal(precomposed, 'asele');
+        assert.equal(decomposed, 'asele');
+        assert.equal(precomposed, decomposed);
+      })
+    });
+
     it('should allow underscore characters', function() {
       cy.window().then(win => {
         let target = win.jQuery.url.slugify('apples_pears');


### PR DESCRIPTION
Fixes #9517

### What this fixes

The client-side slug preview
(`ckan/public/base/javascript/plugins/jquery.url-helpers.js`) produced a
different, incorrect result for text containing å/ä/ö (or other Latin
letters with diacritics) depending on whether that text arrived as
precomposed or decomposed Unicode — most commonly noticeable when a title
is pasted from a source (some word processors, PDF text extraction, etc.)
that uses decomposed Unicode internally. `"Åsele"` typed normally slugified
to `asele`, but the same text pasted in decomposed form slugified to
`a-sele`.

### Root cause

`slugify()` maps the string one UTF-16 code unit at a time through a fixed
table of precomposed code points. A decomposed character splits into a
plain ASCII base letter (which passes through untouched) plus a combining
mark with no entry in the table, which falls through to the default `-`.

This is a Unicode-encoding-form bug rather than a missing-character bug,
so it affects any character in the table that has a canonical Unicode
decomposition into base letter + combining mark (å, ä, ö, é, ü, ñ, ç, and
equivalents in many other languages). It does not affect letters with no
decomposed form at all, such as Danish/Norwegian ø/Ø or German ß — those
are atomic code points that can never arrive "decomposed", so they were
never affected by this bug (already checked: they're correctly mapped).

### The fix

Normalize the input to NFC (`string.normalize('NFC')`) before mapping, so
decomposed input is converted to the same precomposed form the table
already handles correctly. Applied to both `ckan/public/` and
`ckan/public-midnight-blue/` copies of the file, since they contain
identical code.

### Scope note

We also checked the server-side authoritative slug generator
(`ckan.lib.munge.substitute_ascii_equivalents()`) expecting the same bug,
but it already handles decomposed input correctly (it drops unrecognized
characters instead of hyphenating them, which happens to leave the
correct base letter behind). So this PR only touches the client-side
preview — there is no server-side counterpart needed.

### Testing

- Added a regression test to `cypress/e2e/plugins/jquery.url-helpers.cy.js`
  covering: precomposed and decomposed input for the same Nordic character
  produce the same slug.
- Ran the full `jquery.url-helpers.cy.js` spec locally against a CKAN dev
  instance: 9 passing, 0 failing.
- Manually verified in a local CKAN instance: typed and pasted
  (decomposed) versions of the same title with å/ä/ö both produced the
  same, correct slug.

### Checklist

- [x] New/changed tests included
- [x] Existing tests unaffected (no other file touched)
- [ ] Documentation update (none needed — internal implementation detail,
      no user-facing behavior change other than fixing the bug)

### Note

This PR was prepared with the assistance of an AI coding tool (Claude),
under my direction and review — I tested the fix locally (see Testing
above) and read through the diff myself before submitting. I'm new to
contributing to CKAN (and to open source in general), so apologies in
advance for any missteps in process or convention — happy to fix
anything that's off.